### PR TITLE
Implement Drop for vfio_sys Device, unmapping msix for interrupts.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6949,6 +6949,7 @@ dependencies = [
  "bitfield-struct",
  "libc",
  "nix 0.26.4",
+ "pal_event",
  "tracing",
  "vfio-bindings",
 ]

--- a/vm/devices/user_driver/vfio_sys/Cargo.toml
+++ b/vm/devices/user_driver/vfio_sys/Cargo.toml
@@ -12,5 +12,8 @@ nix = { workspace = true, features = ["ioctl"] }
 tracing.workspace = true
 vfio-bindings.workspace = true
 
+[target.'cfg(target_os = "linux")'.dependencies]
+pal_event.workspace = true
+
 [lints]
 workspace = true

--- a/vm/devices/user_driver/vfio_sys/Cargo.toml
+++ b/vm/devices/user_driver/vfio_sys/Cargo.toml
@@ -11,8 +11,6 @@ libc.workspace = true
 nix = { workspace = true, features = ["ioctl"] }
 tracing.workspace = true
 vfio-bindings.workspace = true
-
-[target.'cfg(target_os = "linux")'.dependencies]
 pal_event.workspace = true
 
 [lints]

--- a/vm/devices/user_driver/vfio_sys/src/lib.rs
+++ b/vm/devices/user_driver/vfio_sys/src/lib.rs
@@ -12,6 +12,7 @@ use std::fs;
 use std::fs::File;
 use std::io::BufRead;
 use std::io::BufReader;
+use std::iter;
 use std::os::unix::prelude::*;
 use std::path::Path;
 use vfio_bindings::bindings::vfio::vfio_device_info;
@@ -389,6 +390,17 @@ impl AsRef<File> for Device {
 impl AsFd for Device {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.file.as_fd()
+    }
+}
+
+impl Drop for Device {
+    fn drop(&mut self) {
+        match self.map_msix(0, iter::empty::<pal_event::Event>()) {
+            Ok(_) => (),
+            Err(e) => {
+                tracing::error!("vfio_sys::Device::drop error calling map_msix: {:?}", e);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
GDMA Driver allocates the HWC device interrupt in the new() method. However, there are multiple potential error paths that can result in retries. Any failure in new() causes the interrupt to leak, resulting in the HWC interrupt not getting unmapped. GDMA::New() can then fail on retry due to missing first response as a result of the leaked interrupt.

### Log messages from a lab machine where I force a panic, causing calls to drop() -> map_msix()

```
[10.065737] mana_driver::gdma_driver:  INFO worker_new{ name="UnderhillWorker" action="new"}:init:init/new_underhill_vm:new_mana_device:  Created HWC with eq id: 0, msix: 0
[10.065969] mana_driver::gdma_driver:  INFO worker_new{ name="UnderhillWorker" action="new"}:init:init/new_underhill_vm:new_mana_device:  Max VF resources: GdmaQueryMaxResourcesResp { status: 0, max_sq: 15360, max_rq: 15360, max_cq: 15360, max_eq: 960, max_db: 4096, max_mst: 57344, max_cq_mod_ctx: 4, max_mod_cq: 32, max_msix: 6 }
[10.070091] vfio_sys:  INFO worker_new{ name="UnderhillWorker" action="new"}:init:init/new_underhill_vm:new_mana_device:  Dropping vfio_sys::Device
[10.070174] vfio_sys:  INFO worker_new{ name="UnderhillWorker" action="new"}:init:init/new_underhill_vm:new_mana_device:  vfio_sys::map_msix header.count 0 VFIO_IRQ_SET_DATA_NONE
[10.147768] underhill_core::emuplat::netvsp: ERROR worker_new{ name="UnderhillWorker" action="new"}:init:init/new_underhill_vm:  failed to create mana device pci_id="af87:00:00.0" reset_method=NoReset err=failed to initialize mana device: injecting fake HW failure on 18 attempt
```

In FHR scenarios, the GDMA::new() can fail due to missing the first response as a result of a leaked interrupt.

### Log messages from a lab machine where I perform UH servicing (FHR)

```
[71955.164522] state_unit: INFO servicing_save_vtl2{ correlation_id=4d9f7e7f-158c-46e4-b3a6-2445e35cc9dc}:save_units:state_change{ operation="save"}:  state change complete duration=16.971171ms
[71955.166572] vfio_sys: INFO  Dropping vfio_sys::Device
[71955.166632] vfio_sys: INFO  vfio_sys::map_msix header.count 0 VFIO_IRQ_SET_DATA_NONE
```