### PR TITLE
flowey: Restore packages on Windows

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/local_restore_packages.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_restore_packages.rs
@@ -33,12 +33,15 @@ impl FlowNode for Node {
         for req in &requests {
             match req.arch {
                 CommonArch::X86_64 => {
+                    if matches!(ctx.platform(), FlowPlatform::Linux) {
+                        deps.extend_from_slice(&[ctx
+                            .reqv(|v| crate::init_openvmm_magicpath_openhcl_sysroot::Request {
+                                arch: OpenvmmSysrootArch::X64,
+                                path: v,
+                            })
+                            .into_side_effect()]);
+                    }
                     deps.extend_from_slice(&[
-                        ctx.reqv(|v| crate::init_openvmm_magicpath_openhcl_sysroot::Request {
-                            arch: OpenvmmSysrootArch::X64,
-                            path: v,
-                        })
-                        .into_side_effect(),
                         ctx.reqv(|done| crate::init_openvmm_magicpath_lxutil::Request {
                             arch: LxutilArch::X86_64,
                             done,
@@ -56,12 +59,15 @@ impl FlowNode for Node {
                     ]);
                 }
                 CommonArch::Aarch64 => {
+                    if matches!(ctx.platform(), FlowPlatform::Linux) {
+                        deps.extend_from_slice(&[ctx
+                            .reqv(|v| crate::init_openvmm_magicpath_openhcl_sysroot::Request {
+                                arch: OpenvmmSysrootArch::Aarch64,
+                                path: v,
+                            })
+                            .into_side_effect()]);
+                    }
                     deps.extend_from_slice(&[
-                        ctx.reqv(|v| crate::init_openvmm_magicpath_openhcl_sysroot::Request {
-                            arch: OpenvmmSysrootArch::Aarch64,
-                            path: v,
-                        })
-                        .into_side_effect(),
                         ctx.reqv(|done| crate::init_openvmm_magicpath_lxutil::Request {
                             arch: LxutilArch::Aarch64,
                             done,


### PR DESCRIPTION
Removing one line enables that, thanks to the people who shipped BSD tar in-box with Windows, and the people who decided to depend on that in flowey.

It might look a bit unnecessary at this moment to extract the sysroot under WIndows yet one day that might help in building OpenHCL IGVM files on Windows.

The only issue here is that `flowey` tries to delete its working dir and runs into sharing violations as ProcMon shows:

```
Error: failed to remove directory `R:\src\openvmm\flowey-out\.work`: The process cannot access the file because it is being used by another process. (os error 32)
error: process didn't exit successfully: `target\debug\flowey_hvlite.exe pipeline run restore-packages` (exit code: 0xffffffff)
```

yet the packages are restored properly. Figuring this one out, looking at the AV settings.