### PR TITLE
Fix CI issues due to disconnected 1ES pools and unneeded AzureLogin tasks

### DIFF
--- a/.github/workflows/openvmm-ci.json
+++ b/.github/workflows/openvmm-ci.json
@@ -3196,20 +3196,12 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:32:46\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -3217,7 +3209,7 @@
       ],
       "flowey_lib_common::install_rust": [
         "{\"AutoInstall\":true}",
-        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:1:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:31:32\",\"is_secret\":false}}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:1:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:30:32\",\"is_secret\":false}}",
         "{\"IgnoreVersion\":false}",
         "{\"Version\":\"1.81.0\"}"
       ],
@@ -3226,9 +3218,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -3255,7 +3244,7 @@
         "{\"Version\":\"24.0.1\"}"
       ],
       "flowey_lib_hvlite::git_checkout_openvmm_repo": [
-        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:0:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:30:31\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:0:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:29:31\",\"is_secret\":false}}",
         "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
       ],
       "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [

--- a/.github/workflows/openvmm-ci.json
+++ b/.github/workflows/openvmm-ci.json
@@ -37,13 +37,6 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -53,7 +46,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -66,16 +58,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guide": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"deploy_github_pages\":true,\"done\":{\"backing_var\":\"start1\",\"is_secret\":false}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -149,13 +138,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -166,7 +148,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -185,16 +166,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"target_triple\":\"x86_64-pc-windows-msvc\"}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -286,13 +264,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -303,7 +274,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -322,16 +292,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"target_triple\":\"x86_64-unknown-linux-gnu\"}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -419,13 +386,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -435,7 +395,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -454,13 +413,10 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -546,13 +502,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -563,7 +512,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -582,13 +530,10 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -683,13 +628,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -701,7 +639,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -726,7 +663,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start8\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
@@ -742,9 +679,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -861,13 +795,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -879,7 +806,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -907,7 +833,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start12\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}"
@@ -920,9 +846,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -1033,13 +956,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -1052,7 +968,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -1077,7 +992,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start15\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
@@ -1093,9 +1008,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -1213,13 +1125,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -1231,7 +1136,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -1259,7 +1163,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start19\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
@@ -1272,9 +1176,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -1387,13 +1288,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -1417,7 +1311,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -1446,7 +1339,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
         "{\"arch\":\"Aarch64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start25\",\"is_secret\":false},\"profile\":\"Release\"}"
@@ -1468,9 +1361,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -1617,13 +1507,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -1643,7 +1526,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -1679,7 +1561,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
         "{\"arch\":\"X86_64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start31\",\"is_secret\":false},\"profile\":\"Release\"}"
@@ -1704,9 +1586,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -1857,13 +1736,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -1885,7 +1757,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -1910,7 +1781,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
         "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start33\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"Aarch64\"},{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"Aarch64Devkern\"}]}"
@@ -1920,9 +1791,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -2075,13 +1943,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -2103,7 +1964,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -2128,7 +1988,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
         "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start35\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64Devkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64TestLinuxDirect\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64TestLinuxDirectDevkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64Cvm\"}]}"
@@ -2138,9 +1998,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -2325,13 +2182,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -2342,7 +2192,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -2384,16 +2233,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start39\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-windows-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -2513,13 +2359,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -2536,7 +2375,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -2583,16 +2421,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start43\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -2726,13 +2561,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -2748,7 +2576,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -2802,16 +2629,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start46\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-musl-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -2938,12 +2762,8 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
       "flowey_lib_common::gh_task_azure_login": [
         "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}",
         "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:4:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:387:21\",\"is_secret\":false}}"
       ],
       "flowey_lib_common::git_checkout": [
@@ -2957,7 +2777,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -2976,7 +2795,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3093,12 +2912,8 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
       "flowey_lib_common::gh_task_azure_login": [
         "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}",
         "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:4:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:387:21\",\"is_secret\":false}}"
       ],
       "flowey_lib_common::git_checkout": [
@@ -3112,7 +2927,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -3131,7 +2945,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3248,12 +3062,8 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
       "flowey_lib_common::gh_task_azure_login": [
         "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}",
         "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:4:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:387:21\",\"is_secret\":false}}"
       ],
       "flowey_lib_common::git_checkout": [
@@ -3267,7 +3077,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -3286,7 +3095,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3388,7 +3197,6 @@
         "{\"Version\":\"27.1\"}"
       ],
       "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}",
         "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:32:46\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
       ],
       "flowey_lib_common::gh_task_azure_login": [
@@ -3414,7 +3222,7 @@
         "{\"Version\":\"1.81.0\"}"
       ],
       "flowey_lib_common::use_gh_cli": [
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3477,19 +3285,11 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -3501,13 +3301,10 @@
         "{\"Version\":\"1.81.0\"}"
       ],
       "flowey_lib_common::use_gh_cli": [
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -28,11 +28,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -309,11 +304,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -602,11 +592,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -1095,11 +1080,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -1588,11 +1568,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -2251,11 +2226,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -2645,11 +2615,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -3084,11 +3049,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -4622,11 +4582,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -4805,11 +4760,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5155,11 +5105,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5432,11 +5377,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5721,11 +5661,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6075,11 +6010,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6444,11 +6374,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6801,11 +6726,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -7178,11 +7098,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -19,7 +19,7 @@ jobs:
     name: build mdbook guide [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -301,7 +301,7 @@ jobs:
     name: build and check docs [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -2243,7 +2243,7 @@ jobs:
     name: clippy [windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -3882,7 +3882,7 @@ jobs:
     name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     permissions:
       contents: read
@@ -5713,7 +5713,7 @@ jobs:
     name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -6436,7 +6436,7 @@ jobs:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -4319,48 +4319,11 @@ jobs:
     - name: install Rust
       run: flowey e 19 flowey_lib_common::install_rust 0
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 19 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 19 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 19 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 19 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 19 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 19 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 19 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 19 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar2 }}
-        subscription-id: ${{ env.floweyvar3 }}
-        tenant-id: ${{ env.floweyvar4 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 19 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 19 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 19 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:31:28' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 19 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 0
+      run: flowey e 19 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
   job2:
     name: build and check docs [x64-linux]

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3515,7 +3515,7 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-Intel-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
     - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     permissions:
       contents: read

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -28,15 +28,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -303,15 +294,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -591,15 +573,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -1080,15 +1053,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -1567,15 +1531,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -2226,15 +2181,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -2614,15 +2560,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -3048,15 +2985,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -4582,15 +4510,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -4759,15 +4678,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -5105,15 +5015,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -5376,15 +5277,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -5660,15 +5552,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -6009,15 +5892,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -6374,15 +6248,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -6725,15 +6590,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -7097,15 +6953,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -120,16 +120,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar2 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -151,18 +151,18 @@ jobs:
       run: flowey.exe e 0 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 0 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - run: |
-        flowey.exe v 0 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 0 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -177,18 +177,18 @@ jobs:
       run: flowey.exe e 0 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -199,46 +199,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 0 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 0 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 0 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 0 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 0 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 0 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 0 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 0 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 0 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 0 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 0 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 0 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 0 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -255,13 +218,13 @@ jobs:
       run: flowey.exe e 0 flowey_lib_hvlite::_jobs::build_and_publish_guide 1
       shell: bash
     - run: |
-        flowey.exe v 0 'flowey_lib_hvlite::_jobs::build_and_publish_guide:5:flowey_lib_hvlite/src/_jobs/build_and_publish_guide.rs:52:46' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 0 'flowey_lib_hvlite::_jobs::build_and_publish_guide:5:flowey_lib_hvlite/src/_jobs/build_and_publish_guide.rs:52:46' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - id: flowey_lib_hvlite___jobs__build_and_publish_guide__2
       uses: actions/upload-pages-artifact@v1
       with:
-        path: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar1 }}
       name: Upload pages artifact
     - id: flowey_lib_hvlite___jobs__build_and_publish_guide__3
       uses: actions/deploy-pages@v3
@@ -387,16 +350,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -418,18 +381,18 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 1 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -444,18 +407,18 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -466,46 +429,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 1 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 1 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 1 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 1 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 1 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 1 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 1 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 1 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 1 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 1 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -692,18 +618,18 @@ jobs:
       run: flowey e 10 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey v 10 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - run: |
-        flowey v 10 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey v 10 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -718,18 +644,18 @@ jobs:
       run: flowey e 10 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -740,46 +666,9 @@ jobs:
     - name: installing gh
       run: flowey e 10 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 10 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 10 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 10 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 10 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 10 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 10 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 10 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 10 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 10 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 10 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 10 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 10 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -797,16 +686,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar7 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -957,18 +846,18 @@ jobs:
       run: flowey e 10 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -1154,18 +1043,18 @@ jobs:
       run: flowey e 11 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -1180,18 +1069,18 @@ jobs:
       run: flowey e 11 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -1202,46 +1091,9 @@ jobs:
     - name: installing gh
       run: flowey e 11 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 11 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 11 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 11 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 11 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 11 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 11 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 11 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 11 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 11 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 11 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 11 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 11 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -1268,16 +1120,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -1633,18 +1485,18 @@ jobs:
       run: flowey e 12 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -1659,18 +1511,18 @@ jobs:
       run: flowey e 12 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -1681,46 +1533,9 @@ jobs:
     - name: installing gh
       run: flowey e 12 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 12 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 12 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 12 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 12 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 12 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 12 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 12 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 12 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 12 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 12 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 12 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 12 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -1747,16 +1562,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -2280,16 +2095,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -2311,18 +2126,18 @@ jobs:
       run: flowey.exe e 13 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey.exe v 13 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2337,18 +2152,18 @@ jobs:
       run: flowey.exe e 13 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2359,46 +2174,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 13 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 13 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 13 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 13 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 13 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 13 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 13 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 13 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 13 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 13 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 13 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 13 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -2460,18 +2238,18 @@ jobs:
       run: flowey.exe e 13 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2526,15 +2304,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar11 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar11'
+      name: 🌼 Write to 'floweyvar8'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-unit-tests
-        path: ${{ env.floweyvar11 }}
+        path: ${{ env.floweyvar8 }}
       name: 'publish JUnit test results: x64-windows-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -2665,18 +2443,18 @@ jobs:
       run: flowey e 14 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey v 14 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - run: |
-        flowey v 14 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey v 14 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2691,18 +2469,18 @@ jobs:
       run: flowey e 14 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2713,46 +2491,9 @@ jobs:
     - name: installing gh
       run: flowey e 14 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 14 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 14 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 14 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 14 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 14 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 14 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 14 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 14 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 14 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 14 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 14 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 14 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -2773,16 +2514,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -2879,18 +2620,18 @@ jobs:
       run: flowey e 14 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2951,15 +2692,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 14 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar11 --is-raw-string
+        flowey v 14 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar11'
+      name: 🌼 Write to 'floweyvar8'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-unit-tests
-        path: ${{ env.floweyvar11 }}
+        path: ${{ env.floweyvar8 }}
       name: 'publish JUnit test results: x64-linux-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -3085,16 +2826,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -3122,18 +2863,18 @@ jobs:
       run: flowey e 15 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey v 15 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - run: |
-        flowey v 15 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey v 15 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -3148,18 +2889,18 @@ jobs:
       run: flowey e 15 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -3170,46 +2911,9 @@ jobs:
     - name: installing gh
       run: flowey e 15 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 15 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 15 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 15 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 15 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 15 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 15 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 15 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 15 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 15 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 15 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 15 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 15 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -3304,18 +3008,18 @@ jobs:
       run: flowey e 15 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -3376,15 +3080,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 15 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar11 --is-raw-string
+        flowey v 15 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar11'
+      name: 🌼 Write to 'floweyvar8'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-musl-unit-tests
-        path: ${{ env.floweyvar11 }}
+        path: ${{ env.floweyvar8 }}
       name: 'publish JUnit test results: x64-linux-musl-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -3559,46 +3263,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 16 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 16 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar3 }}
-        subscription-id: ${{ env.floweyvar4 }}
-        tenant-id: ${{ env.floweyvar5 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 16 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 16 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 16 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -3696,6 +3363,40 @@ jobs:
     - name: calculating required VMM tests disk images
       run: flowey.exe e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
       shell: bash
+    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
+      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
+    - run: ${{ secrets.OPENVMM_TENANT_ID }}
+      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
+    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
+      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
+    - name: Create OpenIDConnect Credentials
+      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
+      shell: bash
+    - name: Read Azure Login Credentials
+      run: flowey.exe e 16 flowey_lib_common::gh_task_azure_login 0
+      shell: bash
+    - run: |
+        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar3'
+    - run: |
+        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar4'
+    - run: |
+        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar5'
+    - id: flowey_lib_common__gh_task_azure_login__1
+      uses: Azure/login@v2
+      with:
+        client-id: ${{ env.floweyvar3 }}
+        subscription-id: ${{ env.floweyvar4 }}
+        tenant-id: ${{ env.floweyvar5 }}
+      name: Azure Login
     - name: downloading VMM test disk images
       run: flowey.exe e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
       shell: bash
@@ -3926,46 +3627,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 17 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 17 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar3 }}
-        subscription-id: ${{ env.floweyvar4 }}
-        tenant-id: ${{ env.floweyvar5 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 17 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 17 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 17 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -4063,6 +3727,40 @@ jobs:
     - name: calculating required VMM tests disk images
       run: flowey.exe e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
       shell: bash
+    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
+      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
+    - run: ${{ secrets.OPENVMM_TENANT_ID }}
+      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
+    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
+      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
+    - name: Create OpenIDConnect Credentials
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
+      shell: bash
+    - name: Read Azure Login Credentials
+      run: flowey.exe e 17 flowey_lib_common::gh_task_azure_login 0
+      shell: bash
+    - run: |
+        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar3'
+    - run: |
+        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar4'
+    - run: |
+        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar5'
+    - id: flowey_lib_common__gh_task_azure_login__1
+      uses: Azure/login@v2
+      with:
+        client-id: ${{ env.floweyvar3 }}
+        subscription-id: ${{ env.floweyvar4 }}
+        tenant-id: ${{ env.floweyvar5 }}
+      name: Azure Login
     - name: downloading VMM test disk images
       run: flowey.exe e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
       shell: bash
@@ -4294,46 +3992,9 @@ jobs:
     - name: installing gh
       run: flowey e 18 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 18 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 18 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 18 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 18 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey v 18 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar3 }}
-        subscription-id: ${{ env.floweyvar4 }}
-        tenant-id: ${{ env.floweyvar5 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 18 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 18 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 18 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -4428,6 +4089,40 @@ jobs:
     - name: calculating required VMM tests disk images
       run: flowey e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
       shell: bash
+    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
+      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
+    - run: ${{ secrets.OPENVMM_TENANT_ID }}
+      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
+    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
+      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
+    - name: Create OpenIDConnect Credentials
+      run: flowey e 18 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
+      shell: bash
+    - name: Read Azure Login Credentials
+      run: flowey e 18 flowey_lib_common::gh_task_azure_login 0
+      shell: bash
+    - run: |
+        flowey v 18 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar3'
+    - run: |
+        flowey v 18 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar4'
+    - run: |
+        flowey v 18 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar5'
+    - id: flowey_lib_common__gh_task_azure_login__1
+      uses: Azure/login@v2
+      with:
+        client-id: ${{ env.floweyvar3 }}
+        subscription-id: ${{ env.floweyvar4 }}
+        tenant-id: ${{ env.floweyvar5 }}
+      name: Azure Login
     - name: downloading VMM test disk images
       run: flowey e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
       shell: bash
@@ -4771,16 +4466,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -4802,18 +4497,18 @@ jobs:
       run: flowey e 2 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 2 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey v 2 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 2 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -4828,18 +4523,18 @@ jobs:
       run: flowey e 2 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -4850,46 +4545,9 @@ jobs:
     - name: installing gh
       run: flowey e 2 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 2 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 2 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 2 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 2 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 2 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 2 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 2 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 2 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 2 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 2 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 2 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 2 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -5145,18 +4803,18 @@ jobs:
       run: flowey.exe e 3 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 3 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5171,18 +4829,18 @@ jobs:
       run: flowey.exe e 3 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5193,46 +4851,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 3 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 3 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 3 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 3 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 3 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 3 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 3 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 3 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 3 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar2 }}
-        subscription-id: ${{ env.floweyvar3 }}
-        tenant-id: ${{ env.floweyvar4 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 3 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 3 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 3 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 3 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -5408,18 +5029,18 @@ jobs:
       run: flowey e 4 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 4 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5434,18 +5055,18 @@ jobs:
       run: flowey e 4 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5456,46 +5077,9 @@ jobs:
     - name: installing gh
       run: flowey e 4 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 4 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 4 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 4 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 4 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 4 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 4 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 4 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 4 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar2 }}
-        subscription-id: ${{ env.floweyvar3 }}
-        tenant-id: ${{ env.floweyvar4 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 4 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 4 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 4 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 4 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -5660,16 +5244,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -5691,18 +5275,18 @@ jobs:
       run: flowey.exe e 5 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5717,18 +5301,18 @@ jobs:
       run: flowey.exe e 5 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5739,46 +5323,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 5 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 5 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 5 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 5 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 5 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 5 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 5 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 5 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 5 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 5 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 5 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 5 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 5 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -5997,18 +5544,18 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey.exe v 6 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6023,18 +5570,18 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6045,46 +5592,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 6 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 6 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 6 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 6 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 6 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 6 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 6 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 6 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 6 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 6 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -6102,16 +5612,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -6172,18 +5682,18 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6355,16 +5865,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -6386,18 +5896,18 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6412,18 +5922,18 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6434,46 +5944,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 7 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 7 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 7 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 7 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 7 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 7 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 7 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 7 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 7 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 7 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -6695,18 +6168,18 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey.exe v 8 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6721,18 +6194,18 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6743,46 +6216,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 8 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 8 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 8 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 8 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 8 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 8 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 8 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 8 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 8 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 8 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -6800,16 +6236,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -6870,18 +6306,18 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -7070,18 +6506,18 @@ jobs:
       run: flowey e 9 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -7096,18 +6532,18 @@ jobs:
       run: flowey e 9 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -7118,46 +6554,9 @@ jobs:
     - name: installing gh
       run: flowey e 9 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 9 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 9 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 9 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 9 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 9 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 9 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 9 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 9 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 9 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 9 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 9 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 9 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -7175,16 +6574,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -594,7 +594,7 @@ jobs:
     name: build artifacts [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -1087,7 +1087,7 @@ jobs:
     name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -1580,7 +1580,7 @@ jobs:
     name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -2637,7 +2637,7 @@ jobs:
     name: clippy [linux, macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -3076,7 +3076,7 @@ jobs:
     name: clippy [linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -4249,7 +4249,7 @@ jobs:
     name: run vmm-tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -4614,7 +4614,7 @@ jobs:
     name: test flowey local backend
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -4797,7 +4797,7 @@ jobs:
     name: build and check docs [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -5424,7 +5424,7 @@ jobs:
     name: xtask fmt (linux)
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -7170,7 +7170,7 @@ jobs:
     name: build artifacts [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr.json
+++ b/.github/workflows/openvmm-pr.json
@@ -3196,20 +3196,12 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:32:46\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -3217,7 +3209,7 @@
       ],
       "flowey_lib_common::install_rust": [
         "{\"AutoInstall\":true}",
-        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:1:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:31:32\",\"is_secret\":false}}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:1:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:30:32\",\"is_secret\":false}}",
         "{\"IgnoreVersion\":false}",
         "{\"Version\":\"1.81.0\"}"
       ],
@@ -3226,9 +3218,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -3255,7 +3244,7 @@
         "{\"Version\":\"24.0.1\"}"
       ],
       "flowey_lib_hvlite::git_checkout_openvmm_repo": [
-        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:0:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:30:31\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:0:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:29:31\",\"is_secret\":false}}",
         "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
       ],
       "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [

--- a/.github/workflows/openvmm-pr.json
+++ b/.github/workflows/openvmm-pr.json
@@ -37,13 +37,6 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -53,7 +46,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -66,16 +58,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guide": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"deploy_github_pages\":false,\"done\":{\"backing_var\":\"start1\",\"is_secret\":false}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -149,13 +138,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -166,7 +148,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -185,16 +166,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"target_triple\":\"x86_64-pc-windows-msvc\"}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -286,13 +264,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -303,7 +274,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -322,16 +292,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"target_triple\":\"x86_64-unknown-linux-gnu\"}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -419,13 +386,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -435,7 +395,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -454,13 +413,10 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -546,13 +502,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -563,7 +512,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -582,13 +530,10 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -683,13 +628,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -701,7 +639,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -726,7 +663,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start8\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
@@ -742,9 +679,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -861,13 +795,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -879,7 +806,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -907,7 +833,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start12\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}"
@@ -920,9 +846,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -1033,13 +956,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -1052,7 +968,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -1077,7 +992,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start15\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
@@ -1093,9 +1008,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -1213,13 +1125,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -1231,7 +1136,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -1259,7 +1163,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start19\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
@@ -1272,9 +1176,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -1387,13 +1288,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -1417,7 +1311,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -1446,7 +1339,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
         "{\"arch\":\"Aarch64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start25\",\"is_secret\":false},\"profile\":\"Debug\"}"
@@ -1468,9 +1361,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -1617,13 +1507,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -1643,7 +1526,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -1679,7 +1561,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
         "{\"arch\":\"X86_64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start31\",\"is_secret\":false},\"profile\":\"Debug\"}"
@@ -1704,9 +1586,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -1857,13 +1736,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -1885,7 +1757,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -1910,7 +1781,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
         "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start33\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"Aarch64\"},{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"Aarch64Devkern\"}]}"
@@ -1920,9 +1791,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -2075,13 +1943,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -2103,7 +1964,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -2128,7 +1988,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
         "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start35\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64Devkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64TestLinuxDirect\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64TestLinuxDirectDevkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64Cvm\"}]}"
@@ -2138,9 +1998,6 @@
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -2325,13 +2182,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -2342,7 +2192,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -2384,16 +2233,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start39\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-windows-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -2513,13 +2359,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -2536,7 +2375,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -2583,16 +2421,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start43\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -2726,13 +2561,6 @@
         "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:23:30\",\"is_secret\":false}}",
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:47:24\",\"is_secret\":false}}}",
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
@@ -2748,7 +2576,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -2802,16 +2629,13 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start46\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-musl-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"
@@ -2938,12 +2762,8 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
       "flowey_lib_common::gh_task_azure_login": [
         "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}",
         "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:4:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:387:21\",\"is_secret\":false}}"
       ],
       "flowey_lib_common::git_checkout": [
@@ -2957,7 +2777,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -2976,7 +2795,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3093,12 +2912,8 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
       "flowey_lib_common::gh_task_azure_login": [
         "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}",
         "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:4:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:387:21\",\"is_secret\":false}}"
       ],
       "flowey_lib_common::git_checkout": [
@@ -3112,7 +2927,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -3131,7 +2945,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3248,12 +3062,8 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
       "flowey_lib_common::gh_task_azure_login": [
         "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}",
         "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:4:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:387:21\",\"is_secret\":false}}"
       ],
       "flowey_lib_common::git_checkout": [
@@ -3267,7 +3077,6 @@
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -3286,7 +3095,7 @@
       ],
       "flowey_lib_common::use_gh_cli": [
         "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:160:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3388,7 +3197,6 @@
         "{\"Version\":\"27.1\"}"
       ],
       "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}",
         "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:32:46\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
       ],
       "flowey_lib_common::gh_task_azure_login": [
@@ -3414,7 +3222,7 @@
         "{\"Version\":\"1.81.0\"}"
       ],
       "flowey_lib_common::use_gh_cli": [
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3477,19 +3285,11 @@
       "flowey_lib_common::download_protoc": [
         "{\"Version\":\"27.1\"}"
       ],
-      "flowey_lib_common::gh_download_azure_key_vault_secret": [
-        "{\"key_vault_name\":\"HvLite-PATs\",\"resolved_secret\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\",\"is_secret\":true},\"secret\":\"GitHub-CLI-PAT\"}"
-      ],
-      "flowey_lib_common::gh_task_azure_login": [
-        "{\"Credentials\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_gh_azure_login:3:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:39:60\"},\"is_secret\":true}}",
-        "{\"EnsureLogIn\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:0:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:47:33\",\"is_secret\":false}}"
-      ],
       "flowey_lib_common::git_checkout": [
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
-        "{\"GetAzureCli\":{\"backing_var\":\"flowey_lib_common::gh_download_azure_key_vault_secret:1:flowey_lib_common/src/gh_download_azure_key_vault_secret.rs:48:30\",\"is_secret\":false}}",
         "{\"Version\":\"2.56.0\"}"
       ],
       "flowey_lib_common::install_nodejs": [
@@ -3501,13 +3301,10 @@
         "{\"Version\":\"1.81.0\"}"
       ],
       "flowey_lib_common::use_gh_cli": [
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:54\"},\"is_secret\":true}}}"
+        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36\"},\"is_secret\":false}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_hvlite::_jobs::cfg_gh_azure_login": [
-        "{\"client_id\":{\"gh_var\":\"secrets.OPENVMM_CLIENT_ID\",\"is_secret\":true},\"subscription_id\":{\"gh_var\":\"secrets.OPENVMM_SUBSCRIPTION_ID\",\"is_secret\":true},\"tenant_id\":{\"gh_var\":\"secrets.OPENVMM_TENANT_ID\",\"is_secret\":true}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
         "{\"hvlite_repo_source\":\"GithubSelf\"}"

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -22,7 +22,7 @@ jobs:
     name: build mdbook guide [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -289,7 +289,7 @@ jobs:
     name: build and check docs [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -2231,7 +2231,7 @@ jobs:
     name: clippy [windows], unit tests [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -3870,7 +3870,7 @@ jobs:
     name: run vmm-tests [x64-windows-amd]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     permissions:
       contents: read
@@ -5701,7 +5701,7 @@ jobs:
     name: build artifacts (not for VMM tests) [aarch64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -6424,7 +6424,7 @@ jobs:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3503,7 +3503,7 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Win-Pool-Intel-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
     - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -582,7 +582,7 @@ jobs:
     name: build artifacts [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -1075,7 +1075,7 @@ jobs:
     name: build openhcl [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -1568,7 +1568,7 @@ jobs:
     name: build openhcl [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -2625,7 +2625,7 @@ jobs:
     name: clippy [linux, macos], unit tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -3064,7 +3064,7 @@ jobs:
     name: clippy [linux-musl, misc nostd], unit tests [x64-linux-musl]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -4237,7 +4237,7 @@ jobs:
     name: run vmm-tests [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -4602,7 +4602,7 @@ jobs:
     name: test flowey local backend
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -4785,7 +4785,7 @@ jobs:
     name: build and check docs [x64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -5412,7 +5412,7 @@ jobs:
     name: xtask fmt (linux)
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write
@@ -7158,7 +7158,7 @@ jobs:
     name: build artifacts [aarch64-linux]
     runs-on:
     - self-hosted
-    - 1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3
+    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -4307,48 +4307,11 @@ jobs:
     - name: install Rust
       run: flowey e 19 flowey_lib_common::install_rust 0
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 19 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 19 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 19 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 19 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 19 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 19 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 19 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 19 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar2 }}
-        subscription-id: ${{ env.floweyvar3 }}
-        tenant-id: ${{ env.floweyvar4 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 19 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 19 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 19 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:31:28' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 19 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 0
+      run: flowey e 19 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
   job2:
     name: build and check docs [x64-linux]

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -31,15 +31,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -291,15 +282,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -579,15 +561,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -1068,15 +1041,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -1555,15 +1519,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -2214,15 +2169,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -2602,15 +2548,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -3036,15 +2973,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -4570,15 +4498,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -4747,15 +4666,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -5093,15 +5003,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -5364,15 +5265,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -5648,15 +5540,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -5997,15 +5880,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -6362,15 +6236,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-      shell: bash
     - run: |
         set -x
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -6713,15 +6578,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x
@@ -7085,15 +6941,6 @@ jobs:
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
-      shell: bash
-    - name: Pull Azure Key Vault secrets
-      run: |
-        VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$VPackAccessToken"
-        echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-        MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-        echo "::add-mask::$MsAzurePull"
-        echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
       shell: bash
     - run: |
         set -x

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -31,11 +31,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -297,11 +292,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -590,11 +580,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -1083,11 +1068,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -1576,11 +1556,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -2239,11 +2214,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -2633,11 +2603,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -3072,11 +3037,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -4610,11 +4570,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -4793,11 +4748,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5143,11 +5093,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5420,11 +5365,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5709,11 +5649,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6063,11 +5998,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6432,11 +6362,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6789,11 +6714,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -7166,11 +7086,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -123,16 +123,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -154,18 +154,18 @@ jobs:
       run: flowey.exe e 0 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 0 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey.exe v 0 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 0 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -180,18 +180,18 @@ jobs:
       run: flowey.exe e 0 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -202,46 +202,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 0 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 0 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 0 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 0 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 0 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 0 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 0 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 0 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 0 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 0 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 0 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 0 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 0 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -375,16 +338,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -406,18 +369,18 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 1 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -432,18 +395,18 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -454,46 +417,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 1 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 1 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 1 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 1 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 1 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 1 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 1 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 1 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 1 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 1 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -680,18 +606,18 @@ jobs:
       run: flowey e 10 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey v 10 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - run: |
-        flowey v 10 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar8 }}
-        path: ${{ env.floweyvar9 }}
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey v 10 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -706,18 +632,18 @@ jobs:
       run: flowey e 10 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -728,46 +654,9 @@ jobs:
     - name: installing gh
       run: flowey e 10 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 10 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 10 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 10 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 10 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 10 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 10 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 10 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 10 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 10 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 10 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 10 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 10 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -785,16 +674,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar10 }}
+        persist-credentials: ${{ env.floweyvar7 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -945,18 +834,18 @@ jobs:
       run: flowey e 10 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -1142,18 +1031,18 @@ jobs:
       run: flowey e 11 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -1168,18 +1057,18 @@ jobs:
       run: flowey e 11 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -1190,46 +1079,9 @@ jobs:
     - name: installing gh
       run: flowey e 11 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 11 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 11 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 11 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 11 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 11 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 11 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 11 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 11 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 11 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 11 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 11 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 11 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -1256,16 +1108,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -1621,18 +1473,18 @@ jobs:
       run: flowey e 12 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -1647,18 +1499,18 @@ jobs:
       run: flowey e 12 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -1669,46 +1521,9 @@ jobs:
     - name: installing gh
       run: flowey e 12 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 12 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 12 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 12 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 12 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 12 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 12 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 12 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 12 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 12 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 12 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 12 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 12 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -1735,16 +1550,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -2268,16 +2083,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -2299,18 +2114,18 @@ jobs:
       run: flowey.exe e 13 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey.exe v 13 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2325,18 +2140,18 @@ jobs:
       run: flowey.exe e 13 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2347,46 +2162,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 13 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 13 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 13 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 13 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 13 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 13 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 13 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 13 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 13 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 13 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 13 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 13 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 13 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -2448,18 +2226,18 @@ jobs:
       run: flowey.exe e 13 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2514,15 +2292,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar11 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar11'
+      name: 🌼 Write to 'floweyvar8'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-unit-tests
-        path: ${{ env.floweyvar11 }}
+        path: ${{ env.floweyvar8 }}
       name: 'publish JUnit test results: x64-windows-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -2653,18 +2431,18 @@ jobs:
       run: flowey e 14 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey v 14 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - run: |
-        flowey v 14 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey v 14 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2679,18 +2457,18 @@ jobs:
       run: flowey e 14 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2701,46 +2479,9 @@ jobs:
     - name: installing gh
       run: flowey e 14 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 14 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 14 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 14 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 14 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 14 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 14 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 14 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 14 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 14 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 14 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 14 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 14 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -2761,16 +2502,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -2867,18 +2608,18 @@ jobs:
       run: flowey e 14 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -2939,15 +2680,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 14 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar11 --is-raw-string
+        flowey v 14 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar11'
+      name: 🌼 Write to 'floweyvar8'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-unit-tests
-        path: ${{ env.floweyvar11 }}
+        path: ${{ env.floweyvar8 }}
       name: 'publish JUnit test results: x64-linux-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -3073,16 +2814,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -3110,18 +2851,18 @@ jobs:
       run: flowey e 15 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey v 15 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - run: |
-        flowey v 15 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey v 15 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -3136,18 +2877,18 @@ jobs:
       run: flowey e 15 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -3158,46 +2899,9 @@ jobs:
     - name: installing gh
       run: flowey e 15 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 15 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 15 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 15 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 15 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 15 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 15 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 15 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 15 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 15 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 15 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 15 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 15 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -3292,18 +2996,18 @@ jobs:
       run: flowey e 15 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -3364,15 +3068,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 15 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar11 --is-raw-string
+        flowey v 15 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:104:42' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar11'
+      name: 🌼 Write to 'floweyvar8'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-musl-unit-tests
-        path: ${{ env.floweyvar11 }}
+        path: ${{ env.floweyvar8 }}
       name: 'publish JUnit test results: x64-linux-musl-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -3547,46 +3251,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 16 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 16 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar3 }}
-        subscription-id: ${{ env.floweyvar4 }}
-        tenant-id: ${{ env.floweyvar5 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 16 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 16 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 16 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -3684,6 +3351,40 @@ jobs:
     - name: calculating required VMM tests disk images
       run: flowey.exe e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
       shell: bash
+    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
+      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
+    - run: ${{ secrets.OPENVMM_TENANT_ID }}
+      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
+    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
+      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
+    - name: Create OpenIDConnect Credentials
+      run: flowey.exe e 16 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
+      shell: bash
+    - name: Read Azure Login Credentials
+      run: flowey.exe e 16 flowey_lib_common::gh_task_azure_login 0
+      shell: bash
+    - run: |
+        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar3'
+    - run: |
+        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar4'
+    - run: |
+        flowey.exe v 16 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar5'
+    - id: flowey_lib_common__gh_task_azure_login__1
+      uses: Azure/login@v2
+      with:
+        client-id: ${{ env.floweyvar3 }}
+        subscription-id: ${{ env.floweyvar4 }}
+        tenant-id: ${{ env.floweyvar5 }}
+      name: Azure Login
     - name: downloading VMM test disk images
       run: flowey.exe e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
       shell: bash
@@ -3914,46 +3615,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 17 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 17 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar3 }}
-        subscription-id: ${{ env.floweyvar4 }}
-        tenant-id: ${{ env.floweyvar5 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 17 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 17 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 17 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -4051,6 +3715,40 @@ jobs:
     - name: calculating required VMM tests disk images
       run: flowey.exe e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
       shell: bash
+    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
+      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
+    - run: ${{ secrets.OPENVMM_TENANT_ID }}
+      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
+    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
+      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
+    - name: Create OpenIDConnect Credentials
+      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
+      shell: bash
+    - name: Read Azure Login Credentials
+      run: flowey.exe e 17 flowey_lib_common::gh_task_azure_login 0
+      shell: bash
+    - run: |
+        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar3'
+    - run: |
+        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar4'
+    - run: |
+        flowey.exe v 17 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar5'
+    - id: flowey_lib_common__gh_task_azure_login__1
+      uses: Azure/login@v2
+      with:
+        client-id: ${{ env.floweyvar3 }}
+        subscription-id: ${{ env.floweyvar4 }}
+        tenant-id: ${{ env.floweyvar5 }}
+      name: Azure Login
     - name: downloading VMM test disk images
       run: flowey.exe e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
       shell: bash
@@ -4282,46 +3980,9 @@ jobs:
     - name: installing gh
       run: flowey e 18 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 18 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 18 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 18 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 18 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey v 18 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar3 }}
-        subscription-id: ${{ env.floweyvar4 }}
-        tenant-id: ${{ env.floweyvar5 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 18 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 18 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 18 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -4416,6 +4077,40 @@ jobs:
     - name: calculating required VMM tests disk images
       run: flowey e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
       shell: bash
+    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
+      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
+    - run: ${{ secrets.OPENVMM_TENANT_ID }}
+      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
+    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
+      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
+    - name: Create OpenIDConnect Credentials
+      run: flowey e 18 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
+      shell: bash
+    - name: Read Azure Login Credentials
+      run: flowey e 18 flowey_lib_common::gh_task_azure_login 0
+      shell: bash
+    - run: |
+        flowey v 18 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar3'
+    - run: |
+        flowey v 18 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar4'
+    - run: |
+        flowey v 18 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar5 --is-raw-string
+      shell: bash
+      name: 🌼 Write to 'floweyvar5'
+    - id: flowey_lib_common__gh_task_azure_login__1
+      uses: Azure/login@v2
+      with:
+        client-id: ${{ env.floweyvar3 }}
+        subscription-id: ${{ env.floweyvar4 }}
+        tenant-id: ${{ env.floweyvar5 }}
+      name: Azure Login
     - name: downloading VMM test disk images
       run: flowey e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
       shell: bash
@@ -4759,16 +4454,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -4790,18 +4485,18 @@ jobs:
       run: flowey e 2 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 2 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey v 2 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 2 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -4816,18 +4511,18 @@ jobs:
       run: flowey e 2 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -4838,46 +4533,9 @@ jobs:
     - name: installing gh
       run: flowey e 2 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 2 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 2 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 2 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 2 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 2 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 2 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 2 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 2 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 2 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 2 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 2 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 2 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -5133,18 +4791,18 @@ jobs:
       run: flowey.exe e 3 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 3 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5159,18 +4817,18 @@ jobs:
       run: flowey.exe e 3 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5181,46 +4839,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 3 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 3 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 3 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 3 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 3 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 3 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 3 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 3 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 3 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar2 }}
-        subscription-id: ${{ env.floweyvar3 }}
-        tenant-id: ${{ env.floweyvar4 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 3 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 3 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 3 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 3 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -5396,18 +5017,18 @@ jobs:
       run: flowey e 4 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 4 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5422,18 +5043,18 @@ jobs:
       run: flowey e 4 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5444,46 +5065,9 @@ jobs:
     - name: installing gh
       run: flowey e 4 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 4 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 4 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 4 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 4 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 4 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 4 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 4 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 4 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar2 }}
-        subscription-id: ${{ env.floweyvar3 }}
-        tenant-id: ${{ env.floweyvar4 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 4 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 4 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 4 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 4 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -5648,16 +5232,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -5679,18 +5263,18 @@ jobs:
       run: flowey.exe e 5 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5705,18 +5289,18 @@ jobs:
       run: flowey.exe e 5 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -5727,46 +5311,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 5 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 5 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 5 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 5 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 5 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 5 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 5 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 5 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 5 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 5 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 5 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 5 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 5 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -5985,18 +5532,18 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey.exe v 6 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6011,18 +5558,18 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6033,46 +5580,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 6 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 6 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 6 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 6 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 6 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 6 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 6 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 6 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 6 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 6 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -6090,16 +5600,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -6160,18 +5670,18 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6343,16 +5853,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -6374,18 +5884,18 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6400,18 +5910,18 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6422,46 +5932,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 7 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 7 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 7 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 7 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 7 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 7 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 7 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 7 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 7 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 7 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -6683,18 +6156,18 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::cache 8
       shell: bash
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar9'
+      name: 🌼 Write to 'floweyvar6'
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
+      name: 🌼 Write to 'floweyvar7'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
+        key: ${{ env.floweyvar6 }}
+        path: ${{ env.floweyvar7 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey.exe v 8 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6709,18 +6182,18 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar7 }}
-        path: ${{ env.floweyvar8 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -6731,46 +6204,9 @@ jobs:
     - name: installing gh
       run: flowey.exe e 8 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey.exe v 8 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey.exe v 8 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey.exe v 8 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey.exe e 8 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey.exe e 8 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey.exe e 8 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey.exe e 8 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey.exe v 8 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey.exe e 8 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -6788,16 +6224,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar4 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -6858,18 +6294,18 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -7058,18 +6494,18 @@ jobs:
       run: flowey e 9 flowey_lib_common::cache 4
       shell: bash
     - run: |
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
+      name: 🌼 Write to 'floweyvar3'
     - run: |
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
+        key: ${{ env.floweyvar3 }}
+        path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -7084,18 +6520,18 @@ jobs:
       run: flowey e 9 flowey_lib_common::cache 0
       shell: bash
     - run: |
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
+      name: 🌼 Write to 'floweyvar1'
     - run: |
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
+        key: ${{ env.floweyvar1 }}
+        path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-cli'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-file {0} --is-raw-string
@@ -7106,46 +6542,9 @@ jobs:
     - name: installing gh
       run: flowey e 9 flowey_lib_common::download_gh_cli 1
       shell: bash
-    - run: ${{ secrets.OPENVMM_CLIENT_ID }}
-      shell: flowey v 9 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:0:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:36:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_CLIENT_ID'
-    - run: ${{ secrets.OPENVMM_TENANT_ID }}
-      shell: flowey v 9 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:1:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:37:29' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_TENANT_ID'
-    - run: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
-      shell: flowey v 9 'flowey_lib_hvlite::_jobs::cfg_gh_azure_login:2:flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs:38:35' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'secrets.OPENVMM_SUBSCRIPTION_ID'
-    - name: Create OpenIDConnect Credentials
-      run: flowey e 9 flowey_lib_hvlite::_jobs::cfg_gh_azure_login 3
-      shell: bash
-    - name: Read Azure Login Credentials
-      run: flowey e 9 flowey_lib_common::gh_task_azure_login 0
-      shell: bash
-    - run: |
-        flowey v 9 'flowey_lib_common::gh_task_azure_login:0:flowey_lib_common/src/gh_task_azure_login.rs:53:48' --is-secret --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
-        flowey v 9 'flowey_lib_common::gh_task_azure_login:2:flowey_lib_common/src/gh_task_azure_login.rs:55:60' --is-secret --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
-        flowey v 9 'flowey_lib_common::gh_task_azure_login:1:flowey_lib_common/src/gh_task_azure_login.rs:54:48' --is-secret --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2
-      with:
-        client-id: ${{ env.floweyvar1 }}
-        subscription-id: ${{ env.floweyvar2 }}
-        tenant-id: ${{ env.floweyvar3 }}
-      name: Azure Login
-    - name: installing azure-cli
-      run: flowey e 9 flowey_lib_common::install_azure_cli 0
-      shell: bash
-    - name: Downloading secrets from key vault HvLite-PATs
-      run: flowey e 9 flowey_lib_common::gh_download_azure_key_vault_secret 0
-      shell: bash
+    - run: ${{ github.token }}
+      shell: flowey v 9 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:94:36' --update-from-file {0} --is-raw-string
+      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 9 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -7163,16 +6562,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:468:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar8 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -1773,6 +1773,9 @@ pub mod steps {
 
             /// `github.workspace`
             pub const GITHUB__WORKSPACE: GhContextVar = GhContextVar::new("github.workspace");
+
+            /// `github.token`
+            pub const GITHUB__TOKEN: GhContextVar = GhContextVar::new("github.token");
         }
 
         impl GhContextVar {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -123,11 +123,6 @@ impl IntoPipeline for CheckinGatesCli {
                         hvlite_repo_source: openvmm_repo_source.clone(),
                     },
                 )
-                .dep_on(|_| flowey_lib_hvlite::_jobs::cfg_gh_azure_login::Params {
-                    client_id: client_id.clone(),
-                    tenant_id: tenant_id.clone(),
-                    subscription_id: subscription_id.clone(),
-                })
                 .gh_grant_permissions::<flowey_lib_common::git_checkout::Node>([(
                     GhPermission::Contents,
                     GhPermissionValue::Read,
@@ -902,6 +897,11 @@ impl IntoPipeline for CheckinGatesCli {
                         fail_job_on_test_fail: true,
                         done: ctx.new_done_handle(),
                     }
+                })
+                .dep_on(|_| flowey_lib_hvlite::_jobs::cfg_gh_azure_login::Params {
+                    client_id: client_id.clone(),
+                    tenant_id: tenant_id.clone(),
+                    subscription_id: subscription_id.clone(),
                 });
 
             if let Some(pub_vmm_tests_junit_xml) = pub_vmm_tests_junit_xml {
@@ -941,6 +941,11 @@ impl IntoPipeline for CheckinGatesCli {
                         done: ctx.new_done_handle(),
                     },
                 )
+                .dep_on(|_| flowey_lib_hvlite::_jobs::cfg_gh_azure_login::Params {
+                    client_id: client_id.clone(),
+                    tenant_id: tenant_id.clone(),
+                    subscription_id: subscription_id.clone(),
+                })
                 .finish();
             all_jobs.push(job);
         }

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -105,11 +105,7 @@ impl IntoPipeline for CheckinGatesCli {
 
         if let RepoSource::GithubSelf = &openvmm_repo_source {
             pipeline.gh_set_flowey_bootstrap_template(
-                crate::pipelines_shared::gh_flowey_bootstrap_template::get_template(
-                    &client_id,
-                    &tenant_id,
-                    &subscription_id,
-                ),
+                crate::pipelines_shared::gh_flowey_bootstrap_template::get_template(),
             );
         }
 

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -941,11 +941,6 @@ impl IntoPipeline for CheckinGatesCli {
                         done: ctx.new_done_handle(),
                     },
                 )
-                .dep_on(|_| flowey_lib_hvlite::_jobs::cfg_gh_azure_login::Params {
-                    client_id: client_id.clone(),
-                    tenant_id: tenant_id.clone(),
-                    subscription_id: subscription_id.clone(),
-                })
                 .finish();
             all_jobs.push(job);
         }

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.rs
@@ -2,34 +2,14 @@
 
 //! See [`get_template`]
 
-use flowey::node::prelude::GhContextVar;
-
 /// Get our internal flowey bootstrap template.
 ///
 /// See [`Pipeline::gh_set_flowey_bootstrap_template`]
 ///
 /// [`Pipeline::gh_set_flowey_bootstrap_template`]:
 ///     flowey::pipeline::prelude::Pipeline::gh_set_flowey_bootstrap_template
-pub fn get_template(
-    client_id: &GhContextVar,
-    tenant_id: &GhContextVar,
-    subscription_id: &GhContextVar,
-) -> String {
+pub fn get_template() -> String {
     // to be clear: these replaces are totally custom to this particular
     // bootstrap template. flowey knows nothing of these replacements.
-    let template = include_str!("gh_flowey_bootstrap_template.yml").to_string();
-
-    template
-        .replace(
-            "{{OPENVMM_CLIENT_ID}}",
-            &format!("${{{{ {} }}}}", client_id.as_raw_var_name()),
-        )
-        .replace(
-            "{{OPENVMM_TENANT_ID}}",
-            &format!("${{{{ {} }}}}", tenant_id.as_raw_var_name()),
-        )
-        .replace(
-            "{{OPENVMM_SUBSCRIPTION_ID}}",
-            &format!("${{{{ {} }}}}", subscription_id.as_raw_var_name()),
-        )
+    include_str!("gh_flowey_bootstrap_template.yml").to_string()
 }

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
@@ -1,13 +1,3 @@
-- name: Pull Azure Key Vault secrets
-  run: |
-    VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
-    echo "::add-mask::$VPackAccessToken"
-    echo "VPackAccessToken=$VPackAccessToken" >> $GITHUB_ENV
-    MsAzurePull=$(az keyvault secret show --name "MsAzurePull" --vault-name "HvLite-PATs" --query value --output tsv)
-    echo "::add-mask::$MsAzurePull"
-    echo "MsAzurePull=$MsAzurePull" >> $GITHUB_ENV
-  shell: bash
-
 - run: |
     set -x
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
@@ -1,13 +1,3 @@
-- uses: Azure/login@v2
-  with:
-    # These secrets describe the HvLite-GitHub service principal and associated Azure subscription,
-    # which, along with the GITHUB_TOKEN, are used to authenticate GitHub Actions to Azure with OpenID Connect.
-    # The service principal has federated identity credentials configured describing which branches and
-    # scenarios can be authenticated.
-    client-id: {{OPENVMM_CLIENT_ID}}
-    tenant-id: {{OPENVMM_TENANT_ID}}
-    subscription-id: {{OPENVMM_SUBSCRIPTION_ID}}
-
 - name: Pull Azure Key Vault secrets
   run: |
     VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -25,7 +25,7 @@ pub fn default_gh_hosted(platform: FlowPlatform) -> GhRunner {
 pub fn windows_amd_self_hosted() -> GhRunner {
     GhRunner::SelfHosted(vec![
         "self-hosted".to_string(),
-        "1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3".to_string(),
+        "1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3".to_string(),
     ])
 }
 
@@ -43,7 +43,7 @@ pub fn windows_intel_self_hosted() -> GhRunner {
 pub fn windows_amd_self_hosted_largedisk() -> GhRunner {
     GhRunner::SelfHosted(vec![
         "self-hosted".to_string(),
-        "1ES.Pool=HvLite-GitHub-Win-Pool-WestUS3".to_string(),
+        "1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3".to_string(),
         "1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB".to_string(),
     ])
 }

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -32,7 +32,7 @@ pub fn windows_amd_self_hosted() -> GhRunner {
 pub fn windows_intel_self_hosted() -> GhRunner {
     GhRunner::SelfHosted(vec![
         "self-hosted".to_string(),
-        "1ES.Pool=HvLite-GitHub-Win-Pool-Intel-WestUS3".to_string(),
+        "1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3".to_string(),
         "1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB".to_string(),
     ])
 }
@@ -54,7 +54,7 @@ pub fn windows_amd_self_hosted_largedisk() -> GhRunner {
 pub fn windows_intel_self_hosted_largedisk() -> GhRunner {
     GhRunner::SelfHosted(vec![
         "self-hosted".to_string(),
-        "1ES.Pool=HvLite-GitHub-Win-Pool-Intel-WestUS3".to_string(),
+        "1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3".to_string(),
         "1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB".to_string(),
     ])
 }

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -62,7 +62,7 @@ pub fn windows_intel_self_hosted_largedisk() -> GhRunner {
 pub fn linux_self_hosted() -> GhRunner {
     GhRunner::SelfHosted(vec![
         "self-hosted".to_string(),
-        "1ES.Pool=HvLite-GitHub-Linux-Pool-WestUS3".to_string(),
+        "1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3".to_string(),
     ])
 }
 

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_common.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_common.rs
@@ -91,14 +91,7 @@ impl SimpleFlowNode for Node {
             ));
 
             {
-                let (gh_token, write_gh_token) = ctx.new_secret_var();
-                ctx.req(
-                    flowey_lib_common::gh_download_azure_key_vault_secret::GetSecret {
-                        key_vault_name: "HvLite-PATs".to_string(),
-                        secret: "GitHub-CLI-PAT".into(),
-                        resolved_secret: write_gh_token,
-                    },
-                );
+                let gh_token = ctx.get_gh_context_var(GhContextVar::GITHUB__TOKEN);
 
                 ctx.req(flowey_lib_common::use_gh_cli::Request::WithAuth(
                     flowey_lib_common::use_gh_cli::GhCliAuth::AuthToken(gh_token),

--- a/flowey/flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs
@@ -21,7 +21,6 @@ impl SimpleFlowNode for Node {
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<crate::git_checkout_openvmm_repo::Node>();
         ctx.import::<flowey_lib_common::install_rust::Node>();
-        ctx.import::<flowey_lib_common::gh_download_azure_key_vault_secret::Node>();
     }
 
     fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
@@ -29,14 +28,7 @@ impl SimpleFlowNode for Node {
 
         let hvlite_repo = ctx.reqv(crate::git_checkout_openvmm_repo::req::GetRepoDir);
         let rust_install = ctx.reqv(flowey_lib_common::install_rust::Request::EnsureInstalled);
-        let (gh_token, write_gh_token) = ctx.new_secret_var();
-        ctx.req(
-            flowey_lib_common::gh_download_azure_key_vault_secret::GetSecret {
-                key_vault_name: "HvLite-PATs".to_string(),
-                secret: "GitHub-CLI-PAT".into(),
-                resolved_secret: write_gh_token,
-            },
-        );
+        let gh_token = ctx.get_gh_context_var(GhContextVar::GITHUB__TOKEN);
 
         let test_local = ctx.emit_rust_step(
             "test cargo xflowey build-igvm x64 --install-missing-deps",


### PR DESCRIPTION
This has been a lot of fun to figure out...

When we marked the repo as public the 1ES hosted pools that we were previously using lost their linkage to this repository. This meant that PR tasks were not being picked up. The fix for this was to re-create new pools that are scoped to our repo.

The other issue this change resolves is removing the Azure Login task from stages that do not need it. There are still some tasks that do need access to the key vault (to download test VHD's) but this will get the CI in a much better state.