### PR TITLE
nvme: complete the reset implementation

### DIFF
--- a/vm/devices/storage/nvme/src/pci.rs
+++ b/vm/devices/storage/nvme/src/pci.rs
@@ -426,8 +426,9 @@ impl ChangeDeviceState for NvmeController {
             msix: _,
             registers,
             qe_sizes,
-            workers: _, // TODO
+            workers,
         } = self;
+        workers.reset().await;
         cfg_space.reset();
         *registers = RegState::new();
         *qe_sizes.lock() = Default::default();


### PR DESCRIPTION
Before `reset` was an async function, it was not possible to implement reset for NVMe (which use some external tasks). `reset` was made async a while back, so finish the NVMe implementation.

This fixes the use of NVMe after guest-initiated reset.