### PR TITLE
Move cvm state into backing shared state for snp and tdx

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -206,9 +206,6 @@ struct UhPartitionInner {
     /// This is only set for TDX VMs. For SNP VMs, this is implemented by the
     /// hypervisor. For non-isolated VMs, this isn't a concept.
     untrusted_synic: Option<GlobalSynic>,
-    // TODO: move this into some per-backing state.
-    #[cfg(guest_arch = "x86_64")]
-    cvm: Option<UhCvmPartitionState>,
     guest_vsm: RwLock<GuestVsmState>,
     #[inspect(skip)]
     isolated_memory_protector: Option<Box<dyn ProtectIsolatedMemory>>,
@@ -275,7 +272,8 @@ impl From<EnterMode> for hcl::protocol::EnterMode {
 
 #[cfg(guest_arch = "x86_64")]
 #[derive(Inspect)]
-struct UhCvmPartitionState {
+/// Partition-wide state for CVMs.
+pub struct UhCvmPartitionState {
     #[inspect(skip)]
     cpuid: hardware_cvm::cpuid::CpuidResults,
     /// VPs that have locked their TLB.
@@ -1376,24 +1374,6 @@ impl UhPartition {
 
         let enter_modes = EnterModes::default();
 
-        #[cfg(guest_arch = "x86_64")]
-        let backing_shared_params = BackingSharedParams {
-            cvm_state: cvm_state.as_ref(),
-        };
-        let backing_shared = match isolation {
-            None | Some(IsolationType::Vbs) => BackingShared::Hypervisor,
-            #[cfg(guest_arch = "x86_64")]
-            Some(IsolationType::Snp) => BackingShared::Snp(Arc::new(SnpBacked::new_shared_state(
-                backing_shared_params,
-            )?)),
-            #[cfg(guest_arch = "x86_64")]
-            Some(IsolationType::Tdx) => BackingShared::Tdx(Arc::new(TdxBacked::new_shared_state(
-                backing_shared_params,
-            )?)),
-            #[cfg(guest_arch = "aarch64")]
-            _ => unimplemented!(),
-        };
-
         let partition = Arc::new(UhPartitionInner {
             hcl,
             vps,
@@ -1413,8 +1393,6 @@ impl UhPartition {
             isolation,
             hv,
             untrusted_synic,
-            #[cfg(guest_arch = "x86_64")]
-            cvm: cvm_state,
             guest_vsm: RwLock::new(vsm_state),
             isolated_memory_protector: params.isolated_memory_protector,
             shared_vis_pages_pool: params.shared_vis_pages_pool,
@@ -1426,6 +1404,23 @@ impl UhPartition {
             // Intercept all IOs unless opted out.
             partition.manage_io_port_intercept_region(0, !0, true);
         }
+
+        #[cfg(guest_arch = "x86_64")]
+        let backing_shared_params = BackingSharedParams {
+            cvm_state,
+            _partition: &partition,
+        };
+        let backing_shared = match isolation {
+            None | Some(IsolationType::Vbs) => BackingShared::Hypervisor,
+            #[cfg(guest_arch = "x86_64")]
+            Some(IsolationType::Snp) => BackingShared::Snp(Arc::new(SnpBacked::new_shared_state(
+                backing_shared_params,
+            )?)),
+            #[cfg(guest_arch = "x86_64")]
+            Some(IsolationType::Tdx) => BackingShared::Tdx(Arc::new(TdxBacked::new_shared_state(
+                backing_shared_params,
+            )?)),
+        };
 
         let vps = params
             .topology

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1420,6 +1420,8 @@ impl UhPartition {
             Some(IsolationType::Tdx) => BackingShared::Tdx(Arc::new(TdxBacked::new_shared_state(
                 backing_shared_params,
             )?)),
+            #[cfg(not(guest_arch = "x86_64"))]
+            _ => unreachable!(),
         };
 
         let vps = params

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -34,6 +34,7 @@ use super::UhVpInner;
 use crate::BackingShared;
 use crate::GuestVsmState;
 use crate::GuestVtl;
+use crate::UhCvmPartitionState;
 use crate::WakeReason;
 use guestmem::GuestMemory;
 use hcl::ioctl;
@@ -240,10 +241,8 @@ mod private {
 }
 
 pub struct BackingSharedParams<'a> {
-    #[cfg(guest_arch = "x86_64")]
-    pub(crate) cvm_state: Option<&'a crate::UhCvmPartitionState>,
-    #[cfg(not(guest_arch = "x86_64"))]
-    pub(crate) _phantom: &'a (),
+    pub(crate) _partition: &'a UhPartitionInner,
+    pub(crate) cvm_state: Option<UhCvmPartitionState>,
 }
 
 /// Processor backing.
@@ -256,8 +255,11 @@ pub trait Backing: BackingPrivate {
 
 impl<T: BackingPrivate> Backing for T {}
 
-/// Marker trait for processor backings that have hardware isolation support.
-pub trait HardwareIsolatedBacking: Backing {}
+/// Trait for processor backings that have hardware isolation support.
+pub trait HardwareIsolatedBacking: Backing {
+    /// Gets CVM specific partition state.
+    fn cvm_state(&self) -> &UhCvmPartitionState;
+}
 
 #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
 #[derive(Inspect, Debug)]

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -34,7 +34,6 @@ use super::UhVpInner;
 use crate::BackingShared;
 use crate::GuestVsmState;
 use crate::GuestVtl;
-use crate::UhCvmPartitionState;
 use crate::WakeReason;
 use guestmem::GuestMemory;
 use hcl::ioctl;
@@ -242,7 +241,8 @@ mod private {
 
 pub struct BackingSharedParams<'a> {
     pub(crate) _partition: &'a UhPartitionInner,
-    pub(crate) cvm_state: Option<UhCvmPartitionState>,
+    #[cfg(guest_arch = "x86_64")]
+    pub(crate) cvm_state: Option<crate::UhCvmPartitionState>,
 }
 
 /// Processor backing.
@@ -257,8 +257,9 @@ impl<T: BackingPrivate> Backing for T {}
 
 /// Trait for processor backings that have hardware isolation support.
 pub trait HardwareIsolatedBacking: Backing {
+    #[cfg(guest_arch = "x86_64")]
     /// Gets CVM specific partition state.
-    fn cvm_state(&self) -> &UhCvmPartitionState;
+    fn cvm_state(&self) -> &crate::UhCvmPartitionState;
 }
 
 #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -18,6 +18,7 @@ use crate::processor::UhHypercallHandler;
 use crate::processor::UhProcessor;
 use crate::Error;
 use crate::GuestVtl;
+use crate::UhCvmPartitionState;
 use crate::UhPartitionInner;
 use crate::WakeReason;
 use guestmem::GuestMemory;
@@ -150,11 +151,16 @@ impl SnpBacked {
     }
 }
 
-impl HardwareIsolatedBacking for SnpBacked {}
+impl HardwareIsolatedBacking for SnpBacked {
+    fn cvm_state(&self) -> &UhCvmPartitionState {
+        &self.shared.cvm
+    }
+}
 
 /// Partition-wide shared data for SNP VPs.
 #[derive(Inspect)]
 pub struct SnpBackedShared {
+    cvm: UhCvmPartitionState,
     invlpgb_count_max: u16,
 }
 
@@ -163,19 +169,25 @@ impl BackingPrivate for SnpBacked {
     type BackingShared = SnpBackedShared;
 
     fn new_shared_state(params: BackingSharedParams<'_>) -> Result<Self::BackingShared, Error> {
-        let extended_address_space_sizes = params
-            .cvm_state
-            .unwrap()
+        let cvm = params.cvm_state.unwrap();
+        let extended_address_space_sizes = cvm
             .cpuid
             .registered_result(CpuidFunction::ExtendedAddressSpaceSizes, 0);
         let invlpgb_count_max =
             x86defs::cpuid::ExtendedAddressSpaceSizesEdx::from(extended_address_space_sizes.edx)
                 .invlpgb_count_max();
 
-        Ok(SnpBackedShared { invlpgb_count_max })
+        Ok(SnpBackedShared {
+            invlpgb_count_max,
+            cvm,
+        })
     }
 
     fn new(params: BackingParams<'_, '_, Self>) -> Result<Self, Error> {
+        let crate::BackingShared::Snp(shared) = params.backing_shared else {
+            unreachable!()
+        };
+
         let pfns_handle = params
             .partition
             .shared_vis_pages_pool
@@ -201,20 +213,13 @@ impl BackingPrivate for SnpBacked {
         let overlays: Vec<_> = pfns.collect();
 
         let tsc_aux_virtualized = x86defs::cpuid::ExtendedSevFeaturesEax::from(
-            params
-                .partition
+            shared
                 .cvm
-                .as_ref()
-                .expect("has cvm state")
                 .cpuid
                 .registered_result(CpuidFunction::ExtendedSevFeatures, 0)
                 .eax,
         )
         .tsc_aux_virtualization();
-
-        let crate::BackingShared::Snp(shared) = params.backing_shared else {
-            unreachable!()
-        };
 
         let lapics = [
             SnpApicState {
@@ -1011,8 +1016,6 @@ impl UhProcessor<'_, SnpBacked> {
 
         let stat = match sev_error_code {
             SevExitCode::CPUID => {
-                let cvm = self.partition.cvm.as_ref().unwrap();
-
                 let guest_state = crate::hardware_cvm::cpuid::CpuidGuestState {
                     xfem: vmsa.xcr0(),
                     xss: vmsa.xss(),
@@ -1020,7 +1023,7 @@ impl UhProcessor<'_, SnpBacked> {
                     apic_id: self.inner.vp_info.apic_id,
                 };
 
-                let result = cvm.cpuid.guest_result(
+                let result = self.backing.shared.cvm.cpuid.guest_result(
                     CpuidFunction(vmsa.rax() as u32),
                     vmsa.rcx() as u32,
                     &guest_state,

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -15,6 +15,7 @@ use super::UhEmulationState;
 use super::UhHypercallHandler;
 use super::UhRunVpError;
 use crate::GuestVtl;
+use crate::UhCvmPartitionState;
 use crate::UhPartitionInner;
 use crate::UhProcessor;
 use crate::WakeReason;
@@ -461,11 +462,16 @@ enum UhDirectOverlay {
     Count,
 }
 
-impl HardwareIsolatedBacking for TdxBacked {}
+impl HardwareIsolatedBacking for TdxBacked {
+    fn cvm_state(&self) -> &UhCvmPartitionState {
+        &self.shared.cvm
+    }
+}
 
 /// Partition-wide shared data for TDX VPs.
 #[derive(Inspect)]
 pub struct TdxBackedShared {
+    cvm: UhCvmPartitionState,
     flush_state: VtlArray<RwLock<TdxPartitionFlushState>, 2>,
 }
 
@@ -474,10 +480,11 @@ impl BackingPrivate for TdxBacked {
     type BackingShared = TdxBackedShared;
 
     fn new_shared_state(
-        _params: BackingSharedParams<'_>,
+        params: BackingSharedParams<'_>,
     ) -> Result<Self::BackingShared, crate::Error> {
         Ok(TdxBackedShared {
             flush_state: VtlArray::from_fn(|_| RwLock::new(TdxPartitionFlushState::new())),
+            cvm: params.cvm_state.unwrap(),
         })
     }
 
@@ -1395,7 +1402,7 @@ impl UhProcessor<'_, TdxBacked> {
                     apic_id: self.inner.vp_info.apic_id,
                 };
 
-                let result = self.partition.cvm.as_ref().unwrap().cpuid.guest_result(
+                let result = self.backing.shared.cvm.cpuid.guest_result(
                     CpuidFunction(leaf),
                     subleaf,
                     &guest_state,


### PR DESCRIPTION
This removes a number of unwraps, and makes some things cleaner. I expect that more stuff will move like this over time.