### PR TITLE
Save NVMe state during servicing

### DIFF
--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -11,6 +11,7 @@ use crate::emuplat::EmuplatServicing;
 use crate::nvme_manager::NvmeManager;
 use crate::reference_time::ReferenceTime;
 use crate::servicing;
+use crate::servicing::NvmeSavedState;
 use crate::servicing::ServicingState;
 use crate::vmbus_relay_unit::VmbusRelayHandle;
 use crate::worker::FirmwareType;
@@ -469,7 +470,14 @@ impl LoadedVm {
         if self.isolation.is_some() {
             anyhow::bail!("Servicing is not yet supported for isolated VMs");
         }
+
+        // capabilities_flags used to explicitly disable the feature
+        // which is enabled by default.
         let nvme_keepalive = !capabilities_flags.disable_nvme_keepalive();
+        if let Some(m) = self.nvme_manager.as_mut() {
+            m.set_nvme_keepalive(nvme_keepalive);
+        }
+
         // Do everything before the log flush under a span.
         let mut state = async {
             if !self.stop().await {
@@ -500,8 +508,8 @@ impl LoadedVm {
             let shutdown_nvme = async {
                 if let Some(nvme_manager) = self.nvme_manager.take() {
                     nvme_manager
-                        .shutdown(nvme_keepalive)
-                        .instrument(tracing::info_span!("shutdown_nvme_vfio", %correlation_id))
+                        .shutdown()
+                        .instrument(tracing::info_span!("shutdown_nvme_vfio", %correlation_id, %nvme_keepalive))
                         .await;
                 }
             };
@@ -620,6 +628,25 @@ impl LoadedVm {
         }
 
         let emuplat = (self.emuplat_servicing.save()).context("emuplat save failed")?;
+
+        // Only save NVMe state when there are NVMe controllers and nvme_keepalive
+        // wasn't explicitly disabled through capabilities_flags, otherwise save None.
+        let nvme_state = match self.nvme_manager.as_ref() {
+            Some(n) => {
+                // Do not save NVMe state if there was an error during save
+                // or nvme_keepalive was explicitly disabled,
+                // revert back to the regular nvme_init after boot.
+                match n.save().await {
+                    Ok(s) => Some(NvmeSavedState { nvme_state: s }),
+                    Err(_) => None,
+                }
+            }
+            _ => {
+                // No NVMe controllers present.
+                None
+            }
+        };
+
         let units = self.save_units().await.context("state unit save failed")?;
         let vmgs = self
             .vmgs_thin_client
@@ -638,6 +665,7 @@ impl LoadedVm {
                 vm_stop_reference_time: self.last_state_unit_stop.unwrap().as_100ns(),
                 correlation_id: None,
                 emuplat,
+                nvme_state,
                 flush_logs_result: None,
                 vmgs: (vmgs, vmgs_get_storage_meta),
                 overlay_shutdown_device: self.shutdown_relay.is_some(),

--- a/openhcl/underhill_core/src/servicing.rs
+++ b/openhcl/underhill_core/src/servicing.rs
@@ -35,6 +35,14 @@ mod state {
         pub netvsp_state: Vec<crate::emuplat::netvsp::SavedState>,
     }
 
+    #[derive(Protobuf)]
+    #[mesh(package = "underhill")]
+    pub struct NvmeSavedState {
+        /// NVMe manager (worker) saved state.
+        #[mesh(1)]
+        pub nvme_state: crate::nvme_manager::NvmeManagerSavedState,
+    }
+
     /// Servicing state needed to create the LoadedVm object.
     #[derive(Protobuf)]
     #[mesh(package = "underhill")]
@@ -64,6 +72,9 @@ mod state {
         /// Intercept the host-provided shutdown IC device.
         #[mesh(7)]
         pub overlay_shutdown_device: bool,
+        /// NVMe saved state.
+        #[mesh(8)]
+        pub nvme_state: Option<NvmeSavedState>,
     }
 
     #[derive(Protobuf)]
@@ -120,6 +131,7 @@ pub mod transposed {
         pub firmware_type: Option<Firmware>,
         pub vm_stop_reference_time: Option<u64>,
         pub emuplat: OptionEmuplatSavedState,
+        pub nvme_state: Option<Option<NvmeSavedState>>,
         pub flush_logs_result: Option<Option<FlushLogsResult>>,
         pub vmgs: Option<(
             vmgs::save_restore::state::SavedVmgsState,
@@ -150,6 +162,7 @@ pub mod transposed {
                             get_backed_adjust_gpa_range,
                             netvsp_state,
                         },
+                    nvme_state,
                     flush_logs_result,
                     vmgs,
                     overlay_shutdown_device,
@@ -163,6 +176,7 @@ pub mod transposed {
                         get_backed_adjust_gpa_range: Some(get_backed_adjust_gpa_range),
                         netvsp_state: Some(netvsp_state),
                     },
+                    nvme_state: Some(nvme_state),
                     flush_logs_result: Some(flush_logs_result),
                     vmgs: Some(vmgs),
                     overlay_shutdown_device: Some(overlay_shutdown_device),

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1747,10 +1747,12 @@ async fn new_underhill_vm(
     );
 
     let nvme_manager = if env_cfg.nvme_vfio {
+        let nvme_saved_state = servicing_state.nvme_state.unwrap_or(None);
         let manager = NvmeManager::new(
             &driver_source,
             processor_topology.vp_count(),
             vfio_dma_buffer(&shared_vis_pages_pool),
+            nvme_saved_state,
         );
 
         resolver.add_async_resolver::<DiskHandleKind, _, NvmeDiskConfig, _>(NvmeDiskResolver::new(

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/lib.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/lib.rs
@@ -15,6 +15,7 @@ mod registers;
 mod tests;
 
 pub use self::driver::NvmeDriver;
+pub use self::driver::NvmeDriverSavedState;
 pub use self::namespace::Namespace;
 pub use self::namespace::NamespaceError;
 pub use self::queue_pair::RequestError;

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -6,7 +6,9 @@ use super::spec;
 use crate::page_allocator::PageAllocator;
 use crate::page_allocator::ScopedPages;
 use crate::queues::CompletionQueue;
+use crate::queues::CompletionQueueSavedState;
 use crate::queues::SubmissionQueue;
+use crate::queues::SubmissionQueueSavedState;
 use crate::registers::DeviceRegisters;
 use anyhow::Context;
 use futures::StreamExt;
@@ -15,6 +17,7 @@ use guestmem::GuestMemory;
 use guestmem::GuestMemoryError;
 use inspect::Inspect;
 use inspect_counters::Counter;
+use mesh::payload::Protobuf;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use mesh::Cancel;
@@ -33,6 +36,8 @@ use user_driver::memory::PAGE_SIZE;
 use user_driver::memory::PAGE_SIZE64;
 use user_driver::DeviceBacking;
 use user_driver::HostDmaAllocator;
+use zerocopy::AsBytes;
+use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
 /// Value for unused PRP entries, to catch/mitigate buffer size mismatches.
@@ -137,6 +142,23 @@ impl QueuePair {
     pub async fn shutdown(mut self) -> impl Send {
         self.cancel.cancel();
         self.task.await
+    }
+
+    /// Save queue pair state for servicing.
+    pub async fn save(&self) -> anyhow::Result<QueuePairSavedState> {
+        // Send an RPC request to QueueHandler thread to save its data.
+        let queue_data = self.issuer.send.call(Req::Save, ()).await?;
+
+        // Add more data to the returned response.
+        let mut local_queue_data = queue_data.unwrap();
+        local_queue_data.sq_addr = self.sq_addr();
+        local_queue_data.cq_addr = self.cq_addr();
+
+        local_queue_data.base_mem = Some(self.mem.base_va());
+        local_queue_data.mem_len = Some(self.mem.len());
+        local_queue_data.pfns = Some(self.mem.pfns().to_vec());
+
+        Ok(local_queue_data)
     }
 }
 
@@ -385,6 +407,7 @@ struct PendingCommand {
 enum Req {
     Command(Rpc<spec::Command, spec::Completion>),
     Inspect(inspect::Deferred),
+    Save(Rpc<(), Result<QueuePairSavedState, anyhow::Error>>),
 }
 
 #[derive(Inspect)]
@@ -449,6 +472,9 @@ impl QueueHandler {
                         self.stats.issued.increment();
                     }
                     Req::Inspect(deferred) => deferred.inspect(&self),
+                    Req::Save(queue_state) => {
+                        queue_state.complete(self.save().await);
+                    }
                 },
                 Event::Completion(completion) => {
                     let command = self.commands.remove(completion.cid.into());
@@ -460,6 +486,37 @@ impl QueueHandler {
             }
         }
     }
+
+    /// Save queue data for servicing.
+    pub async fn save(&self) -> anyhow::Result<QueuePairSavedState> {
+        let mut pending_cmds: Vec<PendingCommandSavedState> = Vec::new();
+        for cmd in &self.commands {
+            let mut command: [u8; 64] = [0; 64];
+            command.copy_from_slice(cmd.1.command.as_bytes());
+            let command = PendingCommandSavedState {
+                command,
+                cid: cmd.0 as u16,
+            };
+            pending_cmds.push(
+                //cmd.1.command.as_bytes().into()
+                command,
+            );
+        }
+        // The data is collected from both QueuePair and QueueHandler.
+        Ok(QueuePairSavedState {
+            max_cids: self.max_cids,
+            sq_state: self.sq.save(),
+            cq_state: self.cq.save(),
+            pending_cmds,
+            cpu: 0,         // Will be updated by the caller.
+            msix: 0,        // Will be updated by the caller.
+            sq_addr: 0,     // Will be updated by the caller.
+            cq_addr: 0,     // Will be updated by the caller.
+            base_mem: None, // Will be updated by the caller.
+            mem_len: None,  // Will be updated by the caller.
+            pfns: None,     // Will be updated by the caller.
+        })
+    }
 }
 
 pub(crate) fn admin_cmd(opcode: spec::AdminOpcode) -> spec::Command {
@@ -467,4 +524,52 @@ pub(crate) fn admin_cmd(opcode: spec::AdminOpcode) -> spec::Command {
         cdw0: spec::Cdw0::new().with_opcode(opcode.0),
         ..FromZeroes::new_zeroed()
     }
+}
+
+#[repr(C)]
+#[derive(Protobuf, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
+#[mesh(package = "underhill")]
+pub struct PendingCommandSavedState {
+    #[mesh(1)]
+    pub command: [u8; 64],
+    #[mesh(2)]
+    pub cid: u16,
+}
+
+impl From<&[u8]> for PendingCommandSavedState {
+    fn from(value: &[u8]) -> Self {
+        let mut command: [u8; 64] = [0; 64];
+        command.copy_from_slice(value);
+        let cid = ((command[0] as u16) << 8) | command[1] as u16;
+        Self { command, cid }
+    }
+}
+
+#[derive(Protobuf, Clone, Debug)]
+#[mesh(package = "underhill")]
+pub struct QueuePairSavedState {
+    #[mesh(1)]
+    /// Which CPU handles requests.
+    pub cpu: u32,
+    #[mesh(2)]
+    /// Interrupt vector (MSI-X)
+    pub msix: u32,
+    #[mesh(3)]
+    pub max_cids: usize,
+    #[mesh(4)]
+    pub sq_state: SubmissionQueueSavedState,
+    #[mesh(5)]
+    pub cq_state: CompletionQueueSavedState,
+    #[mesh(6)]
+    pub sq_addr: u64,
+    #[mesh(7)]
+    pub cq_addr: u64,
+    #[mesh(8)]
+    pub base_mem: Option<u64>,
+    #[mesh(9)]
+    pub mem_len: Option<usize>,
+    #[mesh(10)]
+    pub pfns: Option<Vec<u64>>,
+    #[mesh(11)]
+    pub pending_cmds: Vec<PendingCommandSavedState>,
 }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/registers.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/registers.rs
@@ -118,4 +118,8 @@ impl<T: DeviceRegisterIo + Inspect> Bar0<T> {
             backoff.back_off().await;
         }
     }
+
+    pub fn base_va(&self) -> u64 {
+        self.0.base_va()
+    }
 }

--- a/vm/devices/storage/disk_nvme/src/lib.rs
+++ b/vm/devices/storage/disk_nvme/src/lib.rs
@@ -22,17 +22,19 @@ use stackfuture::StackFuture;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
+use std::sync::Arc;
 
 #[derive(Debug, Inspect)]
 pub struct NvmeDisk {
+    /// NVMe namespace mapped to the disk representation.
     #[inspect(flatten)]
-    namespace: nvme_driver::Namespace,
+    namespace: Arc<nvme_driver::Namespace>,
     #[inspect(skip)]
     block_shift: u32,
 }
 
 impl NvmeDisk {
-    pub fn new(namespace: nvme_driver::Namespace) -> Self {
+    pub fn new(namespace: Arc<nvme_driver::Namespace>) -> Self {
         Self {
             block_shift: namespace.block_size().trailing_zeros(),
             namespace,

--- a/vm/devices/storage/nvme/src/pci.rs
+++ b/vm/devices/storage/nvme/src/pci.rs
@@ -40,9 +40,6 @@ use pci_core::spec::hwid::ProgrammingInterface;
 use pci_core::spec::hwid::Subclass;
 use std::sync::Arc;
 use vmcore::device_state::ChangeDeviceState;
-use vmcore::save_restore::SaveError;
-use vmcore::save_restore::SaveRestore;
-use vmcore::save_restore::SavedStateNotSupported;
 use vmcore::vm_task::VmTaskDriverSource;
 
 /// An NVMe controller.
@@ -483,17 +480,22 @@ impl PciConfigSpace for NvmeController {
     }
 }
 
-impl SaveRestore for NvmeController {
-    type SavedState = SavedStateNotSupported;
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::NoSavedState;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
 
-    fn save(&mut self) -> Result<Self::SavedState, SaveError> {
-        Err(SaveError::NotSupported)
-    }
+    impl SaveRestore for NvmeController {
+        type SavedState = NoSavedState;
 
-    fn restore(
-        &mut self,
-        state: Self::SavedState,
-    ) -> Result<(), vmcore::save_restore::RestoreError> {
-        match state {}
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(NoSavedState)
+        }
+
+        fn restore(&mut self, _state: Self::SavedState) -> Result<(), RestoreError> {
+            Ok(())
+        }
     }
 }

--- a/vm/devices/storage/nvme_spec/src/nvm.rs
+++ b/vm/devices/storage/nvme_spec/src/nvm.rs
@@ -15,7 +15,7 @@ use zerocopy::LE;
 use zerocopy::U16;
 
 #[repr(C)]
-#[derive(Debug, AsBytes, FromBytes, FromZeroes, Inspect)]
+#[derive(Debug, AsBytes, FromBytes, FromZeroes, Inspect, Clone)]
 pub struct IdentifyNamespace {
     pub nsze: u64,
     pub ncap: u64,

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -316,4 +316,8 @@ impl<T: MmioIntercept + Send> DeviceRegisterIo for Mapping<T> {
             .mmio_write(self.addr + offset as u64, &data.to_ne_bytes())
             .unwrap();
     }
+
+    fn base_va(&self) -> u64 {
+        self.addr
+    }
 }

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -57,8 +57,24 @@ pub trait DeviceRegisterIo: Send + Sync {
     fn write_u32(&self, offset: usize, data: u32);
     /// Writes a `u64` register.
     fn write_u64(&self, offset: usize, data: u64);
+    /// Returns base virtual address.
+    fn base_va(&self) -> u64;
 }
 
 pub trait HostDmaAllocator: Send + Sync {
     fn allocate_dma_buffer(&self, len: usize) -> anyhow::Result<MemoryBlock>;
+}
+
+pub mod save_restore {
+    use mesh::payload::Protobuf;
+
+    /// Saved state for the VFIO device user mode driver.
+    #[derive(Protobuf, Clone, Debug)]
+    #[mesh(package = "underhill")]
+    pub struct VfioDeviceSavedState {
+        #[mesh(1)]
+        pub pci_id: String,
+        #[mesh(2)]
+        pub msix_info_count: u32,
+    }
 }

--- a/vm/devices/user_driver/src/memory.rs
+++ b/vm/devices/user_driver/src/memory.rs
@@ -155,4 +155,9 @@ impl MemoryBlock {
     pub fn offset_in_page(&self) -> u32 {
         self.base as u32 % PAGE_SIZE as u32
     }
+
+    /// Returns base address of the memory block.
+    pub fn base_va(&self) -> u64 {
+        self.base as u64
+    }
 }

--- a/vm/devices/user_driver/src/vfio.rs
+++ b/vm/devices/user_driver/src/vfio.rs
@@ -327,6 +327,10 @@ impl DeviceRegisterIo for vfio_sys::MappedRegion {
     fn write_u64(&self, offset: usize, data: u64) {
         self.write_u64(offset, data)
     }
+
+    fn base_va(&self) -> u64 {
+        self.as_ptr() as u64
+    }
 }
 
 impl MappedRegionWithFallback {
@@ -408,6 +412,10 @@ impl DeviceRegisterIo for MappedRegionWithFallback {
         self.write_to_mapping(offset, data).unwrap_or_else(|_| {
             self.write_to_file(offset, &data.to_ne_bytes());
         })
+    }
+
+    fn base_va(&self) -> u64 {
+        self.mapping.base_va()
     }
 }
 


### PR DESCRIPTION
This is recreation of #103 which was in itself recreation of #35 

When performing servicing (e.g. reloading of the management layer) the desire is to keep physical devices (DMA-capable devices) intact so reloading process does not need to go through device shutdown (optional but some draining may be needed) and device init steps. Keeping device alive reduces overall blackout time.

This is save-only part of the feature to reduce the scope of impact.
Other parts are coming: memory reservation, fixed pool allocator, restore.