### PR TITLE
Switch private-vso-build.yml and unsafe-reviewers.yml from pull_request to pull_request_target

### DIFF
--- a/.github/workflows/private-vso-build.yml
+++ b/.github/workflows/private-vso-build.yml
@@ -1,7 +1,7 @@
 name: Private VSO build
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [synchronize, opened, reopened, ready_for_review]
 
 concurrency:

--- a/.github/workflows/unsafe-reviewers.yml
+++ b/.github/workflows/unsafe-reviewers.yml
@@ -1,7 +1,7 @@
 name: Unsafe Reviewers Check
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs


### PR DESCRIPTION
Now that the repo is public, the pull request workflows are not able to access repository secrets. There is a separate event called `pull_request_target` that allows this, but you must be very careful when using this. Our repo is already locked down so that it requires a maintainer to kick of CI runs, so we should be OK here.

I believe this change needs to be merged to main first before this behavior can be tested. This makes sense because if you were able to change this type in a fork, you could make the change to the pipeline and the change to snoop secrets at the same time.