### PR TITLE
Additional error logs during platform initialization.

### DIFF
--- a/openhcl/underhill_attestation/src/key_protector.rs
+++ b/openhcl/underhill_attestation/src/key_protector.rs
@@ -250,8 +250,8 @@ impl KeyProtectorExt for KeyProtector {
             tracing::info!(
                 CVM_CONFIDENTIAL,
                 "store new egress key to dek[{}], size {}",
-                egress_idx,
-                new_egress_key.len()
+                egress_idx = egress_idx,
+                egress_key_len = new_egress_key.len()
             );
         }
 

--- a/openhcl/underhill_attestation/src/key_protector.rs
+++ b/openhcl/underhill_attestation/src/key_protector.rs
@@ -249,9 +249,9 @@ impl KeyProtectorExt for KeyProtector {
 
             tracing::info!(
                 CVM_CONFIDENTIAL,
-                "store new egress key to dek[{}], size {}",
                 egress_idx = egress_idx,
-                egress_key_len = new_egress_key.len()
+                egress_key_len = new_egress_key.len(),
+                "store new egress key to dek"
             );
         }
 

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -367,8 +367,10 @@ pub async fn initialize_platform_security(
 
     // Check if the VM id has been changed since last boot with KP write
     let vm_id_changed = if key_protector_by_id.found_id {
+        tracing::info!("VM Id has changed since last boot");
         key_protector_by_id.inner.id_guid != bios_guid
     } else {
+        tracing::info!("First booting of the VM");
         // Previous id in KP not found means this is the first boot,
         // treat id as unchanged for this case.
         false

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -44,7 +44,6 @@ use protocol::vmgs::SecurityProfile;
 use protocol::vmgs::AES_GCM_KEY_LENGTH;
 use secure_key_release::VmgsEncryptionKeys;
 use static_assertions::const_assert_eq;
-use std::any::Any;
 use std::fmt::Debug;
 use tee_call::TeeCall;
 use thiserror::Error;

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -364,10 +364,7 @@ pub async fn initialize_platform_security(
         tcb_version,
     )
     .await
-    .map_err(|e| {
-        tracing::error!("failed to derive keys");
-        AttestationErrorInner::GetDerivedKeys(e)
-    })?;
+    .map_err(AttestationErrorInner::GetDerivedKeys)?;
 
     // All Underhill VMs use VMGS encryption
     tracing::info!("Unlocking VMGS");

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -26,7 +26,6 @@ pub use protocol::igvm_attest::get::runtime_claims::AttestationVmConfig;
 use ::vmgs::EncryptionAlgorithm;
 use ::vmgs::Vmgs;
 use cvm_tracing::CVM_ALLOWED;
-use get_protocol::HOST_VMWP_ATTESTATION_GENERIC_ERROR_CODE;
 use guest_emulation_transport::api::GspExtendedStatusFlags;
 use guest_emulation_transport::api::GuestStateProtection;
 use guest_emulation_transport::api::GuestStateProtectionById;

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -26,6 +26,7 @@ pub use protocol::igvm_attest::get::runtime_claims::AttestationVmConfig;
 use ::vmgs::EncryptionAlgorithm;
 use ::vmgs::Vmgs;
 use cvm_tracing::CVM_ALLOWED;
+use get_protocol::HOST_VMWP_ATTESTATION_GENERIC_ERROR_CODE;
 use guest_emulation_transport::api::GspExtendedStatusFlags;
 use guest_emulation_transport::api::GuestStateProtection;
 use guest_emulation_transport::api::GuestStateProtectionById;
@@ -294,10 +295,7 @@ pub async fn initialize_platform_security(
             driver,
         )
         .await
-        .map_err(|e| {
-            tracing::error!("failed to retrieve key-encryption key");
-            AttestationErrorInner::RequestVmgsEncryptionKeys(e)
-        })?
+        .map_err(AttestationErrorInner::RequestVmgsEncryptionKeys)?
     } else {
         tracing::info!(CVM_ALLOWED, "Key-encryption key retrieval not required");
 
@@ -509,7 +507,7 @@ async fn unlock_vmgs_data_store(
                 // If last time we failed to remove old key then we'll come here.
                 // We have to remove old key before adding egress_key.
                 let key_index = if old_index == 0 { 1 } else { 0 };
-                tracing::trace!(CVM_ALLOWED, key_index, "Remove old key...");
+                tracing::trace!(CVM_ALLOWED, key_index = key_index, "Remove old key...");
                 vmgs.remove_encryption_key(key_index)
                     .await
                     .map_err(UnlockVmgsDataStoreError::RemoveOldVmgsEncryptionKey)?;

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -260,7 +260,6 @@ pub async fn initialize_platform_security(
     suppress_attestation: bool,
     driver: LocalDriver,
 ) -> Result<PlatformAttestationData, Error> {
-
     tracing::info!(CVM_ALLOWED,
         attestation_type=?attestation_type,
         secure_boot=attestation_vm_config.secure_boot,
@@ -280,10 +279,7 @@ pub async fn initialize_platform_security(
     // If attestation is suppressed, return the `agent_data` that is required by
     // TPM AK cert request.
     if suppress_attestation {
-        tracing::info!(
-            CVM_ALLOWED,
-            "Suppressing attestation"
-        );
+        tracing::info!(CVM_ALLOWED, "Suppressing attestation");
 
         return Ok(PlatformAttestationData {
             host_attestation_settings: HostAttestationSettings {
@@ -342,7 +338,7 @@ pub async fn initialize_platform_security(
     // Read Key Protector blob from VMGS
     tracing::info!(
         CVM_ALLOWED,
-        dek_minimal_size=dek_minimal_size,
+        dek_minimal_size = dek_minimal_size,
         "Reading key protector from VMGS"
     );
     let mut key_protector = vmgs::read_key_protector(vmgs, dek_minimal_size)
@@ -397,9 +393,7 @@ pub async fn initialize_platform_security(
     .await
     .map_err(|e| {
         Error::log_error_id(&e);
-        tracing::error!(
-            vmgs_encrypted=vmgs_encrypted,
-            "failed to derive keys");
+        tracing::error!(vmgs_encrypted = vmgs_encrypted, "failed to derive keys");
         AttestationErrorInner::GetDerivedKeys(e)
     })?;
 
@@ -433,8 +427,8 @@ pub async fn initialize_platform_security(
 
     tracing::info!(
         CVM_ALLOWED,
-        state_refresh_request_from_gsp=state_refresh_request_from_gsp,
-        vm_id_changed=vm_id_changed,
+        state_refresh_request_from_gsp = state_refresh_request_from_gsp,
+        vm_id_changed = vm_id_changed,
         "determine if refreshing tpm seeds is needed"
     );
 

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -162,11 +162,7 @@ pub async fn request_vmgs_encryption_keys(
                 rsa_aes_wrapped_key: _,
                 wrapped_des_key: _,
             }) => {
-                tracing::warn!(
-                    CVM_ALLOWED,
-                    retry = i,
-                    "Attempt to get VMGS key-encryption failed"
-                )
+                tracing::warn!(CVM_ALLOWED, retry = i, "Failed to get VMGS key-encryption")
             }
             Err(e) if i == (max_retry - 1) => Err(e)?,
             Err(e) => {

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -154,7 +154,10 @@ pub async fn request_vmgs_encryption_keys(
             Ok(WrappedKeyVmgsEncryptionKeys {
                 rsa_aes_wrapped_key: _,
                 wrapped_des_key: _,
-            }) if i == (max_retry - 1) => break,
+            }) if i == (max_retry - 1) => {
+                tracing::error!("VMGS key-encryption failed after max number of attempts");
+                break;
+            }
             Ok(WrappedKeyVmgsEncryptionKeys {
                 rsa_aes_wrapped_key: _,
                 wrapped_des_key: _,
@@ -162,7 +165,7 @@ pub async fn request_vmgs_encryption_keys(
                 tracing::warn!(
                     CVM_ALLOWED,
                     retry = i,
-                    "VMGS key-encryption key is not released"
+                    "Attempt to get VMGS key-encryption failed"
                 )
             }
             Err(e) if i == (max_retry - 1) => Err(e)?,
@@ -171,7 +174,7 @@ pub async fn request_vmgs_encryption_keys(
                     CVM_ALLOWED,
                     retry = i,
                     error = &e as &dyn std::error::Error,
-                    "VMGS key-encryption key request failed",
+                    "VMGS key-encryption key request failed due to error",
                 )
             }
         }
@@ -186,7 +189,7 @@ pub async fn request_vmgs_encryption_keys(
                 .map_err(RequestVmgsEncryptionKeysError::Pkcs11RsaAesKeyUnwrap)?,
         )
     } else {
-        tracing::warn!(CVM_ALLOWED, "tenant vmgs ingress key is not released");
+        tracing::error!(CVM_ALLOWED, "failed to unwrap VMGS key-encryption key");
 
         get.event_log_fatal(guest_emulation_transport::api::EventLogId::KEY_NOT_RELEASED)
             .await;

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -26,8 +26,6 @@ pub const MAX_HEADER_SIZE: usize = 256;
 // (required due to underlying vmbus pipe message size constraints)
 pub const MAX_PAYLOAD_SIZE: usize = 8192;
 
-pub const HOST_VMWP_ATTESTATION_GENERIC_ERROR_CODE: usize = 0xFFFFFFFF;
-
 const_assert!(MAX_MESSAGE_SIZE >= MAX_HEADER_SIZE + MAX_PAYLOAD_SIZE);
 
 /// {455C0F1B-D51B-40B1-BEAC-87377FE6E041}
@@ -585,6 +583,10 @@ pub const IGVM_ATTEST_MSG_REQ_REPORT_MAX_SIZE: usize = 4096;
 pub const IGVM_ATTEST_MSG_MAX_SHARED_GPA: usize = 16;
 /// Current return pages
 pub const IGVM_ATTEST_MSG_SHARED_GPA: usize = IGVM_ATTEST_MSG_MAX_SHARED_GPA;
+
+// Error from the VM worker process in the host when sending an
+// attestation request.
+pub const IGVM_ATTEST_VMWP_GENERIC_ERROR_CODE: usize = 0xFFFFFFFF;
 
 /// The response payload could be quite large, so pass host
 /// previously shared pages to use for response.

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -26,6 +26,8 @@ pub const MAX_HEADER_SIZE: usize = 256;
 // (required due to underlying vmbus pipe message size constraints)
 pub const MAX_PAYLOAD_SIZE: usize = 8192;
 
+pub const HOST_VMWP_ATTESTATION_GENERIC_ERROR_CODE: usize = 0xFFFFFFFF;
+
 const_assert!(MAX_MESSAGE_SIZE >= MAX_HEADER_SIZE + MAX_PAYLOAD_SIZE);
 
 /// {455C0F1B-D51B-40B1-BEAC-87377FE6E041}

--- a/vm/devices/get/guest_emulation_transport/src/error.rs
+++ b/vm/devices/get/guest_emulation_transport/src/error.rs
@@ -78,6 +78,8 @@ pub enum IgvmAttestError {
         input_size: usize,
         expected_size: usize,
     },
+    #[error("IGVM agent returned an error")]
+    IgvmAgentGenericError,
 }
 
 pub(crate) trait TryIntoProtocolBool {

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -1814,7 +1814,6 @@ async fn request_igvm_attest(
 ) -> Result<Result<Vec<u8>, IgvmAttestError>, FatalError> {
     const ALLOCATED_SHARED_MEMORY_SIZE: usize =
         get_protocol::IGVM_ATTEST_MSG_SHARED_GPA * hvdef::HV_PAGE_SIZE_USIZE;
-    const HOST_GENERIC_ERROR_CODE: usize = 0xFFFFFFFF;
 
     let (Some(shared_pool_allocator), Some(shared_guest_memory)) =
         (&shared_pool_allocator, &shared_guest_memory)
@@ -1854,7 +1853,7 @@ async fn request_igvm_attest(
     };
 
     let response_length = response.length as usize;
-    if response_length == HOST_GENERIC_ERROR_CODE {
+    if response_length == get_protocol::HOST_VMWP_ATTESTATION_GENERIC_ERROR_CODE {
         tracing::error!("Agent returned an error");
         return Ok(Err(IgvmAttestError::IgvmAgentGenericError));
     } else if response_length > ALLOCATED_SHARED_MEMORY_SIZE {

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -1815,6 +1815,7 @@ async fn request_igvm_attest(
     const ALLOCATED_SHARED_MEMORY_SIZE: usize =
         get_protocol::IGVM_ATTEST_MSG_SHARED_GPA * hvdef::HV_PAGE_SIZE_USIZE;
 
+    tracing::info!("Processing request_igvm_attest");
     let (Some(shared_pool_allocator), Some(shared_guest_memory)) =
         (&shared_pool_allocator, &shared_guest_memory)
     else {
@@ -1853,7 +1854,10 @@ async fn request_igvm_attest(
     };
 
     let response_length = response.length as usize;
-    if response_length > ALLOCATED_SHARED_MEMORY_SIZE {
+    if response_length == 0xFFFFFFFF {
+        tracing::error!("IGVM Agent returned an error");
+        return Ok(Err(IgvmAttestError::IgvmAgentGenericError));
+    } else if response_length > ALLOCATED_SHARED_MEMORY_SIZE {
         Err(FatalError::InvalidIgvmAttestResponseSize {
             response_size: response_length,
             maximum_size: ALLOCATED_SHARED_MEMORY_SIZE,

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -1853,7 +1853,7 @@ async fn request_igvm_attest(
     };
 
     let response_length = response.length as usize;
-    if response_length == get_protocol::HOST_VMWP_ATTESTATION_GENERIC_ERROR_CODE {
+    if response_length == get_protocol::IGVM_ATTEST_VMWP_GENERIC_ERROR_CODE {
         return Ok(Err(IgvmAttestError::IgvmAgentGenericError));
     } else if response_length > ALLOCATED_SHARED_MEMORY_SIZE {
         Err(FatalError::InvalidIgvmAttestResponseSize {

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -1814,6 +1814,7 @@ async fn request_igvm_attest(
 ) -> Result<Result<Vec<u8>, IgvmAttestError>, FatalError> {
     const ALLOCATED_SHARED_MEMORY_SIZE: usize =
         get_protocol::IGVM_ATTEST_MSG_SHARED_GPA * hvdef::HV_PAGE_SIZE_USIZE;
+    const HOST_GENERIC_ERROR_CODE: usize = 0xFFFFFFFF;
 
     tracing::info!("Processing request_igvm_attest");
     let (Some(shared_pool_allocator), Some(shared_guest_memory)) =
@@ -1854,8 +1855,8 @@ async fn request_igvm_attest(
     };
 
     let response_length = response.length as usize;
-    if response_length == 0xFFFFFFFF {
-        tracing::error!("IGVM Agent returned an error");
+    if response_length == HOST_GENERIC_ERROR_CODE {
+        tracing::error!("Agent returned an error");
         return Ok(Err(IgvmAttestError::IgvmAgentGenericError));
     } else if response_length > ALLOCATED_SHARED_MEMORY_SIZE {
         Err(FatalError::InvalidIgvmAttestResponseSize {

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -1854,7 +1854,6 @@ async fn request_igvm_attest(
 
     let response_length = response.length as usize;
     if response_length == get_protocol::HOST_VMWP_ATTESTATION_GENERIC_ERROR_CODE {
-        tracing::error!("Agent returned an error");
         return Ok(Err(IgvmAttestError::IgvmAgentGenericError));
     } else if response_length > ALLOCATED_SHARED_MEMORY_SIZE {
         Err(FatalError::InvalidIgvmAttestResponseSize {

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -1816,7 +1816,6 @@ async fn request_igvm_attest(
         get_protocol::IGVM_ATTEST_MSG_SHARED_GPA * hvdef::HV_PAGE_SIZE_USIZE;
     const HOST_GENERIC_ERROR_CODE: usize = 0xFFFFFFFF;
 
-    tracing::info!("Processing request_igvm_attest");
     let (Some(shared_pool_allocator), Some(shared_guest_memory)) =
         (&shared_pool_allocator, &shared_guest_memory)
     else {


### PR DESCRIPTION
Additional error logs during platform initialization.

Example output from a failure.
```
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_core::worker","Fields":"{\"message\":\"failed to start VM\",\"error\":[\"failed to initialize platform security\",\"failed to request vmgs encryption keys\",\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}","Message":"{\"timestamp\":\"13.348678604s\",\"level\":\"ERROR\",\"target\":\"underhill_core::worker\",\"related_activity_id\":\"0829af09-0000-003e-0100-000040000000\",\"fields\":{\"message\":\"failed to start VM\",\"error\":[\"failed to initialize platform security\",\"failed to request vmgs encryption keys\",\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_attestation","Fields":"{\"message\":\"failed to retrieve key-encryption key\",\"attestation_type\":\"Tdx\"}","Message":"{\"timestamp\":\"13.348415765s\",\"level\":\"ERROR\",\"target\":\"underhill_attestation\",\"related_activity_id\":\"6cd39487-0000-003e-0400-000040002000\",\"fields\":{\"message\":\"failed to retrieve key-encryption key\",\"attestation_type\":\"Tdx\"}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"guest_emulation_transport::process_loop","Fields":"{\"message\":\"Agent returned an error\"}","Message":"{\"timestamp\":\"13.348302718s\",\"level\":\"ERROR\",\"target\":\"guest_emulation_transport::process_loop\",\"fields\":{\"message\":\"Agent returned an error\"}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_attestation::secure_key_release","Fields":"{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":8,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}","Message":"{\"timestamp\":\"12.161429040s\",\"level\":\"ERROR\",\"target\":\"underhill_attestation::secure_key_release\",\"related_activity_id\":\"6cd39487-0000-003e-0400-000040002000\",\"fields\":{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":8,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"guest_emulation_transport::process_loop","Fields":"{\"message\":\"Agent returned an error\"}","Message":"{\"timestamp\":\"12.161313919s\",\"level\":\"ERROR\",\"target\":\"guest_emulation_transport::process_loop\",\"fields\":{\"message\":\"Agent returned an error\"}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_attestation::secure_key_release","Fields":"{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":7,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}","Message":"{\"timestamp\":\"10.983605364s\",\"level\":\"ERROR\",\"target\":\"underhill_attestation::secure_key_release\",\"related_activity_id\":\"6cd39487-0000-003e-0400-000040002000\",\"fields\":{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":7,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"guest_emulation_transport::process_loop","Fields":"{\"message\":\"Agent returned an error\"}","Message":"{\"timestamp\":\"10.983426485s\",\"level\":\"ERROR\",\"target\":\"guest_emulation_transport::process_loop\",\"fields\":{\"message\":\"Agent returned an error\"}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_attestation::secure_key_release","Fields":"{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":6,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}","Message":"{\"timestamp\":\"9.476082382s\",\"level\":\"ERROR\",\"target\":\"underhill_attestation::secure_key_release\",\"related_activity_id\":\"6cd39487-0000-003e-0400-000040002000\",\"fields\":{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":6,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"guest_emulation_transport::process_loop","Fields":"{\"message\":\"Agent returned an error\"}","Message":"{\"timestamp\":\"9.476005517s\",\"level\":\"ERROR\",\"target\":\"guest_emulation_transport::process_loop\",\"fields\":{\"message\":\"Agent returned an error\"}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_attestation::secure_key_release","Fields":"{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":5,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}","Message":"{\"timestamp\":\"8.324955956s\",\"level\":\"ERROR\",\"target\":\"underhill_attestation::secure_key_release\",\"related_activity_id\":\"6cd39487-0000-003e-0400-000040002000\",\"fields\":{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":5,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"guest_emulation_transport::process_loop","Fields":"{\"message\":\"Agent returned an error\"}","Message":"{\"timestamp\":\"8.324882401s\",\"level\":\"ERROR\",\"target\":\"guest_emulation_transport::process_loop\",\"fields\":{\"message\":\"Agent returned an error\"}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_attestation::secure_key_release","Fields":"{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":4,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}","Message":"{\"timestamp\":\"7.145144612s\",\"level\":\"ERROR\",\"target\":\"underhill_attestation::secure_key_release\",\"related_activity_id\":\"6cd39487-0000-003e-0400-000040002000\",\"fields\":{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":4,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"guest_emulation_transport::process_loop","Fields":"{\"message\":\"Agent returned an error\"}","Message":"{\"timestamp\":\"7.145070978s\",\"level\":\"ERROR\",\"target\":\"guest_emulation_transport::process_loop\",\"fields\":{\"message\":\"Agent returned an error\"}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_attestation::secure_key_release","Fields":"{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":3,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}","Message":"{\"timestamp\":\"5.937921373s\",\"level\":\"ERROR\",\"target\":\"underhill_attestation::secure_key_release\",\"related_activity_id\":\"6cd39487-0000-003e-0400-000040002000\",\"fields\":{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":3,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"guest_emulation_transport::process_loop","Fields":"{\"message\":\"Agent returned an error\"}","Message":"{\"timestamp\":\"5.937846387s\",\"level\":\"ERROR\",\"target\":\"guest_emulation_transport::process_loop\",\"fields\":{\"message\":\"Agent returned an error\"}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_attestation::secure_key_release","Fields":"{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":2,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}","Message":"{\"timestamp\":\"4.423430944s\",\"level\":\"ERROR\",\"target\":\"underhill_attestation::secure_key_release\",\"related_activity_id\":\"6cd39487-0000-003e-0400-000040002000\",\"fields\":{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":2,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"guest_emulation_transport::process_loop","Fields":"{\"message\":\"Agent returned an error\"}","Message":"{\"timestamp\":\"4.423358113s\",\"level\":\"ERROR\",\"target\":\"guest_emulation_transport::process_loop\",\"fields\":{\"message\":\"Agent returned an error\"}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_attestation::secure_key_release","Fields":"{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":1,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}","Message":"{\"timestamp\":\"3.264854191s\",\"level\":\"ERROR\",\"target\":\"underhill_attestation::secure_key_release\",\"related_activity_id\":\"6cd39487-0000-003e-0400-000040002000\",\"fields\":{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":1,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"guest_emulation_transport::process_loop","Fields":"{\"message\":\"Agent returned an error\"}","Message":"{\"timestamp\":\"3.264712644s\",\"level\":\"ERROR\",\"target\":\"guest_emulation_transport::process_loop\",\"fields\":{\"message\":\"Agent returned an error\"}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"underhill_attestation::secure_key_release","Fields":"{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":0,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}","Message":"{\"timestamp\":\"2.056434015s\",\"level\":\"ERROR\",\"target\":\"underhill_attestation::secure_key_release\",\"related_activity_id\":\"6cd39487-0000-003e-0400-000040002000\",\"fields\":{\"message\":\"VMGS key-encryption key request failed due to error\",\"retry\":0,\"error\":[\"failed to make an IgvmAttest KEY_RELEASE GET request\",\"IGVM agent returned an error\"]}}"}
{"VmId":"70970671-31e9-4b7a-b0c8-4de489492d8b","VmName":"fc5daf76-04f4-4fc3-b377-9dcd78b3f4ba","CorrelationId":"00000000-0000-0000-0000-000000000000","Name":"","Target":"guest_emulation_transport::process_loop","Fields":"{\"message\":\"Agent returned an error\"}","Message":"{\"timestamp\":\"2.056257894s\",\"level\":\"ERROR\",\"target\":\"guest_emulation_transport::process_loop\",\"fields\":{\"message\":\"Agent returned an error\"}}"}
```