### PR TITLE
Set everything to use a workspace-shared rust-version field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ exclude = [
   "xsync"
 ]
 
+[workspace.package]
+rust-version = "1.82"
+
 [workspace.dependencies]
 xtask_fuzz = { path = "xtask/xtask_fuzz" }
 

--- a/flowey/flowey/Cargo.toml
+++ b/flowey/flowey/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "flowey"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 flowey_core.workspace = true

--- a/flowey/flowey_cli/Cargo.toml
+++ b/flowey/flowey_cli/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "flowey_cli"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 flowey_core.workspace = true

--- a/flowey/flowey_core/Cargo.toml
+++ b/flowey/flowey_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "flowey_core"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/flowey/flowey_hvlite/Cargo.toml
+++ b/flowey/flowey_hvlite/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "flowey_hvlite"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 flowey_cli.workspace = true

--- a/flowey/flowey_lib_common/Cargo.toml
+++ b/flowey/flowey_lib_common/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "flowey_lib_common"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 flowey.workspace = true

--- a/flowey/flowey_lib_hvlite/Cargo.toml
+++ b/flowey/flowey_lib_hvlite/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "flowey_lib_hvlite"
 edition = "2021"
-rust-version = "1.82"
+rust-version.workspace = true
 
 [dependencies]
 flowey.workspace = true

--- a/flowey/flowey_trampoline/Cargo.toml
+++ b/flowey/flowey_trampoline/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "flowey_trampoline"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 

--- a/flowey/schema_ado_yaml/Cargo.toml
+++ b/flowey/schema_ado_yaml/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "schema_ado_yaml"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/guest_test_uefi/Cargo.toml
+++ b/guest_test_uefi/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "guest_test_uefi"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 uefi = { workspace = true, features = ["alloc", "global_allocator"] }

--- a/openhcl/azure_profiler_proto/Cargo.toml
+++ b/openhcl/azure_profiler_proto/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "azure_profiler_proto"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/openhcl/bootloader_fdt_parser/Cargo.toml
+++ b/openhcl/bootloader_fdt_parser/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "bootloader_fdt_parser"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 fdt = { workspace = true, features = ["std"] }

--- a/openhcl/build_info/Cargo.toml
+++ b/openhcl/build_info/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "build_info"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/openhcl/diag_client/Cargo.toml
+++ b/openhcl/diag_client/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "diag_client"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 diag_proto.workspace = true

--- a/openhcl/diag_proto/Cargo.toml
+++ b/openhcl/diag_proto/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "diag_proto"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/openhcl/diag_server/Cargo.toml
+++ b/openhcl/diag_server/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "diag_server"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 diag_proto.workspace = true

--- a/openhcl/hcl/Cargo.toml
+++ b/openhcl/hcl/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hcl"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 hvdef = { workspace = true, features = ["std"] }

--- a/openhcl/host_fdt_parser/Cargo.toml
+++ b/openhcl/host_fdt_parser/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "host_fdt_parser"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 std = ["fdt/std", "dep:tracing", "memory_range/std"]

--- a/openhcl/kmsg_defs/Cargo.toml
+++ b/openhcl/kmsg_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "kmsg_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/openhcl/minimal_rt/Cargo.toml
+++ b/openhcl/minimal_rt/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "minimal_rt"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hvdef.workspace = true

--- a/openhcl/minimal_rt_build/Cargo.toml
+++ b/openhcl/minimal_rt_build/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "minimal_rt_build"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 

--- a/openhcl/ohcldiag-dev/Cargo.toml
+++ b/openhcl/ohcldiag-dev/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "ohcldiag-dev"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 diag_client.workspace = true

--- a/openhcl/openhcl_boot/Cargo.toml
+++ b/openhcl/openhcl_boot/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "openhcl_boot"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 aarch64defs.workspace = true

--- a/openhcl/openvmm_hcl/Cargo.toml
+++ b/openhcl/openvmm_hcl/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "openvmm_hcl"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = ["tpm"]

--- a/openhcl/openvmm_hcl_resources/Cargo.toml
+++ b/openhcl/openvmm_hcl_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "openvmm_hcl_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 mesh_worker.workspace = true

--- a/openhcl/profiler_worker/Cargo.toml
+++ b/openhcl/profiler_worker/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "profiler_worker"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh = { workspace = true, features = ["socket2"] }

--- a/openhcl/shared_pool_alloc/Cargo.toml
+++ b/openhcl/shared_pool_alloc/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "shared_pool_alloc"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 vfio = ["user_driver/vfio"]

--- a/openhcl/sidecar/Cargo.toml
+++ b/openhcl/sidecar/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "sidecar"
 edition = "2021"
+rust-version.workspace = true
 
 [[bin]]
 name = "sidecar"

--- a/openhcl/sidecar_client/Cargo.toml
+++ b/openhcl/sidecar_client/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "sidecar_client"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 hvdef = { workspace = true, features = ["std"] }

--- a/openhcl/sidecar_defs/Cargo.toml
+++ b/openhcl/sidecar_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "sidecar_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hvdef.workspace = true

--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "underhill_attestation"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Enable locally compiling and statically linking a copy of OpenSSL.

--- a/openhcl/underhill_confidentiality/Cargo.toml
+++ b/openhcl/underhill_confidentiality/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "underhill_confidentiality"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 std = []

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "underhill_core"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Enable profiler support

--- a/openhcl/underhill_crash/Cargo.toml
+++ b/openhcl/underhill_crash/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "underhill_crash"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 get_protocol.workspace = true

--- a/openhcl/underhill_dump/Cargo.toml
+++ b/openhcl/underhill_dump/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "underhill_dump"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 elfcore.workspace = true

--- a/openhcl/underhill_entry/Cargo.toml
+++ b/openhcl/underhill_entry/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "underhill_entry"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Enable gdbstub support.

--- a/openhcl/underhill_init/Cargo.toml
+++ b/openhcl/underhill_init/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "underhill_init"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kmsg_defs.workspace = true

--- a/openhcl/underhill_mem/Cargo.toml
+++ b/openhcl/underhill_mem/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "underhill_mem"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 guestmem.workspace = true

--- a/openhcl/underhill_threadpool/Cargo.toml
+++ b/openhcl/underhill_threadpool/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "underhill_threadpool"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 inspect = { workspace = true, features = ["std"] }

--- a/openhcl/virt_mshv_vtl/Cargo.toml
+++ b/openhcl/virt_mshv_vtl/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virt_mshv_vtl"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 gdb = []

--- a/openhcl/vmfirmwareigvm_dll/Cargo.toml
+++ b/openhcl/vmfirmwareigvm_dll/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmfirmwareigvm_dll"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 ci = []

--- a/openvmm/hvlite_core/Cargo.toml
+++ b/openvmm/hvlite_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hvlite_core"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 gdb = ["vmm_core/gdb"]

--- a/openvmm/hvlite_defs/Cargo.toml
+++ b/openvmm/hvlite_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hvlite_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hvlite_pcat_locator.workspace = true

--- a/openvmm/hvlite_entry/Cargo.toml
+++ b/openvmm/hvlite_entry/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hvlite_entry"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = ["ttrpc", "grpc"]

--- a/openvmm/hvlite_helpers/Cargo.toml
+++ b/openvmm/hvlite_helpers/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hvlite_helpers"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_backend_resources.workspace = true

--- a/openvmm/hvlite_pcat_locator/Cargo.toml
+++ b/openvmm/hvlite_pcat_locator/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hvlite_pcat_locator"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true

--- a/openvmm/hvlite_ttrpc_vmservice/Cargo.toml
+++ b/openvmm/hvlite_ttrpc_vmservice/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hvlite_ttrpc_vmservice"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true

--- a/openvmm/membacking/Cargo.toml
+++ b/openvmm/membacking/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "membacking"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hvdef.workspace = true

--- a/openvmm/openvmm/Cargo.toml
+++ b/openvmm/openvmm/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "openvmm"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = [

--- a/openvmm/openvmm_resources/Cargo.toml
+++ b/openvmm/openvmm_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "openvmm_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Enable gdbstub support.

--- a/petri/Cargo.toml
+++ b/petri/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "petri"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 pipette_client.workspace = true

--- a/petri/make_imc_hive/Cargo.toml
+++ b/petri/make_imc_hive/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "make_imc_hive"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Wdk_System_OfflineRegistry", "Win32_Foundation", "Win32_Security", "Win32_System_Registry"] }

--- a/petri/petri_artifacts_common/Cargo.toml
+++ b/petri/petri_artifacts_common/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "petri_artifacts_common"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 petri_artifacts_core.workspace = true

--- a/petri/petri_artifacts_core/Cargo.toml
+++ b/petri/petri_artifacts_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "petri_artifacts_core"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/petri/pipette/Cargo.toml
+++ b/petri/pipette/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pipette"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 pipette_protocol.workspace = true

--- a/petri/pipette_client/Cargo.toml
+++ b/petri/pipette_client/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pipette_client"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 pipette_protocol.workspace = true

--- a/petri/pipette_protocol/Cargo.toml
+++ b/petri/pipette_protocol/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pipette_protocol"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true

--- a/support/arc_cyclic_builder/Cargo.toml
+++ b/support/arc_cyclic_builder/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "arc_cyclic_builder"
 edition = "2021"
+rust-version.workspace = true
 
 [dev-dependencies]
 futures-executor.workspace = true

--- a/support/cache_topology/Cargo.toml
+++ b/support/cache_topology/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "cache_topology"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 thiserror.workspace = true

--- a/support/ci_logger/Cargo.toml
+++ b/support/ci_logger/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "ci_logger"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 env_logger.workspace = true

--- a/support/clap_dyn_complete/Cargo.toml
+++ b/support/clap_dyn_complete/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "clap_dyn_complete"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 async-trait.workspace = true

--- a/support/closeable_mutex/Cargo.toml
+++ b/support/closeable_mutex/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "closeable_mutex"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 parking_lot.workspace = true

--- a/support/debug_ptr/Cargo.toml
+++ b/support/debug_ptr/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "debug_ptr"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 

--- a/support/fast_select/Cargo.toml
+++ b/support/fast_select/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "fast_select"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 parking_lot.workspace = true

--- a/support/fdt/Cargo.toml
+++ b/support/fdt/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "fdt"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/support/guid/Cargo.toml
+++ b/support/guid/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "guid"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/support/inspect/Cargo.toml
+++ b/support/inspect/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "inspect"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = ["derive",  "defer", "initiate", "std"]

--- a/support/inspect/fuzz/Cargo.toml
+++ b/support/inspect/fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "fuzz_inspect"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect = { workspace = true, features = ["arbitrary", "initiate", "defer"] }

--- a/support/inspect_counters/Cargo.toml
+++ b/support/inspect_counters/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "inspect_counters"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/support/inspect_derive/Cargo.toml
+++ b/support/inspect_derive/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "inspect_derive"
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/support/inspect_proto/Cargo.toml
+++ b/support/inspect_proto/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "inspect_proto"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect = { workspace = true, features = ["initiate"] }

--- a/support/inspect_rlimit/Cargo.toml
+++ b/support/inspect_rlimit/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "inspect_rlimit"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 inspect = { workspace = true, features = ["std"] }

--- a/support/inspect_task/Cargo.toml
+++ b/support/inspect_task/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "inspect_task"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/support/kmsg/Cargo.toml
+++ b/support/kmsg/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "kmsg"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 thiserror.workspace = true

--- a/support/local_clock/Cargo.toml
+++ b/support/local_clock/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "local_clock"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = ["time_exts", "inspect"]

--- a/support/mesh/Cargo.toml
+++ b/support/mesh/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/support/mesh/mesh_build/Cargo.toml
+++ b/support/mesh/mesh_build/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh_build"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 heck.workspace = true

--- a/support/mesh/mesh_channel/Cargo.toml
+++ b/support/mesh/mesh_channel/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh_channel"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh_node.workspace = true

--- a/support/mesh/mesh_derive/Cargo.toml
+++ b/support/mesh/mesh_derive/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh_derive"
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/support/mesh/mesh_node/Cargo.toml
+++ b/support/mesh/mesh_node/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh_node"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh_derive.workspace = true

--- a/support/mesh/mesh_process/Cargo.toml
+++ b/support/mesh/mesh_process/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh_process"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 debug_ptr.workspace = true

--- a/support/mesh/mesh_protobuf/Cargo.toml
+++ b/support/mesh/mesh_protobuf/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh_protobuf"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/support/mesh/mesh_remote/Cargo.toml
+++ b/support/mesh/mesh_remote/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh_remote"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh_channel.workspace = true

--- a/support/mesh/mesh_rpc/Cargo.toml
+++ b/support/mesh/mesh_rpc/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh_rpc"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 grpc = ["dep:base64", "dep:h2", "dep:tokio", "dep:http", "dep:urlencoding"]

--- a/support/mesh/mesh_rpc/fuzz/Cargo.toml
+++ b/support/mesh/mesh_rpc/fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "fuzz_mesh_ttrpc"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true

--- a/support/mesh/mesh_worker/Cargo.toml
+++ b/support/mesh/mesh_worker/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh_worker"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect = { workspace = true, features = ["std", "defer"] }

--- a/support/mesh_tracing/Cargo.toml
+++ b/support/mesh_tracing/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mesh_tracing"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true

--- a/support/open_enum/Cargo.toml
+++ b/support/open_enum/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "open_enum"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 

--- a/support/openssl_crypto_only/Cargo.toml
+++ b/support/openssl_crypto_only/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "openssl_crypto_only"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 

--- a/support/openssl_kdf/Cargo.toml
+++ b/support/openssl_kdf/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "openssl_kdf"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/support/oversized_box/Cargo.toml
+++ b/support/oversized_box/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "oversized_box"
 edition = "2021"
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/support/pal/Cargo.toml
+++ b/support/pal/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pal"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Disable tests that do not pass in the CI environment.

--- a/support/pal/pal_async/Cargo.toml
+++ b/support/pal/pal_async/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pal_async"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Enable executor_tests module for out-of-crate executor testing.

--- a/support/pal/pal_async_test/Cargo.toml
+++ b/support/pal/pal_async_test/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pal_async_test"
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/support/pal/pal_event/Cargo.toml
+++ b/support/pal/pal_event/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pal_event"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 mesh = ["dep:mesh_protobuf"]

--- a/support/pal/pal_uring/Cargo.toml
+++ b/support/pal/pal_uring/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pal_uring"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Disable tests that do not pass in the CI environment.

--- a/support/safe_x86_intrinsics/Cargo.toml
+++ b/support/safe_x86_intrinsics/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "safe_x86_intrinsics"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 

--- a/support/safeatomic/Cargo.toml
+++ b/support/safeatomic/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "safeatomic"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 zerocopy.workspace = true

--- a/support/serde_helpers/Cargo.toml
+++ b/support/serde_helpers/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "serde_helpers"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guid.workspace = true

--- a/support/sev_guest_device/Cargo.toml
+++ b/support/sev_guest_device/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "sev_guest_device"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bitfield-struct.workspace = true

--- a/support/sparse_mmap/Cargo.toml
+++ b/support/sparse_mmap/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "sparse_mmap"
 edition = "2021"
+rust-version.workspace = true
 
 [build-dependencies]
 cc.workspace = true

--- a/support/sparse_mmap/fuzz/Cargo.toml
+++ b/support/sparse_mmap/fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "fuzz_sparse_mmap"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 sparse_mmap.workspace = true

--- a/support/task_control/Cargo.toml
+++ b/support/task_control/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "task_control"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 fast_select.workspace = true

--- a/support/tdx_guest_device/Cargo.toml
+++ b/support/tdx_guest_device/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "tdx_guest_device"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { workspace = true, features = ["ioctl"] }

--- a/support/tee_call/Cargo.toml
+++ b/support/tee_call/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "tee_call"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sev_guest_device.workspace = true

--- a/support/tempfile_helpers/Cargo.toml
+++ b/support/tempfile_helpers/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "tempfile_helpers"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 tempfile.workspace = true

--- a/support/term/Cargo.toml
+++ b/support/term/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "term"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(windows)'.dependencies.winapi]
 features = [

--- a/support/test_with_tracing/Cargo.toml
+++ b/support/test_with_tracing/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "test_with_tracing"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 test_with_tracing_macro.workspace = true

--- a/support/test_with_tracing/test_with_tracing_macro/Cargo.toml
+++ b/support/test_with_tracing/test_with_tracing_macro/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "test_with_tracing_macro"
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/support/tracelimit/Cargo.toml
+++ b/support/tracelimit/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "tracelimit"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 parking_lot.workspace = true

--- a/support/tracing_helpers/Cargo.toml
+++ b/support/tracing_helpers/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "tracing_helpers"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/support/ucs2/Cargo.toml
+++ b/support/ucs2/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "ucs2"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 mesh = ["mesh_protobuf"]

--- a/support/ucs2/fuzz/Cargo.toml
+++ b/support/ucs2/fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "fuzz_ucs2"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 ucs2.workspace = true

--- a/support/uevent/Cargo.toml
+++ b/support/uevent/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "uevent"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 mesh.workspace = true

--- a/support/unix_socket/Cargo.toml
+++ b/support/unix_socket/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "unix_socket"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 mesh = ["dep:mesh_protobuf"]

--- a/support/vmsocket/Cargo.toml
+++ b/support/vmsocket/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmsocket"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true

--- a/support/win_import_lib/Cargo.toml
+++ b/support/win_import_lib/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "win_import_lib"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/support/win_prng_support/Cargo.toml
+++ b/support/win_prng_support/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "win_prng_support"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 widestring.workspace = true

--- a/support/zerocopy_helpers/Cargo.toml
+++ b/support/zerocopy_helpers/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "zerocopy_helpers"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 zerocopy.workspace = true

--- a/vm/aarch64/aarch64defs/Cargo.toml
+++ b/vm/aarch64/aarch64defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "aarch64defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 open_enum.workspace = true

--- a/vm/aarch64/aarch64emu/Cargo.toml
+++ b/vm/aarch64/aarch64emu/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "aarch64emu"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 aarch64defs.workspace = true

--- a/vm/acpi/Cargo.toml
+++ b/vm/acpi/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "acpi"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 acpi_spec.workspace = true

--- a/vm/acpi_spec/Cargo.toml
+++ b/vm/acpi_spec/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "acpi_spec"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/chipset_arc_mutex_device/Cargo.toml
+++ b/vm/chipset_arc_mutex_device/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "chipset_arc_mutex_device"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/chipset_device/Cargo.toml
+++ b/vm/chipset_device/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "chipset_device"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true

--- a/vm/chipset_device_fuzz/Cargo.toml
+++ b/vm/chipset_device_fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "chipset_device_fuzz"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/chipset_device_resources/Cargo.toml
+++ b/vm/chipset_device_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "chipset_device_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/cvm_tracing/Cargo.toml
+++ b/vm/cvm_tracing/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "cvm_tracing"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 tracing.workspace = true

--- a/vm/devices/chipset/Cargo.toml
+++ b/vm/devices/chipset/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "chipset"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/chipset/fuzz/Cargo.toml
+++ b/vm/devices/chipset/fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "fuzz_chipset"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 xtask_fuzz.workspace = true

--- a/vm/devices/chipset_legacy/Cargo.toml
+++ b/vm/devices/chipset_legacy/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "chipset_legacy"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/chipset_resources/Cargo.toml
+++ b/vm/devices/chipset_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "chipset_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/firmware/firmware_pcat/Cargo.toml
+++ b/vm/devices/firmware/firmware_pcat/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "firmware_pcat"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 generation_id.workspace = true

--- a/vm/devices/firmware/firmware_uefi/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "firmware_uefi"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "fuzz_firmware_uefi"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 uefi_nvram_specvars.workspace = true

--- a/vm/devices/firmware/firmware_uefi_custom_vars/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi_custom_vars/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "firmware_uefi_custom_vars"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 uefi_specs.workspace = true

--- a/vm/devices/firmware/generation_id/Cargo.toml
+++ b/vm/devices/firmware/generation_id/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "generation_id"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guestmem.workspace = true

--- a/vm/devices/firmware/hcl_compat_uefi_nvram_storage/Cargo.toml
+++ b/vm/devices/firmware/hcl_compat_uefi_nvram_storage/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hcl_compat_uefi_nvram_storage"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/devices/firmware/hyperv_secure_boot_templates/Cargo.toml
+++ b/vm/devices/firmware/hyperv_secure_boot_templates/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hyperv_secure_boot_templates"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 firmware_uefi_custom_vars.workspace = true

--- a/vm/devices/firmware/hyperv_uefi_custom_vars_json/Cargo.toml
+++ b/vm/devices/firmware/hyperv_uefi_custom_vars_json/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hyperv_uefi_custom_vars_json"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 firmware_uefi_custom_vars.workspace = true

--- a/vm/devices/firmware/uefi_nvram_specvars/Cargo.toml
+++ b/vm/devices/firmware/uefi_nvram_specvars/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "uefi_nvram_specvars"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/devices/firmware/uefi_nvram_storage/Cargo.toml
+++ b/vm/devices/firmware/uefi_nvram_storage/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "uefi_nvram_storage"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/devices/firmware/uefi_specs/Cargo.toml
+++ b/vm/devices/firmware/uefi_specs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "uefi_specs"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/devices/framebuffer/Cargo.toml
+++ b/vm/devices/framebuffer/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "framebuffer"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 video_core.workspace = true

--- a/vm/devices/get/get_helpers/Cargo.toml
+++ b/vm/devices/get/get_helpers/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "get_helpers"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 get_protocol.workspace = true

--- a/vm/devices/get/get_protocol/Cargo.toml
+++ b/vm/devices/get/get_protocol/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "get_protocol"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guid.workspace = true

--- a/vm/devices/get/get_resources/Cargo.toml
+++ b/vm/devices/get/get_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "get_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/get/guest_crash_device/Cargo.toml
+++ b/vm/devices/get/guest_crash_device/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "guest_crash_device"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 get_protocol.workspace = true

--- a/vm/devices/get/guest_emulation_device/Cargo.toml
+++ b/vm/devices/get/guest_emulation_device/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "guest_emulation_device"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 get_protocol.workspace = true

--- a/vm/devices/get/guest_emulation_log/Cargo.toml
+++ b/vm/devices/get/guest_emulation_log/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "guest_emulation_log"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 get_protocol.workspace = true

--- a/vm/devices/get/guest_emulation_transport/Cargo.toml
+++ b/vm/devices/get/guest_emulation_transport/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "guest_emulation_transport"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 test_utilities = [ "guest_emulation_device" ]

--- a/vm/devices/get/underhill_config/Cargo.toml
+++ b/vm/devices/get/underhill_config/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "underhill_config"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guid = { workspace = true, features = ["mesh", "inspect"] }

--- a/vm/devices/get/vtl2_settings_proto/Cargo.toml
+++ b/vm/devices/get/vtl2_settings_proto/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vtl2_settings_proto"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 pbjson.workspace = true

--- a/vm/devices/hyperv_ic/Cargo.toml
+++ b/vm/devices/hyperv_ic/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hyperv_ic"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hyperv_ic_protocol.workspace = true

--- a/vm/devices/hyperv_ic_guest/Cargo.toml
+++ b/vm/devices/hyperv_ic_guest/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hyperv_ic_guest"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hyperv_ic_protocol.workspace = true

--- a/vm/devices/hyperv_ic_protocol/Cargo.toml
+++ b/vm/devices/hyperv_ic_protocol/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hyperv_ic_protocol"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guid.workspace = true

--- a/vm/devices/hyperv_ic_resources/Cargo.toml
+++ b/vm/devices/hyperv_ic_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hyperv_ic_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true

--- a/vm/devices/input_core/Cargo.toml
+++ b/vm/devices/input_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "input_core"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/mcr_resources/Cargo.toml
+++ b/vm/devices/mcr_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mcr_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/missing_dev/Cargo.toml
+++ b/vm/devices/missing_dev/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "missing_dev"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/missing_dev_resources/Cargo.toml
+++ b/vm/devices/missing_dev_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "missing_dev_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/net/gdma/Cargo.toml
+++ b/vm/devices/net/gdma/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "gdma"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 gdma_defs.workspace = true

--- a/vm/devices/net/gdma_defs/Cargo.toml
+++ b/vm/devices/net/gdma_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "gdma_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guestmem.workspace = true

--- a/vm/devices/net/gdma_resources/Cargo.toml
+++ b/vm/devices/net/gdma_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "gdma_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 net_backend_resources.workspace = true

--- a/vm/devices/net/linux_net_bindings/Cargo.toml
+++ b/vm/devices/net/linux_net_bindings/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "linux_net_bindings"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["ioctl"] }

--- a/vm/devices/net/mana_driver/Cargo.toml
+++ b/vm/devices/net/mana_driver/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "mana_driver"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 gdma_defs.workspace = true

--- a/vm/devices/net/net_backend/Cargo.toml
+++ b/vm/devices/net/net_backend/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "net_backend"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 net_backend_resources.workspace = true

--- a/vm/devices/net/net_backend_resources/Cargo.toml
+++ b/vm/devices/net/net_backend_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "net_backend_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/net/net_consomme/Cargo.toml
+++ b/vm/devices/net/net_consomme/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "net_consomme"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 consomme.workspace = true

--- a/vm/devices/net/net_consomme/consomme/Cargo.toml
+++ b/vm/devices/net/net_consomme/consomme/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "consomme"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/vm/devices/net/net_dio/Cargo.toml
+++ b/vm/devices/net/net_dio/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "net_dio"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 net_backend.workspace = true

--- a/vm/devices/net/net_mana/Cargo.toml
+++ b/vm/devices/net/net_mana/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "net_mana"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 gdma_defs.workspace = true

--- a/vm/devices/net/net_packet_capture/Cargo.toml
+++ b/vm/devices/net/net_packet_capture/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "net_packet_capture"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guestmem.workspace = true

--- a/vm/devices/net/net_tap/Cargo.toml
+++ b/vm/devices/net/net_tap/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "net_tap"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 net_backend.workspace = true

--- a/vm/devices/net/netvsp/Cargo.toml
+++ b/vm/devices/net/netvsp/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "netvsp"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 net_backend.workspace = true

--- a/vm/devices/net/netvsp_resources/Cargo.toml
+++ b/vm/devices/net/netvsp_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "netvsp_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guid.workspace = true

--- a/vm/devices/net/vmswitch/Cargo.toml
+++ b/vm/devices/net/vmswitch/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmswitch"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 guid.workspace = true

--- a/vm/devices/pci/pci_bus/Cargo.toml
+++ b/vm/devices/pci/pci_bus/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pci_bus"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/pci/pci_core/Cargo.toml
+++ b/vm/devices/pci/pci_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pci_core"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/pci/pci_resources/Cargo.toml
+++ b/vm/devices/pci/pci_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "pci_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/pci/vpci/Cargo.toml
+++ b/vm/devices/pci/vpci/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vpci"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 pci_core.workspace = true

--- a/vm/devices/serial/serial_16550/Cargo.toml
+++ b/vm/devices/serial/serial_16550/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "serial_16550"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/serial/serial_16550_resources/Cargo.toml
+++ b/vm/devices/serial/serial_16550_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "serial_16550_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/serial/serial_core/Cargo.toml
+++ b/vm/devices/serial/serial_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "serial_core"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/vm/devices/serial/serial_pl011/Cargo.toml
+++ b/vm/devices/serial/serial_pl011/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "serial_pl011"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/serial/serial_pl011_resources/Cargo.toml
+++ b/vm/devices/serial/serial_pl011_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "serial_pl011_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/serial/serial_socket/Cargo.toml
+++ b/vm/devices/serial/serial_socket/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "serial_socket"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 serial_core.workspace = true

--- a/vm/devices/serial/vmbus_serial_guest/Cargo.toml
+++ b/vm/devices/serial/vmbus_serial_guest/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_serial_guest"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/vm/devices/serial/vmbus_serial_host/Cargo.toml
+++ b/vm/devices/serial/vmbus_serial_host/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_serial_host"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 serial_core.workspace = true

--- a/vm/devices/serial/vmbus_serial_protocol/Cargo.toml
+++ b/vm/devices/serial/vmbus_serial_protocol/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_serial_protocol"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guid.workspace = true

--- a/vm/devices/serial/vmbus_serial_resources/Cargo.toml
+++ b/vm/devices/serial/vmbus_serial_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_serial_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true

--- a/vm/devices/storage/disk_backend/Cargo.toml
+++ b/vm/devices/storage/disk_backend/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_backend"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 scsi_buffers.workspace = true

--- a/vm/devices/storage/disk_backend_resources/Cargo.toml
+++ b/vm/devices/storage/disk_backend_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_backend_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/storage/disk_blob/Cargo.toml
+++ b/vm/devices/storage/disk_blob/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_blob"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/disk_blockdevice/Cargo.toml
+++ b/vm/devices/storage/disk_blockdevice/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_blockdevice"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/disk_file/Cargo.toml
+++ b/vm/devices/storage/disk_file/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_file"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/disk_nvme/Cargo.toml
+++ b/vm/devices/storage/disk_nvme/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_nvme"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/disk_nvme/nvme_driver/Cargo.toml
+++ b/vm/devices/storage/disk_nvme/nvme_driver/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "nvme_driver"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect = { workspace = true, features = ["defer"] }

--- a/vm/devices/storage/disk_prwrap/Cargo.toml
+++ b/vm/devices/storage/disk_prwrap/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_prwrap"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/disk_ramdisk/Cargo.toml
+++ b/vm/devices/storage/disk_ramdisk/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_ramdisk"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/disk_striped/Cargo.toml
+++ b/vm/devices/storage/disk_striped/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_striped"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/disk_vhd1/Cargo.toml
+++ b/vm/devices/storage/disk_vhd1/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_vhd1"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_file.workspace = true

--- a/vm/devices/storage/disk_vhdmp/Cargo.toml
+++ b/vm/devices/storage/disk_vhdmp/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "disk_vhdmp"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/floppy/Cargo.toml
+++ b/vm/devices/storage/floppy/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "floppy"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/storage/floppy_pcat_stub/Cargo.toml
+++ b/vm/devices/storage/floppy_pcat_stub/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "floppy_pcat_stub"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/storage/floppy_resources/Cargo.toml
+++ b/vm/devices/storage/floppy_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "floppy_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/storage/ide/Cargo.toml
+++ b/vm/devices/storage/ide/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "ide"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/storage/ide/fuzz/Cargo.toml
+++ b/vm/devices/storage/ide/fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "fuzz_ide"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 ide.workspace = true

--- a/vm/devices/storage/ide_resources/Cargo.toml
+++ b/vm/devices/storage/ide_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "ide_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 scsidisk_resources.workspace = true

--- a/vm/devices/storage/nvme/Cargo.toml
+++ b/vm/devices/storage/nvme/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "nvme"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/nvme_common/Cargo.toml
+++ b/vm/devices/storage/nvme_common/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "nvme_common"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/nvme_resources/Cargo.toml
+++ b/vm/devices/storage/nvme_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "nvme_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/storage/nvme_spec/Cargo.toml
+++ b/vm/devices/storage/nvme_spec/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "nvme_spec"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 storage_string.workspace = true

--- a/vm/devices/storage/scsi_buffers/Cargo.toml
+++ b/vm/devices/storage/scsi_buffers/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "scsi_buffers"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guestmem.workspace = true

--- a/vm/devices/storage/scsi_buffers/fuzz/Cargo.toml
+++ b/vm/devices/storage/scsi_buffers/fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "fuzz_scsi_buffers"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 scsi_buffers.workspace = true

--- a/vm/devices/storage/scsi_core/Cargo.toml
+++ b/vm/devices/storage/scsi_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "scsi_core"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 scsi_buffers.workspace = true

--- a/vm/devices/storage/scsi_defs/Cargo.toml
+++ b/vm/devices/storage/scsi_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "scsi_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 zerocopy.workspace = true

--- a/vm/devices/storage/scsidisk/Cargo.toml
+++ b/vm/devices/storage/scsidisk/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "scsidisk"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/scsidisk_resources/Cargo.toml
+++ b/vm/devices/storage/scsidisk_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "scsidisk_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/vm/devices/storage/storage_string/Cargo.toml
+++ b/vm/devices/storage/storage_string/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "storage_string"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/vm/devices/storage/storvsp/Cargo.toml
+++ b/vm/devices/storage/storvsp/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "storvsp"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 disk_backend.workspace = true

--- a/vm/devices/storage/storvsp_resources/Cargo.toml
+++ b/vm/devices/storage/storvsp_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "storvsp_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/support/device_emulators/Cargo.toml
+++ b/vm/devices/support/device_emulators/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "device_emulators"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 

--- a/vm/devices/support/fs/fuse/Cargo.toml
+++ b/vm/devices/support/fs/fuse/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "fuse"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Disable tests that do not pass in the CI environment.

--- a/vm/devices/support/fs/lx/Cargo.toml
+++ b/vm/devices/support/fs/lx/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "lx"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 thiserror.workspace = true

--- a/vm/devices/support/fs/lxutil/Cargo.toml
+++ b/vm/devices/support/fs/lxutil/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "lxutil"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Disable tests that do not pass in the CI environment.

--- a/vm/devices/support/fs/plan9/Cargo.toml
+++ b/vm/devices/support/fs/plan9/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "plan9"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 lx.workspace = true

--- a/vm/devices/tpm/Cargo.toml
+++ b/vm/devices/tpm/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "tpm"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 # Without this feature, the crate is a no-op. Disable it by default

--- a/vm/devices/tpm_resources/Cargo.toml
+++ b/vm/devices/tpm_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "tpm_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/uidevices/Cargo.toml
+++ b/vm/devices/uidevices/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "uidevices"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 input_core.workspace = true

--- a/vm/devices/uidevices_resources/Cargo.toml
+++ b/vm/devices/uidevices_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "uidevices_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/user_driver/Cargo.toml
+++ b/vm/devices/user_driver/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "user_driver"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = ["vfio"]

--- a/vm/devices/user_driver/vfio_sys/Cargo.toml
+++ b/vm/devices/user_driver/vfio_sys/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vfio_sys"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 anyhow.workspace = true

--- a/vm/devices/vga/Cargo.toml
+++ b/vm/devices/vga/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vga"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true

--- a/vm/devices/vga_proxy/Cargo.toml
+++ b/vm/devices/vga_proxy/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vga_proxy"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/vm/devices/video_core/Cargo.toml
+++ b/vm/devices/video_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "video_core"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/vm/devices/virtio/virtio/Cargo.toml
+++ b/vm/devices/virtio/virtio/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virtio"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 device_emulators.workspace = true

--- a/vm/devices/virtio/virtio_net/Cargo.toml
+++ b/vm/devices/virtio/virtio_net/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virtio_net"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/devices/virtio/virtio_p9/Cargo.toml
+++ b/vm/devices/virtio/virtio_p9/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virtio_p9"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 plan9.workspace = true

--- a/vm/devices/virtio/virtio_pmem/Cargo.toml
+++ b/vm/devices/virtio/virtio_pmem/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virtio_pmem"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 virtio.workspace = true

--- a/vm/devices/virtio/virtio_resources/Cargo.toml
+++ b/vm/devices/virtio/virtio_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virtio_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 net_backend_resources.workspace = true

--- a/vm/devices/virtio/virtio_serial/Cargo.toml
+++ b/vm/devices/virtio/virtio_serial/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virtio_serial"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 virtio.workspace = true

--- a/vm/devices/virtio/virtiofs/Cargo.toml
+++ b/vm/devices/virtio/virtiofs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virtiofs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 virtio.workspace = true

--- a/vm/devices/vmbus/vmbfs/Cargo.toml
+++ b/vm/devices/vmbus/vmbfs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbfs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmbfs_resources.workspace = true

--- a/vm/devices/vmbus/vmbfs_resources/Cargo.toml
+++ b/vm/devices/vmbus/vmbfs_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbfs_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 mesh.workspace = true

--- a/vm/devices/vmbus/vmbus_async/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_async/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_async"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 smallvec.workspace = true

--- a/vm/devices/vmbus/vmbus_channel/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_channel/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_channel"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmbus_core.workspace = true

--- a/vm/devices/vmbus/vmbus_client/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_client/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_client"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmbus_async.workspace = true

--- a/vm/devices/vmbus/vmbus_core/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_core"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hvdef.workspace = true

--- a/vm/devices/vmbus/vmbus_proxy/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_proxy/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_proxy"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 guestmem.workspace = true

--- a/vm/devices/vmbus/vmbus_relay/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_relay/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_relay"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmbus_async.workspace = true

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_relay_intercept_device"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmbus_channel.workspace = true

--- a/vm/devices/vmbus/vmbus_ring/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_ring/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_ring"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guestmem.workspace = true

--- a/vm/devices/vmbus/vmbus_server/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_server/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_server"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmbus_async.workspace = true

--- a/vm/devices/vmbus/vmbus_user_channel/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_user_channel/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmbus_user_channel"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 vmbus_async.workspace = true

--- a/vm/devices/watchdog/guest_watchdog/Cargo.toml
+++ b/vm/devices/watchdog/guest_watchdog/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "guest_watchdog"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmcore.workspace = true

--- a/vm/devices/watchdog/watchdog_core/Cargo.toml
+++ b/vm/devices/watchdog/watchdog_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "watchdog_core"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmcore.workspace = true

--- a/vm/devices/watchdog/watchdog_vmgs_format/Cargo.toml
+++ b/vm/devices/watchdog/watchdog_vmgs_format/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "watchdog_vmgs_format"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmcore.workspace = true

--- a/vm/hv1/hv1_emulator/Cargo.toml
+++ b/vm/hv1/hv1_emulator/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hv1_emulator"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hvdef = { workspace = true, features = ["std"] }

--- a/vm/hv1/hv1_hypercall/Cargo.toml
+++ b/vm/hv1/hv1_hypercall/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hv1_hypercall"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hvdef.workspace = true

--- a/vm/hv1/hvdef/Cargo.toml
+++ b/vm/hv1/hvdef/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "hvdef"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/hv1/vtl_array/Cargo.toml
+++ b/vm/hv1/vtl_array/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vtl_array"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hvdef.workspace = true

--- a/vm/kvm/Cargo.toml
+++ b/vm/kvm/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "kvm"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 pal.workspace = true

--- a/vm/loader/Cargo.toml
+++ b/vm/loader/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "loader"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 aarch64defs.workspace = true

--- a/vm/loader/igvmfilegen/Cargo.toml
+++ b/vm/loader/igvmfilegen/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 edition = "2021"
 name = "igvmfilegen"
+rust-version.workspace = true
 
 [dependencies]
 igvmfilegen_config.workspace = true

--- a/vm/loader/igvmfilegen_config/Cargo.toml
+++ b/vm/loader/igvmfilegen_config/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "igvmfilegen_config"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/vm/loader/loader_defs/Cargo.toml
+++ b/vm/loader/loader_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "loader_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 std = []

--- a/vm/loader/page_table/Cargo.toml
+++ b/vm/loader/page_table/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "page_table"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 bitfield-struct.workspace = true

--- a/vm/power_resources/Cargo.toml
+++ b/vm/power_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "power_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/vbs_defs/Cargo.toml
+++ b/vm/vbs_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vbs_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 bitfield-struct.workspace = true

--- a/vm/vhd1_defs/Cargo.toml
+++ b/vm/vhd1_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vhd1_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guid.workspace = true

--- a/vm/vmcore/Cargo.toml
+++ b/vm/vmcore/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "vmcore"
 edition = "2021"
-rust-version = "1.82"
+rust-version.workspace = true
 
 [dependencies]
 hvdef.workspace = true

--- a/vm/vmcore/build_rs_guest_arch/Cargo.toml
+++ b/vm/vmcore/build_rs_guest_arch/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "build_rs_guest_arch"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 

--- a/vm/vmcore/guestmem/Cargo.toml
+++ b/vm/vmcore/guestmem/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "guestmem"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/vm/vmcore/guestmem/fuzz/Cargo.toml
+++ b/vm/vmcore/guestmem/fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "fuzz_guestmem"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guestmem.workspace = true

--- a/vm/vmcore/memory_range/Cargo.toml
+++ b/vm/vmcore/memory_range/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "memory_range"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 inspect = ["dep:inspect", "std"]

--- a/vm/vmcore/save_restore_derive/Cargo.toml
+++ b/vm/vmcore/save_restore_derive/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "save_restore_derive"
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/vm/vmcore/vm_resource/Cargo.toml
+++ b/vm/vmcore/vm_resource/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vm_resource"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true

--- a/vm/vmcore/vm_topology/Cargo.toml
+++ b/vm/vmcore/vm_topology/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vm_topology"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/vmgs/vmgs/Cargo.toml
+++ b/vm/vmgs/vmgs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmgs"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/vmgs/vmgs_broker/Cargo.toml
+++ b/vm/vmgs/vmgs_broker/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmgs_broker"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/vmgs/vmgs_format/Cargo.toml
+++ b/vm/vmgs/vmgs_format/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmgs_format"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 open_enum.workspace = true

--- a/vm/vmgs/vmgs_lib/Cargo.toml
+++ b/vm/vmgs/vmgs_lib/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmgs_lib"
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/vm/vmgs/vmgs_resources/Cargo.toml
+++ b/vm/vmgs/vmgs_resources/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmgs_resources"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true

--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmgstool"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/whp/Cargo.toml
+++ b/vm/whp/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "whp"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 unstable_whp = []

--- a/vm/x86/tdcall/Cargo.toml
+++ b/vm/x86/tdcall/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "tdcall"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 default = []

--- a/vm/x86/x86defs/Cargo.toml
+++ b/vm/x86/x86defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "x86defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 open_enum.workspace = true

--- a/vm/x86/x86emu/Cargo.toml
+++ b/vm/x86/x86emu/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "x86emu"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 arbitrary = ["dep:arbitrary", "x86defs/arbitrary"]

--- a/vm/x86/x86emu/fuzz/Cargo.toml
+++ b/vm/x86/x86emu/fuzz/Cargo.toml
@@ -4,6 +4,7 @@
 name = "fuzz_x86emu"
 publish = false
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 xtask_fuzz.workspace = true

--- a/vmm_core/Cargo.toml
+++ b/vmm_core/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmm_core"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 gdb = ["iced-x86", "virt_support_x86emu"]

--- a/vmm_core/state_unit/Cargo.toml
+++ b/vmm_core/state_unit/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "state_unit"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmcore.workspace = true

--- a/vmm_core/virt/Cargo.toml
+++ b/vmm_core/virt/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virt"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 aarch64defs.workspace = true

--- a/vmm_core/virt_hvf/Cargo.toml
+++ b/vmm_core/virt_hvf/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virt_hvf"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
 aarch64defs.workspace = true

--- a/vmm_core/virt_kvm/Cargo.toml
+++ b/vmm_core/virt_kvm/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virt_kvm"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 virt.workspace = true

--- a/vmm_core/virt_mshv/Cargo.toml
+++ b/vmm_core/virt_mshv/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virt_mshv"
 edition = "2021"
+rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 hv1_emulator.workspace = true

--- a/vmm_core/virt_support_aarch64emu/Cargo.toml
+++ b/vmm_core/virt_support_aarch64emu/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virt_support_aarch64emu"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 aarch64defs.workspace = true

--- a/vmm_core/virt_support_apic/Cargo.toml
+++ b/vmm_core/virt_support_apic/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virt_support_apic"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hvdef.workspace = true

--- a/vmm_core/virt_support_gic/Cargo.toml
+++ b/vmm_core/virt_support_gic/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virt_support_gic"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vm_topology.workspace = true

--- a/vmm_core/virt_support_x86emu/Cargo.toml
+++ b/vmm_core/virt_support_x86emu/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virt_support_x86emu"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 guestmem.workspace = true

--- a/vmm_core/virt_whp/Cargo.toml
+++ b/vmm_core/virt_whp/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "virt_whp"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 unstable_whp = ["whp/unstable_whp"]

--- a/vmm_core/vm_loader/Cargo.toml
+++ b/vmm_core/vm_loader/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vm_loader"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 hvdef.workspace = true

--- a/vmm_core/vm_manifest_builder/Cargo.toml
+++ b/vmm_core/vm_manifest_builder/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vm_manifest_builder"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 chipset_resources.workspace = true

--- a/vmm_core/vmm_core_defs/Cargo.toml
+++ b/vmm_core/vmm_core_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmm_core_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 virt.workspace = true

--- a/vmm_core/vmotherboard/Cargo.toml
+++ b/vmm_core/vmotherboard/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmotherboard"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 encryption = ["firmware_uefi/auth-var-verify-crypto"]

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/Cargo.toml
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "petri_artifact_resolver_openvmm_known_paths"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 petri_artifacts_vmm_test.workspace = true

--- a/vmm_tests/petri_artifacts_vmm_test/Cargo.toml
+++ b/vmm_tests/petri_artifacts_vmm_test/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "petri_artifacts_vmm_test"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 petri_artifacts_common.workspace = true

--- a/vmm_tests/vmm_test_images/Cargo.toml
+++ b/vmm_tests/vmm_test_images/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmm_test_images"
 edition = "2021"
+rust-version.workspace = true
 
 [features]
 clap = ["dep:clap"]

--- a/vmm_tests/vmm_test_macros/Cargo.toml
+++ b/vmm_tests/vmm_test_macros/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmm_test_macros"
 edition = "2021"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/vmm_tests/vmm_test_petri_support/Cargo.toml
+++ b/vmm_tests/vmm_test_petri_support/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmm_test_petri_support"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 petri_artifacts_vmm_test.workspace = true

--- a/vmm_tests/vmm_tests/Cargo.toml
+++ b/vmm_tests/vmm_tests/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vmm_tests"
 edition = "2021"
+rust-version.workspace = true
 
 [dev-dependencies]
 petri_artifact_resolver_openvmm_known_paths.workspace = true

--- a/workers/debug_worker/Cargo.toml
+++ b/workers/debug_worker/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "debug_worker"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 debug_worker_defs.workspace = true

--- a/workers/debug_worker_defs/Cargo.toml
+++ b/workers/debug_worker_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "debug_worker_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vmm_core_defs.workspace = true

--- a/workers/vnc_worker/Cargo.toml
+++ b/workers/vnc_worker/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vnc_worker"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 vnc.workspace = true

--- a/workers/vnc_worker/vnc/Cargo.toml
+++ b/workers/vnc_worker/vnc/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vnc"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 pal_async.workspace = true

--- a/workers/vnc_worker_defs/Cargo.toml
+++ b/workers/vnc_worker_defs/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "vnc_worker_defs"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 framebuffer.workspace = true

--- a/xsync/Cargo.toml
+++ b/xsync/Cargo.toml
@@ -5,6 +5,9 @@ default-members = ["xsync"]
 members = ["xsync"]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.82"
+
 [workspace.dependencies]
 anyhow = "1.0"
 cargo_toml = "0.20"

--- a/xsync/xsync/Cargo.toml
+++ b/xsync/xsync/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "xsync"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/xsync/xsync/src/tasks/cargo_toml.rs
+++ b/xsync/xsync/src/tasks/cargo_toml.rs
@@ -2,6 +2,7 @@
 
 use crate::Cmd;
 use anyhow::Context;
+use cargo_toml::PackageTemplate;
 use clap::Parser;
 use clap::Subcommand;
 
@@ -59,7 +60,11 @@ impl Cmd for CargoToml {
             let self::custom_meta::Inherit {
                 profile,
                 patch,
-                workspace: self::custom_meta::InheritWorkspace { lints },
+                workspace:
+                    self::custom_meta::InheritWorkspace {
+                        lints,
+                        rust_version,
+                    },
             } = meta.inherit;
 
             if profile {
@@ -68,6 +73,32 @@ impl Cmd for CargoToml {
 
             if patch {
                 cargo_toml.patch = base_cargo_toml.patch.clone();
+            }
+
+            if rust_version {
+                if cargo_toml.workspace.as_mut().unwrap().package.is_none() {
+                    cargo_toml.workspace.as_mut().unwrap().package =
+                        Some(PackageTemplate::default());
+                }
+
+                (cargo_toml
+                    .workspace
+                    .as_mut()
+                    .unwrap()
+                    .package
+                    .as_mut()
+                    .unwrap()
+                    .rust_version)
+                    .clone_from(
+                        &base_cargo_toml
+                            .workspace
+                            .as_ref()
+                            .unwrap()
+                            .package
+                            .as_ref()
+                            .unwrap()
+                            .rust_version,
+                    );
             }
 
             if lints {
@@ -156,6 +187,7 @@ mod custom_meta {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct InheritWorkspace {
         pub lints: bool,
+        pub rust_version: bool,
     }
 }
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "xtask"
 edition = "2021"
-rust-version = "1.82"
+rust-version.workspace = true
 
 [dependencies]
 vmm_test_images = { workspace = true, features = ["clap"] }

--- a/xtask/src/tasks/fmt/house_rules/package_info.rs
+++ b/xtask/src/tasks/fmt/house_rules/package_info.rs
@@ -1,7 +1,8 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 //! Checks to ensure that the `[package]` sections of Cargo.toml files do not
-//! contain `authors` or `version` fields.
+//! contain `authors` or `version` fields, and that rust-version is properly
+//! workspace.
 //!
 //! Eliding the [version][] sets the version to "0.0.0", which is fine. More
 //! importantly, it means the module cannot be published to crates.io
@@ -21,6 +22,8 @@
 use anyhow::Context;
 use std::ffi::OsStr;
 use std::path::Path;
+use toml_edit::Item;
+use toml_edit::Table;
 
 pub fn check_package_info(f: &Path, fix: bool) -> anyhow::Result<()> {
     if f.file_name() != Some(OsStr::new("Cargo.toml")) {
@@ -39,12 +42,20 @@ pub fn check_package_info(f: &Path, fix: bool) -> anyhow::Result<()> {
         .as_table_mut()
         .with_context(|| format!("invalid package section in {}", f.display()))?;
 
+    let mut rust_version_field = Table::new();
+    rust_version_field.set_dotted(true);
+    rust_version_field.insert("workspace", Item::Value(true.into()));
+    let old_rust_version = package.insert("rust-version", Item::Table(rust_version_field.clone()));
+
     // Note careful use of non-short-circuiting or.
-    let invalid = package.remove("authors").is_some() | package.remove("version").is_some();
+    let invalid = package.remove("authors").is_some()
+        | package.remove("version").is_some()
+        | (old_rust_version.map(|o| o.to_string()) != Some(rust_version_field.to_string()));
+
     if invalid {
         if !fix {
             anyhow::bail!(
-                "invalid inclusion of package authors or version in {}",
+                "invalid inclusion of package authors or version, or non-workspaced rust-version, in {}",
                 f.display()
             );
         }

--- a/xtask/xtask_fuzz/Cargo.toml
+++ b/xtask/xtask_fuzz/Cargo.toml
@@ -3,6 +3,7 @@
 [package]
 name = "xtask_fuzz"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 tracing-subscriber.workspace = true


### PR DESCRIPTION
Enforced via `xtask fmt` and `xsync`. xsync changes still need testing with the internal repo...