### PR TITLE
Add missing argument in nextest docs

### DIFF
--- a/Guide/src/dev_guide/tests/vmm.md
+++ b/Guide/src/dev_guide/tests/vmm.md
@@ -23,7 +23,7 @@ VMM tests are run using standard Rust test infrastructure, and are invoked via
 `cargo test` / `cargo nextest`.
 
 ```bash
-cargo nextest run vmm_tests [TEST_FILTERS]
+cargo nextest run -p vmm_tests [TEST_FILTERS]
 ```
 
 For example, to run a simple VMM test that simply boots using UEFI:


### PR DESCRIPTION
The nextest command line requires a `-p` to specify which package to test, which was missing in the guide.