### PR TITLE
openhcl_boot: verify hv VP index matches dt CPU index

### DIFF
--- a/openhcl/bootloader_fdt_parser/src/lib.rs
+++ b/openhcl/bootloader_fdt_parser/src/lib.rs
@@ -135,8 +135,8 @@ pub enum MemoryAllocationMode {
 /// the host provided device tree.
 #[derive(Debug, Inspect, PartialEq, Eq)]
 pub struct ParsedBootDtInfo {
-    /// The cpus in the system. Note that this is not sorted in any particular
-    /// order.
+    /// The cpus in the system. The index in the vector is also the Hyper-V VP
+    /// index.
     #[inspect(iter_by_index)]
     pub cpus: Vec<Cpu>,
     /// The physical address bits of the system. Today, this is only reported on aarch64.

--- a/openhcl/bootloader_fdt_parser/src/lib.rs
+++ b/openhcl/bootloader_fdt_parser/src/lib.rs
@@ -135,7 +135,7 @@ pub enum MemoryAllocationMode {
 /// the host provided device tree.
 #[derive(Debug, Inspect, PartialEq, Eq)]
 pub struct ParsedBootDtInfo {
-    /// The cpus in the system. The index in the vector is also the Hyper-V VP
+    /// The cpus in the system. The index in the vector is also the mshv VP
     /// index.
     #[inspect(iter_by_index)]
     pub cpus: Vec<Cpu>,

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -267,7 +267,8 @@ impl HvCall {
         Ok(())
     }
 
-    /// Get the corresponding VP indices from a list of apic_ids.
+    /// Get the corresponding VP indices from a list of VP hardware IDs (APIC
+    /// IDs on x64, MPIDR on ARM64).
     pub fn get_vp_index_from_hw_id<const N: usize>(
         &mut self,
         hw_ids: &[HwId],
@@ -307,8 +308,12 @@ impl HvCall {
     }
 }
 
+/// The "hardware ID" used for [`HvCall::get_vp_index_from_hw_id`]. This is the
+/// APIC ID on x64.
 #[cfg(target_arch = "x86_64")]
 pub type HwId = u32;
 
+/// The "hardware ID" used for [`HvCall::get_vp_index_from_hw_id`]. This is the
+/// MPIDR on ARM64.
 #[cfg(target_arch = "aarch64")]
 pub type HwId = u64;

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -738,7 +738,7 @@ fn validate_vp_hw_ids(partition_info: &PartitionInfo) {
     vp_indexes.clear();
     if let Err(err) = hvcall().get_vp_index_from_hw_id(&hw_ids, &mut vp_indexes) {
         panic!(
-            "failed to get VP indexes from hardware ID {:#x}: {:?}",
+            "failed to get VP index for hardware ID {:#x}: {}",
             hw_ids[vp_indexes.len().min(hw_ids.len() - 1)],
             err
         );
@@ -749,7 +749,7 @@ fn validate_vp_hw_ids(partition_info: &PartitionInfo) {
         .find(|(i, &vp_index)| *i as u32 != vp_index)
     {
         panic!(
-            "CPU hardware ID {} does not correspond to VP index {}",
+            "CPU hardware ID {:#x} does not correspond to VP index {}",
             hw_ids[i], vp_index
         );
     }

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -734,7 +734,7 @@ fn validate_vp_hw_ids(partition_info: &PartitionInfo) {
     let mut hw_ids = off_stack!(ArrayVec<HwId, MAX_CPU_COUNT>, ArrayVec::new_const());
     hw_ids.clear();
     hw_ids.extend(partition_info.cpus.iter().map(|c| c.reg as _));
-    let mut vp_indexes = off_stack!(ArrayVec<HwId, MAX_CPU_COUNT>, ArrayVec::new_const());
+    let mut vp_indexes = off_stack!(ArrayVec<u32, MAX_CPU_COUNT>, ArrayVec::new_const());
     vp_indexes.clear();
     if let Err(err) = hvcall().get_vp_index_from_hw_id(&hw_ids, &mut vp_indexes) {
         panic!(

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -564,6 +564,8 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
         panic!("no cpus");
     }
 
+    validate_vp_hw_ids(partition_info);
+
     setup_vtl2_vp(partition_info);
     setup_vtl2_memory(&p, partition_info);
     verify_imported_regions_hash(&p);
@@ -705,6 +707,51 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
         } else {
             panic!("unsupported arch")
         }
+    }
+}
+
+/// Ensure that mshv VP indexes for the CPUs listed in the partition info
+/// correspond to the N in the cpu@N devicetree node name. OpenVMM assumes that
+/// this will be the case.
+fn validate_vp_hw_ids(partition_info: &PartitionInfo) {
+    use host_params::MAX_CPU_COUNT;
+    use hypercall::HwId;
+
+    if partition_info.isolation.is_hardware_isolated() {
+        // TODO TDX SNP: we don't have a GHCB/GHCI page set up to communicate
+        // with the hypervisor here, so we can't easily perform the check. Since
+        // there is no security impact to this check, we can skip it for now; if
+        // the VM fails to boot, then this is due to a host contract violation.
+        //
+        // For TDX, we could use ENUM TOPOLOGY to validate that the TD VCPU
+        // indexes correspond to the APIC IDs in the right order. I am not
+        // certain if there are places where we depend on this mapping today.
+        return;
+    }
+
+    // Ensure the host and hypervisor agree on VP index ordering.
+
+    let mut hw_ids = off_stack!(ArrayVec<HwId, MAX_CPU_COUNT>, ArrayVec::new_const());
+    hw_ids.clear();
+    hw_ids.extend(partition_info.cpus.iter().map(|c| c.reg as _));
+    let mut vp_indexes = off_stack!(ArrayVec<HwId, MAX_CPU_COUNT>, ArrayVec::new_const());
+    vp_indexes.clear();
+    if let Err(err) = hvcall().get_vp_index_from_hw_id(&hw_ids, &mut vp_indexes) {
+        panic!(
+            "failed to get VP indexes from hardware ID {:#x}: {:?}",
+            hw_ids[vp_indexes.len().min(hw_ids.len() - 1)],
+            err
+        );
+    }
+    if let Some((i, &vp_index)) = vp_indexes
+        .iter()
+        .enumerate()
+        .find(|(i, &vp_index)| *i as u32 != vp_index)
+    {
+        panic!(
+            "CPU hardware ID {} does not correspond to VP index {}",
+            hw_ids[i], vp_index
+        );
     }
 }
 


### PR DESCRIPTION
Code in various places assumes that the hypervisor VP index is the same as the devicetree CPU index. Validate this early, in the boot loader, and then remove code elsewhere that half-heartedly tries to support alternative mappings. The host already guarantees this in practice, so let's take an explicit dependency.

If we ever weaken this requirement, we can just update the boot loader to reorder the CPU nodes to match the actual configuration before passing them on.