### PR TITLE
gh-actions: trigger PrivateVsoBuild via a `workflow_run`

### DIFF
--- a/.github/workflows/private-vso-build-trampoline.yml
+++ b/.github/workflows/private-vso-build-trampoline.yml
@@ -1,0 +1,23 @@
+name: Private VSO build Trampoline
+on:
+  pull_request_target:
+    types: [synchronize, opened, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  PrivateBuildTrampoline:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      # adapted from https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
+      - name: Save GITHUB_REF
+        run: |
+          mkdir -p ./ghref
+          echo $GITHUB_REF > ./ghref/github_ref
+      - uses: actions/upload-artifact@v4
+        with:
+          name: github-ref-${{ github.run_number }}
+          path: ghref/

--- a/.github/workflows/private-vso-build.yml
+++ b/.github/workflows/private-vso-build.yml
@@ -5,10 +5,6 @@ on:
     types:
       - completed
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
-
 permissions:
   id-token: write
   contents: read
@@ -17,6 +13,9 @@ jobs:
   PrivateBuild:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+
       # adapted from https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
       - name: 'Download artifact'
         uses: actions/github-script@v6

--- a/.github/workflows/private-vso-build.yml
+++ b/.github/workflows/private-vso-build.yml
@@ -1,8 +1,9 @@
 name: Private VSO build
 on:
-  workflow_dispatch:
-  pull_request_target:
-    types: [synchronize, opened, reopened, ready_for_review]
+  workflow_run:
+    workflows: [Private VSO build Trampoline]
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -14,14 +15,49 @@ permissions:
 
 jobs:
   PrivateBuild:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
+      # adapted from https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
+            });
+
+            let matchArtifacts = allArtifacts.data.artifacts.filter((artifact) => {
+                return artifact.name.startsWith("github-ref-");
+            });
+
+            if (matchArtifacts.length > 0) {
+                matchArtifacts.sort((a, b) => {
+                    let numA = parseInt(a.name.split('-').pop());
+                    let numB = parseInt(b.name.split('-').pop());
+                    return numB - numA;
+                });
+                let largestArtifact = matchArtifacts;
+                console.log(largestArtifact.name);
+            } else {
+                console.log("No matching artifacts found");
+            }
+
+            let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/github-ref.zip`, Buffer.from(download.data));
+
       - uses: Azure/login@v1
         with:
           # These secrets describe the HvLite-GitHub service principal and associated Azure subscription,
           # which, along with the GITHUB_TOKEN, are used to authenticate GitHub Actions to Azure with OpenID Connect.
-          # The service principal has federated identity credentials configured describing which branches and 
+          # The service principal has federated identity credentials configured describing which branches and
           # scenarios can be authenticated.
           client-id: ${{ secrets.OPENVMM_CLIENT_ID }}
           tenant-id: ${{ secrets.OPENVMM_TENANT_ID }}
@@ -45,11 +81,14 @@ jobs:
 
       - name: Run VSO build
         shell: bash
-        run: python .github/scripts/trigger-vso-pipeline.py 109784 ${{ steps.AzureKeyVault.outputs.HvliteMirrorPAT }} --commit ${GITHUB_REF}
+        run: |
+          unzip github-ref.zip
+          GITHUB_REF=$(cat ./github_ref)
+          python .github/scripts/trigger-vso-pipeline.py 109784 ${{ steps.AzureKeyVault.outputs.HvliteMirrorPAT }} --commit ${GITHUB_REF}
 
       - name: Cancel VSO build
         shell: bash
-        run: | 
+        run: |
             build=$(cat build-id)
             echo "Build: $build"
             python .github/scripts/trigger-vso-pipeline.py 109784 ${{ steps.AzureKeyVault.outputs.HvliteMirrorPAT }} --cancel "$build"


### PR DESCRIPTION
Work around the fact that `pull_request` triggers don't have access to repo secrets, which we need in order to auth with azure and kick off a CI run.