### PR TITLE
[SNP Guest VSM] ModifyVtlProtectionMask hypercall handling 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6777,6 +6777,7 @@ dependencies = [
  "futures",
  "guestmem",
  "hcl",
+ "hv1_emulator",
  "hvdef",
  "inspect",
  "memory_range",
@@ -6788,6 +6789,7 @@ dependencies = [
  "underhill_threadpool",
  "virt_mshv_vtl",
  "vm_topology",
+ "vtl_array",
  "x86defs",
 ]
 

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -192,16 +192,20 @@ pub enum ApplyVtlProtectionsError {
         hv_error: HvError,
         vtl: HvInputVtl,
     },
-    #[error("{failed_operation} when protecting pages {range} for vtl {vtl:?}")]
+    #[error(
+        "{failed_operation} when protecting pages {range} with {permissions:x?} for vtl {vtl:?}"
+    )]
     Snp {
         failed_operation: snp::SnpPageError,
         range: MemoryRange,
+        permissions: x86defs::snp::SevRmpAdjust,
         vtl: HvInputVtl,
     },
-    #[error("tdcall failed with {error:?} when protecting pages {range} for vtl {vtl:?}")]
+    #[error("tdcall failed with {error:?} when protecting pages {range} with permissions {permissions:x?} for vtl {vtl:?}")]
     Tdx {
         error: TdCallResultCode,
         range: MemoryRange,
+        permissions: x86defs::tdx::TdgMemPageGpaAttr,
         vtl: HvInputVtl,
     },
     #[error("no valid protections for vtl {0:?}")]
@@ -3034,7 +3038,7 @@ impl Hcl {
 
         let query = mshv_rmpquery {
             start_pfn: gpa / HV_PAGE_SIZE,
-            page_count,
+            page_count,s
             terminate_on_failure: 0,
             ram: 0,
             padding: Default::default(),

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -3037,7 +3037,7 @@ impl Hcl {
 
         let query = mshv_rmpquery {
             start_pfn: gpa / HV_PAGE_SIZE,
-            page_count,s
+            page_count,
             terminate_on_failure: 0,
             ram: 0,
             padding: Default::default(),

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -189,6 +189,7 @@ pub enum ApplyVtlProtectionsError {
     Hypervisor {
         range: MemoryRange,
         output: HypercallOutput,
+        #[source]
         hv_error: HvError,
         vtl: HvInputVtl,
     },
@@ -196,6 +197,7 @@ pub enum ApplyVtlProtectionsError {
         "{failed_operation} when protecting pages {range} with {permissions:x?} for vtl {vtl:?}"
     )]
     Snp {
+        #[source]
         failed_operation: snp::SnpPageError,
         range: MemoryRange,
         permissions: x86defs::snp::SevRmpAdjust,

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -352,7 +352,6 @@ mod ioctls {
     const MSHV_VTL_TDCALL: u16 = 0x32;
     const MSHV_VTL_READ_VMX_CR4_FIXED1: u16 = 0x33;
     const MSHV_VTL_GUEST_VSM_VMSA_PFN: u16 = 0x34;
-    #[cfg(debug_assertions)]
     const MSHV_VTL_RMPQUERY: u16 = 0x35;
     const MSHV_INVLPGB: u16 = 0x36;
     const MSHV_TLBSYNC: u16 = 0x37;
@@ -394,7 +393,6 @@ mod ioctls {
 
     #[repr(C, packed)]
     #[derive(Copy, Clone)]
-    #[cfg(debug_assertions)]
     pub struct mshv_rmpquery {
         /// Execute the rmpquery instruction on the set of memory pages specified
         pub start_pfn: ::std::os::raw::c_ulonglong,
@@ -508,7 +506,6 @@ mod ioctls {
         mshv_rmpadjust
     );
 
-    #[cfg(debug_assertions)]
     ioctl_write_ptr!(
         /// Executes the rmpquery instruction on a page range.
         hcl_rmpquery_pages,

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -5,8 +5,10 @@
 
 use super::hcl_pvalidate_pages;
 use super::hcl_rmpadjust_pages;
+use super::hcl_rmpquery_pages;
 use super::mshv_pvalidate;
 use super::mshv_rmpadjust;
+use super::mshv_rmpquery;
 use super::HclVp;
 use super::MshvVtl;
 use super::NoRunner;
@@ -44,10 +46,10 @@ pub enum SnpError {
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum SnpPageError {
-    #[error("pvalidate failed")]
-    Pvalidate(SnpError),
-    #[error("rmpadjust failed")]
-    Rmpadjust(SnpError),
+    #[error("pvalidate failed with error {0}")]
+    Pvalidate(#[source] SnpError),
+    #[error("rmpadjust failed with error {0}")]
+    Rmpadjust(#[source] SnpError),
 }
 
 impl MshvVtl {
@@ -127,6 +129,41 @@ impl MshvVtl {
         }
 
         Ok(())
+    }
+
+    /// Gets the current vtl permissions for a page.
+    pub fn rmpquery_page(&self, gpa: u64, vtl: GuestVtl) -> SevRmpAdjust {
+        let page_count = 1u64;
+        let mut flags = [u64::from(SevRmpAdjust::new().with_target_vmpl(match vtl {
+            GuestVtl::Vtl0 => 2,
+            GuestVtl::Vtl1 => 1,
+        })); 1];
+
+        let mut page_size = [0; 1];
+        let mut pages_processed = 0u64;
+
+        debug_assert!(flags.len() == page_count as usize);
+        debug_assert!(page_size.len() == page_count as usize);
+
+        let query = mshv_rmpquery {
+            start_pfn: gpa / HV_PAGE_SIZE,
+            page_count,
+            terminate_on_failure: 0,
+            ram: 0,
+            padding: Default::default(),
+            flags: flags.as_mut_ptr(),
+            page_size: page_size.as_mut_ptr(),
+            pages_processed: &mut pages_processed,
+        };
+
+        // SAFETY: the input query is the correct type for this ioctl
+        unsafe {
+            hcl_rmpquery_pages(self.file.as_raw_fd(), &query).expect("should always succeed");
+        }
+
+        assert!(pages_processed <= page_count);
+
+        SevRmpAdjust::from(flags[0])
     }
 }
 

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -46,9 +46,9 @@ pub enum SnpError {
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum SnpPageError {
-    #[error("pvalidate failed with error {0}")]
+    #[error("pvalidate failed")]
     Pvalidate(#[source] SnpError),
-    #[error("rmpadjust failed with error {0}")]
+    #[error("rmpadjust failed")]
     Rmpadjust(#[source] SnpError),
 }
 

--- a/openhcl/underhill_mem/Cargo.toml
+++ b/openhcl/underhill_mem/Cargo.toml
@@ -9,12 +9,14 @@ rust-version.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]
 guestmem.workspace = true
 hcl.workspace = true
+hv1_emulator.workspace = true
 hvdef.workspace = true
 memory_range.workspace = true
 underhill_threadpool.workspace = true
 virt_mshv_vtl.workspace = true
 vm_topology.workspace = true
 x86defs.workspace = true
+vtl_array.workspace = true
 
 inspect.workspace = true
 pal_async.workspace = true

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -30,6 +30,7 @@ mod mapping {
     use hcl::ioctl::MshvVtl;
     use hcl::ioctl::MshvVtlLow;
     use hcl::GuestVtl;
+    use hv1_emulator::hv::VtlProtectHypercallOverlay;
     use hvdef::hypercall::AcceptMemoryType;
     use hvdef::hypercall::HostVisibilityType;
     use hvdef::hypercall::HvInputVtl;
@@ -38,6 +39,7 @@ mod mapping {
     use hvdef::HvRepResult;
     use hvdef::HypercallCode;
     use hvdef::Vtl;
+    use hvdef::HV_MAP_GPA_PERMISSIONS_ALL;
     use hvdef::HV_PAGE_SIZE;
     use inspect::Inspect;
     use memory_range::MemoryRange;
@@ -48,8 +50,11 @@ mod mapping {
     use thiserror::Error;
     use virt_mshv_vtl::ProtectIsolatedMemory;
     use vm_topology::memory::MemoryLayout;
+    use vtl_array::VtlArray;
     use x86defs::snp::SevRmpAdjust;
     use x86defs::tdx::GpaVmAttributes;
+    use x86defs::tdx::TdgMemPageAttrWriteR8;
+    use x86defs::tdx::TdgMemPageGpaAttr;
 
     /// An implementation of a [`GuestMemoryAccess`] trait for Underhill VMs.
     #[derive(Debug, Inspect)]
@@ -413,229 +418,98 @@ mod mapping {
     #[error("failed to register memory with kernel")]
     struct RegistrationError;
 
+    /// Currently built for hardware CVMs, which only define permissions for VTL
+    /// 0 and VTL 1 to express what those VTLs have access to. If this were to
+    /// extend to non-hardware CVMs, those would need to define permissions
+    /// instead for VTL 2 and VTL 1 to express what the lower VTLs have access
+    /// to.
+    ///
     /// Default VTL memory permissions applied to any mapped memory
-    enum DefaultVtlPermissions {
-        /// Specifies the permissions granted to lower VTLs, i.e. the mask for
-        /// VTL 2 indicates what permissions VTL 0 and VTL 1 have to the memory.
-        /// VTL 0 cannot specify VTL permissions.
-        Vbs {
-            vtl1: Option<HvMapGpaFlags>,
-            vtl2: HvMapGpaFlags,
-        },
-        /// Specifies the permissions the VTL itself has to the memory. VTL 2
-        /// cannot specify its own permissions.
-        Snp {
-            vtl0: SevRmpAdjust,
-            vtl1: Option<SevRmpAdjust>,
-        },
-        /// Specifies the permissions the VTL itself has to the memory. VTL 2
-        /// cannot specify its own permissions.
-        Tdx {
-            vtl0: GpaVmAttributes,
-            vtl1: Option<GpaVmAttributes>,
-        },
+    struct DefaultVtlPermissions {
+        vtl0: HvMapGpaFlags,
+        vtl1: Option<HvMapGpaFlags>,
     }
 
     impl DefaultVtlPermissions {
-        fn new(isolation: IsolationType) -> Self {
+        fn set(&mut self, vtl: Vtl, permissions: HvMapGpaFlags) {
+            match vtl {
+                Vtl::Vtl0 => self.vtl0 = permissions,
+                Vtl::Vtl1 => self.vtl1 = Some(permissions),
+                Vtl::Vtl2 => unreachable!(),
+            }
+        }
+    }
+
+    /// Represents the vtl permissions on a page for a given isolation type
+    #[derive(Copy, Clone)]
+    enum GpaVtlPermissions {
+        Vbs(HvMapGpaFlags),
+        Snp(SevRmpAdjust),
+        Tdx((TdgMemPageGpaAttr, TdgMemPageAttrWriteR8)),
+    }
+
+    impl GpaVtlPermissions {
+        fn new(isolation: IsolationType, vtl: Vtl, protections: HvMapGpaFlags) -> Self {
             match isolation {
-                IsolationType::Vbs => DefaultVtlPermissions::Vbs {
-                    vtl1: None,
-                    vtl2: hvdef::HV_MAP_GPA_PERMISSIONS_ALL.with_adjustable(true),
-                },
+                IsolationType::Vbs => GpaVtlPermissions::Vbs(protections),
                 IsolationType::Snp => {
-                    let mut protections = DefaultVtlPermissions::Snp {
-                        vtl0: SevRmpAdjust::new(),
-                        vtl1: None,
-                    };
-                    protections.set(hvdef::HV_MAP_GPA_PERMISSIONS_ALL, Vtl::Vtl0);
-                    protections
+                    let mut vtl_permissions = GpaVtlPermissions::Snp(SevRmpAdjust::new());
+                    vtl_permissions.set(vtl, protections);
+                    vtl_permissions
                 }
                 IsolationType::Tdx => {
-                    let mut protections = DefaultVtlPermissions::Tdx {
-                        vtl0: GpaVmAttributes::new(),
-                        vtl1: None,
-                    };
-                    protections.set(hvdef::HV_MAP_GPA_PERMISSIONS_ALL, Vtl::Vtl0);
-                    protections
+                    let mut vtl_permissions = GpaVtlPermissions::Tdx((
+                        TdgMemPageGpaAttr::new(),
+                        TdgMemPageAttrWriteR8::new(),
+                    ));
+                    vtl_permissions.set(vtl, protections);
+                    vtl_permissions
                 }
             }
         }
 
-        fn get(&self, vtl: Vtl) -> Option<HvMapGpaFlags> {
+        fn set(&mut self, vtl: Vtl, protections: HvMapGpaFlags) {
             match self {
-                DefaultVtlPermissions::Vbs { vtl1, vtl2 } => match vtl {
-                    Vtl::Vtl0 => unreachable!(),
-                    Vtl::Vtl1 => *vtl1,
-                    Vtl::Vtl2 => Some(*vtl2),
-                },
-                DefaultVtlPermissions::Snp { vtl0, vtl1 } => match vtl {
-                    Vtl::Vtl0 => Some(
-                        HvMapGpaFlags::new()
-                            .with_readable(vtl0.enable_read())
-                            .with_writable(vtl0.enable_write())
-                            .with_kernel_executable(vtl0.enable_kernel_execute())
-                            .with_user_executable(vtl0.enable_user_execute()),
-                    ),
-                    Vtl::Vtl1 => vtl1.map(|v| {
-                        HvMapGpaFlags::new()
-                            .with_readable(v.enable_read())
-                            .with_writable(v.enable_write())
-                            .with_kernel_executable(v.enable_kernel_execute())
-                            .with_user_executable(v.enable_user_execute())
-                    }),
-                    Vtl::Vtl2 => unreachable!(),
-                },
-                DefaultVtlPermissions::Tdx { vtl0, vtl1 } => match vtl {
-                    Vtl::Vtl0 => Some(
-                        HvMapGpaFlags::new()
-                            .with_readable(vtl0.read())
-                            .with_writable(vtl0.write())
-                            .with_kernel_executable(vtl0.kernel_execute())
-                            .with_user_executable(vtl0.user_execute()),
-                    ),
-                    Vtl::Vtl1 => vtl1.map(|v| {
-                        HvMapGpaFlags::new()
-                            .with_readable(v.read())
-                            .with_writable(v.write())
-                            .with_kernel_executable(v.kernel_execute())
-                            .with_user_executable(v.user_execute())
-                    }),
-                    Vtl::Vtl2 => unreachable!(),
-                },
-            }
-        }
-
-        fn set(&mut self, protections: HvMapGpaFlags, vtl: Vtl) {
-            match self {
-                DefaultVtlPermissions::Vbs { vtl1, vtl2 } => match vtl {
-                    Vtl::Vtl0 => unreachable!(),
-                    Vtl::Vtl1 => *vtl1 = Some(protections),
-                    Vtl::Vtl2 => *vtl2 = protections,
-                },
-                DefaultVtlPermissions::Snp { vtl0, vtl1 } => {
-                    let rmpadjust = SevRmpAdjust::new()
+                GpaVtlPermissions::Vbs(flags) => *flags = protections,
+                GpaVtlPermissions::Snp(rmpadjust) => {
+                    *rmpadjust = SevRmpAdjust::new()
                         .with_enable_read(protections.readable())
                         .with_enable_write(protections.writable())
                         .with_enable_user_execute(protections.user_executable())
-                        .with_enable_kernel_execute(protections.kernel_executable());
-                    match vtl {
-                        Vtl::Vtl0 => {
-                            *vtl0 = rmpadjust.with_target_vmpl(x86defs::snp::Vmpl::Vmpl2.into())
-                        }
-                        Vtl::Vtl1 => {
-                            *vtl1 =
-                                Some(rmpadjust.with_target_vmpl(x86defs::snp::Vmpl::Vmpl1.into()))
-                        }
-                        Vtl::Vtl2 => unreachable!(), // Cannot set VTL 2 protections
-                    };
+                        .with_enable_kernel_execute(protections.kernel_executable())
+                        .with_target_vmpl(match vtl {
+                            Vtl::Vtl0 => x86defs::snp::Vmpl::Vmpl2.into(),
+                            Vtl::Vtl1 => x86defs::snp::Vmpl::Vmpl1.into(),
+                            Vtl::Vtl2 => unreachable!(), // Cannot set VTL 2 protections
+                        });
                 }
-                DefaultVtlPermissions::Tdx { vtl0, vtl1 } => {
-                    let attributes = GpaVmAttributes::new()
+                GpaVtlPermissions::Tdx((attributes, mask)) => {
+                    let vm_attributes = GpaVmAttributes::new()
                         .with_valid(true)
                         .with_read(protections.readable())
                         .with_write(protections.writable())
                         .with_kernel_execute(protections.kernel_executable())
                         .with_user_execute(protections.user_executable());
 
-                    match vtl {
-                        Vtl::Vtl0 => *vtl0 = attributes,
-                        Vtl::Vtl1 => *vtl1 = Some(attributes),
-                        Vtl::Vtl2 => unreachable!(), // Cannot set VTL 2 protections
-                    };
-                }
-            }
-        }
-
-        fn apply(
-            &self,
-            range: MemoryRange,
-            vtl: Vtl,
-            mshv_vtl: &MshvVtl,
-            mshv_hvcall: &MshvHvcall,
-        ) -> Result<(), ApplyVtlProtectionsError> {
-            match self {
-                DefaultVtlPermissions::Vbs { vtl1, vtl2 } => {
-                    let protections = match vtl {
-                        Vtl::Vtl0 => unreachable!(),
-                        Vtl::Vtl1 => vtl1.ok_or(ApplyVtlProtectionsError::InvalidVtl(Vtl::Vtl1))?,
-
-                        Vtl::Vtl2 => *vtl2,
-                    };
-
-                    mshv_hvcall.modify_vtl_protection_mask(
-                        range,
-                        protections,
-                        HvInputVtl::from(vtl),
-                    )
-                }
-                DefaultVtlPermissions::Snp { vtl0, vtl1 } => {
-                    let rmpadjust = match vtl {
-                        Vtl::Vtl0 => *vtl0,
-                        Vtl::Vtl1 => vtl1.ok_or(ApplyVtlProtectionsError::InvalidVtl(Vtl::Vtl1))?,
-                        Vtl::Vtl2 => unreachable!(),
-                    };
-
-                    mshv_vtl
-                        .rmpadjust_pages(range, rmpadjust, false)
-                        .map_err(|err| ApplyVtlProtectionsError::Snp {
-                            failed_operation: err,
-                            range,
-                            vtl: vtl.into(),
-                        })
-                    // TODO SNP: Flush TLB
-                }
-                DefaultVtlPermissions::Tdx { vtl0, vtl1 } => {
-                    let (attributes, mask) = match vtl {
+                    let (new_attributes, new_mask) = match vtl {
                         Vtl::Vtl0 => {
-                            let vm_attributes = *vtl0;
-                            let attributes =
-                                x86defs::tdx::TdgMemPageGpaAttr::new().with_l2_vm1(vm_attributes);
-                            let mask = x86defs::tdx::TdgMemPageAttrWriteR8::new()
-                                .with_l2_vm1(vm_attributes.to_mask());
+                            let attributes = TdgMemPageGpaAttr::new().with_l2_vm1(vm_attributes);
+                            let mask =
+                                TdgMemPageAttrWriteR8::new().with_l2_vm1(vm_attributes.to_mask());
                             (attributes, mask)
                         }
                         Vtl::Vtl1 => {
-                            let vm_attributes =
-                                vtl1.ok_or(ApplyVtlProtectionsError::InvalidVtl(Vtl::Vtl1))?;
-                            let attributes =
-                                x86defs::tdx::TdgMemPageGpaAttr::new().with_l2_vm2(vm_attributes);
-                            let mask = x86defs::tdx::TdgMemPageAttrWriteR8::new()
-                                .with_l2_vm2(vm_attributes.to_mask());
+                            let attributes = TdgMemPageGpaAttr::new().with_l2_vm2(vm_attributes);
+                            let mask =
+                                TdgMemPageAttrWriteR8::new().with_l2_vm2(vm_attributes.to_mask());
                             (attributes, mask)
                         }
                         Vtl::Vtl2 => unreachable!(),
                     };
 
-                    mshv_vtl
-                        .tdx_set_page_attributes(range, attributes, mask)
-                        .map_err(|err| ApplyVtlProtectionsError::Tdx {
-                            error: err,
-                            range,
-                            vtl: vtl.into(),
-                        })
+                    *attributes = new_attributes;
+                    *mask = new_mask;
                 }
-            }
-        }
-
-        fn apply_all(
-            &self,
-            range: MemoryRange,
-            mshv_vtl: &MshvVtl,
-            mshv_hvcall: &MshvHvcall,
-        ) -> Result<(), ApplyVtlProtectionsError> {
-            self.apply(range, Vtl::Vtl0, mshv_vtl, mshv_hvcall)?;
-            if self.has_vtl1_protections() {
-                self.apply(range, Vtl::Vtl1, mshv_vtl, mshv_hvcall)?;
-            }
-            Ok(())
-        }
-
-        fn has_vtl1_protections(&self) -> bool {
-            match self {
-                DefaultVtlPermissions::Vbs { vtl1, .. } => vtl1.is_some(),
-                DefaultVtlPermissions::Snp { vtl1, .. } => vtl1.is_some(),
-                DefaultVtlPermissions::Tdx { vtl1, .. } => vtl1.is_some(),
             }
         }
     }
@@ -649,7 +523,6 @@ mod mapping {
         mshv_hvcall: MshvHvcall,
         mshv_vtl: MshvVtl,
         isolation: IsolationType,
-        vtl_permissions: Mutex<DefaultVtlPermissions>,
     }
 
     impl MemoryAcceptor {
@@ -669,7 +542,6 @@ mod mapping {
                 mshv_hvcall,
                 mshv_vtl,
                 isolation,
-                vtl_permissions: Mutex::new(DefaultVtlPermissions::new(isolation)),
             })
         }
 
@@ -689,9 +561,9 @@ mod mapping {
                 }
 
                 IsolationType::Tdx => {
-                    let attributes = x86defs::tdx::TdgMemPageGpaAttr::new()
-                        .with_l2_vm1(GpaVmAttributes::FULL_ACCESS);
-                    let mask = x86defs::tdx::TdgMemPageAttrWriteR8::new()
+                    let attributes =
+                        TdgMemPageGpaAttr::new().with_l2_vm1(GpaVmAttributes::FULL_ACCESS);
+                    let mask = TdgMemPageAttrWriteR8::new()
                         .with_l2_vm1(GpaVmAttributes::FULL_ACCESS.to_mask());
 
                     self.mshv_vtl
@@ -726,43 +598,85 @@ mod mapping {
                 .modify_gpa_visibility(host_visibility, gpns)
         }
 
-        /// Apply the default protections on memory for the specified VTL.
-        pub fn apply_default_vtl_protections(
+        /// Apply the initial protections on lower-vtl memory.
+        ///
+        ///  After initialization, the default protections should be applied.
+        pub fn apply_initial_lower_vtl_protections(
+            &self,
+            range: MemoryRange,
+        ) -> Result<(), ApplyVtlProtectionsError> {
+            self.apply_protections_from_flags(range, Vtl::Vtl0, HV_MAP_GPA_PERMISSIONS_ALL)
+        }
+
+        /// Query the current permissions for a vtl on a page.
+        fn vtl_permissions(&self, vtl: Vtl, gpa: u64) -> GpaVtlPermissions {
+            match self.isolation {
+                IsolationType::Vbs => unimplemented!(),
+                IsolationType::Snp => {
+                    // TODO CVM GUEST VSM: track the permissions directly in
+                    // underhill. For now, use rmpquery.
+                    assert!(self.isolation == IsolationType::Snp);
+                    let rmpadjust = self.mshv_vtl.rmpquery_page(gpa, vtl);
+
+                    GpaVtlPermissions::Snp(rmpadjust)
+                }
+                IsolationType::Tdx => todo!(),
+            }
+        }
+
+        fn apply_protections_from_flags(
             &self,
             range: MemoryRange,
             vtl: Vtl,
+            flags: HvMapGpaFlags,
         ) -> Result<(), ApplyVtlProtectionsError> {
-            // TODO GUEST VSM: Changes to vtl protections will need to be
-            // synchronized with any checks for VTL protections (e.g. rmpquery)
-            self.vtl_permissions
-                .lock()
-                .apply(range, vtl, &self.mshv_vtl, &self.mshv_hvcall)
+            let permissions = GpaVtlPermissions::new(self.isolation, vtl, flags);
+            self.apply_protections(range, vtl, permissions)
         }
 
-        /// Apply the default protections on memory for all valid VTLs.
-        pub fn apply_all_default_protections(
+        fn apply_protections(
             &self,
             range: MemoryRange,
+            vtl: Vtl,
+            protections: GpaVtlPermissions,
         ) -> Result<(), ApplyVtlProtectionsError> {
-            // TODO GUEST VSM: Changes to vtl protections will need to be
-            // synchronized with any checks for VTL protections (e.g. rmpquery)
-            // and the TLB
-            self.vtl_permissions
-                .lock()
-                .apply_all(range, &self.mshv_vtl, &self.mshv_hvcall)
-        }
+            match protections {
+                GpaVtlPermissions::Vbs(flags) => {
+                    // For VBS-isolated VMs, the permissions apply to all lower
+                    // VTLs. Therefore VTL 0 cannot set its own permissions.
+                    assert_ne!(vtl, Vtl::Vtl0);
 
-        /// Get the default protections for the specified VTL.
-        pub fn default_vtl_protections(&self, vtl: Vtl) -> Option<HvMapGpaFlags> {
-            let protector = self.vtl_permissions.lock();
-            protector.get(vtl)
-        }
-
-        /// Change the default protections on memory for the specified VTL. The
-        /// caller is responsible for validating the new protections.
-        pub fn update_default_vtl_protections(&self, default_protections: HvMapGpaFlags, vtl: Vtl) {
-            let mut protector = self.vtl_permissions.lock();
-            (*protector).set(default_protections, vtl);
+                    self.mshv_hvcall
+                        .modify_vtl_protection_mask(range, flags, HvInputVtl::from(vtl))
+                }
+                GpaVtlPermissions::Snp(rmpadjust) => {
+                    // For SNP VMs, the permissions apply to the specified VTL.
+                    // Therefore VTL 2 cannot specify its own permissions.
+                    assert_ne!(vtl, Vtl::Vtl2);
+                    self.mshv_vtl
+                        .rmpadjust_pages(range, rmpadjust, false)
+                        .map_err(|err| ApplyVtlProtectionsError::Snp {
+                            failed_operation: err,
+                            range,
+                            permissions: rmpadjust,
+                            vtl: vtl.into(),
+                        })
+                    // TODO SNP: Flush TLB
+                }
+                GpaVtlPermissions::Tdx((attributes, mask)) => {
+                    // For TDX VMs, the permissions apply to the specified VTL.
+                    // Therefore VTL 2 cannot specify its own permissions.
+                    assert_ne!(vtl, Vtl::Vtl2);
+                    self.mshv_vtl
+                        .tdx_set_page_attributes(range, attributes, mask)
+                        .map_err(|err| ApplyVtlProtectionsError::Tdx {
+                            error: err,
+                            range,
+                            permissions: attributes,
+                            vtl: vtl.into(),
+                        })
+                }
+            }
         }
     }
 
@@ -772,11 +686,33 @@ mod mapping {
         inner: Mutex<HardwareIsolatedMemoryProtectorInner>,
         layout: MemoryLayout,
         acceptor: Arc<MemoryAcceptor>,
+        hypercall_overlay: VtlArray<Arc<Mutex<Option<HypercallOverlay>>>, 2>,
+    }
+
+    struct HypercallOverlayProtector {
+        vtl: Vtl,
+        protector: Arc<dyn ProtectIsolatedMemory>,
+    }
+
+    struct HypercallOverlay {
+        gpn: u64,
+        permissions: GpaVtlPermissions,
+    }
+
+    impl VtlProtectHypercallOverlay for HypercallOverlayProtector {
+        fn change_overlay(&self, gpn: u64) {
+            self.protector.change_hypercall_overlay(self.vtl, gpn)
+        }
+
+        fn disable_overlay(&self) {
+            self.protector.disable_hypercall_overlay(self.vtl)
+        }
     }
 
     struct HardwareIsolatedMemoryProtectorInner {
         shared: Arc<GuestMemoryMapping>,
         encrypted: Arc<GuestMemoryMapping>,
+        default_vtl_permissions: DefaultVtlPermissions,
     }
 
     impl HardwareIsolatedMemoryProtector {
@@ -791,10 +727,73 @@ mod mapping {
             acceptor: Arc<MemoryAcceptor>,
         ) -> Self {
             Self {
-                inner: Mutex::new(HardwareIsolatedMemoryProtectorInner { shared, encrypted }),
+                inner: Mutex::new(HardwareIsolatedMemoryProtectorInner {
+                    shared,
+                    encrypted,
+                    // Grant only VTL 0 all permissions. This will be altered
+                    // later by VTL 1 enablement and by VTL 1 itself.
+                    default_vtl_permissions: DefaultVtlPermissions {
+                        vtl0: HV_MAP_GPA_PERMISSIONS_ALL,
+                        vtl1: None,
+                    },
+                }),
                 layout,
                 acceptor,
+                hypercall_overlay: VtlArray::from_fn(|_| Arc::new(Mutex::new(None))),
             }
+        }
+
+        fn apply_protections_with_overlay_handling(
+            &self,
+            vtl: Vtl,
+            ranges: &[MemoryRange],
+            protections: HvMapGpaFlags,
+        ) -> Result<(), ApplyVtlProtectionsError> {
+            // The overlay page cannot change over the course of this operation
+            let mut overlay_lock = self.hypercall_overlay[vtl].lock();
+            for range in ranges {
+                match overlay_lock.as_mut() {
+                    Some(overlay) if range.contains_addr(overlay.gpn * HV_PAGE_SIZE) => {
+                        overlay.permissions.set(vtl, protections);
+
+                        let overlay_address = overlay.gpn * HV_PAGE_SIZE;
+                        let overlay_offset = range.offset_of(overlay_address).unwrap();
+                        let (left, right) = range.split_at_offset(overlay_offset);
+
+                        self.acceptor
+                            .apply_protections_from_flags(left, vtl, protections)?;
+                        let sub_range =
+                            MemoryRange::new((overlay.gpn + 1) * HV_PAGE_SIZE..right.end());
+                        if !sub_range.is_empty() {
+                            self.acceptor.apply_protections_from_flags(
+                                sub_range,
+                                vtl,
+                                protections,
+                            )?;
+                        }
+                    }
+                    _ => {
+                        self.acceptor
+                            .apply_protections_from_flags(*range, vtl, protections)?;
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        /// Restore the original protections on the page that is overlaid.
+        fn restore_overlay_permissions(
+            &self,
+            vtl: Vtl,
+            overlay: &HypercallOverlay,
+        ) -> Result<(), ApplyVtlProtectionsError> {
+            let range =
+                MemoryRange::new(overlay.gpn * HV_PAGE_SIZE..(overlay.gpn + 1) * HV_PAGE_SIZE);
+
+            self.acceptor
+                .apply_protections(range, vtl, overlay.permissions)?;
+
+            Ok(())
         }
     }
 
@@ -809,6 +808,18 @@ mod mapping {
                     .any(|r| r.range.contains_addr(gpn * HV_PAGE_SIZE))
                 {
                     return Err((HvError::OperationDenied, 0));
+                }
+
+                // Don't allow the hypercall overlay to have shared visibility.
+                if shared {
+                    for vtl in [Vtl::Vtl1, Vtl::Vtl0] {
+                        let overlay = self.hypercall_overlay[vtl].lock();
+                        if let Some(overlay) = &*overlay {
+                            if overlay.gpn == gpn {
+                                return Err((HvError::OperationDenied, 0));
+                            }
+                        }
+                    }
                 }
             }
 
@@ -901,11 +912,24 @@ mod mapping {
             }
 
             if !shared {
-                // Apply vtl protections so that the guest can use them.
+                // Apply vtl protections so that the guest can use them. The
+                // hypercall overlay should not be host visible, so just apply
+                // the default protections directly without handling of the
+                // hypercall overlay.
                 for &range in &ranges {
-                    self.acceptor.apply_all_default_protections(range).expect(
-                        "everything should be in a state where we can apply VTL protections",
-                    );
+                    self.acceptor
+                        .apply_protections_from_flags(
+                            range,
+                            Vtl::Vtl0,
+                            inner.default_vtl_permissions.vtl0,
+                        )
+                        .expect("should be able to apply default protections");
+
+                    if let Some(vtl1_protections) = inner.default_vtl_permissions.vtl1 {
+                        self.acceptor
+                            .apply_protections_from_flags(range, Vtl::Vtl1, vtl1_protections)
+                            .expect("everything should be in a state where we can apply VTL protections");
+                    }
                 }
             }
 
@@ -942,14 +966,14 @@ mod mapping {
             Ok(())
         }
 
-        fn default_vtl_protections(&self, vtl: GuestVtl) -> Option<HvMapGpaFlags> {
-            self.acceptor.default_vtl_protections(vtl.into())
+        fn default_vtl0_protections(&self) -> HvMapGpaFlags {
+            self.inner.lock().default_vtl_permissions.vtl0
         }
 
         fn change_default_vtl_protections(
             &self,
-            vtl_protections: HvMapGpaFlags,
             vtl: GuestVtl,
+            vtl_protections: HvMapGpaFlags,
         ) -> Result<(), HvError> {
             // Prevent visibility changes while VTL protections are being
             // applied.
@@ -960,11 +984,11 @@ mod mapping {
             //
             // TODO GUEST VSM: Changes to vtl protections will need to be
             // synchronized with any checks for VTL protections (e.g. rmpquery)
-            let inner = self.inner.lock();
+            let mut inner = self.inner.lock();
 
-            self.acceptor
-                .update_default_vtl_protections(vtl_protections, vtl.into());
+            inner.default_vtl_permissions.set(vtl, vtl_protections);
 
+            let mut ranges = Vec::new();
             for ram_range in self.layout.ram().iter() {
                 let mut protect_start = ram_range.range.start();
                 let mut page_count = 0;
@@ -979,12 +1003,7 @@ mod mapping {
                     if !inner.encrypted.check_bitmap(gpn) {
                         if page_count > 0 {
                             let end_address = protect_start + (page_count * PAGE_SIZE as u64);
-                            self.acceptor
-                                .apply_default_vtl_protections(
-                                    MemoryRange::new(protect_start..end_address),
-                                    vtl.into(),
-                                )
-                                .expect("applying vtl 1 protections should succeed");
+                            ranges.push(MemoryRange::new(protect_start..end_address));
                         }
                         protect_start = (gpn + 1) * PAGE_SIZE as u64;
                         page_count = 0;
@@ -995,16 +1014,134 @@ mod mapping {
 
                 if page_count > 0 {
                     let end_address = protect_start + (page_count * PAGE_SIZE as u64);
-                    self.acceptor
-                        .apply_default_vtl_protections(
-                            MemoryRange::new(protect_start..end_address),
-                            vtl.into(),
-                        )
-                        .expect("applying vtl 1 protections should succeed");
+                    ranges.push(MemoryRange::new(protect_start..end_address));
                 }
             }
 
+            self.apply_protections_with_overlay_handling(vtl, &ranges, vtl_protections)
+                .expect("applying vtl protections should succeed");
+
             Ok(())
+        }
+
+        fn change_vtl_protections(
+            &self,
+            vtl: Vtl,
+            gpns: &[u64],
+            protections: HvMapGpaFlags,
+        ) -> HvRepResult {
+            assert!(vtl < Vtl::Vtl2);
+            // Validate the ranges are RAM.
+            for &gpn in gpns {
+                if !self
+                    .layout
+                    .ram()
+                    .iter()
+                    .any(|r| r.range.contains_addr(gpn * HV_PAGE_SIZE))
+                {
+                    return Err((HvError::OperationDenied, 0));
+                }
+            }
+
+            // Prevent visibility changes while VTL protections are being
+            // applied. This does not need to be synchronized against other
+            // threads performing VTL protection changes; whichever thread
+            // finishes last will control the outcome.
+            let inner = self.inner.lock();
+
+            // Protections cannot be applied to a host-visible page
+            if gpns.iter().any(|&gpn| inner.shared.check_bitmap(gpn)) {
+                return Err((HvError::OperationDenied, 0));
+            }
+
+            // TODO GUEST VSM: For hardware-isolated VMs, track vtl protections in a bitmap
+
+            let ranges = PagedRange::new(0, gpns.len() * PagedRange::PAGE_SIZE, gpns)
+                .unwrap()
+                .ranges()
+                .map(|r| r.map(|r| MemoryRange::new(r.start..r.end)))
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(); // Ok to unwrap, we've validated the gpns above.
+
+            self.apply_protections_with_overlay_handling(vtl, &ranges, protections)
+                .expect("applying vtl protections should succeed");
+
+            // TODO CVM GUEST VSM: flush TLB and wait for the tlb lock
+            Ok(())
+        }
+
+        fn hypercall_overlay_protector(
+            self: Arc<Self>,
+            vtl: Vtl,
+        ) -> Box<dyn VtlProtectHypercallOverlay> {
+            Box::new(HypercallOverlayProtector {
+                vtl,
+                protector: self.clone(),
+            })
+        }
+
+        fn change_hypercall_overlay(&self, vtl: Vtl, gpn: u64) {
+            // Should already have written contents to the page via the guest
+            // memory object, confirming that this is a guest page
+            assert!(self
+                .layout
+                .ram()
+                .iter()
+                .any(|r| r.range.contains_addr(gpn * HV_PAGE_SIZE)));
+
+            let _lock = self.inner.lock();
+
+            let mut overlay = self.hypercall_overlay[vtl].lock();
+
+            // Restore permissions on the previous overlay
+            if let Some(overlay) = overlay.as_ref() {
+                self.restore_overlay_permissions(vtl, overlay)
+                    .expect("applying vtl protections should succeed");
+            }
+
+            let current_permissions = match self.acceptor.isolation {
+                IsolationType::Vbs => unreachable!(),
+                IsolationType::Snp => self.acceptor.vtl_permissions(vtl, gpn * HV_PAGE_SIZE),
+                IsolationType::Tdx => {
+                    // TODO TDX GUEST VSM: implement acceptor.vtl_permissions
+                    // For now, since guest vsm isn't enabled, this overlay can
+                    // only exist for VTL 0, which can't change its own
+                    // permissions. So assume that the permissions haven't
+                    // changed since VTL 2 initialized guest memory and they're
+                    // still all.
+                    GpaVtlPermissions::new(IsolationType::Tdx, vtl, HV_MAP_GPA_PERMISSIONS_ALL)
+                }
+            };
+
+            *overlay = Some(HypercallOverlay {
+                gpn,
+                permissions: current_permissions,
+            });
+
+            self.acceptor
+                .apply_protections_from_flags(
+                    MemoryRange::new(gpn * HV_PAGE_SIZE..(gpn + 1) * HV_PAGE_SIZE),
+                    vtl,
+                    HV_MAP_GPA_PERMISSIONS_ALL,
+                )
+                .expect("applying vtl protections should succeed");
+
+            // TODO CVM GUEST VSM: flush TLB
+        }
+
+        fn disable_hypercall_overlay(&self, vtl: Vtl) {
+            let _lock = self.inner.lock();
+
+            let mut overlay = self.hypercall_overlay[vtl].lock();
+
+            if let Some(overlay) = overlay.as_ref() {
+                self.restore_overlay_permissions(vtl, overlay)
+                    .expect("applying vtl protections should succeed");
+            }
+
+            *overlay = None;
+
+            // TODO CVM GUEST VSM: flush TLB
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -44,6 +44,7 @@ use hcl::ioctl::Hcl;
 use hcl::ioctl::SetVsmPartitionConfigError;
 use hcl::GuestVtl;
 use hv1_emulator::hv::GlobalHv;
+use hv1_emulator::hv::VtlProtectHypercallOverlay;
 use hv1_emulator::message_queues::MessageQueues;
 use hv1_emulator::synic::GlobalSynic;
 use hv1_emulator::synic::SintProxied;
@@ -208,7 +209,7 @@ struct UhPartitionInner {
     untrusted_synic: Option<GlobalSynic>,
     guest_vsm: RwLock<GuestVsmState>,
     #[inspect(skip)]
-    isolated_memory_protector: Option<Box<dyn ProtectIsolatedMemory>>,
+    isolated_memory_protector: Option<Arc<dyn ProtectIsolatedMemory>>,
     #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
     #[inspect(skip)]
     shared_vis_pages_pool: Option<shared_pool_alloc::SharedPoolAllocator>,
@@ -296,6 +297,14 @@ enum GuestVsmState {
 impl GuestVsmState {
     #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
     fn get_vtl1_mut(&mut self) -> Option<&mut GuestVsmVtl1State> {
+        match self {
+            GuestVsmState::Enabled { vtl1 } => Some(vtl1),
+            _ => None,
+        }
+    }
+
+    #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
+    fn get_vtl1(&self) -> Option<&GuestVsmVtl1State> {
         match self {
             GuestVsmState::Enabled { vtl1 } => Some(vtl1),
             _ => None,
@@ -1081,7 +1090,7 @@ pub struct UhPartitionNewParams<'a> {
     /// Must be a power of two.
     pub vtom: Option<u64>,
     /// An object to call to change host visibility on guest memory.
-    pub isolated_memory_protector: Option<Box<dyn ProtectIsolatedMemory>>,
+    pub isolated_memory_protector: Option<Arc<dyn ProtectIsolatedMemory>>,
     /// Allocator for shared visibility pages.
     pub shared_vis_pages_pool: Option<shared_pool_alloc::SharedPoolAllocator>,
     /// Handle synic messages and events.
@@ -1101,6 +1110,7 @@ pub struct UhPartitionNewParams<'a> {
 pub trait ProtectIsolatedMemory: Send + Sync {
     /// Changes host visibility on guest memory.
     fn change_host_visibility(&self, shared: bool, gpns: &[u64]) -> HvRepResult;
+
     /// Queries host visibility on guest memory.
     fn query_host_visibility(
         &self,
@@ -1108,16 +1118,38 @@ pub trait ProtectIsolatedMemory: Send + Sync {
         host_visibility: &mut [HostVisibilityType],
     ) -> HvRepResult;
 
-    /// Gets the default protections/permissions for a VTL.
-    fn default_vtl_protections(&self, vtl: GuestVtl) -> Option<HvMapGpaFlags>;
+    /// Gets the default protections/permissions for VTL 0.
+    fn default_vtl0_protections(&self) -> HvMapGpaFlags;
+
     /// Changes the default protections/permissions for a VTL. For VBS-isolated
     /// VMs, the protections apply to all vtls lower than the specified one. For
     /// hardware-isolated VMs, they apply just to the given vtl.
     fn change_default_vtl_protections(
         &self,
-        protections: HvMapGpaFlags,
         vtl: GuestVtl,
+        protections: HvMapGpaFlags,
     ) -> Result<(), HvError>;
+
+    /// Changes the vtl protections on a range of guest memory.
+    fn change_vtl_protections(
+        &self,
+        vtl: Vtl,
+        gpns: &[u64],
+        protections: HvMapGpaFlags,
+    ) -> HvRepResult;
+
+    /// Retrieves a protector for the hypercall code page overlay for a target
+    /// VTL.
+    fn hypercall_overlay_protector(
+        self: Arc<Self>,
+        vtl: Vtl,
+    ) -> Box<dyn VtlProtectHypercallOverlay>;
+
+    /// Changes the overlay for the hypercall code page for a target VTL.
+    fn change_hypercall_overlay(&self, vtl: Vtl, gpn: u64);
+
+    /// Disables the overlay for the hypercall code page for a target VTL.
+    fn disable_hypercall_overlay(&self, vtl: Vtl);
 }
 
 impl UhPartition {
@@ -1341,6 +1373,14 @@ impl UhPartition {
                 vendor: caps.vendor,
                 tsc_frequency,
                 ref_time,
+                vtl0_hypercall_page_protector: params
+                    .isolated_memory_protector
+                    .as_ref()
+                    .map(|p| p.clone().hypercall_overlay_protector(Vtl::Vtl0)),
+                vtl1_hypercall_page_protector: params
+                    .isolated_memory_protector
+                    .as_ref()
+                    .map(|p| p.clone().hypercall_overlay_protector(Vtl::Vtl1)),
             }))
         } else {
             None
@@ -1394,7 +1434,7 @@ impl UhPartition {
             hv,
             untrusted_synic,
             guest_vsm: RwLock::new(vsm_state),
-            isolated_memory_protector: params.isolated_memory_protector,
+            isolated_memory_protector: params.isolated_memory_protector.clone(),
             shared_vis_pages_pool: params.shared_vis_pages_pool,
             no_sidecar_hotplug: params.no_sidecar_hotplug.into(),
             use_mmio_hypercalls: params.use_mmio_hypercalls,

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1373,14 +1373,12 @@ impl UhPartition {
                 vendor: caps.vendor,
                 tsc_frequency,
                 ref_time,
-                vtl0_hypercall_page_protector: params
-                    .isolated_memory_protector
-                    .as_ref()
-                    .map(|p| p.clone().hypercall_overlay_protector(Vtl::Vtl0)),
-                vtl1_hypercall_page_protector: params
-                    .isolated_memory_protector
-                    .as_ref()
-                    .map(|p| p.clone().hypercall_overlay_protector(Vtl::Vtl1)),
+                hypercall_page_protectors: VtlArray::from_fn(|vtl| {
+                    params
+                        .isolated_memory_protector
+                        .as_ref()
+                        .map(|p| p.clone().hypercall_overlay_protector(vtl))
+                }),
             }))
         } else {
             None

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1133,7 +1133,7 @@ pub trait ProtectIsolatedMemory: Send + Sync {
     /// Changes the vtl protections on a range of guest memory.
     fn change_vtl_protections(
         &self,
-        vtl: Vtl,
+        vtl: GuestVtl,
         gpns: &[u64],
         protections: HvMapGpaFlags,
     ) -> HvRepResult;
@@ -1142,14 +1142,14 @@ pub trait ProtectIsolatedMemory: Send + Sync {
     /// VTL.
     fn hypercall_overlay_protector(
         self: Arc<Self>,
-        vtl: Vtl,
+        vtl: GuestVtl,
     ) -> Box<dyn VtlProtectHypercallOverlay>;
 
     /// Changes the overlay for the hypercall code page for a target VTL.
-    fn change_hypercall_overlay(&self, vtl: Vtl, gpn: u64);
+    fn change_hypercall_overlay(&self, vtl: GuestVtl, gpn: u64);
 
     /// Disables the overlay for the hypercall code page for a target VTL.
-    fn disable_hypercall_overlay(&self, vtl: Vtl);
+    fn disable_hypercall_overlay(&self, vtl: GuestVtl);
 }
 
 impl UhPartition {
@@ -1374,10 +1374,10 @@ impl UhPartition {
                 tsc_frequency,
                 ref_time,
                 hypercall_page_protectors: VtlArray::from_fn(|vtl| {
-                    params
-                        .isolated_memory_protector
-                        .as_ref()
-                        .map(|p| p.clone().hypercall_overlay_protector(vtl))
+                    params.isolated_memory_protector.as_ref().map(|p| {
+                        p.clone()
+                            .hypercall_overlay_protector(vtl.try_into().expect("no vtl 2"))
+                    })
                 }),
             }))
         } else {

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -1387,12 +1387,10 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::ModifyVtlProtectionMask
         }
 
         if let Some(vtl) = target_vtl {
-            if vtl > self.vp.last_vtl() {
-                return Err((HvError::AccessDenied, 0));
-            }
+            let _target_vtl = self.target_vtl_no_higher(vtl).map_err(|e| (e, 0))?;
         }
 
-        let target_vtl = target_vtl.unwrap_or(self.vp.last_vtl());
+        let target_vtl = target_vtl.unwrap_or(self.vp.last_vtl().into());
         if target_vtl == Vtl::Vtl0 {
             return Err((HvError::InvalidParameter, 0));
         }
@@ -1400,7 +1398,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::ModifyVtlProtectionMask
         // A VTL cannot change its own VTL permissions until it has enabled VTL protection and
         // configured default permissions. Higher VTLs are not under this restriction (as they may
         // need to apply default permissions before VTL protection is enabled).
-        if target_vtl == self.vp.last_vtl() {
+        if target_vtl == self.vp.last_vtl().into() {
             if let Some(guest_vsm) = self.vp.partition.guest_vsm.read().get_vtl1() {
                 if !guest_vsm.enable_vtl_protection {
                     return Err((HvError::AccessDenied, 0));
@@ -1436,7 +1434,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::ModifyVtlProtectionMask
                 .isolated_memory_protector
                 .as_ref()
                 .expect("has a memory protector")
-                .change_vtl_protections(Vtl::Vtl0, gpa_pages, map_flags)?;
+                .change_vtl_protections(GuestVtl::Vtl0, gpa_pages, map_flags)?;
         } else {
             // TODO VBS GUEST VSM: verify this logic is correct
             // TODO VBS GUEST VSM: validation on map_flags, similar to default

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -1372,6 +1372,92 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::ModifySparseGpaPageHostVisibility
     }
 }
 
+impl<T: CpuIo, B: Backing> hv1_hypercall::ModifyVtlProtectionMask
+    for UhHypercallHandler<'_, '_, T, B>
+{
+    fn modify_vtl_protection_mask(
+        &mut self,
+        partition_id: u64,
+        map_flags: hvdef::HvMapGpaFlags,
+        target_vtl: Option<Vtl>,
+        gpa_pages: &[u64],
+    ) -> hvdef::HvRepResult {
+        if partition_id != hvdef::HV_PARTITION_ID_SELF {
+            return Err((HvError::AccessDenied, 0));
+        }
+
+        if let Some(vtl) = target_vtl {
+            if vtl > self.vp.last_vtl() {
+                return Err((HvError::AccessDenied, 0));
+            }
+        }
+
+        let target_vtl = target_vtl.unwrap_or(self.vp.last_vtl());
+        if target_vtl == Vtl::Vtl0 {
+            return Err((HvError::InvalidParameter, 0));
+        }
+
+        // A VTL cannot change its own VTL permissions until it has enabled VTL protection and
+        // configured default permissions. Higher VTLs are not under this restriction (as they may
+        // need to apply default permissions before VTL protection is enabled).
+        if target_vtl == self.vp.last_vtl() {
+            if let Some(guest_vsm) = self.vp.partition.guest_vsm.read().get_vtl1() {
+                if !guest_vsm.enable_vtl_protection {
+                    return Err((HvError::AccessDenied, 0));
+                }
+            } else {
+                return Err((HvError::AccessDenied, 0));
+            }
+        }
+
+        if self.vp.partition.is_hardware_isolated() {
+            // VTL 1 mut be enabled already.
+            let mut guest_vsm_lock = self.vp.partition.guest_vsm.write();
+            let guest_vsm = guest_vsm_lock
+                .get_vtl1_mut()
+                .ok_or((HvError::InvalidVtlState, 0))?;
+            let guest_vsm_inner = guest_vsm.inner.get_hardware_cvm_mut().unwrap();
+
+            if !crate::validate_vtl_gpa_flags(
+                map_flags,
+                guest_vsm_inner.mbec_enabled,
+                guest_vsm_inner.shadow_supervisor_stack_enabled,
+            ) {
+                return Err((HvError::InvalidRegisterValue, 0));
+            }
+
+            // The contract for VSM is that the VTL protections describe what
+            // the lower VTLs are allowed to access. Hardware CVMs set the
+            // protections on the VTL itself. Therefore, for a hardware CVM,
+            // given that only VTL 1 can set the protections, the default
+            // permissions should be changed for VTL 0.
+            self.vp
+                .partition
+                .isolated_memory_protector
+                .as_ref()
+                .expect("has a memory protector")
+                .change_vtl_protections(Vtl::Vtl0, gpa_pages, map_flags)?;
+        } else {
+            // TODO VBS GUEST VSM: verify this logic is correct
+            // TODO VBS GUEST VSM: validation on map_flags, similar to default
+            // protections mask changes
+            // Can receive an intercept on adjust permissions, and for isolated
+            // VMs if the page is unaccepted
+            if self.vp.partition.isolation.is_some() {
+                return Err((HvError::OperationDenied, 0));
+            } else {
+                if !gpa_pages.is_empty() && !self.vp.partition.is_gpa_lower_vtl_ram(gpa_pages[0]) {
+                    return Err((HvError::OperationDenied, 0));
+                } else {
+                    panic!("Should not be handling this hypercall for guest ram");
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 impl<T: CpuIo, B: Backing> hv1_hypercall::QuerySparseGpaPageHostVisibility
     for UhHypercallHandler<'_, '_, T, B>
 {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1195,6 +1195,7 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, HypervisorBackedX86> {
             hv1_hypercall::HvX64StartVirtualProcessor,
             hv1_hypercall::HvGetVpIndexFromApicId,
             hv1_hypercall::HvSetVpRegisters,
+            hv1_hypercall::HvModifyVtlProtectionMask
         ]
     );
 }

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -670,6 +670,7 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, SnpBacked> {
             hv1_hypercall::HvFlushVirtualAddressSpace,
             hv1_hypercall::HvFlushVirtualAddressSpaceEx,
             hv1_hypercall::HvSetVpRegisters,
+            hv1_hypercall::HvModifyVtlProtectionMask,
         ],
     );
 
@@ -926,14 +927,15 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let mut vmsa = self.runner.vmsa_mut(self.last_vtl());
+        let lower_vtl = self.last_vtl();
+        let mut vmsa = self.runner.vmsa_mut(lower_vtl);
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();
 
         vmsa.v_intr_cntrl_mut().set_guest_busy(false);
 
         // TODO CVM GUEST VSM actually check and run vtl 1
         self.unlock_tlb_lock(Vtl::Vtl2);
-        let tlb_halt = self.should_halt_for_tlb_unlock(GuestVtl::Vtl0);
+        let tlb_halt = self.should_halt_for_tlb_unlock(lower_vtl);
 
         self.runner.set_halted(
             self.backing.lapics[GuestVtl::Vtl0].halted

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -927,15 +927,14 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let lower_vtl = self.last_vtl();
-        let mut vmsa = self.runner.vmsa_mut(lower_vtl);
+        let mut vmsa = self.runner.vmsa_mut(self.last_vtl());
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();
 
         vmsa.v_intr_cntrl_mut().set_guest_busy(false);
 
         // TODO CVM GUEST VSM actually check and run vtl 1
         self.unlock_tlb_lock(Vtl::Vtl2);
-        let tlb_halt = self.should_halt_for_tlb_unlock(lower_vtl);
+        let tlb_halt = self.should_halt_for_tlb_unlock(Vtl::Vtl0);
 
         self.runner.set_halted(
             self.backing.lapics[GuestVtl::Vtl0].halted

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -934,7 +934,7 @@ impl UhProcessor<'_, SnpBacked> {
 
         // TODO CVM GUEST VSM actually check and run vtl 1
         self.unlock_tlb_lock(Vtl::Vtl2);
-        let tlb_halt = self.should_halt_for_tlb_unlock(Vtl::Vtl0);
+        let tlb_halt = self.should_halt_for_tlb_unlock(GuestVtl::Vtl0);
 
         self.runner.set_halted(
             self.backing.lapics[GuestVtl::Vtl0].halted

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -98,7 +98,6 @@ pub struct GlobalHvParams {
 impl GlobalHv {
     /// Returns a new hypervisor emulator instance.
     pub fn new(params: GlobalHvParams) -> Self {
-        let [vtl0_protector, vtl1_protector] = params.hypercall_page_protectors.into_array();
         Self {
             partition_state: Arc::new(GlobalHvState {
                 vendor: params.vendor,
@@ -106,10 +105,9 @@ impl GlobalHv {
                 is_ref_time_backed_by_tsc: params.ref_time.is_backed_by_tsc(),
                 ref_time: params.ref_time,
             }),
-            vtl_mutable_state: VtlArray::from([
-                Arc::new(Mutex::new(MutableHvState::new(vtl0_protector))),
-                Arc::new(Mutex::new(MutableHvState::new(vtl1_protector))),
-            ]),
+            vtl_mutable_state: params
+                .hypercall_page_protectors
+                .map(|protector| Arc::new(Mutex::new(MutableHvState::new(protector)))),
             synic: VtlArray::from_fn(|_| GlobalSynic::new(params.max_vp_count)),
         }
     }

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -517,6 +517,6 @@ const INTEL_HYPERCALL_PAGE: HypercallPage = hypercall_page(false);
 pub trait VtlProtectHypercallOverlay: Send + Sync {
     /// Change the location of the overlay.
     fn change_overlay(&self, gpn: u64);
-    /// To handle removal or disablement of the overlay.
+    /// Disable the overlay.
     fn disable_overlay(&self);
 }

--- a/vm/hv1/vtl_array/src/lib.rs
+++ b/vm/hv1/vtl_array/src/lib.rs
@@ -44,9 +44,15 @@ impl<T, const N: usize> VtlArray<T, N> {
         }
     }
 
-    /// Returns the raw underlying array
-    pub fn into_array(self) -> [T; N] {
-        self.data
+    /// Maps over the vtl array using the raw underlying array
+    pub fn map<U, F>(self, f: F) -> VtlArray<U, N>
+    where
+        F: FnMut(T) -> U,
+    {
+        assert!(N > 0 && N <= 3);
+        VtlArray {
+            data: self.data.map(f),
+        }
     }
 }
 

--- a/vm/hv1/vtl_array/src/lib.rs
+++ b/vm/hv1/vtl_array/src/lib.rs
@@ -43,6 +43,11 @@ impl<T, const N: usize> VtlArray<T, N> {
             data: core::array::from_fn(|i| f(Vtl::try_from(i as u8).unwrap())),
         }
     }
+
+    /// Returns the raw underlying array
+    pub fn into_array(self) -> [T; N] {
+        self.data
+    }
 }
 
 impl<T> From<[T; 1]> for VtlArray<T, 1> {

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1361,6 +1361,8 @@ impl VtlPartition {
                     vendor,
                     tsc_frequency,
                     ref_time,
+                    vtl0_hypercall_page_protector: None,
+                    vtl1_hypercall_page_protector: None,
                 }))
             }
         } else {

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1361,8 +1361,7 @@ impl VtlPartition {
                     vendor,
                     tsc_frequency,
                     ref_time,
-                    vtl0_hypercall_page_protector: None,
-                    vtl1_hypercall_page_protector: None,
+                    hypercall_page_protectors: vtl_array::VtlArray::from_fn(|_| None),
                 }))
             }
         } else {


### PR DESCRIPTION
Implements ModifyVtlProtectionMask hypercall handling for SNP VMs with guest VSM.

Tested with:

SNP without guest vsm
TDX-isolated VMs
Non-isolated with and without guest vsm
VBS-isolated with and without guest vsm