### PR TITLE
loader: fix sidecar offset

### DIFF
--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -700,16 +700,14 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
         let page_end = page_base + page_count - 1;
         match self.accepted_ranges.entry(page_base..=page_end) {
             Entry::Overlapping(entry) => {
-                let (overlap_start, overlap_end, overlap_info) = entry.get();
-                let overlap_len = overlap_end - overlap_start + 1;
-
-                Err(anyhow::anyhow!("new region at page base {:#x}, len {:#x}, acceptance {:?} overlaps with existing region at page base {:#x}, len {}, tag {}",
-                    page_base,
-                    page_count,
+                let (overlap_start, overlap_end, ref overlap_info) = *entry.get();
+                Err(anyhow::anyhow!(
+                    "{} at {} ({:?}) overlaps {} at {}",
+                    tag,
+                    MemoryRange::from_4k_gpn_range(page_base..page_end + 1),
                     acceptance,
-                    overlap_start,
-                    overlap_len,
-                    overlap_info.tag
+                    overlap_info.tag,
+                    MemoryRange::from_4k_gpn_range(overlap_start..overlap_end + 1),
                 ))
             }
             Entry::Vacant(entry) => {

--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -219,7 +219,7 @@ where
     // If an AP kernel was provided, load it next.
     let (sidecar_size, sidecar_entrypoint) = if let Some(sidecar) = sidecar {
         // Sidecar load addr must be 2MB aligned
-        let offset = align_up_to_large_page_size(offset);
+        offset = align_up_to_large_page_size(offset);
 
         let load_info = crate::elf::load_static_elf(
             importer,

--- a/vmm_core/vm_loader/src/lib.rs
+++ b/vmm_core/vm_loader/src/lib.rs
@@ -101,16 +101,14 @@ impl<R> Loader<'_, R> {
         let page_end = page_base + page_count - 1;
         match self.accepted_ranges.entry(page_base..=page_end) {
             Entry::Overlapping(entry) => {
-                let (overlap_start, overlap_end, overlap_info) = entry.get();
-                let overlap_len = overlap_end - overlap_start + 1;
-
-                Err(anyhow::anyhow!("new region at page base {:#x}, len {:#x}, acceptance {:?} overlaps with existing region at page base {:#x}, len {}, tag {}",
-                    page_base,
-                    page_count,
+                let (overlap_start, overlap_end, ref overlap_info) = *entry.get();
+                Err(anyhow::anyhow!(
+                    "{} at {} ({:?}) overlaps {} at {}",
+                    tag,
+                    MemoryRange::from_4k_gpn_range(page_base..page_end + 1),
                     acceptance,
-                    overlap_start,
-                    overlap_len,
-                    overlap_info.tag
+                    overlap_info.tag,
+                    MemoryRange::from_4k_gpn_range(overlap_start..overlap_end + 1),
                 ))
             }
             Entry::Vacant(entry) => {


### PR DESCRIPTION
If the sidecar kernel is not already 2MB aligned, then the offset is miscomputed due to variable shadowing. Fix this.

In the future, we should get rid of this 2MB requirement, since sidecar can use 4KB pages relatively easily and has a small enough working set that the page size will not affect TLB pressure.

Also, fix some error strings to be more concise and useful.