### PR TITLE
VmBus: add OpenHCL support for confidential external memory in a CVM

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -297,6 +297,7 @@ async fn launch_workers(
     let env_cfg = UnderhillEnvCfg {
         vmbus_max_version: opt.vmbus_max_version,
         vmbus_enable_mnf: opt.vmbus_enable_mnf,
+        vmbus_force_confidential_external_memory: opt.vmbus_force_confidential_external_memory,
         cmdline_append: opt.cmdline_append.clone(),
         reformat_vmgs: opt.reformat_vmgs,
         vtl0_starts_paused: opt.vtl0_starts_paused,

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -152,11 +152,8 @@ impl Options {
                     .map_err(|x| anyhow::anyhow!("Error parsing vmbus max version: {}", x))
             })
             .transpose()?;
-        let vmbus_enable_mnf = if legacy_openhcl_env("OPENHCL_VMBUS_ENABLE_MNF").is_some() {
-            Some(parse_legacy_env_bool("OPENHCL_VMBUS_ENABLE_MNF"))
-        } else {
-            None
-        };
+        let vmbus_enable_mnf =
+            legacy_openhcl_env("OPENHCL_VMBUS_ENABLE_MNF").map(|v| parse_bool(Some(v)));
         let vmbus_force_confidential_external_memory =
             parse_env_bool("OPENHCL_VMBUS_FORCE_CONFIDENTIAL_EXTERNAL_MEMORY");
         let cmdline_append =

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -34,7 +34,7 @@ pub struct Options {
     pub vmbus_enable_mnf: Option<bool>,
 
     /// (OPENHCL_VMBUS_FORCE_CONF_EXT_MEM=1)
-    /// Force the use of confidential external memory for all non-relay vmbus channels. Fo testing
+    /// Force the use of confidential external memory for all non-relay vmbus channels. For testing
     /// purposes only.
     pub vmbus_force_confidential_external_memory: bool,
 
@@ -156,7 +156,7 @@ impl Options {
         };
         let vmbus_force_confidential_external_memory =
             legacy_openhcl_env("OPENHCL_VMBUS_FORCE_CONF_EXT_MEM").is_some()
-                && parse_env_bool("UNDERHILL_VMBUS_FORCE_CONF_EXT_MEM");
+                && parse_env_bool("OPENHCL_VMBUS_FORCE_CONF_EXT_MEM");
         let cmdline_append =
             legacy_openhcl_env("OPENHCL_CMDLINE_APPEND").map(|x| x.to_string_lossy().into_owned());
         let force_load_vtl0_image = legacy_openhcl_env("OPENHCL_FORCE_LOAD_VTL0_IMAGE")

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -33,6 +33,11 @@ pub struct Options {
     /// Enable handling of MNF in the Underhill vmbus server, instead of the host.
     pub vmbus_enable_mnf: Option<bool>,
 
+    /// (OPENHCL_VMBUS_FORCE_CONF_EXT_MEM=1)
+    /// Force the use of confidential external memory for all non-relay vmbus channels. Fo testing
+    /// purposes only.
+    pub vmbus_force_confidential_external_memory: bool,
+
     /// (OPENHCL_CMDLINE_APPEND=\<string\>)
     /// Command line to append to VTL0, only used with direct boot.
     pub cmdline_append: Option<String>,
@@ -149,6 +154,9 @@ impl Options {
         } else {
             None
         };
+        let vmbus_force_confidential_external_memory =
+            legacy_openhcl_env("OPENHCL_VMBUS_FORCE_CONF_EXT_MEM").is_some()
+                && parse_env_bool("UNDERHILL_VMBUS_FORCE_CONF_EXT_MEM");
         let cmdline_append =
             legacy_openhcl_env("OPENHCL_CMDLINE_APPEND").map(|x| x.to_string_lossy().into_owned());
         let force_load_vtl0_image = legacy_openhcl_env("OPENHCL_FORCE_LOAD_VTL0_IMAGE")
@@ -202,6 +210,7 @@ impl Options {
             pid,
             vmbus_max_version,
             vmbus_enable_mnf,
+            vmbus_force_confidential_external_memory,
             cmdline_append,
             vnc_port: vnc_port.unwrap_or(3),
             framebuffer_gpa_base,

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -33,9 +33,11 @@ pub struct Options {
     /// Enable handling of MNF in the Underhill vmbus server, instead of the host.
     pub vmbus_enable_mnf: Option<bool>,
 
-    /// (OPENHCL_VMBUS_FORCE_CONF_EXT_MEM=1)
+    /// (OPENHCL_VMBUS_FORCE_CONFIDENTIAL_EXTERNAL_MEMORY=1)
     /// Force the use of confidential external memory for all non-relay vmbus channels. For testing
     /// purposes only.
+    ///
+    /// N.B.: Not all vmbus devices support this feature, so enabling it may cause failures.
     pub vmbus_force_confidential_external_memory: bool,
 
     /// (OPENHCL_CMDLINE_APPEND=\<string\>)

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -122,13 +122,16 @@ impl Options {
             })
         }
 
-        let parse_env_bool = |name| {
-            legacy_openhcl_env(name)
+        fn parse_bool(value: Option<std::ffi::OsString>) -> bool {
+            value
                 .map(|v| v.to_ascii_lowercase() == "true" || v == "1")
                 .unwrap_or_default()
-        };
+        }
 
-        let parse_env_number = |name| {
+        let parse_legacy_env_bool = |name| parse_bool(legacy_openhcl_env(name));
+        let parse_env_bool = |name| parse_bool(std::env::var_os(name));
+
+        let parse_legacy_env_number = |name| {
             legacy_openhcl_env(name)
                 .map(|v| {
                     v.to_string_lossy().parse().context(format!(
@@ -139,8 +142,8 @@ impl Options {
                 .transpose()
         };
 
-        let mut wait_for_start = parse_env_bool("OPENHCL_WAIT_FOR_START");
-        let mut reformat_vmgs = parse_env_bool("OPENHCL_REFORMAT_VMGS");
+        let mut wait_for_start = parse_legacy_env_bool("OPENHCL_WAIT_FOR_START");
+        let mut reformat_vmgs = parse_legacy_env_bool("OPENHCL_REFORMAT_VMGS");
         let mut pid = legacy_openhcl_env("OPENHCL_PID_FILE_PATH")
             .map(|x| x.to_string_lossy().into_owned().into());
         let vmbus_max_version = legacy_openhcl_env("OPENHCL_VMBUS_MAX_VERSION")
@@ -150,30 +153,30 @@ impl Options {
             })
             .transpose()?;
         let vmbus_enable_mnf = if legacy_openhcl_env("OPENHCL_VMBUS_ENABLE_MNF").is_some() {
-            Some(parse_env_bool("OPENHCL_VMBUS_ENABLE_MNF"))
+            Some(parse_legacy_env_bool("OPENHCL_VMBUS_ENABLE_MNF"))
         } else {
             None
         };
         let vmbus_force_confidential_external_memory =
-            legacy_openhcl_env("OPENHCL_VMBUS_FORCE_CONF_EXT_MEM").is_some()
-                && parse_env_bool("OPENHCL_VMBUS_FORCE_CONF_EXT_MEM");
+            parse_env_bool("OPENHCL_VMBUS_FORCE_CONFIDENTIAL_EXTERNAL_MEMORY");
         let cmdline_append =
             legacy_openhcl_env("OPENHCL_CMDLINE_APPEND").map(|x| x.to_string_lossy().into_owned());
         let force_load_vtl0_image = legacy_openhcl_env("OPENHCL_FORCE_LOAD_VTL0_IMAGE")
             .map(|x| x.to_string_lossy().into_owned());
-        let mut vnc_port = parse_env_number("OPENHCL_VNC_PORT")?.map(|x| x as u32);
-        let framebuffer_gpa_base = parse_env_number("OPENHCL_FRAMEBUFFER_GPA_BASE")?;
-        let vtl0_starts_paused = parse_env_bool("OPENHCL_VTL0_STARTS_PAUSED");
-        let serial_wait_for_rts = parse_env_bool("OPENHCL_SERIAL_WAIT_FOR_RTS");
-        let nvme_vfio = parse_env_bool("OPENHCL_NVME_VFIO");
-        let emulate_apic = parse_env_bool("OPENHCL_EMULATE_APIC");
-        let mcr = parse_env_bool("OPENHCL_MCR_DEVICE");
-        let enable_shared_visibility_pool = parse_env_bool("OPENHCL_ENABLE_SHARED_VISIBILITY_POOL");
-        let cvm_guest_vsm = parse_env_bool("OPENHCL_CVM_GUEST_VSM");
-        let halt_on_guest_halt = parse_env_bool("OPENHCL_HALT_ON_GUEST_HALT");
-        let no_sidecar_hotplug = parse_env_bool("OPENHCL_NO_SIDECAR_HOTPLUG");
-        let gdbstub = parse_env_bool("OPENHCL_GDBSTUB");
-        let gdbstub_port = parse_env_number("OPENHCL_GDBSTUB_PORT")?.map(|x| x as u32);
+        let mut vnc_port = parse_legacy_env_number("OPENHCL_VNC_PORT")?.map(|x| x as u32);
+        let framebuffer_gpa_base = parse_legacy_env_number("OPENHCL_FRAMEBUFFER_GPA_BASE")?;
+        let vtl0_starts_paused = parse_legacy_env_bool("OPENHCL_VTL0_STARTS_PAUSED");
+        let serial_wait_for_rts = parse_legacy_env_bool("OPENHCL_SERIAL_WAIT_FOR_RTS");
+        let nvme_vfio = parse_legacy_env_bool("OPENHCL_NVME_VFIO");
+        let emulate_apic = parse_legacy_env_bool("OPENHCL_EMULATE_APIC");
+        let mcr = parse_legacy_env_bool("OPENHCL_MCR_DEVICE");
+        let enable_shared_visibility_pool =
+            parse_legacy_env_bool("OPENHCL_ENABLE_SHARED_VISIBILITY_POOL");
+        let cvm_guest_vsm = parse_legacy_env_bool("OPENHCL_CVM_GUEST_VSM");
+        let halt_on_guest_halt = parse_legacy_env_bool("OPENHCL_HALT_ON_GUEST_HALT");
+        let no_sidecar_hotplug = parse_legacy_env_bool("OPENHCL_NO_SIDECAR_HOTPLUG");
+        let gdbstub = parse_legacy_env_bool("OPENHCL_GDBSTUB");
+        let gdbstub_port = parse_legacy_env_number("OPENHCL_GDBSTUB_PORT")?.map(|x| x as u32);
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2533,7 +2533,7 @@ async fn new_underhill_vm(
         // N.B. The channel ID offset can break older Linux versions (that only support vmbus
         //      protocol V1 and Win7) because they don't support channel IDs above 255.
         let vmbus = VmbusServer::builder(&tp, synic.clone(), gm.untrusted_dma_memory().clone())
-            .trusted_gm(Some(gm.vtl0().clone()))
+            .trusted_gm(gm.trusted_memory().cloned())
             .hvsock_notify(hvsock_notify)
             .server_relay(server_relay)
             .enable_channel_id_offset(!with_vmbus_relay)

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -256,6 +256,8 @@ pub struct UnderhillEnvCfg {
     pub vmbus_max_version: Option<u32>,
     /// Handle MNF in the Underhill vmbus server, rather than the host.
     pub vmbus_enable_mnf: Option<bool>,
+    /// Force the use of confidential external memory for all non-relay vmbus channels.
+    pub vmbus_force_confidential_external_memory: bool,
     /// Command line to append to VTL0 command line. Only used for linux direct.
     pub cmdline_append: Option<String>,
     /// (dev feature) Reformat VMGS file on boot
@@ -2538,6 +2540,7 @@ async fn new_underhill_vm(
             .max_version(env_cfg.vmbus_max_version)
             .delay_max_version(firmware_type == FirmwareType::Uefi)
             .enable_mnf(enable_mnf)
+            .force_confidential_external_memory(env_cfg.vmbus_force_confidential_external_memory)
             .build()
             .context("failed to create vmbus server")?;
 

--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -49,6 +49,7 @@ pub struct MemoryMappings {
 }
 
 impl MemoryMappings {
+    /// Includes all VTL0 memory (trusted and untrusted).
     pub fn vtl0(&self) -> &GuestMemory {
         &self.vtl0_gm
     }
@@ -58,6 +59,7 @@ impl MemoryMappings {
     pub fn untrusted_dma_memory(&self) -> &GuestMemory {
         &self.untrusted_dma_memory
     }
+    /// Includes only trusted VTL0 memory.
     pub fn trusted_memory(&self) -> Option<&GuestMemory> {
         self.trusted_memory.as_ref()
     }

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -1318,7 +1318,15 @@ impl Nic {
         let worker = Worker {
             channel_idx,
             target_vp: open_request.open_data.target_vp,
-            mem: self.resources.guest_memory.clone(),
+            mem: if open_request.use_confidential_external_memory {
+                self.resources
+                    .trusted_memory
+                    .as_ref()
+                    .expect("trusted memory should be present if confidential memory is requested")
+                    .clone()
+            } else {
+                self.resources.untrusted_memory.clone()
+            },
             channel: NetChannel {
                 adapter: self.adapter.clone(),
                 queue,
@@ -1502,9 +1510,16 @@ impl Nic {
                     let version = check_version(version)
                         .ok_or(NetRestoreError::UnsupportedVersion(version))?;
 
+                    let request = requests[0].as_ref().unwrap();
                     let buffers = Arc::new(ChannelBuffers {
                         version,
-                        mem: self.resources.guest_memory.clone(),
+                        mem: if request.use_confidential_external_memory {
+                            self.resources.trusted_memory.as_ref().expect(
+                                "trusted memory should be present if confidential memory is requested"
+                            ).clone()
+                        } else {
+                            self.resources.untrusted_memory.clone()
+                        },
                         recv_buffer: ReceiveBuffer::new(
                             &self.resources.gpadl_map,
                             receive_buffer.gpadl_id,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -1318,15 +1318,7 @@ impl Nic {
         let worker = Worker {
             channel_idx,
             target_vp: open_request.open_data.target_vp,
-            mem: if open_request.use_confidential_external_memory {
-                self.resources
-                    .trusted_memory
-                    .as_ref()
-                    .expect("trusted memory should be present if confidential memory is requested")
-                    .clone()
-            } else {
-                self.resources.untrusted_memory.clone()
-            },
+            mem: self.resources.guest_memory(open_request).clone(),
             channel: NetChannel {
                 adapter: self.adapter.clone(),
                 queue,
@@ -1513,13 +1505,7 @@ impl Nic {
                     let request = requests[0].as_ref().unwrap();
                     let buffers = Arc::new(ChannelBuffers {
                         version,
-                        mem: if request.use_confidential_external_memory {
-                            self.resources.trusted_memory.as_ref().expect(
-                                "trusted memory should be present if confidential memory is requested"
-                            ).clone()
-                        } else {
-                            self.resources.untrusted_memory.clone()
-                        },
+                        mem: self.resources.guest_memory(request).clone(),
                         recv_buffer: ReceiveBuffer::new(
                             &self.resources.gpadl_map,
                             receive_buffer.gpadl_id,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -1318,7 +1318,11 @@ impl Nic {
         let worker = Worker {
             channel_idx,
             target_vp: open_request.open_data.target_vp,
-            mem: self.resources.guest_memory(open_request).clone(),
+            mem: self
+                .resources
+                .offer_resources
+                .guest_memory(open_request)
+                .clone(),
             channel: NetChannel {
                 adapter: self.adapter.clone(),
                 queue,
@@ -1505,7 +1509,7 @@ impl Nic {
                     let request = requests[0].as_ref().unwrap();
                     let buffers = Arc::new(ChannelBuffers {
                         version,
-                        mem: self.resources.guest_memory(request).clone(),
+                        mem: self.resources.offer_resources.guest_memory(request).clone(),
                         recv_buffer: ReceiveBuffer::new(
                             &self.resources.gpadl_map,
                             receive_buffer.gpadl_id,

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -102,10 +102,7 @@ impl MockVmbus {
 impl ParentBus for MockVmbus {
     async fn add_child(&self, request: OfferInput) -> anyhow::Result<OfferResources> {
         *(self.child_info.lock().await) = Some(request);
-        Ok(OfferResources {
-            untrusted_memory: self.memory.clone(),
-            trusted_memory: None,
-        })
+        Ok(OfferResources::new(self.memory.clone(), None))
     }
     fn clone_bus(&self) -> Box<dyn ParentBus> {
         Box::new(self.clone())

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -103,8 +103,8 @@ impl ParentBus for MockVmbus {
     async fn add_child(&self, request: OfferInput) -> anyhow::Result<OfferResources> {
         *(self.child_info.lock().await) = Some(request);
         Ok(OfferResources {
-            ring_mem: self.memory.clone(),
-            guest_mem: self.memory.clone(),
+            untrusted_memory: self.memory.clone(),
+            trusted_memory: None,
         })
     }
     fn clone_bus(&self) -> Box<dyn ParentBus> {
@@ -430,6 +430,8 @@ impl TestNicDevice {
             },
             // The interrupt used to signal the guest.
             interrupt: host_to_guest_interrupt,
+            use_confidential_ring: false,
+            use_confidential_external_memory: false,
         };
 
         let open_response = self
@@ -536,6 +538,8 @@ impl TestNicDevice {
                                                     user_data: UserDefinedData::new_zeroed(),
                                                 },
                                                 interrupt: host_to_guest_interrupt.clone(),
+                                                use_confidential_external_memory: false,
+                                                use_confidential_ring: false,
                                             }),
                                             gpadls,
                                         })

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -103,6 +103,7 @@ impl ParentBus for MockVmbus {
     async fn add_child(&self, request: OfferInput) -> anyhow::Result<OfferResources> {
         *(self.child_info.lock().await) = Some(request);
         Ok(OfferResources {
+            ring_mem: self.memory.clone(),
             guest_mem: self.memory.clone(),
         })
     }

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -1489,7 +1489,15 @@ impl StorageDevice {
         let channel = gpadl_channel(&driver, &self.resources, open_request, channel_index)
             .context("failed to create vmbus channel")?;
 
-        let mem = self.resources.guest_memory.clone();
+        let mem = if open_request.use_confidential_external_memory {
+            self.resources
+                .trusted_memory
+                .as_ref()
+                .expect("trusted memory should be present if confidential memory is requested")
+                .clone()
+        } else {
+            self.resources.untrusted_memory.clone()
+        };
         let channel_control = self.resources.channel_control.clone();
 
         tracing::debug!(

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -1489,15 +1489,6 @@ impl StorageDevice {
         let channel = gpadl_channel(&driver, &self.resources, open_request, channel_index)
             .context("failed to create vmbus channel")?;
 
-        let mem = if open_request.use_confidential_external_memory {
-            self.resources
-                .trusted_memory
-                .as_ref()
-                .expect("trusted memory should be present if confidential memory is requested")
-                .clone()
-        } else {
-            self.resources.untrusted_memory.clone()
-        };
         let channel_control = self.resources.channel_control.clone();
 
         tracing::debug!(
@@ -1515,7 +1506,7 @@ impl StorageDevice {
             controller,
             channel,
             channel_index,
-            mem,
+            self.resources.guest_memory(open_request).clone(),
             channel_control,
             self.io_queue_depth,
             self.protocol.clone(),

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -1506,7 +1506,10 @@ impl StorageDevice {
             controller,
             channel,
             channel_index,
-            self.resources.guest_memory(open_request).clone(),
+            self.resources
+                .offer_resources
+                .guest_memory(open_request)
+                .clone(),
             channel_control,
             self.io_queue_depth,
             self.protocol.clone(),

--- a/vm/devices/vmbus/vmbus_channel/src/bus.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/bus.rs
@@ -32,6 +32,8 @@ pub struct OfferInput {
 /// Resources for an offered channel.
 #[derive(Debug)]
 pub struct OfferResources {
+    /// Guest memory access for ring buffers.
+    pub ring_mem: GuestMemory,
     /// Guest memory access.
     pub guest_mem: GuestMemory,
 }
@@ -207,6 +209,10 @@ pub struct OfferParams {
     /// The order in which channels with the same interface will be offered to
     /// the guest (optional).
     pub offer_order: Option<u32>,
+    /// Indicates whether the channel supports using encrypted memory for any
+    /// external GPADLs and GPA direct ranges. This is only used when hardware
+    /// isolation is in use.
+    pub allow_encrypted_memory: bool,
 }
 
 impl OfferParams {

--- a/vm/devices/vmbus/vmbus_channel/src/bus.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/bus.rs
@@ -33,9 +33,9 @@ pub struct OfferInput {
 #[derive(Debug)]
 pub struct OfferResources {
     /// Guest memory access for ring buffers.
-    pub ring_mem: GuestMemory,
+    pub untrusted_memory: GuestMemory,
     /// Guest memory access.
-    pub guest_mem: GuestMemory,
+    pub trusted_memory: Option<GuestMemory>,
 }
 
 /// A request from the VMBus control plane.
@@ -160,6 +160,12 @@ pub struct OpenRequest {
     pub open_data: OpenData,
     /// The interrupt used to signal the guest.
     pub interrupt: Interrupt,
+    /// Indicates if the current guest supports the use of confidential ring
+    /// buffers.
+    pub use_confidential_ring: bool,
+    /// Indicates if the current guest supports the use of confidential external
+    /// memory.
+    pub use_confidential_external_memory: bool,
 }
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Protobuf)]

--- a/vm/devices/vmbus/vmbus_channel/src/channel.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/channel.rs
@@ -118,6 +118,7 @@ impl<T: Any> IntoAny for T {
 /// Resources used by the device to communicate with the guest.
 #[derive(Debug, Default)]
 pub struct DeviceResources {
+    pub(crate) ring_memory: GuestMemory,
     /// Guest memory access.
     pub guest_memory: GuestMemory,
     /// A map providing access to GPADLs.
@@ -366,6 +367,7 @@ async fn offer_generic(
 
     let (subchannel_enable_send, subchannel_enable_recv) = mesh::channel();
     channel.install(DeviceResources {
+        ring_memory: offer_result.ring_mem,
         guest_memory: offer_result.guest_mem,
         gpadl_map: gpadl_map.clone().view(),
         channels: resources,

--- a/vm/devices/vmbus/vmbus_channel/src/channel.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/channel.rs
@@ -118,9 +118,10 @@ impl<T: Any> IntoAny for T {
 /// Resources used by the device to communicate with the guest.
 #[derive(Debug, Default)]
 pub struct DeviceResources {
-    pub(crate) ring_memory: GuestMemory,
-    /// Guest memory access.
-    pub guest_memory: GuestMemory,
+    /// Untrusted guest memory access.
+    pub untrusted_memory: GuestMemory,
+    /// Trusted guest memory access.
+    pub trusted_memory: Option<GuestMemory>,
     /// A map providing access to GPADLs.
     pub gpadl_map: GpadlMapView,
     /// The control object for enabling subchannels.
@@ -367,8 +368,8 @@ async fn offer_generic(
 
     let (subchannel_enable_send, subchannel_enable_recv) = mesh::channel();
     channel.install(DeviceResources {
-        ring_memory: offer_result.ring_mem,
-        guest_memory: offer_result.guest_mem,
+        untrusted_memory: offer_result.untrusted_memory,
+        trusted_memory: offer_result.trusted_memory,
         gpadl_map: gpadl_map.clone().view(),
         channels: resources,
         channel_control: ChannelControl {

--- a/vm/devices/vmbus/vmbus_channel/src/gpadl_ring.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/gpadl_ring.rs
@@ -216,14 +216,7 @@ pub fn gpadl_channel(
     channel_idx: u16,
 ) -> Result<RawAsyncChannel<GpadlRingMem>, Error> {
     let (in_ring, out_ring) = make_rings(
-        if open_request.use_confidential_ring {
-            resources
-                .trusted_memory
-                .as_ref()
-                .expect("trusted memory should be set if confidential ring is requested")
-        } else {
-            &resources.untrusted_memory
-        },
+        resources.offer_resources.ring_memory(open_request),
         &resources.gpadl_map,
         &open_request.open_data,
     )?;

--- a/vm/devices/vmbus/vmbus_channel/src/gpadl_ring.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/gpadl_ring.rs
@@ -216,7 +216,7 @@ pub fn gpadl_channel(
     channel_idx: u16,
 ) -> Result<RawAsyncChannel<GpadlRingMem>, Error> {
     let (in_ring, out_ring) = make_rings(
-        &resources.guest_memory,
+        &resources.ring_memory,
         &resources.gpadl_map,
         &open_request.open_data,
     )?;

--- a/vm/devices/vmbus/vmbus_channel/src/gpadl_ring.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/gpadl_ring.rs
@@ -216,7 +216,14 @@ pub fn gpadl_channel(
     channel_idx: u16,
 ) -> Result<RawAsyncChannel<GpadlRingMem>, Error> {
     let (in_ring, out_ring) = make_rings(
-        &resources.ring_memory,
+        if open_request.use_confidential_ring {
+            resources
+                .trusted_memory
+                .as_ref()
+                .expect("trusted memory should be set if confidential ring is requested")
+        } else {
+            &resources.untrusted_memory
+        },
         &resources.gpadl_map,
         &open_request.open_data,
     )?;

--- a/vm/devices/vmbus/vmbus_channel/src/offer.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/offer.rs
@@ -85,7 +85,7 @@ impl Offer {
         });
 
         let offer = Self {
-            guest_mem: result.guest_mem,
+            guest_mem: result.ring_mem,
             task,
             open_recv,
             gpadl_map,

--- a/vm/devices/vmbus/vmbus_core/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_core/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 hvdef.workspace = true
 inspect.workspace = true
-guid.workspace = true
+guid = { workspace = true, features = ["inspect"] }
 mesh.workspace = true
 open_enum.workspace = true
 

--- a/vm/devices/vmbus/vmbus_core/src/protocol.rs
+++ b/vm/devices/vmbus/vmbus_core/src/protocol.rs
@@ -463,9 +463,9 @@ pub struct OfferChannel {
 #[mesh(transparent)]
 pub struct OfferFlags {
     pub enumerate_device_interface: bool, // 0x1
-    /// Indicates the channel can use an encrypted ring buffer on a hardware-isolated VM.
+    /// Indicates the channel must use an encrypted ring buffer on a hardware-isolated VM.
     pub confidential_ring_buffer: bool, // 0x2
-    /// Indicates the channel can use encrypted additional GPADLs and GPA direct ranges on a
+    /// Indicates the channel must use encrypted additional GPADLs and GPA direct ranges on a
     /// hardware-isolated VM.
     pub confidential_external_memory: bool, // 0x4
     #[bits(1)]

--- a/vm/devices/vmbus/vmbus_core/src/protocol.rs
+++ b/vm/devices/vmbus/vmbus_core/src/protocol.rs
@@ -164,7 +164,8 @@ pub struct FeatureFlags {
     /// If not used, the client ID is zero.
     pub client_id: bool,
 
-    /// Indicates the `confidential_channel` offer flag is supported.
+    /// Indicates the `confidential_ring_buffer` and `confidential_external_memory` offer flags are
+    /// supported.
     pub confidential_channels: bool,
 
     #[bits(27)]
@@ -463,8 +464,11 @@ pub struct OfferChannel {
 pub struct OfferFlags {
     pub enumerate_device_interface: bool, // 0x1
     /// Indicates the channel can use an encrypted ring buffer on a hardware-isolated VM.
-    pub confidential_channel: bool, // 0x2
-    #[bits(2)]
+    pub confidential_ring_buffer: bool, // 0x2
+    /// Indicates the channel can use encrypted additional GPADLs and GPA direct ranges on a
+    /// hardware-isolated VM.
+    pub confidential_external_memory: bool, // 0x4
+    #[bits(1)]
     _reserved1: u16,
     pub named_pipe_mode: bool, // 0x10
     #[bits(8)]

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -884,8 +884,12 @@ impl RelayTask {
             // Preserve channel enumeration order from the host within the same
             // interface type.
             offer_order: Some(channel_id),
-            // Strip the confidential flag for relay channels if the host set it.
-            flags: offer.offer.flags.with_confidential_channel(false),
+            // Strip the confidential flags for relay channels if the host set it.
+            flags: offer
+                .offer
+                .flags
+                .with_confidential_ring_buffer(false)
+                .with_confidential_external_memory(false),
             user_defined: offer.offer.user_defined,
             monitor_id: use_mnf.then_some(offer.offer.monitor_id),
         };

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -884,7 +884,7 @@ impl RelayTask {
             // Preserve channel enumeration order from the host within the same
             // interface type.
             offer_order: Some(channel_id),
-            // Strip the confidential flags for relay channels if the host set it.
+            // Strip the confidential flags for relay channels if the host set them.
             flags: offer
                 .offer
                 .flags

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -165,6 +165,7 @@ impl<T: Notifier> Inspect for ServerWithNotifier<'_, T> {
             resp.binary("feature_flags", u32::from(info.version.feature_flags));
             resp.field("interrupt_page", info.interrupt_page);
             resp.field("modifying", info.modifying);
+            resp.field("client_id", info.client_id);
             trusted = info.trusted;
         }
 
@@ -3365,7 +3366,7 @@ fn send_offer<N: Notifier>(notifier: &mut N, channel: &mut Channel, version: Ver
     let mut flags = channel.offer.flags;
     if !version.feature_flags.confidential_channels() {
         flags.set_confidential_ring_buffer(false);
-        flags.with_confidential_external_memory(false);
+        flags.set_confidential_external_memory(false);
     }
 
     let msg = protocol::OfferChannel {

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -5234,6 +5234,12 @@ mod tests {
 
         env.offer(1); // non-confidential
         env.offer_with_flags(2, OfferFlags::new().with_confidential_ring_buffer(true));
+        env.offer_with_flags(
+            3,
+            OfferFlags::new()
+                .with_confidential_ring_buffer(true)
+                .with_confidential_external_memory(true),
+        );
 
         // Untrusted messages are rejected when the connection is trusted.
         let error = env
@@ -5265,6 +5271,15 @@ mod tests {
             OfferFlags::new().with_confidential_ring_buffer(true)
         );
 
+        let offer = env.notifier.get_message::<protocol::OfferChannel>();
+        assert_eq!(offer.channel_id, ChannelId(3));
+        assert_eq!(
+            offer.flags,
+            OfferFlags::new()
+                .with_confidential_ring_buffer(true)
+                .with_confidential_external_memory(true)
+        );
+
         env.notifier
             .check_message(OutgoingMessage::new(&protocol::AllOffersDelivered {}));
     }
@@ -5290,7 +5305,8 @@ mod tests {
             2,
             OfferFlags::new()
                 .with_named_pipe_mode(true)
-                .with_confidential_ring_buffer(true),
+                .with_confidential_ring_buffer(true)
+                .with_confidential_external_memory(true),
         );
 
         env.send_message(in_msg_ex(
@@ -5307,7 +5323,7 @@ mod tests {
             OfferFlags::new().with_enumerate_device_interface(true)
         );
 
-        // The confidential channel flag is not sent without the feature flag.
+        // The confidential channel flags are not sent without the feature flag.
         let offer = env.notifier.get_message::<protocol::OfferChannel>();
         assert_eq!(offer.channel_id, ChannelId(2));
         assert_eq!(offer.flags, OfferFlags::new().with_named_pipe_mode(true));

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1489,16 +1489,14 @@ impl VmbusServerControl {
         let (send, recv) = mesh::oneshot();
         self.send.send(OfferRequest::Offer(offer_info, send));
         recv.await.flatten()?;
-        Ok(OfferResources {
-            untrusted_memory: self.mem.clone(),
-            trusted_memory: if flags.confidential_ring_buffer()
-                || flags.confidential_external_memory()
-            {
+        Ok(OfferResources::new(
+            self.mem.clone(),
+            if flags.confidential_ring_buffer() || flags.confidential_external_memory() {
                 self.trusted_mem.clone()
             } else {
                 None
             },
-        })
+        ))
     }
 
     async fn offer(&self, request: OfferInput) -> anyhow::Result<OfferResources> {

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -210,6 +210,7 @@ impl ProxyTask {
             channel_type,
             use_mnf: (offer.ChannelFlags & VMBUS_CHANNEL_REQUEST_MONITORED_NOTIFICATION) != 0,
             offer_order: id.try_into().ok(),
+            allow_confidential_external_memory: false,
         };
         let (request_send, request_recv) = mesh::channel();
         let (server_request_send, server_request_recv) = mesh::channel();


### PR DESCRIPTION
This change adds a new offer flag which indicates that a device can use encrypted memory for additional GPADLs (other than the ring buffer) and GPA Direct packets. VmBus devices can specify they are capable of using encrypted memory when they create a new offer, and the flag will be sent to the guest if the guest uses the `confidential_channels` feature flag.

Since there are currently no devices that support this feature, an environment variable is added to force the use of encrypted memory for all non-relay channels. This works with the NVMe driver (which can perform bounce buffering in OpenHCL), but if used with the MANA driver it will cause OpenHCL to crash.

This change also updates the policy regarding confidential and host-visible memory to enforce that the correct type is used by the guest. If an offer uses the confidential ring or confidential external memory flags, the guest is now required to actually use encrypted memory for the respective buffers.