### PR TITLE
CI: Update upload-pages-artifact and deploy-pages actions to latest

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -220,12 +220,12 @@ jobs:
       shell: bash
       name: 🌼 Write to 'floweyvar1'
     - id: flowey_lib_hvlite___jobs__build_and_publish_guide__2
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: ${{ env.floweyvar1 }}
       name: Upload pages artifact
     - id: flowey_lib_hvlite___jobs__build_and_publish_guide__3
-      uses: actions/deploy-pages@v3
+      uses: actions/deploy-pages@v4
       name: Deploy to GitHub Pages
     - name: 🌼 write_into Var
       run: flowey.exe e 0 flowey_lib_hvlite::artifact_guide::publish 0

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_publish_guide.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_publish_guide.rs
@@ -49,12 +49,12 @@ impl SimpleFlowNode for Node {
 
         if deploy_github_pages && matches!(ctx.backend(), FlowBackend::Github) {
             let did_upload = ctx
-                .emit_gh_step("Upload pages artifact", "actions/upload-pages-artifact@v1")
+                .emit_gh_step("Upload pages artifact", "actions/upload-pages-artifact@v3")
                 .with("path", rendered_guide.map(ctx, |x| x.display().to_string()))
                 .finish(ctx);
 
             let did_deploy = ctx
-                .emit_gh_step("Deploy to GitHub Pages", "actions/deploy-pages@v3")
+                .emit_gh_step("Deploy to GitHub Pages", "actions/deploy-pages@v4")
                 .run_after(did_upload)
                 .finish(ctx);
 


### PR DESCRIPTION
I noticed this warning in the CI build logs which is a little confusing because it doesn't look like we are using versions of the actions that are being deprecated. However I did notice we are using old versions of upload-pages-artifact and deploy-pages.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/