### PR TITLE
Flowey: Move secret variables closer to where they are used

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -93,16 +93,6 @@ impl IntoPipeline for CheckinGatesCli {
             }
         };
 
-        // These secrets describe the HvLite-GitHub service principal and associated Azure subscription,
-        // which, along with the GITHUB_TOKEN, are used to authenticate GitHub Actions to Azure with OpenID Connect.
-        // The service principal has federated identity credentials configured describing which branches and
-        // scenarios can be authenticated.
-        // To learn more about these secrets and using OIDC, see
-        // <https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux#use-the-azure-login-action-with-openid-connect>
-        let client_id = pipeline.gh_use_secret("OPENVMM_CLIENT_ID");
-        let tenant_id = pipeline.gh_use_secret("OPENVMM_TENANT_ID");
-        let subscription_id = pipeline.gh_use_secret("OPENVMM_SUBSCRIPTION_ID");
-
         if let RepoSource::GithubSelf = &openvmm_repo_source {
             pipeline.gh_set_flowey_bootstrap_template(
                 crate::pipelines_shared::gh_flowey_bootstrap_template::get_template(),
@@ -888,6 +878,16 @@ impl IntoPipeline for CheckinGatesCli {
                 CommonTriple::AARCH64_WINDOWS_MSVC => &use_vmm_tests_archive_windows_aarch64,
                 _ => unreachable!(),
             };
+
+            // These secrets describe the HvLite-GitHub service principal and associated Azure subscription,
+            // which, along with the GITHUB_TOKEN, are used to authenticate GitHub Actions to Azure with OpenID Connect.
+            // The service principal has federated identity credentials configured describing which branches and
+            // scenarios can be authenticated.
+            // To learn more about these secrets and using OIDC, see
+            // <https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux#use-the-azure-login-action-with-openid-connect>
+            let client_id = pipeline.gh_use_secret("OPENVMM_CLIENT_ID");
+            let tenant_id = pipeline.gh_use_secret("OPENVMM_TENANT_ID");
+            let subscription_id = pipeline.gh_use_secret("OPENVMM_SUBSCRIPTION_ID");
 
             let mut vmm_tests_run_job = pipeline
                 .new_job(platform, arch, format!("run vmm-tests [{label}]"))


### PR DESCRIPTION
This cleanup change moves these three secret variables closer to where they are used by the pipeline.