### PR TITLE
CVM log updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6524,6 +6524,7 @@ version = "0.0.0"
 dependencies = [
  "base64 0.21.7",
  "base64-serde",
+ "cvm_tracing",
  "get_protocol",
  "getrandom",
  "guest_emulation_transport",

--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -25,6 +25,7 @@ tdx_guest_device.workspace = true
 tee_call.workspace = true
 pal_async.workspace = true
 tracing.workspace = true
+cvm_tracing.workspace = true
 
 base64.workspace = true
 base64-serde.workspace = true

--- a/openhcl/underhill_attestation/src/hardware_key_sealing.rs
+++ b/openhcl/underhill_attestation/src/hardware_key_sealing.rs
@@ -12,6 +12,7 @@ use crate::protocol::vmgs::HardwareKeyProtector;
 use openssl_kdf::kdf::Kbkdf;
 use thiserror::Error;
 use zerocopy::AsBytes;
+use cvm_tracing::CVM_ALLOWED;
 
 #[allow(missing_docs)] // self-explanatory fields
 #[derive(Debug, Error)]
@@ -140,7 +141,7 @@ impl HardwareKeyProtectorExt for HardwareKeyProtector {
         )
         .map_err(HardwareKeySealingError::HmacAfterEncrypt)?;
 
-        tracing::info!("encrypt egress_key using hardware derived key");
+        tracing::info!(CVM_ALLOWED, "encrypt egress_key using hardware derived key");
 
         Ok(hardware_key_protector)
     }
@@ -170,7 +171,7 @@ impl HardwareKeyProtectorExt for HardwareKeyProtector {
         }
         decrypted_ingress_key.copy_from_slice(&output[..vmgs::AES_GCM_KEY_LENGTH]);
 
-        tracing::info!("decrypt ingress_key using hardware derived key");
+        tracing::info!(CVM_ALLOWED, "decrypt ingress_key using hardware derived key");
 
         Ok(decrypted_ingress_key)
     }

--- a/openhcl/underhill_attestation/src/hardware_key_sealing.rs
+++ b/openhcl/underhill_attestation/src/hardware_key_sealing.rs
@@ -9,10 +9,10 @@ use crate::crypto;
 use crate::protocol::igvm_attest;
 use crate::protocol::vmgs;
 use crate::protocol::vmgs::HardwareKeyProtector;
+use cvm_tracing::CVM_ALLOWED;
 use openssl_kdf::kdf::Kbkdf;
 use thiserror::Error;
 use zerocopy::AsBytes;
-use cvm_tracing::CVM_ALLOWED;
 
 #[allow(missing_docs)] // self-explanatory fields
 #[derive(Debug, Error)]
@@ -171,7 +171,10 @@ impl HardwareKeyProtectorExt for HardwareKeyProtector {
         }
         decrypted_ingress_key.copy_from_slice(&output[..vmgs::AES_GCM_KEY_LENGTH]);
 
-        tracing::info!(CVM_ALLOWED, "decrypt ingress_key using hardware derived key");
+        tracing::info!(
+            CVM_ALLOWED,
+            "decrypt ingress_key using hardware derived key"
+        );
 
         Ok(decrypted_ingress_key)
     }

--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -12,15 +12,15 @@ use zerocopy::FromBytes;
 #[derive(Debug, Error)]
 pub enum AkCertError {
     #[error("AK cert response size is too small to parse")]
-    AkCertResponseSizeTooSmall,
+    SizeTooSmall,
     #[error(
         "AK cert response size {specified_size} specified in the header is larger then the actual size {size}"
     )]
-    AkCertResponseSizeMismatch { size: usize, specified_size: usize },
+    SizeMismatch { size: usize, specified_size: usize },
     #[error(
         "AK cert response header version {version} does match the expected version {expected_version}"
     )]
-    AkCertResponseHeaderVersionMismatch { version: u32, expected_version: u32 },
+    HeaderVersionMismatch { version: u32, expected_version: u32 },
 }
 
 /// Parse a `AK_CERT_REQUEST` response and return the payload (i.e., the AK cert).
@@ -30,19 +30,19 @@ pub fn parse_response(response: &[u8]) -> Result<Vec<u8>, AkCertError> {
     const HEADER_SIZE: usize = size_of::<IgvmAttestAkCertResponseHeader>();
 
     let Some(header) = IgvmAttestAkCertResponseHeader::read_from_prefix(response) else {
-        Err(AkCertError::AkCertResponseSizeTooSmall)?
+        Err(AkCertError::SizeTooSmall)?
     };
 
     let size = header.data_size as usize;
     if size > response.len() {
-        Err(AkCertError::AkCertResponseSizeMismatch {
+        Err(AkCertError::SizeMismatch {
             size: response.len(),
             specified_size: size,
         })?
     }
 
     if header.version != AK_CERT_RESPONSE_HEADER_VERSION {
-        Err(AkCertError::AkCertResponseHeaderVersionMismatch {
+        Err(AkCertError::HeaderVersionMismatch {
             version: header.version,
             expected_version: AK_CERT_RESPONSE_HEADER_VERSION,
         })?

--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -6,8 +6,8 @@
 
 use crate::protocol::igvm_attest::get::IgvmAttestAkCertResponseHeader;
 use crate::protocol::igvm_attest::get::AK_CERT_RESPONSE_HEADER_VERSION;
-use zerocopy::FromBytes;
 use thiserror::Error;
+use zerocopy::FromBytes;
 
 #[derive(Debug, Error)]
 pub enum AkCertError {

--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -4,31 +4,45 @@
 //! The module for `AK_CERT_REQUEST` request type that supports parsing the
 //! response.
 
-use crate::igvm_attest::Error;
 use crate::protocol::igvm_attest::get::IgvmAttestAkCertResponseHeader;
 use crate::protocol::igvm_attest::get::AK_CERT_RESPONSE_HEADER_VERSION;
 use zerocopy::FromBytes;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AkCertError {
+    #[error("AK cert response size is too small to parse")]
+    AkCertResponseSizeTooSmall,
+    #[error(
+        "AK cert response size {specified_size} specified in the header is larger then the actual size {size}"
+    )]
+    AkCertResponseSizeMismatch { size: usize, specified_size: usize },
+    #[error(
+        "AK cert response header version {version} does match the expected version {expected_version}"
+    )]
+    AkCertResponseHeaderVersionMismatch { version: u32, expected_version: u32 },
+}
 
 /// Parse a `AK_CERT_REQUEST` response and return the payload (i.e., the AK cert).
 ///
 /// Returns `Ok(Vec<u8>)` on successfully validating the response, otherwise returns an error.
-pub fn parse_response(response: &[u8]) -> Result<Vec<u8>, Error> {
+pub fn parse_response(response: &[u8]) -> Result<Vec<u8>, AkCertError> {
     const HEADER_SIZE: usize = size_of::<IgvmAttestAkCertResponseHeader>();
 
     let Some(header) = IgvmAttestAkCertResponseHeader::read_from_prefix(response) else {
-        Err(Error::AkCertResponseSizeTooSmall)?
+        Err(AkCertError::AkCertResponseSizeTooSmall)?
     };
 
     let size = header.data_size as usize;
     if size > response.len() {
-        Err(Error::AkCertResponseSizeMismatch {
+        Err(AkCertError::AkCertResponseSizeMismatch {
             size: response.len(),
             specified_size: size,
         })?
     }
 
     if header.version != AK_CERT_RESPONSE_HEADER_VERSION {
-        Err(Error::AkCertResponseHeaderVersionMismatch {
+        Err(AkCertError::AkCertResponseHeaderVersionMismatch {
             version: header.version,
             expected_version: AK_CERT_RESPONSE_HEADER_VERSION,
         })?

--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -9,8 +9,8 @@ use crate::protocol::igvm_attest::get::AK_CERT_RESPONSE_HEADER_VERSION;
 use thiserror::Error;
 use zerocopy::FromBytes;
 
-#[derive(Debug, Error)]
 /// AkCertError is returned by parse_ak_cert_response() in emuplat/tpm.rs
+#[derive(Debug, Error)]
 pub enum AkCertError {
     #[error("AK cert response size is too small to parse")]
     SizeTooSmall,

--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 use zerocopy::FromBytes;
 
 #[derive(Debug, Error)]
+/// AkCertError is returned by parse_ak_cert_response() in emuplat/tpm.rs 
 pub enum AkCertError {
     #[error("AK cert response size is too small to parse")]
     SizeTooSmall,

--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use zerocopy::FromBytes;
 
 #[derive(Debug, Error)]
-/// AkCertError is returned by parse_ak_cert_response() in emuplat/tpm.rs 
+/// AkCertError is returned by parse_ak_cert_response() in emuplat/tpm.rs
 pub enum AkCertError {
     #[error("AK cert response size is too small to parse")]
     SizeTooSmall,

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -34,16 +34,6 @@ pub enum Error {
         report_size: usize,
         expected_size: usize,
     },
-    #[error("AK cert response size is too small to parse")]
-    AkCertResponseSizeTooSmall,
-    #[error(
-        "AK cert response size {specified_size} specified in the header is larger then the actual size {size}"
-    )]
-    AkCertResponseSizeMismatch { size: usize, specified_size: usize },
-    #[error(
-        "AK cert response header version {version} does match the expected version {expected_version}"
-    )]
-    AkCertResponseHeaderVersionMismatch { version: u32, expected_version: u32 },
 }
 
 /// Helper struct to create `IgvmAttestRequest` in raw bytes.

--- a/openhcl/underhill_attestation/src/key_protector.rs
+++ b/openhcl/underhill_attestation/src/key_protector.rs
@@ -7,11 +7,11 @@ use crate::crypto;
 use crate::protocol::vmgs::KeyProtector;
 use crate::protocol::vmgs::AES_GCM_KEY_LENGTH;
 use crate::Keys;
+use cvm_tracing::CVM_ALLOWED;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use openssl::pkey::Private;
 use openssl::rsa::Rsa;
 use thiserror::Error;
-use cvm_tracing::CVM_ALLOWED;
-use cvm_tracing::CVM_CONFIDENTIAL;
 
 #[allow(missing_docs)] // self-explanatory fields
 #[derive(Debug, Error)]
@@ -155,7 +155,11 @@ impl KeyProtectorExt for KeyProtector {
 
             if found_ingress_dek {
                 if use_des_key {
-                    tracing::info!(CVM_CONFIDENTIAL, "dek[{}] hold an AES-wrapped key", ingress_idx);
+                    tracing::info!(
+                        CVM_CONFIDENTIAL,
+                        "dek[{}] hold an AES-wrapped key",
+                        ingress_idx
+                    );
 
                     // The DEK buffer should contain an AES-wrapped key.
                     let dek_buffer = &self.dek[ingress_idx].dek_buffer;
@@ -172,7 +176,11 @@ impl KeyProtectorExt for KeyProtector {
                     }
                     ingress_key[..aes_unwrapped_key.len()].copy_from_slice(&aes_unwrapped_key);
                 } else {
-                    tracing::info!(CVM_CONFIDENTIAL, "dek[{}] hold an RSA-wrapped key", ingress_idx);
+                    tracing::info!(
+                        CVM_CONFIDENTIAL,
+                        "dek[{}] hold an RSA-wrapped key",
+                        ingress_idx
+                    );
 
                     ingress_key[..rsa_unwrapped_key.len()].copy_from_slice(&rsa_unwrapped_key);
                 }
@@ -239,7 +247,8 @@ impl KeyProtectorExt for KeyProtector {
             self.dek[egress_idx].dek_buffer[..new_egress_key.len()]
                 .copy_from_slice(&new_egress_key);
 
-            tracing::info!(CVM_CONFIDENTIAL,
+            tracing::info!(
+                CVM_CONFIDENTIAL,
                 "store new egress key to dek[{}], size {}",
                 egress_idx,
                 new_egress_key.len()

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -251,7 +251,10 @@ pub async fn initialize_platform_security(
     // If attestation is suppressed, return the `agent_data` that is required by
     // TPM AK cert request.
     if suppress_attestation {
-        tracing::info!(CVM_ALLOWED, "Attestation is suppressed, assuming unlocked vmgs and stateless tpm");
+        tracing::info!(
+            CVM_ALLOWED,
+            "Attestation is suppressed, assuming unlocked vmgs and stateless tpm"
+        );
 
         return Ok(PlatformAttestationData {
             host_attestation_settings: HostAttestationSettings {
@@ -268,14 +271,17 @@ pub async fn initialize_platform_security(
         AttestationType::Host | AttestationType::Unsupported => None,
     };
 
-    tracing::info!(CVM_ALLOWED, "Initializing platform type {:?}", attestation_type);
+    tracing::info!(
+        CVM_ALLOWED,
+        "Initializing platform type {:?}",
+        attestation_type
+    );
 
     let VmgsEncryptionKeys {
         ingress_rsa_kek,
         wrapped_des_key,
         tcb_version,
     } = if let Some(tee_call) = tee_call.as_ref() {
-
         tracing::info!(CVM_ALLOWED, "Retrieving key-encryption key");
 
         // Retrieve the tenant key via attestation
@@ -290,7 +296,6 @@ pub async fn initialize_platform_security(
         .await
         .map_err(ErrorInner::RequestVmgsEncryptionKeys)?
     } else {
-
         tracing::info!(CVM_ALLOWED, "Assuming no key-encryption key");
 
         // Attestation is unavailable, assume no tenant key
@@ -375,7 +380,8 @@ pub async fn initialize_platform_security(
         refresh_tpm_seeds: { state_refresh_request_from_gsp | vm_id_changed },
     };
 
-    tracing::info!(CVM_ALLOWED,
+    tracing::info!(
+        CVM_ALLOWED,
         state_refresh_request_from_gsp,
         vm_id_changed,
         "determine if refreshing tpm seeds is needed"
@@ -413,7 +419,10 @@ async fn unlock_vmgs_data_store(
         egress: new_egress_key,
     }) = derived_keys
     else {
-        tracing::info!(CVM_ALLOWED, "Encryption disabled, skipping unlock vmgs data store");
+        tracing::info!(
+            CVM_ALLOWED,
+            "Encryption disabled, skipping unlock vmgs data store"
+        );
         return Ok(());
     };
 
@@ -431,7 +440,8 @@ async fn unlock_vmgs_data_store(
             Ok(index) => old_index = index,
             Err(e) if new_key => {
                 // If last time is provisioning and we failed to persist KP then we'll come here.
-                tracing::trace!(CVM_ALLOWED,
+                tracing::trace!(
+                    CVM_ALLOWED,
                     error = &e as &dyn std::error::Error,
                     "Unlock with ingress key error"
                 );
@@ -448,7 +458,10 @@ async fn unlock_vmgs_data_store(
         }
     } else {
         // The datastore is not encrypted which means it's during provision.
-        tracing::info!(CVM_ALLOWED, "vmgs data store is not encrypted, provisioning.");
+        tracing::info!(
+            CVM_ALLOWED,
+            "vmgs data store is not encrypted, provisioning."
+        );
         provision = true;
     }
 
@@ -613,7 +626,6 @@ async fn get_derived_keys(
 
     // If sources of encryption used last are missing, attempt to unseal VMGS key with hardware key
     if (no_kek && found_dek) || (no_gsp && requires_gsp) || (no_gsp_by_id && requires_gsp_by_id) {
-
         tracing::info!("Unseal VMGS key-encryption key with hardware key");
         // If possible, get ingressKey from hardware sealed data
         let (hardware_key_protector, hardware_derived_keys) = if let Some(tee_call) = tee_call {

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -10,6 +10,7 @@ use crate::protocol;
 use crate::protocol::vmgs::AGENT_DATA_MAX_SIZE;
 use crate::AttestationVmConfig;
 use crate::IgvmAttestRequestHelper;
+use cvm_tracing::CVM_ALLOWED;
 use guest_emulation_transport::GuestEmulationTransportClient;
 use openssl::pkey::Private;
 use openssl::rsa::Rsa;
@@ -153,6 +154,7 @@ pub async fn request_vmgs_encryption_keys(
                 wrapped_des_key: _,
             }) => {
                 tracing::warn!(
+                    CVM_ALLOWED,
                     retry = i,
                     "tenant wrapped vmgs key-encryption key is not released"
                 )
@@ -160,6 +162,7 @@ pub async fn request_vmgs_encryption_keys(
             Err(e) if i == (max_retry - 1) => Err(e)?,
             Err(e) => {
                 tracing::error!(
+                    CVM_ALLOWED,
                     retry = i,
                     error = &e as &dyn std::error::Error,
                     "tenant wrapped vmgs key-encryption key request failed",
@@ -177,7 +180,7 @@ pub async fn request_vmgs_encryption_keys(
                 .map_err(RequestVmgsEncryptionKeysError::Pkcs11RsaAesKeyUnwrap)?,
         )
     } else {
-        tracing::warn!("tenant vmgs ingress key is not released");
+        tracing::warn!(CVM_ALLOWED, "tenant vmgs ingress key is not released");
         None
     };
 

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -117,6 +117,9 @@ pub async fn request_vmgs_encryption_keys(
     let mut timer = pal_async::timer::PolledTimer::new(&driver);
 
     for i in 0..max_retry {
+
+        tracing::info!(CVM_ALLOWED, attempt=i, "attempt to get VMGS key-encryption key");
+
         // Get attestation report on each iteration. Failures here are fatal.
         let result = tee_call
             .get_attestation_report(&igvm_attest_request_helper.runtime_claims_hash)
@@ -156,7 +159,7 @@ pub async fn request_vmgs_encryption_keys(
                 tracing::warn!(
                     CVM_ALLOWED,
                     retry = i,
-                    "tenant wrapped vmgs key-encryption key is not released"
+                    "VMGS key-encryption key is not released"
                 )
             }
             Err(e) if i == (max_retry - 1) => Err(e)?,
@@ -165,7 +168,7 @@ pub async fn request_vmgs_encryption_keys(
                     CVM_ALLOWED,
                     retry = i,
                     error = &e as &dyn std::error::Error,
-                    "tenant wrapped vmgs key-encryption key request failed",
+                    "VMGS key-encryption key request failed",
                 )
             }
         }

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -117,8 +117,11 @@ pub async fn request_vmgs_encryption_keys(
     let mut timer = pal_async::timer::PolledTimer::new(&driver);
 
     for i in 0..max_retry {
-
-        tracing::info!(CVM_ALLOWED, attempt=i, "attempt to get VMGS key-encryption key");
+        tracing::info!(
+            CVM_ALLOWED,
+            attempt = i,
+            "attempt to get VMGS key-encryption key"
+        );
 
         // Get attestation report on each iteration. Failures here are fatal.
         let result = tee_call


### PR DESCRIPTION
1. Moved AkCert errors to akcert.rs.
2. Updated CVM attestation traces to include CVM_ALLOWED or CVM_CONFIDENTIAL.
3. Additional info traces during CVM initialization.