### PR TITLE
openhcl_boot: pass the constants into the asm!() statements.

### DIFF
--- a/openhcl/openhcl_boot/src/arch/aarch64/entry.S
+++ b/openhcl/openhcl_boot/src/arch/aarch64/entry.S
@@ -35,13 +35,13 @@ _start:
 
     adrp    x1, {stack}
     add     x1, x1, :lo12:{stack}
-    mov     x2, #0x5060          // Lower 16 bits of the stack cookie
-    movk    x2, #0x3040, lsl 16  // Higher 16 bits of the stack cookie, keep the lower bits
-    str     x2, [x1]             // Store the stack cookie at the bottom
-    add     x1, x1, #32768       // Stack size
-    sub     x1, x1, #8           // Leave 8 bytes for the stack cookie at the top
-    str     x2, [x1]             // Store the stack cookie at the top
-    sub     x1, x1, #8           // Set the stack pointer
+    mov     x2, {STACK_COOKIE_LO}           // Lower 16 bits of the stack cookie
+    movk    x2, {STACK_COOKIE_HI}, lsl 16   // Higher 16 bits of the stack cookie, keep the lower bits
+    str     x2, [x1]                        // Store the stack cookie at the bottom
+    add     x1, x1, {STACK_SIZE}            // Stack size
+    sub     x1, x1, #8                      // Leave 8 bytes for the stack cookie at the top
+    str     x2, [x1]                        // Store the stack cookie at the top
+    sub     x1, x1, #8                      // Set the stack pointer
     mov     sp, x1
 
     // Set the vector table up.

--- a/openhcl/openhcl_boot/src/arch/aarch64/mod.rs
+++ b/openhcl/openhcl_boot/src/arch/aarch64/mod.rs
@@ -15,6 +15,9 @@ pub use memory::verify_imported_regions_hash;
 pub use vp::setup_vtl2_vp;
 pub use vsm::get_isolation_type;
 
+use crate::rt::STACK_COOKIE;
+use crate::rt::STACK_SIZE;
+
 // Entry point.
 #[cfg(minimal_rt)]
 core::arch::global_asm! {
@@ -22,4 +25,7 @@ core::arch::global_asm! {
     start = sym crate::rt::start,
     relocate = sym minimal_rt::reloc::relocate,
     stack = sym crate::rt::STACK,
+    STACK_COOKIE_LO = const (STACK_COOKIE as u16),
+    STACK_COOKIE_HI = const ((STACK_COOKIE >> 16) as u16),
+    STACK_SIZE = const STACK_SIZE,
 }

--- a/openhcl/openhcl_boot/src/arch/x86_64/entry.S
+++ b/openhcl/openhcl_boot/src/arch/x86_64/entry.S
@@ -10,25 +10,25 @@
 
 .globl _start
 _start:
-    mov     rbx, rdi                            // Save arg rdi
-    lea     rdi, __bss_start[rip]               // Put BSS base in rdi
-    lea     rcx, _end[rip]                      // Put BSS end in rcx
-    sub     rcx, rdi                            // Compute BSS len in rcx
-    xor     eax, eax                            // Clear eax
-    cld                                         // Clear the direction flag for the string operation
-    rep     stosb                               // Zero BSS: memset(rdi, al, rcx)
-    mov     rdi, rbx                            // Restore rdi
-    lea     rsp, 32768 + {stack}[rip]           // Set stack pointer
-    mov     dword ptr {stack}[rip], 0x30405060  // Set stack cookie
-    mov     rax, cr4                            // Read CR4 into rax
-    or      rax, 0x600                          // Set OSFXSR and OSXMMEXCPT for SSE support
-    mov     cr4, rax                            // Set CR4 from rax with previous values set
-    push    rsi                                 // caller save rsi
-    push    rdi                                 // caller save rdi
-    lea     rdx, _DYNAMIC[rip]                  // The start of the dynamic section, rip-relative
-    lea     rdi, __ehdr_start[rip]              // The mapped base of the image, rip-relative
-    mov     rsi, rdi                            // The virtual address of the image
-    call    {relocate}                          // call relocate to fixup relocation entries
-    pop     rdi                                 // restore rdi (arg 0) to call start
-    mov     rsi, [rsp]                          // restore rsi (arg 1) to call start (leave on stack to align)
-    jmp     {start}                             // jump to start
+    mov     rbx, rdi                                // Save arg rdi
+    lea     rdi, __bss_start[rip]                   // Put BSS base in rdi
+    lea     rcx, _end[rip]                          // Put BSS end in rcx
+    sub     rcx, rdi                                // Compute BSS len in rcx
+    xor     eax, eax                                // Clear eax
+    cld                                             // Clear the direction flag for the string operation
+    rep     stosb                                   // Zero BSS: memset(rdi, al, rcx)
+    mov     rdi, rbx                                // Restore rdi
+    lea     rsp, {STACK_SIZE} + {stack}[rip]        // Set stack pointer
+    mov     dword ptr {stack}[rip], {STACK_COOKIE}  // Set stack cookie
+    mov     rax, cr4                                // Read CR4 into rax
+    or      rax, 0x600                              // Set OSFXSR and OSXMMEXCPT for SSE support
+    mov     cr4, rax                                // Set CR4 from rax with previous values set
+    push    rsi                                     // caller save rsi
+    push    rdi                                     // caller save rdi
+    lea     rdx, _DYNAMIC[rip]                      // The start of the dynamic section, rip-relative
+    lea     rdi, __ehdr_start[rip]                  // The mapped base of the image, rip-relative
+    mov     rsi, rdi                                // The virtual address of the image
+    call    {relocate}                              // call relocate to fixup relocation entries
+    pop     rdi                                     // restore rdi (arg 0) to call start
+    mov     rsi, [rsp]                              // restore rsi (arg 1) to call start (leave on stack to align)
+    jmp     {start}                                 // jump to start

--- a/openhcl/openhcl_boot/src/arch/x86_64/mod.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/mod.rs
@@ -17,6 +17,9 @@ pub use memory::verify_imported_regions_hash;
 pub use vp::setup_vtl2_vp;
 pub use vsm::get_isolation_type;
 
+use crate::rt::STACK_COOKIE;
+use crate::rt::STACK_SIZE;
+
 pub fn physical_address_bits() -> u8 {
     unimplemented!("physical_address_bits not implemented on x64")
 }
@@ -28,4 +31,6 @@ core::arch::global_asm! {
     relocate = sym minimal_rt::reloc::relocate,
     start = sym crate::rt::start,
     stack = sym crate::rt::STACK,
+    STACK_COOKIE = const STACK_COOKIE,
+    STACK_SIZE = const STACK_SIZE,
 }

--- a/openhcl/openhcl_boot/src/rt.rs
+++ b/openhcl/openhcl_boot/src/rt.rs
@@ -3,7 +3,8 @@
 //! Architecture-independent runtime support.
 
 // This must match the hardcoded value set at the entry point in the asm.
-const STACK_SIZE: usize = 32768;
+pub(crate) const STACK_SIZE: usize = 32768;
+pub(crate) const STACK_COOKIE: u32 = 0x30405060;
 
 #[repr(C, align(16))]
 pub struct Stack([u8; STACK_SIZE]);
@@ -19,7 +20,7 @@ pub fn verify_stack_cookie() {
     // is bogus.
     unsafe {
         let stack_ptr = core::ptr::addr_of!(STACK).cast::<u32>();
-        if core::ptr::read(stack_ptr) != 0x30405060 {
+        if core::ptr::read(stack_ptr) != STACK_COOKIE {
             panic!("Stack was overrun - check for large variables");
         }
     }


### PR DESCRIPTION
The entry.S files use few hardcoded constansts. As of Rust 1.82, there's a new feature allowing to pass constants into the inline assembly. Use that to improve the code structure.