### PR TITLE
openhcl_boot: tell Linux not to probe for a PCI bus

### DIFF
--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -175,6 +175,9 @@ fn build_kernel_command_line(
         "clearcpuid=pcid",
         // Disable all attempts to use an IOMMU, including swiotlb.
         "iommu=off",
+        // Don't probe for a PCI bus. PCI devices currently come from VPCI. When
+        // this changes, we will explicitly enumerate a PCI bus via devicetree.
+        "pci=off",
     ];
 
     const AARCH64_KERNEL_PARAMETERS: &[&str] = &[];


### PR DESCRIPTION
By default on x86, Linux probes for a PCI bus via the usual 0xcf8 method. For OpenHCL, this is unnecessary--there is no PCI bus there with a Hyper-V host, and for non-Hyper-V hosts we would expect the PCI bus to be explicitly enumerated.

This reduces exits to the host during boot and it removes another possible CVM attack vector.