### PR TITLE
Fix last_vtl usage to apply only to intercept handling, and populate it for ARM 64

### DIFF
--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -6,6 +6,7 @@
 use super::private::BackingPrivate;
 use super::BackingState;
 use super::Error;
+use super::GuestVtl;
 use super::HclVp;
 use super::NoRunner;
 use super::ProcessorRunner;
@@ -17,7 +18,6 @@ use hvdef::HvRegisterValue;
 use hvdef::HvX64RegisterName;
 use hvdef::HvX64RegisterPage;
 use hvdef::HypercallCode;
-use hvdef::Vtl;
 use hvdef::HV_PARTITION_ID_SELF;
 use hvdef::HV_VP_INDEX_SELF;
 use sidecar_client::SidecarVp;
@@ -66,7 +66,7 @@ impl ProcessorRunner<'_, MshvX64> {
     }
 
     /// Returns the last VTL according to the register page.
-    pub fn reg_page_vtl(&self) -> Option<Vtl> {
+    pub fn reg_page_vtl(&self) -> Option<GuestVtl> {
         self.reg_page()
             .map(|reg_page| reg_page.vtl.try_into().unwrap())
     }

--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -77,6 +77,8 @@ impl ProcessorRunner<'_, MshvX64> {
 
     /// Returns the last VTL according to the register page.
     pub fn reg_page_vtl(&self) -> Result<GuestVtl, RegisterPageVtlError> {
+        // Note: if available, the register page is only valid if VTL 2 is
+        // handling an intercept.
         let vtl = self
             .reg_page()
             .ok_or(RegisterPageVtlError::NoRegisterPage)?

--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -68,7 +68,7 @@ impl ProcessorRunner<'_, MshvX64> {
     /// Returns the last VTL according to the register page.
     pub fn reg_page_vtl(&self) -> Option<GuestVtl> {
         self.reg_page()
-            .map(|reg_page| reg_page.vtl.try_into().unwrap())
+            .and_then(|reg_page| reg_page.vtl.try_into().ok())
     }
 
     /// Returns a reference to the current VTL's CPU context.

--- a/openhcl/hcl/src/lib.rs
+++ b/openhcl/hcl/src/lib.rs
@@ -55,7 +55,7 @@ impl From<GuestVtl> for Vtl {
 /// The specified VTL is not supported in the current context.
 #[derive(Debug, Error)]
 #[error("unsupported guest VTL")]
-pub struct UnsupportedGuestVtl;
+pub struct UnsupportedGuestVtl(pub u8);
 
 impl TryFrom<Vtl> for GuestVtl {
     type Error = UnsupportedGuestVtl;
@@ -64,7 +64,7 @@ impl TryFrom<Vtl> for GuestVtl {
         Ok(match value {
             Vtl::Vtl0 => GuestVtl::Vtl0,
             Vtl::Vtl1 => GuestVtl::Vtl1,
-            _ => return Err(UnsupportedGuestVtl),
+            _ => return Err(UnsupportedGuestVtl(value.into())),
         })
     }
 }
@@ -76,7 +76,7 @@ impl TryFrom<u8> for GuestVtl {
         Ok(match value {
             0 => GuestVtl::Vtl0,
             1 => GuestVtl::Vtl1,
-            _ => return Err(UnsupportedGuestVtl),
+            _ => return Err(UnsupportedGuestVtl(value)),
         })
     }
 }

--- a/openhcl/hcl/src/lib.rs
+++ b/openhcl/hcl/src/lib.rs
@@ -68,3 +68,15 @@ impl TryFrom<Vtl> for GuestVtl {
         })
     }
 }
+
+impl TryFrom<u8> for GuestVtl {
+    type Error = UnsupportedGuestVtl;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => GuestVtl::Vtl0,
+            1 => GuestVtl::Vtl1,
+            _ => return Err(UnsupportedGuestVtl),
+        })
+    }
+}

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -139,7 +139,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             //
             // TODO GUEST_VSM: last_vtl currently always returns 0 (which is wrong),
             // so for any VP outside of the BSP, this will fail
-            if self.vp.last_vtl() < GuestVtl::Vtl1 {
+            if self.vp.intercepted_vtl() < GuestVtl::Vtl1 {
                 if vtl1_state_inner.enabled_on_vp_count > 0 || vp_index != current_vp_index {
                     return Err(HvError::AccessDenied);
                 }
@@ -230,7 +230,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         }
 
         let vtl = self
-            .target_vtl_no_higher(vtl.unwrap_or_else(|| self.vp.last_vtl().into()))
+            .target_vtl_no_higher(vtl.unwrap_or_else(|| self.vp.intercepted_vtl().into()))
             .map_err(|e| (e, 0))?;
 
         for (i, (&name, output)) in zip(registers, output).enumerate() {
@@ -395,7 +395,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::SetVpRegisters
         }
 
         let target_vtl = vtl
-            .map_or_else(|| Ok(self.vp.last_vtl()), |vtl| vtl.try_into())
+            .map_or_else(|| Ok(self.vp.intercepted_vtl()), |vtl| vtl.try_into())
             .map_err(|_| (HvError::InvalidParameter, 0))?;
 
         for (i, reg) in registers.iter().enumerate() {

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -139,7 +139,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             //
             // TODO GUEST_VSM: last_vtl currently always returns 0 (which is wrong),
             // so for any VP outside of the BSP, this will fail
-            if self.vp.intercepted_vtl() < GuestVtl::Vtl1 {
+            if self.intercepted_vtl < GuestVtl::Vtl1 {
                 if vtl1_state_inner.enabled_on_vp_count > 0 || vp_index != current_vp_index {
                     return Err(HvError::AccessDenied);
                 }
@@ -230,7 +230,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         }
 
         let vtl = self
-            .target_vtl_no_higher(vtl.unwrap_or_else(|| self.vp.intercepted_vtl().into()))
+            .target_vtl_no_higher(vtl.unwrap_or_else(|| self.intercepted_vtl.into()))
             .map_err(|e| (e, 0))?;
 
         for (i, (&name, output)) in zip(registers, output).enumerate() {
@@ -395,7 +395,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::SetVpRegisters
         }
 
         let target_vtl = vtl
-            .map_or_else(|| Ok(self.vp.intercepted_vtl()), |vtl| vtl.try_into())
+            .map_or_else(|| Ok(self.intercepted_vtl), |vtl| vtl.try_into())
             .map_err(|_| (HvError::InvalidParameter, 0))?;
 
         for (i, reg) in registers.iter().enumerate() {
@@ -493,6 +493,17 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         guest_vsm_inner.deny_lower_vtl_startup = value.deny_lower_vtl_startup();
 
         Ok(())
+    }
+
+    // TODO CVM: change this to intercepted vtl by creating an intercepted_vtl
+    // that's available outside of guest vsm state, and split out the "next vtl"
+    // that's used in VTL 2 exit handling.
+    /// The lower VTL that was running before the VTL 2 entry. During a vtl switch,
+    /// this reflects the vtl that should be exited to.
+    pub fn last_vtl(&self) -> Vtl {
+        self.cvm_guest_vsm
+            .as_ref()
+            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl)
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -494,17 +494,6 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
         Ok(())
     }
-
-    // TODO CVM: change this to intercepted vtl by creating an intercepted_vtl
-    // that's available outside of guest vsm state, and split out the "next vtl"
-    // that's used in VTL 2 exit handling.
-    /// The lower VTL that was running before the VTL 2 entry. During a vtl switch,
-    /// this reflects the vtl that should be exited to.
-    pub fn last_vtl(&self) -> Vtl {
-        self.cvm_guest_vsm
-            .as_ref()
-            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl)
-    }
 }
 
 pub(crate) struct XsetbvExitInput {

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -403,6 +403,9 @@ pub enum UhRunVpError {
     HypercallRetry(#[source] guestmem::GuestMemoryError),
     #[error("unexpected debug exception with dr6 value {0:#x}")]
     UnexpectedDebugException(u64),
+    /// Handling an intercept on behalf of an invalid Lower VTL
+    #[error("invalid intercepted vtl")]
+    InvalidInterceptedVtl,
 }
 
 /// Underhill processor run error

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -404,8 +404,8 @@ pub enum UhRunVpError {
     #[error("unexpected debug exception with dr6 value {0:#x}")]
     UnexpectedDebugException(u64),
     /// Handling an intercept on behalf of an invalid Lower VTL
-    #[error("invalid intercepted vtl")]
-    InvalidInterceptedVtl,
+    #[error("invalid intercepted vtl {0:?}")]
+    InvalidInterceptedVtl(Option<u8>),
 }
 
 /// Underhill processor run error

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -493,7 +493,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn handle_debug_exception(&mut self, vtl: Vtl) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_debug_exception(&mut self, vtl: GuestVtl) -> Result<(), VpHaltReason<UhRunVpError>> {
         // FUTURE: Underhill does not yet support VTL1 so this is only tested with VTL0.
         if vtl == GuestVtl::Vtl0 {
             let debug_regs: virt::x86::vp::DebugRegisters = self
@@ -926,7 +926,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn write_msr(&mut self, msr: u32, value: u64, vtl: Vtl) -> Result<(), MsrError> {
+    fn write_msr(&mut self, msr: u32, value: u64, vtl: GuestVtl) -> Result<(), MsrError> {
         if msr & 0xf0000000 == 0x40000000 {
             if let Some(hv) = self.hv_mut(vtl) {
                 let r = hv.msr_write(msr, value);
@@ -962,7 +962,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn read_msr(&mut self, msr: u32, vtl: Vtl) -> Result<u64, MsrError> {
+    fn read_msr(&mut self, msr: u32, vtl: GuestVtl) -> Result<u64, MsrError> {
         if msr & 0xf0000000 == 0x40000000 {
             if let Some(hv) = &mut self.hv(vtl) {
                 let r = hv.msr_read(msr);
@@ -990,7 +990,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         &mut self,
         devices: &D,
         interruption_pending: bool,
-        vtl: Vtl,
+        vtl: GuestVtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>>
     where
         for<'b> UhEmulationState<'b, 'a, D, T>:
@@ -1016,7 +1016,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         &mut self,
         devices: &D,
         intercept_state: &aarch64emu::InterceptState,
-        vtl: Vtl,
+        vtl: GuestVtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>>
     where
         for<'b> UhEmulationState<'b, 'a, D, T>:
@@ -1137,7 +1137,7 @@ struct UhEmulationState<'a, 'b, T: CpuIo, U: Backing> {
     vp: &'a mut UhProcessor<'b, U>,
     interruption_pending: bool,
     devices: &'a T,
-    vtl: Vtl,
+    vtl: GuestVtl,
 }
 
 struct UhHypercallHandler<'a, 'b, T, B: Backing> {
@@ -1152,7 +1152,7 @@ struct UhHypercallHandler<'a, 'b, T, B: Backing> {
     /// This should always be false if hardware isolation is not in use, as the distinction does
     /// not exist in that case.
     trusted: bool,
-    intercepted_vtl: Vtl,
+    intercepted_vtl: GuestVtl,
 }
 
 impl<T, B: Backing> UhHypercallHandler<'_, '_, T, B> {

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -35,7 +35,6 @@ use crate::BackingShared;
 use crate::GuestVsmState;
 use crate::GuestVtl;
 use crate::WakeReason;
-use guestmem::GuestMemory;
 use hcl::ioctl;
 use hcl::ioctl::ProcessorRunner;
 use hv1_emulator::hv::ProcessorVtlHv;
@@ -225,11 +224,6 @@ mod private {
         ///
         /// This is used for hypervisor-managed and untrusted SINTs.
         fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16);
-
-        /// The VTL that was running when the VP exited into VTL2, with the
-        /// exception of a successful vtl switch, where it will return the VTL
-        /// that will run on VTL 2 exit.
-        fn intercepted_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl;
 
         /// Copies shared registers (per VSM TLFS spec) from the last VTL to
         /// the target VTL that will become active.
@@ -929,22 +923,22 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn write_msr(&mut self, msr: u32, value: u64) -> Result<(), MsrError> {
-        let last_vtl = self.intercepted_vtl();
+    fn write_msr(&mut self, msr: u32, value: u64, vtl: Vtl) -> Result<(), MsrError> {
         if msr & 0xf0000000 == 0x40000000 {
-            if let Some(hv) = self.hv_mut(last_vtl) {
+            if let Some(hv) = self.hv_mut(vtl) {
                 let r = hv.msr_write(msr, value);
                 if !matches!(r, Err(MsrError::Unknown)) {
                     return r;
                 }
             }
         }
+
         match msr {
             hvdef::HV_X64_MSR_GUEST_CRASH_CTL => {
                 self.crash_control = hvdef::GuestCrashCtl::from(value);
                 let crash = VtlCrash {
                     vp_index: self.vp_index(),
-                    last_vtl,
+                    last_vtl: vtl,
                     control: self.crash_control,
                     parameters: self.crash_reg,
                 };
@@ -965,10 +959,9 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn read_msr(&mut self, msr: u32) -> Result<u64, MsrError> {
-        let last_vtl = self.intercepted_vtl();
+    fn read_msr(&mut self, msr: u32, vtl: Vtl) -> Result<u64, MsrError> {
         if msr & 0xf0000000 == 0x40000000 {
-            if let Some(hv) = &mut self.hv(last_vtl) {
+            if let Some(hv) = &mut self.hv(vtl) {
                 let r = hv.msr_read(msr);
                 if !matches!(r, Err(MsrError::Unknown)) {
                     return r;
@@ -994,17 +987,19 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         &mut self,
         devices: &D,
         interruption_pending: bool,
+        vtl: Vtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>>
     where
         for<'b> UhEmulationState<'b, 'a, D, T>:
             virt_support_x86emu::emulate::EmulatorSupport<Error = UhRunVpError>,
     {
-        let guest_memory = self.intercepted_vtl_gm();
+        let guest_memory = &self.partition.gm[vtl];
         virt_support_x86emu::emulate::emulate(
             &mut UhEmulationState {
                 vp: &mut *self,
                 interruption_pending,
                 devices,
+                vtl,
             },
             guest_memory,
             devices,
@@ -1018,17 +1013,19 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         &mut self,
         devices: &D,
         intercept_state: &aarch64emu::InterceptState,
+        vtl: Vtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>>
     where
         for<'b> UhEmulationState<'b, 'a, D, T>:
             virt_support_aarch64emu::emulate::EmulatorSupport<Error = UhRunVpError>,
     {
-        let guest_memory = self.intercepted_vtl_gm();
+        let guest_memory = &self.partition.gm[vtl];
         virt_support_aarch64emu::emulate::emulate(
             &mut UhEmulationState {
                 vp: &mut *self,
                 interruption_pending: intercept_state.interruption_pending,
                 devices,
+                vtl,
             },
             intercept_state,
             guest_memory,
@@ -1042,15 +1039,6 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
             *self.partition.guest_vsm.read(),
             GuestVsmState::NotPlatformSupported
         )
-    }
-
-    fn intercepted_vtl(&self) -> GuestVtl {
-        T::intercepted_vtl(self)
-    }
-
-    /// Returns the guest memory object that should be used based on the last vtl
-    fn intercepted_vtl_gm(&self) -> &'a GuestMemory {
-        &self.partition.gm[self.intercepted_vtl()]
     }
 
     fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv> {
@@ -1146,6 +1134,7 @@ struct UhEmulationState<'a, 'b, T: CpuIo, U: Backing> {
     vp: &'a mut UhProcessor<'b, U>,
     interruption_pending: bool,
     devices: &'a T,
+    vtl: Vtl,
 }
 
 struct UhHypercallHandler<'a, 'b, T, B: Backing> {
@@ -1160,11 +1149,12 @@ struct UhHypercallHandler<'a, 'b, T, B: Backing> {
     /// This should always be false if hardware isolation is not in use, as the distinction does
     /// not exist in that case.
     trusted: bool,
+    intercepted_vtl: Vtl,
 }
 
 impl<T, B: Backing> UhHypercallHandler<'_, '_, T, B> {
     fn target_vtl_no_higher(&self, target_vtl: Vtl) -> Result<GuestVtl, HvError> {
-        if Vtl::from(self.vp.intercepted_vtl()) < target_vtl {
+        if Vtl::from(self.intercepted_vtl) < target_vtl {
             return Err(HvError::AccessDenied);
         }
         Ok(target_vtl.try_into().unwrap())
@@ -1296,7 +1286,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::PostMessage for UhHypercallHandler<'_,
         );
 
         self.bus.post_synic_message(
-            self.vp.intercepted_vtl().into(),
+            self.intercepted_vtl.into(),
             connection_id,
             self.trusted,
             message,
@@ -1309,7 +1299,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::SignalEvent for UhHypercallHandler<'_,
         tracing::trace!(connection_id, "handling signal event intercept");
 
         self.bus
-            .signal_synic_event(self.vp.intercepted_vtl().into(), connection_id, flag)
+            .signal_synic_event(self.intercepted_vtl.into(), connection_id, flag)
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -229,7 +229,7 @@ mod private {
         /// The VTL that was running when the VP exited into VTL2, with the
         /// exception of a successful vtl switch, where it will return the VTL
         /// that will run on VTL 2 exit.
-        fn last_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl;
+        fn intercepted_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl;
 
         /// Copies shared registers (per VSM TLFS spec) from the last VTL to
         /// the target VTL that will become active.
@@ -930,7 +930,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
 
     #[cfg(guest_arch = "x86_64")]
     fn write_msr(&mut self, msr: u32, value: u64) -> Result<(), MsrError> {
-        let last_vtl = self.last_vtl();
+        let last_vtl = self.intercepted_vtl();
         if msr & 0xf0000000 == 0x40000000 {
             if let Some(hv) = self.hv_mut(last_vtl) {
                 let r = hv.msr_write(msr, value);
@@ -966,7 +966,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
 
     #[cfg(guest_arch = "x86_64")]
     fn read_msr(&mut self, msr: u32) -> Result<u64, MsrError> {
-        let last_vtl = self.last_vtl();
+        let last_vtl = self.intercepted_vtl();
         if msr & 0xf0000000 == 0x40000000 {
             if let Some(hv) = &mut self.hv(last_vtl) {
                 let r = hv.msr_read(msr);
@@ -999,7 +999,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         for<'b> UhEmulationState<'b, 'a, D, T>:
             virt_support_x86emu::emulate::EmulatorSupport<Error = UhRunVpError>,
     {
-        let guest_memory = self.last_vtl_gm();
+        let guest_memory = self.intercepted_vtl_gm();
         virt_support_x86emu::emulate::emulate(
             &mut UhEmulationState {
                 vp: &mut *self,
@@ -1023,7 +1023,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         for<'b> UhEmulationState<'b, 'a, D, T>:
             virt_support_aarch64emu::emulate::EmulatorSupport<Error = UhRunVpError>,
     {
-        let guest_memory = self.last_vtl_gm();
+        let guest_memory = self.intercepted_vtl_gm();
         virt_support_aarch64emu::emulate::emulate(
             &mut UhEmulationState {
                 vp: &mut *self,
@@ -1044,13 +1044,13 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         )
     }
 
-    fn last_vtl(&self) -> GuestVtl {
-        T::last_vtl(self)
+    fn intercepted_vtl(&self) -> GuestVtl {
+        T::intercepted_vtl(self)
     }
 
     /// Returns the guest memory object that should be used based on the last vtl
-    fn last_vtl_gm(&self) -> &'a GuestMemory {
-        &self.partition.gm[self.last_vtl()]
+    fn intercepted_vtl_gm(&self) -> &'a GuestMemory {
+        &self.partition.gm[self.intercepted_vtl()]
     }
 
     fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv> {
@@ -1164,7 +1164,7 @@ struct UhHypercallHandler<'a, 'b, T, B: Backing> {
 
 impl<T, B: Backing> UhHypercallHandler<'_, '_, T, B> {
     fn target_vtl_no_higher(&self, target_vtl: Vtl) -> Result<GuestVtl, HvError> {
-        if Vtl::from(self.vp.last_vtl()) < target_vtl {
+        if Vtl::from(self.vp.intercepted_vtl()) < target_vtl {
             return Err(HvError::AccessDenied);
         }
         Ok(target_vtl.try_into().unwrap())
@@ -1296,7 +1296,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::PostMessage for UhHypercallHandler<'_,
         );
 
         self.bus.post_synic_message(
-            self.vp.last_vtl().into(),
+            self.vp.intercepted_vtl().into(),
             connection_id,
             self.trusted,
             message,
@@ -1309,7 +1309,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::SignalEvent for UhHypercallHandler<'_,
         tracing::trace!(connection_id, "handling signal event intercept");
 
         self.bus
-            .signal_synic_event(self.vp.last_vtl().into(), connection_id, flag)
+            .signal_synic_event(self.vp.intercepted_vtl().into(), connection_id, flag)
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -493,9 +493,9 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn handle_debug_exception(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_debug_exception(&mut self, vtl: Vtl) -> Result<(), VpHaltReason<UhRunVpError>> {
         // FUTURE: Underhill does not yet support VTL1 so this is only tested with VTL0.
-        if self.last_vtl() == GuestVtl::Vtl0 {
+        if vtl == GuestVtl::Vtl0 {
             let debug_regs: virt::x86::vp::DebugRegisters = self
                 .access_state(Vtl::Vtl0)
                 .debug_regs()
@@ -526,7 +526,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
             return Err(VpHaltReason::HwBreak(bp));
         }
 
-        panic!("unexpected debug exception in VTL {:?}", self.last_vtl());
+        panic!("unexpected debug exception in VTL {:?}", vtl);
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -268,7 +268,7 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
 
         let intercepted_vtl =
             Self::intercepted_vtl(&message.header).map_err(|UnsupportedGuestVtl(vtl)| {
-                VpHaltReason::InvalidVmState(UhRunVpError::InvalidInterceptedVtl(Some(vtl)))
+                VpHaltReason::InvalidVmState(UhRunVpError::InvalidInterceptedVtl(vtl))
             })?;
         let guest_memory = &self.partition.gm[intercepted_vtl];
         let smccc_convention = message.immediate == 0;
@@ -308,7 +308,7 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
 
         let intercepted_vtl =
             Self::intercepted_vtl(&message.header).map_err(|UnsupportedGuestVtl(vtl)| {
-                VpHaltReason::InvalidVmState(UhRunVpError::InvalidInterceptedVtl(Some(vtl)))
+                VpHaltReason::InvalidVmState(UhRunVpError::InvalidInterceptedVtl(vtl))
             })?;
         self.emulate(dev, &intercept_state, intercepted_vtl).await?;
         Ok(())

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -226,7 +226,7 @@ impl BackingPrivate for HypervisorBackedArm64 {
 }
 
 impl UhProcessor<'_, HypervisorBackedArm64> {
-    fn intercepted_vtl(message_header: &hvdef::HvArm64InterceptMessageHeader) -> Option<Vtl> {
+    fn intercepted_vtl(message_header: &hvdef::HvArm64InterceptMessageHeader) -> Option<GuestVtl> {
         message_header.execution_state.vtl().try_into().ok()
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -651,10 +651,9 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBacked>
             u128::from_ne_bytes(event_info.as_bytes().try_into().unwrap()),
         )];
 
-        let last_vtl = self.vtl;
         self.vp
             .runner
-            .set_vp_registers_hvcall(last_vtl.into(), regs)
+            .set_vp_registers_hvcall(self.vtl.into(), regs)
             .expect("set_vp_registers hypercall for setting pending event should not fail");
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -318,10 +318,8 @@ impl BackingPrivate for HypervisorBackedX86 {
     }
 
     // If there's no register page, assume only VTL0 is supported.
-    fn last_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl {
-        this.runner
-            .reg_page_vtl()
-            .map_or(GuestVtl::Vtl0, |vtl| vtl.try_into().unwrap())
+    fn intercepted_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl {
+        this.runner.reg_page_vtl().unwrap_or(GuestVtl::Vtl0)
     }
 
     fn switch_vtl_state(_this: &mut UhProcessor<'_, Self>, _target_vtl: GuestVtl) {
@@ -467,7 +465,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         let is_64bit =
             message.header.execution_state.cr0_pe() && message.header.execution_state.efer_lma();
 
-        let guest_memory = self.last_vtl_gm();
+        let guest_memory = self.intercepted_vtl_gm();
         let handler = UhHypercallHandler {
             vp: self,
             bus,
@@ -619,7 +617,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
             hvdef::HvX64MsrInterceptMessage::ref_from_prefix(self.runner.exit_message().payload())
                 .unwrap();
         let rip = next_rip(&message.header);
-        let last_vtl = self.last_vtl();
+        let last_vtl = self.intercepted_vtl();
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "msr");
 
@@ -717,12 +715,12 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
     fn handle_unrecoverable_exception(&self) -> Result<(), VpHaltReason<UhRunVpError>> {
         Err(VpHaltReason::TripleFault {
-            vtl: self.last_vtl().into(),
+            vtl: self.intercepted_vtl().into(),
         })
     }
 
     fn handle_halt(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let last_vtl = self.last_vtl();
+        let last_vtl = self.intercepted_vtl();
         self.backing.lapics.as_mut().unwrap()[last_vtl].halt();
         Ok(())
     }
@@ -1010,11 +1008,11 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
         // Note: the restriction to VTL 1 support also means that for WHP, which doesn't support VTL 1
         // the HvCheckSparseGpaPageVtlAccess hypercall--which is unimplemented in whp--will never be made.
         if mode == virt_support_x86emu::emulate::TranslateMode::Execute
-            && self.vp.last_vtl() == GuestVtl::Vtl0
+            && self.vp.intercepted_vtl() == GuestVtl::Vtl0
             && self.vp.vtl1_supported()
         {
             // Should always be called after translate gva with the tlb lock flag
-            debug_assert!(self.vp.is_tlb_locked(Vtl::Vtl2, self.vp.last_vtl()));
+            debug_assert!(self.vp.is_tlb_locked(Vtl::Vtl2, self.vp.intercepted_vtl()));
 
             let mbec_user_execute = self
                 .vp
@@ -1065,7 +1063,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
             }
         };
 
-        let target_vtl = self.vp.last_vtl();
+        let target_vtl = self.vp.intercepted_vtl();
 
         // The translation will be used, so set the appropriate page table bits
         // (the access/dirty bit).
@@ -1119,7 +1117,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
             ),
         ];
 
-        let last_vtl = self.vp.last_vtl();
+        let last_vtl = self.vp.intercepted_vtl();
 
         self.vp
             .runner
@@ -1152,7 +1150,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
     }
 
     fn lapic_base_address(&self) -> Option<u64> {
-        let last_vtl = self.vp.last_vtl();
+        let last_vtl = self.vp.intercepted_vtl();
         self.vp
             .backing
             .lapics
@@ -1161,7 +1159,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
     }
 
     fn lapic_read(&mut self, address: u64, data: &mut [u8]) {
-        let last_vtl = self.vp.last_vtl();
+        let last_vtl = self.vp.intercepted_vtl();
         self.vp.backing.lapics.as_mut().unwrap()[last_vtl].mmio_read(
             self.vp.partition,
             &mut self.vp.runner,
@@ -1173,7 +1171,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
     }
 
     fn lapic_write(&mut self, address: u64, data: &[u8]) {
-        let last_vtl = self.vp.last_vtl();
+        let last_vtl = self.vp.intercepted_vtl();
         self.vp.backing.lapics.as_mut().unwrap()[last_vtl].mmio_write(
             self.vp.partition,
             &mut self.vp.runner,
@@ -1547,7 +1545,7 @@ impl<T> hv1_hypercall::SetVpRegisters for UhHypercallHandler<'_, '_, T, Hypervis
         }
 
         let target_vtl = self
-            .target_vtl_no_higher(vtl.unwrap_or(self.vp.last_vtl().into()))
+            .target_vtl_no_higher(vtl.unwrap_or(self.vp.intercepted_vtl().into()))
             .map_err(|e| (e, 0))?;
 
         for (i, reg) in registers.iter().enumerate() {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -223,55 +223,63 @@ impl BackingPrivate for HypervisorBackedX86 {
                         UhRunVpError::InvalidInterceptedVtl,
                     ))?;
 
-            let stat = match this.runner.exit_message().header.typ {
+            let message_type = this.runner.exit_message().header.typ;
+
+            let mut intercept_handler = InterceptHandler {
+                vp: this,
+                intercepted_vtl,
+            };
+
+            let stat = match message_type {
                 HvMessageType::HvMessageTypeX64IoPortIntercept => {
-                    this.handle_io_port_exit(dev, intercepted_vtl).await?;
+                    intercept_handler.handle_io_port_exit(dev).await?;
                     &mut this.backing.stats.io_port
                 }
                 HvMessageType::HvMessageTypeUnmappedGpa
                 | HvMessageType::HvMessageTypeGpaIntercept => {
-                    this.handle_mmio_exit(dev, intercepted_vtl).await?;
+                    intercept_handler.handle_mmio_exit(dev).await?;
                     &mut this.backing.stats.mmio
                 }
                 HvMessageType::HvMessageTypeUnacceptedGpa => {
-                    this.handle_unaccepted_gpa_intercept(dev, intercepted_vtl)
+                    intercept_handler
+                        .handle_unaccepted_gpa_intercept(dev)
                         .await?;
                     &mut this.backing.stats.unaccepted_gpa
                 }
                 HvMessageType::HvMessageTypeHypercallIntercept => {
-                    this.handle_hypercall_exit(dev, intercepted_vtl)?;
+                    intercept_handler.handle_hypercall_exit(dev)?;
                     &mut this.backing.stats.hypercall
                 }
                 HvMessageType::HvMessageTypeSynicSintDeliverable => {
-                    this.handle_synic_deliverable_exit();
+                    intercept_handler.handle_synic_deliverable_exit();
                     &mut this.backing.stats.synic_deliverable
                 }
                 HvMessageType::HvMessageTypeX64InterruptionDeliverable => {
-                    this.handle_interrupt_deliverable_exit(dev)?;
+                    intercept_handler.handle_interrupt_deliverable_exit(dev)?;
                     &mut this.backing.stats.interrupt_deliverable
                 }
                 HvMessageType::HvMessageTypeX64CpuidIntercept => {
-                    this.handle_cpuid_intercept()?;
+                    intercept_handler.handle_cpuid_intercept()?;
                     &mut this.backing.stats.cpuid
                 }
                 HvMessageType::HvMessageTypeMsrIntercept => {
-                    this.handle_msr_intercept(dev, intercepted_vtl)?;
+                    intercept_handler.handle_msr_intercept(dev)?;
                     &mut this.backing.stats.msr
                 }
                 HvMessageType::HvMessageTypeX64ApicEoi => {
-                    this.handle_eoi(dev)?;
+                    intercept_handler.handle_eoi(dev)?;
                     &mut this.backing.stats.eoi
                 }
                 HvMessageType::HvMessageTypeUnrecoverableException => {
-                    this.handle_unrecoverable_exception(intercepted_vtl)?;
+                    intercept_handler.handle_unrecoverable_exception()?;
                     &mut this.backing.stats.unrecoverable_exception
                 }
                 HvMessageType::HvMessageTypeX64Halt => {
-                    this.handle_halt(intercepted_vtl)?;
+                    intercept_handler.handle_halt()?;
                     &mut this.backing.stats.halt
                 }
                 HvMessageType::HvMessageTypeExceptionIntercept => {
-                    this.handle_exception(intercepted_vtl)?;
+                    intercept_handler.handle_exception()?;
                     &mut this.backing.stats.exception_intercept
                 }
                 reason => unreachable!("unknown exit reason: {:#x?}", reason),
@@ -387,21 +395,18 @@ fn next_rip(value: &HvX64InterceptMessageHeader) -> u64 {
     value.rip.wrapping_add(value.instruction_len() as u64)
 }
 
-impl UhProcessor<'_, HypervisorBackedX86> {
-    fn set_rip(&mut self, rip: u64) -> Result<(), VpHaltReason<UhRunVpError>> {
-        self.runner
-            .set_vp_register(HvX64RegisterName::Rip, rip.into())
-            .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::AdvanceRip(e)))?;
+struct InterceptHandler<'a, 'b> {
+    vp: &'a mut UhProcessor<'b, HypervisorBackedX86>,
+    intercepted_vtl: GuestVtl,
+}
 
-        Ok(())
-    }
-
+impl InterceptHandler<'_, '_> {
     fn handle_interrupt_deliverable_exit(
         &mut self,
         bus: &impl CpuIo,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64InterruptionDeliverableMessage::ref_from_prefix(
-            self.runner.exit_message().payload(),
+            self.vp.runner.exit_message().payload(),
         )
         .unwrap();
 
@@ -410,11 +415,13 @@ impl UhProcessor<'_, HypervisorBackedX86> {
             hvdef::HvX64PendingInterruptionType::HV_X64_PENDING_INTERRUPT
         );
 
-        self.backing
+        self.vp
+            .backing
             .deliverability_notifications
             .set_interrupt_notification(false);
 
-        self.backing
+        self.vp
+            .backing
             .next_deliverability_notifications
             .set_interrupt_notification(false);
 
@@ -424,7 +431,8 @@ impl UhProcessor<'_, HypervisorBackedX86> {
                 .with_event_type(hvdef::HV_X64_PENDING_EVENT_EXT_INT)
                 .with_vector(vector);
 
-            self.runner
+            self.vp
+                .runner
                 .set_vp_register(HvX64RegisterName::PendingEvent0, u128::from(event).into())
                 .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::Event(e)))?;
         }
@@ -434,7 +442,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
     fn handle_synic_deliverable_exit(&mut self) {
         let message = hvdef::HvX64SynicSintDeliverableMessage::ref_from_prefix(
-            self.runner.exit_message().payload(),
+            self.vp.runner.exit_message().payload(),
         )
         .unwrap();
 
@@ -443,24 +451,27 @@ impl UhProcessor<'_, HypervisorBackedX86> {
             "sint deliverable"
         );
 
-        self.backing.deliverability_notifications.set_sints(
-            self.backing.deliverability_notifications.sints() & !message.deliverable_sints,
+        self.vp.backing.deliverability_notifications.set_sints(
+            self.vp.backing.deliverability_notifications.sints() & !message.deliverable_sints,
         );
 
         // This is updated by `deliver_synic_messages below`, so clear it here.
-        self.backing.next_deliverability_notifications.set_sints(0);
+        self.vp
+            .backing
+            .next_deliverability_notifications
+            .set_sints(0);
 
         // These messages are always VTL0, as VTL1 does not own any VMBUS channels.
-        self.deliver_synic_messages(GuestVtl::Vtl0, message.deliverable_sints);
+        self.vp
+            .deliver_synic_messages(GuestVtl::Vtl0, message.deliverable_sints);
     }
 
     fn handle_hypercall_exit(
         &mut self,
         bus: &impl CpuIo,
-        intercepted_vtl: Vtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64HypercallInterceptMessage::ref_from_prefix(
-            self.runner.exit_message().payload(),
+            self.vp.runner.exit_message().payload(),
         )
         .unwrap();
 
@@ -469,12 +480,12 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         let is_64bit =
             message.header.execution_state.cr0_pe() && message.header.execution_state.efer_lma();
 
-        let guest_memory = &self.partition.gm[intercepted_vtl];
+        let guest_memory = &self.vp.partition.gm[self.intercepted_vtl];
         let handler = UhHypercallHandler {
-            vp: self,
+            vp: self.vp,
             bus,
             trusted: false,
-            intercepted_vtl,
+            intercepted_vtl: self.intercepted_vtl,
         };
         UhHypercallHandler::MSHV_DISPATCHER.dispatch(
             guest_memory,
@@ -487,10 +498,9 @@ impl UhProcessor<'_, HypervisorBackedX86> {
     async fn handle_mmio_exit(
         &mut self,
         dev: &impl CpuIo,
-        intercepted_vtl: Vtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(
-            self.runner.exit_message().payload(),
+            self.vp.runner.exit_message().payload(),
         )
         .unwrap();
 
@@ -500,29 +510,30 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         // Fast path for monitor page writes.
         if Some(message.guest_physical_address & !(HV_PAGE_SIZE - 1))
-            == self.partition.monitor_page.gpa()
+            == self.vp.partition.monitor_page.gpa()
             && message.header.intercept_access_type == HvInterceptAccessType::WRITE
         {
             let instruction_bytes = message.instruction_bytes;
             let instruction_bytes = &instruction_bytes[..message.instruction_byte_count as usize];
             let tlb_lock_held = message.memory_access_info.gva_gpa_valid()
                 || message.memory_access_info.tlb_locked();
-            let mut state = self.emulator_state();
+            let mut state = self.vp.emulator_state();
             if let Some(bit) = virt_support_x86emu::emulate::emulate_mnf_write_fast_path(
                 instruction_bytes,
                 &mut state,
                 interruption_pending,
                 tlb_lock_held,
             ) {
-                self.set_emulator_state(&state);
-                if let Some(connection_id) = self.partition.monitor_page.write_bit(bit) {
+                self.vp.set_emulator_state(&state);
+                if let Some(connection_id) = self.vp.partition.monitor_page.write_bit(bit) {
                     signal_mnf(dev, connection_id);
                 }
                 return Ok(());
             }
         }
 
-        self.emulate(dev, interruption_pending, intercepted_vtl)
+        self.vp
+            .emulate(dev, interruption_pending, self.intercepted_vtl)
             .await?;
         Ok(())
     }
@@ -530,50 +541,49 @@ impl UhProcessor<'_, HypervisorBackedX86> {
     async fn handle_io_port_exit(
         &mut self,
         dev: &impl CpuIo,
-        intercepted_vtl: Vtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64IoPortInterceptMessage::ref_from_prefix(
-            self.runner.exit_message().payload(),
+            self.vp.runner.exit_message().payload(),
         )
         .unwrap();
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "io_port");
 
-        assert_eq!(message.rax, self.runner.cpu_context().gps[protocol::RAX]);
+        assert_eq!(message.rax, self.vp.runner.cpu_context().gps[protocol::RAX]);
 
         let interruption_pending = message.header.execution_state.interruption_pending();
 
         if message.access_info.string_op() || message.access_info.rep_prefix() {
-            self.emulate(dev, interruption_pending, intercepted_vtl)
+            self.vp
+                .emulate(dev, interruption_pending, self.intercepted_vtl)
                 .await
         } else {
             let next_rip = next_rip(&message.header);
             let access_size = message.access_info.access_size();
             virt_support_x86emu::emulate::emulate_io(
-                self.vp_index(),
+                self.vp.vp_index(),
                 message.header.intercept_access_type == HvInterceptAccessType::WRITE,
                 message.port_number,
-                &mut self.runner.cpu_context_mut().gps[protocol::RAX],
+                &mut self.vp.runner.cpu_context_mut().gps[protocol::RAX],
                 access_size,
                 dev,
             )
             .await;
-            self.set_rip(next_rip)
+            self.vp.set_rip(self.intercepted_vtl, next_rip)
         }
     }
 
     async fn handle_unaccepted_gpa_intercept(
         &mut self,
         dev: &impl CpuIo,
-        intercepted_vtl: Vtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         let gpa = hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(
-            self.runner.exit_message().payload(),
+            self.vp.runner.exit_message().payload(),
         )
         .unwrap()
         .guest_physical_address;
 
-        if self.partition.is_gpa_lower_vtl_ram(gpa) {
+        if self.vp.partition.is_gpa_lower_vtl_ram(gpa) {
             // The host may have moved the page to an unaccepted state, so fail
             // here. This does not apply to VTL 2 memory - for unaccepted pages,
             // the intercept goes to host VTL0.
@@ -587,14 +597,14 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         } else {
             // TODO SNP: for hardware isolation, if the intercept is due to a guest
             // error, inject a machine check
-            self.handle_mmio_exit(dev, intercepted_vtl).await?;
+            self.handle_mmio_exit(dev).await?;
             Ok(())
         }
     }
 
     fn handle_cpuid_intercept(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64CpuidInterceptMessage::ref_from_prefix(
-            self.runner.exit_message().payload(),
+            self.vp.runner.exit_message().payload(),
         )
         .unwrap();
 
@@ -607,29 +617,26 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "cpuid");
 
-        let [eax, ebx, ecx, edx] = self.partition.cpuid.lock().result(
+        let [eax, ebx, ecx, edx] = self.vp.partition.cpuid.lock().result(
             message.rax as u32,
             message.rcx as u32,
             &default_result,
         );
 
         let next_rip = next_rip(&message.header);
-        self.runner.cpu_context_mut().gps[protocol::RAX] = eax.into();
-        self.runner.cpu_context_mut().gps[protocol::RBX] = ebx.into();
-        self.runner.cpu_context_mut().gps[protocol::RCX] = ecx.into();
-        self.runner.cpu_context_mut().gps[protocol::RDX] = edx.into();
+        self.vp.runner.cpu_context_mut().gps[protocol::RAX] = eax.into();
+        self.vp.runner.cpu_context_mut().gps[protocol::RBX] = ebx.into();
+        self.vp.runner.cpu_context_mut().gps[protocol::RCX] = ecx.into();
+        self.vp.runner.cpu_context_mut().gps[protocol::RDX] = edx.into();
 
-        self.set_rip(next_rip)
+        self.vp.set_rip(self.intercepted_vtl, next_rip)
     }
 
-    fn handle_msr_intercept(
-        &mut self,
-        dev: &impl CpuIo,
-        intercepted_vtl: Vtl,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message =
-            hvdef::HvX64MsrInterceptMessage::ref_from_prefix(self.runner.exit_message().payload())
-                .unwrap();
+    fn handle_msr_intercept(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
+        let message = hvdef::HvX64MsrInterceptMessage::ref_from_prefix(
+            self.vp.runner.exit_message().payload(),
+        )
+        .unwrap();
         let rip = next_rip(&message.header);
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "msr");
@@ -637,18 +644,18 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         let msr = message.msr_number;
         match message.header.intercept_access_type {
             HvInterceptAccessType::READ => {
-                let r = if let Some(lapics) = &mut self.backing.lapics {
-                    lapics[intercepted_vtl].msr_read(
-                        self.partition,
-                        &mut self.runner,
-                        &self.vmtime,
+                let r = if let Some(lapics) = &mut self.vp.backing.lapics {
+                    lapics[self.intercepted_vtl].msr_read(
+                        self.vp.partition,
+                        &mut self.vp.runner,
+                        &self.vp.vmtime,
                         dev,
                         msr,
                     )
                 } else {
                     Err(MsrError::Unknown)
                 };
-                let r = r.or_else_if_unknown(|| self.read_msr(msr, intercepted_vtl));
+                let r = r.or_else_if_unknown(|| self.vp.read_msr(msr, self.intercepted_vtl));
 
                 let value = match r {
                     Ok(v) => v,
@@ -657,22 +664,22 @@ impl UhProcessor<'_, HypervisorBackedX86> {
                         0
                     }
                     Err(MsrError::InvalidAccess) => {
-                        self.inject_gpf();
+                        self.vp.inject_gpf(self.intercepted_vtl);
                         // Do not advance RIP.
                         return Ok(());
                     }
                 };
 
-                self.runner.cpu_context_mut().gps[protocol::RAX] = value & 0xffff_ffff;
-                self.runner.cpu_context_mut().gps[protocol::RDX] = value >> 32;
+                self.vp.runner.cpu_context_mut().gps[protocol::RAX] = value & 0xffff_ffff;
+                self.vp.runner.cpu_context_mut().gps[protocol::RDX] = value >> 32;
             }
             HvInterceptAccessType::WRITE => {
                 let value = (message.rax & 0xffff_ffff) | (message.rdx << 32);
-                let r = if let Some(lapic) = &mut self.backing.lapics {
-                    lapic[intercepted_vtl].msr_write(
-                        self.partition,
-                        &mut self.runner,
-                        &self.vmtime,
+                let r = if let Some(lapic) = &mut self.vp.backing.lapics {
+                    lapic[self.intercepted_vtl].msr_write(
+                        self.vp.partition,
+                        &mut self.vp.runner,
+                        &self.vp.vmtime,
                         dev,
                         msr,
                         value,
@@ -680,14 +687,15 @@ impl UhProcessor<'_, HypervisorBackedX86> {
                 } else {
                     Err(MsrError::Unknown)
                 };
-                let r = r.or_else_if_unknown(|| self.write_msr(msr, value, intercepted_vtl));
+                let r =
+                    r.or_else_if_unknown(|| self.vp.write_msr(msr, value, self.intercepted_vtl));
                 match r {
                     Ok(()) => {}
                     Err(MsrError::Unknown) => {
                         tracing::trace!(msr, value, "unknown msr write");
                     }
                     Err(MsrError::InvalidAccess) => {
-                        self.inject_gpf();
+                        self.vp.inject_gpf(self.intercepted_vtl);
                         // Do not advance RIP.
                         return Ok(());
                     }
@@ -696,10 +704,57 @@ impl UhProcessor<'_, HypervisorBackedX86> {
             _ => unreachable!(),
         }
 
-        self.set_rip(rip)
+        self.vp.set_rip(self.intercepted_vtl, rip)
     }
 
-    fn inject_gpf(&mut self) {
+    fn handle_eoi(&self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
+        let message =
+            hvdef::HvX64ApicEoiMessage::ref_from_prefix(self.vp.runner.exit_message().payload())
+                .unwrap();
+
+        tracing::trace!(msg = %format_args!("{:x?}", message), "eoi");
+
+        dev.handle_eoi(message.interrupt_vector);
+        Ok(())
+    }
+
+    fn handle_unrecoverable_exception(&self) -> Result<(), VpHaltReason<UhRunVpError>> {
+        Err(VpHaltReason::TripleFault {
+            vtl: self.intercepted_vtl.into(),
+        })
+    }
+
+    fn handle_halt(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
+        self.vp.backing.lapics.as_mut().unwrap()[self.intercepted_vtl].halt();
+        Ok(())
+    }
+
+    fn handle_exception(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
+        let message = hvdef::HvX64ExceptionInterceptMessage::ref_from_prefix(
+            self.vp.runner.exit_message().payload(),
+        )
+        .unwrap();
+
+        match x86defs::Exception(message.vector as u8) {
+            x86defs::Exception::DEBUG if cfg!(feature = "gdb") => {
+                self.vp.handle_debug_exception(self.intercepted_vtl)?
+            }
+            _ => tracing::error!("unexpected exception type {:#x?}", message.vector),
+        }
+        Ok(())
+    }
+}
+
+impl UhProcessor<'_, HypervisorBackedX86> {
+    fn set_rip(&mut self, _vtl: GuestVtl, rip: u64) -> Result<(), VpHaltReason<UhRunVpError>> {
+        self.runner
+            .set_vp_register(HvX64RegisterName::Rip, rip.into())
+            .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::AdvanceRip(e)))?;
+
+        Ok(())
+    }
+
+    fn inject_gpf(&mut self, _vtl: GuestVtl) {
         let exception_event = hvdef::HvX64PendingExceptionEvent::new()
             .with_event_pending(true)
             .with_event_type(hvdef::HV_X64_PENDING_EVENT_EXCEPTION)
@@ -713,48 +768,6 @@ impl UhProcessor<'_, HypervisorBackedX86> {
                 u128::from(exception_event).into(),
             )
             .expect("set_vp_register should succeed for pending event");
-    }
-
-    fn handle_eoi(&self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message =
-            hvdef::HvX64ApicEoiMessage::ref_from_prefix(self.runner.exit_message().payload())
-                .unwrap();
-
-        tracing::trace!(msg = %format_args!("{:x?}", message), "eoi");
-
-        dev.handle_eoi(message.interrupt_vector);
-        Ok(())
-    }
-
-    fn handle_unrecoverable_exception(
-        &self,
-        intercepted_vtl: Vtl,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        Err(VpHaltReason::TripleFault {
-            vtl: intercepted_vtl.into(),
-        })
-    }
-
-    fn handle_halt(&mut self, intercepted_vtl: Vtl) -> Result<(), VpHaltReason<UhRunVpError>> {
-        self.backing.lapics.as_mut().unwrap()[intercepted_vtl].halt();
-        Ok(())
-    }
-
-    fn handle_exception(&mut self, intercepted_vtl: Vtl) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message = hvdef::HvX64ExceptionInterceptMessage::ref_from_prefix(
-            self.runner.exit_message().payload(),
-        )
-        .unwrap();
-
-        let _ = intercepted_vtl;
-
-        match x86defs::Exception(message.vector as u8) {
-            x86defs::Exception::DEBUG if cfg!(feature = "gdb") => {
-                self.handle_debug_exception(intercepted_vtl)?
-            }
-            _ => tracing::error!("unexpected exception type {:#x?}", message.vector),
-        }
-        Ok(())
     }
 
     fn emulator_state(&mut self) -> x86emu::CpuState {
@@ -1220,7 +1233,7 @@ impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, Hyperv
     }
 
     fn set_rip(&mut self, rip: u64) {
-        self.vp.set_rip(rip).unwrap()
+        self.vp.set_rip(self.intercepted_vtl, rip).unwrap()
     }
 
     fn gp(&mut self, n: hv1_hypercall::X64HypercallRegister) -> u64 {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -219,9 +219,9 @@ impl BackingPrivate for HypervisorBackedX86 {
             let intercepted_vtl =
                 this.runner
                     .reg_page_vtl()
-                    .ok_or(VpHaltReason::InvalidVmState(
-                        UhRunVpError::InvalidInterceptedVtl,
-                    ))?;
+                    .map_err(|ioctl::x64::InterceptedVtlError(vtl)| {
+                        VpHaltReason::InvalidVmState(UhRunVpError::InvalidInterceptedVtl(vtl))
+                    })?;
 
             let message_type = this.runner.exit_message().header.typ;
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -216,22 +216,30 @@ impl BackingPrivate for HypervisorBackedX86 {
         };
 
         if intercepted {
+            let intercepted_vtl =
+                this.runner
+                    .reg_page_vtl()
+                    .ok_or(VpHaltReason::InvalidVmState(
+                        UhRunVpError::InvalidInterceptedVtl,
+                    ))?;
+
             let stat = match this.runner.exit_message().header.typ {
                 HvMessageType::HvMessageTypeX64IoPortIntercept => {
-                    this.handle_io_port_exit(dev).await?;
+                    this.handle_io_port_exit(dev, intercepted_vtl).await?;
                     &mut this.backing.stats.io_port
                 }
                 HvMessageType::HvMessageTypeUnmappedGpa
                 | HvMessageType::HvMessageTypeGpaIntercept => {
-                    this.handle_mmio_exit(dev).await?;
+                    this.handle_mmio_exit(dev, intercepted_vtl).await?;
                     &mut this.backing.stats.mmio
                 }
                 HvMessageType::HvMessageTypeUnacceptedGpa => {
-                    this.handle_unaccepted_gpa_intercept(dev).await?;
+                    this.handle_unaccepted_gpa_intercept(dev, intercepted_vtl)
+                        .await?;
                     &mut this.backing.stats.unaccepted_gpa
                 }
                 HvMessageType::HvMessageTypeHypercallIntercept => {
-                    this.handle_hypercall_exit(dev)?;
+                    this.handle_hypercall_exit(dev, intercepted_vtl)?;
                     &mut this.backing.stats.hypercall
                 }
                 HvMessageType::HvMessageTypeSynicSintDeliverable => {
@@ -247,7 +255,7 @@ impl BackingPrivate for HypervisorBackedX86 {
                     &mut this.backing.stats.cpuid
                 }
                 HvMessageType::HvMessageTypeMsrIntercept => {
-                    this.handle_msr_intercept(dev)?;
+                    this.handle_msr_intercept(dev, intercepted_vtl)?;
                     &mut this.backing.stats.msr
                 }
                 HvMessageType::HvMessageTypeX64ApicEoi => {
@@ -255,15 +263,15 @@ impl BackingPrivate for HypervisorBackedX86 {
                     &mut this.backing.stats.eoi
                 }
                 HvMessageType::HvMessageTypeUnrecoverableException => {
-                    this.handle_unrecoverable_exception()?;
+                    this.handle_unrecoverable_exception(intercepted_vtl)?;
                     &mut this.backing.stats.unrecoverable_exception
                 }
                 HvMessageType::HvMessageTypeX64Halt => {
-                    this.handle_halt()?;
+                    this.handle_halt(intercepted_vtl)?;
                     &mut this.backing.stats.halt
                 }
                 HvMessageType::HvMessageTypeExceptionIntercept => {
-                    this.handle_exception()?;
+                    this.handle_exception(intercepted_vtl)?;
                     &mut this.backing.stats.exception_intercept
                 }
                 reason => unreachable!("unknown exit reason: {:#x?}", reason),
@@ -380,10 +388,6 @@ fn next_rip(value: &HvX64InterceptMessageHeader) -> u64 {
 }
 
 impl UhProcessor<'_, HypervisorBackedX86> {
-    fn intercepted_vtl(&self) -> Option<Vtl> {
-        self.runner.reg_page_vtl()
-    }
-
     fn set_rip(&mut self, rip: u64) -> Result<(), VpHaltReason<UhRunVpError>> {
         self.runner
             .set_vp_register(HvX64RegisterName::Rip, rip.into())
@@ -453,6 +457,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
     fn handle_hypercall_exit(
         &mut self,
         bus: &impl CpuIo,
+        intercepted_vtl: Vtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64HypercallInterceptMessage::ref_from_prefix(
             self.runner.exit_message().payload(),
@@ -463,10 +468,6 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         let is_64bit =
             message.header.execution_state.cr0_pe() && message.header.execution_state.efer_lma();
-
-        let intercepted_vtl = self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
-            UhRunVpError::InvalidInterceptedVtl,
-        ))?;
 
         let guest_memory = &self.partition.gm[intercepted_vtl];
         let handler = UhHypercallHandler {
@@ -486,6 +487,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
     async fn handle_mmio_exit(
         &mut self,
         dev: &impl CpuIo,
+        intercepted_vtl: Vtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(
             self.runner.exit_message().payload(),
@@ -520,20 +522,15 @@ impl UhProcessor<'_, HypervisorBackedX86> {
             }
         }
 
-        self.emulate(
-            dev,
-            interruption_pending,
-            self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
-                UhRunVpError::InvalidInterceptedVtl,
-            ))?,
-        )
-        .await?;
+        self.emulate(dev, interruption_pending, intercepted_vtl)
+            .await?;
         Ok(())
     }
 
     async fn handle_io_port_exit(
         &mut self,
         dev: &impl CpuIo,
+        intercepted_vtl: Vtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64IoPortInterceptMessage::ref_from_prefix(
             self.runner.exit_message().payload(),
@@ -547,14 +544,8 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         let interruption_pending = message.header.execution_state.interruption_pending();
 
         if message.access_info.string_op() || message.access_info.rep_prefix() {
-            self.emulate(
-                dev,
-                interruption_pending,
-                self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
-                    UhRunVpError::InvalidInterceptedVtl,
-                ))?,
-            )
-            .await
+            self.emulate(dev, interruption_pending, intercepted_vtl)
+                .await
         } else {
             let next_rip = next_rip(&message.header);
             let access_size = message.access_info.access_size();
@@ -574,6 +565,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
     async fn handle_unaccepted_gpa_intercept(
         &mut self,
         dev: &impl CpuIo,
+        intercepted_vtl: Vtl,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         let gpa = hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(
             self.runner.exit_message().payload(),
@@ -595,7 +587,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         } else {
             // TODO SNP: for hardware isolation, if the intercept is due to a guest
             // error, inject a machine check
-            self.handle_mmio_exit(dev).await?;
+            self.handle_mmio_exit(dev, intercepted_vtl).await?;
             Ok(())
         }
     }
@@ -630,14 +622,15 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         self.set_rip(next_rip)
     }
 
-    fn handle_msr_intercept(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_msr_intercept(
+        &mut self,
+        dev: &impl CpuIo,
+        intercepted_vtl: Vtl,
+    ) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message =
             hvdef::HvX64MsrInterceptMessage::ref_from_prefix(self.runner.exit_message().payload())
                 .unwrap();
         let rip = next_rip(&message.header);
-        let intercepted_vtl = self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
-            UhRunVpError::InvalidInterceptedVtl,
-        ))?;
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "msr");
 
@@ -733,31 +726,32 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         Ok(())
     }
 
-    fn handle_unrecoverable_exception(&self) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let intercepted_vtl = self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
-            UhRunVpError::InvalidInterceptedVtl,
-        ))?;
+    fn handle_unrecoverable_exception(
+        &self,
+        intercepted_vtl: Vtl,
+    ) -> Result<(), VpHaltReason<UhRunVpError>> {
         Err(VpHaltReason::TripleFault {
             vtl: intercepted_vtl.into(),
         })
     }
 
-    fn handle_halt(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let intercepted_vtl = self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
-            UhRunVpError::InvalidInterceptedVtl,
-        ))?;
+    fn handle_halt(&mut self, intercepted_vtl: Vtl) -> Result<(), VpHaltReason<UhRunVpError>> {
         self.backing.lapics.as_mut().unwrap()[intercepted_vtl].halt();
         Ok(())
     }
 
-    fn handle_exception(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_exception(&mut self, intercepted_vtl: Vtl) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64ExceptionInterceptMessage::ref_from_prefix(
             self.runner.exit_message().payload(),
         )
         .unwrap();
 
+        let _ = intercepted_vtl;
+
         match x86defs::Exception(message.vector as u8) {
-            x86defs::Exception::DEBUG if cfg!(feature = "gdb") => self.handle_debug_exception()?,
+            x86defs::Exception::DEBUG if cfg!(feature = "gdb") => {
+                self.handle_debug_exception(intercepted_vtl)?
+            }
             _ => tracing::error!("unexpected exception type {:#x?}", message.vector),
         }
         Ok(())

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -464,9 +464,9 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         let is_64bit =
             message.header.execution_state.cr0_pe() && message.header.execution_state.efer_lma();
 
-        let intercepted_vtl = self
-            .intercepted_vtl()
-            .unwrap_or(message.header.execution_state.vtl().try_into().unwrap());
+        let intercepted_vtl = self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
+            UhRunVpError::InvalidInterceptedVtl,
+        ))?;
 
         let guest_memory = &self.partition.gm[intercepted_vtl];
         let handler = UhHypercallHandler {
@@ -523,7 +523,9 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         self.emulate(
             dev,
             interruption_pending,
-            self.intercepted_vtl().expect("intercepted vtl is valid"),
+            self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
+                UhRunVpError::InvalidInterceptedVtl,
+            ))?,
         )
         .await?;
         Ok(())
@@ -548,7 +550,9 @@ impl UhProcessor<'_, HypervisorBackedX86> {
             self.emulate(
                 dev,
                 interruption_pending,
-                self.intercepted_vtl().expect("intercepted vtl is valid"),
+                self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
+                    UhRunVpError::InvalidInterceptedVtl,
+                ))?,
             )
             .await
         } else {
@@ -631,7 +635,9 @@ impl UhProcessor<'_, HypervisorBackedX86> {
             hvdef::HvX64MsrInterceptMessage::ref_from_prefix(self.runner.exit_message().payload())
                 .unwrap();
         let rip = next_rip(&message.header);
-        let intercepted_vtl = self.intercepted_vtl().expect("intercepted vtl is valid");
+        let intercepted_vtl = self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
+            UhRunVpError::InvalidInterceptedVtl,
+        ))?;
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "msr");
 
@@ -728,14 +734,18 @@ impl UhProcessor<'_, HypervisorBackedX86> {
     }
 
     fn handle_unrecoverable_exception(&self) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let intercepted_vtl = self.intercepted_vtl().expect("register page is valid");
+        let intercepted_vtl = self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
+            UhRunVpError::InvalidInterceptedVtl,
+        ))?;
         Err(VpHaltReason::TripleFault {
             vtl: intercepted_vtl.into(),
         })
     }
 
     fn handle_halt(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let intercepted_vtl = self.intercepted_vtl().expect("register page is valid");
+        let intercepted_vtl = self.intercepted_vtl().ok_or(VpHaltReason::InvalidVmState(
+            UhRunVpError::InvalidInterceptedVtl,
+        ))?;
         self.backing.lapics.as_mut().unwrap()[intercepted_vtl].halt();
         Ok(())
     }

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -418,14 +418,12 @@ impl BackingPrivate for SnpBacked {
             .expect("requesting deliverability is not a fallable operation");
     }
 
-    fn intercepted_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl {
-        this.cvm_guest_vsm
-            .as_ref()
-            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.current_vtl)
-    }
-
     fn switch_vtl_state(this: &mut UhProcessor<'_, Self>, target_vtl: GuestVtl) {
-        let current_vtl = this.intercepted_vtl();
+        let current_vtl = this
+            .cvm_guest_vsm
+            .as_ref()
+            .expect("has guest vsm state")
+            .current_vtl;
         assert!(current_vtl != target_vtl);
 
         let [vmsa0, vmsa1] = this.runner.vmsas_mut();
@@ -540,19 +538,19 @@ fn hv_table_from_snp(selector: &SevSelector) -> hvdef::HvX64TableRegister {
     }
 }
 
-impl TranslateGvaSupport for UhProcessor<'_, SnpBacked> {
+impl<T: CpuIo> TranslateGvaSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     type Error = UhRunVpError;
 
     fn guest_memory(&self) -> &GuestMemory {
-        self.intercepted_vtl_gm()
+        &self.vp.partition.gm[self.vtl]
     }
 
     fn acquire_tlb_lock(&mut self) {
-        self.set_tlb_lock(Vtl::Vtl2, self.intercepted_vtl())
+        self.vp.set_tlb_lock(Vtl::Vtl2, self.vtl)
     }
 
     fn registers(&mut self) -> Result<TranslationRegisters, Self::Error> {
-        let vmsa = self.runner.vmsa(self.intercepted_vtl());
+        let vmsa = self.vp.runner.vmsa(self.vtl);
         Ok(TranslationRegisters {
             cr0: vmsa.cr0(),
             cr4: vmsa.cr4(),
@@ -561,7 +559,7 @@ impl TranslateGvaSupport for UhProcessor<'_, SnpBacked> {
             rflags: vmsa.rflags(),
             ss: from_seg(hv_seg_from_snp(&vmsa.ss())),
             encryption_mode: virt_support_x86emu::translate::EncryptionMode::Vtom(
-                self.partition.caps.vtom.unwrap(),
+                self.vp.partition.caps.vtom.unwrap(),
             ),
         })
     }
@@ -865,11 +863,13 @@ impl UhProcessor<'_, SnpBacked> {
                             )
                             .map_err(UhRunVpError::HypercallParameters)?;
 
+                        let intercepted_vtl = self.last_vtl();
                         let mut handler = GhcbEnlightenedHypercall {
                             handler: UhHypercallHandler {
                                 vp: self,
                                 bus: dev,
                                 trusted: false,
+                                intercepted_vtl,
                             },
                             control: &mut input_control,
                             output_gpa,
@@ -928,7 +928,7 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let mut vmsa = self.runner.vmsa_mut(self.intercepted_vtl());
+        let mut vmsa = self.runner.vmsa_mut(self.last_vtl());
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();
 
         vmsa.v_intr_cntrl_mut().set_guest_busy(false);
@@ -951,7 +951,7 @@ impl UhProcessor<'_, SnpBacked> {
             .run()
             .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::Run(err)))?;
 
-        let entered_from_vtl = self.intercepted_vtl();
+        let entered_from_vtl = self.last_vtl();
         let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
 
         // TODO SNP: The guest busy bit needs to be tested and set atomically.
@@ -1010,7 +1010,7 @@ impl UhProcessor<'_, SnpBacked> {
                 .lazy_eoi();
         }
 
-        let mut vmsa = self.runner.vmsa_mut(self.intercepted_vtl());
+        let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
         let sev_error_code = SevExitCode(vmsa.guest_error_code());
 
         let stat = match sev_error_code {
@@ -1058,8 +1058,10 @@ impl UhProcessor<'_, SnpBacked> {
                             vtl: entered_from_vtl,
                         })
                         .msr_write(msr, value)
-                        .or_else_if_unknown(|| self.write_msr(msr, value))
-                        .or_else_if_unknown(|| self.write_msr_cvm(dev, msr, value));
+                        .or_else_if_unknown(|| self.write_msr(msr, value, entered_from_vtl))
+                        .or_else_if_unknown(|| {
+                            self.write_msr_cvm(dev, msr, value, entered_from_vtl)
+                        });
 
                     match r {
                         Ok(()) => false,
@@ -1080,8 +1082,8 @@ impl UhProcessor<'_, SnpBacked> {
                             vtl: entered_from_vtl,
                         })
                         .msr_read(msr)
-                        .or_else_if_unknown(|| self.read_msr(msr))
-                        .or_else_if_unknown(|| self.read_msr_cvm(dev, msr));
+                        .or_else_if_unknown(|| self.read_msr(msr, entered_from_vtl))
+                        .or_else_if_unknown(|| self.read_msr_cvm(dev, msr, entered_from_vtl));
 
                     let value = match r {
                         Ok(v) => Some(v),
@@ -1125,7 +1127,7 @@ impl UhProcessor<'_, SnpBacked> {
             SevExitCode::IOIO => {
                 let io_info = x86defs::snp::SevIoAccessInfo::from(vmsa.exit_info1() as u32);
                 if io_info.string_access() || io_info.rep_access() {
-                    self.emulate(dev, false).await?;
+                    self.emulate(dev, false, entered_from_vtl).await?;
                 } else {
                     let len = if io_info.access_size32() {
                         4
@@ -1154,12 +1156,13 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::VMMCALL => {
-                let is_64bit = self.long_mode();
-                let guest_memory = self.intercepted_vtl_gm();
+                let is_64bit = self.long_mode(entered_from_vtl);
+                let guest_memory = &self.partition.gm[entered_from_vtl];
                 let handler = UhHypercallHandler {
                     vp: &mut *self,
                     bus: dev,
                     trusted: true,
+                    intercepted_vtl: entered_from_vtl,
                 };
 
                 // Note: Successful VtlCall/Return handling will change the
@@ -1222,7 +1225,7 @@ impl UhProcessor<'_, SnpBacked> {
 
                 if emulate {
                     has_intercept = false;
-                    self.emulate(dev, false).await?;
+                    self.emulate(dev, false, entered_from_vtl).await?;
                     &mut self.backing.exit_stats.npf
                 } else {
                     &mut self.backing.exit_stats.npf_spurious
@@ -1383,8 +1386,8 @@ impl UhProcessor<'_, SnpBacked> {
         Ok(())
     }
 
-    fn long_mode(&self) -> bool {
-        let vmsa = self.runner.vmsa(self.intercepted_vtl());
+    fn long_mode(&self, vtl: Vtl) -> bool {
+        let vmsa = self.runner.vmsa(vtl);
         vmsa.cr0() & x86defs::X64_CR0_PE != 0 && vmsa.efer() & x86defs::X64_EFER_LMA != 0
     }
 }
@@ -1401,7 +1404,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn state(&mut self) -> Result<x86emu::CpuState, Self::Error> {
-        let vmsa = self.vp.runner.vmsa(self.vp.intercepted_vtl());
+        let vmsa = self.vp.runner.vmsa(self.vtl);
         Ok(x86emu::CpuState {
             gps: [
                 vmsa.rax(),
@@ -1437,7 +1440,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn set_state(&mut self, state: x86emu::CpuState) -> Result<(), Self::Error> {
-        let mut vmsa = self.vp.runner.vmsa_mut(self.vp.intercepted_vtl());
+        let mut vmsa = self.vp.runner.vmsa_mut(self.vtl);
         let x86emu::CpuState {
             gps: [rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi, r8, r9, r10, r11, r12, r13, r14, r15],
             segs: _, // immutable
@@ -1468,17 +1471,13 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn get_xmm(&mut self, reg: usize) -> Result<u128, Self::Error> {
-        Ok(self
-            .vp
-            .runner
-            .vmsa(self.vp.intercepted_vtl())
-            .xmm_registers(reg))
+        Ok(self.vp.runner.vmsa(self.vtl).xmm_registers(reg))
     }
 
     fn set_xmm(&mut self, reg: usize, value: u128) -> Result<(), Self::Error> {
         self.vp
             .runner
-            .vmsa_mut(self.vp.intercepted_vtl())
+            .vmsa_mut(self.vtl)
             .set_xmm_registers(reg, value);
         Ok(())
     }
@@ -1488,7 +1487,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn physical_address(&self) -> Option<u64> {
-        Some(self.vp.runner.vmsa(self.vp.intercepted_vtl()).exit_info2())
+        Some(self.vp.runner.vmsa(self.vtl).exit_info2())
     }
 
     fn initial_gva_translation(&self) -> Option<virt_support_x86emu::emulate::InitialTranslation> {
@@ -1504,7 +1503,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
         _gpa: u64,
         _mode: virt_support_x86emu::emulate::TranslateMode,
     ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError<Self::Error>> {
-        // TODO SNP
+        // TODO GUEST VSM
         // TODO lock tlb?
         Ok(())
     }
@@ -1520,7 +1519,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
         >,
         Self::Error,
     > {
-        emulate_translate_gva(self.vp, gva, mode)
+        emulate_translate_gva(self, gva, mode)
     }
 
     fn inject_pending_event(&mut self, event_info: hvdef::HvX64PendingEvent) {
@@ -1532,17 +1531,14 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
 
         let exception = HvX64PendingExceptionEvent::from(u128::from(event_info.reg_0));
 
-        self.vp
-            .runner
-            .vmsa_mut(self.vp.intercepted_vtl())
-            .set_event_inject(
-                SevEventInjectInfo::new()
-                    .with_valid(true)
-                    .with_interruption_type(x86defs::snp::SEV_INTR_TYPE_EXCEPT)
-                    .with_vector(exception.vector() as u8)
-                    .with_deliver_error_code(exception.deliver_error_code())
-                    .with_error_code(exception.error_code()),
-            );
+        self.vp.runner.vmsa_mut(self.vtl).set_event_inject(
+            SevEventInjectInfo::new()
+                .with_valid(true)
+                .with_interruption_type(x86defs::snp::SEV_INTR_TYPE_EXCEPT)
+                .with_vector(exception.vector() as u8)
+                .with_deliver_error_code(exception.deliver_error_code())
+                .with_error_code(exception.error_code()),
+        );
     }
 
     fn is_gpa_mapped(&self, gpa: u64, write: bool) -> bool {
@@ -1554,13 +1550,11 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn lapic_base_address(&self) -> Option<u64> {
-        self.vp.backing.lapics[self.vp.intercepted_vtl()]
-            .lapic
-            .base_address()
+        self.vp.backing.lapics[self.vtl].lapic.base_address()
     }
 
     fn lapic_read(&mut self, address: u64, data: &mut [u8]) {
-        let vtl = self.vp.intercepted_vtl();
+        let vtl = self.vtl;
         self.vp.backing.lapics[vtl]
             .lapic
             .access(&mut SnpApicClient {
@@ -1574,7 +1568,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn lapic_write(&mut self, address: u64, data: &[u8]) {
-        let vtl = self.vp.intercepted_vtl();
+        let vtl = self.vtl;
         self.vp.backing.lapics[vtl]
             .lapic
             .access(&mut SnpApicClient {
@@ -1590,18 +1584,15 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
 
 impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, SnpBacked> {
     fn rip(&mut self) -> u64 {
-        self.vp.runner.vmsa(self.vp.intercepted_vtl()).rip()
+        self.vp.runner.vmsa(self.intercepted_vtl).rip()
     }
 
     fn set_rip(&mut self, rip: u64) {
-        self.vp
-            .runner
-            .vmsa_mut(self.vp.intercepted_vtl())
-            .set_rip(rip);
+        self.vp.runner.vmsa_mut(self.intercepted_vtl).set_rip(rip);
     }
 
     fn gp(&mut self, n: hv1_hypercall::X64HypercallRegister) -> u64 {
-        let vmsa = self.vp.runner.vmsa(self.vp.intercepted_vtl());
+        let vmsa = self.vp.runner.vmsa(self.intercepted_vtl);
         match n {
             hv1_hypercall::X64HypercallRegister::Rax => vmsa.rax(),
             hv1_hypercall::X64HypercallRegister::Rcx => vmsa.rcx(),
@@ -1614,7 +1605,7 @@ impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, SnpBac
     }
 
     fn set_gp(&mut self, n: hv1_hypercall::X64HypercallRegister, value: u64) {
-        let mut vmsa = self.vp.runner.vmsa_mut(self.vp.intercepted_vtl());
+        let mut vmsa = self.vp.runner.vmsa_mut(self.intercepted_vtl);
         match n {
             hv1_hypercall::X64HypercallRegister::Rax => vmsa.set_rax(value),
             hv1_hypercall::X64HypercallRegister::Rcx => vmsa.set_rcx(value),
@@ -1627,16 +1618,13 @@ impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, SnpBac
     }
 
     fn xmm(&mut self, n: usize) -> u128 {
-        self.vp
-            .runner
-            .vmsa(self.vp.intercepted_vtl())
-            .xmm_registers(n)
+        self.vp.runner.vmsa(self.intercepted_vtl).xmm_registers(n)
     }
 
     fn set_xmm(&mut self, n: usize, value: u128) {
         self.vp
             .runner
-            .vmsa_mut(self.vp.intercepted_vtl())
+            .vmsa_mut(self.intercepted_vtl)
             .set_xmm_registers(n, value);
     }
 }
@@ -2046,8 +2034,8 @@ fn advance_to_next_instruction(vmsa: &mut VmsaWrapper<'_, &mut SevVmsa>) {
 }
 
 impl UhProcessor<'_, SnpBacked> {
-    fn read_msr_cvm(&mut self, _dev: &impl CpuIo, msr: u32) -> Result<u64, MsrError> {
-        let vmsa = self.runner.vmsa(self.intercepted_vtl());
+    fn read_msr_cvm(&mut self, _dev: &impl CpuIo, msr: u32, vtl: Vtl) -> Result<u64, MsrError> {
+        let vmsa = self.runner.vmsa(vtl);
         let value = match msr {
             x86defs::X64_MSR_FS_BASE => vmsa.fs().base,
             x86defs::X64_MSR_GS_BASE => vmsa.gs().base,
@@ -2099,8 +2087,14 @@ impl UhProcessor<'_, SnpBacked> {
         Ok(value)
     }
 
-    fn write_msr_cvm(&mut self, _dev: &impl CpuIo, msr: u32, value: u64) -> Result<(), MsrError> {
-        let mut vmsa = self.runner.vmsa_mut(self.intercepted_vtl());
+    fn write_msr_cvm(
+        &mut self,
+        _dev: &impl CpuIo,
+        msr: u32,
+        value: u64,
+        vtl: Vtl,
+    ) -> Result<(), MsrError> {
+        let mut vmsa = self.runner.vmsa_mut(vtl);
         match msr {
             x86defs::X64_MSR_FS_BASE => {
                 let fs = vmsa.fs();
@@ -2241,7 +2235,7 @@ impl<T: CpuIo> hv1_hypercall::VtlCall for UhHypercallHandler<'_, '_, T, SnpBacke
 
 impl<T: CpuIo> hv1_hypercall::VtlSwitchOps for UhHypercallHandler<'_, '_, T, SnpBacked> {
     fn advance_ip(&mut self) {
-        let is_64bit = self.vp.long_mode();
+        let is_64bit = self.vp.long_mode(self.intercepted_vtl);
         let mut io = hv1_hypercall::X64RegisterIo::new(self, is_64bit);
         io.advance_ip();
     }
@@ -2249,7 +2243,7 @@ impl<T: CpuIo> hv1_hypercall::VtlSwitchOps for UhHypercallHandler<'_, '_, T, Snp
     fn inject_invalid_opcode_fault(&mut self) {
         self.vp
             .runner
-            .vmsa_mut(self.vp.intercepted_vtl())
+            .vmsa_mut(self.intercepted_vtl)
             .set_event_inject(
                 SevEventInjectInfo::new()
                     .with_valid(true)
@@ -2296,7 +2290,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressListEx
         }
 
         // Mark that this VP needs to wait for all TLB locks to be released before returning.
-        self.vp.set_wait_for_tlb_locks(self.vp.intercepted_vtl());
+        self.vp.set_wait_for_tlb_locks(self.intercepted_vtl);
         Ok(())
     }
 }
@@ -2330,7 +2324,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressSpaceEx
         self.do_flush_virtual_address_space(&processor_set, flags);
 
         // Mark that this VP needs to wait for all TLB locks to be released before returning.
-        self.vp.set_wait_for_tlb_locks(self.vp.intercepted_vtl());
+        self.vp.set_wait_for_tlb_locks(self.intercepted_vtl);
         Ok(())
     }
 }
@@ -2388,10 +2382,7 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, SnpBacked> {
     fn do_flush_virtual_address_space(&mut self, processor_set: &[u32], flags: HvFlushFlags) {
         let only_self = processor_set.len() == 1 && processor_set[0] == self.vp.vp_index().index();
         if only_self && flags.non_global_mappings_only() {
-            self.vp
-                .runner
-                .vmsa_mut(self.vp.intercepted_vtl())
-                .set_pcpu_id(0);
+            self.vp.runner.vmsa_mut(self.intercepted_vtl).set_pcpu_id(0);
         } else {
             let rax = SevInvlpgbRax::new()
                 .with_asid_valid(true)

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -818,6 +818,10 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     fn handle_vmgexit(&mut self, dev: &impl CpuIo) -> Result<(), UhRunVpError> {
+        let intercepted_vtl = self
+            .cvm_guest_vsm
+            .as_ref()
+            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
         let message = hvdef::HvX64VmgexitInterceptMessage::ref_from_prefix(
             self.runner.exit_message().payload(),
         )
@@ -863,7 +867,6 @@ impl UhProcessor<'_, SnpBacked> {
                             )
                             .map_err(UhRunVpError::HypercallParameters)?;
 
-                        let intercepted_vtl = self.last_vtl();
                         let mut handler = GhcbEnlightenedHypercall {
                             handler: UhHypercallHandler {
                                 vp: self,
@@ -928,7 +931,16 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let mut vmsa = self.runner.vmsa_mut(self.last_vtl());
+        // TODO CVM: change this to intercepted vtl by creating an intercepted_vtl
+        // that's available outside of guest vsm state and that's only valid during
+        // intercept handling, and split out the "next vtl" that's used in VTL 2
+        // exit handling.
+        let last_vtl = self
+            .cvm_guest_vsm
+            .as_ref()
+            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
+
+        let mut vmsa = self.runner.vmsa_mut(last_vtl);
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();
 
         vmsa.v_intr_cntrl_mut().set_guest_busy(false);
@@ -951,7 +963,10 @@ impl UhProcessor<'_, SnpBacked> {
             .run()
             .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::Run(err)))?;
 
-        let entered_from_vtl = self.last_vtl();
+        let entered_from_vtl = self
+            .cvm_guest_vsm
+            .as_ref()
+            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
         let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
 
         // TODO SNP: The guest busy bit needs to be tested and set atomically.
@@ -1348,7 +1363,7 @@ impl UhProcessor<'_, SnpBacked> {
 
         // Process debug exceptions before handling other intercepts.
         if cfg!(feature = "gdb") && sev_error_code == SevExitCode::EXCP_DB {
-            return self.handle_debug_exception();
+            return self.handle_debug_exception(entered_from_vtl);
         }
 
         // If there is an unhandled intercept message from the hypervisor, then

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -424,7 +424,6 @@ impl BackingPrivate for SnpBacked {
             .as_ref()
             .expect("has guest vsm state")
             .current_vtl;
-        assert!(current_vtl != target_vtl);
 
         let [vmsa0, vmsa1] = this.runner.vmsas_mut();
         let (current_vmsa, mut target_vmsa) = match (current_vtl, target_vtl) {
@@ -817,11 +816,11 @@ impl UhProcessor<'_, SnpBacked> {
         self.deliver_synic_messages(GuestVtl::Vtl0, message.deliverable_sints);
     }
 
-    fn handle_vmgexit(&mut self, dev: &impl CpuIo) -> Result<(), UhRunVpError> {
-        let intercepted_vtl = self
-            .cvm_guest_vsm
-            .as_ref()
-            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
+    fn handle_vmgexit(
+        &mut self,
+        dev: &impl CpuIo,
+        intercepted_vtl: GuestVtl,
+    ) -> Result<(), UhRunVpError> {
         let message = hvdef::HvX64VmgexitInterceptMessage::ref_from_prefix(
             self.runner.exit_message().payload(),
         )
@@ -931,14 +930,12 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        // TODO CVM: change this to intercepted vtl by creating an intercepted_vtl
-        // that's available outside of guest vsm state and that's only valid during
-        // intercept handling, and split out the "next vtl" that's used in VTL 2
-        // exit handling.
+        // TODO CVM GUEST VSM: split out the "next vtl" that VTL 2 will exit to from
+        // last_vtl/current_vtl
         let last_vtl = self
             .cvm_guest_vsm
             .as_ref()
-            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
+            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
 
         let mut vmsa = self.runner.vmsa_mut(last_vtl);
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();
@@ -966,7 +963,7 @@ impl UhProcessor<'_, SnpBacked> {
         let entered_from_vtl = self
             .cvm_guest_vsm
             .as_ref()
-            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
+            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
         let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
 
         // TODO SNP: The guest busy bit needs to be tested and set atomically.
@@ -1296,7 +1293,7 @@ impl UhProcessor<'_, SnpBacked> {
                 has_intercept = false;
                 match self.runner.exit_message().header.typ {
                     HvMessageType::HvMessageTypeX64SevVmgexitIntercept => {
-                        self.handle_vmgexit(dev)
+                        self.handle_vmgexit(dev, entered_from_vtl)
                             .map_err(VpHaltReason::InvalidVmState)?;
                     }
                     _ => has_intercept = true,
@@ -1401,7 +1398,7 @@ impl UhProcessor<'_, SnpBacked> {
         Ok(())
     }
 
-    fn long_mode(&self, vtl: Vtl) -> bool {
+    fn long_mode(&self, vtl: GuestVtl) -> bool {
         let vmsa = self.runner.vmsa(vtl);
         vmsa.cr0() & x86defs::X64_CR0_PE != 0 && vmsa.efer() & x86defs::X64_EFER_LMA != 0
     }
@@ -2049,7 +2046,12 @@ fn advance_to_next_instruction(vmsa: &mut VmsaWrapper<'_, &mut SevVmsa>) {
 }
 
 impl UhProcessor<'_, SnpBacked> {
-    fn read_msr_cvm(&mut self, _dev: &impl CpuIo, msr: u32, vtl: Vtl) -> Result<u64, MsrError> {
+    fn read_msr_cvm(
+        &mut self,
+        _dev: &impl CpuIo,
+        msr: u32,
+        vtl: GuestVtl,
+    ) -> Result<u64, MsrError> {
         let vmsa = self.runner.vmsa(vtl);
         let value = match msr {
             x86defs::X64_MSR_FS_BASE => vmsa.fs().base,
@@ -2107,7 +2109,7 @@ impl UhProcessor<'_, SnpBacked> {
         _dev: &impl CpuIo,
         msr: u32,
         value: u64,
-        vtl: Vtl,
+        vtl: GuestVtl,
     ) -> Result<(), MsrError> {
         let mut vmsa = self.runner.vmsa_mut(vtl);
         match msr {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -418,14 +418,15 @@ impl BackingPrivate for SnpBacked {
             .expect("requesting deliverability is not a fallable operation");
     }
 
-    fn last_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl {
+    fn intercepted_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl {
         this.cvm_guest_vsm
             .as_ref()
             .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.current_vtl)
     }
 
     fn switch_vtl_state(this: &mut UhProcessor<'_, Self>, target_vtl: GuestVtl) {
-        let current_vtl = this.last_vtl();
+        let current_vtl = this.intercepted_vtl();
+        assert!(current_vtl != target_vtl);
 
         let [vmsa0, vmsa1] = this.runner.vmsas_mut();
         let (current_vmsa, mut target_vmsa) = match (current_vtl, target_vtl) {
@@ -543,15 +544,15 @@ impl TranslateGvaSupport for UhProcessor<'_, SnpBacked> {
     type Error = UhRunVpError;
 
     fn guest_memory(&self) -> &GuestMemory {
-        self.last_vtl_gm()
+        self.intercepted_vtl_gm()
     }
 
     fn acquire_tlb_lock(&mut self) {
-        self.set_tlb_lock(Vtl::Vtl2, self.last_vtl())
+        self.set_tlb_lock(Vtl::Vtl2, self.intercepted_vtl())
     }
 
     fn registers(&mut self) -> Result<TranslationRegisters, Self::Error> {
-        let vmsa = self.runner.vmsa(self.last_vtl());
+        let vmsa = self.runner.vmsa(self.intercepted_vtl());
         Ok(TranslationRegisters {
             cr0: vmsa.cr0(),
             cr4: vmsa.cr4(),
@@ -927,7 +928,7 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let mut vmsa = self.runner.vmsa_mut(self.last_vtl());
+        let mut vmsa = self.runner.vmsa_mut(self.intercepted_vtl());
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();
 
         vmsa.v_intr_cntrl_mut().set_guest_busy(false);
@@ -950,7 +951,7 @@ impl UhProcessor<'_, SnpBacked> {
             .run()
             .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::Run(err)))?;
 
-        let entered_from_vtl = self.last_vtl();
+        let entered_from_vtl = self.intercepted_vtl();
         let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
 
         // TODO SNP: The guest busy bit needs to be tested and set atomically.
@@ -1009,7 +1010,7 @@ impl UhProcessor<'_, SnpBacked> {
                 .lazy_eoi();
         }
 
-        let mut vmsa = self.runner.vmsa_mut(self.last_vtl());
+        let mut vmsa = self.runner.vmsa_mut(self.intercepted_vtl());
         let sev_error_code = SevExitCode(vmsa.guest_error_code());
 
         let stat = match sev_error_code {
@@ -1154,7 +1155,7 @@ impl UhProcessor<'_, SnpBacked> {
 
             SevExitCode::VMMCALL => {
                 let is_64bit = self.long_mode();
-                let guest_memory = self.last_vtl_gm();
+                let guest_memory = self.intercepted_vtl_gm();
                 let handler = UhHypercallHandler {
                     vp: &mut *self,
                     bus: dev,
@@ -1383,7 +1384,7 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     fn long_mode(&self) -> bool {
-        let vmsa = self.runner.vmsa(self.last_vtl());
+        let vmsa = self.runner.vmsa(self.intercepted_vtl());
         vmsa.cr0() & x86defs::X64_CR0_PE != 0 && vmsa.efer() & x86defs::X64_EFER_LMA != 0
     }
 }
@@ -1400,7 +1401,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn state(&mut self) -> Result<x86emu::CpuState, Self::Error> {
-        let vmsa = self.vp.runner.vmsa(self.vp.last_vtl());
+        let vmsa = self.vp.runner.vmsa(self.vp.intercepted_vtl());
         Ok(x86emu::CpuState {
             gps: [
                 vmsa.rax(),
@@ -1436,7 +1437,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn set_state(&mut self, state: x86emu::CpuState) -> Result<(), Self::Error> {
-        let mut vmsa = self.vp.runner.vmsa_mut(self.vp.last_vtl());
+        let mut vmsa = self.vp.runner.vmsa_mut(self.vp.intercepted_vtl());
         let x86emu::CpuState {
             gps: [rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi, r8, r9, r10, r11, r12, r13, r14, r15],
             segs: _, // immutable
@@ -1467,13 +1468,17 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn get_xmm(&mut self, reg: usize) -> Result<u128, Self::Error> {
-        Ok(self.vp.runner.vmsa(self.vp.last_vtl()).xmm_registers(reg))
+        Ok(self
+            .vp
+            .runner
+            .vmsa(self.vp.intercepted_vtl())
+            .xmm_registers(reg))
     }
 
     fn set_xmm(&mut self, reg: usize, value: u128) -> Result<(), Self::Error> {
         self.vp
             .runner
-            .vmsa_mut(self.vp.last_vtl())
+            .vmsa_mut(self.vp.intercepted_vtl())
             .set_xmm_registers(reg, value);
         Ok(())
     }
@@ -1483,7 +1488,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn physical_address(&self) -> Option<u64> {
-        Some(self.vp.runner.vmsa(self.vp.last_vtl()).exit_info2())
+        Some(self.vp.runner.vmsa(self.vp.intercepted_vtl()).exit_info2())
     }
 
     fn initial_gva_translation(&self) -> Option<virt_support_x86emu::emulate::InitialTranslation> {
@@ -1529,7 +1534,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
 
         self.vp
             .runner
-            .vmsa_mut(self.vp.last_vtl())
+            .vmsa_mut(self.vp.intercepted_vtl())
             .set_event_inject(
                 SevEventInjectInfo::new()
                     .with_valid(true)
@@ -1549,13 +1554,13 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn lapic_base_address(&self) -> Option<u64> {
-        self.vp.backing.lapics[self.vp.last_vtl()]
+        self.vp.backing.lapics[self.vp.intercepted_vtl()]
             .lapic
             .base_address()
     }
 
     fn lapic_read(&mut self, address: u64, data: &mut [u8]) {
-        let vtl = self.vp.last_vtl();
+        let vtl = self.vp.intercepted_vtl();
         self.vp.backing.lapics[vtl]
             .lapic
             .access(&mut SnpApicClient {
@@ -1569,7 +1574,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
     }
 
     fn lapic_write(&mut self, address: u64, data: &[u8]) {
-        let vtl = self.vp.last_vtl();
+        let vtl = self.vp.intercepted_vtl();
         self.vp.backing.lapics[vtl]
             .lapic
             .access(&mut SnpApicClient {
@@ -1585,15 +1590,18 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
 
 impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, SnpBacked> {
     fn rip(&mut self) -> u64 {
-        self.vp.runner.vmsa(self.vp.last_vtl()).rip()
+        self.vp.runner.vmsa(self.vp.intercepted_vtl()).rip()
     }
 
     fn set_rip(&mut self, rip: u64) {
-        self.vp.runner.vmsa_mut(self.vp.last_vtl()).set_rip(rip);
+        self.vp
+            .runner
+            .vmsa_mut(self.vp.intercepted_vtl())
+            .set_rip(rip);
     }
 
     fn gp(&mut self, n: hv1_hypercall::X64HypercallRegister) -> u64 {
-        let vmsa = self.vp.runner.vmsa(self.vp.last_vtl());
+        let vmsa = self.vp.runner.vmsa(self.vp.intercepted_vtl());
         match n {
             hv1_hypercall::X64HypercallRegister::Rax => vmsa.rax(),
             hv1_hypercall::X64HypercallRegister::Rcx => vmsa.rcx(),
@@ -1606,7 +1614,7 @@ impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, SnpBac
     }
 
     fn set_gp(&mut self, n: hv1_hypercall::X64HypercallRegister, value: u64) {
-        let mut vmsa = self.vp.runner.vmsa_mut(self.vp.last_vtl());
+        let mut vmsa = self.vp.runner.vmsa_mut(self.vp.intercepted_vtl());
         match n {
             hv1_hypercall::X64HypercallRegister::Rax => vmsa.set_rax(value),
             hv1_hypercall::X64HypercallRegister::Rcx => vmsa.set_rcx(value),
@@ -1619,13 +1627,16 @@ impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, SnpBac
     }
 
     fn xmm(&mut self, n: usize) -> u128 {
-        self.vp.runner.vmsa(self.vp.last_vtl()).xmm_registers(n)
+        self.vp
+            .runner
+            .vmsa(self.vp.intercepted_vtl())
+            .xmm_registers(n)
     }
 
     fn set_xmm(&mut self, n: usize, value: u128) {
         self.vp
             .runner
-            .vmsa_mut(self.vp.last_vtl())
+            .vmsa_mut(self.vp.intercepted_vtl())
             .set_xmm_registers(n, value);
     }
 }
@@ -2036,7 +2047,7 @@ fn advance_to_next_instruction(vmsa: &mut VmsaWrapper<'_, &mut SevVmsa>) {
 
 impl UhProcessor<'_, SnpBacked> {
     fn read_msr_cvm(&mut self, _dev: &impl CpuIo, msr: u32) -> Result<u64, MsrError> {
-        let vmsa = self.runner.vmsa(self.last_vtl());
+        let vmsa = self.runner.vmsa(self.intercepted_vtl());
         let value = match msr {
             x86defs::X64_MSR_FS_BASE => vmsa.fs().base,
             x86defs::X64_MSR_GS_BASE => vmsa.gs().base,
@@ -2089,7 +2100,7 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     fn write_msr_cvm(&mut self, _dev: &impl CpuIo, msr: u32, value: u64) -> Result<(), MsrError> {
-        let mut vmsa = self.runner.vmsa_mut(self.last_vtl());
+        let mut vmsa = self.runner.vmsa_mut(self.intercepted_vtl());
         match msr {
             x86defs::X64_MSR_FS_BASE => {
                 let fs = vmsa.fs();
@@ -2238,7 +2249,7 @@ impl<T: CpuIo> hv1_hypercall::VtlSwitchOps for UhHypercallHandler<'_, '_, T, Snp
     fn inject_invalid_opcode_fault(&mut self) {
         self.vp
             .runner
-            .vmsa_mut(self.vp.last_vtl())
+            .vmsa_mut(self.vp.intercepted_vtl())
             .set_event_inject(
                 SevEventInjectInfo::new()
                     .with_valid(true)
@@ -2285,7 +2296,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressListEx
         }
 
         // Mark that this VP needs to wait for all TLB locks to be released before returning.
-        self.vp.set_wait_for_tlb_locks(self.vp.last_vtl());
+        self.vp.set_wait_for_tlb_locks(self.vp.intercepted_vtl());
         Ok(())
     }
 }
@@ -2319,7 +2330,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressSpaceEx
         self.do_flush_virtual_address_space(&processor_set, flags);
 
         // Mark that this VP needs to wait for all TLB locks to be released before returning.
-        self.vp.set_wait_for_tlb_locks(self.vp.last_vtl());
+        self.vp.set_wait_for_tlb_locks(self.vp.intercepted_vtl());
         Ok(())
     }
 }
@@ -2377,7 +2388,10 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, SnpBacked> {
     fn do_flush_virtual_address_space(&mut self, processor_set: &[u32], flags: HvFlushFlags) {
         let only_self = processor_set.len() == 1 && processor_set[0] == self.vp.vp_index().index();
         if only_self && flags.non_global_mappings_only() {
-            self.vp.runner.vmsa_mut(self.vp.last_vtl()).set_pcpu_id(0);
+            self.vp
+                .runner
+                .vmsa_mut(self.vp.intercepted_vtl())
+                .set_pcpu_id(0);
         } else {
             let rax = SevInvlpgbRax::new()
                 .with_asid_valid(true)

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1403,7 +1403,7 @@ impl UhProcessor<'_, TdxBacked> {
                     apic_id: self.inner.vp_info.apic_id,
                 };
 
-                let result = self.partition.cvm.as_ref().unwrap().cpuid.guest_result(
+                let result = self.backing.shared.cvm.cpuid.guest_result(
                     CpuidFunction(leaf),
                     subleaf,
                     &guest_state,

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -769,12 +769,6 @@ impl BackingPrivate for TdxBacked {
         }
     }
 
-    fn intercepted_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl {
-        this.cvm_guest_vsm
-            .as_ref()
-            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.current_vtl)
-    }
-
     fn switch_vtl_state(_this: &mut UhProcessor<'_, Self>, _target_vtl: GuestVtl) {
         todo!()
     }
@@ -1273,8 +1267,12 @@ impl UhProcessor<'_, TdxBacked> {
                 let io_qual = ExitQualificationIo::from(exit_info.qualification() as u32);
 
                 if io_qual.is_string() || io_qual.rep_prefix() {
-                    self.emulate(dev, self.backing.interruption_information.valid())
-                        .await?;
+                    self.emulate(
+                        dev,
+                        self.backing.interruption_information.valid(),
+                        self.last_vtl(),
+                    )
+                    .await?;
                 } else {
                     let len = match io_qual.access_size() {
                         IO_SIZE_8_BIT => 1,
@@ -1316,7 +1314,7 @@ impl UhProcessor<'_, TdxBacked> {
                         dev,
                     })
                     .msr_read(msr)
-                    .or_else_if_unknown(|| self.read_msr(msr))
+                    .or_else_if_unknown(|| self.read_msr(msr, self.last_vtl()))
                     .or_else_if_unknown(|| self.read_msr_cvm(msr));
 
                 let value = match result {
@@ -1363,7 +1361,7 @@ impl UhProcessor<'_, TdxBacked> {
                         dev,
                     })
                     .msr_write(msr, value)
-                    .or_else_if_unknown(|| self.write_msr(msr, value))
+                    .or_else_if_unknown(|| self.write_msr(msr, value, self.last_vtl()))
                     .or_else_if_unknown(|| self.write_msr_cvm(msr, value));
 
                 let inject_gp = match result {
@@ -1431,11 +1429,13 @@ impl UhProcessor<'_, TdxBacked> {
                     let is_64bit = self.backing.cr0.read(&self.runner) & X64_CR0_PE != 0
                         && self.backing.efer & X64_EFER_LMA != 0;
 
-                    let guest_memory = self.intercepted_vtl_gm();
+                    let intercepted_vtl = self.last_vtl();
+                    let guest_memory = &self.partition.gm[intercepted_vtl];
                     let handler = UhHypercallHandler {
                         vp: &mut *self,
                         bus: dev,
                         trusted: true,
+                        intercepted_vtl,
                     };
 
                     UhHypercallHandler::TDX_DISPATCHER.dispatch(
@@ -1539,7 +1539,8 @@ impl UhProcessor<'_, TdxBacked> {
                 // sufficient, as it may be a write access where the page is
                 // protected, but we don't yet support MNF/guest VSM so this is
                 // okay enough.
-                let is_readable_ram = self.guest_memory().check_gpa_readable(exit_info.gpa());
+                let is_readable_ram =
+                    self.partition.gm[self.last_vtl()].check_gpa_readable(exit_info.gpa());
                 if is_readable_ram {
                     tracelimit::warn_ratelimited!(
                         gpa = exit_info.gpa(),
@@ -1567,8 +1568,12 @@ impl UhProcessor<'_, TdxBacked> {
                     }
 
                     // Emulate the access.
-                    self.emulate(dev, self.backing.interruption_information.valid())
-                        .await?;
+                    self.emulate(
+                        dev,
+                        self.backing.interruption_information.valid(),
+                        self.last_vtl(),
+                    )
+                    .await?;
                 }
 
                 &mut self.backing.exit_stats.ept_violation
@@ -1701,10 +1706,12 @@ impl UhProcessor<'_, TdxBacked> {
             // guests will issue hypercalls without the boundary bit set,
             // whereas UEFI will issue with the bit set.
             let guest_memory = &self.partition.untrusted_dma_memory;
+            let last_vtl = self.last_vtl();
             let handler = UhHypercallHandler {
                 vp: &mut *self,
                 bus: dev,
                 trusted: false,
+                intercepted_vtl: last_vtl,
             };
 
             UhHypercallHandler::TDCALL_DISPATCHER.dispatch(guest_memory, TdHypercall(handler));
@@ -1712,7 +1719,7 @@ impl UhProcessor<'_, TdxBacked> {
     }
 
     fn read_tdvmcall_msr(&mut self, msr: u32) -> Result<u64, MsrError> {
-        let last_vtl = self.intercepted_vtl();
+        let last_vtl = self.last_vtl();
         match msr {
             msr @ (hvdef::HV_X64_MSR_GUEST_OS_ID | hvdef::HV_X64_MSR_VP_INDEX) => {
                 self.hv(last_vtl).unwrap().msr_read(msr)
@@ -1726,11 +1733,11 @@ impl UhProcessor<'_, TdxBacked> {
     }
 
     fn write_tdvmcall_msr(&mut self, msr: u32, value: u64) -> Result<(), MsrError> {
-        let last_vtl = self.intercepted_vtl();
         match msr {
-            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => {
-                self.hv_mut(last_vtl).unwrap().msr_write(msr, value)?
-            }
+            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => self
+                .hv_mut(self.last_vtl())
+                .unwrap()
+                .msr_write(msr, value)?,
             _ => {
                 self.untrusted_synic.as_mut().unwrap().write_nontimer_msr(
                     &self.partition.gm[GuestVtl::Vtl0],
@@ -2083,7 +2090,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, TdxBacked> {
         >,
         Self::Error,
     > {
-        emulate_translate_gva(self.vp, gva, mode)
+        emulate_translate_gva(self, gva, mode)
     }
 
     fn inject_pending_event(&mut self, event_info: hvdef::HvX64PendingEvent) {
@@ -2112,26 +2119,30 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, TdxBacked> {
     }
 }
 
-impl TranslateGvaSupport for UhProcessor<'_, TdxBacked> {
+impl<T: CpuIo> TranslateGvaSupport for UhEmulationState<'_, '_, T, TdxBacked> {
     type Error = UhRunVpError;
 
     fn guest_memory(&self) -> &guestmem::GuestMemory {
-        self.intercepted_vtl_gm()
+        &self.vp.partition.gm[self.vtl]
     }
 
     fn acquire_tlb_lock(&mut self) {
-        self.set_tlb_lock(Vtl::Vtl2, self.intercepted_vtl())
+        self.vp.set_tlb_lock(Vtl::Vtl2, self.vtl)
     }
 
     fn registers(&mut self) -> Result<TranslationRegisters, Self::Error> {
-        let cr0 = self.backing.cr0.read(&self.runner);
-        let cr4 = self.backing.cr4.read(&self.runner);
-        let efer = self.backing.efer;
+        let cr0 = self.vp.backing.cr0.read(&self.vp.runner);
+        let cr4 = self.vp.backing.cr4.read(&self.vp.runner);
+        let efer = self.vp.backing.efer;
         let cr3 = self
+            .vp
             .runner
             .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR3);
-        let ss = self.read_segment(GuestVtl::Vtl0, TdxSegmentReg::Ss).into();
-        let rflags = self.runner.tdx_enter_guest_state().rflags;
+        let ss = self
+            .vp
+            .read_segment(GuestVtl::Vtl0, TdxSegmentReg::Ss)
+            .into();
+        let rflags = self.vp.runner.tdx_enter_guest_state().rflags;
         Ok(TranslationRegisters {
             cr0,
             cr4,
@@ -2140,7 +2151,7 @@ impl TranslateGvaSupport for UhProcessor<'_, TdxBacked> {
             ss,
             rflags,
             encryption_mode: virt_support_x86emu::translate::EncryptionMode::Vtom(
-                self.partition.caps.vtom.unwrap(),
+                self.vp.partition.caps.vtom.unwrap(),
             ),
         })
     }
@@ -3141,7 +3152,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressListEx
         self.hcvm_validate_flush_inputs(&processor_set, flags, true)
             .map_err(|e| (e, 0))?;
 
-        let vtl = self.vp.intercepted_vtl();
+        let vtl = self.intercepted_vtl;
         {
             let mut flush_state = self.vp.backing.shared.flush_state[vtl].write();
 
@@ -3199,7 +3210,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressSpaceEx
         flags: HvFlushFlags,
     ) -> hvdef::HvResult<()> {
         self.hcvm_validate_flush_inputs(&processor_set, flags, false)?;
-        let vtl = self.vp.intercepted_vtl();
+        let vtl = self.intercepted_vtl;
 
         {
             let mut flush_state = self.vp.backing.shared.flush_state[vtl].write();

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -774,589 +774,6 @@ impl BackingPrivate for TdxBacked {
     }
 }
 
-struct InterceptHandler<'a, 'b> {
-    vp: &'a mut UhProcessor<'b, TdxBacked>,
-    intercepted_vtl: GuestVtl,
-}
-
-impl InterceptHandler<'_, '_> {
-    async fn handle_vmx_exit(
-        &mut self,
-        dev: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let exit_info = TdxExit(self.vp.runner.tdx_vp_enter_exit_info());
-        let next_interruption = exit_info.idt_vectoring_info();
-
-        // Acknowledge the APIC interrupt/NMI if it was delivered.
-        if self.vp.backing.interruption_information.valid()
-            && (!next_interruption.valid()
-                || self.vp.backing.interruption_information.interruption_type()
-                    != next_interruption.interruption_type())
-        {
-            match self.vp.backing.interruption_information.interruption_type() {
-                INTERRUPT_TYPE_EXTERNAL if !self.vp.backing.lapic.is_offloaded() => {
-                    // This must be a pending APIC interrupt. Acknowledge it.
-                    tracing::debug!(
-                        vector = self.vp.backing.interruption_information.vector(),
-                        "acknowledging interrupt"
-                    );
-                    self.vp
-                        .backing
-                        .lapic
-                        .acknowledge_interrupt(self.vp.backing.interruption_information.vector());
-                }
-                INTERRUPT_TYPE_NMI => {
-                    // This must be a pending NMI.
-                    tracing::debug!("acknowledging NMI");
-                    self.vp.backing.nmi_pending = false;
-                }
-                _ => {}
-            }
-        }
-
-        if self.vp.backing.lapic.is_offloaded() {
-            // It's possible with vAPIC that we take an exit in the window where
-            // hardware has moved a bit from IRR to ISR, but has not injected
-            // the interrupt into the guest. In this case, we need to track that
-            // we must inject the interrupt before we return to the guest,
-            // otherwise the interrupt will be lost and the guest left in a bad
-            // state.
-            //
-            // TODO TDX: Unclear what kind of exits these would be, but they
-            // should be spurious EPT exits. Can we validate or assert that
-            // somehow? If we were to somehow call some other path which would
-            // set interruption_information before we inject this one, we would
-            // lose this interrupt.
-            if next_interruption.valid() {
-                tracing::debug!(
-                    ?next_interruption,
-                    vp_index = self.vp.vp_index().index(),
-                    "exit requires reinjecting interrupt"
-                );
-                self.vp.backing.interruption_information = next_interruption;
-                self.vp.backing.exception_error_code = exit_info.idt_vectoring_error_code();
-                self.vp
-                    .backing
-                    .exit_stats
-                    .needs_interrupt_reinject
-                    .increment();
-            } else {
-                self.vp.backing.interruption_information = Default::default();
-            }
-        } else {
-            // Ignore (and later recalculate) the next interruption if it is an
-            // external interrupt or NMI, since it may change if the APIC state
-            // changes.
-            if next_interruption.valid()
-                && !matches!(
-                    next_interruption.interruption_type(),
-                    INTERRUPT_TYPE_EXTERNAL | INTERRUPT_TYPE_NMI
-                )
-            {
-                self.vp.backing.interruption_information = next_interruption;
-                self.vp.backing.exception_error_code = exit_info.idt_vectoring_error_code();
-            } else {
-                self.vp.backing.interruption_information = Default::default();
-            }
-        }
-
-        let mut breakpoint_debug_exception = false;
-        let stat = match exit_info.code().vmx_exit() {
-            VmxExit::IO_INSTRUCTION => {
-                let io_qual = ExitQualificationIo::from(exit_info.qualification() as u32);
-
-                if io_qual.is_string() || io_qual.rep_prefix() {
-                    self.vp
-                        .emulate(
-                            dev,
-                            self.vp.backing.interruption_information.valid(),
-                            self.intercepted_vtl,
-                        )
-                        .await?;
-                } else {
-                    let len = match io_qual.access_size() {
-                        IO_SIZE_8_BIT => 1,
-                        IO_SIZE_16_BIT => 2,
-                        IO_SIZE_32_BIT => 4,
-                        _ => panic!(
-                            "tdx module returned invalid io instr size {}",
-                            io_qual.access_size()
-                        ),
-                    };
-
-                    let mut rax = self.vp.runner.tdx_enter_guest_state().rax();
-                    emulate_io(
-                        self.vp.inner.vp_info.base.vp_index,
-                        !io_qual.is_in(),
-                        io_qual.port(),
-                        &mut rax,
-                        len,
-                        dev,
-                    )
-                    .await;
-                    self.vp.runner.tdx_enter_guest_state_mut().set_rax(rax);
-
-                    self.vp.advance_to_next_instruction();
-                }
-                &mut self.vp.backing.exit_stats.io
-            }
-            VmxExit::MSR_READ => {
-                let enter_state = self.vp.runner.tdx_enter_guest_state();
-                let msr = enter_state.rcx() as u32;
-
-                let result = self
-                    .vp
-                    .backing
-                    .lapic
-                    .access(&mut TdxApicClient {
-                        partition: self.vp.partition,
-                        vmtime: &self.vp.vmtime,
-                        apic_page: zerocopy::transmute_mut!(self.vp.runner.tdx_apic_page_mut()),
-                        dev,
-                    })
-                    .msr_read(msr)
-                    .or_else_if_unknown(|| self.vp.read_msr(msr, self.intercepted_vtl))
-                    .or_else_if_unknown(|| self.vp.read_msr_cvm(msr, self.intercepted_vtl));
-
-                let value = match result {
-                    Ok(v) => Some(v),
-                    Err(MsrError::Unknown) => match msr {
-                        X86X_MSR_EFER => Some(self.vp.backing.efer),
-                        _ => {
-                            tracelimit::error_ratelimited!(msr, "unknown tdx cvm msr read");
-                            Some(0)
-                        }
-                    },
-                    Err(MsrError::InvalidAccess) => None,
-                };
-
-                let inject_gp = if let Some(value) = value {
-                    let enter_state = self.vp.runner.tdx_enter_guest_state_mut();
-                    enter_state.set_rax((value as u32).into());
-                    enter_state.set_rdx(((value >> 32) as u32).into());
-                    false
-                } else {
-                    true
-                };
-
-                if inject_gp {
-                    self.vp.inject_gpf();
-                } else {
-                    self.vp.advance_to_next_instruction();
-                }
-                &mut self.vp.backing.exit_stats.msr_read
-            }
-            VmxExit::MSR_WRITE => {
-                let enter_state = self.vp.runner.tdx_enter_guest_state();
-                let msr = enter_state.rcx() as u32;
-                let value =
-                    (enter_state.rax() as u32 as u64) | ((enter_state.rdx() as u32 as u64) << 32);
-
-                let result = self
-                    .vp
-                    .backing
-                    .lapic
-                    .access(&mut TdxApicClient {
-                        partition: self.vp.partition,
-                        vmtime: &self.vp.vmtime,
-                        apic_page: zerocopy::transmute_mut!(self.vp.runner.tdx_apic_page_mut()),
-                        dev,
-                    })
-                    .msr_write(msr, value)
-                    .or_else_if_unknown(|| self.vp.write_msr(msr, value, self.intercepted_vtl))
-                    .or_else_if_unknown(|| self.vp.write_msr_cvm(msr, value, self.intercepted_vtl));
-
-                let inject_gp = match result {
-                    Ok(()) => false,
-                    Err(MsrError::Unknown) => {
-                        tracelimit::error_ratelimited!(msr, value, "unknown tdx cvm msr write");
-                        false
-                    }
-                    Err(MsrError::InvalidAccess) => true,
-                };
-
-                if inject_gp {
-                    self.vp.inject_gpf();
-                } else {
-                    self.vp.advance_to_next_instruction();
-                }
-                &mut self.vp.backing.exit_stats.msr_write
-            }
-            VmxExit::CPUID => {
-                let xss = self.vp.runner.tdx_vp_state().msr_xss;
-                let enter_state = self.vp.runner.tdx_enter_guest_state();
-                let leaf = enter_state.rax() as u32;
-                let subleaf = enter_state.rcx() as u32;
-                let xfem = self
-                    .vp
-                    .runner
-                    .get_vp_register(HvX64RegisterName::Xfem)
-                    .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err)))?
-                    .as_u64();
-                let guest_state = crate::hardware_cvm::cpuid::CpuidGuestState {
-                    xfem,
-                    xss,
-                    cr4: self.vp.backing.cr4.read(&self.vp.runner),
-                    apic_id: self.vp.inner.vp_info.apic_id,
-                };
-
-                let result = self.vp.partition.cvm.as_ref().unwrap().cpuid.guest_result(
-                    CpuidFunction(leaf),
-                    subleaf,
-                    &guest_state,
-                );
-
-                tracing::trace!(leaf, subleaf, "cpuid");
-
-                let [eax, ebx, ecx, edx] = self.vp.partition.cpuid.lock().result(
-                    leaf,
-                    subleaf,
-                    &[result.eax, result.ebx, result.ecx, result.edx],
-                );
-
-                tracing::trace!(eax, ebx, ecx, edx, "cpuid result");
-
-                let enter_state = self.vp.runner.tdx_enter_guest_state_mut();
-                enter_state.set_rax(eax.into());
-                enter_state.set_rbx(ebx.into());
-                enter_state.set_rcx(ecx.into());
-                enter_state.set_rdx(edx.into());
-
-                self.vp.advance_to_next_instruction();
-                &mut self.vp.backing.exit_stats.cpuid
-            }
-            VmxExit::VMCALL_INSTRUCTION => {
-                if exit_info.cpl() != 0 {
-                    self.vp.inject_gpf();
-                } else {
-                    let is_64bit = self.vp.backing.cr0.read(&self.vp.runner) & X64_CR0_PE != 0
-                        && self.vp.backing.efer & X64_EFER_LMA != 0;
-
-                    let guest_memory = &self.vp.partition.gm[self.intercepted_vtl];
-                    let handler = UhHypercallHandler {
-                        vp: &mut *self.vp,
-                        bus: dev,
-                        trusted: true,
-                        intercepted_vtl: self.intercepted_vtl,
-                    };
-
-                    UhHypercallHandler::TDX_DISPATCHER.dispatch(
-                        guest_memory,
-                        hv1_hypercall::X64RegisterIo::new(handler, is_64bit),
-                    );
-                }
-                &mut self.vp.backing.exit_stats.vmcall
-            }
-            VmxExit::HLT_INSTRUCTION => {
-                self.vp.backing.halted = true;
-
-                // TODO: see lots of these exits while waiting at frontpage.
-                // Probably expected, given we will still get L1 timer
-                // interrupts?
-
-                // Clear interrupt shadow.
-                let mask = Interruptibility::new().with_blocked_by_sti(true);
-                let value = Interruptibility::new().with_blocked_by_sti(false);
-                self.vp.runner.write_vmcs32(
-                    GuestVtl::Vtl0,
-                    VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
-                    mask.into(),
-                    value.into(),
-                );
-                self.vp.advance_to_next_instruction();
-                &mut self.vp.backing.exit_stats.hlt
-            }
-            VmxExit::CR_ACCESS => {
-                let qual = CrAccessQualification::from(exit_info.qualification());
-                let cr;
-                let value;
-                match qual.access_type() {
-                    CR_ACCESS_TYPE_MOV_TO_CR => {
-                        cr = qual.cr();
-                        value =
-                            self.vp.runner.tdx_enter_guest_state().gps[qual.gp_register() as usize];
-                    }
-                    CR_ACCESS_TYPE_LMSW => {
-                        cr = 0;
-                        let cr0 = self.vp.backing.cr0.read(&self.vp.runner);
-                        // LMSW updates the low four bits only.
-                        value = (qual.lmsw_source_data() as u64 & 0xf) | (cr0 & !0xf);
-                    }
-                    access_type => unreachable!("not registered for cr access type {access_type}"),
-                }
-                let r = match cr {
-                    0 => self.vp.backing.cr0.write(value, &mut self.vp.runner),
-                    4 => self.vp.backing.cr4.write(value, &mut self.vp.runner),
-                    cr => unreachable!("not registered for cr{cr} accesses"),
-                };
-                if r.is_ok() {
-                    self.vp.update_execution_mode().expect("BUGBUG");
-                    self.vp.advance_to_next_instruction();
-                } else {
-                    tracelimit::warn_ratelimited!(cr, value, "failed to write cr");
-                    self.vp.inject_gpf();
-                }
-                &mut self.vp.backing.exit_stats.cr_access
-            }
-            VmxExit::XSETBV => {
-                let enter_state = self.vp.runner.tdx_enter_guest_state();
-                if let Some(value) =
-                    hardware_cvm::validate_xsetbv_exit(hardware_cvm::XsetbvExitInput {
-                        rax: enter_state.rax(),
-                        rcx: enter_state.rcx(),
-                        rdx: enter_state.rdx(),
-                        cr4: self.vp.backing.cr4.read(&self.vp.runner),
-                        cpl: exit_info.cpl(),
-                    })
-                {
-                    self.vp
-                        .runner
-                        .set_vp_register(HvX64RegisterName::Xfem, value.into())
-                        .map_err(|err| {
-                            VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err))
-                        })?;
-                    self.vp.advance_to_next_instruction();
-                } else {
-                    self.vp.inject_gpf();
-                }
-                &mut self.vp.backing.exit_stats.xsetbv
-            }
-            VmxExit::WBINVD_INSTRUCTION => {
-                // TODO TDX: forward the request to the host via TD.VMCALL
-                // see HvlRequestCacheFlush
-                self.vp.advance_to_next_instruction();
-                &mut self.vp.backing.exit_stats.wbinvd
-            }
-            VmxExit::EPT_VIOLATION => {
-                // TODO TDX: If this is an access to a shared gpa, we need to
-                // check the intercept page to see if this is a real exit or
-                // spurious. This exit is only real if the hypervisor has
-                // delivered an intercept message for this GPA.
-                //
-                // However, at this point the kernel has cleared that
-                // information so some kind of redesign is required to figure
-                // this out.
-                //
-                // For now, we instead treat EPTs on readable RAM as spurious
-                // and log appropriately. This check is also not entirely
-                // sufficient, as it may be a write access where the page is
-                // protected, but we don't yet support MNF/guest VSM so this is
-                // okay enough.
-                let is_readable_ram =
-                    self.vp.partition.gm[self.intercepted_vtl].check_gpa_readable(exit_info.gpa());
-                if is_readable_ram {
-                    tracelimit::warn_ratelimited!(
-                        gpa = exit_info.gpa(),
-                        "possible spurious EPT violation, ignoring"
-                    );
-                } else {
-                    // If this was an EPT violation while handling an iret, and
-                    // that iret cleared the NMI blocking state, restore it.
-                    if !next_interruption.valid() {
-                        let ept_info = VmxEptExitQualification::from(exit_info.qualification());
-                        if ept_info.nmi_unmasking_due_to_iret() {
-                            let mask = Interruptibility::new().with_blocked_by_nmi(true);
-                            let value = Interruptibility::new().with_blocked_by_nmi(true);
-                            let old_interruptibility: Interruptibility = self
-                                .vp
-                                .runner
-                                .write_vmcs32(
-                                    GuestVtl::Vtl0,
-                                    VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
-                                    mask.into(),
-                                    value.into(),
-                                )
-                                .into();
-                            assert!(!old_interruptibility.blocked_by_nmi());
-                        }
-                    }
-
-                    // Emulate the access.
-                    self.vp
-                        .emulate(
-                            dev,
-                            self.vp.backing.interruption_information.valid(),
-                            self.intercepted_vtl,
-                        )
-                        .await?;
-                }
-
-                &mut self.vp.backing.exit_stats.ept_violation
-            }
-            VmxExit::TPR_BELOW_THRESHOLD => {
-                // Loop around to reevaluate the APIC.
-                &mut self.vp.backing.exit_stats.tpr_below_threshold
-            }
-            VmxExit::INTERRUPT_WINDOW => {
-                // Loop around to reevaluate the APIC.
-                &mut self.vp.backing.exit_stats.interrupt_window
-            }
-            VmxExit::NMI_WINDOW => {
-                // Loop around to reevaluate pending NMIs.
-                &mut self.vp.backing.exit_stats.nmi_window
-            }
-            VmxExit::HW_INTERRUPT => {
-                // Check if the interrupt was triggered by a hardware breakpoint.
-                let debug_regs = self
-                    .vp
-                    .access_state(Vtl::Vtl0)
-                    .debug_regs()
-                    .expect("register query should not fail");
-
-                // The lowest four bits of DR6 indicate which of the
-                // four breakpoints triggered.
-                breakpoint_debug_exception = debug_regs.dr6.trailing_zeros() < 4;
-                &mut self.vp.backing.exit_stats.hw_interrupt
-            }
-            VmxExit::SMI_INTR => &mut self.vp.backing.exit_stats.smi_intr,
-            VmxExit::PAUSE_INSTRUCTION => &mut self.vp.backing.exit_stats.pause,
-            VmxExit::TDCALL => {
-                // If the proxy synic is local, then the host did not get this
-                // instruction, and we need to handle it.
-                if self.vp.untrusted_synic.is_some() {
-                    self.handle_tdvmcall(dev);
-                }
-                &mut self.vp.backing.exit_stats.tdcall
-            }
-            VmxExit::TRIPLE_FAULT => {
-                return Err(VpHaltReason::TripleFault {
-                    vtl: self.intercepted_vtl.into(),
-                })
-            }
-            _ => {
-                return Err(VpHaltReason::Hypervisor(UhRunVpError::UnknownVmxExit(
-                    exit_info.code().vmx_exit(),
-                )))
-            }
-        };
-        stat.increment();
-
-        // Breakpoint exceptions may return a non-fatal error.
-        // We dispatch here to correctly increment the counter.
-        if cfg!(feature = "gdb") && breakpoint_debug_exception {
-            self.vp.handle_debug_exception(self.intercepted_vtl)?;
-        }
-
-        Ok(())
-    }
-
-    fn handle_tdvmcall(&mut self, dev: &impl CpuIo) {
-        let regs = self.vp.runner.tdx_enter_guest_state();
-        if regs.r10() == 0 {
-            // Architectural VMCALL.
-            let result = match VmxExit(regs.r11() as u32) {
-                VmxExit::MSR_WRITE => {
-                    let msr = regs.r12() as u32;
-                    let value = regs.r13();
-                    match self.write_tdvmcall_msr(msr, value) {
-                        Ok(()) => {
-                            tracing::debug!(msr, value, "tdvmcall msr write");
-                            TdVmCallR10Result::SUCCESS
-                        }
-                        Err(err) => {
-                            tracelimit::warn_ratelimited!(
-                                msr,
-                                value,
-                                ?err,
-                                "failed tdvmcall msr write"
-                            );
-                            TdVmCallR10Result::OPERAND_INVALID
-                        }
-                    }
-                }
-                VmxExit::MSR_READ => {
-                    let msr = regs.r12() as u32;
-                    match self.read_tdvmcall_msr(msr) {
-                        Ok(value) => {
-                            tracing::debug!(msr, value, "tdvmcall msr read");
-                            self.vp.runner.tdx_enter_guest_state_mut().set_r11(value);
-                            TdVmCallR10Result::SUCCESS
-                        }
-                        Err(err) => {
-                            tracelimit::warn_ratelimited!(msr, ?err, "failed tdvmcall msr read");
-                            TdVmCallR10Result::OPERAND_INVALID
-                        }
-                    }
-                }
-                subfunction => {
-                    tracelimit::warn_ratelimited!(
-                        ?subfunction,
-                        "architectural vmcall not supported"
-                    );
-                    TdVmCallR10Result::OPERAND_INVALID
-                }
-            };
-            let regs = self.vp.runner.tdx_enter_guest_state_mut();
-            regs.set_r10(result.0);
-            regs.rip = regs.rip.wrapping_add(4);
-        } else {
-            // This hypercall is normally handled by the hypervisor, so the gpas
-            // given by the guest should all be shared. The hypervisor allows
-            // gpas to be set with or without the shared gpa boundary bit, which
-            // untrusted_dma_memory correctly models. Note that some Linux
-            // guests will issue hypercalls without the boundary bit set,
-            // whereas UEFI will issue with the bit set.
-            let guest_memory = &self.vp.partition.untrusted_dma_memory;
-            let handler = UhHypercallHandler {
-                vp: &mut *self.vp,
-                bus: dev,
-                trusted: false,
-                intercepted_vtl: self.intercepted_vtl,
-            };
-
-            UhHypercallHandler::TDCALL_DISPATCHER.dispatch(guest_memory, TdHypercall(handler));
-        }
-    }
-
-    fn read_tdvmcall_msr(&mut self, msr: u32) -> Result<u64, MsrError> {
-        match msr {
-            msr @ (hvdef::HV_X64_MSR_GUEST_OS_ID | hvdef::HV_X64_MSR_VP_INDEX) => {
-                self.vp.hv(self.intercepted_vtl).unwrap().msr_read(msr)
-            }
-            _ => self
-                .vp
-                .untrusted_synic
-                .as_mut()
-                .unwrap()
-                .read_nontimer_msr(msr),
-        }
-    }
-
-    fn write_tdvmcall_msr(&mut self, msr: u32, value: u64) -> Result<(), MsrError> {
-        match msr {
-            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => self
-                .vp
-                .hv_mut(self.intercepted_vtl)
-                .unwrap()
-                .msr_write(msr, value)?,
-            _ => {
-                self.vp
-                    .untrusted_synic
-                    .as_mut()
-                    .unwrap()
-                    .write_nontimer_msr(&self.vp.partition.gm[GuestVtl::Vtl0], msr, value)?;
-                // Propagate sint MSR writes to the hypervisor as well
-                // so that the hypervisor can directly inject events.
-                if matches!(msr, hvdef::HV_X64_MSR_SINT0..=hvdef::HV_X64_MSR_SINT15) {
-                    if let Err(err) = self.vp.runner.set_vp_register(
-                        HvX64RegisterName(
-                            HvX64RegisterName::Sint0.0 + (msr - hvdef::HV_X64_MSR_SINT0),
-                        ),
-                        value.into(),
-                    ) {
-                        tracelimit::warn_ratelimited!(
-                            error = &err as &dyn std::error::Error,
-                            "failed to set sint register"
-                        );
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
 impl UhProcessor<'_, TdxBacked> {
     /// Returns `Ok(false)` if the APIC offload needs to be disabled and the
     /// poll retried.
@@ -1770,11 +1187,454 @@ impl UhProcessor<'_, TdxBacked> {
         };
 
         stat.increment();
-        let mut intercept_handler = InterceptHandler {
-            vp: self,
-            intercepted_vtl: entered_from_vtl,
+        self.handle_vmx_exit(dev, entered_from_vtl).await?;
+        Ok(())
+    }
+
+    async fn handle_vmx_exit(
+        &mut self,
+        dev: &impl CpuIo,
+        intercepted_vtl: GuestVtl,
+    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+        let exit_info = TdxExit(self.runner.tdx_vp_enter_exit_info());
+        let next_interruption = exit_info.idt_vectoring_info();
+
+        // Acknowledge the APIC interrupt/NMI if it was delivered.
+        if self.backing.interruption_information.valid()
+            && (!next_interruption.valid()
+                || self.backing.interruption_information.interruption_type()
+                    != next_interruption.interruption_type())
+        {
+            match self.backing.interruption_information.interruption_type() {
+                INTERRUPT_TYPE_EXTERNAL if !self.backing.lapic.is_offloaded() => {
+                    // This must be a pending APIC interrupt. Acknowledge it.
+                    tracing::debug!(
+                        vector = self.backing.interruption_information.vector(),
+                        "acknowledging interrupt"
+                    );
+                    self.backing
+                        .lapic
+                        .acknowledge_interrupt(self.backing.interruption_information.vector());
+                }
+                INTERRUPT_TYPE_NMI => {
+                    // This must be a pending NMI.
+                    tracing::debug!("acknowledging NMI");
+                    self.backing.nmi_pending = false;
+                }
+                _ => {}
+            }
+        }
+
+        if self.backing.lapic.is_offloaded() {
+            // It's possible with vAPIC that we take an exit in the window where
+            // hardware has moved a bit from IRR to ISR, but has not injected
+            // the interrupt into the guest. In this case, we need to track that
+            // we must inject the interrupt before we return to the guest,
+            // otherwise the interrupt will be lost and the guest left in a bad
+            // state.
+            //
+            // TODO TDX: Unclear what kind of exits these would be, but they
+            // should be spurious EPT exits. Can we validate or assert that
+            // somehow? If we were to somehow call some other path which would
+            // set interruption_information before we inject this one, we would
+            // lose this interrupt.
+            if next_interruption.valid() {
+                tracing::debug!(
+                    ?next_interruption,
+                    vp_index = self.vp_index().index(),
+                    "exit requires reinjecting interrupt"
+                );
+                self.backing.interruption_information = next_interruption;
+                self.backing.exception_error_code = exit_info.idt_vectoring_error_code();
+                self.backing.exit_stats.needs_interrupt_reinject.increment();
+            } else {
+                self.backing.interruption_information = Default::default();
+            }
+        } else {
+            // Ignore (and later recalculate) the next interruption if it is an
+            // external interrupt or NMI, since it may change if the APIC state
+            // changes.
+            if next_interruption.valid()
+                && !matches!(
+                    next_interruption.interruption_type(),
+                    INTERRUPT_TYPE_EXTERNAL | INTERRUPT_TYPE_NMI
+                )
+            {
+                self.backing.interruption_information = next_interruption;
+                self.backing.exception_error_code = exit_info.idt_vectoring_error_code();
+            } else {
+                self.backing.interruption_information = Default::default();
+            }
+        }
+
+        let mut breakpoint_debug_exception = false;
+        let stat = match exit_info.code().vmx_exit() {
+            VmxExit::IO_INSTRUCTION => {
+                let io_qual = ExitQualificationIo::from(exit_info.qualification() as u32);
+
+                if io_qual.is_string() || io_qual.rep_prefix() {
+                    self.emulate(
+                        dev,
+                        self.backing.interruption_information.valid(),
+                        intercepted_vtl,
+                    )
+                    .await?;
+                } else {
+                    let len = match io_qual.access_size() {
+                        IO_SIZE_8_BIT => 1,
+                        IO_SIZE_16_BIT => 2,
+                        IO_SIZE_32_BIT => 4,
+                        _ => panic!(
+                            "tdx module returned invalid io instr size {}",
+                            io_qual.access_size()
+                        ),
+                    };
+
+                    let mut rax = self.runner.tdx_enter_guest_state().rax();
+                    emulate_io(
+                        self.inner.vp_info.base.vp_index,
+                        !io_qual.is_in(),
+                        io_qual.port(),
+                        &mut rax,
+                        len,
+                        dev,
+                    )
+                    .await;
+                    self.runner.tdx_enter_guest_state_mut().set_rax(rax);
+
+                    self.advance_to_next_instruction();
+                }
+                &mut self.backing.exit_stats.io
+            }
+            VmxExit::MSR_READ => {
+                let enter_state = self.runner.tdx_enter_guest_state();
+                let msr = enter_state.rcx() as u32;
+
+                let result = self
+                    .backing
+                    .lapic
+                    .access(&mut TdxApicClient {
+                        partition: self.partition,
+                        vmtime: &self.vmtime,
+                        apic_page: zerocopy::transmute_mut!(self.runner.tdx_apic_page_mut()),
+                        dev,
+                    })
+                    .msr_read(msr)
+                    .or_else_if_unknown(|| self.read_msr(msr, intercepted_vtl))
+                    .or_else_if_unknown(|| self.read_msr_cvm(msr, intercepted_vtl));
+
+                let value = match result {
+                    Ok(v) => Some(v),
+                    Err(MsrError::Unknown) => match msr {
+                        X86X_MSR_EFER => Some(self.backing.efer),
+                        _ => {
+                            tracelimit::error_ratelimited!(msr, "unknown tdx cvm msr read");
+                            Some(0)
+                        }
+                    },
+                    Err(MsrError::InvalidAccess) => None,
+                };
+
+                let inject_gp = if let Some(value) = value {
+                    let enter_state = self.runner.tdx_enter_guest_state_mut();
+                    enter_state.set_rax((value as u32).into());
+                    enter_state.set_rdx(((value >> 32) as u32).into());
+                    false
+                } else {
+                    true
+                };
+
+                if inject_gp {
+                    self.inject_gpf();
+                } else {
+                    self.advance_to_next_instruction();
+                }
+                &mut self.backing.exit_stats.msr_read
+            }
+            VmxExit::MSR_WRITE => {
+                let enter_state = self.runner.tdx_enter_guest_state();
+                let msr = enter_state.rcx() as u32;
+                let value =
+                    (enter_state.rax() as u32 as u64) | ((enter_state.rdx() as u32 as u64) << 32);
+
+                let result = self
+                    .backing
+                    .lapic
+                    .access(&mut TdxApicClient {
+                        partition: self.partition,
+                        vmtime: &self.vmtime,
+                        apic_page: zerocopy::transmute_mut!(self.runner.tdx_apic_page_mut()),
+                        dev,
+                    })
+                    .msr_write(msr, value)
+                    .or_else_if_unknown(|| self.write_msr(msr, value, intercepted_vtl))
+                    .or_else_if_unknown(|| self.write_msr_cvm(msr, value, intercepted_vtl));
+
+                let inject_gp = match result {
+                    Ok(()) => false,
+                    Err(MsrError::Unknown) => {
+                        tracelimit::error_ratelimited!(msr, value, "unknown tdx cvm msr write");
+                        false
+                    }
+                    Err(MsrError::InvalidAccess) => true,
+                };
+
+                if inject_gp {
+                    self.inject_gpf();
+                } else {
+                    self.advance_to_next_instruction();
+                }
+                &mut self.backing.exit_stats.msr_write
+            }
+            VmxExit::CPUID => {
+                let xss = self.runner.tdx_vp_state().msr_xss;
+                let enter_state = self.runner.tdx_enter_guest_state();
+                let leaf = enter_state.rax() as u32;
+                let subleaf = enter_state.rcx() as u32;
+                let xfem = self
+                    .runner
+                    .get_vp_register(HvX64RegisterName::Xfem)
+                    .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err)))?
+                    .as_u64();
+                let guest_state = crate::hardware_cvm::cpuid::CpuidGuestState {
+                    xfem,
+                    xss,
+                    cr4: self.backing.cr4.read(&self.runner),
+                    apic_id: self.inner.vp_info.apic_id,
+                };
+
+                let result = self.partition.cvm.as_ref().unwrap().cpuid.guest_result(
+                    CpuidFunction(leaf),
+                    subleaf,
+                    &guest_state,
+                );
+
+                tracing::trace!(leaf, subleaf, "cpuid");
+
+                let [eax, ebx, ecx, edx] = self.partition.cpuid.lock().result(
+                    leaf,
+                    subleaf,
+                    &[result.eax, result.ebx, result.ecx, result.edx],
+                );
+
+                tracing::trace!(eax, ebx, ecx, edx, "cpuid result");
+
+                let enter_state = self.runner.tdx_enter_guest_state_mut();
+                enter_state.set_rax(eax.into());
+                enter_state.set_rbx(ebx.into());
+                enter_state.set_rcx(ecx.into());
+                enter_state.set_rdx(edx.into());
+
+                self.advance_to_next_instruction();
+                &mut self.backing.exit_stats.cpuid
+            }
+            VmxExit::VMCALL_INSTRUCTION => {
+                if exit_info.cpl() != 0 {
+                    self.inject_gpf();
+                } else {
+                    let is_64bit = self.backing.cr0.read(&self.runner) & X64_CR0_PE != 0
+                        && self.backing.efer & X64_EFER_LMA != 0;
+
+                    let guest_memory = &self.partition.gm[intercepted_vtl];
+                    let handler = UhHypercallHandler {
+                        vp: &mut *self,
+                        bus: dev,
+                        trusted: true,
+                        intercepted_vtl,
+                    };
+
+                    UhHypercallHandler::TDX_DISPATCHER.dispatch(
+                        guest_memory,
+                        hv1_hypercall::X64RegisterIo::new(handler, is_64bit),
+                    );
+                }
+                &mut self.backing.exit_stats.vmcall
+            }
+            VmxExit::HLT_INSTRUCTION => {
+                self.backing.halted = true;
+
+                // TODO: see lots of these exits while waiting at frontpage.
+                // Probably expected, given we will still get L1 timer
+                // interrupts?
+
+                // Clear interrupt shadow.
+                let mask = Interruptibility::new().with_blocked_by_sti(true);
+                let value = Interruptibility::new().with_blocked_by_sti(false);
+                self.runner.write_vmcs32(
+                    GuestVtl::Vtl0,
+                    VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
+                    mask.into(),
+                    value.into(),
+                );
+                self.advance_to_next_instruction();
+                &mut self.backing.exit_stats.hlt
+            }
+            VmxExit::CR_ACCESS => {
+                let qual = CrAccessQualification::from(exit_info.qualification());
+                let cr;
+                let value;
+                match qual.access_type() {
+                    CR_ACCESS_TYPE_MOV_TO_CR => {
+                        cr = qual.cr();
+                        value =
+                            self.runner.tdx_enter_guest_state().gps[qual.gp_register() as usize];
+                    }
+                    CR_ACCESS_TYPE_LMSW => {
+                        cr = 0;
+                        let cr0 = self.backing.cr0.read(&self.runner);
+                        // LMSW updates the low four bits only.
+                        value = (qual.lmsw_source_data() as u64 & 0xf) | (cr0 & !0xf);
+                    }
+                    access_type => unreachable!("not registered for cr access type {access_type}"),
+                }
+                let r = match cr {
+                    0 => self.backing.cr0.write(value, &mut self.runner),
+                    4 => self.backing.cr4.write(value, &mut self.runner),
+                    cr => unreachable!("not registered for cr{cr} accesses"),
+                };
+                if r.is_ok() {
+                    self.update_execution_mode().expect("BUGBUG");
+                    self.advance_to_next_instruction();
+                } else {
+                    tracelimit::warn_ratelimited!(cr, value, "failed to write cr");
+                    self.inject_gpf();
+                }
+                &mut self.backing.exit_stats.cr_access
+            }
+            VmxExit::XSETBV => {
+                let enter_state = self.runner.tdx_enter_guest_state();
+                if let Some(value) =
+                    hardware_cvm::validate_xsetbv_exit(hardware_cvm::XsetbvExitInput {
+                        rax: enter_state.rax(),
+                        rcx: enter_state.rcx(),
+                        rdx: enter_state.rdx(),
+                        cr4: self.backing.cr4.read(&self.runner),
+                        cpl: exit_info.cpl(),
+                    })
+                {
+                    self.runner
+                        .set_vp_register(HvX64RegisterName::Xfem, value.into())
+                        .map_err(|err| {
+                            VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err))
+                        })?;
+                    self.advance_to_next_instruction();
+                } else {
+                    self.inject_gpf();
+                }
+                &mut self.backing.exit_stats.xsetbv
+            }
+            VmxExit::WBINVD_INSTRUCTION => {
+                // TODO TDX: forward the request to the host via TD.VMCALL
+                // see HvlRequestCacheFlush
+                self.advance_to_next_instruction();
+                &mut self.backing.exit_stats.wbinvd
+            }
+            VmxExit::EPT_VIOLATION => {
+                // TODO TDX: If this is an access to a shared gpa, we need to
+                // check the intercept page to see if this is a real exit or
+                // spurious. This exit is only real if the hypervisor has
+                // delivered an intercept message for this GPA.
+                //
+                // However, at this point the kernel has cleared that
+                // information so some kind of redesign is required to figure
+                // this out.
+                //
+                // For now, we instead treat EPTs on readable RAM as spurious
+                // and log appropriately. This check is also not entirely
+                // sufficient, as it may be a write access where the page is
+                // protected, but we don't yet support MNF/guest VSM so this is
+                // okay enough.
+                let is_readable_ram =
+                    self.partition.gm[intercepted_vtl].check_gpa_readable(exit_info.gpa());
+                if is_readable_ram {
+                    tracelimit::warn_ratelimited!(
+                        gpa = exit_info.gpa(),
+                        "possible spurious EPT violation, ignoring"
+                    );
+                } else {
+                    // If this was an EPT violation while handling an iret, and
+                    // that iret cleared the NMI blocking state, restore it.
+                    if !next_interruption.valid() {
+                        let ept_info = VmxEptExitQualification::from(exit_info.qualification());
+                        if ept_info.nmi_unmasking_due_to_iret() {
+                            let mask = Interruptibility::new().with_blocked_by_nmi(true);
+                            let value = Interruptibility::new().with_blocked_by_nmi(true);
+                            let old_interruptibility: Interruptibility = self
+                                .runner
+                                .write_vmcs32(
+                                    GuestVtl::Vtl0,
+                                    VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
+                                    mask.into(),
+                                    value.into(),
+                                )
+                                .into();
+                            assert!(!old_interruptibility.blocked_by_nmi());
+                        }
+                    }
+
+                    // Emulate the access.
+                    self.emulate(
+                        dev,
+                        self.backing.interruption_information.valid(),
+                        intercepted_vtl,
+                    )
+                    .await?;
+                }
+
+                &mut self.backing.exit_stats.ept_violation
+            }
+            VmxExit::TPR_BELOW_THRESHOLD => {
+                // Loop around to reevaluate the APIC.
+                &mut self.backing.exit_stats.tpr_below_threshold
+            }
+            VmxExit::INTERRUPT_WINDOW => {
+                // Loop around to reevaluate the APIC.
+                &mut self.backing.exit_stats.interrupt_window
+            }
+            VmxExit::NMI_WINDOW => {
+                // Loop around to reevaluate pending NMIs.
+                &mut self.backing.exit_stats.nmi_window
+            }
+            VmxExit::HW_INTERRUPT => {
+                // Check if the interrupt was triggered by a hardware breakpoint.
+                let debug_regs = self
+                    .access_state(Vtl::Vtl0)
+                    .debug_regs()
+                    .expect("register query should not fail");
+
+                // The lowest four bits of DR6 indicate which of the
+                // four breakpoints triggered.
+                breakpoint_debug_exception = debug_regs.dr6.trailing_zeros() < 4;
+                &mut self.backing.exit_stats.hw_interrupt
+            }
+            VmxExit::SMI_INTR => &mut self.backing.exit_stats.smi_intr,
+            VmxExit::PAUSE_INSTRUCTION => &mut self.backing.exit_stats.pause,
+            VmxExit::TDCALL => {
+                // If the proxy synic is local, then the host did not get this
+                // instruction, and we need to handle it.
+                if self.untrusted_synic.is_some() {
+                    self.handle_tdvmcall(dev, intercepted_vtl);
+                }
+                &mut self.backing.exit_stats.tdcall
+            }
+            VmxExit::TRIPLE_FAULT => {
+                return Err(VpHaltReason::TripleFault {
+                    vtl: intercepted_vtl.into(),
+                })
+            }
+            _ => {
+                return Err(VpHaltReason::Hypervisor(UhRunVpError::UnknownVmxExit(
+                    exit_info.code().vmx_exit(),
+                )))
+            }
         };
-        intercept_handler.handle_vmx_exit(dev).await?;
+        stat.increment();
+
+        // Breakpoint exceptions may return a non-fatal error.
+        // We dispatch here to correctly increment the counter.
+        if cfg!(feature = "gdb") && breakpoint_debug_exception {
+            self.handle_debug_exception(intercepted_vtl)?;
+        }
 
         Ok(())
     }
@@ -1794,9 +1654,127 @@ impl UhProcessor<'_, TdxBacked> {
         self.backing.exception_error_code = 0;
     }
 
+    fn handle_tdvmcall(&mut self, dev: &impl CpuIo, intercepted_vtl: GuestVtl) {
+        let regs = self.runner.tdx_enter_guest_state();
+        if regs.r10() == 0 {
+            // Architectural VMCALL.
+            let result = match VmxExit(regs.r11() as u32) {
+                VmxExit::MSR_WRITE => {
+                    let msr = regs.r12() as u32;
+                    let value = regs.r13();
+                    match self.write_tdvmcall_msr(msr, value, intercepted_vtl) {
+                        Ok(()) => {
+                            tracing::debug!(msr, value, "tdvmcall msr write");
+                            TdVmCallR10Result::SUCCESS
+                        }
+                        Err(err) => {
+                            tracelimit::warn_ratelimited!(
+                                msr,
+                                value,
+                                ?err,
+                                "failed tdvmcall msr write"
+                            );
+                            TdVmCallR10Result::OPERAND_INVALID
+                        }
+                    }
+                }
+                VmxExit::MSR_READ => {
+                    let msr = regs.r12() as u32;
+                    match self.read_tdvmcall_msr(msr, intercepted_vtl) {
+                        Ok(value) => {
+                            tracing::debug!(msr, value, "tdvmcall msr read");
+                            self.runner.tdx_enter_guest_state_mut().set_r11(value);
+                            TdVmCallR10Result::SUCCESS
+                        }
+                        Err(err) => {
+                            tracelimit::warn_ratelimited!(msr, ?err, "failed tdvmcall msr read");
+                            TdVmCallR10Result::OPERAND_INVALID
+                        }
+                    }
+                }
+                subfunction => {
+                    tracelimit::warn_ratelimited!(
+                        ?subfunction,
+                        "architectural vmcall not supported"
+                    );
+                    TdVmCallR10Result::OPERAND_INVALID
+                }
+            };
+            let regs = self.runner.tdx_enter_guest_state_mut();
+            regs.set_r10(result.0);
+            regs.rip = regs.rip.wrapping_add(4);
+        } else {
+            // This hypercall is normally handled by the hypervisor, so the gpas
+            // given by the guest should all be shared. The hypervisor allows
+            // gpas to be set with or without the shared gpa boundary bit, which
+            // untrusted_dma_memory correctly models. Note that some Linux
+            // guests will issue hypercalls without the boundary bit set,
+            // whereas UEFI will issue with the bit set.
+            let guest_memory = &self.partition.untrusted_dma_memory;
+            let handler = UhHypercallHandler {
+                vp: &mut *self,
+                bus: dev,
+                trusted: false,
+                intercepted_vtl,
+            };
+
+            UhHypercallHandler::TDCALL_DISPATCHER.dispatch(guest_memory, TdHypercall(handler));
+        }
+    }
+
+    fn read_tdvmcall_msr(&mut self, msr: u32, intercepted_vtl: GuestVtl) -> Result<u64, MsrError> {
+        match msr {
+            msr @ (hvdef::HV_X64_MSR_GUEST_OS_ID | hvdef::HV_X64_MSR_VP_INDEX) => {
+                self.hv(intercepted_vtl).unwrap().msr_read(msr)
+            }
+            _ => self
+                .untrusted_synic
+                .as_mut()
+                .unwrap()
+                .read_nontimer_msr(msr),
+        }
+    }
+
+    fn write_tdvmcall_msr(
+        &mut self,
+        msr: u32,
+        value: u64,
+        intercepted_vtl: GuestVtl,
+    ) -> Result<(), MsrError> {
+        match msr {
+            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => self
+                .hv_mut(intercepted_vtl)
+                .unwrap()
+                .msr_write(msr, value)?,
+            _ => {
+                self.untrusted_synic.as_mut().unwrap().write_nontimer_msr(
+                    &self.partition.gm[GuestVtl::Vtl0],
+                    msr,
+                    value,
+                )?;
+                // Propagate sint MSR writes to the hypervisor as well
+                // so that the hypervisor can directly inject events.
+                if matches!(msr, hvdef::HV_X64_MSR_SINT0..=hvdef::HV_X64_MSR_SINT15) {
+                    if let Err(err) = self.runner.set_vp_register(
+                        HvX64RegisterName(
+                            HvX64RegisterName::Sint0.0 + (msr - hvdef::HV_X64_MSR_SINT0),
+                        ),
+                        value.into(),
+                    ) {
+                        tracelimit::warn_ratelimited!(
+                            error = &err as &dyn std::error::Error,
+                            "failed to set sint register"
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn read_msr_cvm(&self, msr: u32, vtl: GuestVtl) -> Result<u64, MsrError> {
-        // TODO TDX: port remaining tdx and common values from PvlIm.c
-        // PvlImHandleMsrIntercept
+        // TODO TDX: port remaining tdx and common values
         //
         // TODO TDX: consider if this can be shared with SnpBacked's
         // implementation. For the most part other than Intel/TDX specific

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -774,6 +774,589 @@ impl BackingPrivate for TdxBacked {
     }
 }
 
+struct InterceptHandler<'a, 'b> {
+    vp: &'a mut UhProcessor<'b, TdxBacked>,
+    intercepted_vtl: GuestVtl,
+}
+
+impl InterceptHandler<'_, '_> {
+    async fn handle_vmx_exit(
+        &mut self,
+        dev: &impl CpuIo,
+    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+        let exit_info = TdxExit(self.vp.runner.tdx_vp_enter_exit_info());
+        let next_interruption = exit_info.idt_vectoring_info();
+
+        // Acknowledge the APIC interrupt/NMI if it was delivered.
+        if self.vp.backing.interruption_information.valid()
+            && (!next_interruption.valid()
+                || self.vp.backing.interruption_information.interruption_type()
+                    != next_interruption.interruption_type())
+        {
+            match self.vp.backing.interruption_information.interruption_type() {
+                INTERRUPT_TYPE_EXTERNAL if !self.vp.backing.lapic.is_offloaded() => {
+                    // This must be a pending APIC interrupt. Acknowledge it.
+                    tracing::debug!(
+                        vector = self.vp.backing.interruption_information.vector(),
+                        "acknowledging interrupt"
+                    );
+                    self.vp
+                        .backing
+                        .lapic
+                        .acknowledge_interrupt(self.vp.backing.interruption_information.vector());
+                }
+                INTERRUPT_TYPE_NMI => {
+                    // This must be a pending NMI.
+                    tracing::debug!("acknowledging NMI");
+                    self.vp.backing.nmi_pending = false;
+                }
+                _ => {}
+            }
+        }
+
+        if self.vp.backing.lapic.is_offloaded() {
+            // It's possible with vAPIC that we take an exit in the window where
+            // hardware has moved a bit from IRR to ISR, but has not injected
+            // the interrupt into the guest. In this case, we need to track that
+            // we must inject the interrupt before we return to the guest,
+            // otherwise the interrupt will be lost and the guest left in a bad
+            // state.
+            //
+            // TODO TDX: Unclear what kind of exits these would be, but they
+            // should be spurious EPT exits. Can we validate or assert that
+            // somehow? If we were to somehow call some other path which would
+            // set interruption_information before we inject this one, we would
+            // lose this interrupt.
+            if next_interruption.valid() {
+                tracing::debug!(
+                    ?next_interruption,
+                    vp_index = self.vp.vp_index().index(),
+                    "exit requires reinjecting interrupt"
+                );
+                self.vp.backing.interruption_information = next_interruption;
+                self.vp.backing.exception_error_code = exit_info.idt_vectoring_error_code();
+                self.vp
+                    .backing
+                    .exit_stats
+                    .needs_interrupt_reinject
+                    .increment();
+            } else {
+                self.vp.backing.interruption_information = Default::default();
+            }
+        } else {
+            // Ignore (and later recalculate) the next interruption if it is an
+            // external interrupt or NMI, since it may change if the APIC state
+            // changes.
+            if next_interruption.valid()
+                && !matches!(
+                    next_interruption.interruption_type(),
+                    INTERRUPT_TYPE_EXTERNAL | INTERRUPT_TYPE_NMI
+                )
+            {
+                self.vp.backing.interruption_information = next_interruption;
+                self.vp.backing.exception_error_code = exit_info.idt_vectoring_error_code();
+            } else {
+                self.vp.backing.interruption_information = Default::default();
+            }
+        }
+
+        let mut breakpoint_debug_exception = false;
+        let stat = match exit_info.code().vmx_exit() {
+            VmxExit::IO_INSTRUCTION => {
+                let io_qual = ExitQualificationIo::from(exit_info.qualification() as u32);
+
+                if io_qual.is_string() || io_qual.rep_prefix() {
+                    self.vp
+                        .emulate(
+                            dev,
+                            self.vp.backing.interruption_information.valid(),
+                            self.intercepted_vtl,
+                        )
+                        .await?;
+                } else {
+                    let len = match io_qual.access_size() {
+                        IO_SIZE_8_BIT => 1,
+                        IO_SIZE_16_BIT => 2,
+                        IO_SIZE_32_BIT => 4,
+                        _ => panic!(
+                            "tdx module returned invalid io instr size {}",
+                            io_qual.access_size()
+                        ),
+                    };
+
+                    let mut rax = self.vp.runner.tdx_enter_guest_state().rax();
+                    emulate_io(
+                        self.vp.inner.vp_info.base.vp_index,
+                        !io_qual.is_in(),
+                        io_qual.port(),
+                        &mut rax,
+                        len,
+                        dev,
+                    )
+                    .await;
+                    self.vp.runner.tdx_enter_guest_state_mut().set_rax(rax);
+
+                    self.vp.advance_to_next_instruction();
+                }
+                &mut self.vp.backing.exit_stats.io
+            }
+            VmxExit::MSR_READ => {
+                let enter_state = self.vp.runner.tdx_enter_guest_state();
+                let msr = enter_state.rcx() as u32;
+
+                let result = self
+                    .vp
+                    .backing
+                    .lapic
+                    .access(&mut TdxApicClient {
+                        partition: self.vp.partition,
+                        vmtime: &self.vp.vmtime,
+                        apic_page: zerocopy::transmute_mut!(self.vp.runner.tdx_apic_page_mut()),
+                        dev,
+                    })
+                    .msr_read(msr)
+                    .or_else_if_unknown(|| self.vp.read_msr(msr, self.intercepted_vtl))
+                    .or_else_if_unknown(|| self.vp.read_msr_cvm(msr, self.intercepted_vtl));
+
+                let value = match result {
+                    Ok(v) => Some(v),
+                    Err(MsrError::Unknown) => match msr {
+                        X86X_MSR_EFER => Some(self.vp.backing.efer),
+                        _ => {
+                            tracelimit::error_ratelimited!(msr, "unknown tdx cvm msr read");
+                            Some(0)
+                        }
+                    },
+                    Err(MsrError::InvalidAccess) => None,
+                };
+
+                let inject_gp = if let Some(value) = value {
+                    let enter_state = self.vp.runner.tdx_enter_guest_state_mut();
+                    enter_state.set_rax((value as u32).into());
+                    enter_state.set_rdx(((value >> 32) as u32).into());
+                    false
+                } else {
+                    true
+                };
+
+                if inject_gp {
+                    self.vp.inject_gpf();
+                } else {
+                    self.vp.advance_to_next_instruction();
+                }
+                &mut self.vp.backing.exit_stats.msr_read
+            }
+            VmxExit::MSR_WRITE => {
+                let enter_state = self.vp.runner.tdx_enter_guest_state();
+                let msr = enter_state.rcx() as u32;
+                let value =
+                    (enter_state.rax() as u32 as u64) | ((enter_state.rdx() as u32 as u64) << 32);
+
+                let result = self
+                    .vp
+                    .backing
+                    .lapic
+                    .access(&mut TdxApicClient {
+                        partition: self.vp.partition,
+                        vmtime: &self.vp.vmtime,
+                        apic_page: zerocopy::transmute_mut!(self.vp.runner.tdx_apic_page_mut()),
+                        dev,
+                    })
+                    .msr_write(msr, value)
+                    .or_else_if_unknown(|| self.vp.write_msr(msr, value, self.intercepted_vtl))
+                    .or_else_if_unknown(|| self.vp.write_msr_cvm(msr, value, self.intercepted_vtl));
+
+                let inject_gp = match result {
+                    Ok(()) => false,
+                    Err(MsrError::Unknown) => {
+                        tracelimit::error_ratelimited!(msr, value, "unknown tdx cvm msr write");
+                        false
+                    }
+                    Err(MsrError::InvalidAccess) => true,
+                };
+
+                if inject_gp {
+                    self.vp.inject_gpf();
+                } else {
+                    self.vp.advance_to_next_instruction();
+                }
+                &mut self.vp.backing.exit_stats.msr_write
+            }
+            VmxExit::CPUID => {
+                let xss = self.vp.runner.tdx_vp_state().msr_xss;
+                let enter_state = self.vp.runner.tdx_enter_guest_state();
+                let leaf = enter_state.rax() as u32;
+                let subleaf = enter_state.rcx() as u32;
+                let xfem = self
+                    .vp
+                    .runner
+                    .get_vp_register(HvX64RegisterName::Xfem)
+                    .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err)))?
+                    .as_u64();
+                let guest_state = crate::hardware_cvm::cpuid::CpuidGuestState {
+                    xfem,
+                    xss,
+                    cr4: self.vp.backing.cr4.read(&self.vp.runner),
+                    apic_id: self.vp.inner.vp_info.apic_id,
+                };
+
+                let result = self.vp.partition.cvm.as_ref().unwrap().cpuid.guest_result(
+                    CpuidFunction(leaf),
+                    subleaf,
+                    &guest_state,
+                );
+
+                tracing::trace!(leaf, subleaf, "cpuid");
+
+                let [eax, ebx, ecx, edx] = self.vp.partition.cpuid.lock().result(
+                    leaf,
+                    subleaf,
+                    &[result.eax, result.ebx, result.ecx, result.edx],
+                );
+
+                tracing::trace!(eax, ebx, ecx, edx, "cpuid result");
+
+                let enter_state = self.vp.runner.tdx_enter_guest_state_mut();
+                enter_state.set_rax(eax.into());
+                enter_state.set_rbx(ebx.into());
+                enter_state.set_rcx(ecx.into());
+                enter_state.set_rdx(edx.into());
+
+                self.vp.advance_to_next_instruction();
+                &mut self.vp.backing.exit_stats.cpuid
+            }
+            VmxExit::VMCALL_INSTRUCTION => {
+                if exit_info.cpl() != 0 {
+                    self.vp.inject_gpf();
+                } else {
+                    let is_64bit = self.vp.backing.cr0.read(&self.vp.runner) & X64_CR0_PE != 0
+                        && self.vp.backing.efer & X64_EFER_LMA != 0;
+
+                    let guest_memory = &self.vp.partition.gm[self.intercepted_vtl];
+                    let handler = UhHypercallHandler {
+                        vp: &mut *self.vp,
+                        bus: dev,
+                        trusted: true,
+                        intercepted_vtl: self.intercepted_vtl,
+                    };
+
+                    UhHypercallHandler::TDX_DISPATCHER.dispatch(
+                        guest_memory,
+                        hv1_hypercall::X64RegisterIo::new(handler, is_64bit),
+                    );
+                }
+                &mut self.vp.backing.exit_stats.vmcall
+            }
+            VmxExit::HLT_INSTRUCTION => {
+                self.vp.backing.halted = true;
+
+                // TODO: see lots of these exits while waiting at frontpage.
+                // Probably expected, given we will still get L1 timer
+                // interrupts?
+
+                // Clear interrupt shadow.
+                let mask = Interruptibility::new().with_blocked_by_sti(true);
+                let value = Interruptibility::new().with_blocked_by_sti(false);
+                self.vp.runner.write_vmcs32(
+                    GuestVtl::Vtl0,
+                    VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
+                    mask.into(),
+                    value.into(),
+                );
+                self.vp.advance_to_next_instruction();
+                &mut self.vp.backing.exit_stats.hlt
+            }
+            VmxExit::CR_ACCESS => {
+                let qual = CrAccessQualification::from(exit_info.qualification());
+                let cr;
+                let value;
+                match qual.access_type() {
+                    CR_ACCESS_TYPE_MOV_TO_CR => {
+                        cr = qual.cr();
+                        value =
+                            self.vp.runner.tdx_enter_guest_state().gps[qual.gp_register() as usize];
+                    }
+                    CR_ACCESS_TYPE_LMSW => {
+                        cr = 0;
+                        let cr0 = self.vp.backing.cr0.read(&self.vp.runner);
+                        // LMSW updates the low four bits only.
+                        value = (qual.lmsw_source_data() as u64 & 0xf) | (cr0 & !0xf);
+                    }
+                    access_type => unreachable!("not registered for cr access type {access_type}"),
+                }
+                let r = match cr {
+                    0 => self.vp.backing.cr0.write(value, &mut self.vp.runner),
+                    4 => self.vp.backing.cr4.write(value, &mut self.vp.runner),
+                    cr => unreachable!("not registered for cr{cr} accesses"),
+                };
+                if r.is_ok() {
+                    self.vp.update_execution_mode().expect("BUGBUG");
+                    self.vp.advance_to_next_instruction();
+                } else {
+                    tracelimit::warn_ratelimited!(cr, value, "failed to write cr");
+                    self.vp.inject_gpf();
+                }
+                &mut self.vp.backing.exit_stats.cr_access
+            }
+            VmxExit::XSETBV => {
+                let enter_state = self.vp.runner.tdx_enter_guest_state();
+                if let Some(value) =
+                    hardware_cvm::validate_xsetbv_exit(hardware_cvm::XsetbvExitInput {
+                        rax: enter_state.rax(),
+                        rcx: enter_state.rcx(),
+                        rdx: enter_state.rdx(),
+                        cr4: self.vp.backing.cr4.read(&self.vp.runner),
+                        cpl: exit_info.cpl(),
+                    })
+                {
+                    self.vp
+                        .runner
+                        .set_vp_register(HvX64RegisterName::Xfem, value.into())
+                        .map_err(|err| {
+                            VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err))
+                        })?;
+                    self.vp.advance_to_next_instruction();
+                } else {
+                    self.vp.inject_gpf();
+                }
+                &mut self.vp.backing.exit_stats.xsetbv
+            }
+            VmxExit::WBINVD_INSTRUCTION => {
+                // TODO TDX: forward the request to the host via TD.VMCALL
+                // see HvlRequestCacheFlush
+                self.vp.advance_to_next_instruction();
+                &mut self.vp.backing.exit_stats.wbinvd
+            }
+            VmxExit::EPT_VIOLATION => {
+                // TODO TDX: If this is an access to a shared gpa, we need to
+                // check the intercept page to see if this is a real exit or
+                // spurious. This exit is only real if the hypervisor has
+                // delivered an intercept message for this GPA.
+                //
+                // However, at this point the kernel has cleared that
+                // information so some kind of redesign is required to figure
+                // this out.
+                //
+                // For now, we instead treat EPTs on readable RAM as spurious
+                // and log appropriately. This check is also not entirely
+                // sufficient, as it may be a write access where the page is
+                // protected, but we don't yet support MNF/guest VSM so this is
+                // okay enough.
+                let is_readable_ram =
+                    self.vp.partition.gm[self.intercepted_vtl].check_gpa_readable(exit_info.gpa());
+                if is_readable_ram {
+                    tracelimit::warn_ratelimited!(
+                        gpa = exit_info.gpa(),
+                        "possible spurious EPT violation, ignoring"
+                    );
+                } else {
+                    // If this was an EPT violation while handling an iret, and
+                    // that iret cleared the NMI blocking state, restore it.
+                    if !next_interruption.valid() {
+                        let ept_info = VmxEptExitQualification::from(exit_info.qualification());
+                        if ept_info.nmi_unmasking_due_to_iret() {
+                            let mask = Interruptibility::new().with_blocked_by_nmi(true);
+                            let value = Interruptibility::new().with_blocked_by_nmi(true);
+                            let old_interruptibility: Interruptibility = self
+                                .vp
+                                .runner
+                                .write_vmcs32(
+                                    GuestVtl::Vtl0,
+                                    VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
+                                    mask.into(),
+                                    value.into(),
+                                )
+                                .into();
+                            assert!(!old_interruptibility.blocked_by_nmi());
+                        }
+                    }
+
+                    // Emulate the access.
+                    self.vp
+                        .emulate(
+                            dev,
+                            self.vp.backing.interruption_information.valid(),
+                            self.intercepted_vtl,
+                        )
+                        .await?;
+                }
+
+                &mut self.vp.backing.exit_stats.ept_violation
+            }
+            VmxExit::TPR_BELOW_THRESHOLD => {
+                // Loop around to reevaluate the APIC.
+                &mut self.vp.backing.exit_stats.tpr_below_threshold
+            }
+            VmxExit::INTERRUPT_WINDOW => {
+                // Loop around to reevaluate the APIC.
+                &mut self.vp.backing.exit_stats.interrupt_window
+            }
+            VmxExit::NMI_WINDOW => {
+                // Loop around to reevaluate pending NMIs.
+                &mut self.vp.backing.exit_stats.nmi_window
+            }
+            VmxExit::HW_INTERRUPT => {
+                // Check if the interrupt was triggered by a hardware breakpoint.
+                let debug_regs = self
+                    .vp
+                    .access_state(Vtl::Vtl0)
+                    .debug_regs()
+                    .expect("register query should not fail");
+
+                // The lowest four bits of DR6 indicate which of the
+                // four breakpoints triggered.
+                breakpoint_debug_exception = debug_regs.dr6.trailing_zeros() < 4;
+                &mut self.vp.backing.exit_stats.hw_interrupt
+            }
+            VmxExit::SMI_INTR => &mut self.vp.backing.exit_stats.smi_intr,
+            VmxExit::PAUSE_INSTRUCTION => &mut self.vp.backing.exit_stats.pause,
+            VmxExit::TDCALL => {
+                // If the proxy synic is local, then the host did not get this
+                // instruction, and we need to handle it.
+                if self.vp.untrusted_synic.is_some() {
+                    self.handle_tdvmcall(dev);
+                }
+                &mut self.vp.backing.exit_stats.tdcall
+            }
+            VmxExit::TRIPLE_FAULT => {
+                return Err(VpHaltReason::TripleFault {
+                    vtl: self.intercepted_vtl.into(),
+                })
+            }
+            _ => {
+                return Err(VpHaltReason::Hypervisor(UhRunVpError::UnknownVmxExit(
+                    exit_info.code().vmx_exit(),
+                )))
+            }
+        };
+        stat.increment();
+
+        // Breakpoint exceptions may return a non-fatal error.
+        // We dispatch here to correctly increment the counter.
+        if cfg!(feature = "gdb") && breakpoint_debug_exception {
+            self.vp.handle_debug_exception(self.intercepted_vtl)?;
+        }
+
+        Ok(())
+    }
+
+    fn handle_tdvmcall(&mut self, dev: &impl CpuIo) {
+        let regs = self.vp.runner.tdx_enter_guest_state();
+        if regs.r10() == 0 {
+            // Architectural VMCALL.
+            let result = match VmxExit(regs.r11() as u32) {
+                VmxExit::MSR_WRITE => {
+                    let msr = regs.r12() as u32;
+                    let value = regs.r13();
+                    match self.write_tdvmcall_msr(msr, value) {
+                        Ok(()) => {
+                            tracing::debug!(msr, value, "tdvmcall msr write");
+                            TdVmCallR10Result::SUCCESS
+                        }
+                        Err(err) => {
+                            tracelimit::warn_ratelimited!(
+                                msr,
+                                value,
+                                ?err,
+                                "failed tdvmcall msr write"
+                            );
+                            TdVmCallR10Result::OPERAND_INVALID
+                        }
+                    }
+                }
+                VmxExit::MSR_READ => {
+                    let msr = regs.r12() as u32;
+                    match self.read_tdvmcall_msr(msr) {
+                        Ok(value) => {
+                            tracing::debug!(msr, value, "tdvmcall msr read");
+                            self.vp.runner.tdx_enter_guest_state_mut().set_r11(value);
+                            TdVmCallR10Result::SUCCESS
+                        }
+                        Err(err) => {
+                            tracelimit::warn_ratelimited!(msr, ?err, "failed tdvmcall msr read");
+                            TdVmCallR10Result::OPERAND_INVALID
+                        }
+                    }
+                }
+                subfunction => {
+                    tracelimit::warn_ratelimited!(
+                        ?subfunction,
+                        "architectural vmcall not supported"
+                    );
+                    TdVmCallR10Result::OPERAND_INVALID
+                }
+            };
+            let regs = self.vp.runner.tdx_enter_guest_state_mut();
+            regs.set_r10(result.0);
+            regs.rip = regs.rip.wrapping_add(4);
+        } else {
+            // This hypercall is normally handled by the hypervisor, so the gpas
+            // given by the guest should all be shared. The hypervisor allows
+            // gpas to be set with or without the shared gpa boundary bit, which
+            // untrusted_dma_memory correctly models. Note that some Linux
+            // guests will issue hypercalls without the boundary bit set,
+            // whereas UEFI will issue with the bit set.
+            let guest_memory = &self.vp.partition.untrusted_dma_memory;
+            let handler = UhHypercallHandler {
+                vp: &mut *self.vp,
+                bus: dev,
+                trusted: false,
+                intercepted_vtl: self.intercepted_vtl,
+            };
+
+            UhHypercallHandler::TDCALL_DISPATCHER.dispatch(guest_memory, TdHypercall(handler));
+        }
+    }
+
+    fn read_tdvmcall_msr(&mut self, msr: u32) -> Result<u64, MsrError> {
+        match msr {
+            msr @ (hvdef::HV_X64_MSR_GUEST_OS_ID | hvdef::HV_X64_MSR_VP_INDEX) => {
+                self.vp.hv(self.intercepted_vtl).unwrap().msr_read(msr)
+            }
+            _ => self
+                .vp
+                .untrusted_synic
+                .as_mut()
+                .unwrap()
+                .read_nontimer_msr(msr),
+        }
+    }
+
+    fn write_tdvmcall_msr(&mut self, msr: u32, value: u64) -> Result<(), MsrError> {
+        match msr {
+            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => self
+                .vp
+                .hv_mut(self.intercepted_vtl)
+                .unwrap()
+                .msr_write(msr, value)?,
+            _ => {
+                self.vp
+                    .untrusted_synic
+                    .as_mut()
+                    .unwrap()
+                    .write_nontimer_msr(&self.vp.partition.gm[GuestVtl::Vtl0], msr, value)?;
+                // Propagate sint MSR writes to the hypervisor as well
+                // so that the hypervisor can directly inject events.
+                if matches!(msr, hvdef::HV_X64_MSR_SINT0..=hvdef::HV_X64_MSR_SINT15) {
+                    if let Err(err) = self.vp.runner.set_vp_register(
+                        HvX64RegisterName(
+                            HvX64RegisterName::Sint0.0 + (msr - hvdef::HV_X64_MSR_SINT0),
+                        ),
+                        value.into(),
+                    ) {
+                        tracelimit::warn_ratelimited!(
+                            error = &err as &dyn std::error::Error,
+                            "failed to set sint register"
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 impl UhProcessor<'_, TdxBacked> {
     /// Returns `Ok(false)` if the APIC offload needs to be disabled and the
     /// poll retried.
@@ -1152,6 +1735,11 @@ impl UhProcessor<'_, TdxBacked> {
             return Ok(());
         }
 
+        let entered_from_vtl = self
+            .cvm_guest_vsm
+            .as_ref()
+            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
+
         let exit_info = TdxExit(self.runner.tdx_vp_enter_exit_info());
 
         // Result codes above PENDING_INTERRUPT indicate the L2 was never entered.
@@ -1182,457 +1770,11 @@ impl UhProcessor<'_, TdxBacked> {
         };
 
         stat.increment();
-        self.handle_vmx_exit(dev).await?;
-        Ok(())
-    }
-
-    async fn handle_vmx_exit(
-        &mut self,
-        dev: &impl CpuIo,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let exit_info = TdxExit(self.runner.tdx_vp_enter_exit_info());
-        let next_interruption = exit_info.idt_vectoring_info();
-        let intercepted_vtl = self
-            .cvm_guest_vsm
-            .as_ref()
-            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
-
-        // Acknowledge the APIC interrupt/NMI if it was delivered.
-        if self.backing.interruption_information.valid()
-            && (!next_interruption.valid()
-                || self.backing.interruption_information.interruption_type()
-                    != next_interruption.interruption_type())
-        {
-            match self.backing.interruption_information.interruption_type() {
-                INTERRUPT_TYPE_EXTERNAL if !self.backing.lapic.is_offloaded() => {
-                    // This must be a pending APIC interrupt. Acknowledge it.
-                    tracing::debug!(
-                        vector = self.backing.interruption_information.vector(),
-                        "acknowledging interrupt"
-                    );
-                    self.backing
-                        .lapic
-                        .acknowledge_interrupt(self.backing.interruption_information.vector());
-                }
-                INTERRUPT_TYPE_NMI => {
-                    // This must be a pending NMI.
-                    tracing::debug!("acknowledging NMI");
-                    self.backing.nmi_pending = false;
-                }
-                _ => {}
-            }
-        }
-
-        if self.backing.lapic.is_offloaded() {
-            // It's possible with vAPIC that we take an exit in the window where
-            // hardware has moved a bit from IRR to ISR, but has not injected
-            // the interrupt into the guest. In this case, we need to track that
-            // we must inject the interrupt before we return to the guest,
-            // otherwise the interrupt will be lost and the guest left in a bad
-            // state.
-            //
-            // TODO TDX: Unclear what kind of exits these would be, but they
-            // should be spurious EPT exits. Can we validate or assert that
-            // somehow? If we were to somehow call some other path which would
-            // set interruption_information before we inject this one, we would
-            // lose this interrupt.
-            if next_interruption.valid() {
-                tracing::debug!(
-                    ?next_interruption,
-                    vp_index = self.vp_index().index(),
-                    "exit requires reinjecting interrupt"
-                );
-                self.backing.interruption_information = next_interruption;
-                self.backing.exception_error_code = exit_info.idt_vectoring_error_code();
-                self.backing.exit_stats.needs_interrupt_reinject.increment();
-            } else {
-                self.backing.interruption_information = Default::default();
-            }
-        } else {
-            // Ignore (and later recalculate) the next interruption if it is an
-            // external interrupt or NMI, since it may change if the APIC state
-            // changes.
-            if next_interruption.valid()
-                && !matches!(
-                    next_interruption.interruption_type(),
-                    INTERRUPT_TYPE_EXTERNAL | INTERRUPT_TYPE_NMI
-                )
-            {
-                self.backing.interruption_information = next_interruption;
-                self.backing.exception_error_code = exit_info.idt_vectoring_error_code();
-            } else {
-                self.backing.interruption_information = Default::default();
-            }
-        }
-
-        let mut breakpoint_debug_exception = false;
-        let stat = match exit_info.code().vmx_exit() {
-            VmxExit::IO_INSTRUCTION => {
-                let io_qual = ExitQualificationIo::from(exit_info.qualification() as u32);
-
-                if io_qual.is_string() || io_qual.rep_prefix() {
-                    self.emulate(
-                        dev,
-                        self.backing.interruption_information.valid(),
-                        intercepted_vtl,
-                    )
-                    .await?;
-                } else {
-                    let len = match io_qual.access_size() {
-                        IO_SIZE_8_BIT => 1,
-                        IO_SIZE_16_BIT => 2,
-                        IO_SIZE_32_BIT => 4,
-                        _ => panic!(
-                            "tdx module returned invalid io instr size {}",
-                            io_qual.access_size()
-                        ),
-                    };
-
-                    let mut rax = self.runner.tdx_enter_guest_state().rax();
-                    emulate_io(
-                        self.inner.vp_info.base.vp_index,
-                        !io_qual.is_in(),
-                        io_qual.port(),
-                        &mut rax,
-                        len,
-                        dev,
-                    )
-                    .await;
-                    self.runner.tdx_enter_guest_state_mut().set_rax(rax);
-
-                    self.advance_to_next_instruction();
-                }
-                &mut self.backing.exit_stats.io
-            }
-            VmxExit::MSR_READ => {
-                let enter_state = self.runner.tdx_enter_guest_state();
-                let msr = enter_state.rcx() as u32;
-
-                let result = self
-                    .backing
-                    .lapic
-                    .access(&mut TdxApicClient {
-                        partition: self.partition,
-                        vmtime: &self.vmtime,
-                        apic_page: zerocopy::transmute_mut!(self.runner.tdx_apic_page_mut()),
-                        dev,
-                    })
-                    .msr_read(msr)
-                    .or_else_if_unknown(|| self.read_msr(msr, intercepted_vtl))
-                    .or_else_if_unknown(|| self.read_msr_cvm(msr));
-
-                let value = match result {
-                    Ok(v) => Some(v),
-                    Err(MsrError::Unknown) => match msr {
-                        X86X_MSR_EFER => Some(self.backing.efer),
-                        _ => {
-                            tracelimit::error_ratelimited!(msr, "unknown tdx cvm msr read");
-                            Some(0)
-                        }
-                    },
-                    Err(MsrError::InvalidAccess) => None,
-                };
-
-                let inject_gp = if let Some(value) = value {
-                    let enter_state = self.runner.tdx_enter_guest_state_mut();
-                    enter_state.set_rax((value as u32).into());
-                    enter_state.set_rdx(((value >> 32) as u32).into());
-                    false
-                } else {
-                    true
-                };
-
-                if inject_gp {
-                    self.inject_gpf();
-                } else {
-                    self.advance_to_next_instruction();
-                }
-                &mut self.backing.exit_stats.msr_read
-            }
-            VmxExit::MSR_WRITE => {
-                let enter_state = self.runner.tdx_enter_guest_state();
-                let msr = enter_state.rcx() as u32;
-                let value =
-                    (enter_state.rax() as u32 as u64) | ((enter_state.rdx() as u32 as u64) << 32);
-
-                let result = self
-                    .backing
-                    .lapic
-                    .access(&mut TdxApicClient {
-                        partition: self.partition,
-                        vmtime: &self.vmtime,
-                        apic_page: zerocopy::transmute_mut!(self.runner.tdx_apic_page_mut()),
-                        dev,
-                    })
-                    .msr_write(msr, value)
-                    .or_else_if_unknown(|| self.write_msr(msr, value, intercepted_vtl))
-                    .or_else_if_unknown(|| self.write_msr_cvm(msr, value));
-
-                let inject_gp = match result {
-                    Ok(()) => false,
-                    Err(MsrError::Unknown) => {
-                        tracelimit::error_ratelimited!(msr, value, "unknown tdx cvm msr write");
-                        false
-                    }
-                    Err(MsrError::InvalidAccess) => true,
-                };
-
-                if inject_gp {
-                    self.inject_gpf();
-                } else {
-                    self.advance_to_next_instruction();
-                }
-                &mut self.backing.exit_stats.msr_write
-            }
-            VmxExit::CPUID => {
-                let xss = self.runner.tdx_vp_state().msr_xss;
-                let enter_state = self.runner.tdx_enter_guest_state();
-                let leaf = enter_state.rax() as u32;
-                let subleaf = enter_state.rcx() as u32;
-                let xfem = self
-                    .runner
-                    .get_vp_register(HvX64RegisterName::Xfem)
-                    .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err)))?
-                    .as_u64();
-                let guest_state = crate::hardware_cvm::cpuid::CpuidGuestState {
-                    xfem,
-                    xss,
-                    cr4: self.backing.cr4.read(&self.runner),
-                    apic_id: self.inner.vp_info.apic_id,
-                };
-
-                let result = self.backing.shared.cvm.cpuid.guest_result(
-                    CpuidFunction(leaf),
-                    subleaf,
-                    &guest_state,
-                );
-
-                tracing::trace!(leaf, subleaf, "cpuid");
-
-                let [eax, ebx, ecx, edx] = self.partition.cpuid.lock().result(
-                    leaf,
-                    subleaf,
-                    &[result.eax, result.ebx, result.ecx, result.edx],
-                );
-
-                tracing::trace!(eax, ebx, ecx, edx, "cpuid result");
-
-                let enter_state = self.runner.tdx_enter_guest_state_mut();
-                enter_state.set_rax(eax.into());
-                enter_state.set_rbx(ebx.into());
-                enter_state.set_rcx(ecx.into());
-                enter_state.set_rdx(edx.into());
-
-                self.advance_to_next_instruction();
-                &mut self.backing.exit_stats.cpuid
-            }
-            VmxExit::VMCALL_INSTRUCTION => {
-                if exit_info.cpl() != 0 {
-                    self.inject_gpf();
-                } else {
-                    let is_64bit = self.backing.cr0.read(&self.runner) & X64_CR0_PE != 0
-                        && self.backing.efer & X64_EFER_LMA != 0;
-
-                    let guest_memory = &self.partition.gm[intercepted_vtl];
-                    let handler = UhHypercallHandler {
-                        vp: &mut *self,
-                        bus: dev,
-                        trusted: true,
-                        intercepted_vtl,
-                    };
-
-                    UhHypercallHandler::TDX_DISPATCHER.dispatch(
-                        guest_memory,
-                        hv1_hypercall::X64RegisterIo::new(handler, is_64bit),
-                    );
-                }
-                &mut self.backing.exit_stats.vmcall
-            }
-            VmxExit::HLT_INSTRUCTION => {
-                self.backing.halted = true;
-
-                // TODO: see lots of these exits while waiting at frontpage.
-                // Probably expected, given we will still get L1 timer
-                // interrupts?
-
-                // Clear interrupt shadow.
-                let mask = Interruptibility::new().with_blocked_by_sti(true);
-                let value = Interruptibility::new().with_blocked_by_sti(false);
-                self.runner.write_vmcs32(
-                    GuestVtl::Vtl0,
-                    VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
-                    mask.into(),
-                    value.into(),
-                );
-                self.advance_to_next_instruction();
-                &mut self.backing.exit_stats.hlt
-            }
-            VmxExit::CR_ACCESS => {
-                let qual = CrAccessQualification::from(exit_info.qualification());
-                let cr;
-                let value;
-                match qual.access_type() {
-                    CR_ACCESS_TYPE_MOV_TO_CR => {
-                        cr = qual.cr();
-                        value =
-                            self.runner.tdx_enter_guest_state().gps[qual.gp_register() as usize];
-                    }
-                    CR_ACCESS_TYPE_LMSW => {
-                        cr = 0;
-                        let cr0 = self.backing.cr0.read(&self.runner);
-                        // LMSW updates the low four bits only.
-                        value = (qual.lmsw_source_data() as u64 & 0xf) | (cr0 & !0xf);
-                    }
-                    access_type => unreachable!("not registered for cr access type {access_type}"),
-                }
-                let r = match cr {
-                    0 => self.backing.cr0.write(value, &mut self.runner),
-                    4 => self.backing.cr4.write(value, &mut self.runner),
-                    cr => unreachable!("not registered for cr{cr} accesses"),
-                };
-                if r.is_ok() {
-                    self.update_execution_mode().expect("BUGBUG");
-                    self.advance_to_next_instruction();
-                } else {
-                    tracelimit::warn_ratelimited!(cr, value, "failed to write cr");
-                    self.inject_gpf();
-                }
-                &mut self.backing.exit_stats.cr_access
-            }
-            VmxExit::XSETBV => {
-                let enter_state = self.runner.tdx_enter_guest_state();
-                if let Some(value) =
-                    hardware_cvm::validate_xsetbv_exit(hardware_cvm::XsetbvExitInput {
-                        rax: enter_state.rax(),
-                        rcx: enter_state.rcx(),
-                        rdx: enter_state.rdx(),
-                        cr4: self.backing.cr4.read(&self.runner),
-                        cpl: exit_info.cpl(),
-                    })
-                {
-                    self.runner
-                        .set_vp_register(HvX64RegisterName::Xfem, value.into())
-                        .map_err(|err| {
-                            VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err))
-                        })?;
-                    self.advance_to_next_instruction();
-                } else {
-                    self.inject_gpf();
-                }
-                &mut self.backing.exit_stats.xsetbv
-            }
-            VmxExit::WBINVD_INSTRUCTION => {
-                // TODO TDX: forward the request to the host via TD.VMCALL
-                // see HvlRequestCacheFlush
-                self.advance_to_next_instruction();
-                &mut self.backing.exit_stats.wbinvd
-            }
-            VmxExit::EPT_VIOLATION => {
-                // TODO TDX: If this is an access to a shared gpa, we need to
-                // check the intercept page to see if this is a real exit or
-                // spurious. This exit is only real if the hypervisor has
-                // delivered an intercept message for this GPA.
-                //
-                // However, at this point the kernel has cleared that
-                // information so some kind of redesign is required to figure
-                // this out.
-                //
-                // For now, we instead treat EPTs on readable RAM as spurious
-                // and log appropriately. This check is also not entirely
-                // sufficient, as it may be a write access where the page is
-                // protected, but we don't yet support MNF/guest VSM so this is
-                // okay enough.
-                let is_readable_ram =
-                    self.partition.gm[intercepted_vtl].check_gpa_readable(exit_info.gpa());
-                if is_readable_ram {
-                    tracelimit::warn_ratelimited!(
-                        gpa = exit_info.gpa(),
-                        "possible spurious EPT violation, ignoring"
-                    );
-                } else {
-                    // If this was an EPT violation while handling an iret, and
-                    // that iret cleared the NMI blocking state, restore it.
-                    if !next_interruption.valid() {
-                        let ept_info = VmxEptExitQualification::from(exit_info.qualification());
-                        if ept_info.nmi_unmasking_due_to_iret() {
-                            let mask = Interruptibility::new().with_blocked_by_nmi(true);
-                            let value = Interruptibility::new().with_blocked_by_nmi(true);
-                            let old_interruptibility: Interruptibility = self
-                                .runner
-                                .write_vmcs32(
-                                    GuestVtl::Vtl0,
-                                    VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
-                                    mask.into(),
-                                    value.into(),
-                                )
-                                .into();
-                            assert!(!old_interruptibility.blocked_by_nmi());
-                        }
-                    }
-
-                    // Emulate the access.
-                    self.emulate(
-                        dev,
-                        self.backing.interruption_information.valid(),
-                        intercepted_vtl,
-                    )
-                    .await?;
-                }
-
-                &mut self.backing.exit_stats.ept_violation
-            }
-            VmxExit::TPR_BELOW_THRESHOLD => {
-                // Loop around to reevaluate the APIC.
-                &mut self.backing.exit_stats.tpr_below_threshold
-            }
-            VmxExit::INTERRUPT_WINDOW => {
-                // Loop around to reevaluate the APIC.
-                &mut self.backing.exit_stats.interrupt_window
-            }
-            VmxExit::NMI_WINDOW => {
-                // Loop around to reevaluate pending NMIs.
-                &mut self.backing.exit_stats.nmi_window
-            }
-            VmxExit::HW_INTERRUPT => {
-                // Check if the interrupt was triggered by a hardware breakpoint.
-                let debug_regs = self
-                    .access_state(Vtl::Vtl0)
-                    .debug_regs()
-                    .expect("register query should not fail");
-
-                // The lowest four bits of DR6 indicate which of the
-                // four breakpoints triggered.
-                breakpoint_debug_exception = debug_regs.dr6.trailing_zeros() < 4;
-                &mut self.backing.exit_stats.hw_interrupt
-            }
-            VmxExit::SMI_INTR => &mut self.backing.exit_stats.smi_intr,
-            VmxExit::PAUSE_INSTRUCTION => &mut self.backing.exit_stats.pause,
-            VmxExit::TDCALL => {
-                // If the proxy synic is local, then the host did not get this
-                // instruction, and we need to handle it.
-                if self.untrusted_synic.is_some() {
-                    self.handle_tdvmcall(dev);
-                }
-                &mut self.backing.exit_stats.tdcall
-            }
-            VmxExit::TRIPLE_FAULT => {
-                return Err(VpHaltReason::TripleFault {
-                    vtl: self.last_vtl().into(),
-                })
-            }
-            _ => {
-                return Err(VpHaltReason::Hypervisor(UhRunVpError::UnknownVmxExit(
-                    exit_info.code().vmx_exit(),
-                )))
-            }
+        let mut intercept_handler = InterceptHandler {
+            vp: self,
+            intercepted_vtl: entered_from_vtl,
         };
-        stat.increment();
-
-        // Breakpoint exceptions may return a non-fatal error.
-        // We dispatch here to correctly increment the counter.
-        if cfg!(feature = "gdb") && breakpoint_debug_exception {
-            self.handle_debug_exception(self.last_vtl())?;
-        }
+        intercept_handler.handle_vmx_exit(dev).await?;
 
         Ok(())
     }
@@ -1652,133 +1794,7 @@ impl UhProcessor<'_, TdxBacked> {
         self.backing.exception_error_code = 0;
     }
 
-    fn handle_tdvmcall(&mut self, dev: &impl CpuIo) {
-        let intercepted_vtl = self
-            .cvm_guest_vsm
-            .as_ref()
-            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
-        let regs = self.runner.tdx_enter_guest_state();
-        if regs.r10() == 0 {
-            // Architectural VMCALL.
-            let result = match VmxExit(regs.r11() as u32) {
-                VmxExit::MSR_WRITE => {
-                    let msr = regs.r12() as u32;
-                    let value = regs.r13();
-                    match self.write_tdvmcall_msr(msr, value) {
-                        Ok(()) => {
-                            tracing::debug!(msr, value, "tdvmcall msr write");
-                            TdVmCallR10Result::SUCCESS
-                        }
-                        Err(err) => {
-                            tracelimit::warn_ratelimited!(
-                                msr,
-                                value,
-                                ?err,
-                                "failed tdvmcall msr write"
-                            );
-                            TdVmCallR10Result::OPERAND_INVALID
-                        }
-                    }
-                }
-                VmxExit::MSR_READ => {
-                    let msr = regs.r12() as u32;
-                    match self.read_tdvmcall_msr(msr) {
-                        Ok(value) => {
-                            tracing::debug!(msr, value, "tdvmcall msr read");
-                            self.runner.tdx_enter_guest_state_mut().set_r11(value);
-                            TdVmCallR10Result::SUCCESS
-                        }
-                        Err(err) => {
-                            tracelimit::warn_ratelimited!(msr, ?err, "failed tdvmcall msr read");
-                            TdVmCallR10Result::OPERAND_INVALID
-                        }
-                    }
-                }
-                subfunction => {
-                    tracelimit::warn_ratelimited!(
-                        ?subfunction,
-                        "architectural vmcall not supported"
-                    );
-                    TdVmCallR10Result::OPERAND_INVALID
-                }
-            };
-            let regs = self.runner.tdx_enter_guest_state_mut();
-            regs.set_r10(result.0);
-            regs.rip = regs.rip.wrapping_add(4);
-        } else {
-            // This hypercall is normally handled by the hypervisor, so the gpas
-            // given by the guest should all be shared. The hypervisor allows
-            // gpas to be set with or without the shared gpa boundary bit, which
-            // untrusted_dma_memory correctly models. Note that some Linux
-            // guests will issue hypercalls without the boundary bit set,
-            // whereas UEFI will issue with the bit set.
-            let guest_memory = &self.partition.untrusted_dma_memory;
-            let handler = UhHypercallHandler {
-                vp: &mut *self,
-                bus: dev,
-                trusted: false,
-                intercepted_vtl,
-            };
-
-            UhHypercallHandler::TDCALL_DISPATCHER.dispatch(guest_memory, TdHypercall(handler));
-        }
-    }
-
-    fn read_tdvmcall_msr(&mut self, msr: u32) -> Result<u64, MsrError> {
-        let intercepted_vtl = self
-            .cvm_guest_vsm
-            .as_ref()
-            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
-        match msr {
-            msr @ (hvdef::HV_X64_MSR_GUEST_OS_ID | hvdef::HV_X64_MSR_VP_INDEX) => {
-                self.hv(intercepted_vtl).unwrap().msr_read(msr)
-            }
-            _ => self
-                .untrusted_synic
-                .as_mut()
-                .unwrap()
-                .read_nontimer_msr(msr),
-        }
-    }
-
-    fn write_tdvmcall_msr(&mut self, msr: u32, value: u64) -> Result<(), MsrError> {
-        let intercepted_vtl = self
-            .cvm_guest_vsm
-            .as_ref()
-            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
-        match msr {
-            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => self
-                .hv_mut(intercepted_vtl)
-                .unwrap()
-                .msr_write(msr, value)?,
-            _ => {
-                self.untrusted_synic.as_mut().unwrap().write_nontimer_msr(
-                    &self.partition.gm[GuestVtl::Vtl0],
-                    msr,
-                    value,
-                )?;
-                // Propagate sint MSR writes to the hypervisor as well
-                // so that the hypervisor can directly inject events.
-                if matches!(msr, hvdef::HV_X64_MSR_SINT0..=hvdef::HV_X64_MSR_SINT15) {
-                    if let Err(err) = self.runner.set_vp_register(
-                        HvX64RegisterName(
-                            HvX64RegisterName::Sint0.0 + (msr - hvdef::HV_X64_MSR_SINT0),
-                        ),
-                        value.into(),
-                    ) {
-                        tracelimit::warn_ratelimited!(
-                            error = &err as &dyn std::error::Error,
-                            "failed to set sint register"
-                        );
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn read_msr_cvm(&self, msr: u32) -> Result<u64, MsrError> {
+    fn read_msr_cvm(&self, msr: u32, vtl: GuestVtl) -> Result<u64, MsrError> {
         // TODO TDX: port remaining tdx and common values from PvlIm.c
         // PvlImHandleMsrIntercept
         //
@@ -1822,9 +1838,7 @@ impl UhProcessor<'_, TdxBacked> {
             x86defs::X86X_IA32_MSR_MISC_ENABLE => Ok(hv1_emulator::x86::MISC_ENABLE.into()),
             x86defs::X86X_IA32_MSR_FEATURE_CONTROL => Ok(VMX_FEATURE_CONTROL_LOCKED),
             x86defs::X86X_MSR_CR_PAT => {
-                let pat = self
-                    .runner
-                    .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_PAT);
+                let pat = self.runner.read_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_PAT);
                 Ok(pat)
             }
 
@@ -1845,7 +1859,7 @@ impl UhProcessor<'_, TdxBacked> {
         }
     }
 
-    fn write_msr_cvm(&mut self, msr: u32, value: u64) -> Result<(), MsrError> {
+    fn write_msr_cvm(&mut self, msr: u32, value: u64, vtl: GuestVtl) -> Result<(), MsrError> {
         let state = self.runner.tdx_vp_state_mut();
 
         match msr {
@@ -1862,7 +1876,7 @@ impl UhProcessor<'_, TdxBacked> {
             x86defs::X86X_MSR_SFMASK => state.msr_sfmask = value,
             x86defs::X86X_MSR_SYSENTER_CS => {
                 self.runner.write_vmcs32(
-                    GuestVtl::Vtl0,
+                    vtl,
                     VmcsField::VMX_VMCS_GUEST_SYSENTER_CS_MSR,
                     !0,
                     value as u32,
@@ -1870,7 +1884,7 @@ impl UhProcessor<'_, TdxBacked> {
             }
             x86defs::X86X_MSR_SYSENTER_EIP => {
                 self.runner.write_vmcs64(
-                    GuestVtl::Vtl0,
+                    vtl,
                     VmcsField::VMX_VMCS_GUEST_SYSENTER_EIP_MSR,
                     !0,
                     value,
@@ -1878,7 +1892,7 @@ impl UhProcessor<'_, TdxBacked> {
             }
             x86defs::X86X_MSR_SYSENTER_ESP => {
                 self.runner.write_vmcs64(
-                    GuestVtl::Vtl0,
+                    vtl,
                     VmcsField::VMX_VMCS_GUEST_SYSENTER_ESP_MSR,
                     !0,
                     value,
@@ -1896,7 +1910,7 @@ impl UhProcessor<'_, TdxBacked> {
             x86defs::X86X_IA32_MSR_MISC_ENABLE => return Ok(()),
             x86defs::X86X_MSR_CR_PAT => {
                 self.runner
-                    .write_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_PAT, !0, value);
+                    .write_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_PAT, !0, value);
             }
 
             x86defs::X86X_MSR_MCG_STATUS => {


### PR DESCRIPTION
Remove hardcoding of last vtl to VTL 0. Retrieve the actual last vtl that was running from the intercept message.

Tested booting of ARM, SNP, TDX, and Trusted Launch VMs