### PR TITLE
Add a helper to wake vps in VTL 2 without touching wake_reasons

### DIFF
--- a/openhcl/virt_underhill/src/lib.rs
+++ b/openhcl/virt_underhill/src/lib.rs
@@ -551,9 +551,7 @@ struct WakeReason {
     message_queues: bool,
     hv_start_enable_vtl_vp: bool,
     intcon: bool,
-    inspect: bool,
-    tlb_flush: bool,
-    #[bits(26)]
+    #[bits(28)]
     _reserved: u32,
 }
 
@@ -563,9 +561,6 @@ impl WakeReason {
     const MESSAGE_QUEUES: Self = Self::new().with_message_queues(true);
     const HV_START_ENABLE_VP_VTL: Self = Self::new().with_hv_start_enable_vtl_vp(true); // StartVp/EnableVpVtl handling
     const INTCON: Self = Self::new().with_intcon(true);
-    const INSPECT: Self = Self::new().with_inspect(true);
-    #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
-    const TLB_FLUSH: Self = Self::new().with_tlb_flush(true);
 }
 
 /// Immutable access to useful bits of Partition state.
@@ -705,7 +700,7 @@ impl UhPartitionInner {
         // Wake VPs to propagate updates.
         if wake_vps {
             for vp in self.vps.iter() {
-                vp.wake(Vtl::Vtl0, WakeReason::INSPECT);
+                vp.wake_vtl2();
             }
         }
     }

--- a/openhcl/virt_underhill/src/processor/hardware_cvm/tlb_lock.rs
+++ b/openhcl/virt_underhill/src/processor/hardware_cvm/tlb_lock.rs
@@ -4,7 +4,6 @@
 
 use crate::HardwareIsolatedBacking;
 use crate::UhProcessor;
-use crate::WakeReason;
 use hvdef::Vtl;
 use std::sync::atomic::Ordering;
 
@@ -133,8 +132,7 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
                             // synchronize with its sleep state as a spurious IPI is not
                             // harmful.
                             if other_lock.sleeping.load(Ordering::SeqCst) {
-                                self.partition.vps[blocked_vp]
-                                    .wake(target_vtl, WakeReason::TLB_FLUSH);
+                                self.partition.vps[blocked_vp].wake_vtl2();
                             }
                         }
                     }

--- a/openhcl/virt_underhill/src/processor/mod.rs
+++ b/openhcl/virt_underhill/src/processor/mod.rs
@@ -334,6 +334,12 @@ impl UhVpInner {
         }
     }
 
+    pub fn wake_vtl2(&self) {
+        if let Some(waker) = &*self.waker.read() {
+            waker.wake_by_ref();
+        }
+    }
+
     #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
     pub fn set_sidecar_exit_reason(&self, reason: SidecarExitReason) {
         self.sidecar_exit_reason.lock().get_or_insert_with(|| {

--- a/openhcl/virt_underhill/src/processor/tdx/mod.rs
+++ b/openhcl/virt_underhill/src/processor/tdx/mod.rs
@@ -3177,18 +3177,18 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressSpaceEx
 }
 
 impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
-    pub fn wake_processors_for_tlb_flush(&mut self, vtl: Vtl, processor_set: Option<Vec<u32>>) {
+    pub fn wake_processors_for_tlb_flush(&mut self, _vtl: Vtl, processor_set: Option<Vec<u32>>) {
         // TODO: Add additional checks? HCL checks that VP is active and in target VTL
         if let Some(processors) = processor_set {
             for vp in processors {
                 if self.vp.vp_index().index() != vp {
-                    self.vp.partition.vps[vp as usize].wake(vtl, WakeReason::TLB_FLUSH);
+                    self.vp.partition.vps[vp as usize].wake_vtl2();
                 }
             }
         } else {
             for vp in self.vp.partition.vps.iter() {
                 if self.vp.vp_index().index() != vp.cpu_index {
-                    vp.wake(vtl, WakeReason::TLB_FLUSH);
+                    vp.wake_vtl2();
                 }
             }
         }


### PR DESCRIPTION
This is meant as a perf optimization, as it allows us to skip scanning the wake_reasons in cases where there's nothing else waking us up.