### PR TITLE
virt_support_x86emu: downgrade expected trace to debug

### DIFF
--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -397,7 +397,7 @@ pub async fn emulate<T: EmulatorSupport>(
                 ));
             }
             x86emu::Error::InstructionException(exception, error_code, cause) => {
-                tracelimit::error_ratelimited!(
+                tracelimit::debug!(
                     ?exception,
                     ?error_code,
                     ?cause,

--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -397,7 +397,7 @@ pub async fn emulate<T: EmulatorSupport>(
                 ));
             }
             x86emu::Error::InstructionException(exception, error_code, cause) => {
-                tracelimit::debug!(
+                tracing::trace!(
                     ?exception,
                     ?error_code,
                     ?cause,


### PR DESCRIPTION
It's not an error for the instruction emulator to need to inject an exception, e.g., due to single stepping in the debugger.

Reported by @neerajsi-msft.