### PR TITLE
Guide: openhcl: Remove the redundant backquote of powershell command

### DIFF
--- a/Guide/src/user_guide/openhcl/run/hyperv.md
+++ b/Guide/src/user_guide/openhcl/run/hyperv.md
@@ -27,7 +27,7 @@ Enbable [Hyper-V](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-wi
 Once you get the right Windows Version, run the following command once before starting your VM.  Note that this enabled loading unsigned images, and must be done as administrator.
 
 ```powershell
-`Set-ItemProperty "HKLM:/Software/Microsoft/Windows NT/CurrentVersion/Virtualization" -Name "AllowFirmwareLoadFromFile" -Value 1 -Type DWORD | Out-Null`
+Set-ItemProperty "HKLM:/Software/Microsoft/Windows NT/CurrentVersion/Virtualization" -Name "AllowFirmwareLoadFromFile" -Value 1 -Type DWORD | Out-Null
 ```
 
 ### File access


### PR DESCRIPTION
The backquote is redundant because ```powershell .. ``` is already used. Therefore remove it, otherwise when copied, the backquote '`' is also copied in the command, which gives the error:

	Out-Null` : The term 'Out-Null`' is not recognized as the name of a cmdlet...