### PR TITLE
Move exit_vtl to vp cvm state and remove the option

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -276,6 +276,8 @@ impl From<EnterMode> for hcl::protocol::EnterMode {
 pub struct UhCvmVpState {
     /// The VTLs on this VP waiting for TLB locks on other VPs.
     vtls_tlb_waiting: VtlArray<bool, 2>,
+    /// Used in VTL 2 exit code to determine which VTL to exit to.
+    exit_vtl: GuestVtl,
 }
 
 #[cfg(guest_arch = "x86_64")]
@@ -284,6 +286,7 @@ impl UhCvmVpState {
     pub fn new() -> Self {
         Self {
             vtls_tlb_waiting: VtlArray::new(false),
+            exit_vtl: GuestVtl::Vtl0,
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -20,17 +20,9 @@ use hvdef::HvMapGpaFlags;
 use hvdef::HvRegisterVsmPartitionConfig;
 use hvdef::HvResult;
 use hvdef::Vtl;
-use inspect::Inspect;
-use inspect::InspectMut;
 use std::iter::zip;
 use virt::io::CpuIo;
 use zerocopy::FromZeroes;
-
-#[derive(Inspect, InspectMut)]
-pub struct GuestVsmVpState {
-    // Used in VTL 2 exit code to determine which VTL to exit to.
-    pub exit_vtl: GuestVtl,
-}
 
 impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
     pub fn hcvm_enable_partition_vtl(
@@ -356,11 +348,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         tracing::trace!("handling vtl call");
 
         self.vp.switch_vtl(self.intercepted_vtl, GuestVtl::Vtl1);
-        self.vp
-            .cvm_guest_vsm
-            .as_mut()
-            .expect("has guest vsm state")
-            .exit_vtl = GuestVtl::Vtl1;
+        self.vp.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl1;
 
         // TODO GUEST_VSM: Force reevaluation of the VTL 1 APIC in case delivery of
         // low-priority interrupts was suppressed while in VTL 0.

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -903,10 +903,7 @@ impl UhProcessor<'_, SnpBacked> {
     async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
         // TODO CVM GUEST VSM: actually check if there is an interrupt waiting
         // for VTL 1 and switch to it if there is
-        let next_vtl = self
-            .cvm_guest_vsm
-            .as_ref()
-            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.exit_vtl);
+        let next_vtl = self.backing.cvm.exit_vtl;
 
         let mut vmsa = self.runner.vmsa_mut(next_vtl);
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();
@@ -931,9 +928,7 @@ impl UhProcessor<'_, SnpBacked> {
         // Set the lazy EOI bit just before running.
         let lazy_eoi = self.sync_lazy_eoi(next_vtl);
 
-        if let Some(gvsm_state) = self.cvm_guest_vsm.as_mut() {
-            gvsm_state.exit_vtl = next_vtl; // TODO GUEST VSM: update next_vtl based on interrupts
-        }
+        // TODO GUEST VSM: update next_vtl based on interrupts
 
         let mut has_intercept = self
             .runner

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1100,10 +1100,7 @@ impl UhProcessor<'_, TdxBacked> {
     }
 
     async fn run_vp_tdx(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let next_vtl = self
-            .cvm_guest_vsm
-            .as_ref()
-            .map_or(GuestVtl::Vtl0, |gvsm_state| gvsm_state.exit_vtl);
+        let next_vtl = self.backing.cvm.exit_vtl;
 
         if self.backing.interruption_information.valid() {
             tracing::debug!(


### PR DESCRIPTION
This removes some expects, and removes one more field from UhProcessor that isn't used globally. The option also isn't needed, since we can just leave this at Vtl0.