### PR TITLE
Switch private-vso-build.yml to use GITHUB_REF instead of GITHUB_SHA

### DIFF
--- a/.github/workflows/private-vso-build.yml
+++ b/.github/workflows/private-vso-build.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run VSO build
         shell: bash
-        run: python .github/scripts/trigger-vso-pipeline.py 109784 ${{ steps.AzureKeyVault.outputs.HvliteMirrorPAT }} --commit ${GITHUB_SHA}
+        run: python .github/scripts/trigger-vso-pipeline.py 109784 ${{ steps.AzureKeyVault.outputs.HvliteMirrorPAT }} --commit ${GITHUB_REF}
 
       - name: Cancel VSO build
         shell: bash


### PR DESCRIPTION
This change should ensure that the private VSO pipeline runs on the content of the pull request instead of the main branch.