### PR TITLE
hcl: add IsolationType::None

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1291,7 +1291,7 @@ pub struct Hcl {
     supports_vtl_ret_action: bool,
     supports_register_page: bool,
     dr6_shared: bool,
-    isolation: Option<IsolationType>,
+    isolation: IsolationType,
     snp_register_bitmap: [u8; 64],
     sidecar: Option<SidecarClient>,
 }
@@ -1300,12 +1300,26 @@ pub struct Hcl {
 // TODO: Add guest_arch cfgs.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum IsolationType {
+    /// No isolation.
+    None,
     /// Hyper-V software isolation.
     Vbs,
     /// AMD SNP.
     Snp,
     /// Intel TDX.
     Tdx,
+}
+
+impl IsolationType {
+    /// Returns true if the isolation type is not `None`.
+    pub fn is_isolated(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    /// Returns whether the isolation type is hardware-backed.
+    pub fn is_hardware_isolated(&self) -> bool {
+        matches!(self, Self::Snp | Self::Tdx)
+    }
 }
 
 impl Hcl {
@@ -1395,13 +1409,13 @@ impl HclVp {
         hcl: &Hcl,
         vp: u32,
         map_reg_page: bool,
-        isolation_type: Option<IsolationType>,
+        isolation_type: IsolationType,
     ) -> Result<Self, Error> {
         let fd = &hcl.mshv_vtl.file;
         let run = MappedPage::new(fd, vp as i64).map_err(|e| Error::MmapVp(e, None))?;
 
         let backing = match isolation_type {
-            None | Some(IsolationType::Vbs) => BackingState::Mshv {
+            IsolationType::None | IsolationType::Vbs => BackingState::Mshv {
                 reg_page: if map_reg_page {
                     Some(
                         MappedPage::new(fd, HCL_REG_PAGE_OFFSET | vp as i64)
@@ -1411,13 +1425,13 @@ impl HclVp {
                     None
                 },
             },
-            Some(IsolationType::Snp) => BackingState::Snp {
+            IsolationType::Snp => BackingState::Snp {
                 vmsa: MappedPage::new(fd, HCL_VMSA_PAGE_OFFSET | vp as i64)
                     .map_err(|e| Error::MmapVp(e, Some(Vtl::Vtl0)))?,
                 vmsa_vtl1: MappedPage::new(fd, HCL_VMSA_GUEST_VSM_PAGE_OFFSET | vp as i64)
                     .map_err(|e| Error::MmapVp(e, Some(Vtl::Vtl1)))?,
             },
-            Some(IsolationType::Tdx) => BackingState::Tdx {
+            IsolationType::Tdx => BackingState::Tdx {
                 apic_page: MappedPage::new(fd, MSHV_APIC_PAGE_OFFSET | vp as i64)
                     .map_err(|e| Error::MmapVp(e, Some(Vtl::Vtl0)))?,
             },
@@ -1949,41 +1963,38 @@ impl Hcl {
 
         // TODO SNP: When it's checked in, the isolation type should instead be queried
         // from the kernel.
-        let (isolation_type, hardware_isolated) = {
-            let isolation_type_raw = if cfg!(guest_arch = "x86_64") {
-                // xtask-fmt allow-target-arch cpu-intrinsic
-                #[cfg(target_arch = "x86_64")]
-                {
-                    let result = safe_x86_intrinsics::cpuid(
-                        hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION,
-                        0,
-                    );
-                    result.ebx & 0xF
+        let isolation = if cfg!(guest_arch = "x86_64") {
+            // xtask-fmt allow-target-arch cpu-intrinsic
+            #[cfg(target_arch = "x86_64")]
+            {
+                let result = safe_x86_intrinsics::cpuid(
+                    hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION,
+                    0,
+                );
+                match result.ebx & 0xF {
+                    0 => IsolationType::None,
+                    1 => IsolationType::Vbs,
+                    2 => IsolationType::Snp,
+                    3 => IsolationType::Tdx,
+                    ty => panic!("unknown isolation type {ty:#x}"),
                 }
-                // xtask-fmt allow-target-arch cpu-intrinsic
-                #[cfg(not(target_arch = "x86_64"))]
-                {
-                    0
-                }
-            } else {
-                0
-            };
-            match isolation_type_raw {
-                0 => (None, false),
-                1 => (Some(IsolationType::Vbs), false),
-                2 => (Some(IsolationType::Snp), true),
-                3 => (Some(IsolationType::Tdx), true),
-                _ => unreachable!(),
             }
+            // xtask-fmt allow-target-arch cpu-intrinsic
+            #[cfg(not(target_arch = "x86_64"))]
+            {
+                unreachable!()
+            }
+        } else {
+            IsolationType::None
         };
 
         // Override certain features for hardware isolated VMs.
         // TODO: vtl return actions are inhibited for hardware isolated VMs because they currently
         // are a pessimization since interrupt handling (and synic handling) are all done from
         // within VTL2. Future vtl return actions may be different, requiring granular handling.
-        let supports_vtl_ret_action = supports_vtl_ret_action && !hardware_isolated;
-        let supports_register_page = supports_register_page && !hardware_isolated;
-        let dr6_shared = dr6_shared && !hardware_isolated;
+        let supports_vtl_ret_action = supports_vtl_ret_action && !isolation.is_hardware_isolated();
+        let supports_register_page = supports_register_page && !isolation.is_hardware_isolated();
+        let dr6_shared = dr6_shared && !isolation.is_hardware_isolated();
         let snp_register_bitmap = [0u8; 64];
 
         Ok(Hcl {
@@ -1993,7 +2004,7 @@ impl Hcl {
             supports_vtl_ret_action,
             supports_register_page,
             dr6_shared,
-            isolation: isolation_type,
+            isolation,
             snp_register_bitmap,
             sidecar,
         })
@@ -2119,7 +2130,7 @@ impl Hcl {
             "requesting interrupt"
         );
 
-        assert!(!self.is_hardware_isolated());
+        assert!(!self.isolation.is_hardware_isolated());
 
         let request = AssertVirtualInterrupt {
             partition_id: HV_PARTITION_ID_SELF,
@@ -2171,7 +2182,7 @@ impl Hcl {
     }
 
     fn hvcall_signal_event_direct(&self, vp: u32, sint: u8, flag: u16) -> Result<bool, Error> {
-        assert!(!self.is_hardware_isolated());
+        assert!(!self.isolation.is_hardware_isolated());
 
         let signal_event_input = hvdef::hypercall::SignalEventDirect {
             target_partition: HV_PARTITION_ID_SELF,
@@ -2210,7 +2221,7 @@ impl Hcl {
     ) -> Result<(), HvError> {
         tracing::trace!(vp, sint, "posting message");
 
-        assert!(!self.is_hardware_isolated());
+        assert!(!self.isolation.is_hardware_isolated());
         let post_message = hvdef::hypercall::PostMessageDirect {
             partition_id: HV_PARTITION_ID_SELF,
             vp_index: vp,
@@ -2583,15 +2594,15 @@ impl Hcl {
         );
 
         match self.isolation {
-            None | Some(IsolationType::Vbs) => caps,
+            IsolationType::None | IsolationType::Vbs => caps,
             // TODO SNP: Return actions may be useful, but with alternate injection many of these need
             // cannot actually be processed by the hypervisor without returning to VTL2.
             // Filter them out for now.
-            Some(IsolationType::Snp) => hvdef::HvRegisterVsmCapabilities::new()
+            IsolationType::Snp => hvdef::HvRegisterVsmCapabilities::new()
                 .with_deny_lower_vtl_startup(caps.deny_lower_vtl_startup())
                 .with_intercept_page_available(caps.intercept_page_available()),
             // TODO TDX: Figure out what these values should be.
-            Some(IsolationType::Tdx) => hvdef::HvRegisterVsmCapabilities::new()
+            IsolationType::Tdx => hvdef::HvRegisterVsmCapabilities::new()
                 .with_deny_lower_vtl_startup(caps.deny_lower_vtl_startup())
                 .with_intercept_page_available(caps.intercept_page_available()),
         }
@@ -2636,7 +2647,7 @@ impl Hcl {
             .with_reserved(0);
 
         tracing::trace!(enable_guest_vsm, "set_guest_vsm_partition_config");
-        if self.is_hardware_isolated() {
+        if self.isolation.is_hardware_isolated() {
             unimplemented!("set_guest_vsm_partition_config");
         }
 
@@ -2655,7 +2666,7 @@ impl Hcl {
     #[cfg(guest_arch = "x86_64")]
     pub fn set_pm_timer_assist(&self, port: Option<u16>) -> Result<(), HvError> {
         tracing::debug!(?port, "set_pm_timer_assist");
-        if self.is_hardware_isolated() {
+        if self.isolation.is_hardware_isolated() {
             if port.is_some() {
                 unimplemented!("set_pm_timer_assist");
             }
@@ -2690,7 +2701,7 @@ impl Hcl {
         map_flags: HvMapGpaFlags,
         target_vtl: HvInputVtl,
     ) -> Result<(), ApplyVtlProtectionsError> {
-        if self.is_hardware_isolated() {
+        if self.isolation.is_hardware_isolated() {
             // TODO SNP TODO TDX - required for vmbus relay monitor page support
             todo!();
         }
@@ -2706,7 +2717,7 @@ impl Hcl {
         target_vtl: GuestVtl,
         flags: HvMapGpaFlags,
     ) -> Result<Option<CheckVtlAccessResult>, Error> {
-        assert!(!self.is_hardware_isolated());
+        assert!(!self.isolation.is_hardware_isolated());
 
         let header = hvdef::hypercall::CheckSparseGpaPageVtlAccess {
             partition_id: HV_PARTITION_ID_SELF,
@@ -2874,16 +2885,8 @@ impl Hcl {
     }
 
     /// Returns the isolation type for the partition.
-    pub fn isolation(&self) -> Option<IsolationType> {
+    pub fn isolation(&self) -> IsolationType {
         self.isolation
-    }
-
-    /// Returns whether the partition is hardware isolated.
-    pub fn is_hardware_isolated(&self) -> bool {
-        matches!(
-            self.isolation,
-            Some(IsolationType::Snp | IsolationType::Tdx)
-        )
     }
 
     /// Reads MSR_IA32_VMX_CR4_FIXED1 in kernel mode.

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -2375,7 +2375,7 @@ impl Hcl {
     {
         use hvdef::hypercall;
 
-        assert!(!self.is_hardware_isolated());
+        assert!(!self.isolation.is_hardware_isolated());
         assert!(
             control_flags.input_vtl().use_target_vtl(),
             "did not specify a target VTL"

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -129,7 +129,7 @@ pub(crate) struct LoadedVm {
     /// The various guest memory objects.
     pub memory: underhill_mem::MemoryMappings,
     pub firmware_type: FirmwareType,
-    pub isolation: Option<IsolationType>,
+    pub isolation: IsolationType,
     // contain task handles which must be kept live
     pub _chipset_devices: ChipsetDevices,
     // keep the unit task alive
@@ -467,7 +467,7 @@ impl LoadedVm {
         deadline: std::time::Instant,
         capabilities_flags: SaveGuestVtl2StateFlags,
     ) -> anyhow::Result<ServicingState> {
-        if self.isolation.is_some() {
+        if self.isolation.is_isolated() {
             anyhow::bail!("Servicing is not yet supported for isolated VMs");
         }
         let nvme_keepalive = !capabilities_flags.disable_nvme_keepalive();

--- a/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
+++ b/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
@@ -193,7 +193,7 @@ pub fn read_vtl2_params(
     };
 
     let (cvm_cpuid_info, snp_secrets) = {
-        if hcl.isolation() == Some(hcl::ioctl::IsolationType::Snp) {
+        if isolation == hcl::ioctl::IsolationType::Snp {
             let mut cpuid_pages: Vec<u8> =
                 vec![0; (HV_PAGE_SIZE * PARAVISOR_CONFIG_CPUID_SIZE_PAGES) as usize];
             mapping
@@ -217,7 +217,7 @@ pub fn read_vtl2_params(
         }
     };
 
-    let accepted_regions = if hcl.isolation().is_some() {
+    let accepted_regions = if isolation.is_isolated() {
         parsed_openhcl_boot.accepted_ranges.clone()
     } else {
         Vec::new()

--- a/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
+++ b/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
@@ -10,6 +10,7 @@
 
 use anyhow::Context;
 use bootloader_fdt_parser::ParsedBootDtInfo;
+use hcl::ioctl::IsolationType;
 use hvdef::HV_PAGE_SIZE;
 use inspect::Inspect;
 use loader_defs::paravisor::ParavisorMeasuredVtl2Config;
@@ -142,7 +143,7 @@ impl Vtl2ParamsMap {
 
 /// Reads the VTL 2 parameters from the vtl-boot-data region.
 pub fn read_vtl2_params(
-    hcl: &hcl::ioctl::Hcl,
+    isolation: IsolationType,
 ) -> anyhow::Result<(RuntimeParameters, MeasuredVtl2Info)> {
     let parsed_openhcl_boot = ParsedBootDtInfo::new().context("failed to parse openhcl_boot dt")?;
 
@@ -193,7 +194,7 @@ pub fn read_vtl2_params(
     };
 
     let (cvm_cpuid_info, snp_secrets) = {
-        if isolation == hcl::ioctl::IsolationType::Snp {
+        if isolation == IsolationType::Snp {
             let mut cpuid_pages: Vec<u8> =
                 vec![0; (HV_PAGE_SIZE * PARAVISOR_CONFIG_CPUID_SIZE_PAGES) as usize];
             mapping

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2338,17 +2338,17 @@ async fn new_underhill_vm(
 
         let (get_attestation_report, request_ak_cert) = {
             // Ak cert renewal depends on the ability to get an attestation report
-            // TODO VBS: Removing the VBS check when VBS TeeCall is implemented.
-            let get_attestation_report = if !matches!(isolation, hcl::ioctl::IsolationType::Vbs) {
-                Some(
+            let get_attestation_report = match isolation {
+                hcl::ioctl::IsolationType::Snp | hcl::ioctl::IsolationType::Tdx => Some(
                     GetTpmGetAttestationReportHelperHandle::new(
                         attestation_type,
                         attestation_vm_config,
                     )
                     .into_resource(),
-                )
-            } else {
-                None
+                ),
+                // TODO VBS: Removing the VBS check when VBS TeeCall is implemented.
+                hcl::ioctl::IsolationType::Vbs => None,
+                hcl::ioctl::IsolationType::None => None,
             };
 
             // Always attempt AK cert and let TPM to decide the course of action

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1164,13 +1164,13 @@ async fn new_underhill_vm(
 
     let mut hcl = hcl::ioctl::Hcl::new(sidecar).context("failed to open HCL driver")?;
     let isolation = hcl.isolation();
-    let hardware_isolated = hcl.is_hardware_isolated();
+    let hardware_isolated = isolation.is_hardware_isolated();
 
     let is_restoring = servicing_state.is_some();
     let servicing_state = OptionServicingInitState::from(servicing_state);
 
     assert!(
-        !(is_restoring && isolation.is_some()),
+        !(is_restoring && isolation.is_isolated()),
         "restoring an isolated VM is not yet supported"
     );
 
@@ -1240,8 +1240,9 @@ async fn new_underhill_vm(
     hcl.set_allowed_hypercalls(allowed_hypercalls.as_slice());
 
     // Read the initial configuration from the IGVM parameters.
-    let (runtime_params, measured_vtl2_info) = crate::loader::vtl2_config::read_vtl2_params(&hcl)
-        .context("failed to read load parameters")?;
+    let (runtime_params, measured_vtl2_info) =
+        crate::loader::vtl2_config::read_vtl2_params(isolation)
+            .context("failed to read load parameters")?;
 
     let boot_info = runtime_params.parsed_openhcl_boot();
 
@@ -1254,7 +1255,7 @@ async fn new_underhill_vm(
     // Determine the amount of shared memory to reserve from VTL0.
     let shared_pool_size = match isolation {
         #[cfg(guest_arch = "x86_64")]
-        Some(hcl::ioctl::IsolationType::Snp) => {
+        hcl::ioctl::IsolationType::Snp => {
             let cpu_bytes = boot_info.cpus.len() as u64
                 * virt_mshv_vtl::snp_shared_pages_required_per_cpu()
                 * hvdef::HV_PAGE_SIZE;
@@ -1262,7 +1263,7 @@ async fn new_underhill_vm(
             round_up_to_2mb(cpu_bytes + device_dma + attestation)
         }
         #[cfg(guest_arch = "x86_64")]
-        Some(hcl::ioctl::IsolationType::Tdx) => {
+        hcl::ioctl::IsolationType::Tdx => {
             let cpu_bytes = boot_info.cpus.len() as u64
                 * virt_mshv_vtl::tdx_shared_pages_required_per_cpu()
                 * hvdef::HV_PAGE_SIZE;
@@ -1327,7 +1328,7 @@ async fn new_underhill_vm(
     //
     // TODO: centralize cpuid querying logic.
     #[cfg(guest_arch = "x86_64")]
-    let x2apic = if hcl.is_hardware_isolated() {
+    let x2apic = if isolation.is_hardware_isolated() {
         // For hardware CVMs, always enable x2apic support at boot.
         vm_topology::processor::x86::X2ApicState::Enabled
     } else if safe_x86_intrinsics::cpuid(x86defs::cpuid::CpuidFunction::VersionAndFeatures.0, 0).ecx
@@ -1519,10 +1520,10 @@ async fn new_underhill_vm(
     };
 
     let attestation_type = match isolation {
-        Some(hcl::ioctl::IsolationType::Snp) => underhill_attestation::AttestationType::Snp,
-        Some(hcl::ioctl::IsolationType::Tdx) => underhill_attestation::AttestationType::Tdx,
-        Some(hcl::ioctl::IsolationType::Vbs) => underhill_attestation::AttestationType::Unsupported, // TODO VBS
-        None => underhill_attestation::AttestationType::Host,
+        hcl::ioctl::IsolationType::Snp => underhill_attestation::AttestationType::Snp,
+        hcl::ioctl::IsolationType::Tdx => underhill_attestation::AttestationType::Tdx,
+        hcl::ioctl::IsolationType::Vbs => underhill_attestation::AttestationType::Unsupported, // TODO VBS
+        hcl::ioctl::IsolationType::None => underhill_attestation::AttestationType::Host,
     };
 
     // Decrypt VMGS state before the VMGS file is used for anything.
@@ -1553,7 +1554,7 @@ async fn new_underhill_vm(
             // responses via shared memory, which requires both `shared_vis_pages_pool` and
             // `gm.untrusted_dma_memory` to be available.
             let suppress_attestation = dps.general.suppress_attestation.unwrap_or_default();
-            if isolation.is_some() {
+            if isolation.is_isolated() {
                 validate_isolated_configuration(&dps)
                     .context("invalid host-provided configuration for isolated VM")?;
             }
@@ -2337,19 +2338,18 @@ async fn new_underhill_vm(
 
         let (get_attestation_report, request_ak_cert) = {
             // Ak cert renewal depends on the ability to get an attestation report
-            let get_attestation_report =
-                // TODO VBS: Removing the VBS check when VBS TeeCall is implemented.
-                if !matches!(isolation, Some(hcl::ioctl::IsolationType::Vbs)) {
-                    isolation.map(|_| {
-                        GetTpmGetAttestationReportHelperHandle::new(
-                            attestation_type,
-                            attestation_vm_config,
-                        )
-                        .into_resource()
-                    })
-                } else {
-                    None
-                };
+            // TODO VBS: Removing the VBS check when VBS TeeCall is implemented.
+            let get_attestation_report = if !matches!(isolation, hcl::ioctl::IsolationType::Vbs) {
+                Some(
+                    GetTpmGetAttestationReportHelperHandle::new(
+                        attestation_type,
+                        attestation_vm_config,
+                    )
+                    .into_resource(),
+                )
+            } else {
+                None
+            };
 
             // Always attempt AK cert and let TPM to decide the course of action
             // based on the response.
@@ -2804,7 +2804,7 @@ async fn new_underhill_vm(
             &runtime_params,
             load_kind,
             &dps,
-            isolation.is_some(),
+            isolation.is_isolated(),
         )
         .instrument(tracing::info_span!("load_firmware"))
         .await?;

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -450,6 +450,7 @@ mod mapping {
     impl GpaVtlPermissions {
         fn new(isolation: IsolationType, vtl: Vtl, protections: HvMapGpaFlags) -> Self {
             match isolation {
+                IsolationType::None => unreachable!(),
                 IsolationType::Vbs => GpaVtlPermissions::Vbs(protections),
                 IsolationType::Snp => {
                     let mut vtl_permissions = GpaVtlPermissions::Snp(SevRmpAdjust::new());
@@ -547,6 +548,7 @@ mod mapping {
         /// Accept pages for VTL0.
         pub fn accept_vtl0_pages(&self, range: MemoryRange) -> Result<(), AcceptPagesError> {
             match self.isolation {
+                IsolationType::None => unreachable!(),
                 IsolationType::Vbs => self
                     .mshv_hvcall
                     .accept_gpa_pages(range, AcceptMemoryType::RAM),
@@ -574,6 +576,7 @@ mod mapping {
 
         fn unaccept_vtl0_pages(&self, range: MemoryRange) {
             match self.isolation {
+                IsolationType::None => unreachable!(),
                 IsolationType::Vbs => {
                     // TODO VBS: is there something to do here?
                 }

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -613,7 +613,7 @@ mod mapping {
         /// Query the current permissions for a vtl on a page.
         fn vtl_permissions(&self, vtl: Vtl, gpa: u64) -> GpaVtlPermissions {
             match self.isolation {
-                IsolationType::Vbs => unimplemented!(),
+                IsolationType::None | IsolationType::Vbs => unimplemented!(),
                 IsolationType::Snp => {
                     // TODO CVM GUEST VSM: track the permissions directly in
                     // underhill. For now, use rmpquery.
@@ -1111,7 +1111,7 @@ mod mapping {
             }
 
             let current_permissions = match self.acceptor.isolation {
-                IsolationType::Vbs => unreachable!(),
+                IsolationType::None | IsolationType::Vbs => unreachable!(),
                 IsolationType::Snp => self
                     .acceptor
                     .vtl_permissions(vtl.into(), gpn * HV_PAGE_SIZE),

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -166,8 +166,8 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         // TODO GUEST_VSM: construct APIC (including overlays, vp assist page) for VTL 1
 
         // Register the VMSA with the hypervisor
-        let hv_vp_context = match self.vp.partition.isolation.expect("has isolation type") {
-            virt::IsolationType::Vbs => unreachable!(),
+        let hv_vp_context = match self.vp.partition.isolation {
+            virt::IsolationType::None | virt::IsolationType::Vbs => unreachable!(),
             virt::IsolationType::Snp => {
                 // For VTL 1, user mode needs to explicitly register the VMSA
                 // with the hypervisor via the EnableVpVtl hypercall.
@@ -423,7 +423,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             return Err(HvError::InvalidParameter);
         }
 
-        assert!(self.partition.isolation.is_some());
+        assert!(self.partition.isolation.is_isolated());
 
         // Features currently supported by openhcl.
         let allowed_bits = HvRegisterVsmPartitionConfig::new()

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -733,7 +733,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
         match vtl {
             Vtl::Vtl0 => true,
             Vtl::Vtl1 => {
-                if self.partition.is_hardware_isolated() {
+                if self.partition.isolation.is_hardware_isolated() {
                     *self.inner.hcvm_vtl1_enabled.lock()
                 } else {
                     // TODO: when there's support for returning VTL 1 registers,
@@ -878,7 +878,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                     .map_err(UhRunVpError::State)?;
 
                     if vtl == GuestVtl::Vtl1 {
-                        assert!(self.partition.is_hardware_isolated());
+                        assert!(self.partition.isolation.is_hardware_isolated());
                         // Should not have already initialized the hv emulator for this vtl
                         assert!(self.hv(vtl).is_none());
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -1408,7 +1408,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::ModifyVtlProtectionMask
             }
         }
 
-        if self.vp.partition.is_hardware_isolated() {
+        if self.vp.partition.isolation.is_hardware_isolated() {
             // VTL 1 mut be enabled already.
             let mut guest_vsm_lock = self.vp.partition.guest_vsm.write();
             let guest_vsm = guest_vsm_lock
@@ -1441,7 +1441,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::ModifyVtlProtectionMask
             // protections mask changes
             // Can receive an intercept on adjust permissions, and for isolated
             // VMs if the page is unaccepted
-            if self.vp.partition.isolation.is_some() {
+            if self.vp.partition.isolation.is_isolated() {
                 return Err((HvError::OperationDenied, 0));
             } else {
                 if !gpa_pages.is_empty() && !self.vp.partition.is_gpa_lower_vtl_ram(gpa_pages[0]) {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -802,7 +802,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
             return Err(HvError::InvalidParameter);
         }
 
-        assert!(self.partition.isolation.is_some());
+        assert!(self.partition.isolation.is_isolated());
 
         let status: HvRegisterVsmPartitionStatus = self.partition.vsm_status();
 

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -762,7 +762,11 @@ impl InitializedVm {
                 hv_config,
                 vmtime: &vmtime_source,
                 user_mode_apic: cfg.hypervisor.user_mode_apic,
-                isolation: cfg.hypervisor.with_isolation.map(|typ| typ.into()),
+                isolation: cfg
+                    .hypervisor
+                    .with_isolation
+                    .map(|typ| typ.into())
+                    .unwrap_or(virt::IsolationType::None),
             })
             .context("failed to create the prototype partition")?;
 

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -15,7 +15,7 @@ const MAX_CPUS: usize = 2048;
 pub fn hv_cpuid_leaves(
     topology: &ProcessorTopology<X86Topology>,
     emulate_apic: bool,
-    isolation: Option<IsolationType>,
+    isolation: IsolationType,
     access_vsm: bool,
     mut hardware_isolated: Option<&mut dyn FnMut(u32, u32) -> [u32; 4]>,
     vtom: Option<u64>,
@@ -125,7 +125,7 @@ pub fn hv_cpuid_leaves(
                     // compatible with APIC hardware offloads.
                     // However, Lazy EOI on SNP is beneficial and requires the
                     // Hyper-V MSRs to function. Enable it there regardless.
-                    isolation == Some(IsolationType::Snp)
+                    isolation == IsolationType::Snp
                 }
             };
 
@@ -137,7 +137,7 @@ pub fn hv_cpuid_leaves(
 
             if hardware_isolated.is_some() {
                 // TODO TDX too when it's ready
-                if isolation == Some(IsolationType::Snp) {
+                if isolation == IsolationType::Snp {
                     enlightenments = enlightenments
                         .with_use_hypercall_for_remote_flush_and_local_flush_entire(true);
                 }
@@ -175,7 +175,7 @@ pub fn hv_cpuid_leaves(
                 split_u128(
                     hvdef::HvIsolationConfiguration::new()
                         .with_paravisor_present(true)
-                        .with_isolation_type(IsolationType::to_hv(isolation).0)
+                        .with_isolation_type(isolation.to_hv().0)
                         .with_shared_gpa_boundary_active(true)
                         .with_shared_gpa_boundary_bits(
                             vtom.expect("cvm requires vtom").trailing_zeros() as u8,

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -134,7 +134,7 @@ pub struct ProtoPartitionConfig<'a> {
     /// Use the user-mode APIC emulator, if supported.
     pub user_mode_apic: bool,
     /// Isolation type for this partition.
-    pub isolation: Option<IsolationType>,
+    pub isolation: IsolationType,
 }
 
 /// Partition creation configuration.

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -65,12 +65,26 @@ pub trait Hypervisor: 'static {
 /// Isolation type for a partition.
 #[derive(Eq, PartialEq, Debug, Copy, Clone, Inspect)]
 pub enum IsolationType {
+    /// No isolation.
+    None,
     /// Hypervisor based isolation.
     Vbs,
     /// Secure nested paging (AMD SEV-SNP) - hardware based isolation.
     Snp,
     /// Trust domain extensions (Intel TDX) - hardware based isolation.
     Tdx,
+}
+
+impl IsolationType {
+    /// Returns true if the isolation type is not `None`.
+    pub fn is_isolated(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    /// Returns whether the isolation type is hardware-backed.
+    pub fn is_hardware_isolated(&self) -> bool {
+        matches!(self, Self::Snp | Self::Tdx)
+    }
 }
 
 /// An unexpected isolation type was provided.
@@ -80,22 +94,22 @@ pub struct UnexpectedIsolationType;
 impl IsolationType {
     pub fn from_hv(
         value: hvdef::HvPartitionIsolationType,
-    ) -> Result<Option<Self>, UnexpectedIsolationType> {
+    ) -> Result<Self, UnexpectedIsolationType> {
         match value {
-            hvdef::HvPartitionIsolationType::NONE => Ok(None),
-            hvdef::HvPartitionIsolationType::VBS => Ok(Some(IsolationType::Vbs)),
-            hvdef::HvPartitionIsolationType::SNP => Ok(Some(IsolationType::Snp)),
-            hvdef::HvPartitionIsolationType::TDX => Ok(Some(IsolationType::Tdx)),
+            hvdef::HvPartitionIsolationType::NONE => Ok(IsolationType::None),
+            hvdef::HvPartitionIsolationType::VBS => Ok(IsolationType::Vbs),
+            hvdef::HvPartitionIsolationType::SNP => Ok(IsolationType::Snp),
+            hvdef::HvPartitionIsolationType::TDX => Ok(IsolationType::Tdx),
             _ => Err(UnexpectedIsolationType),
         }
     }
 
-    pub fn to_hv(isolation_type: Option<Self>) -> hvdef::HvPartitionIsolationType {
-        match isolation_type {
-            None => hvdef::HvPartitionIsolationType::NONE,
-            Some(IsolationType::Vbs) => hvdef::HvPartitionIsolationType::VBS,
-            Some(IsolationType::Snp) => hvdef::HvPartitionIsolationType::SNP,
-            Some(IsolationType::Tdx) => hvdef::HvPartitionIsolationType::TDX,
+    pub fn to_hv(self) -> hvdef::HvPartitionIsolationType {
+        match self {
+            IsolationType::None => hvdef::HvPartitionIsolationType::NONE,
+            IsolationType::Vbs => hvdef::HvPartitionIsolationType::VBS,
+            IsolationType::Snp => hvdef::HvPartitionIsolationType::SNP,
+            IsolationType::Tdx => hvdef::HvPartitionIsolationType::TDX,
         }
     }
 }

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -770,7 +770,7 @@ impl virt::Hypervisor for Kvm {
         &'a mut self,
         config: ProtoPartitionConfig<'a>,
     ) -> Result<Self::ProtoPartition<'a>, Self::Error> {
-        if config.isolation.is_some() {
+        if config.isolation.is_isolated() {
             return Err(KvmError::IsolationNotSupported);
         }
 

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -113,7 +113,7 @@ impl virt::Hypervisor for Kvm {
         &mut self,
         config: ProtoPartitionConfig<'a>,
     ) -> Result<Self::ProtoPartition<'a>, Self::Error> {
-        if config.isolation.is_some() {
+        if config.isolation.is_isolated() {
             return Err(KvmError::IsolationNotSupported);
         }
 

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -88,7 +88,7 @@ impl virt::Hypervisor for LinuxMshv {
         &mut self,
         config: ProtoPartitionConfig<'a>,
     ) -> Result<MshvProtoPartition<'a>, Self::Error> {
-        if config.isolation.is_some() {
+        if config.isolation.is_isolated() {
             return Err(Error::IsolationNotSupported);
         }
 

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -103,7 +103,7 @@ pub struct WhpPartitionInner {
     cpuid: virt::CpuidLeafSet,
     vtl0_alias_map_offset: Option<u64>,
     monitor_page: MonitorPage,
-    isolation: Option<IsolationType>,
+    isolation: IsolationType,
 }
 
 #[derive(Inspect)]
@@ -460,7 +460,7 @@ impl virt::ScrubVtl for WhpPartition {
     type Error = Error;
 
     fn scrub(&self, vtl: Vtl) -> Result<(), Error> {
-        assert!(self.inner.isolation.is_none());
+        assert!(!self.inner.isolation.is_isolated());
         assert_eq!(vtl, Vtl::Vtl2);
 
         let vtl2 = self.inner.vtl2.as_ref().ok_or(Error::NoVtl2)?;
@@ -493,7 +493,7 @@ impl virt::AcceptInitialPages for WhpPartition {
     type Error = Error;
 
     fn accept_initial_pages(&self, pages: &[(MemoryRange, PageVisibility)]) -> Result<(), Error> {
-        assert!(self.inner.isolation.is_some());
+        assert!(self.inner.isolation.is_isolated());
 
         for (range, vis) in pages {
             self.inner
@@ -522,13 +522,13 @@ impl virt::Partition for WhpPartition {
     fn supports_vtl_scrub(
         &self,
     ) -> Option<&dyn virt::ScrubVtl<Error = <Self as virt::Hv1>::Error>> {
-        self.inner.isolation.is_none().then_some(self)
+        (!self.inner.isolation.is_isolated()).then_some(self)
     }
 
     fn supports_initial_accept_pages(
         &self,
     ) -> Option<&dyn virt::AcceptInitialPages<Error = <Self as virt::Hv1>::Error>> {
-        self.inner.isolation.is_some().then_some(self)
+        self.inner.isolation.is_isolated().then_some(self)
     }
 
     fn doorbell_registration(
@@ -923,7 +923,7 @@ impl WhpPartitionInner {
                     cpuid.extend(hv1_emulator::cpuid::hv_cpuid_leaves(
                         proto_config.processor_topology,
                         proto_config.user_mode_apic,
-                        None,
+                        IsolationType::None,
                         false,
                         None,
                         None,
@@ -947,7 +947,7 @@ impl WhpPartitionInner {
 
             // TODO: Supporting the alias map with isolation requires additional
             // mapper changes that are not implemented yet.
-            if vtl2_config.vtl0_alias_map && proto_config.isolation.is_some() {
+            if vtl2_config.vtl0_alias_map && proto_config.isolation.is_isolated() {
                 todo!("alias map and isolation requires memory mapper changes")
             }
 
@@ -1381,16 +1381,16 @@ impl VtlPartition {
             .map(|vp| vp.apic_id)
             .collect();
 
-        let mapper: Box<dyn MemoryMapper> = if let Some(isolation_type) = config.isolation {
+        let mapper: Box<dyn MemoryMapper> = if config.isolation.is_isolated() {
             // VTL2 late map support is ignored, since memory acceptance
             // requires explicit calls from the guest in order to access
             // memory.
 
             assert!(!with_overlays);
 
-            match isolation_type {
+            match config.isolation {
                 IsolationType::Vbs => {}
-                _ => unimplemented!("isolation type unsupported: {isolation_type:?}"),
+                ty => unimplemented!("isolation type unsupported: {ty:?}"),
             }
 
             Box::new(memory::vtl2_mapper::VtlMemoryMapper::new(


### PR DESCRIPTION
Instead of awkwardly passing around Option<IsolationType> everywhere, include the `None` case in `IsolationType`.

There is just one place, in `underhill_mem`, where this weakens the compile-time type checking. It doesn't seem worth adding the extra `Option` everywhere just to maintain this. `underhill_mem` can redefine a more limited enum if it really wants to avoid a few `unreachable!`s.