### PR TITLE
[SNP Guest VSM] Clarify the role of the exit vtl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ dependencies = [
  "fs-err",
  "getrandom",
  "hvdef",
+ "inspect",
  "libc",
  "memory_range",
  "nix 0.26.4",

--- a/openhcl/hcl/Cargo.toml
+++ b/openhcl/hcl/Cargo.toml
@@ -14,6 +14,7 @@ sidecar_client.workspace = true
 tdcall = { workspace = true, features = ["tracing"] }
 vtl_array.workspace = true
 x86defs.workspace = true
+inspect.workspace = true
 
 parking_lot.workspace = true
 signal-hook.workspace = true

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1924,11 +1924,7 @@ impl<T: Backing> ProcessorRunner<'_, T> {
         // SAFETY: self.run is mapped, and the target_vtl field can only be
         // mutated or accessed by this object and only before the kernel is
         // invoked during `run`
-        unsafe {
-            let run_vtl = self.run.as_ref().target_vtl.target_vtl().unwrap();
-            assert!(run_vtl.is_none() || (run_vtl.unwrap() != Vtl::from(vtl)));
-            self.run.as_mut().target_vtl = vtl.into()
-        }
+        unsafe { self.run.as_mut().target_vtl = vtl.into() }
     }
 }
 

--- a/openhcl/hcl/src/lib.rs
+++ b/openhcl/hcl/src/lib.rs
@@ -11,6 +11,7 @@
 
 use hvdef::hypercall::HvInputVtl;
 use hvdef::Vtl;
+use inspect::Inspect;
 use thiserror::Error;
 
 pub mod ioctl;
@@ -23,7 +24,7 @@ pub mod vmsa;
 ///
 /// This is useful to use instead of [`Vtl`] to statically ensure that the VTL
 /// is not VTL2.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Inspect, PartialEq, Eq, PartialOrd, Ord)]
 pub enum GuestVtl {
     /// VTL0
     Vtl0,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -29,7 +29,6 @@ use zerocopy::FromZeroes;
 #[derive(Inspect, InspectMut)]
 pub struct GuestVsmVpState {
     // Used in VTL 2 exit code to determine which VTL to exit to.
-    #[inspect(with = "|x| u8::from(*x)")]
     pub exit_vtl: GuestVtl,
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -928,7 +928,8 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                         );
                         self.cvm_guest_vsm = Some(GuestVsmVpState {
                             // TODO CVM GUEST VSM: Revisit during AP startup if this is correct
-                            current_vtl: GuestVtl::Vtl0,
+                            last_vtl: None,
+                            exit_vtl: GuestVtl::Vtl0,
                         })
                     }
                 }
@@ -1121,8 +1122,6 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
     fn switch_vtl(&mut self, target_vtl: GuestVtl) {
         T::switch_vtl_state(self, target_vtl);
-
-        self.runner.set_exit_vtl(target_vtl);
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -234,9 +234,13 @@ mod private {
         /// This is used for hypervisor-managed and untrusted SINTs.
         fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16);
 
-        /// Copies shared registers (per VSM TLFS spec) from the last VTL to
+        /// Copies shared registers (per VSM TLFS spec) from the source VTL to
         /// the target VTL that will become active.
-        fn switch_vtl_state(this: &mut UhProcessor<'_, Self>, target_vtl: GuestVtl);
+        fn switch_vtl_state(
+            this: &mut UhProcessor<'_, Self>,
+            source_vtl: GuestVtl,
+            target_vtl: GuestVtl,
+        );
 
         /// Returns whether this VP should be put to sleep in usermode, or
         /// whether it's ready to proceed into the kernel.
@@ -928,7 +932,6 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                         );
                         self.cvm_guest_vsm = Some(GuestVsmVpState {
                             // TODO CVM GUEST VSM: Revisit during AP startup if this is correct
-                            last_vtl: None,
                             exit_vtl: GuestVtl::Vtl0,
                         })
                     }
@@ -1120,8 +1123,8 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
-    fn switch_vtl(&mut self, target_vtl: GuestVtl) {
-        T::switch_vtl_state(self, target_vtl);
+    fn switch_vtl(&mut self, source_vtl: GuestVtl, target_vtl: GuestVtl) {
+        T::switch_vtl_state(self, source_vtl, target_vtl);
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -219,7 +219,11 @@ impl BackingPrivate for HypervisorBackedArm64 {
 
     /// Copies shared registers (per VSM TLFS spec) from the last VTL to
     /// the target VTL that will become active.
-    fn switch_vtl_state(_this: &mut UhProcessor<'_, Self>, _target_vtl: GuestVtl) {
+    fn switch_vtl_state(
+        _this: &mut UhProcessor<'_, Self>,
+        _source_vtl: GuestVtl,
+        _target_vtl: GuestVtl,
+    ) {
         unreachable!("vtl switching should be managed by the hypervisor");
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -373,7 +373,11 @@ impl BackingPrivate for HypervisorBackedX86 {
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
     }
 
-    fn switch_vtl_state(_this: &mut UhProcessor<'_, Self>, _target_vtl: GuestVtl) {
+    fn switch_vtl_state(
+        _this: &mut UhProcessor<'_, Self>,
+        _source_vtl: GuestVtl,
+        _target_vtl: GuestVtl,
+    ) {
         unreachable!("vtl switching should be managed by the hypervisor");
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -917,7 +917,7 @@ impl UhProcessor<'_, SnpBacked> {
         let tlb_halt = self.should_halt_for_tlb_unlock(next_vtl);
 
         let halt = self.backing.lapics[next_vtl].halted
-            || self.backing.lapics[next_vtl].startup_suspend // TODO GUEST VSM
+            || self.backing.lapics[next_vtl].startup_suspend
             || tlb_halt;
 
         if halt && next_vtl == GuestVtl::Vtl1 && !tlb_halt {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -917,11 +917,11 @@ impl UhProcessor<'_, SnpBacked> {
         let tlb_halt = self.should_halt_for_tlb_unlock(next_vtl);
 
         let halt = self.backing.lapics[next_vtl].halted
-            || self.backing.lapics[GuestVtl::Vtl0].startup_suspend // TODO GUEST VSM
+            || self.backing.lapics[next_vtl].startup_suspend // TODO GUEST VSM
             || tlb_halt;
 
-        if halt && next_vtl == GuestVtl::Vtl1 {
-            tracelimit::warn_ratelimited!("halting VTL 1, which will halt the guest");
+        if halt && next_vtl == GuestVtl::Vtl1 && !tlb_halt {
+            tracelimit::warn_ratelimited!("halting VTL 1, which might halt the guest");
         }
 
         self.runner.set_halted(halt);

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -391,15 +391,13 @@ impl BackingPrivate for SnpBacked {
             .expect("requesting deliverability is not a fallable operation");
     }
 
-    fn switch_vtl_state(this: &mut UhProcessor<'_, Self>, target_vtl: GuestVtl) {
-        let current_vtl = this
-            .cvm_guest_vsm
-            .as_ref()
-            .expect("has guest vsm state")
-            .last_vtl;
-
+    fn switch_vtl_state(
+        this: &mut UhProcessor<'_, Self>,
+        source_vtl: GuestVtl,
+        target_vtl: GuestVtl,
+    ) {
         let [vmsa0, vmsa1] = this.runner.vmsas_mut();
-        let (current_vmsa, mut target_vmsa) = match (current_vtl, target_vtl) {
+        let (current_vmsa, mut target_vmsa) = match (source_vtl, target_vtl) {
             (GuestVtl::Vtl0, GuestVtl::Vtl1) => (vmsa0, vmsa1),
             (GuestVtl::Vtl1, GuestVtl::Vtl0) => (vmsa1, vmsa0),
             _ => unreachable!(),
@@ -934,7 +932,6 @@ impl UhProcessor<'_, SnpBacked> {
         let lazy_eoi = self.sync_lazy_eoi(next_vtl);
 
         if let Some(gvsm_state) = self.cvm_guest_vsm.as_mut() {
-            gvsm_state.intercepted_vtl = None;
             gvsm_state.exit_vtl = next_vtl; // TODO GUEST VSM: update next_vtl based on interrupts
         }
 
@@ -942,17 +939,6 @@ impl UhProcessor<'_, SnpBacked> {
             .runner
             .run()
             .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::Run(err)))?;
-
-        // If VTL 2 entered due to an intercept, fix up the last vtl
-        let mut set_intercepted_vtl = || {
-            if let Some(gvsm_state) = self.cvm_guest_vsm.as_mut() {
-                gvsm_state.intercepted_vtl = Some(next_vtl);
-            }
-        };
-
-        if has_intercept {
-            set_intercepted_vtl();
-        }
 
         let entered_from_vtl = next_vtl;
         let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
@@ -1046,7 +1032,6 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::MSR => {
-                set_intercepted_vtl();
                 let is_write = vmsa.exit_info1() & 1 != 0;
                 let msr = vmsa.rcx() as u32;
 
@@ -1129,7 +1114,6 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::IOIO => {
-                set_intercepted_vtl();
                 let io_info = x86defs::snp::SevIoAccessInfo::from(vmsa.exit_info1() as u32);
                 if io_info.string_access() || io_info.rep_access() {
                     self.emulate(dev, false, entered_from_vtl).await?;
@@ -1161,7 +1145,6 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::VMMCALL => {
-                set_intercepted_vtl();
                 let is_64bit = self.long_mode(entered_from_vtl);
                 let guest_memory = &self.partition.gm[entered_from_vtl];
                 let handler = UhHypercallHandler {
@@ -1195,7 +1178,6 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::NPF if has_intercept => {
-                set_intercepted_vtl();
                 // Determine whether an NPF needs to be handled. If not, assume this fault is spurious
                 // and that the instruction can be retried. The intercept itself may be presented by the
                 // hypervisor as either a GPA intercept or an exception intercept.
@@ -1285,7 +1267,6 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::VMGEXIT if has_intercept => {
-                set_intercepted_vtl();
                 has_intercept = false;
                 match self.runner.exit_message().header.typ {
                     HvMessageType::HvMessageTypeX64SevVmgexitIntercept => {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -396,7 +396,7 @@ impl BackingPrivate for SnpBacked {
             .cvm_guest_vsm
             .as_ref()
             .expect("has guest vsm state")
-            .current_vtl;
+            .last_vtl;
 
         let [vmsa0, vmsa1] = this.runner.vmsas_mut();
         let (current_vmsa, mut target_vmsa) = match (current_vtl, target_vtl) {
@@ -903,40 +903,58 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        // TODO CVM GUEST VSM: split out the "next vtl" that VTL 2 will exit to from
-        // last_vtl/current_vtl
-        let last_vtl = self
+        // TODO CVM GUEST VSM: actually check if there is an interrupt waiting
+        // for VTL 1 and switch to it if there is
+        let next_vtl = self
             .cvm_guest_vsm
             .as_ref()
-            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
+            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.exit_vtl);
 
-        let mut vmsa = self.runner.vmsa_mut(last_vtl);
+        let mut vmsa = self.runner.vmsa_mut(next_vtl);
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();
 
         vmsa.v_intr_cntrl_mut().set_guest_busy(false);
 
-        // TODO CVM GUEST VSM actually check and run vtl 1
         self.unlock_tlb_lock(Vtl::Vtl2);
-        let tlb_halt = self.should_halt_for_tlb_unlock(GuestVtl::Vtl0);
+        let tlb_halt = self.should_halt_for_tlb_unlock(next_vtl);
 
-        self.runner.set_halted(
-            self.backing.lapics[GuestVtl::Vtl0].halted
-                || self.backing.lapics[GuestVtl::Vtl0].startup_suspend
-                || tlb_halt,
-        );
+        let halt = self.backing.lapics[next_vtl].halted
+            || self.backing.lapics[GuestVtl::Vtl0].startup_suspend // TODO GUEST VSM
+            || tlb_halt;
+
+        if halt && next_vtl == GuestVtl::Vtl1 {
+            tracelimit::warn_ratelimited!("halting VTL 1, which will halt the guest");
+        }
+
+        self.runner.set_halted(halt);
+
+        self.runner.set_exit_vtl(next_vtl);
 
         // Set the lazy EOI bit just before running.
-        let lazy_eoi = self.sync_lazy_eoi(GuestVtl::Vtl0);
+        let lazy_eoi = self.sync_lazy_eoi(next_vtl);
+
+        if let Some(gvsm_state) = self.cvm_guest_vsm.as_mut() {
+            gvsm_state.intercepted_vtl = None;
+            gvsm_state.exit_vtl = next_vtl; // TODO GUEST VSM: update next_vtl based on interrupts
+        }
 
         let mut has_intercept = self
             .runner
             .run()
             .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::Run(err)))?;
 
-        let entered_from_vtl = self
-            .cvm_guest_vsm
-            .as_ref()
-            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
+        // If VTL 2 entered due to an intercept, fix up the last vtl
+        let mut set_intercepted_vtl = || {
+            if let Some(gvsm_state) = self.cvm_guest_vsm.as_mut() {
+                gvsm_state.intercepted_vtl = Some(next_vtl);
+            }
+        };
+
+        if has_intercept {
+            set_intercepted_vtl();
+        }
+
+        let entered_from_vtl = next_vtl;
         let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
 
         // TODO SNP: The guest busy bit needs to be tested and set atomically.
@@ -1028,6 +1046,7 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::MSR => {
+                set_intercepted_vtl();
                 let is_write = vmsa.exit_info1() & 1 != 0;
                 let msr = vmsa.rcx() as u32;
 
@@ -1110,6 +1129,7 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::IOIO => {
+                set_intercepted_vtl();
                 let io_info = x86defs::snp::SevIoAccessInfo::from(vmsa.exit_info1() as u32);
                 if io_info.string_access() || io_info.rep_access() {
                     self.emulate(dev, false, entered_from_vtl).await?;
@@ -1141,6 +1161,7 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::VMMCALL => {
+                set_intercepted_vtl();
                 let is_64bit = self.long_mode(entered_from_vtl);
                 let guest_memory = &self.partition.gm[entered_from_vtl];
                 let handler = UhHypercallHandler {
@@ -1174,6 +1195,7 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::NPF if has_intercept => {
+                set_intercepted_vtl();
                 // Determine whether an NPF needs to be handled. If not, assume this fault is spurious
                 // and that the instruction can be retried. The intercept itself may be presented by the
                 // hypervisor as either a GPA intercept or an exception intercept.
@@ -1263,6 +1285,7 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::VMGEXIT if has_intercept => {
+                set_intercepted_vtl();
                 has_intercept = false;
                 match self.runner.exit_message().header.typ {
                     HvMessageType::HvMessageTypeX64SevVmgexitIntercept => {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1146,6 +1146,8 @@ impl UhProcessor<'_, TdxBacked> {
             .run()
             .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::Run(e)))?;
 
+        // TODO GUEST_VSM: set the last vtl
+
         *self.runner.tdx_vp_entry_flags_mut() = TdxVmFlags::new();
 
         if !has_intercept {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -768,7 +768,11 @@ impl BackingPrivate for TdxBacked {
         }
     }
 
-    fn switch_vtl_state(_this: &mut UhProcessor<'_, Self>, _target_vtl: GuestVtl) {
+    fn switch_vtl_state(
+        _this: &mut UhProcessor<'_, Self>,
+        _source_vtl: GuestVtl,
+        _target_vtl: GuestVtl,
+    ) {
         todo!()
     }
 }
@@ -1096,6 +1100,11 @@ impl UhProcessor<'_, TdxBacked> {
     }
 
     async fn run_vp_tdx(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
+        let next_vtl = self
+            .cvm_guest_vsm
+            .as_ref()
+            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.exit_vtl);
+
         if self.backing.interruption_information.valid() {
             tracing::debug!(
                 vector = self.backing.interruption_information.vector(),
@@ -1146,18 +1155,13 @@ impl UhProcessor<'_, TdxBacked> {
             .run()
             .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::Run(e)))?;
 
-        // TODO GUEST_VSM: set the last vtl
-
         *self.runner.tdx_vp_entry_flags_mut() = TdxVmFlags::new();
 
         if !has_intercept {
             return Ok(());
         }
 
-        let entered_from_vtl = self
-            .cvm_guest_vsm
-            .as_ref()
-            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.current_vtl);
+        let entered_from_vtl = next_vtl;
 
         let exit_info = TdxExit(self.runner.tdx_vp_enter_exit_info());
 


### PR DESCRIPTION
Defines the roles of the various lower-vtl usages for guest vsm support in CVMs. With this change, the exit handling code is in charge of deciding what VTL to exit to and which VTL was entered from. VtlCall/Return hypercall handling stores the intended exit VTL as a hint to exit VTL 2 code.

Tested: SNP and TDX VMs boot, SNP with guest VSM runs VTL 1