### PR TITLE
CI: Switch from explicitly using Azure/login@v2.2.0 to Azure/login@v2

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3391,7 +3391,7 @@ jobs:
       shell: bash
       name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2.2.0
+      uses: Azure/login@v2
       with:
         client-id: ${{ env.floweyvar2 }}
         subscription-id: ${{ env.floweyvar3 }}
@@ -3755,7 +3755,7 @@ jobs:
       shell: bash
       name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2.2.0
+      uses: Azure/login@v2
       with:
         client-id: ${{ env.floweyvar2 }}
         subscription-id: ${{ env.floweyvar3 }}
@@ -4117,7 +4117,7 @@ jobs:
       shell: bash
       name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__gh_task_azure_login__1
-      uses: Azure/login@v2.2.0
+      uses: Azure/login@v2
       with:
         client-id: ${{ env.floweyvar2 }}
         subscription-id: ${{ env.floweyvar3 }}

--- a/.github/workflows/refresh-vso.yml
+++ b/.github/workflows/refresh-vso.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Azure Login
-        uses: Azure/login@v2.2.0
+        uses: Azure/login@v2
         with:
           # These secrets describe the HvLite-GitHub service principal and associated Azure subscription,
           # which, along with the GITHUB_TOKEN, are used to authenticate GitHub Actions to Azure with OpenID Connect.

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -1671,7 +1671,7 @@ pub mod steps {
             /// let (tenant_id, write_tenant_id) = ctx.new_secret_var();
             /// let (subscription_id, write_subscription_id) = ctx.new_secret_var();
             /// ... <insert rust step writing to each of those secrets>
-            /// GhStepBuilder::new("Azure Login", "Azure/login@v2.2.0")
+            /// GhStepBuilder::new("Azure Login", "Azure/login@v2")
             ///               .with("client-id", client_id)
             ///               .with("tenant-id", tenant_id)
             ///               .with("subscription-id", subscription_id)
@@ -1679,7 +1679,7 @@ pub mod steps {
             ///
             /// ```ignore
             /// - name: Azure Login
-            ///   uses: Azure/login@v2.2.0
+            ///   uses: Azure/login@v2
             ///   with:
             ///     client-id: ${{ env.floweyvar1 }} // Assuming the backend wrote client_id to floweyvar1
             ///     tenant-id: ${{ env.floweyvar2 }} // Assuming the backend wrote tenant-id to floweyvar2

--- a/flowey/flowey_lib_common/src/gh_task_azure_login.rs
+++ b/flowey/flowey_lib_common/src/gh_task_azure_login.rs
@@ -1,6 +1,6 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
-//! Github Actions Task Wrapper: `Azure/login@v2.2.0`
+//! Github Actions Task Wrapper: `Azure/login@v2`
 
 use flowey::node::prelude::*;
 
@@ -73,7 +73,7 @@ impl FlowNode for Node {
         });
 
         let logged_in = ctx
-            .emit_gh_step("Azure Login", "Azure/login@v2.2.0")
+            .emit_gh_step("Azure Login", "Azure/login@v2")
             .with("client-id", client_id)
             .with("tenant-id", tenant_id)
             .with("subscription-id", subscription_id)


### PR DESCRIPTION
This change switches the version requirement of Azure/login to use @v2 instead of a hard-coded full version number. This means we will automatically pick up new v2.x versions of the action when they are tagged by the maintainer.