### PR TITLE
Shutdown relay device should mirror guest connectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,6 +3137,7 @@ dependencies = [
  "hyperv_ic_resources",
  "inspect",
  "mesh",
+ "mesh_channel",
  "task_control",
  "thiserror 2.0.12",
  "tracing",
@@ -3184,6 +3185,7 @@ name = "hyperv_ic_resources"
 version = "0.0.0"
 dependencies = [
  "mesh",
+ "mesh_channel",
  "vm_resource",
 ]
 
@@ -4891,6 +4893,7 @@ dependencies = [
  "macaddr",
  "mcr_resources",
  "mesh",
+ "mesh_channel",
  "mesh_process",
  "mesh_rpc",
  "mesh_worker",
@@ -7317,6 +7320,7 @@ dependencies = [
  "mcr_resources",
  "memory_range",
  "mesh",
+ "mesh_channel",
  "mesh_process",
  "mesh_tracing",
  "mesh_worker",

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1321,7 +1321,7 @@ impl MshvHvcall {
             - size_of::<hvdef::hypercall::ModifyVtlProtectionMask>())
             / size_of::<u64>();
 
-        let span = tracing::span!(tracing::Level::INFO, "modify_vtl_protection_mask", ?range);
+        let span = tracing::span!(tracing::Level::INFO, "modify_vtl_protection_mask", %range);
         let _enter = span.enter();
 
         let start = range.start() / HV_PAGE_SIZE;

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -134,6 +134,7 @@ guid.workspace = true
 inspect.workspace = true
 kmsg.workspace = true
 local_clock.workspace = true
+mesh_channel.workspace = true
 mesh_process.workspace = true
 mesh_worker.workspace = true
 mesh.workspace = true

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -19,6 +19,7 @@ mod nvme_manager;
 mod options;
 mod reference_time;
 mod servicing;
+mod shutdown_relay;
 mod threadpool_vm_task_backend;
 mod vmbus_relay_unit;
 mod vp;

--- a/openhcl/underhill_core/src/shutdown_relay.rs
+++ b/openhcl/underhill_core/src/shutdown_relay.rs
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+//! Implements shutdown relay device between guest and host.
+
+use futures::FutureExt;
+use futures::StreamExt;
+use hyperv_ic_resources::shutdown::ShutdownParams;
+use hyperv_ic_resources::shutdown::ShutdownResult;
+use hyperv_ic_resources::shutdown::ShutdownRpc;
+use mesh::rpc::PendingRpc;
+use mesh::rpc::Rpc;
+use mesh::rpc::RpcError;
+use mesh::rpc::RpcSend;
+use state_unit::SpawnedUnit;
+use state_unit::StateUnits;
+use vmbus_channel::channel::VmbusDevice;
+use vmbus_relay_intercept_device::InterceptDeviceVmbusControl;
+use vmcore::vm_task::VmTaskDriverSource;
+use vmm_core::vmbus_unit::ChannelUnit;
+use vmm_core::vmbus_unit::VmbusServerHandle;
+use vmm_core::vmbus_unit::offer_generic_channel_unit;
+
+/// The current vmbus state of the guest portion of the shutdown relay device.
+enum ShutdownRelayDeviceVmbusState {
+    Offered(SpawnedUnit<ChannelUnit<dyn VmbusDevice>>),
+    Revoked(Box<dyn VmbusDevice>),
+    None,
+}
+
+/// The current state of the guest/VTL0 vmbus device.
+enum ShutdownConnectionState {
+    Unregistered,
+    Disconnected(
+        PendingRpc<(
+            mesh_channel::MpscSender<Rpc<ShutdownParams, ShutdownResult>>,
+            mesh::OneshotReceiver<()>,
+        )>,
+    ),
+    Connected(
+        (
+            mesh_channel::MpscSender<Rpc<ShutdownParams, ShutdownResult>>,
+            mesh::OneshotReceiver<()>,
+        ),
+    ),
+}
+
+/// Tracks state of the shutdown relay connecting the host visible shutdown
+/// device and the guest visible shutdown device.
+pub(crate) struct ShutdownRelayDevice {
+    pub driver: VmTaskDriverSource,
+    pub host_client_control: InterceptDeviceVmbusControl,
+    pub host_notification: mesh::Receiver<Rpc<ShutdownParams, ShutdownResult>>,
+    pub guest_notifier: mesh::Sender<ShutdownRpc>,
+    vmbus_state: ShutdownRelayDeviceVmbusState,
+    shutdown_connection_state: ShutdownConnectionState,
+}
+
+/// Event messages from the shutdown relay.
+pub(crate) enum ShutdownRelayMessage {
+    GuestConnectivityChange(Result<bool, mesh::RecvError>),
+    ShutdownRequest(Rpc<ShutdownParams, ShutdownResult>),
+}
+
+impl ShutdownRelayDevice {
+    /// Create a new instance.
+    pub fn new(
+        driver: VmTaskDriverSource,
+        host_client_control: InterceptDeviceVmbusControl,
+        host_notification: mesh::Receiver<Rpc<ShutdownParams, ShutdownResult>>,
+        guest_notifier: mesh::Sender<ShutdownRpc>,
+        shutdown_device: SpawnedUnit<ChannelUnit<dyn VmbusDevice>>,
+    ) -> Self {
+        Self {
+            driver,
+            host_client_control,
+            host_notification,
+            guest_notifier,
+            vmbus_state: ShutdownRelayDeviceVmbusState::Offered(shutdown_device),
+            shutdown_connection_state: ShutdownConnectionState::Unregistered,
+        }
+    }
+
+    /// Prepare for VM start.
+    pub async fn start(&mut self, state_units: &StateUnits, vmbus: &VmbusServerHandle) {
+        if matches!(self.vmbus_state, ShutdownRelayDeviceVmbusState::Revoked(_)) {
+            let revoked =
+                std::mem::replace(&mut self.vmbus_state, ShutdownRelayDeviceVmbusState::None);
+            let ShutdownRelayDeviceVmbusState::Revoked(vmbus_device) = revoked else {
+                panic!("shutdown relay not in revoked state");
+            };
+            match offer_generic_channel_unit(&self.driver, state_units, vmbus, vmbus_device).await {
+                Ok(device_unit) => {
+                    let _ = std::mem::replace(
+                        &mut self.vmbus_state,
+                        ShutdownRelayDeviceVmbusState::Offered(device_unit),
+                    );
+                }
+                Err(err) => {
+                    tracing::error!(
+                        error = err.as_ref() as &dyn std::error::Error,
+                        "Failed to start shutdown relay device"
+                    );
+                }
+            };
+        }
+    }
+
+    /// Prepare for VM stop.
+    pub async fn stop(&mut self) {
+        // The version of openhcl that the VTL0 guest resumes with may not
+        // support the shutdown relay device, so always remove it during
+        // stop. It will be recreated on the next start if supported.
+        if matches!(self.vmbus_state, ShutdownRelayDeviceVmbusState::Offered(_)) {
+            let offered =
+                std::mem::replace(&mut self.vmbus_state, ShutdownRelayDeviceVmbusState::None);
+            let ShutdownRelayDeviceVmbusState::Offered(vmbus_device) = offered else {
+                panic!("shutdown relay not in offered state");
+            };
+            let shutdown_ic = vmbus_device.remove().await.revoke_generic().await;
+            let _ = std::mem::replace(
+                &mut self.vmbus_state,
+                ShutdownRelayDeviceVmbusState::Revoked(shutdown_ic),
+            );
+        }
+    }
+
+    /// Fetch the next shutdown relay event.
+    pub async fn next_message(&mut self) -> ShutdownRelayMessage {
+        futures::select! {
+            message = async {
+                if matches!(self.shutdown_connection_state, ShutdownConnectionState::Unregistered) {
+                    self.shutdown_connection_state = ShutdownConnectionState::Disconnected(self.guest_notifier.call(ShutdownRpc::WaitReady, ()));
+                }
+                let result = match &mut self.shutdown_connection_state {
+                    ShutdownConnectionState::Disconnected(rpc) => {
+                        match rpc.await {
+                            Ok(result) => Ok(ShutdownConnectionState::Connected(result)),
+                            Err(RpcError::Channel(err)) => Err(err),
+                            _ => Err(mesh::RecvError::Closed),
+                        }
+                    }
+                    ShutdownConnectionState::Connected((_, rpc)) => {
+                        match rpc.await {
+                            Ok(()) | Err(mesh::RecvError::Closed) => Ok(ShutdownConnectionState::Disconnected(self.guest_notifier.call(ShutdownRpc::WaitReady, ()))),
+                            Err(err) => Err(err),
+                        }
+                    }
+                    ShutdownConnectionState::Unregistered => unreachable!(),
+                };
+                if result.is_ok() {
+                    self.shutdown_connection_state = result.unwrap();
+                    Ok(matches!(self.shutdown_connection_state, ShutdownConnectionState::Connected(_)))
+                } else {
+                    result.map(|_| false)
+                }
+            }.fuse() => ShutdownRelayMessage::GuestConnectivityChange(message),
+            message = self.host_notification.select_next_some() => ShutdownRelayMessage::ShutdownRequest(message)
+        }
+    }
+
+    /// Connect the host visible shutdown device.
+    pub fn connect_to_host(&mut self) {
+        self.host_client_control.connect();
+    }
+
+    /// Disconnect the host visible shutdown device.
+    pub fn disconnect_from_host(&mut self) {
+        self.host_client_control.disconnect();
+    }
+
+    /// Send a shutdown message to the guest-visible shutdown device and return
+    /// the result.
+    pub async fn send_shutdown_to_guest(&self, params: ShutdownParams) -> ShutdownResult {
+        let ShutdownConnectionState::Connected((notifier, _)) = &self.shutdown_connection_state
+        else {
+            tracing::info!("Shutdown message cannot be relayed when device is not connected");
+            return ShutdownResult::NotReady;
+        };
+        tracing::info!(?params, "Relaying shutdown message");
+        let result = match notifier.call(|x| x, params).await {
+            Ok(result) => result,
+            Err(RpcError::Channel(mesh::RecvError::Closed)) => ShutdownResult::NotReady,
+            Err(err) => {
+                tracing::error!(
+                    error = &err as &dyn std::error::Error,
+                    "Failed to relay shutdown notification to guest"
+                );
+                ShutdownResult::Failed(hyperv_ic_guest::shutdown::E_FAIL)
+            }
+        };
+        match result {
+            ShutdownResult::Ok => (),
+            ShutdownResult::AlreadyInProgress => {
+                tracing::warn!("shutdown request already in progress");
+            }
+            ShutdownResult::Failed(_) => {
+                tracing::warn!(?result, "Shutdown request failed");
+            }
+            ShutdownResult::NotReady => {
+                tracing::warn!("Guest shutdown channel not connected");
+            }
+        };
+        result
+    }
+}

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -47,6 +47,7 @@ use crate::reference_time::ReferenceTime;
 use crate::servicing;
 use crate::servicing::ServicingState;
 use crate::servicing::transposed::OptionServicingInitState;
+use crate::shutdown_relay::ShutdownRelayDevice;
 use crate::threadpool_vm_task_backend::ThreadpoolBackend;
 use crate::vmbus_relay_unit::VmbusRelayHandle;
 use crate::wrapped_partition::WrappedPartition;
@@ -2836,20 +2837,10 @@ async fn new_underhill_vm(
         );
     }
 
-    let mut vmbus_intercept_devices = Vec::new();
-
     let shutdown_relay = if let Some(recv) = intercepted_shutdown_ic {
         let mut shutdown_guest = ShutdownGuestIc::new();
-        let recv_host_shutdown = shutdown_guest.get_shutdown_notifier();
-        let (send_guest_shutdown, recv_guest_shutdown) = mesh::channel();
-
-        // Expose a different shutdown device to the VTL0 guest.
-        vmbus_device_handles.push(
-            hyperv_ic_resources::shutdown::ShutdownIcHandle {
-                recv: recv_guest_shutdown,
-            }
-            .into_resource(),
-        );
+        let host_notification = shutdown_guest.get_shutdown_notifier();
+        let (guest_notifier, recv_guest_shutdown) = mesh::channel();
 
         let shutdown_guest = SimpleVmbusClientDeviceWrapper::new(
             driver_source.simple(),
@@ -2863,9 +2854,30 @@ async fn new_underhill_vm(
                 .context("shutdown relay dma client")?,
             shutdown_guest,
         )?;
-        vmbus_intercept_devices.push(shutdown_guest.detach(driver_source.simple(), recv)?);
 
-        Some((recv_host_shutdown, send_guest_shutdown))
+        let host_client_control = shutdown_guest.detach(driver_source.simple(), recv)?;
+
+        // Expose a different shutdown device to the VTL0 guest.
+        let vmbus = vmbus_server.as_ref().unwrap();
+        let vtl0_device = offer_vmbus_device_handle_unit(
+            &driver_source,
+            &state_units,
+            vmbus,
+            &resolver,
+            hyperv_ic_resources::shutdown::ShutdownIcHandle {
+                recv: recv_guest_shutdown,
+            }
+            .into_resource(),
+        )
+        .await?;
+
+        Some(ShutdownRelayDevice::new(
+            driver_source.clone(),
+            host_client_control,
+            host_notification,
+            guest_notifier,
+            vtl0_device,
+        ))
     } else {
         None
     };
@@ -2981,7 +2993,6 @@ async fn new_underhill_vm(
         vmbus_server,
         host_vmbus_relay,
         _vmbus_devices: vmbus_devices,
-        _vmbus_intercept_devices: vmbus_intercept_devices,
         _ide_accel_devices: ide_accel_devices,
         network_settings,
         shutdown_relay,

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -73,6 +73,7 @@ guid.workspace = true
 inspect.workspace = true
 inspect_proto.workspace = true
 mesh.workspace = true
+mesh_channel.workspace = true
 mesh_rpc.workspace = true
 mesh_process.workspace = true
 mesh_worker.workspace = true

--- a/vm/devices/hyperv_ic/Cargo.toml
+++ b/vm/devices/hyperv_ic/Cargo.toml
@@ -17,6 +17,7 @@ vm_resource.workspace = true
 
 inspect.workspace = true
 mesh.workspace = true
+mesh_channel.workspace = true
 task_control.workspace = true
 async-trait.workspace = true
 futures.workspace = true

--- a/vm/devices/hyperv_ic_resources/Cargo.toml
+++ b/vm/devices/hyperv_ic_resources/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true
+mesh_channel.workspace = true
 vm_resource.workspace = true
 
 [lints]

--- a/vm/devices/vmbus/vmbus_channel/src/channel.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/channel.rs
@@ -274,6 +274,14 @@ impl<T: ?Sized> std::fmt::Debug for ChannelHandle<T> {
     }
 }
 
+impl<T: ?Sized> ChannelHandle<T> {
+    /// Revokes the channel, returning a generic device if the VMBus server is
+    /// still running.
+    pub async fn revoke_generic(self) -> Option<Box<dyn VmbusDevice>> {
+        self.0.revoke().await
+    }
+}
+
 impl<T: 'static + VmbusDevice> ChannelHandle<T> {
     /// Revokes the channel, returning it if the VMBus server is still running.
     pub async fn revoke(self) -> Option<T> {

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -57,11 +57,6 @@ use vmcore::save_restore::SavedStateBlob;
 use vmcore::save_restore::SavedStateRoot;
 use zerocopy::FromZeros;
 
-pub enum OfferResponse {
-    Ignore,
-    Open,
-}
-
 pub trait SimpleVmbusClientDevice {
     /// The saved state type.
     type SavedState: SavedStateRoot + Send + Sync;
@@ -76,7 +71,7 @@ pub trait SimpleVmbusClientDevice {
     fn instance_id(&self) -> Guid;
 
     /// Respond to a new channel offer for a device matching instance_id().
-    fn offer(&self, offer: &vmbus_core::protocol::OfferChannel) -> OfferResponse;
+    fn offer(&self, offer: &vmbus_core::protocol::OfferChannel);
 
     /// Open successful for the channel number `channel_idx`.
     ///
@@ -131,11 +126,34 @@ pub trait SaveRestoreSimpleVmbusClientDevice: SimpleVmbusClientDevice {
     ) -> Result<Self::Runner>;
 }
 
+enum InterceptDeviceVmbusControlCommands {
+    Connect,
+    Disconnect,
+}
+
+pub struct InterceptDeviceVmbusControl {
+    send_control: mesh::Sender<InterceptDeviceVmbusControlCommands>,
+}
+
+impl InterceptDeviceVmbusControl {
+    pub fn connect(&self) {
+        self.send_control
+            .send(InterceptDeviceVmbusControlCommands::Connect);
+    }
+
+    pub fn disconnect(&self) {
+        self.send_control
+            .send(InterceptDeviceVmbusControlCommands::Disconnect);
+    }
+}
+
 #[derive(InspectMut)]
 pub struct SimpleVmbusClientDeviceWrapper<T: SimpleVmbusClientDeviceAsync> {
     instance_id: Guid,
     #[inspect(skip)]
     spawner: Arc<dyn SpawnDriver>,
+    #[inspect(skip)]
+    device_control: InterceptDeviceVmbusControl,
     #[inspect(mut)]
     vmbus_listener: TaskControl<SimpleVmbusClientDeviceTask<T>, SimpleVmbusClientDeviceTaskState>,
 }
@@ -148,14 +166,21 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceWrapper<T> {
         device: T,
     ) -> Result<Self> {
         let spawner = Arc::new(driver.clone());
+        // Create a new control to proxy the internal one. This will serve the
+        // dual purpose of allowing external control and detecting when the
+        // device should be stopped.
+        let (send_control, recv_control) = mesh::channel();
+        let device_control = InterceptDeviceVmbusControl { send_control };
         Ok(Self {
             instance_id: device.instance_id(),
+            spawner: spawner.clone(),
+            device_control,
             vmbus_listener: TaskControl::new(SimpleVmbusClientDeviceTask::new(
                 device,
+                recv_control,
                 spawner.clone(),
                 dma_alloc,
             )),
-            spawner,
         })
     }
 
@@ -167,28 +192,44 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceWrapper<T> {
         mut self,
         driver: impl SpawnDriver,
         recv_relay: mesh::Receiver<InterceptChannelRequest>,
-    ) -> Result<mesh::OneshotSender<()>> {
+    ) -> Result<InterceptDeviceVmbusControl> {
         self.vmbus_listener.insert(
             &self.spawner,
             format!("{}", self.instance_id),
             SimpleVmbusClientDeviceTaskState {
+                connect_to_vmbus: false,
                 offer: None,
                 recv_relay,
                 vtl_pages: None,
             },
         );
-        let (driver_send, driver_recv) = mesh::oneshot();
+        let (send_control, recv_control) = mesh::channel();
         driver
             .spawn(
                 format!("vmbus_relay_device {}", self.instance_id),
-                async move {
-                    self.vmbus_listener.start();
-                    let _ = driver_recv.await;
-                    self.vmbus_listener.stop().await;
-                },
+                self.run_device_task(recv_control),
             )
             .detach();
-        Ok(driver_send)
+
+        Ok(InterceptDeviceVmbusControl { send_control })
+    }
+
+    async fn run_device_task(
+        mut self,
+        mut recv: mesh::Receiver<InterceptDeviceVmbusControlCommands>,
+    ) {
+        self.vmbus_listener.start();
+        loop {
+            let msg = recv.next().await;
+            if msg.is_none() {
+                break;
+            }
+            match msg.unwrap() {
+                InterceptDeviceVmbusControlCommands::Connect => self.device_control.connect(),
+                InterceptDeviceVmbusControlCommands::Disconnect => self.device_control.disconnect(),
+            }
+        }
+        self.vmbus_listener.stop().await;
     }
 }
 
@@ -212,6 +253,7 @@ impl<T: SimpleVmbusClientDeviceAsync> InspectTaskMut<T::Runner> for RelayDeviceT
 
 #[derive(InspectMut)]
 struct SimpleVmbusClientDeviceTaskState {
+    connect_to_vmbus: bool,
     offer: Option<OfferInfo>,
     #[inspect(skip)]
     recv_relay: mesh::Receiver<InterceptChannelRequest>,
@@ -223,6 +265,7 @@ struct SimpleVmbusClientDeviceTaskState {
 
 struct SimpleVmbusClientDeviceTask<T: SimpleVmbusClientDeviceAsync> {
     device: TaskControl<RelayDeviceTask<T>, T::Runner>,
+    recv_control: mesh::Receiver<InterceptDeviceVmbusControlCommands>,
     saved_state: Option<T::SavedState>,
     spawner: Arc<dyn SpawnDriver>,
     dma_alloc: Arc<dyn DmaClient>,
@@ -256,9 +299,15 @@ impl<T: SimpleVmbusClientDeviceAsync> InspectTaskMut<SimpleVmbusClientDeviceTask
 }
 
 impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
-    pub fn new(device: T, spawner: Arc<dyn SpawnDriver>, dma_alloc: Arc<dyn DmaClient>) -> Self {
+    pub fn new(
+        device: T,
+        recv_control: mesh::Receiver<InterceptDeviceVmbusControlCommands>,
+        spawner: Arc<dyn SpawnDriver>,
+        dma_alloc: Arc<dyn DmaClient>,
+    ) -> Self {
         Self {
             device: TaskControl::new(RelayDeviceTask(device)),
+            recv_control,
             saved_state: None,
             spawner,
             dma_alloc,
@@ -280,28 +329,30 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
         offer: OfferInfo,
         state: &mut SimpleVmbusClientDeviceTaskState,
     ) -> Result<()> {
-        tracing::info!(?offer, "matching channel offered");
-
         if offer.offer.is_dedicated != 1 {
             tracing::warn!(offer = ?offer.offer, "All offers should be dedicated with Win8+ host")
         }
 
-        if matches!(
-            self.device.task_mut().0.offer(&offer.offer),
-            OfferResponse::Ignore
-        ) {
+        state.offer = Some(offer);
+        self.device
+            .task_mut()
+            .0
+            .offer(&state.offer.as_ref().unwrap().offer);
+        if !state.connect_to_vmbus {
             return Ok(());
         }
 
         let interrupt_event = pal_event::Event::new();
         let (memory, ring_gpadl_id) = self
-            .reserve_memory(state, &offer.request_send, 4)
+            .reserve_memory(state, 4)
             .await
             .context("reserve memory")?;
-        state.offer = Some(offer);
-        let offer = state.offer.as_ref().unwrap();
         let opened = self
-            .open_channel(&offer.request_send, ring_gpadl_id, &interrupt_event)
+            .open_channel(
+                &state.offer.as_ref().unwrap().request_send,
+                ring_gpadl_id,
+                &interrupt_event,
+            )
             .await
             .context("open channel")?;
         let channel = self
@@ -319,7 +370,10 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
             self.device
                 .task_mut()
                 .0
-                .open(offer.offer.subchannel_index, channel)
+                .open(
+                    state.offer.as_ref().unwrap().offer.subchannel_index,
+                    channel,
+                )
                 .context("device open callback")?
         };
         self.insert_runner(state, device_runner);
@@ -328,14 +382,14 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
     }
 
     /// Start channel after it has been stopped.
-    async fn handle_start(&mut self, state: &mut SimpleVmbusClientDeviceTaskState) {
+    async fn handle_start(&mut self, state: &mut SimpleVmbusClientDeviceTaskState) -> Result<()> {
         if self.device.is_running() {
-            return;
+            return Ok(());
         }
 
         let offer = state.offer.take();
         if offer.is_none() {
-            return;
+            return Ok(());
         }
 
         // If there is a previous valid offer, open the channel again.
@@ -344,6 +398,9 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
                 err = err.as_ref() as &dyn std::error::Error,
                 "Failed to reconnect vmbus channel"
             );
+            Err(err)
+        } else {
+            Ok(())
         }
     }
 
@@ -413,7 +470,6 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
     async fn reserve_memory(
         &mut self,
         state: &mut SimpleVmbusClientDeviceTaskState,
-        request_send: &mesh::Sender<ChannelRequest>,
         page_count: usize,
     ) -> Result<(MemoryBlock, GpadlId)> {
         // Incoming and outgoing rings require a minimum of two pages apiece:
@@ -432,7 +488,11 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
             .collect();
 
         let gpadl_id = GpadlId(state.vtl_pages.as_ref().unwrap().pfns()[1] as u32);
-        request_send
+        state
+            .offer
+            .as_ref()
+            .unwrap()
+            .request_send
             .call_failable(
                 ChannelRequest::Gpadl,
                 GpadlRequest {
@@ -541,6 +601,26 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
         };
     }
 
+    async fn handle_connect_request(&mut self, state: &mut SimpleVmbusClientDeviceTaskState) {
+        if state.connect_to_vmbus {
+            return;
+        }
+
+        state.connect_to_vmbus = true;
+        if self.handle_start(state).await.is_err() {
+            state.connect_to_vmbus = false;
+        }
+    }
+
+    async fn handle_disconnect_request(&mut self, state: &mut SimpleVmbusClientDeviceTaskState) {
+        if !state.connect_to_vmbus {
+            return;
+        }
+
+        state.connect_to_vmbus = false;
+        self.handle_stop(state).await;
+    }
+
     /// Handle vmbus messages from the host and control messages from the
     /// device wrapper.
     pub async fn process_messages(&mut self, state: &mut SimpleVmbusClientDeviceTaskState) {
@@ -548,6 +628,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
             enum Event {
                 Request(InterceptChannelRequest),
                 Revoke(()),
+                Control(InterceptDeviceVmbusControlCommands),
             }
             let revoke = pin!(async {
                 if let Some(offer) = &mut state.offer {
@@ -559,6 +640,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
             let Some(r) = (
                 (&mut state.recv_relay).map(Event::Request),
                 futures::stream::once(revoke).map(Event::Revoke),
+                (&mut self.recv_control).map(Event::Control),
             )
                 .merge()
                 .next()
@@ -574,6 +656,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
                     // Any extraneous offer notifications (e.g. from a request offers
                     // query) are ignored.
                     if !self.device.is_running() {
+                        tracing::info!(?offer, "matching channel offered");
                         if let Err(err) = self.handle_offer(offer, state).await {
                             tracing::error!(
                                 error = err.as_ref() as &dyn std::error::Error,
@@ -583,7 +666,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
                     }
                 }
                 Event::Request(InterceptChannelRequest::Start) => {
-                    self.handle_start(state).await;
+                    let _ = self.handle_start(state).await;
                 }
                 Event::Request(InterceptChannelRequest::Stop(rpc)) => {
                     rpc.handle(async |()| self.handle_stop(state).await).await;
@@ -593,6 +676,12 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
                 }
                 Event::Request(InterceptChannelRequest::Restore(saved_state)) => {
                     self.handle_restore(&saved_state);
+                }
+                Event::Control(InterceptDeviceVmbusControlCommands::Connect) => {
+                    self.handle_connect_request(state).await;
+                }
+                Event::Control(InterceptDeviceVmbusControlCommands::Disconnect) => {
+                    self.handle_disconnect_request(state).await;
                 }
             }
         }

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -53,8 +53,8 @@ use zerocopy::KnownLayout;
 /// An error caused by a channel operation.
 #[derive(Debug, Error)]
 pub enum ChannelError {
-    #[error("unknown channel ID")]
-    UnknownChannelId,
+    #[error("unknown channel ID {0}")]
+    UnknownChannelId(u32),
     #[error("unknown GPADL ID")]
     UnknownGpadlId,
     #[error("parse error")]
@@ -981,7 +981,7 @@ impl ChannelList {
     ) -> Result<(OfferId, &mut Channel), ChannelError> {
         let offer_id = assigned_channels
             .get(channel_id)
-            .ok_or(ChannelError::UnknownChannelId)?;
+            .ok_or(ChannelError::UnknownChannelId(channel_id.0))?;
         let channel = &mut self[offer_id];
         if channel.state.is_released() {
             return Err(ChannelError::ChannelReleased);
@@ -1001,7 +1001,7 @@ impl ChannelList {
     ) -> Result<(OfferId, &Channel), ChannelError> {
         let offer_id = assigned_channels
             .get(channel_id)
-            .ok_or(ChannelError::UnknownChannelId)?;
+            .ok_or(ChannelError::UnknownChannelId(channel_id.0))?;
         let channel = &self[offer_id];
         if channel.state.is_released() {
             return Err(ChannelError::ChannelReleased);

--- a/vmm_core/src/vmbus_unit.rs
+++ b/vmm_core/src/vmbus_unit.rs
@@ -130,6 +130,13 @@ pub async fn offer_channel_unit<T: 'static + VmbusDevice>(
     Ok(unit)
 }
 
+impl<T: ?Sized> ChannelUnit<T> {
+    /// Revokes a channel, returning a generic channel.
+    pub async fn revoke_generic(self) -> Box<dyn VmbusDevice> {
+        self.0.revoke_generic().await.unwrap()
+    }
+}
+
 impl<T: 'static + VmbusDevice> ChannelUnit<T> {
     /// Revokes a channel.
     pub async fn revoke(self) -> T {
@@ -222,6 +229,26 @@ impl<T: SimpleVmbusDevice> StateUnit for &'_ SimpleChannelUnit<T> {
     }
 }
 
+/// Offers a generic channel, creates a unit for it, and adds it to `state_units`.
+pub async fn offer_generic_channel_unit(
+    driver_source: &VmTaskDriverSource,
+    state_units: &StateUnits,
+    vmbus: &VmbusServerHandle,
+    channel: Box<dyn VmbusDevice>,
+) -> anyhow::Result<SpawnedUnit<ChannelUnit<dyn VmbusDevice>>> {
+    let offer = channel.offer();
+    let name = format!("{}:{}", offer.interface_name, offer.instance_id);
+    let handle =
+        offer_generic_channel(&driver_source.simple(), vmbus.control.as_ref(), channel).await?;
+    let unit = state_units
+        .add(name)
+        .depends_on(vmbus.unit.handle())
+        .spawn(driver_source.simple(), |recv| {
+            run_async_unit(ChannelUnit(handle), recv)
+        })?;
+    Ok(unit)
+}
+
 /// Offers a channel, creates a unit for it, and adds it to `state_units`.
 pub async fn offer_vmbus_device_handle_unit(
     driver_source: &VmTaskDriverSource,
@@ -233,15 +260,5 @@ pub async fn offer_vmbus_device_handle_unit(
     let channel = resolver
         .resolve(resource, ResolveVmbusDeviceHandleParams { driver_source })
         .await?;
-    let offer = channel.0.offer();
-    let name = format!("{}:{}", offer.interface_name, offer.instance_id);
-    let handle =
-        offer_generic_channel(&driver_source.simple(), vmbus.control.as_ref(), channel.0).await?;
-    let unit = state_units
-        .add(name)
-        .depends_on(vmbus.unit.handle())
-        .spawn(driver_source.simple(), |recv| {
-            run_async_unit(ChannelUnit(handle), recv)
-        })?;
-    Ok(unit)
+    offer_generic_channel_unit(driver_source, state_units, vmbus, channel.0).await
 }

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
@@ -121,12 +121,12 @@ async fn openhcl_servicing_shutdown_ic(
     // Make sure the disk showed up.
     cmd!(sh, "ls /dev/sda").run().await?;
 
-    let shutdown_ic = vm.wait_for_enlightened_shutdown_ready().await?;
+    let (_, shutdown_device_stopped) = vm.wait_for_enlightened_shutdown_ready().await?;
     vm.restart_openhcl(igvm_file, OpenHclServicingFlags::default())
         .await?;
     // VTL2 will disconnect and then reconnect the shutdown IC across a servicing event.
     tracing::info!("waiting for shutdown IC to close");
-    shutdown_ic.await.unwrap_err();
+    shutdown_device_stopped.await.unwrap_err();
     vm.wait_for_enlightened_shutdown_ready().await?;
 
     // Make sure the VTL0 disk is still present by reading it.


### PR DESCRIPTION
Mirror guest vmbus connection status with shutdown device. This allows the host to determine if there is a shutdown device connected.
Rescind guest shutdown device on stop in case VM is moving to a version that does not support shutdown relay (e.g. moving to an older version). If the VM resumes without support for the shutdown relay device, the host device will be enumerated as a new device to the guest and will be used directly. If the resume occurs with support, it will just be setup again. This does mean the guest will see device removal/arrival around operations like servicing.
The logic for dealing with the shutdown relay has gotten hefty enough that it has been moved into its own file.