### PR TITLE
Pin Vtl2 memory if its being carve out by itself

### DIFF
--- a/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
@@ -8,6 +8,7 @@ use crate::host_params::shim_params::IsolationType;
 use crate::host_params::PartitionInfo;
 use crate::hypercall::hvcall;
 use crate::ShimParams;
+use host_fdt_parser::MemoryAllocationMode;
 use memory_range::MemoryRange;
 use sha2::Digest;
 use sha2::Sha384;
@@ -24,6 +25,30 @@ pub fn setup_vtl2_memory(shim_params: &ShimParams, partition_info: &PartitionInf
     // TODO: if applying vtl 2 protections for non-isolated VMs moves to the
     // boot shim, apply them here.
     if let IsolationType::None = shim_params.isolation_type {
+        match partition_info.memory_allocation_mode {
+            MemoryAllocationMode::Vtl2 { .. } => {
+                let result = safe_x86_intrinsics::cpuid(
+                    hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION,
+                    0,
+                );
+                let is_pinning_supported = hvdef::HvEnlightenmentInformation::from(
+                    result.eax as u128
+                        | (result.ebx as u128) << 32
+                        | (result.ecx as u128) << 64
+                        | (result.edx as u128) << 96,
+                )
+                .use_gpa_pinning_hypercall();
+
+                if is_pinning_supported {
+                    for entry in partition_info.vtl2_ram.iter() {
+                        hvcall()
+                            .pin_gpa_range(entry.range)
+                            .expect("Failed to pin the VTl2 memory");
+                    }
+                }
+            }
+            MemoryAllocationMode::Host => {}
+        }
         return;
     }
 

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -1,16 +1,23 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 //! Hypercall infrastructure.
-
 use crate::single_threaded::SingleThreaded;
+use arrayvec::ArrayVec;
 use core::cell::RefCell;
 use core::cell::UnsafeCell;
+use core::cmp;
 use core::mem::size_of;
+use hvdef::hypercall::HvGpaRange;
+use hvdef::hypercall::HvGpaRangeExtended;
 use hvdef::hypercall::HvInputVtl;
 use hvdef::HV_PAGE_SIZE;
 use memory_range::MemoryRange;
 use minimal_rt::arch::hypercall::invoke_hypercall;
 use zerocopy::AsBytes;
+
+const PIN_REQUEST_HEADER_SIZE: usize = size_of::<hvdef::hypercall::PinUnpinGpaPageRangesHeader>();
+const MAX_INPUT_ELEMENTS: usize =
+    (HV_PAGE_SIZE as usize - PIN_REQUEST_HEADER_SIZE) / size_of::<u64>();
 
 /// Page-aligned, page-sized buffer for use with hypercalls
 #[repr(C, align(4096))]
@@ -194,6 +201,90 @@ impl HvCall {
             output.result()?;
 
             current_page += count;
+        }
+
+        Ok(())
+    }
+
+    fn to_hv_gva_range_array(
+        memory_range: &MemoryRange,
+    ) -> ArrayVec<HvGpaRange, MAX_INPUT_ELEMENTS> {
+        const PAGES_PER_ENTRY: u64 = 2048;
+        const PAGE_SIZE: u64 = HV_PAGE_SIZE;
+        let mut ranges = ArrayVec::new();
+
+        // Calculate the total number of pages in the memory range
+        let total_pages = (memory_range.end() - memory_range.start()).div_ceil(PAGE_SIZE);
+
+        // Iterate over the memory range in chunks of 2048 pages
+        let mut current_page = memory_range.start() >> 12; // Convert start address to page number
+        let mut remaining_pages = total_pages;
+
+        while remaining_pages > 0 {
+            // Determine how many pages to use in this HvGvaRange (either 2048 or the remaining pages if fewer)
+            let pages_in_this_range = cmp::min(PAGES_PER_ENTRY, remaining_pages);
+
+            ranges.push(HvGpaRange(
+                HvGpaRangeExtended::new()
+                    .with_additional_pages(pages_in_this_range - 1)
+                    .with_large_page(false)
+                    .with_gpa_page_number(current_page)
+                    .into_bits(),
+            ));
+
+            // Move to the next chunk of pages
+            current_page += pages_in_this_range;
+            remaining_pages -= pages_in_this_range;
+        }
+
+        ranges
+    }
+
+    // Hypercall to pin vtl2 memory
+    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
+    pub fn pin_gpa_range(&mut self, memory_range: MemoryRange) -> Result<(), hvdef::HvError> {
+        const PAGES_PER_ENTRY: u64 = 2048;
+
+        // Calculate the total number of pages per request
+        let max_bytes_per_request = PAGES_PER_ENTRY * MAX_INPUT_ELEMENTS as u64 * HV_PAGE_SIZE;
+
+        // Track the current start of the memory range
+        let mut current_start = memory_range.start();
+        let mut remaining_size_bytes = memory_range.end() - memory_range.start();
+
+        let header = hvdef::hypercall::PinUnpinGpaPageRangesHeader { reserved: 0 };
+        let input_offset = size_of::<hvdef::hypercall::PinUnpinGpaPageRangesHeader>();
+
+        while remaining_size_bytes > 0 {
+            // Determine the size for this chunk of memory
+            let chunk_bytes = cmp::min(remaining_size_bytes, max_bytes_per_request);
+
+            let chunk_end = current_start + chunk_bytes;
+
+            // Create a sub-range for this chunk
+            let sub_range = MemoryRange::new(current_start..chunk_end);
+
+            // Get HvGvaRange for this sub-range
+            let gva_ranges: ArrayVec<HvGpaRange, MAX_INPUT_ELEMENTS> =
+                Self::to_hv_gva_range_array(&sub_range);
+
+            // Write the header and gva_ranges to the buffer
+            header.write_to_prefix(Self::input_page().buffer.as_mut_slice());
+
+            gva_ranges.write_to_prefix(&mut Self::input_page().buffer[input_offset..]);
+
+            // Call the hypercall with the current chunk
+            let output = self.dispatch_hvcall(
+                hvdef::HypercallCode::HvCallPinGpaPageRanges,
+                Some(gva_ranges.len()),
+            );
+
+            // Check if the hypercall was successful
+            output.result()?;
+
+            // Update remaining memory range for the next iteration
+            remaining_size_bytes -= chunk_bytes;
+            current_start = chunk_end;
         }
 
         Ok(())


### PR DESCRIPTION
Pin VTL2 memory if it is being carved out independently. In the current implementation, specifically in add-on mode, the host ensures that VTL2 memory is physically backed. This change enhances that mechanism by explicitly pinning the VTL2 memory when it is carved out.