### PR TITLE
TDX: Add support for kernel IPI offloading (needs kernel version bump)

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1582,7 +1582,8 @@ impl<'a, T: Backing> ProcessorRunner<'a, T> {
         // SAFETY: the `ipi_offload_irr` field of the run page
         // is atomically accessed by everyone.
         unsafe {
-            let offload_irr = &*(addr_of!((*self.run.as_ptr()).ipi_offload_irr) as *const [AtomicU32; 8]);
+            let offload_irr =
+                &*(addr_of!((*self.run.as_ptr()).ipi_offload_irr).cast::<[AtomicU32; 8]>());
 
             let mut r = [0; 8];
             let mut found = false;

--- a/openhcl/hcl/src/protocol.rs
+++ b/openhcl/hcl/src/protocol.rs
@@ -124,6 +124,7 @@ pub struct hcl_run {
     pub context: [u8; 1024],
     pub vtl_ret_actions: [u8; VTL_RETURN_ACTION_SIZE],
     pub proxy_irr: [u32; 8],
+    pub ipi_offload_irr: [u32; 8],
     pub target_vtl: HvInputVtl,
 }
 

--- a/openhcl/virt_underhill/src/processor/tdx/mod.rs
+++ b/openhcl/virt_underhill/src/processor/tdx/mod.rs
@@ -791,10 +791,10 @@ impl UhProcessor<'_, TdxBacked> {
         };
 
         // TODO TDX: filter proxy IRRs.
-        proxy_irr.and_then(|irr| Some(pull_irr(irr)));
+        proxy_irr.map(|irr| pull_irr(irr));
 
         // Pull state from kernel IPI offload irr
-        kernel_irr.and_then(|irr| Some(pull_irr(irr)));
+        kernel_irr.map(|irr| pull_irr(irr));
 
         let ApicWork {
             init,

--- a/openhcl/virt_underhill/src/processor/tdx/mod.rs
+++ b/openhcl/virt_underhill/src/processor/tdx/mod.rs
@@ -791,10 +791,14 @@ impl UhProcessor<'_, TdxBacked> {
         };
 
         // TODO TDX: filter proxy IRRs.
-        proxy_irr.map(|irr| pull_irr(irr));
+        if let Some(irr) = proxy_irr {
+            pull_irr(irr);
+        }
 
         // Pull state from kernel IPI offload irr
-        kernel_irr.map(|irr| pull_irr(irr));
+        if let Some(irr) = kernel_irr {
+            pull_irr(irr);
+        }
 
         let ApicWork {
             init,


### PR DESCRIPTION
The user<-> kernel transitions during IPI handling incur a significant amount of overhead on both the send and receive sides. These changes support handling IPIs entirely in-kernel, eliminating these transitions.

(Needs kernel PR to be merged and kernel version bumped)