### PR TITLE
virt_mshv_vtl: move gdb feature checks to runtime checks

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1134,8 +1134,12 @@ impl UhPartition {
         // intercept on behalf of the guest. In the future, Underhill should
         // register for these intercepts itself.
         if params.intercept_debug_exceptions {
+            if !cfg!(feature = "gdb") {
+                return Err(Error::InvalidDebugConfiguration);
+            }
+
             cfg_if::cfg_if! {
-                if #[cfg(all(feature = "gdb", guest_arch = "x86_64"))] {
+                if #[cfg(guest_arch = "x86_64")] {
                     let debug_exception_vector = 0x1;
                     hcl.register_intercept(
                         HvInterceptType::HvInterceptTypeException,

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -19,8 +19,6 @@ cfg_if::cfg_if! {
         use hvdef::HvX64SegmentRegister;
         use virt::x86::MsrError;
         use virt::vp::AccessVpState;
-        #[cfg(feature = "gdb")]
-        use virt::x86::HardwareBreakpoint;
     } else if #[cfg(guest_arch = "aarch64")] {
         use hv1_hypercall::Arm64RegisterState;
         use hvdef::HvArm64RegisterName;
@@ -485,7 +483,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         }
     }
 
-    #[cfg(all(feature = "gdb", guest_arch = "x86_64"))]
+    #[cfg(guest_arch = "x86_64")]
     fn handle_debug_exception(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
         // FUTURE: Underhill does not yet support VTL1 so this is only tested with VTL0.
         if self.last_vtl() == Vtl::Vtl0 {
@@ -514,7 +512,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                     UhRunVpError::UnexpectedDebugException(debug_regs.dr6),
                 ));
             }
-            let bp = HardwareBreakpoint::from_dr7(debug_regs.dr7, dr[i], i);
+            let bp = virt::x86::HardwareBreakpoint::from_dr7(debug_regs.dr7, dr[i], i);
 
             return Err(VpHaltReason::HwBreak(bp));
         }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -721,8 +721,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         .unwrap();
 
         match x86defs::Exception(message.vector as u8) {
-            #[cfg(all(feature = "gdb", guest_arch = "x86_64"))]
-            x86defs::Exception::DEBUG => self.handle_debug_exception()?,
+            x86defs::Exception::DEBUG if cfg!(feature = "gdb") => self.handle_debug_exception()?,
             _ => tracing::error!("unexpected exception type {:#x?}", message.vector),
         }
         Ok(())

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1341,8 +1341,7 @@ impl UhProcessor<'_, SnpBacked> {
         stat.increment();
 
         // Process debug exceptions before handling other intercepts.
-        #[cfg(all(feature = "gdb", guest_arch = "x86_64"))]
-        if sev_error_code == SevExitCode::EXCP_DB {
+        if cfg!(feature = "gdb") && sev_error_code == SevExitCode::EXCP_DB {
             return self.handle_debug_exception();
         }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1604,8 +1604,7 @@ impl UhProcessor<'_, TdxBacked> {
 
         // Breakpoint exceptions may return a non-fatal error.
         // We dispatch here to correctly increment the counter.
-        if breakpoint_debug_exception {
-            #[cfg(all(feature = "gdb", guest_arch = "x86_64"))]
+        if cfg!(feature = "gdb") && breakpoint_debug_exception {
             self.handle_debug_exception()?;
         }
 


### PR DESCRIPTION
Avoid having code that conditionally builds based on feature configuration by moving the gdb-related code to runtime checks instead of compile-time `cfg` attributes. These will still get compiled out at compile time, but the compiler will ensure the code actually builds.