### PR TITLE
Use VTL-aware direct hypercall to get/set registers when possible

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -224,7 +224,7 @@ mod private {
         /// message slot.
         ///
         /// This is used for hypervisor-managed and untrusted SINTs.
-        fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16);
+        fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, vtl: Vtl, sints: u16);
 
         /// The VTL that was running when the VP exited into VTL2, with the
         /// exception of a successful vtl switch, where it will return the VTL
@@ -815,7 +815,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                             #[cfg(guest_arch = "aarch64")]
                             let sint_reg =
                                 HvArm64RegisterName(HvArm64RegisterName::Sint0.0 + sint as u32);
-                            self.runner.get_vp_register(sint_reg).unwrap().as_u64()
+                            self.runner.get_vp_register(sint_reg, vtl).unwrap().as_u64()
                         };
                         masked_sints |= (HvSynicSint::from(sint_msr).masked() as u16) << sint;
                     }
@@ -890,7 +890,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         };
 
         if sints & untrusted_sints != 0 {
-            T::request_untrusted_sint_readiness(self, sints & untrusted_sints);
+            T::request_untrusted_sint_readiness(self, vtl, sints & untrusted_sints);
         }
     }
 
@@ -1181,7 +1181,7 @@ impl<T: CpuIo, B: Backing> Arm64RegisterState for UhHypercallHandler<'_, '_, T, 
     fn pc(&mut self) -> u64 {
         self.vp
             .runner
-            .get_vp_register(HvArm64RegisterName::XPc)
+            .get_vp_register(HvArm64RegisterName::XPc, self.vp.last_vtl())
             .expect("get vp register cannot fail")
             .as_u64()
     }
@@ -1189,14 +1189,17 @@ impl<T: CpuIo, B: Backing> Arm64RegisterState for UhHypercallHandler<'_, '_, T, 
     fn set_pc(&mut self, pc: u64) {
         self.vp
             .runner
-            .set_vp_register(HvArm64RegisterName::XPc, pc.into())
+            .set_vp_register(HvArm64RegisterName::XPc, pc.into(), self.vp.last_vtl())
             .expect("set vp register cannot fail");
     }
 
     fn x(&mut self, n: u8) -> u64 {
         self.vp
             .runner
-            .get_vp_register(HvArm64RegisterName(HvArm64RegisterName::X0.0 + n as u32))
+            .get_vp_register(
+                HvArm64RegisterName(HvArm64RegisterName::X0.0 + n as u32),
+                self.vp.last_vtl(),
+            )
             .expect("get vp register cannot fail")
             .as_u64()
     }
@@ -1207,6 +1210,7 @@ impl<T: CpuIo, B: Backing> Arm64RegisterState for UhHypercallHandler<'_, '_, T, 
             .set_vp_register(
                 HvArm64RegisterName(HvArm64RegisterName::X0.0 + n as u32),
                 v.into(),
+                self.vp.last_vtl(),
             )
             .expect("set vp register cannot fail")
     }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -146,6 +146,7 @@ impl BackingPrivate for HypervisorBackedArm64 {
                 .set_vp_register(
                     VpRegisterName::DeliverabilityNotifications,
                     u64::from(notifications).into(),
+                    Vtl::Vtl0,
                 )
                 .expect("requesting deliverability is not a fallable operation");
             this.backing.deliverability_notifications =
@@ -208,7 +209,7 @@ impl BackingPrivate for HypervisorBackedArm64 {
             .set_interrupt_notification(true);
     }
 
-    fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16) {
+    fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, _vtl: Vtl, sints: u16) {
         this.backing
             .next_deliverability_notifications
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
@@ -344,7 +345,9 @@ impl AccessCpuState for UhProcessor<'_, HypervisorBackedArm64> {
         if self.backing.cpu_state.sp.is_some() {
             expensive_regs.push((HvArm64RegisterName::XSp, self.sp()));
         }
-        self.runner.set_vp_registers(expensive_regs).unwrap();
+        self.runner
+            .set_vp_registers(expensive_regs, Vtl::Vtl0)
+            .unwrap();
         self.runner.cpu_context_mut().x = self.backing.cpu_state.x;
         self.runner.cpu_context_mut().q = self.backing.cpu_state.q;
     }
@@ -354,7 +357,7 @@ impl AccessCpuState for UhProcessor<'_, HypervisorBackedArm64> {
         if index == 18 && !self.backing.cpu_state.x18_valid {
             let reg_val = self
                 .runner
-                .get_vp_register(HvArm64RegisterName::X18)
+                .get_vp_register(HvArm64RegisterName::X18, Vtl::Vtl0)
                 .expect("register query should not fail");
             self.backing.cpu_state.x[18] = reg_val.as_u64();
             self.backing.cpu_state.x18_valid = true;
@@ -416,7 +419,7 @@ impl AccessCpuState for UhProcessor<'_, HypervisorBackedArm64> {
         if self.backing.cpu_state.sp.is_none() {
             let reg_val = self
                 .runner
-                .get_vp_register(HvArm64RegisterName::XSp)
+                .get_vp_register(HvArm64RegisterName::XSp, Vtl::Vtl0)
                 .expect("register query should not fail");
             self.backing.cpu_state.sp = Some(reg_val.as_u64());
         }
@@ -447,7 +450,7 @@ impl AccessCpuState for UhProcessor<'_, HypervisorBackedArm64> {
         if self.backing.cpu_state.pc.is_none() {
             let reg_val = self
                 .runner
-                .get_vp_register(HvArm64RegisterName::XPc)
+                .get_vp_register(HvArm64RegisterName::XPc, Vtl::Vtl0)
                 .expect("register query should not fail");
             self.backing.cpu_state.pc = Some(reg_val.as_u64());
         }
@@ -462,7 +465,7 @@ impl AccessCpuState for UhProcessor<'_, HypervisorBackedArm64> {
         if self.backing.cpu_state.cpsr.is_none() {
             let reg_val = self
                 .runner
-                .get_vp_register(HvArm64RegisterName::Cpsr)
+                .get_vp_register(HvArm64RegisterName::Cpsr, Vtl::Vtl0)
                 .expect("register query should not fail");
             self.backing.cpu_state.cpsr = Some(reg_val.as_u64());
         }
@@ -552,7 +555,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBacked>
             let cpsr: Cpsr64 = self
                 .vp
                 .runner
-                .get_vp_register(HvArm64RegisterName::SpsrEl2)
+                .get_vp_register(HvArm64RegisterName::SpsrEl2, Vtl::Vtl0)
                 .map_err(UhRunVpError::EmulationState)?
                 .as_u64()
                 .into();
@@ -786,7 +789,7 @@ impl UhVpStateAccess<'_, '_, HypervisorBackedArm64> {
         regs.get_values(values.iter_mut());
         self.vp
             .runner
-            .set_vp_registers(names.iter().copied().zip(values))
+            .set_vp_registers(names.iter().copied().zip(values), self.vtl)
             .map_err(vp_state::Error::SetRegisters)?;
         Ok(())
     }
@@ -802,7 +805,7 @@ impl UhVpStateAccess<'_, '_, HypervisorBackedArm64> {
         let mut values = [HvRegisterValue::new_zeroed(); N];
         self.vp
             .runner
-            .get_vp_registers(&names, &mut values)
+            .get_vp_registers(&names, &mut values, self.vtl)
             .map_err(vp_state::Error::GetRegisters)?;
 
         regs.set_values(values.into_iter());
@@ -857,6 +860,7 @@ mod save_restore {
     use anyhow::anyhow;
     use hvdef::HvArm64RegisterName;
     use hvdef::HvInternalActivityRegister;
+    use hvdef::Vtl;
     use virt::Processor;
     use vmcore::save_restore::RestoreError;
     use vmcore::save_restore::SaveError;
@@ -888,7 +892,7 @@ mod save_restore {
 
             let internal_activity = self
                 .runner
-                .get_vp_register(HvArm64RegisterName::InternalActivityState)
+                .get_vp_register(HvArm64RegisterName::InternalActivityState, Vtl::Vtl0)
                 .map_err(|err| {
                     SaveError::Other(anyhow!("unable to query startup suspend: {}", err))
                 })?;
@@ -909,7 +913,10 @@ mod save_restore {
             if state.startup_suspend {
                 let reg = u64::from(HvInternalActivityRegister::new().with_startup_suspend(true));
                 self.runner
-                    .set_vp_registers([(HvArm64RegisterName::InternalActivityState, reg)])
+                    .set_vp_registers(
+                        [(HvArm64RegisterName::InternalActivityState, reg)],
+                        Vtl::Vtl0,
+                    )
                     .map_err(|err| {
                         RestoreError::Other(anyhow!(
                             "unable to set internal activity register: {}",

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -398,7 +398,7 @@ impl BackingPrivate for SnpBacked {
         unreachable!("extint managed through software apic")
     }
 
-    fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16) {
+    fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, vtl: Vtl, sints: u16) {
         if this.backing.hv_sint_notifications & !sints == 0 {
             return;
         }
@@ -410,6 +410,7 @@ impl BackingPrivate for SnpBacked {
             .set_vp_register(
                 HvX64RegisterName::DeliverabilityNotifications,
                 u64::from(notifications).into(),
+                vtl,
             )
             .expect("requesting deliverability is not a fallable operation");
     }


### PR DESCRIPTION
Modify ProcessorRunner::get_reg and ProcessorRunner::set_reg to use a direct hypercall when possible, instead of our dedicated get/set-register ioctl. Certain registers have special handling in the kernel ioctl handler. Those are left as-is. Get/set for other registers is now made with a direct hypercall.

This has the benefit of being VTL-aware, so this change also adds a VTL parameter.

This change also removes some proliferation of (g|s)et_vp_registers?(_inner)?, hopefully making it simpler and cleaner. The singular (g|s)et_vp_register is left as an ergonomic convenience.

One unaddressed capability is making ioctls/hypercalls on a batch of registers. This is not strictly a regression, because MSHV_VP_MAX_REGISTERS was previously 1.