### PR TITLE
Remove not-really-helpful hv getters

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -247,8 +247,8 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
     ) -> HvResult<hvdef::HvRegisterValue> {
         match name.into() {
             hvdef::HvX64RegisterName::VsmCodePageOffsets => Ok(u64::from(
-                self.vp
-                    .hv(vtl)
+                self.vp.hv[vtl]
+                    .as_ref()
                     .expect("hv emulator exists for cvm")
                     .vsm_code_page_offsets(true),
             )

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1721,7 +1721,7 @@ impl UhProcessor<'_, TdxBacked> {
     fn read_tdvmcall_msr(&mut self, msr: u32, intercepted_vtl: GuestVtl) -> Result<u64, MsrError> {
         match msr {
             msr @ (hvdef::HV_X64_MSR_GUEST_OS_ID | hvdef::HV_X64_MSR_VP_INDEX) => {
-                self.hv(intercepted_vtl).unwrap().msr_read(msr)
+                self.hv[intercepted_vtl].as_ref().unwrap().msr_read(msr)
             }
             _ => self
                 .untrusted_synic
@@ -1738,8 +1738,8 @@ impl UhProcessor<'_, TdxBacked> {
         intercepted_vtl: GuestVtl,
     ) -> Result<(), MsrError> {
         match msr {
-            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => self
-                .hv_mut(intercepted_vtl)
+            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => self.hv[intercepted_vtl]
+                .as_mut()
                 .unwrap()
                 .msr_write(msr, value)?,
             _ => {


### PR DESCRIPTION
These helpers really don't add much, and in fact can't even be used everywhere we access hv due to adding a function call boundary. Just get rid of them.