### PR TITLE
Move tlb_lock_info to CvmPartitionState

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -302,6 +302,11 @@ pub struct UhCvmPartitionState {
         with = "|arr| inspect::iter_by_index(arr.iter()).map_value(|bb| inspect::iter_by_index(bb.iter().map(|v| *v)))"
     )]
     tlb_locked_vps: VtlArray<BitBox<AtomicU64>, 2>,
+    /// The current status of TLB locks, per-VP.
+    #[inspect(
+        with = "|vec| inspect::iter_by_index(vec.iter().map(|arr| inspect::iter_by_index(arr.iter())))"
+    )]
+    tlb_lock_info: Vec<VtlArray<TlbLockInfo, 2>>,
 }
 
 #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
@@ -541,10 +546,6 @@ struct UhVpInner {
     #[inspect(with = "|arr| inspect::iter_by_index(arr.iter().map(|v| v.lock().is_some()))")]
     hv_start_enable_vtl_vp: VtlArray<Mutex<Option<Box<hvdef::hypercall::InitialVpContextX64>>>, 2>,
     sidecar_exit_reason: Mutex<Option<SidecarExitReason>>,
-    // TODO: move the below into some per-backing state, as it's only used on HCVM,
-    // but needs to be accessed by other VPs.
-    /// The current status of TLB locks.
-    tlb_lock_info: VtlArray<TlbLockInfo, 2>,
 }
 
 #[derive(Debug, Inspect)]
@@ -1265,7 +1266,7 @@ impl UhPartition {
                 // TODO: determine CPU index, which in theory could be different
                 // from the VP index.
                 let cpu_index = vp_info.base.vp_index.index();
-                UhVpInner::new(cpu_index, vp_info, params.topology.vp_count() as usize)
+                UhVpInner::new(cpu_index, vp_info)
             })
             .collect();
 
@@ -1625,25 +1626,32 @@ impl UhPartition {
         isolation: IsolationType,
         vp_count: usize,
     ) -> Result<Option<UhCvmPartitionState>, Error> {
-        let cvm_state = match isolation {
-            IsolationType::Snp => Some(UhCvmPartitionState {
-                cpuid: cvm_cpuid::CpuidResults::new(cvm_cpuid::CpuidResultsIsolationType::Snp {
+        let cpuid = match isolation {
+            IsolationType::Snp => Some(
+                cvm_cpuid::CpuidResults::new(cvm_cpuid::CpuidResultsIsolationType::Snp {
                     cpuid_pages: cvm_cpuid_info.unwrap(),
                 })
                 .map_err(Error::CvmCpuid)?,
-                tlb_locked_vps: VtlArray::from_fn(|_| {
-                    BitVec::repeat(false, vp_count).into_boxed_bitslice()
-                }),
-            }),
-            IsolationType::Tdx => Some(UhCvmPartitionState {
-                cpuid: cvm_cpuid::CpuidResults::new(cvm_cpuid::CpuidResultsIsolationType::Tdx)
+            ),
+            IsolationType::Tdx => Some(
+                cvm_cpuid::CpuidResults::new(cvm_cpuid::CpuidResultsIsolationType::Tdx)
                     .map_err(Error::CvmCpuid)?,
-                tlb_locked_vps: VtlArray::from_fn(|_| {
-                    BitVec::repeat(false, vp_count).into_boxed_bitslice()
-                }),
-            }),
+            ),
             IsolationType::Vbs | IsolationType::None => None,
         };
+
+        let cvm_state = cpuid.map(|cpuid| {
+            let tlb_lock_info = (0..vp_count)
+                .map(|_| VtlArray::from_fn(|_| TlbLockInfo::new(vp_count)))
+                .collect();
+            let tlb_locked_vps =
+                VtlArray::from_fn(|_| BitVec::repeat(false, vp_count).into_boxed_bitslice());
+            UhCvmPartitionState {
+                cpuid,
+                tlb_locked_vps,
+                tlb_lock_info,
+            }
+        });
 
         Ok(cvm_state)
     }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -548,6 +548,7 @@ struct UhVpInner {
     sidecar_exit_reason: Mutex<Option<SidecarExitReason>>,
 }
 
+#[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
 #[derive(Debug, Inspect)]
 struct TlbLockInfo {
     /// The set of VPs that are waiting for this VP to release the TLB lock.
@@ -565,6 +566,7 @@ struct TlbLockInfo {
     sleeping: AtomicBool,
 }
 
+#[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
 impl TlbLockInfo {
     fn new(vp_count: usize) -> Self {
         Self {

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/tlb_lock.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/tlb_lock.rs
@@ -19,7 +19,7 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
         // any VP that acquires the lock after this point is guaranteed to see
         // state that this VP has already flushed.
         let self_index = self.vp_index().index() as usize;
-        let self_lock = &self.inner.tlb_lock_info[target_vtl];
+        let self_lock = &self.backing.cvm_partition_state().tlb_lock_info[self_index][target_vtl];
         for vp in self.backing.cvm_partition_state().tlb_locked_vps[target_vtl]
             .clone()
             .iter_ones()
@@ -42,7 +42,8 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
             // Now advise the target VP that it is blocking this VP.
             // Because the wait by the current VP on the target VP is known to
             // be new, this bit should not already be set.
-            let other_lock_blocked = &self.partition.vps[vp].tlb_lock_info[target_vtl].blocked_vps;
+            let other_lock_blocked =
+                &self.backing.cvm_partition_state().tlb_lock_info[vp][target_vtl].blocked_vps;
             let _was_other_lock_blocked = other_lock_blocked.set_aliased(self_index, true);
             debug_assert!(!_was_other_lock_blocked);
 
@@ -108,12 +109,13 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
                 // of blocked VPs may be changing, it must be captured locally, since the
                 // VP set scan below cannot safely be performed on a VP set that may be
                 // changing.
-                for blocked_vp in self.inner.tlb_lock_info[target_vtl]
+                for blocked_vp in self.backing.cvm_partition_state().tlb_lock_info[self_index]
+                    [target_vtl]
                     .blocked_vps
                     .clone()
                     .iter_ones()
                 {
-                    self.inner.tlb_lock_info[target_vtl]
+                    self.backing.cvm_partition_state().tlb_lock_info[self_index][target_vtl]
                         .blocked_vps
                         .set_aliased(blocked_vp, false);
 
@@ -121,7 +123,8 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
                     // Note that the target VP may have already marked itself as not
                     // blocked if is has already noticed that the lock has already
                     // been released on the current VP.
-                    let other_lock = &self.partition.vps[blocked_vp].tlb_lock_info[target_vtl];
+                    let other_lock =
+                        &self.backing.cvm_partition_state().tlb_lock_info[blocked_vp][target_vtl];
                     if other_lock.blocking_vps.set_aliased(self_index, false) {
                         let other_old_count =
                             other_lock.blocking_vp_count.fetch_sub(1, Ordering::Relaxed);
@@ -145,12 +148,13 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
 
     /// Returns whether the VP should halt to wait for the TLB lock of the specified VTL.
     pub fn should_halt_for_tlb_unlock(&mut self, target_vtl: GuestVtl) -> bool {
-        let vtl_tlb_waiting = &mut self.backing.cvm_state_mut().vtls_tlb_waiting[target_vtl];
+        let self_index = self.vp_index().index() as usize;
         // No wait is required if this VP is not blocked on the TLB lock.
-        if *vtl_tlb_waiting {
+        if self.backing.cvm_state_mut().vtls_tlb_waiting[target_vtl] {
             // No wait is required unless this VP is blocked on another VP that
             // holds the TLB flush lock.
-            let self_lock = &self.inner.tlb_lock_info[target_vtl];
+            let self_lock =
+                &self.backing.cvm_partition_state().tlb_lock_info[self_index][target_vtl];
             if self_lock.blocking_vp_count.load(Ordering::Relaxed) != 0 {
                 self_lock.sleeping.store(true, Ordering::Relaxed);
                 // Now that this VP has been marked as sleeping, check to see
@@ -162,10 +166,10 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
 
                 self_lock.sleeping.store(false, Ordering::Relaxed);
             }
-            *vtl_tlb_waiting = false;
+            self.backing.cvm_state_mut().vtls_tlb_waiting[target_vtl] = false;
         } else {
             debug_assert_eq!(
-                self.inner.tlb_lock_info[target_vtl]
+                self.backing.cvm_partition_state().tlb_lock_info[self_index][target_vtl]
                     .blocking_vp_count
                     .load(Ordering::Relaxed),
                 0

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -323,7 +323,7 @@ pub enum SidecarRemoveExit {
 
 impl UhVpInner {
     // Create a new vp's state.
-    pub fn new(cpu_index: u32, vp_info: TargetVpInfo, vp_count: usize) -> Self {
+    pub fn new(cpu_index: u32, vp_info: TargetVpInfo) -> Self {
         Self {
             wake_reasons: Default::default(),
             message_queues: VtlArray::from_fn(|_| MessageQueues::new()),
@@ -333,7 +333,6 @@ impl UhVpInner {
             hcvm_vtl1_enabled: Mutex::new(false),
             hv_start_enable_vtl_vp: VtlArray::from_fn(|_| Mutex::new(None)),
             sidecar_exit_reason: Default::default(),
-            tlb_lock_info: VtlArray::<_, 2>::from_fn(|_| super::TlbLockInfo::new(vp_count)),
         }
     }
 


### PR DESCRIPTION
This is only used for CVM, so now it's in CVM only state.