### PR TITLE
Build: update private VSO pipeline to use release/lkg instead of main

### DIFF
--- a/.github/scripts/trigger-vso-pipeline.py
+++ b/.github/scripts/trigger-vso-pipeline.py
@@ -35,6 +35,7 @@ def main(pipeline_id: str, token: str, commit: str, cancel: str, organization: s
 
             build = {
                       'definition': {'id': pipeline_id},
+                      'sourceBranch': 'release/lkg',
                       'templateParameters': {'OssSubmoduleCommit': commit}
                     }
             build = client.queue_build(build, project=project)


### PR DESCRIPTION
Occasionally the closed source main branch can be broken by open source commits (for example if some shared state changes and requires a fixup). This change moves the `Private VSO Build` check to use the closed source LKG branch so the target is in a known good state.