### PR TITLE
Update codeowners with new team names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,15 @@
 # File containing policy for file ownership
 
 # Reviewers for all files in the repository
-* @microsoft/hvlite
+* @microsoft/openvmm-maintain
 
 # Any CI changes require special approval
-/ci/ @microsoft/hvlite-ci-config-reviewers
-/.github/ @microsoft/hvlite-ci-config-reviewers
+/ci/ @microsoft/openvmm-ci-reviewers
+/.github/ @microsoft/openvmm-ci-reviewers
 
 # VTL2 settings is an API consumed by various partner teams. VTL2 Settings
 # approvers evaluate for consistency and to help ensure no breaking changes
-/vm/devices/get/underhill_config/* @microsoft/hvlite-vtl2-settings-approvers
+/vm/devices/get/underhill_config/* @microsoft/openvmm-vtl2-settings-approvers
 
 # Cargo dependencies
-/Cargo.lock @microsoft/hvlite-dependency-reviewers
+/Cargo.lock @microsoft/openvmm-dependency-reviewers


### PR DESCRIPTION
This change updates the CODEOWNERS file to have the new OpenVMM teams.