### PR TITLE
openhcl_boot: specify boot CPUs when sidecar is enabled

### DIFF
--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -65,6 +65,7 @@ fn build_kernel_command_line(
     cmdline: &mut ArrayString<COMMAND_LINE_SIZE>,
     partition_info: &PartitionInfo,
     can_trust_host: bool,
+    sidecar: Option<&SidecarConfig<'_>>,
 ) -> Result<(), CommandLineTooLong> {
     // For reference:
     // https://www.kernel.org/doc/html/v5.15/admin-guide/kernel-parameters.html
@@ -212,6 +213,10 @@ fn build_kernel_command_line(
             "{}=1 ",
             underhill_confidentiality::OPENHCL_CONFIDENTIAL_ENV_VAR_NAME
         )?;
+    }
+
+    if let Some(sidecar) = sidecar {
+        write!(cmdline, "{} ", sidecar.kernel_command_line())?;
     }
 
     // If we're isolated we can't trust the host-provided cmdline
@@ -575,7 +580,14 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
     );
 
     let mut cmdline = off_stack!(ArrayString<COMMAND_LINE_SIZE>, ArrayString::new_const());
-    build_kernel_command_line(&p, &mut cmdline, partition_info, can_trust_host).unwrap();
+    build_kernel_command_line(
+        &p,
+        &mut cmdline,
+        partition_info,
+        can_trust_host,
+        sidecar.as_ref(),
+    )
+    .unwrap();
 
     let mut fdt = off_stack!(Fdt, zeroed());
     fdt.header.len = fdt.data.len() as u32;


### PR DESCRIPTION
If sidecar is enabled, then pass `boot_cpus=a,b,c` to the Linux kernel, which tells it to boot only the base VP of each sidecar node.

This will be ignored by the current included Linux kernel. A concurrent patch to add support for the boot_cpus option is pending.