### PR TITLE
build_support/macos: only sign openvmm binary

### DIFF
--- a/build_support/macos/sign_and_run.sh
+++ b/build_support/macos/sign_and_run.sh
@@ -2,7 +2,14 @@
 
 set -e
 
-# Add entitlements for using hypervisor framework.
-entitlements=$(dirname "$0")/entitlements.xml
-codesign --entitlements "$entitlements" -f -s - "$1" > /dev/null
+case "$CARGO_PKG_NAME" in
+    "openvmm")
+        # Add entitlements for using hypervisor framework.
+        entitlements=$(dirname "$0")/entitlements.xml
+        codesign --entitlements "$entitlements" -f -s - "$1" > /dev/null
+        ;;
+    *)
+        ;;
+esac
+
 exec "$@"


### PR DESCRIPTION
The openvmm binary must be signed so that it has access to the hypervisor framework.  Other binaries don't need to be signed. Update the runner script to look at the package name to avoid signing binaries unnecessarily, speeding up non-openvmm invocations.