### PR TITLE
Move the all-good job to a gh hosted runner

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -5062,9 +5062,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-rustdoc/
   job20:
     name: openvmm checkin gates
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    runs-on: windows-latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -5050,9 +5050,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-rustdoc/
   job20:
     name: openvmm checkin gates
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    runs-on: windows-latest
     permissions:
       contents: read
       id-token: write

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -908,7 +908,7 @@ impl IntoPipeline for CheckinGatesCli {
                 FlowArch::X86_64,
                 "openvmm checkin gates",
             )
-            .gh_set_pool(crate::pipelines_shared::gh_pools::default_x86_pool(
+            .gh_set_pool(crate::pipelines_shared::gh_pools::default_gh_hosted(
                 FlowPlatform::Windows,
             ))
             .finish();


### PR DESCRIPTION
This job doesn't really do anything, so it doesn't need to be on our specialized self-hosted runners. Moving it to a GH hosted runner should speed up machine allocation for this job a little, and reduce the overall pressure on our self-hosted pools.