### PR TITLE
virt_mshv_vtl: use GuestVtl instead of Vtl

### DIFF
--- a/openhcl/hcl/src/lib.rs
+++ b/openhcl/hcl/src/lib.rs
@@ -8,8 +8,62 @@
 // UNSAFETY: Calling ioctls.
 #![allow(unsafe_code)]
 
+use hvdef::hypercall::HvInputVtl;
+use hvdef::Vtl;
+use thiserror::Error;
+
 pub mod ioctl;
 pub mod protocol;
 pub mod stats;
 pub mod vmbus;
 pub mod vmsa;
+
+/// The VTL, exclusive of the paravisor VTL (VTL2).
+///
+/// This is useful to use instead of [`Vtl`] to statically ensure that the VTL
+/// is not VTL2.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum GuestVtl {
+    /// VTL0
+    Vtl0,
+    /// VTL1
+    Vtl1,
+}
+
+impl From<GuestVtl> for HvInputVtl {
+    fn from(value: GuestVtl) -> Self {
+        Vtl::from(value).into()
+    }
+}
+
+impl From<GuestVtl> for u8 {
+    fn from(value: GuestVtl) -> Self {
+        Vtl::from(value).into()
+    }
+}
+
+impl From<GuestVtl> for Vtl {
+    fn from(value: GuestVtl) -> Self {
+        match value {
+            GuestVtl::Vtl0 => Vtl::Vtl0,
+            GuestVtl::Vtl1 => Vtl::Vtl1,
+        }
+    }
+}
+
+/// The specified VTL is not supported in the current context.
+#[derive(Debug, Error)]
+#[error("unsupported guest VTL")]
+pub struct UnsupportedGuestVtl;
+
+impl TryFrom<Vtl> for GuestVtl {
+    type Error = UnsupportedGuestVtl;
+
+    fn try_from(value: Vtl) -> Result<Self, Self::Error> {
+        Ok(match value {
+            Vtl::Vtl0 => GuestVtl::Vtl0,
+            Vtl::Vtl1 => GuestVtl::Vtl1,
+            _ => return Err(UnsupportedGuestVtl),
+        })
+    }
+}

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -28,6 +28,7 @@ mod mapping {
     use hcl::ioctl::MshvHvcall;
     use hcl::ioctl::MshvVtl;
     use hcl::ioctl::MshvVtlLow;
+    use hcl::GuestVtl;
     use hvdef::hypercall::AcceptMemoryType;
     use hvdef::hypercall::HostVisibilityType;
     use hvdef::hypercall::HvInputVtl;
@@ -940,14 +941,14 @@ mod mapping {
             Ok(())
         }
 
-        fn default_vtl_protections(&self, vtl: Vtl) -> Option<HvMapGpaFlags> {
-            self.acceptor.default_vtl_protections(vtl)
+        fn default_vtl_protections(&self, vtl: GuestVtl) -> Option<HvMapGpaFlags> {
+            self.acceptor.default_vtl_protections(vtl.into())
         }
 
         fn change_default_vtl_protections(
             &self,
             vtl_protections: HvMapGpaFlags,
-            vtl: Vtl,
+            vtl: GuestVtl,
         ) -> Result<(), HvError> {
             // Prevent visibility changes while VTL protections are being
             // applied.
@@ -961,7 +962,7 @@ mod mapping {
             let inner = self.inner.lock();
 
             self.acceptor
-                .update_default_vtl_protections(vtl_protections, vtl);
+                .update_default_vtl_protections(vtl_protections, vtl.into());
 
             for ram_range in self.layout.ram().iter() {
                 let mut protect_start = ram_range.range.start();
@@ -980,7 +981,7 @@ mod mapping {
                             self.acceptor
                                 .apply_default_vtl_protections(
                                     MemoryRange::new(protect_start..end_address),
-                                    vtl,
+                                    vtl.into(),
                                 )
                                 .expect("applying vtl 1 protections should succeed");
                         }
@@ -996,7 +997,7 @@ mod mapping {
                     self.acceptor
                         .apply_default_vtl_protections(
                             MemoryRange::new(protect_start..end_address),
-                            vtl,
+                            vtl.into(),
                         )
                         .expect("applying vtl 1 protections should succeed");
                 }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -41,6 +41,7 @@ use bitvec::vec::BitVec;
 use guestmem::GuestMemory;
 use hcl::ioctl::Hcl;
 use hcl::ioctl::SetVsmPartitionConfigError;
+use hcl::GuestVtl;
 use hv1_emulator::hv::GlobalHv;
 use hv1_emulator::message_queues::MessageQueues;
 use hv1_emulator::synic::GlobalSynic;
@@ -402,7 +403,7 @@ impl virt::irqcon::ControlGic for UhPartitionInner {
                 .with_interrupt_type(hvdef::HvInterruptType::HvArm64InterruptTypeFixed),
             0,
             irq_id,
-            Vtl::Vtl0,
+            GuestVtl::Vtl0,
         ) {
             tracelimit::warn_ratelimited!(
                 error = &err as &dyn std::error::Error,
@@ -635,7 +636,8 @@ impl virt::Partition for UhPartition {
     }
 
     fn request_msi(&self, vtl: Vtl, request: MsiRequest) {
-        self.inner.request_msi(vtl, request)
+        self.inner
+            .request_msi(vtl.try_into().expect("higher vtl not configured"), request)
     }
 
     fn request_yield(&self, _vp_index: VpIndex) {
@@ -649,6 +651,7 @@ impl virt::X86Partition for UhPartition {
     }
 
     fn pulse_lint(&self, vp_index: VpIndex, vtl: Vtl, lint: u8) {
+        let vtl = GuestVtl::try_from(vtl).expect("higher vtl not configured");
         if let Some(apic) = &self.inner.lapic {
             apic[vtl].lint(vp_index, lint.into(), |vp_index| {
                 self.inner
@@ -721,6 +724,7 @@ impl UhPartitionInner {
 
 impl virt::Synic for UhPartition {
     fn post_message(&self, vtl: Vtl, vp_index: VpIndex, sint: u8, typ: u32, payload: &[u8]) {
+        let vtl = GuestVtl::try_from(vtl).expect("higher vtl not configured");
         let Some(vp) = self.inner.vp(vp_index) else {
             tracelimit::warn_ratelimited!(
                 vp = vp_index.index(),
@@ -816,7 +820,7 @@ impl UhPartitionInner {
     pub(crate) fn synic_interrupt(
         &self,
         vp_index: VpIndex,
-        vtl: Vtl,
+        vtl: GuestVtl,
     ) -> impl '_ + hv1_emulator::RequestInterrupt {
         move |vector, auto_eoi| {
             self.lapic.as_ref().unwrap()[vtl].synic_interrupt(
@@ -832,7 +836,7 @@ impl UhPartitionInner {
     fn synic_interrupt(
         &self,
         _vp_index: VpIndex,
-        _vtl: Vtl,
+        _vtl: GuestVtl,
     ) -> impl '_ + hv1_emulator::RequestInterrupt {
         move |_, _| {}
     }
@@ -849,7 +853,7 @@ struct UhEventPortParams {
     vp: VpIndex,
     sint: u8,
     flag: u16,
-    vtl: Vtl,
+    vtl: GuestVtl,
 }
 
 impl vmcore::synic::GuestEventPort for UhEventPort {
@@ -912,6 +916,7 @@ impl vmcore::synic::GuestEventPort for UhEventPort {
     }
 
     fn set(&mut self, vtl: Vtl, vp: u32, sint: u8, flag: u16) {
+        let vtl = GuestVtl::try_from(vtl).expect("higher vtl not configured");
         *self.params.lock() = Some(UhEventPortParams {
             vp: VpIndex::new(vp),
             sint,
@@ -934,6 +939,7 @@ impl virt::Hv1 for UhPartition {
 
 impl virt::DeviceBuilder for UhPartition {
     fn build(&self, vtl: Vtl, device_id: u64) -> Result<Self::Device, Self::Error> {
+        let vtl = GuestVtl::try_from(vtl).expect("higher vtl not configured");
         let device = self
             .inner
             .software_devices
@@ -967,7 +973,7 @@ impl virt::VtlMemoryProtection for UhPartition {
 
 struct UhInterruptTarget {
     partition: Arc<UhPartitionInner>,
-    vtl: Vtl,
+    vtl: GuestVtl,
 }
 
 impl pci_core::msi::MsiInterruptTarget for UhInterruptTarget {
@@ -979,7 +985,7 @@ impl pci_core::msi::MsiInterruptTarget for UhInterruptTarget {
 }
 
 impl UhPartitionInner {
-    fn request_msi(&self, vtl: Vtl, request: MsiRequest) {
+    fn request_msi(&self, vtl: GuestVtl, request: MsiRequest) {
         if let Some(lapic) = &self.lapic {
             tracing::trace!(?request, "interrupt");
             lapic[vtl].request_interrupt(request.address, request.data, |vp_index| {
@@ -1012,7 +1018,7 @@ impl IoApicRouting for UhPartitionInner {
     // The IO-APIC is always hooked up to VTL0.
     fn assert_irq(&self, irq: u8) {
         self.irq_routes
-            .assert_irq(irq, |request| self.request_msi(Vtl::Vtl0, request))
+            .assert_irq(irq, |request| self.request_msi(GuestVtl::Vtl0, request))
     }
 }
 
@@ -1104,14 +1110,14 @@ pub trait ProtectIsolatedMemory: Send + Sync {
     ) -> HvRepResult;
 
     /// Gets the default protections/permissions for a VTL.
-    fn default_vtl_protections(&self, vtl: Vtl) -> Option<HvMapGpaFlags>;
+    fn default_vtl_protections(&self, vtl: GuestVtl) -> Option<HvMapGpaFlags>;
     /// Changes the default protections/permissions for a VTL. For VBS-isolated
     /// VMs, the protections apply to all vtls lower than the specified one. For
     /// hardware-isolated VMs, they apply just to the given vtl.
     fn change_default_vtl_protections(
         &self,
         protections: HvMapGpaFlags,
-        vtl: Vtl,
+        vtl: GuestVtl,
     ) -> Result<(), HvError>;
 }
 
@@ -1432,7 +1438,7 @@ impl UhPartition {
                 interrupt_targets: VtlArray::from_fn(|vtl| {
                     Arc::new(UhInterruptTarget {
                         partition: partition.clone(),
-                        vtl,
+                        vtl: vtl.try_into().unwrap(),
                     })
                 }),
             },
@@ -1530,7 +1536,7 @@ impl UhPartition {
                     let privs = result.eax as u64 | ((result.ebx as u64) << 32);
                     if hvdef::HvPartitionPrivilege::from(privs).access_vsm() {
                         let guest_vsm_config = hcl.get_guest_vsm_partition_config();
-                        guest_vsm_config.maximum_vtl() >= u8::from(Vtl::Vtl1)
+                        guest_vsm_config.maximum_vtl() >= u8::from(GuestVtl::Vtl1)
                     } else {
                         false
                     }
@@ -1550,7 +1556,7 @@ impl UhPartition {
         );
         if hvdef::HvPartitionPrivilege::from(privs.as_u64()).access_vsm() {
             let guest_vsm_config = hcl.get_guest_vsm_partition_config();
-            guest_vsm_config.maximum_vtl() >= u8::from(Vtl::Vtl1)
+            guest_vsm_config.maximum_vtl() >= u8::from(GuestVtl::Vtl1)
         } else {
             false
         }
@@ -1872,7 +1878,7 @@ pub struct VtlCrash {
     /// The VP that crashed.
     pub vp_index: VpIndex,
     /// The VTL that crashed.
-    pub last_vtl: Vtl,
+    pub last_vtl: GuestVtl,
     /// The crash control information.
     pub control: GuestCrashCtl,
     /// The crash parameters.

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -34,6 +34,7 @@ use super::UhPartitionInner;
 use super::UhVpInner;
 use crate::BackingShared;
 use crate::GuestVsmState;
+use crate::GuestVtl;
 use crate::WakeReason;
 use guestmem::GuestMemory;
 use hcl::ioctl;
@@ -129,7 +130,7 @@ struct VtlsTlbLocked {
 
 #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
 impl VtlsTlbLocked {
-    fn get(&self, requesting_vtl: Vtl, target_vtl: Vtl) -> bool {
+    fn get(&self, requesting_vtl: Vtl, target_vtl: GuestVtl) -> bool {
         match requesting_vtl {
             Vtl::Vtl0 => unreachable!(),
             Vtl::Vtl1 => self.vtl1[target_vtl],
@@ -137,7 +138,7 @@ impl VtlsTlbLocked {
         }
     }
 
-    fn set(&mut self, requesting_vtl: Vtl, target_vtl: Vtl, value: bool) {
+    fn set(&mut self, requesting_vtl: Vtl, target_vtl: GuestVtl, value: bool) {
         match requesting_vtl {
             Vtl::Vtl0 => unreachable!(),
             Vtl::Vtl1 => self.vtl1[target_vtl] = value,
@@ -160,9 +161,9 @@ mod private {
     use crate::processor::UhProcessor;
     use crate::BackingShared;
     use crate::Error;
+    use crate::GuestVtl;
     use crate::UhPartitionInner;
     use hcl::ioctl::ProcessorRunner;
-    use hvdef::Vtl;
     use inspect::InspectMut;
     use std::future::Future;
     use virt::io::CpuIo;
@@ -198,7 +199,7 @@ mod private {
 
         fn access_vp_state<'a, 'p>(
             this: &'a mut UhProcessor<'p, Self>,
-            vtl: Vtl,
+            vtl: GuestVtl,
         ) -> Self::StateAccess<'p, 'a>;
 
         fn run_vp(
@@ -210,7 +211,7 @@ mod private {
         /// Returns true if the VP is ready to run the given VTL, false if it is halted.
         fn poll_apic(
             this: &mut UhProcessor<'_, Self>,
-            vtl: Vtl,
+            vtl: GuestVtl,
             scan_irr: bool,
         ) -> Result<bool, UhRunVpError>;
 
@@ -229,11 +230,11 @@ mod private {
         /// The VTL that was running when the VP exited into VTL2, with the
         /// exception of a successful vtl switch, where it will return the VTL
         /// that will run on VTL 2 exit.
-        fn last_vtl(this: &UhProcessor<'_, Self>) -> Vtl;
+        fn last_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl;
 
         /// Copies shared registers (per VSM TLFS spec) from the last VTL to
         /// the target VTL that will become active.
-        fn switch_vtl_state(this: &mut UhProcessor<'_, Self>, target_vtl: Vtl);
+        fn switch_vtl_state(this: &mut UhProcessor<'_, Self>, target_vtl: GuestVtl);
 
         fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}
     }
@@ -322,13 +323,13 @@ impl UhVpInner {
     }
 
     /// Queues a message for sending, optionally alerting the hypervisor if the queue is empty.
-    pub fn post_message(&self, vtl: Vtl, sint: u8, message: &HvMessage) {
+    pub fn post_message(&self, vtl: GuestVtl, sint: u8, message: &HvMessage) {
         if self.message_queues[vtl].enqueue_message(sint, message) {
             self.wake(vtl, WakeReason::MESSAGE_QUEUES);
         }
     }
 
-    pub fn wake(&self, vtl: Vtl, reason: WakeReason) {
+    pub fn wake(&self, vtl: GuestVtl, reason: WakeReason) {
         let reason = u64::from(reason.0) << (vtl as u8 * 32);
         if self.wake_reasons.fetch_or(reason, Ordering::Release) & reason == 0 {
             if let Some(waker) = &*self.waker.read() {
@@ -449,13 +450,13 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         T::inspect_extra(self, resp);
     }
 
-    fn update_synic(&mut self, vtl: Vtl, untrusted_synic: bool) {
+    fn update_synic(&mut self, vtl: GuestVtl, untrusted_synic: bool) {
         loop {
             let hv = self.hv[vtl].as_mut().unwrap();
 
             let ref_time_now = hv.ref_time_now();
             let synic = if untrusted_synic {
-                debug_assert_eq!(vtl, Vtl::Vtl0);
+                debug_assert_eq!(vtl, GuestVtl::Vtl0);
                 self.untrusted_synic.as_mut().unwrap()
             } else {
                 &mut hv.synic
@@ -488,9 +489,9 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     #[cfg(all(feature = "gdb", guest_arch = "x86_64"))]
     fn handle_debug_exception(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
         // FUTURE: Underhill does not yet support VTL1 so this is only tested with VTL0.
-        if self.last_vtl() == Vtl::Vtl0 {
+        if self.last_vtl() == GuestVtl::Vtl0 {
             let debug_regs: virt::x86::vp::DebugRegisters = self
-                .access_state(Vtl::Vtl0)
+                .access_state(GuestVtl::Vtl0)
                 .debug_regs()
                 .expect("register query should not fail");
 
@@ -651,12 +652,12 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                 };
 
                 if self.untrusted_synic.is_some() {
-                    self.update_synic(Vtl::Vtl0, true);
+                    self.update_synic(GuestVtl::Vtl0, true);
                 }
 
                 // TODO CVM GUEST VSM: Split ready into two to track per-vtl
                 let mut ready = false;
-                for vtl in [Vtl::Vtl1, Vtl::Vtl0] {
+                for vtl in [GuestVtl::Vtl1, GuestVtl::Vtl0] {
                     // Process interrupts.
                     if self.hv(vtl).is_some() {
                         self.update_synic(vtl, false);
@@ -707,7 +708,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
     fn flush_async_requests(&mut self) -> Result<(), Self::RunVpError> {
         if self.inner.wake_reasons.load(Ordering::Relaxed) != 0 {
             let scan_irr = self.handle_wake()?;
-            for vtl in [Vtl::Vtl1, Vtl::Vtl0] {
+            for vtl in [GuestVtl::Vtl1, GuestVtl::Vtl0] {
                 if scan_irr[vtl] {
                     T::poll_apic(self, vtl, true)?;
                 }
@@ -717,7 +718,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
     }
 
     fn access_state(&mut self, vtl: Vtl) -> Self::StateAccess<'_> {
-        T::access_vp_state(self, vtl)
+        T::access_vp_state(self, vtl.try_into().unwrap())
     }
 
     fn vtl_inspectable(&self, vtl: Vtl) -> bool {
@@ -761,7 +762,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         let hv = {
             let vtl0_hv = partition.hv.as_ref().map(|hv| {
                 hv.add_vp(
-                    partition.gm[Vtl::Vtl0].clone(),
+                    partition.gm[GuestVtl::Vtl0].clone(),
                     vp_info.base.vp_index,
                     Vtl::Vtl0,
                 )
@@ -812,8 +813,8 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         let wake_reasons_raw = self.inner.wake_reasons.swap(0, Ordering::SeqCst);
         let wake_reasons_vtl: [WakeReason; 2] = zerocopy::transmute!(wake_reasons_raw);
         for (vtl, wake_reasons) in [
-            (Vtl::Vtl1, wake_reasons_vtl[1]),
-            (Vtl::Vtl0, wake_reasons_vtl[0]),
+            (GuestVtl::Vtl1, wake_reasons_vtl[1]),
+            (GuestVtl::Vtl0, wake_reasons_vtl[0]),
         ] {
             if wake_reasons.message_queues() {
                 let pending_sints = self.inner.message_queues[vtl].pending_sints();
@@ -863,12 +864,12 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                         "starting vp with initial registers"
                     );
                     hv1_emulator::hypercall::set_x86_vp_context(
-                        &mut self.access_state(vtl),
+                        &mut self.access_state(vtl.into()),
                         &context,
                     )
                     .map_err(UhRunVpError::State)?;
 
-                    if vtl == Vtl::Vtl1 {
+                    if vtl == GuestVtl::Vtl1 {
                         assert!(self.partition.is_hardware_isolated());
                         // Should not have already initialized the hv emulator for this vtl
                         assert!(self.hv(vtl).is_none());
@@ -879,14 +880,14 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                                 .as_ref()
                                 .expect("has an hv emulator")
                                 .add_vp(
-                                    self.partition.gm[Vtl::Vtl1].clone(),
+                                    self.partition.gm[GuestVtl::Vtl1].clone(),
                                     self.vp_index(),
                                     Vtl::Vtl1,
                                 ),
                         );
                         self.cvm_guest_vsm = Some(GuestVsmVpState {
                             // TODO CVM GUEST VSM: Revisit during AP startup if this is correct
-                            current_vtl: Vtl::Vtl0,
+                            current_vtl: GuestVtl::Vtl0,
                         })
                     }
                 }
@@ -896,7 +897,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         Ok(wake_reasons_vtl.map(|w| w.intcon()).into())
     }
 
-    fn request_sint_notifications(&mut self, vtl: Vtl, sints: u16) {
+    fn request_sint_notifications(&mut self, vtl: GuestVtl, sints: u16) {
         if sints == 0 {
             return;
         }
@@ -1035,7 +1036,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         )
     }
 
-    fn last_vtl(&self) -> Vtl {
+    fn last_vtl(&self) -> GuestVtl {
         T::last_vtl(self)
     }
 
@@ -1044,16 +1045,16 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         &self.partition.gm[self.last_vtl()]
     }
 
-    fn hv(&self, vtl: Vtl) -> Option<&ProcessorVtlHv> {
+    fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv> {
         self.hv[vtl].as_ref()
     }
 
     #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
-    fn hv_mut(&mut self, vtl: Vtl) -> Option<&mut ProcessorVtlHv> {
+    fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
         self.hv[vtl].as_mut()
     }
 
-    fn deliver_synic_messages(&mut self, vtl: Vtl, sints: u16) {
+    fn deliver_synic_messages(&mut self, vtl: GuestVtl, sints: u16) {
         let proxied_sints = self.hv(vtl).map_or(!0, |hv| hv.synic.proxied_sints());
         let pending_sints =
             self.inner.message_queues[vtl].post_pending_messages(sints, |sint, message| {
@@ -1090,7 +1091,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
-    fn switch_vtl(&mut self, target_vtl: Vtl) {
+    fn switch_vtl(&mut self, target_vtl: GuestVtl) {
         T::switch_vtl_state(self, target_vtl);
 
         self.runner.set_exit_vtl(target_vtl);
@@ -1153,6 +1154,15 @@ struct UhHypercallHandler<'a, 'b, T, B: Backing> {
     trusted: bool,
 }
 
+impl<T, B: Backing> UhHypercallHandler<'_, '_, T, B> {
+    fn target_vtl_no_higher(&self, target_vtl: Vtl) -> Result<GuestVtl, HvError> {
+        if Vtl::from(self.vp.last_vtl()) < target_vtl {
+            return Err(HvError::AccessDenied);
+        }
+        Ok(target_vtl.try_into().unwrap())
+    }
+}
+
 impl<T, B: Backing> hv1_hypercall::GetVpIndexFromApicId for UhHypercallHandler<'_, '_, T, B> {
     fn get_vp_index_from_apic_id(
         &mut self,
@@ -1167,9 +1177,7 @@ impl<T, B: Backing> hv1_hypercall::GetVpIndexFromApicId for UhHypercallHandler<'
             return Err((HvError::InvalidPartitionId, 0));
         }
 
-        if self.vp.last_vtl() < target_vtl {
-            return Err((HvError::AccessDenied, 0));
-        }
+        let _target_vtl = self.target_vtl_no_higher(target_vtl).map_err(|e| (e, 0))?;
 
         #[cfg(guest_arch = "aarch64")]
         if true {
@@ -1260,10 +1268,7 @@ impl<T, B: Backing> hv1_hypercall::StartVirtualProcessor<hvdef::hypercall::Initi
             return Err(HvError::InvalidVpIndex);
         }
 
-        if self.vp.last_vtl() < target_vtl {
-            return Err(HvError::AccessDenied);
-        }
-
+        let target_vtl = self.target_vtl_no_higher(target_vtl)?;
         let target_vp = &self.vp.partition.vps[target_vp as usize];
 
         // TODO CVM GUEST VSM: probably some validation on vtl1_enabled
@@ -1282,8 +1287,12 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::PostMessage for UhHypercallHandler<'_,
             "handling post message intercept"
         );
 
-        self.bus
-            .post_synic_message(self.vp.last_vtl(), connection_id, self.trusted, message)
+        self.bus.post_synic_message(
+            self.vp.last_vtl().into(),
+            connection_id,
+            self.trusted,
+            message,
+        )
     }
 }
 
@@ -1292,7 +1301,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::SignalEvent for UhHypercallHandler<'_,
         tracing::trace!(connection_id, "handling signal event intercept");
 
         self.bus
-            .signal_synic_event(self.vp.last_vtl(), connection_id, flag)
+            .signal_synic_event(self.vp.last_vtl().into(), connection_id, flag)
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -491,7 +491,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         // FUTURE: Underhill does not yet support VTL1 so this is only tested with VTL0.
         if self.last_vtl() == GuestVtl::Vtl0 {
             let debug_regs: virt::x86::vp::DebugRegisters = self
-                .access_state(GuestVtl::Vtl0)
+                .access_state(Vtl::Vtl0)
                 .debug_regs()
                 .expect("register query should not fail");
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/tlb_lock.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/tlb_lock.rs
@@ -4,6 +4,7 @@
 
 use crate::HypervisorBacked;
 use crate::UhProcessor;
+use hcl::GuestVtl;
 use hvdef::hypercall::HvInputVtl;
 use hvdef::HvAllArchRegisterName;
 use hvdef::Vtl;
@@ -23,7 +24,7 @@ impl<'a> UhProcessor<'a, HypervisorBacked> {
     }
 
     /// Lock the TLB of the target VTL on the current VP.
-    pub fn set_tlb_lock(&mut self, requesting_vtl: Vtl, target_vtl: Vtl) {
+    pub fn set_tlb_lock(&mut self, requesting_vtl: Vtl, target_vtl: GuestVtl) {
         debug_assert_eq!(requesting_vtl, Vtl::Vtl2);
 
         if self.is_tlb_locked(requesting_vtl, target_vtl) {
@@ -44,7 +45,7 @@ impl<'a> UhProcessor<'a, HypervisorBacked> {
     }
 
     /// Check the status of the TLB lock of the target VTL on the current VP.
-    pub fn is_tlb_locked(&mut self, requesting_vtl: Vtl, target_vtl: Vtl) -> bool {
+    pub fn is_tlb_locked(&mut self, requesting_vtl: Vtl, target_vtl: GuestVtl) -> bool {
         debug_assert_eq!(requesting_vtl, Vtl::Vtl2);
         let local_status = self.vtls_tlb_locked.get(requesting_vtl, target_vtl);
         // The hypervisor may lock the TLB without us knowing, but the inverse should never happen.
@@ -54,7 +55,7 @@ impl<'a> UhProcessor<'a, HypervisorBacked> {
         local_status
     }
 
-    fn is_tlb_locked_in_hypervisor(&self, target_vtl: Vtl) -> bool {
+    fn is_tlb_locked_in_hypervisor(&self, target_vtl: GuestVtl) -> bool {
         let name = HvAllArchRegisterName(
             HvAllArchRegisterName::VsmVpSecureConfigVtl0.0 + target_vtl as u32,
         );

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -25,6 +25,7 @@ use crate::Error;
 use crate::GuestVsmState;
 use crate::GuestVsmVtl1State;
 use crate::GuestVsmVtl1StateInner;
+use crate::GuestVtl;
 use hcl::ioctl;
 use hcl::ioctl::ApplyVtlProtectionsError;
 use hcl::protocol;
@@ -136,14 +137,14 @@ impl BackingPrivate for HypervisorBackedX86 {
                 .get_vp_register(HvX64RegisterName::ApicBase)
                 .unwrap()
                 .as_u64();
-            let mut lapic0 = arr[Vtl::Vtl0].add_apic(params.vp_info);
+            let mut lapic0 = arr[GuestVtl::Vtl0].add_apic(params.vp_info);
             lapic0.set_apic_base(apic_base).unwrap();
-            let mut lapic1 = arr[Vtl::Vtl1].add_apic(params.vp_info);
+            let mut lapic1 = arr[GuestVtl::Vtl1].add_apic(params.vp_info);
             lapic1.set_apic_base(apic_base).unwrap();
 
             [
-                apic::UhApicState::new(lapic0, Vtl::Vtl0, &params.vp_info.base),
-                apic::UhApicState::new(lapic1, Vtl::Vtl1, &params.vp_info.base),
+                apic::UhApicState::new(lapic0, GuestVtl::Vtl0, &params.vp_info.base),
+                apic::UhApicState::new(lapic1, GuestVtl::Vtl1, &params.vp_info.base),
             ]
             .into()
         });
@@ -162,9 +163,9 @@ impl BackingPrivate for HypervisorBackedX86 {
 
     fn access_vp_state<'a, 'p>(
         this: &'a mut UhProcessor<'p, Self>,
-        vtl: Vtl,
+        vtl: GuestVtl,
     ) -> Self::StateAccess<'p, 'a> {
-        assert_eq!(vtl, Vtl::Vtl0);
+        assert_eq!(vtl, GuestVtl::Vtl0);
         UhVpStateAccess::new(this, vtl)
     }
 
@@ -288,7 +289,7 @@ impl BackingPrivate for HypervisorBackedX86 {
 
     fn poll_apic(
         this: &mut UhProcessor<'_, Self>,
-        vtl: Vtl,
+        vtl: GuestVtl,
         scan_irr: bool,
     ) -> Result<bool, UhRunVpError> {
         this.poll_apic(vtl, scan_irr)
@@ -307,11 +308,13 @@ impl BackingPrivate for HypervisorBackedX86 {
     }
 
     // If there's no register page, assume only VTL0 is supported.
-    fn last_vtl(this: &UhProcessor<'_, Self>) -> Vtl {
-        this.runner.reg_page_vtl().unwrap_or(Vtl::Vtl0)
+    fn last_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl {
+        this.runner
+            .reg_page_vtl()
+            .map_or(GuestVtl::Vtl0, |vtl| vtl.try_into().unwrap())
     }
 
-    fn switch_vtl_state(_this: &mut UhProcessor<'_, Self>, _target_vtl: Vtl) {
+    fn switch_vtl_state(_this: &mut UhProcessor<'_, Self>, _target_vtl: GuestVtl) {
         unreachable!("vtl switching should be managed by the hypervisor");
     }
 }
@@ -437,7 +440,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         self.backing.next_deliverability_notifications.set_sints(0);
 
         // These messages are always VTL0, as VTL1 does not own any VMBUS channels.
-        self.deliver_synic_messages(Vtl::Vtl0, message.deliverable_sints);
+        self.deliver_synic_messages(GuestVtl::Vtl0, message.deliverable_sints);
     }
 
     fn handle_hypercall_exit(
@@ -704,7 +707,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
     fn handle_unrecoverable_exception(&self) -> Result<(), VpHaltReason<UhRunVpError>> {
         Err(VpHaltReason::TripleFault {
-            vtl: self.last_vtl(),
+            vtl: self.last_vtl().into(),
         })
     }
 
@@ -784,9 +787,9 @@ impl UhProcessor<'_, HypervisorBackedX86> {
     fn set_vsm_partition_config(
         &mut self,
         value: HvRegisterVsmPartitionConfig,
-        vtl: Vtl,
+        vtl: GuestVtl,
     ) -> Result<(), HvError> {
-        if vtl != Vtl::Vtl1 {
+        if vtl != GuestVtl::Vtl1 {
             return Err(HvError::InvalidParameter);
         }
 
@@ -794,7 +797,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         let status: HvRegisterVsmPartitionStatus = self.partition.vsm_status();
 
-        let vtl1_enabled = VtlSet::from(status.enabled_vtl_set()).is_set(Vtl::Vtl1);
+        let vtl1_enabled = VtlSet::from(status.enabled_vtl_set()).is_set(GuestVtl::Vtl1);
         if !vtl1_enabled {
             return Err(HvError::InvalidVtlState);
         }
@@ -846,9 +849,10 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         // For VBS-isolated VMs, protections apply to VTLs lower than the one specified when
         // setting VsmPartitionConfig.
-        let mbec_enabled = VtlSet::from(status.mbec_enabled_vtl_set()).is_set(Vtl::Vtl0);
+        let mbec_enabled = VtlSet::from(status.mbec_enabled_vtl_set()).is_set(GuestVtl::Vtl0);
         let shadow_supervisor_stack_enabled =
-            VtlSet::from(status.supervisor_shadow_stack_enabled_vtl_set() as u16).is_set(Vtl::Vtl0);
+            VtlSet::from(status.supervisor_shadow_stack_enabled_vtl_set() as u16)
+                .is_set(GuestVtl::Vtl0);
 
         if !validate_vtl_gpa_flags(protections, mbec_enabled, shadow_supervisor_stack_enabled) {
             return Err(HvError::InvalidRegisterValue);
@@ -883,7 +887,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         }
 
         let hc_regs = [(HvX64RegisterName::VsmPartitionConfig, u64::from(value))];
-        self.runner.set_vp_registers_hvcall(vtl, hc_regs)?;
+        self.runner.set_vp_registers_hvcall(vtl.into(), hc_regs)?;
         guest_vsm.enable_vtl_protection = true;
 
         Ok(())
@@ -997,7 +1001,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
         // Note: the restriction to VTL 1 support also means that for WHP, which doesn't support VTL 1
         // the HvCheckSparseGpaPageVtlAccess hypercall--which is unimplemented in whp--will never be made.
         if mode == virt_support_x86emu::emulate::TranslateMode::Execute
-            && self.vp.last_vtl() == Vtl::Vtl0
+            && self.vp.last_vtl() == GuestVtl::Vtl0
             && self.vp.vtl1_supported()
         {
             // Should always be called after translate gva with the tlb lock flag
@@ -1022,7 +1026,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
                 .vp
                 .partition
                 .hcl
-                .check_vtl_access(gpa, Vtl::Vtl0, flags)
+                .check_vtl_access(gpa, GuestVtl::Vtl0, flags)
                 .map_err(|e| EmuCheckVtlAccessError::Hypervisor(UhRunVpError::VtlAccess(e)))?;
 
             if let Some(ioctl::CheckVtlAccessResult { vtl, denied_flags }) = access_result {
@@ -1110,7 +1114,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
 
         self.vp
             .runner
-            .set_vp_registers_hvcall(last_vtl, regs)
+            .set_vp_registers_hvcall(last_vtl.into(), regs)
             .expect("set_vp_registers hypercall for setting pending event should not fail");
     }
 
@@ -1532,7 +1536,9 @@ impl<T> hv1_hypercall::SetVpRegisters for UhHypercallHandler<'_, '_, T, Hypervis
             return Err((HvError::InvalidVpIndex, 0));
         }
 
-        let target_vtl = vtl.unwrap_or(self.vp.last_vtl());
+        let target_vtl = self
+            .target_vtl_no_higher(vtl.unwrap_or(self.vp.last_vtl().into()))
+            .map_err(|e| (e, 0))?;
 
         for (i, reg) in registers.iter().enumerate() {
             if reg.name == HvX64RegisterName::VsmPartitionConfig.into() {
@@ -1553,6 +1559,7 @@ mod save_restore {
     use super::HypervisorBackedX86;
     use super::UhProcessor;
     use anyhow::Context;
+    use hcl::GuestVtl;
     use hvdef::HvInternalActivityRegister;
     use hvdef::HvX64RegisterName;
     use virt::irqcon::MsiRequest;
@@ -1818,7 +1825,7 @@ mod save_restore {
                     );
 
                     self.partition.request_msi(
-                        hvdef::Vtl::Vtl0,
+                        GuestVtl::Vtl0,
                         MsiRequest::new_x86(
                             virt::irqcon::DeliveryMode::INIT,
                             self.inner.vp_info.apic_id,

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -13,6 +13,7 @@ use super::HardwareIsolatedBacking;
 use super::UhEmulationState;
 use super::UhHypercallHandler;
 use super::UhRunVpError;
+use crate::GuestVtl;
 use crate::UhPartitionInner;
 use crate::UhProcessor;
 use crate::WakeReason;
@@ -267,7 +268,8 @@ impl VirtualRegister {
 
         // If guest owned bits of the physical register have changed, then update
         // the guest owned bits of the physical field.
-        let old_physical_reg = runner.read_vmcs64(Vtl::Vtl0, self.register.physical_vmcs_field());
+        let old_physical_reg =
+            runner.read_vmcs64(GuestVtl::Vtl0, self.register.physical_vmcs_field());
 
         tracing::trace!(old_physical_reg, "old_physical_reg");
 
@@ -279,7 +281,7 @@ impl VirtualRegister {
             tracing::trace!(new_physical_reg, "new_physical_reg");
 
             runner.write_vmcs64(
-                Vtl::Vtl0,
+                GuestVtl::Vtl0,
                 self.register.physical_vmcs_field(),
                 !0,
                 new_physical_reg,
@@ -287,12 +289,12 @@ impl VirtualRegister {
         }
 
         self.shadow_value = value;
-        runner.write_vmcs64(Vtl::Vtl0, self.register.shadow_vmcs_field(), !0, value);
+        runner.write_vmcs64(GuestVtl::Vtl0, self.register.shadow_vmcs_field(), !0, value);
         Ok(())
     }
 
     fn read(&self, runner: &ProcessorRunner<'_, Tdx>) -> u64 {
-        let physical_reg = runner.read_vmcs64(Vtl::Vtl0, self.register.physical_vmcs_field());
+        let physical_reg = runner.read_vmcs64(GuestVtl::Vtl0, self.register.physical_vmcs_field());
 
         // Get the bits owned by the host from the shadow and the bits owned by the
         // guest from the physical value.
@@ -524,27 +526,27 @@ impl BackingPrivate for TdxBacked {
 
         params
             .runner
-            .set_l2_ctls(Vtl::Vtl0, controls)
+            .set_l2_ctls(GuestVtl::Vtl0, controls)
             .map_err(crate::Error::FailedToSetL2Ctls)?;
 
         // Set guest/host masks for CR0 and CR4. These enable shadowing these
         // registers since TDX requires certain bits to be set at all times.
         let initial_cr0 = params
             .runner
-            .read_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR0);
+            .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR0);
         assert_eq!(initial_cr0, X64_CR0_PE | X64_CR0_NE);
 
         // N.B. CR0.PE and CR0.PG are guest owned but still intercept when they
         // are changed for caching purposes and to ensure EFER is managed
         // properly due to the need to change execution state.
         params.runner.write_vmcs64(
-            Vtl::Vtl0,
+            GuestVtl::Vtl0,
             VmcsField::VMX_VMCS_CR0_READ_SHADOW,
             !0,
             X64_CR0_PE | X64_CR0_NE,
         );
         params.runner.write_vmcs64(
-            Vtl::Vtl0,
+            GuestVtl::Vtl0,
             VmcsField::VMX_VMCS_CR0_GUEST_HOST_MASK,
             !0,
             !ShadowedRegister::Cr0.guest_owned_mask() | X64_CR0_PE | X64_CR0_PG,
@@ -552,7 +554,7 @@ impl BackingPrivate for TdxBacked {
 
         let initial_cr4 = params
             .runner
-            .read_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR4);
+            .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR4);
         assert_eq!(initial_cr4, X64_CR4_MCE | X64_CR4_VMXE);
 
         // Allowed cr4 bits depend on the values allowed by the SEAM.
@@ -564,9 +566,9 @@ impl BackingPrivate for TdxBacked {
 
         params
             .runner
-            .write_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_CR4_READ_SHADOW, !0, 0);
+            .write_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_CR4_READ_SHADOW, !0, 0);
         params.runner.write_vmcs64(
-            Vtl::Vtl0,
+            GuestVtl::Vtl0,
             VmcsField::VMX_VMCS_CR4_GUEST_HOST_MASK,
             !0,
             !(ShadowedRegister::Cr4.guest_owned_mask() & allowed_cr4_bits),
@@ -580,7 +582,7 @@ impl BackingPrivate for TdxBacked {
             if word != u64::MAX {
                 params
                     .runner
-                    .write_msr_bitmap(Vtl::Vtl0, i as u32, !0, word);
+                    .write_msr_bitmap(GuestVtl::Vtl0, i as u32, !0, word);
             }
         }
 
@@ -599,7 +601,7 @@ impl BackingPrivate for TdxBacked {
         let overlays: Vec<_> = pfns.collect();
 
         let mut lapic =
-            params.partition.lapic.as_ref().unwrap()[Vtl::Vtl0].add_apic(params.vp_info);
+            params.partition.lapic.as_ref().unwrap()[GuestVtl::Vtl0].add_apic(params.vp_info);
 
         // Initialize APIC base to match the reset VM state.
         let apic_base = vp::Apic::at_reset(&params.partition.caps, params.vp_info).apic_base;
@@ -608,13 +610,16 @@ impl BackingPrivate for TdxBacked {
         // Cache the processor controls.
         let processor_controls = params
             .runner
-            .read_vmcs32(Vtl::Vtl0, VmcsField::VMX_VMCS_PROCESSOR_CONTROLS)
+            .read_vmcs32(GuestVtl::Vtl0, VmcsField::VMX_VMCS_PROCESSOR_CONTROLS)
             .into();
 
         // Cache the secondary processor controls.
         let secondary_processor_controls = params
             .runner
-            .read_vmcs32(Vtl::Vtl0, VmcsField::VMX_VMCS_SECONDARY_PROCESSOR_CONTROLS)
+            .read_vmcs32(
+                GuestVtl::Vtl0,
+                VmcsField::VMX_VMCS_SECONDARY_PROCESSOR_CONTROLS,
+            )
             .into();
 
         // TODO: This needs to come from a private pool
@@ -662,10 +667,10 @@ impl BackingPrivate for TdxBacked {
 
     fn access_vp_state<'a, 'p>(
         this: &'a mut UhProcessor<'p, Self>,
-        vtl: Vtl,
+        vtl: GuestVtl,
     ) -> Self::StateAccess<'p, 'a> {
         // TODO GUEST_VSM: VTL 1 access not supported yet.
-        assert_eq!(vtl, Vtl::Vtl0);
+        assert_eq!(vtl, GuestVtl::Vtl0);
         UhVpStateAccess::new(this, vtl)
     }
 
@@ -693,11 +698,11 @@ impl BackingPrivate for TdxBacked {
 
         let reg_count = if let Some(synic) = &mut this.untrusted_synic {
             synic.set_simp(
-                &this.partition.gm[Vtl::Vtl0],
+                &this.partition.gm[GuestVtl::Vtl0],
                 reg(pfns[UhDirectOverlay::Sipp as usize]),
             );
             synic.set_siefp(
-                &this.partition.gm[Vtl::Vtl0],
+                &this.partition.gm[GuestVtl::Vtl0],
                 reg(pfns[UhDirectOverlay::Sifp as usize]),
             );
             // Set the SIEFP in the hypervisor so that the hypervisor can
@@ -728,7 +733,7 @@ impl BackingPrivate for TdxBacked {
     // TODO TDX GUEST VSM
     fn poll_apic(
         this: &mut UhProcessor<'_, Self>,
-        _vtl: Vtl,
+        _vtl: GuestVtl,
         scan_irr: bool,
     ) -> Result<bool, UhRunVpError> {
         if !this.try_poll_apic(scan_irr)? {
@@ -759,13 +764,13 @@ impl BackingPrivate for TdxBacked {
         }
     }
 
-    fn last_vtl(this: &UhProcessor<'_, Self>) -> Vtl {
+    fn last_vtl(this: &UhProcessor<'_, Self>) -> GuestVtl {
         this.cvm_guest_vsm
             .as_ref()
-            .map_or(Vtl::Vtl0, |gvsm_state| gvsm_state.current_vtl)
+            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.current_vtl)
     }
 
-    fn switch_vtl_state(_this: &mut UhProcessor<'_, Self>, _target_vtl: Vtl) {
+    fn switch_vtl_state(_this: &mut UhProcessor<'_, Self>, _target_vtl: GuestVtl) {
         todo!()
     }
 }
@@ -832,7 +837,7 @@ impl UhProcessor<'_, TdxBacked> {
         if self.backing.tpr_threshold != new_tpr_threshold {
             tracing::trace!(new_tpr_threshold, "setting tpr threshold");
             self.runner.write_vmcs32(
-                Vtl::Vtl0,
+                GuestVtl::Vtl0,
                 VmcsField::VMX_VMCS_TPR_THRESHOLD,
                 !0,
                 new_tpr_threshold.into(),
@@ -843,7 +848,7 @@ impl UhProcessor<'_, TdxBacked> {
         if self.backing.processor_controls != new_processor_controls {
             tracing::debug!(?new_processor_controls, "requesting window change");
             self.runner.write_vmcs32(
-                Vtl::Vtl0,
+                GuestVtl::Vtl0,
                 VmcsField::VMX_VMCS_PROCESSOR_CONTROLS,
                 !0,
                 new_processor_controls.into(),
@@ -885,7 +890,7 @@ impl UhProcessor<'_, TdxBacked> {
                 {
                     let tmr = tmr[0] as u64 | ((tmr[1] as u64) << 32);
                     if *eoi_exit != tmr {
-                        self.runner.write_vmcs64(Vtl::Vtl0, field, !0, tmr);
+                        self.runner.write_vmcs64(GuestVtl::Vtl0, field, !0, tmr);
                         *eoi_exit = tmr;
                     }
                 }
@@ -952,7 +957,7 @@ impl UhProcessor<'_, TdxBacked> {
         // Once for read and once for write.
         for offset in [0, 0x100] {
             self.runner.write_msr_bitmap(
-                Vtl::Vtl0,
+                GuestVtl::Vtl0,
                 offset + X2APIC_MSR_BASE / 64,
                 !0,
                 !offload_bitmap,
@@ -970,7 +975,7 @@ impl UhProcessor<'_, TdxBacked> {
                 .secondary_processor_controls
                 .set_virtual_interrupt_delivery(offload);
             self.runner.write_vmcs32(
-                Vtl::Vtl0,
+                GuestVtl::Vtl0,
                 VmcsField::VMX_VMCS_SECONDARY_PROCESSOR_CONTROLS,
                 !0,
                 self.backing.secondary_processor_controls.into(),
@@ -1004,7 +1009,7 @@ impl UhProcessor<'_, TdxBacked> {
         // Ensure the interrupt is not blocked by RFLAGS.IF or interrupt shadow.
         let interruptibility: Interruptibility = self
             .runner
-            .read_vmcs32(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY)
+            .read_vmcs32(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY)
             .into();
 
         let rflags = RFlags::from(self.runner.tdx_enter_guest_state().rflags);
@@ -1044,7 +1049,7 @@ impl UhProcessor<'_, TdxBacked> {
 
         let interruptibility: Interruptibility = self
             .runner
-            .read_vmcs32(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY)
+            .read_vmcs32(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY)
             .into();
 
         if interruptibility.blocked_by_nmi()
@@ -1076,7 +1081,7 @@ impl UhProcessor<'_, TdxBacked> {
         if self.backing.startup_suspend {
             let address = (vector as u64) << 12;
             self.write_segment(
-                Vtl::Vtl0,
+                GuestVtl::Vtl0,
                 TdxSegmentReg::Cs,
                 SegmentRegister {
                     base: address,
@@ -1101,14 +1106,14 @@ impl UhProcessor<'_, TdxBacked> {
             );
 
             self.runner.write_vmcs32(
-                Vtl::Vtl0,
+                GuestVtl::Vtl0,
                 VmcsField::VMX_VMCS_ENTRY_INTERRUPT_INFO,
                 !0,
                 self.backing.interruption_information.into(),
             );
             if self.backing.interruption_information.deliver_error_code() {
                 self.runner.write_vmcs32(
-                    Vtl::Vtl0,
+                    GuestVtl::Vtl0,
                     VmcsField::VMX_VMCS_ENTRY_EXCEPTION_ERROR_CODE,
                     !0,
                     self.backing.exception_error_code,
@@ -1116,16 +1121,20 @@ impl UhProcessor<'_, TdxBacked> {
             }
             self.backing.interruption_set = true;
         } else if self.backing.interruption_set {
-            self.runner
-                .write_vmcs32(Vtl::Vtl0, VmcsField::VMX_VMCS_ENTRY_INTERRUPT_INFO, !0, 0);
+            self.runner.write_vmcs32(
+                GuestVtl::Vtl0,
+                VmcsField::VMX_VMCS_ENTRY_INTERRUPT_INFO,
+                !0,
+                0,
+            );
             self.backing.interruption_set = false;
         }
 
         // We're about to return to VTL 0, so do any pending flushes, unlock our
         // TLB locks, and wait for any others we're supposed to.
-        self.do_tlb_flush(Vtl::Vtl0);
+        self.do_tlb_flush(GuestVtl::Vtl0);
         self.unlock_tlb_lock(Vtl::Vtl2);
-        let tlb_halt = self.should_halt_for_tlb_unlock(Vtl::Vtl0);
+        let tlb_halt = self.should_halt_for_tlb_unlock(GuestVtl::Vtl0);
 
         self.runner
             .set_halted(self.backing.halted || self.backing.startup_suspend || tlb_halt);
@@ -1442,7 +1451,7 @@ impl UhProcessor<'_, TdxBacked> {
                 let mask = Interruptibility::new().with_blocked_by_sti(true);
                 let value = Interruptibility::new().with_blocked_by_sti(false);
                 self.runner.write_vmcs32(
-                    Vtl::Vtl0,
+                    GuestVtl::Vtl0,
                     VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
                     mask.into(),
                     value.into(),
@@ -1542,7 +1551,7 @@ impl UhProcessor<'_, TdxBacked> {
                             let old_interruptibility: Interruptibility = self
                                 .runner
                                 .write_vmcs32(
-                                    Vtl::Vtl0,
+                                    GuestVtl::Vtl0,
                                     VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
                                     mask.into(),
                                     value.into(),
@@ -1593,7 +1602,11 @@ impl UhProcessor<'_, TdxBacked> {
                 }
                 &mut self.backing.exit_stats.tdcall
             }
-            VmxExit::TRIPLE_FAULT => return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 }),
+            VmxExit::TRIPLE_FAULT => {
+                return Err(VpHaltReason::TripleFault {
+                    vtl: self.last_vtl().into(),
+                })
+            }
             _ => {
                 return Err(VpHaltReason::Hypervisor(UhRunVpError::UnknownVmxExit(
                     exit_info.code().vmx_exit(),
@@ -1716,7 +1729,7 @@ impl UhProcessor<'_, TdxBacked> {
             }
             _ => {
                 self.untrusted_synic.as_mut().unwrap().write_nontimer_msr(
-                    &self.partition.gm[Vtl::Vtl0],
+                    &self.partition.gm[GuestVtl::Vtl0],
                     msr,
                     value,
                 )?;
@@ -1787,7 +1800,7 @@ impl UhProcessor<'_, TdxBacked> {
             x86defs::X86X_MSR_CR_PAT => {
                 let pat = self
                     .runner
-                    .read_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_PAT);
+                    .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_PAT);
                 Ok(pat)
             }
 
@@ -1825,7 +1838,7 @@ impl UhProcessor<'_, TdxBacked> {
             x86defs::X86X_MSR_SFMASK => state.msr_sfmask = value,
             x86defs::X86X_MSR_SYSENTER_CS => {
                 self.runner.write_vmcs32(
-                    Vtl::Vtl0,
+                    GuestVtl::Vtl0,
                     VmcsField::VMX_VMCS_GUEST_SYSENTER_CS_MSR,
                     !0,
                     value as u32,
@@ -1833,7 +1846,7 @@ impl UhProcessor<'_, TdxBacked> {
             }
             x86defs::X86X_MSR_SYSENTER_EIP => {
                 self.runner.write_vmcs64(
-                    Vtl::Vtl0,
+                    GuestVtl::Vtl0,
                     VmcsField::VMX_VMCS_GUEST_SYSENTER_EIP_MSR,
                     !0,
                     value,
@@ -1841,7 +1854,7 @@ impl UhProcessor<'_, TdxBacked> {
             }
             x86defs::X86X_MSR_SYSENTER_ESP => {
                 self.runner.write_vmcs64(
-                    Vtl::Vtl0,
+                    GuestVtl::Vtl0,
                     VmcsField::VMX_VMCS_GUEST_SYSENTER_ESP_MSR,
                     !0,
                     value,
@@ -1859,7 +1872,7 @@ impl UhProcessor<'_, TdxBacked> {
             x86defs::X86X_IA32_MSR_MISC_ENABLE => return Ok(()),
             x86defs::X86X_MSR_CR_PAT => {
                 self.runner
-                    .write_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_PAT, !0, value);
+                    .write_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_PAT, !0, value);
             }
 
             x86defs::X86X_MSR_MCG_STATUS => {
@@ -1892,7 +1905,7 @@ impl UhProcessor<'_, TdxBacked> {
 
     fn write_segment(
         &mut self,
-        vtl: Vtl,
+        vtl: GuestVtl,
         seg: TdxSegmentReg,
         reg: SegmentRegister,
     ) -> Result<(), vp_state::Error> {
@@ -1914,7 +1927,7 @@ impl UhProcessor<'_, TdxBacked> {
         Ok(())
     }
 
-    fn read_segment(&self, vtl: Vtl, seg: TdxSegmentReg) -> SegmentRegister {
+    fn read_segment(&self, vtl: GuestVtl, seg: TdxSegmentReg) -> SegmentRegister {
         let selector = self.runner.read_vmcs16(vtl, seg.selector());
         let base = self.runner.read_vmcs64(vtl, seg.base());
         let limit = self.runner.read_vmcs32(vtl, seg.limit());
@@ -1950,12 +1963,22 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, TdxBacked> {
         Ok(x86emu::CpuState {
             gps: enter_state.gps,
             segs: [
-                self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Es).into(),
+                self.vp
+                    .read_segment(GuestVtl::Vtl0, TdxSegmentReg::Es)
+                    .into(),
                 cs.into(),
-                self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Ss).into(),
-                self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Ds).into(),
-                self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Fs).into(),
-                self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Gs).into(),
+                self.vp
+                    .read_segment(GuestVtl::Vtl0, TdxSegmentReg::Ss)
+                    .into(),
+                self.vp
+                    .read_segment(GuestVtl::Vtl0, TdxSegmentReg::Ds)
+                    .into(),
+                self.vp
+                    .read_segment(GuestVtl::Vtl0, TdxSegmentReg::Fs)
+                    .into(),
+                self.vp
+                    .read_segment(GuestVtl::Vtl0, TdxSegmentReg::Gs)
+                    .into(),
             ],
             rip: enter_state.rip,
             rflags: enter_state.rflags.into(),
@@ -2102,8 +2125,8 @@ impl TranslateGvaSupport for UhProcessor<'_, TdxBacked> {
         let efer = self.backing.efer;
         let cr3 = self
             .runner
-            .read_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR3);
-        let ss = self.read_segment(Vtl::Vtl0, TdxSegmentReg::Ss).into();
+            .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR3);
+        let ss = self.read_segment(GuestVtl::Vtl0, TdxSegmentReg::Ss).into();
         let rflags = self.runner.tdx_enter_guest_state().rflags;
         Ok(TranslationRegisters {
             cr0,
@@ -2230,7 +2253,7 @@ impl UhProcessor<'_, TdxBacked> {
         // Update the local value of EFER and the VMCS.
         self.backing.efer = efer;
         self.runner
-            .write_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_EFER, !0, efer);
+            .write_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_EFER, !0, efer);
         Ok(())
     }
 
@@ -2265,7 +2288,7 @@ impl UhProcessor<'_, TdxBacked> {
 
     fn write_table_register(
         &mut self,
-        vtl: Vtl,
+        vtl: GuestVtl,
         table: TdxTableReg,
         reg: TableRegister,
     ) -> Result<(), vp_state::Error> {
@@ -2276,7 +2299,7 @@ impl UhProcessor<'_, TdxBacked> {
         Ok(())
     }
 
-    fn read_table_register(&self, vtl: Vtl, table: TdxTableReg) -> TableRegister {
+    fn read_table_register(&self, vtl: GuestVtl, table: TdxTableReg) -> TableRegister {
         let base = self.runner.read_vmcs64(vtl, table.base_code());
         let limit = self.runner.read_vmcs32(vtl, table.limit_code());
 
@@ -2301,7 +2324,7 @@ impl UhProcessor<'_, TdxBacked> {
 
         let mut entry_controls = self
             .runner
-            .read_vmcs32(Vtl::Vtl0, VmcsField::VMX_VMCS_ENTRY_CONTROLS);
+            .read_vmcs32(GuestVtl::Vtl0, VmcsField::VMX_VMCS_ENTRY_CONTROLS);
         if lma {
             entry_controls |= VMX_ENTRY_CONTROL_LONG_MODE_GUEST;
         } else {
@@ -2309,7 +2332,7 @@ impl UhProcessor<'_, TdxBacked> {
         }
 
         self.runner.write_vmcs32(
-            Vtl::Vtl0,
+            GuestVtl::Vtl0,
             VmcsField::VMX_VMCS_ENTRY_CONTROLS,
             !0,
             entry_controls,
@@ -2339,7 +2362,7 @@ impl<T: CpuIo> ApicClient for TdxApicClient<'_, T> {
     }
 
     fn wake(&mut self, vp_index: VpIndex) {
-        self.partition.vps[vp_index.index() as usize].wake(Vtl::Vtl0, WakeReason::INTCON);
+        self.partition.vps[vp_index.index() as usize].wake(GuestVtl::Vtl0, WakeReason::INTCON);
     }
 
     fn eoi(&mut self, vector: u8) {
@@ -2463,24 +2486,28 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
         tracing::trace!("not getting cr8, must read from apic page or apic tpr");
         let cr8 = 0;
 
-        let cs = self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Cs);
-        let ds = self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Ds);
-        let es = self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Es);
-        let fs = self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Fs);
-        let gs = self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Gs);
-        let ss = self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Ss);
-        let tr = self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Tr);
-        let ldtr = self.vp.read_segment(Vtl::Vtl0, TdxSegmentReg::Ldtr);
+        let cs = self.vp.read_segment(GuestVtl::Vtl0, TdxSegmentReg::Cs);
+        let ds = self.vp.read_segment(GuestVtl::Vtl0, TdxSegmentReg::Ds);
+        let es = self.vp.read_segment(GuestVtl::Vtl0, TdxSegmentReg::Es);
+        let fs = self.vp.read_segment(GuestVtl::Vtl0, TdxSegmentReg::Fs);
+        let gs = self.vp.read_segment(GuestVtl::Vtl0, TdxSegmentReg::Gs);
+        let ss = self.vp.read_segment(GuestVtl::Vtl0, TdxSegmentReg::Ss);
+        let tr = self.vp.read_segment(GuestVtl::Vtl0, TdxSegmentReg::Tr);
+        let ldtr = self.vp.read_segment(GuestVtl::Vtl0, TdxSegmentReg::Ldtr);
 
-        let gdtr = self.vp.read_table_register(Vtl::Vtl0, TdxTableReg::Gdtr);
-        let idtr = self.vp.read_table_register(Vtl::Vtl0, TdxTableReg::Idtr);
+        let gdtr = self
+            .vp
+            .read_table_register(GuestVtl::Vtl0, TdxTableReg::Gdtr);
+        let idtr = self
+            .vp
+            .read_table_register(GuestVtl::Vtl0, TdxTableReg::Idtr);
 
         let cr0 = self.vp.read_cr0();
         let cr2 = self.vp.runner.tdx_vp_state().cr2;
         let cr3 = self
             .vp
             .runner
-            .read_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR3);
+            .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR3);
         let cr4 = self.vp.read_cr4();
 
         let efer = self.vp.backing.efer;
@@ -2583,21 +2610,28 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
         enter_state.rflags = *rflags;
 
         // Set segment registers
-        self.vp.write_segment(Vtl::Vtl0, TdxSegmentReg::Cs, *cs)?;
-        self.vp.write_segment(Vtl::Vtl0, TdxSegmentReg::Ds, *ds)?;
-        self.vp.write_segment(Vtl::Vtl0, TdxSegmentReg::Es, *es)?;
-        self.vp.write_segment(Vtl::Vtl0, TdxSegmentReg::Fs, *fs)?;
-        self.vp.write_segment(Vtl::Vtl0, TdxSegmentReg::Gs, *gs)?;
-        self.vp.write_segment(Vtl::Vtl0, TdxSegmentReg::Ss, *ss)?;
-        self.vp.write_segment(Vtl::Vtl0, TdxSegmentReg::Tr, *tr)?;
         self.vp
-            .write_segment(Vtl::Vtl0, TdxSegmentReg::Ldtr, *ldtr)?;
+            .write_segment(GuestVtl::Vtl0, TdxSegmentReg::Cs, *cs)?;
+        self.vp
+            .write_segment(GuestVtl::Vtl0, TdxSegmentReg::Ds, *ds)?;
+        self.vp
+            .write_segment(GuestVtl::Vtl0, TdxSegmentReg::Es, *es)?;
+        self.vp
+            .write_segment(GuestVtl::Vtl0, TdxSegmentReg::Fs, *fs)?;
+        self.vp
+            .write_segment(GuestVtl::Vtl0, TdxSegmentReg::Gs, *gs)?;
+        self.vp
+            .write_segment(GuestVtl::Vtl0, TdxSegmentReg::Ss, *ss)?;
+        self.vp
+            .write_segment(GuestVtl::Vtl0, TdxSegmentReg::Tr, *tr)?;
+        self.vp
+            .write_segment(GuestVtl::Vtl0, TdxSegmentReg::Ldtr, *ldtr)?;
 
         // Set table registers
         self.vp
-            .write_table_register(Vtl::Vtl0, TdxTableReg::Gdtr, *gdtr)?;
+            .write_table_register(GuestVtl::Vtl0, TdxTableReg::Gdtr, *gdtr)?;
         self.vp
-            .write_table_register(Vtl::Vtl0, TdxTableReg::Idtr, *idtr)?;
+            .write_table_register(GuestVtl::Vtl0, TdxTableReg::Idtr, *idtr)?;
 
         self.vp.write_cr0(*cr0)?;
 
@@ -2607,7 +2641,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
 
         self.vp
             .runner
-            .write_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR3, !0, *cr3);
+            .write_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_CR3, !0, *cr3);
 
         self.vp.write_cr4(*cr4)?;
 
@@ -2634,7 +2668,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
         let interruptibility: Interruptibility = self
             .vp
             .runner
-            .read_vmcs32(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY)
+            .read_vmcs32(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY)
             .into();
         Ok(vp::Activity {
             mp_state,
@@ -2669,7 +2703,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
             .with_blocked_by_movss(interrupt_shadow)
             .with_blocked_by_nmi(nmi_masked);
         self.vp.runner.write_vmcs32(
-            Vtl::Vtl0,
+            GuestVtl::Vtl0,
             VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY,
             !0,
             interruptibility.into(),
@@ -2732,7 +2766,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
         let msr_cr_pat = self
             .vp
             .runner
-            .read_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_PAT);
+            .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_PAT);
         Ok(vp::CacheControl {
             msr_cr_pat,
             msr_mtrr_def_type: 0, // TODO TDX: MTRRs
@@ -2749,9 +2783,12 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
             fixed: _,
             variable: _,
         } = *value;
-        self.vp
-            .runner
-            .write_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_PAT, !0, msr_cr_pat);
+        self.vp.runner.write_vmcs64(
+            GuestVtl::Vtl0,
+            VmcsField::VMX_VMCS_GUEST_PAT,
+            !0,
+            msr_cr_pat,
+        );
         Ok(())
     }
 
@@ -2761,16 +2798,16 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
         let sysenter_cs = self
             .vp
             .runner
-            .read_vmcs32(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_SYSENTER_CS_MSR)
+            .read_vmcs32(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_SYSENTER_CS_MSR)
             .into();
         let sysenter_eip = self
             .vp
             .runner
-            .read_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_SYSENTER_EIP_MSR);
+            .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_SYSENTER_EIP_MSR);
         let sysenter_esp = self
             .vp
             .runner
-            .read_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_SYSENTER_ESP_MSR);
+            .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_SYSENTER_ESP_MSR);
 
         Ok(vp::VirtualMsrs {
             kernel_gs_base: state.msr_kernel_gs_base,
@@ -2803,19 +2840,19 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
         state.msr_sfmask = sfmask;
 
         self.vp.runner.write_vmcs32(
-            Vtl::Vtl0,
+            GuestVtl::Vtl0,
             VmcsField::VMX_VMCS_GUEST_SYSENTER_CS_MSR,
             !0,
             sysenter_cs as u32,
         );
         self.vp.runner.write_vmcs64(
-            Vtl::Vtl0,
+            GuestVtl::Vtl0,
             VmcsField::VMX_VMCS_GUEST_SYSENTER_EIP_MSR,
             !0,
             sysenter_eip,
         );
         self.vp.runner.write_vmcs64(
-            Vtl::Vtl0,
+            GuestVtl::Vtl0,
             VmcsField::VMX_VMCS_GUEST_SYSENTER_ESP_MSR,
             !0,
             sysenter_esp,
@@ -2843,7 +2880,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
         let dr7 = self
             .vp
             .runner
-            .read_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_DR7);
+            .read_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_DR7);
 
         Ok(vp::DebugRegisters {
             dr0: values[0].as_u64(),
@@ -2877,7 +2914,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
 
         self.vp
             .runner
-            .write_vmcs64(Vtl::Vtl0, VmcsField::VMX_VMCS_GUEST_DR7, !0, dr7);
+            .write_vmcs64(GuestVtl::Vtl0, VmcsField::VMX_VMCS_GUEST_DR7, !0, dr7);
 
         Ok(())
     }
@@ -3182,7 +3219,11 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressSpaceEx
 }
 
 impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
-    pub fn wake_processors_for_tlb_flush(&mut self, _vtl: Vtl, processor_set: Option<Vec<u32>>) {
+    pub fn wake_processors_for_tlb_flush(
+        &mut self,
+        _vtl: GuestVtl,
+        processor_set: Option<Vec<u32>>,
+    ) {
         // TODO: Add additional checks? HCL checks that VP is active and in target VTL
         if let Some(processors) = processor_set {
             for vp in processors {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -6,8 +6,8 @@ use crate::TdxBacked;
 use crate::UhProcessor;
 use hcl::ioctl::tdx::Tdx;
 use hcl::ioctl::ProcessorRunner;
+use hcl::GuestVtl;
 use hvdef::hypercall::HvGvaRange;
-use hvdef::Vtl;
 use inspect::Inspect;
 use std::collections::VecDeque;
 use std::num::Wrapping;
@@ -67,7 +67,7 @@ impl TdxFlushState {
 
 impl UhProcessor<'_, TdxBacked> {
     /// Completes any pending TLB flush activity on the current VP.
-    pub(super) fn do_tlb_flush(&mut self, target_vtl: Vtl) {
+    pub(super) fn do_tlb_flush(&mut self, target_vtl: GuestVtl) {
         let partition_flush_state = self.backing.shared.flush_state[target_vtl].read();
 
         // NOTE: It is theoretically possible that we haven't run in so long that the
@@ -114,7 +114,7 @@ impl UhProcessor<'_, TdxBacked> {
     /// Performs any TLB flush by list that may be required. Returns true
     /// if successful, false if a flush entire is required instead.
     fn try_flush_list(
-        target_vtl: Vtl,
+        target_vtl: GuestVtl,
         partition_flush_state: &TdxPartitionFlushState,
         gva_list_count: &mut Wrapping<usize>,
         runner: &mut ProcessorRunner<'_, Tdx>,
@@ -151,7 +151,7 @@ impl UhProcessor<'_, TdxBacked> {
     }
 
     fn do_flush_list(
-        target_vtl: Vtl,
+        target_vtl: GuestVtl,
         flush_addrs: &[HvGvaRange],
         runner: &mut ProcessorRunner<'_, Tdx>,
         flush_page: &shared_pool_alloc::SharedPoolHandle,

--- a/openhcl/virt_mshv_vtl/src/processor/vp_state.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/vp_state.rs
@@ -2,16 +2,17 @@
 
 use super::Backing;
 use super::UhProcessor;
+use crate::GuestVtl;
 use thiserror::Error;
 
 pub struct UhVpStateAccess<'a, 'b, T: Backing> {
     pub(crate) vp: &'a mut UhProcessor<'b, T>,
     #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
-    pub(crate) vtl: hvdef::Vtl,
+    pub(crate) vtl: GuestVtl,
 }
 
 impl<'a, 'p, T: Backing> UhVpStateAccess<'a, 'p, T> {
-    pub(crate) fn new(vp: &'a mut UhProcessor<'p, T>, vtl: hvdef::Vtl) -> Self {
+    pub(crate) fn new(vp: &'a mut UhProcessor<'p, T>, vtl: GuestVtl) -> Self {
         Self { vp, vtl }
     }
 }

--- a/vm/hv1/vtl_array/src/lib.rs
+++ b/vm/hv1/vtl_array/src/lib.rs
@@ -71,17 +71,17 @@ where
     }
 }
 
-impl<T, const N: usize> Index<Vtl> for VtlArray<T, N> {
+impl<T, V: Into<Vtl>, const N: usize> Index<V> for VtlArray<T, N> {
     type Output = T;
 
-    fn index(&self, index: Vtl) -> &Self::Output {
-        &self.data[index as usize]
+    fn index(&self, index: V) -> &Self::Output {
+        &self.data[index.into() as usize]
     }
 }
 
-impl<T, const N: usize> IndexMut<Vtl> for VtlArray<T, N> {
-    fn index_mut(&mut self, index: Vtl) -> &mut Self::Output {
-        &mut self.data[index as usize]
+impl<T, V: Into<Vtl>, const N: usize> IndexMut<V> for VtlArray<T, N> {
+    fn index_mut(&mut self, index: V) -> &mut Self::Output {
+        &mut self.data[index.into() as usize]
     }
 }
 
@@ -134,12 +134,12 @@ impl VtlSet {
     }
 
     /// Returns true if the given [`Vtl`] is set.
-    pub fn is_set(&self, vtl: Vtl) -> bool {
-        self.bits[vtl as usize]
+    pub fn is_set<V: Into<Vtl>>(&self, vtl: V) -> bool {
+        self.bits[vtl.into() as usize]
     }
 
     /// Returns true if the given [`Vtl`] is not set.
-    pub fn is_clear(&self, vtl: Vtl) -> bool {
+    pub fn is_clear<V: Into<Vtl>>(&self, vtl: V) -> bool {
         !self.is_set(vtl)
     }
 


### PR DESCRIPTION
When we know statically that we're referring to VTL0/VTL1 and not VTL2, use the new enum `GuestVtl` instead of `Vtl`. This allows the compiler to generate better code, it allows the reader to better understand the invariants, and it provides more safeguards that the guest is not able to manipulate VTL2 state.

As part of this, fix a few bugs.