### PR TITLE
Remove stale comments in gh_flowey_bootstrap_template.rs

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.rs
@@ -9,7 +9,5 @@
 /// [`Pipeline::gh_set_flowey_bootstrap_template`]:
 ///     flowey::pipeline::prelude::Pipeline::gh_set_flowey_bootstrap_template
 pub fn get_template() -> String {
-    // to be clear: these replaces are totally custom to this particular
-    // bootstrap template. flowey knows nothing of these replacements.
     include_str!("gh_flowey_bootstrap_template.yml").to_string()
 }


### PR DESCRIPTION
This change removes some comments from the gh_flowey_bootstrap_template.rs file that are no longer relevant. It is also a test for the new `pull_request_target` event for the VSO pipeline and unsafe reviewers check.