### PR TITLE
Support multiple Github actions runners on the same machine

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -30,36 +30,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -260,36 +264,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -502,36 +510,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -944,36 +956,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -1386,36 +1402,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -1998,36 +2018,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -2341,36 +2365,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -2729,36 +2757,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -4207,36 +4239,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -4339,36 +4375,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -4638,36 +4678,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -4864,36 +4908,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -5102,36 +5150,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -5405,36 +5457,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -5723,36 +5779,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -6029,36 +6089,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -6355,36 +6419,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -33,36 +33,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -248,36 +252,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -490,36 +498,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -932,36 +944,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -1374,36 +1390,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -1978,36 +1998,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -2329,36 +2353,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -2717,36 +2745,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -3105,36 +3137,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -3285,36 +3321,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -3533,36 +3573,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -3759,36 +3803,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -3997,36 +4045,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -4300,36 +4352,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -4618,36 +4674,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -4924,36 +4984,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-pc-windows-msvc --profile flowey-ci
       working-directory: flowey_bootstrap
@@ -5242,36 +5306,40 @@ jobs:
       shell: bash
     - run: |
         set -x
+        i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+        sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        . "${{ runner.tool_cache }}/cargo/env"
+        echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
         rustup show
       if: runner.os == 'Linux'
       name: rustup (Linux)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
       name: rustup (Windows X64)
       shell: bash
     - run: |
         set -x
+        echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+        echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
         curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y
-        echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+        echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
       name: rustup (Windows ARM64)
       shell: bash
     - uses: actions/checkout@v4
       with:
         path: flowey_bootstrap
-    - name: Update Index
-      run: |
-        rustc -vV
-        cargo update --dry-run
-      working-directory: flowey_bootstrap
-      shell: bash
     - name: Build flowey
       run: CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="-Z threads=8" cargo build -p flowey_hvlite --target x86_64-unknown-linux-gnu --profile flowey-ci
       working-directory: flowey_bootstrap

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
@@ -1,41 +1,69 @@
+# TODO: Add additional installers for all prerequisites that get skipped if
+# the programs are already installed.
+
+# Known additional prerequisites on Windows:
+#   - Git and bash, both added to path
+#   - For running VMM tests, Hyper-V and WHP must be enabled
+#   - Visual Studio Build Tools
+#     - Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+#     - Microsoft.VisualStudio.Component.VC.Tools.ARM64
+#     - Microsoft.VisualStudio.Component.Windows11SDK.22621
+#     - Microsoft.VisualStudio.Component.VC.Llvm.Clang (added to path)
+
+#### Flowey Build Dependencies
+
+# Installs rustup/cargo to a runner-specific directory to avoid
+# different runners simultaneously changing the same rust
+# installation and causing issues.
+
+# On Linux, install gcc and rust to build flowey. 
+# In case there are multiple runners on the same system,
+# retry apt-get update failure in case another process has the lock
+# use DPkg::Lock::Timeout to wait for other installs to finish 
+# (doesn't seem to work for apt-get update)
 - run: |
     set -x
+    i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
+    sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
+    echo "RUSTUP_HOME=${{ runner.tool_cache }}/rustup" >> "$GITHUB_ENV"
+    echo "CARGO_HOME=${{ runner.tool_cache }}/cargo" >> "$GITHUB_ENV"
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    . "${{ runner.tool_cache }}/cargo/env"
+    echo "${{ runner.tool_cache }}/cargo/bin" >> "$GITHUB_PATH"
     rustup show
   if: runner.os == 'Linux'
   name: rustup (Linux)
   shell: bash
 
+# Building flowey on Windows requires MSVC from Visual Studio Build Tools,
+# but that currently needs to be preinstalled on the actions runner.
 - run: |
     set -x
+    echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+    echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
     curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
     ./rustup-init.exe -y
-    echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+    echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
   if: runner.os == 'Windows' && runner.arch == 'X64'
   name: rustup (Windows X64)
   shell: bash
 
 - run: |
     set -x
+    echo "RUSTUP_HOME=${{ runner.tool_cache }}\\rustup" >> "$GITHUB_ENV"
+    echo "CARGO_HOME=${{ runner.tool_cache }}\\cargo" >> "$GITHUB_ENV"
     curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
     ./rustup-init.exe -y
-    echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
+    echo "${{ runner.tool_cache }}\\cargo\\bin" >> $GITHUB_PATH
   if: runner.os == 'Windows' && runner.arch == 'ARM64'
   name: rustup (Windows ARM64)
   shell: bash
 
+#### Build Flowey
+
 - uses: actions/checkout@v4
   with:
     path: flowey_bootstrap
-
-# Authentication token used to download the crates are automatically checked into the index.
-# The token expires after 7 days, so this line pulls in a new token without updating the lock file.
-- name: Update Index
-  run: |
-    rustc -vV
-    cargo update --dry-run
-  working-directory: flowey_bootstrap
-  shell: bash
 
 # - CARGO_INCREMENTAL=0 - no need to waste time on incremental artifacts in CI
 # - RUSTC_BOOTSTRAP=1 + RUSTFLAGS="-Z threads=8" - use of the unstable parallel


### PR DESCRIPTION
Use separate rustup and cargo directories for each Github runner in case there are multiple on the same machine, and introduce retries for apt-get to avoid errors related to multiple processes trying to install things. Also makes sure that GCC is installed on Linux. 