### PR TITLE
openhcl_boot: Pass the value for the DMA cache coherency

### DIFF
--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -84,6 +84,7 @@ pub struct VmbusDeviceTreeInfo {
     p_ranges: StringId,
     p_vtl: StringId,
     p_vmbus_connection_id: StringId,
+    p_dma_coherent: StringId,
     p_interrupt_parent: StringId,
     p_interrupts: StringId,
     interrupt_cell_value: Option<u32>,
@@ -104,6 +105,7 @@ fn write_vmbus<'a, T>(
         p_ranges,
         p_vtl,
         p_vmbus_connection_id,
+        p_dma_coherent,
         p_interrupt_parent,
         p_interrupts,
         interrupt_cell_value,
@@ -113,6 +115,7 @@ fn write_vmbus<'a, T>(
         .start_node(name)?
         .add_u32(p_address_cells, 2)?
         .add_u32(p_size_cells, 2)?
+        .add_null(p_dma_coherent)?
         .add_str(p_compatible, "microsoft,vmbus")?
         .add_u32(p_vtl, u8::from(vtl).into())?
         .add_u32(p_vmbus_connection_id, vmbus.connection_id)?;
@@ -191,6 +194,7 @@ pub fn write_dt(
     let p_reftime_sidecar_end = builder.add_string("reftime_sidecar_end")?;
     let p_vtl = builder.add_string(igvm_defs::dt::IGVM_DT_VTL_PROPERTY)?;
     let p_vmbus_connection_id = builder.add_string("microsoft,message-connection-id")?;
+    let p_dma_coherent = builder.add_string("dma-coherent")?;
     let p_igvm_type = builder.add_string(IGVM_DT_IGVM_TYPE_PROPERTY)?;
     let p_openhcl_memory = builder.add_string("openhcl,memory-type")?;
 
@@ -388,6 +392,7 @@ pub fn write_dt(
         p_ranges,
         p_vtl,
         p_vmbus_connection_id,
+        p_dma_coherent,
         p_interrupt_parent,
         p_interrupts,
         interrupt_cell_value: if cfg!(target_arch = "aarch64") {


### PR DESCRIPTION
The Linux kernel does not assume that the DMA is cache coherent on arm64 whereas VMBus transation always are. No spec saying that could be found, yet the vmbus driver in the Linux kernel makes sure that is true in the ACPI case by checking on the _CCA property.

Here we have DT and should let the kernel DMA subsystem know that DMA on the bus is cache coherent to save on teh CPU cache maintenance. The kernel has all it needs for picking up this standard property from DT.

This might land some perf gains and/or uncover subtle bugs on arm64 yet we have to have this.

For validation, I booted the guest up, and checked that the flag was set in the driver:

```
[0.008750] hv_vmbus: >>>>> of_property_read_bool(np, "dma-coherent") == 1
[0.008750] hv_vmbus: >>>>> pdev->dev.dma_coherent == 1
```