### PR TITLE
Remove references to "-msft" in CI and tests

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
@@ -103,7 +103,7 @@ pub struct BuildIgvmCliCustomizations {
 
     /// Ensure perf tools are included in the release initrd.
     ///
-    /// Ensures that openvmm_hcl_msft is not stripped, so that perf tools work
+    /// Ensures that openvmm_hcl is not stripped, so that perf tools work
     /// correctly, and requires that the file be built in `--release` mode, so
     /// that perf numbers are more representative of production binaries.
     #[clap(long, requires = "release")]

--- a/flowey/flowey_lib_hvlite/src/artifact_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/artifact_openhcl_igvm_from_recipe.rs
@@ -180,7 +180,7 @@ pub mod resolve {
 
                         let Some(recipe) = super::filename_to_recipe(entry_file_stem) else {
                             anyhow::bail!(
-                                "unexpected file in openhcl_msft_igvm artifact folder: {}",
+                                "unexpected file in openhcl_igvm artifact folder: {}",
                                 entry.path().display()
                             );
                         };

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -274,7 +274,7 @@ fn uefi_firmware_path(arch: MachineArch) -> anyhow::Result<PathBuf> {
 fn openhcl_bin_path(version: OpenhclVersion, flavor: OpenhclFlavor) -> anyhow::Result<PathBuf> {
     let (path, name, cmd) = match (version, flavor) {
         (OpenhclVersion::Latest, OpenhclFlavor::Standard) => (
-            "flowey-out/artifacts/build-igvm-msft/debug/x64",
+            "flowey-out/artifacts/build-igvm/debug/x64",
             "openhcl-x64.bin",
             MissingCommand::XFlowey {
                 description: "OpenHCL IGVM file",
@@ -282,7 +282,7 @@ fn openhcl_bin_path(version: OpenhclVersion, flavor: OpenhclFlavor) -> anyhow::R
             },
         ),
         (OpenhclVersion::Latest, OpenhclFlavor::Cvm) => (
-            "flowey-out/artifacts/build-igvm-msft/debug/x64-cvm",
+            "flowey-out/artifacts/build-igvm/debug/x64-cvm",
             "openhcl-x64-cvm.bin",
             MissingCommand::XFlowey {
                 description: "OpenHCL IGVM file",
@@ -290,7 +290,7 @@ fn openhcl_bin_path(version: OpenhclVersion, flavor: OpenhclFlavor) -> anyhow::R
             },
         ),
         (OpenhclVersion::Latest, OpenhclFlavor::LinuxDirect) => (
-            "flowey-out/artifacts/build-igvm-msft/debug/x64-test-linux-direct",
+            "flowey-out/artifacts/build-igvm/debug/x64-test-linux-direct",
             "openhcl-x64-test-linux-direct.bin",
             MissingCommand::XFlowey {
                 description: "OpenHCL IGVM file",
@@ -314,11 +314,11 @@ fn openhcl_extras_path(
 
     let (path, name) = match item {
         OpenhclExtras::UmBin => (
-            "flowey-out/artifacts/build-igvm-msft/debug/x64-test-linux-direct",
+            "flowey-out/artifacts/build-igvm/debug/x64-test-linux-direct",
             "openvmm_hcl_msft",
         ),
         OpenhclExtras::UmDbg => (
-            "flowey-out/artifacts/build-igvm-msft/debug/x64-test-linux-direct",
+            "flowey-out/artifacts/build-igvm/debug/x64-test-linux-direct",
             "openvmm_hcl_msft.dbg",
         ),
     };

--- a/xtask/src/tasks/build_igvm.rs
+++ b/xtask/src/tasks/build_igvm.rs
@@ -174,7 +174,7 @@ impl Xtask for BuildIgvm {
         log::warn!("  NOTE: The new `xflowey build-igvm` command has DIFFERENT output filenames and directories!");
         log::warn!("");
         log::warn!("    Old: `target/x86_64-unknown-linux-musl/debug/underhill-cvm.bin`");
-        log::warn!("    New: `flowey-out/artifacts/build-igvm-msft/x64-cvm/openhcl-cvm-x64.bin`");
+        log::warn!("    New: `flowey-out/artifacts/build-igvm/x64-cvm/openhcl-cvm-x64.bin`");
         log::warn!("");
 
         anyhow::bail!("`cargo xtask build-igvm` has been deleted!");


### PR DESCRIPTION
This should make it possible to once again run vmm tests locally without manually renaming folders. Let's see what breaks...