### PR TITLE
Remove Azure/login@v2 from the flowey bootstrap template

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -28,11 +28,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -309,11 +304,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -602,11 +592,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -1095,11 +1080,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -1588,11 +1568,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -2251,11 +2226,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -2645,11 +2615,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -3084,11 +3049,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -4622,11 +4582,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -4805,11 +4760,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5155,11 +5105,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5432,11 +5377,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5721,11 +5661,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6075,11 +6010,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6444,11 +6374,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6801,11 +6726,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -7178,11 +7098,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -31,11 +31,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -297,11 +292,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -590,11 +580,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -1083,11 +1068,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -1576,11 +1556,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -2239,11 +2214,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -2633,11 +2603,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -3072,11 +3037,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -4610,11 +4570,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -4793,11 +4748,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5143,11 +5093,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5420,11 +5365,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -5709,11 +5649,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6063,11 +5998,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6432,11 +6362,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -6789,11 +6714,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)
@@ -7166,11 +7086,6 @@ jobs:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
       shell: bash
-    - uses: Azure/login@v2
-      with:
-        client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
-        tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
-        subscription-id: ${{ secrets.OPENVMM_SUBSCRIPTION_ID }}
     - name: Pull Azure Key Vault secrets
       run: |
         VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -105,11 +105,7 @@ impl IntoPipeline for CheckinGatesCli {
 
         if let RepoSource::GithubSelf = &openvmm_repo_source {
             pipeline.gh_set_flowey_bootstrap_template(
-                crate::pipelines_shared::gh_flowey_bootstrap_template::get_template(
-                    &client_id,
-                    &tenant_id,
-                    &subscription_id,
-                ),
+                crate::pipelines_shared::gh_flowey_bootstrap_template::get_template(),
             );
         }
 

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.rs
@@ -2,34 +2,14 @@
 
 //! See [`get_template`]
 
-use flowey::node::prelude::GhContextVar;
-
 /// Get our internal flowey bootstrap template.
 ///
 /// See [`Pipeline::gh_set_flowey_bootstrap_template`]
 ///
 /// [`Pipeline::gh_set_flowey_bootstrap_template`]:
 ///     flowey::pipeline::prelude::Pipeline::gh_set_flowey_bootstrap_template
-pub fn get_template(
-    client_id: &GhContextVar,
-    tenant_id: &GhContextVar,
-    subscription_id: &GhContextVar,
-) -> String {
+pub fn get_template() -> String {
     // to be clear: these replaces are totally custom to this particular
     // bootstrap template. flowey knows nothing of these replacements.
-    let template = include_str!("gh_flowey_bootstrap_template.yml").to_string();
-
-    template
-        .replace(
-            "{{OPENVMM_CLIENT_ID}}",
-            &format!("${{{{ {} }}}}", client_id.as_raw_var_name()),
-        )
-        .replace(
-            "{{OPENVMM_TENANT_ID}}",
-            &format!("${{{{ {} }}}}", tenant_id.as_raw_var_name()),
-        )
-        .replace(
-            "{{OPENVMM_SUBSCRIPTION_ID}}",
-            &format!("${{{{ {} }}}}", subscription_id.as_raw_var_name()),
-        )
+    include_str!("gh_flowey_bootstrap_template.yml").to_string()
 }

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
@@ -1,13 +1,3 @@
-- uses: Azure/login@v2
-  with:
-    # These secrets describe the HvLite-GitHub service principal and associated Azure subscription,
-    # which, along with the GITHUB_TOKEN, are used to authenticate GitHub Actions to Azure with OpenID Connect.
-    # The service principal has federated identity credentials configured describing which branches and
-    # scenarios can be authenticated.
-    client-id: {{OPENVMM_CLIENT_ID}}
-    tenant-id: {{OPENVMM_TENANT_ID}}
-    subscription-id: {{OPENVMM_SUBSCRIPTION_ID}}
-
 - name: Pull Azure Key Vault secrets
   run: |
     VPackAccessToken=$(az keyvault secret show --name "VPackAccessToken" --vault-name "HvLite-PATs" --query value --output tsv)


### PR DESCRIPTION
This change removes the Azure/login@v2 action from the flowey bootstrap template which is no longer needed. This won't fully solve all of the current CI issues, but it should get us a lot further.