### PR TITLE
Guide: clarify project goals

### DIFF
--- a/Guide/src/index.md
+++ b/Guide/src/index.md
@@ -1,7 +1,10 @@
 # Introduction
 
-OpenVMM is a modular, cross-platform, general-purpose Virtual Machine Monitor
-(VMM), written in Rust.
+OpenVMM is a modular, cross-platform Virtual Machine Monitor (VMM), written in
+Rust.
+
+Although it can function as a traditional VMM, OpenVMM's development is
+currently focused on its role in the [OpenHCL paravisor][paravisor].
 
 The project is open-source, MIT Licensed, and developed publicly at
 [microsoft/openvmm](https://github.com/microsoft/openvmm) on GitHub.
@@ -13,49 +16,15 @@ virtualization backends:
 
 | Host OS             | Architecture  | Virtualization API                     |
 | ------------------- | ------------- | -------------------------------------- |
+| Linux ([paravisor]) | x64 / Aarch64 | MSHV (using [VSM] / [TDX] / [SEV-SNP]) |
 | Windows             | x64 / Aarch64 | WHP (Windows Hypervisor Platform)      |
 | Linux               | x64           | KVM                                    |
 |                     | x64           | MSHV (Microsoft Hypervisor)            |
 | macOS               | Aarch64       | Hypervisor.framework                   |
-| Linux ([paravisor]) | x64 / Aarch64 | MSHV (using [VSM] / [TDX] / [SEV-SNP]) |
 
-**General Purpose**
+**Running in the OpenHCL paravisor**
 
-Similar to other general-purpose VMMs (such as Hyper-V, QEMU, VirtualBox),
-OpenVMM is able to host a wide variety of both modern and legacy guest operating
-systems on-top of its flexible virtual hardware platform.
-
-- Modern operating systems can boot via UEFI, and interface with a wide
-selection of paravirtualized devices for services like networking, storage, and
-graphics.
-
-- Legacy x86 operating systems can boot via BIOS, and are presented with a
-PC-compatible emulated device platform which includes legacy hardware such as
-IDE hard-disk/optical drives, floppy disk drives, and VGA graphics cards.
-
-OpenVMM is regularly tested to ensure compatibility with popular operating
-systems (such as Windows, Linux, and FreeBSD), and strives to maintain reasonable
-compatibility with other, more niche/legacy operating systems as well.
-
-**Modular**
-
-OpenVMM is designed from the ground up to support a wide variety of distinct
-virtualization scenarios, each with their own unique needs and constraints.
-
-Rather than relying on a "one size fits all" solution, the OpenVMM project
-enables users to build specialized versions of OpenVMM with the precise set of
-features required to power their particular scenario.
-
-For example: A build of OpenVMM designed to run on a user's personal PC might
-compile-in all available features, in order support a wide variety of
-workloads, whereas a build of OpenVMM designed to run linux container
-workloads might opt for a narrow set of enabled features, in order to minimize
-resource consumption and VM-visible surface area.
-
-* * *
-
-One particularly notable use-case of OpenVMM is in
-[**OpenHCL**](./user_guide/openhcl.md) (AKA, OpenVMM as a paravisor).
+OpenVMM is the VMM that runs in the [OpenHCL paravisor][paravisor].
 
 Unlike in traditional virtualization, where a VMM runs in a privileged host/root
 partition and provides virtualization services to a unprivileged guest
@@ -73,11 +42,71 @@ enabling several important Azure scenarios:
   next-generation hardware accelerator), without requiring any modifications to
   the guest VM image.
 
-- Enabling existing guest operating systems to run inside hardware-backed
-  [Confidential VMs].
+- Enabling existing guest operating systems to run inside [Confidential VMs].
 
 - Powering [Trusted Launch VMs] - VMs that support Secure Boot, and include a
   vTPM.
+
+**Standalone VMM**
+
+OpenVMM can also run as a general-purpose VMM on a Windows, Linux, or macOS
+host. At the moment, this is primarily a development vehicle: most of the same
+code runs in OpenVMM on a host and OpenVMM in a paravisor, and it is often
+easier to test it on a host.
+
+We will continue to build and test OpenVMM in this configuration, but currently
+we are not focused on the goal of supporting this for production workloads. It
+is missing many of the features and interface stability that are required for
+general-purpose use. We recommend you consider other Rust-based VMMs such as
+[Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) for
+such use cases.
+
+***Relationship to other Rust-based VMMs***
+
+OpenVMM's core security principles are aligned with those of the Rust-based
+Cloud Hypervisor, Firecracker, and crosvm projects, which is why we also chose
+to write OpenVMM in Rust. However, OpenVMM's unique goal of running efficiently
+in a paravisor environment made it difficult to leverage existing projects.
+OpenVMM requires fine-grained control over thread and task scheduling in order
+to avoid introducing jitter and other performance issues into guest VMs. It is
+difficult to achieve these requirements with traditional, thread-based
+designs.
+
+Instead, OpenVMM uses Rust's `async` support throughout its codebase, decoupling
+the policy details of _where_ code runs (which OS threads) from the mechanism of
+_what_ runs (device-specific emulators). In a paravisor or resource-constrained
+environment, OpenVMM can run with one thread per guest CPU and ensure that
+device work is cooperatively scheduled along with the guest OS. In more
+traditional virtualization host, OpenVMM can run with one thread per device to
+use host CPUs to fully parallelize guest CPU and IO processing.
+
+This approach has a significant impact on the design and implementation of the
+codebase, and bringing this model to an existing VMM would be a major
+undertaking. We came to the conclusion that a new project was the best way to
+achieve this goal.
+
+We are indebted to the Rust VMM community for their trailblazing work. Now that
+the OpenVMM project is open source, we hope to find ways to collaborate on
+shared code while maintaining the benefits of the OpenVMM architecture.
+
+**Guest Compatibility**
+
+Similar to other general-purpose VMMs (such as Hyper-V, QEMU, VirtualBox),
+OpenVMM is able to host a wide variety of both modern and legacy guest operating
+systems on-top of its flexible virtual hardware platform.
+
+- Modern operating systems can boot via UEFI, and interface with a wide
+selection of paravirtualized devices for services like networking, storage, and
+graphics.
+
+- Legacy x86 operating systems can boot via BIOS, and are presented with a
+PC-compatible emulated device platform which includes legacy hardware such as
+IDE hard-disk/optical drives, floppy disk drives, and VGA graphics cards.
+
+OpenVMM is regularly tested to ensure compatibility with popular operating
+systems (such as Windows, Linux, and FreeBSD), and strives to maintain
+reasonable compatibility with other, more niche/legacy operating systems as
+well.
 
 * * *
 
@@ -93,9 +122,14 @@ following links:
 | [[Github] OpenVMM issue tracker](https://github.com/microsoft/openvmm/issues) | Reporting OpenVMM issues                  |
 
 [paravisor]: ./user_guide/openhcl.md
-[VSM]: https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/vsm
+[VSM]:
+    https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/tlfs/vsm
 [Azure Boost]: https://learn.microsoft.com/en-us/azure/azure-boost/overview
-[Confidential VMs]: https://azure.microsoft.com/en-us/solutions/confidential-compute
-[Trusted Launch VMs]: https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch
-[TDX]: https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html
-[SEV-SNP]: https://www.amd.com/content/dam/amd/en/documents/epyc-business-docs/white-papers/SEV-SNP-strengthening-vm-isolation-with-integrity-protection-and-more.pdf
+[Confidential VMs]:
+    https://azure.microsoft.com/en-us/solutions/confidential-compute
+[Trusted Launch VMs]:
+    https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch
+[TDX]:
+    https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html
+[SEV-SNP]:
+    https://www.amd.com/content/dam/amd/en/documents/epyc-business-docs/white-papers/SEV-SNP-strengthening-vm-isolation-with-integrity-protection-and-more.pdf

--- a/Guide/src/user_guide/openhcl.md
+++ b/Guide/src/user_guide/openhcl.md
@@ -18,8 +18,7 @@ enabling several important Azure scenarios:
   next-generation hardware accelerator), without requiring any modifications to
   the guest VM image.
 
-- Enabling existing guest operating systems to run inside hardware-backed
-  [Confidential VMs].
+- Enabling existing guest operating systems to run inside [Confidential VMs].
 
 - Powering [Trusted Launch VMs] - VMs that support Secure Boot, and include a
   vTPM.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 [![Build Status](https://github.com/microsoft/openvmm/actions/workflows/openvmm-ci.yaml/badge.svg?branch=main)](https://github.com/microsoft/openvmm/actions/workflows/openvmm-ci.yaml)
 
-OpenVMM is a modular, cross-platform, general-purpose Virtual Machine Monitor (VMM), written in Rust.
+OpenVMM is a modular, cross-platform Virtual Machine Monitor (VMM), written in
+Rust.
+
+Although it can function as a traditional VMM, OpenVMM's development is
+currently focused on its role in the OpenHCL paravisor.
+
+This repo is the home for both projects.
 
 For more information, read our [guide](https://openvmm.dev/)
 or our [introductory blog post](https://techcommunity.microsoft.com/t5/windows-os-platform-blog/openhcl-the-new-open-source-paravisor/ba-p/4273172).


### PR DESCRIPTION
The OpenVMM project is currently focused on building a VMM for running in the OpenHCL paravisor. Clarify this in the documentation to avoid confusion with other Rust-based VMM projects.