### PR TITLE
flowey: only build with LTO on macOS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 
 [alias]
 xtask = "run -p xtask --profile xtask --"
-xflowey = "run -p flowey_hvlite --profile flowey -- pipeline run"
+xflowey = "run --quiet -p flowey_trampoline -- run -p flowey_hvlite --profile flowey -- pipeline run"
 
 [env]
 # Use the packaged openssl libraries on musl targets.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,6 +1691,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "flowey_trampoline"
+version = "0.0.0"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   # openvmm
   "openvmm/openvmm",
   # repo tooling
+  "flowey/flowey_trampoline",
   "flowey/flowey_hvlite",
   "xtask",
   # openhcl
@@ -518,8 +519,8 @@ inherits = 'dev'
 opt-level = 1
 
 [profile.flowey]
-# work around linkme bug on macos, <https://github.com/dtolnay/linkme/issues/61>
-lto = 'thin'
+# This exists to support the use of flowey_trampoline, which overrides part of
+# the profile definition via environment variables.
 inherits = 'dev'
 
 [profile.flowey-ci]

--- a/flowey/flowey_trampoline/Cargo.toml
+++ b/flowey/flowey_trampoline/Cargo.toml
@@ -1,0 +1,10 @@
+# Copyright (C) Microsoft Corporation. All rights reserved.
+
+[package]
+name = "flowey_trampoline"
+edition = "2021"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/flowey/flowey_trampoline/src/main.rs
+++ b/flowey/flowey_trampoline/src/main.rs
@@ -1,0 +1,49 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+//! Crate used to fix up environment variables before running another cargo
+//! command, to be used in cargo aliases.
+//!
+//! This crate is used to work around a bug in the `linkme` crate on macOS,
+//! <https://github.com/dtolnay/linkme/issues/61>. If a binary is built without
+//! LTO on macOS, sometimes `linkme` will fail to include all the elements of a
+//! distributed slice. This causes flowey runs to fail.
+//!
+//! To work around this, we set the `CARGO_PROFILE_FLOWEY_LTO` environment
+//! variable to `thin` before running the `cargo` binary. This will cause the
+//! `flowey_hvlite` binary to be built with thin LTO, which will work around the
+//! `linkme` bug.
+//!
+//! We don't want to set this for non-macOS environments because it slows down
+//! builds.
+//!
+//! This crate can be removed when the `linkme` bug is fixed or when cargo gains
+//! enough support to do this kind of thing natively.
+
+use std::process::Command;
+
+fn main() {
+    let args = std::env::args_os().collect::<Vec<_>>();
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let mut cmd = Command::new(cargo);
+    cmd.args(&args[1..]);
+
+    // Conditionally set LTO via environment variable. Note that this inherits
+    // to any child invocations of cargo, which is what we want.
+    //
+    // This check isn't completely accurate, since we might be cross compiling
+    // flowey from or to a different OS. But it's good enough for now.
+    if cfg!(target_os = "macos") {
+        cmd.env("CARGO_PROFILE_FLOWEY_LTO", "thin");
+    }
+
+    #[cfg(unix)]
+    {
+        let err = std::os::unix::process::CommandExt::exec(&mut cmd);
+        panic!("failed to exec: {:?}", err);
+    }
+    #[cfg(not(unix))]
+    {
+        let status = cmd.status().expect("failed to run command");
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}


### PR DESCRIPTION
To restore build performance of flowey on non-macOS systems, add a trampoline binary to build flowey with LTO only on macOS.

Ideally, we'd work around this in a less invasive way, but cargo does not have support for target-specific profile options, target-specific environment variables, target-specific aliases, or anything else I can think of that would help here.

(We could also have a config.toml that gets passed to flowey invocations and sets a custom rust flag specifically for macos. However, due to other cargo limitations, that would require that all flowey invocations occur at the root of the workspace, which is annoying.)