### PR TITLE
gh-actions: hotfix for #138

### DIFF
--- a/.github/workflows/private-vso-build.yml
+++ b/.github/workflows/private-vso-build.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
 
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       # adapted from https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run
       - name: 'Download artifact'
         uses: actions/github-script@v6
@@ -68,11 +73,6 @@ jobs:
           keyvault: 'HvLite-PATs'
           secrets: 'HvliteMirrorPAT'
         id: AzureKeyVault
-
-      - name: Checkout actions
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Install dependencies
         shell: bash


### PR DESCRIPTION
Ah, yes, of course - the quintessential "checking out the repo deletes the entire working directory" footgun.

That's one of those things flowey just takes care of for you, but when you're writing flows manually... gotta keep your guard up. _sigh_.

Hopefully the last hotfix for now?