### PR TITLE
openvmm: remove Hyper-V Lite description

### DIFF
--- a/openvmm/hvlite_entry/src/cli_args.rs
+++ b/openvmm/hvlite_entry/src/cli_args.rs
@@ -33,6 +33,9 @@ use std::str::FromStr;
 use thiserror::Error;
 
 /// OpenVMM virtual machine monitor.
+///
+/// This is not yet a stable interface and may change radically between
+/// versions.
 #[derive(Parser)]
 pub struct Options {
     /// processor count


### PR DESCRIPTION
We are not Hyper-V Lite.