### PR TITLE
Delete unwanted lints in future additions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -593,7 +593,6 @@ unnecessary_box_returns = "warn"
 # useful, but _very_ tedious to fix
 #   doc_markdown = "warn"
 
-
 # Nested if / else if statements can be easier to read than an equivalent
 # flattened statements.
 collapsible_else_if = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -592,13 +592,7 @@ unnecessary_box_returns = "warn"
 #
 # useful, but _very_ tedious to fix
 #   doc_markdown = "warn"
-# will be useful to weed-out stubbed codepaths in production
-#   todo = "warn"
-#   unimplemented = "warn"
-# useful, but will require a follow-up PR to enable
-#   map_err_ignore = "warn"
-# useful, but requires a follow-up PR to enable
-#   unused_self = "warn"
+
 
 # Nested if / else if statements can be easier to read than an equivalent
 # flattened statements.


### PR DESCRIPTION
Start of what is needed to activate the unused self lint - did not touch public functions yet or incomplete functions (where this would have been largely meaningless). Turns many methods into associated functions