### PR TITLE
openhcl: propagate isolation type from boot loader

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1953,10 +1953,11 @@ impl Hcl {
         let mshv_fd = Mshv::new()?;
 
         // Validate the hypervisor's advertised isolation type matches the
-        // requested isolation type. In CVM scenarios, this is not trusted,
-        // so we still need the isolation type from the caller.
+        // requested isolation type. In CVM scenarios, this is not trusted, so
+        // we still need the isolation type from the caller.
         //
-        // FUTURE: the kernel driver should probably tell us this.
+        // FUTURE: the kernel driver should probably tell us this, especially
+        // since the kernel ABI is different for different isolation types.
         let supported_isolation = if cfg!(guest_arch = "x86_64") {
             // xtask-fmt allow-target-arch cpu-intrinsic
             #[cfg(target_arch = "x86_64")]

--- a/openhcl/openhcl_boot/src/arch/aarch64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/aarch64/memory.rs
@@ -26,7 +26,7 @@ pub fn setup_vtl2_memory(_shim_params: &ShimParams, _partition_info: &PartitionI
         .expect("setting vsm config shouldn't fail");
 }
 
-pub fn physical_address_bits() -> u8 {
+pub fn physical_address_bits(_isolation: crate::IsolationType) -> u8 {
     let mut mmfr0: u64;
     // SAFETY: Reading a system register into u64 allocated on the stack, single-threaded.
     unsafe {

--- a/openhcl/openhcl_boot/src/arch/aarch64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/aarch64/memory.rs
@@ -26,7 +26,7 @@ pub fn setup_vtl2_memory(_shim_params: &ShimParams, _partition_info: &PartitionI
         .expect("setting vsm config shouldn't fail");
 }
 
-pub fn physical_address_bits(_isolation: crate::IsolationType) -> u8 {
+pub fn physical_address_bits() -> u8 {
     let mut mmfr0: u64;
     // SAFETY: Reading a system register into u64 allocated on the stack, single-threaded.
     unsafe {

--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -452,10 +452,12 @@ pub fn write_dt(
 
     let p_isolation_type = openhcl_builder.add_string("isolation-type")?;
     let isolation_type = match partition_info.isolation {
-        IsolationType::Vbs => "vbs",
-        IsolationType::Snp => "snp",
-        IsolationType::Tdx => "tdx",
         IsolationType::None => "none",
+        IsolationType::Vbs => "vbs",
+        #[cfg(target_arch = "x86_64")]
+        IsolationType::Snp => "snp",
+        #[cfg(target_arch = "x86_64")]
+        IsolationType::Tdx => "tdx",
     };
     openhcl_builder = openhcl_builder.add_str(p_isolation_type, isolation_type)?;
 

--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -4,6 +4,7 @@
 //! Module used to write the device tree used by the OpenHCL kernel and
 //! usermode.
 
+use crate::host_params::shim_params::IsolationType;
 use crate::host_params::PartitionInfo;
 use crate::host_params::COMMAND_LINE_SIZE;
 use crate::sidecar::SidecarConfig;
@@ -448,6 +449,15 @@ pub fn write_dt(
 
     // Add information used by openhcl usermode.
     let mut openhcl_builder = root_builder.start_node("openhcl")?;
+
+    let p_isolation_type = openhcl_builder.add_string("isolation-type")?;
+    let isolation_type = match partition_info.isolation {
+        IsolationType::Vbs => "vbs",
+        IsolationType::Snp => "snp",
+        IsolationType::Tdx => "tdx",
+        IsolationType::None => "none",
+    };
+    openhcl_builder = openhcl_builder.add_str(p_isolation_type, isolation_type)?;
 
     // Indicate what kind of memory allocation mode was done by the bootloader
     // to usermode.

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -442,6 +442,7 @@ impl PartitionInfo {
             vtl2_full_config_region: vtl2_config_region,
             vtl2_config_region_reclaim: vtl2_config_region_reclaim_struct,
             partition_ram: _,
+            isolation,
             bsp_reg,
             cpus,
             vmbus_vtl0: _,
@@ -452,6 +453,8 @@ impl PartitionInfo {
             memory_allocation_mode: _,
             entropy,
         } = storage;
+
+        *isolation = params.isolation_type;
 
         *vtl2_config_region = MemoryRange::new(
             params.parameter_region_start

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -13,6 +13,7 @@ use host_fdt_parser::MemoryEntry;
 use host_fdt_parser::VmbusInfo;
 use memory_range::subtract_ranges;
 use memory_range::MemoryRange;
+use shim_params::IsolationType;
 
 mod dt;
 mod mmio;
@@ -54,6 +55,8 @@ pub struct PartitionInfo {
     pub vtl2_config_region_reclaim: MemoryRange,
     /// The full memory map provided by the host.
     pub partition_ram: ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>,
+    /// The partiton's isolation type.
+    pub isolation: IsolationType,
     /// The reg field in device tree for the BSP. This is either the apic_id on
     /// x64, or mpidr on aarch64.
     pub bsp_reg: u32,
@@ -83,6 +86,7 @@ impl PartitionInfo {
             vtl2_full_config_region: MemoryRange::EMPTY,
             vtl2_config_region_reclaim: MemoryRange::EMPTY,
             partition_ram: ArrayVec::new_const(),
+            isolation: IsolationType::None,
             bsp_reg: 0,
             cpus: ArrayVec::new_const(),
             vmbus_vtl2: VmbusInfo {

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -720,6 +720,7 @@ mod test {
     use super::x86_boot::build_e820_map;
     use super::x86_boot::E820Ext;
     use crate::dt::write_dt;
+    use crate::host_params::shim_params::IsolationType;
     use crate::host_params::PartitionInfo;
     use crate::host_params::MAX_CPU_COUNT;
     use crate::reserved_memory_regions;
@@ -763,6 +764,7 @@ mod test {
             vtl2_full_config_region: MemoryRange::EMPTY,
             vtl2_config_region_reclaim: MemoryRange::EMPTY,
             partition_ram: ArrayVec::new(),
+            isolation: IsolationType::None,
             bsp_reg: cpus[0].reg as u32,
             cpus,
             cmdline: ArrayString::new(),

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1156,15 +1156,20 @@ async fn new_underhill_vm(
         }
     }
 
-    let driver_source = VmTaskDriverSource::new(ThreadpoolBackend::new(tp.clone()));
+    // Read the initial configuration from the IGVM parameters.
+    let (runtime_params, measured_vtl2_info) =
+        crate::loader::vtl2_config::read_vtl2_params().context("failed to read load parameters")?;
 
-    // Try to open the sidecar device, if it is present.
-    let sidecar = sidecar_client::SidecarClient::new(|cpu| tp.driver(cpu).clone())
-        .context("failed to open sidecar device")?;
+    let isolation = match runtime_params.parsed_openhcl_boot().isolation {
+        bootloader_fdt_parser::IsolationType::None => hcl::ioctl::IsolationType::None,
+        bootloader_fdt_parser::IsolationType::Vbs => hcl::ioctl::IsolationType::Vbs,
+        bootloader_fdt_parser::IsolationType::Snp => hcl::ioctl::IsolationType::Snp,
+        bootloader_fdt_parser::IsolationType::Tdx => hcl::ioctl::IsolationType::Tdx,
+    };
 
-    let mut hcl = hcl::ioctl::Hcl::new(sidecar).context("failed to open HCL driver")?;
-    let isolation = hcl.isolation();
     let hardware_isolated = isolation.is_hardware_isolated();
+
+    let driver_source = VmTaskDriverSource::new(ThreadpoolBackend::new(tp.clone()));
 
     let is_restoring = servicing_state.is_some();
     let servicing_state = OptionServicingInitState::from(servicing_state);
@@ -1186,6 +1191,12 @@ async fn new_underhill_vm(
 
     let uevent_listener =
         Arc::new(UeventListener::new(tp.driver(0)).context("failed to start uevent listener")?);
+
+    // Try to open the sidecar device, if it is present.
+    let sidecar = sidecar_client::SidecarClient::new(|cpu| tp.driver(cpu).clone())
+        .context("failed to open sidecar device")?;
+
+    let mut hcl = hcl::ioctl::Hcl::new(isolation, sidecar).context("failed to open HCL driver")?;
 
     // Set the hypercalls that this process will use.
     let mut allowed_hypercalls = vec![
@@ -1238,11 +1249,6 @@ async fn new_underhill_vm(
     }
 
     hcl.set_allowed_hypercalls(allowed_hypercalls.as_slice());
-
-    // Read the initial configuration from the IGVM parameters.
-    let (runtime_params, measured_vtl2_info) =
-        crate::loader::vtl2_config::read_vtl2_params(isolation)
-            .context("failed to read load parameters")?;
 
     let boot_info = runtime_params.parsed_openhcl_boot();
 


### PR DESCRIPTION
Instead of querying the hypervisor (!) to determine the partition's isolation type from inside openvmm, reuse the decision already made by the boot loader. The boot loader gets this from the measured shim parameters, so this is the most correct and secure option.
    
This also eliminates an mshv_vtl dependency from the startup path, which will be necessary for supporting non-mshv_vtl-based scenarios.