### PR TITLE
Updates to the getting started sections of the openvmm developer guide

### DIFF
--- a/Guide/src/dev_guide/contrib/pr.md
+++ b/Guide/src/dev_guide/contrib/pr.md
@@ -1,3 +1,3 @@
 # Submitting Changes
 
-Follow the [CONTRIBUTING](https://github.com/microsoft/openvmm/blob/main/CONTRIBUTING.md) guide.
+Follow the [CONTRIBUTING](https://github.com/microsoft/openvmm/blob/main/CONTRIBUTE.MD) guide.

--- a/Guide/src/dev_guide/getting_started/build_openvmm.md
+++ b/Guide/src/dev_guide/getting_started/build_openvmm.md
@@ -6,10 +6,10 @@
   - [Getting started on Windows](./windows.md)
   - [Getting started on Linux / WSL2](./linux.md).
 
-* * *
-
+```admonish tip
 It is strongly suggested that you use WSL2, and [cross compile](./suggested_dev_env.md#wsl2-cross-compiling-from-wsl2-to-windows)
 for Windows when necessary.
+```
 
 ## Build Dependencies
 
@@ -26,23 +26,6 @@ cargo xflowey restore-packages
 
 If you intend to cross-compile, refer to the command's `--help` for additional
 options related to downloading packages for other architectures.
-
-### \[Linux] Additional Dependencies
-
-On Linux, there are various other dependencies you will need depending on what
-you're working on. On Debian-based distros such as Ubuntu, running the following
-command within WSL will install these dependencies.
-
-In the future, it is likely that this step will be folded into the
-`cargo xflowey restore-packages` command.
-
-```bash
-$ sudo apt install \
-  binutils              \
-  build-essential       \
-  gcc-aarch64-linux-gnu \
-  libssl-dev
-```
 
 ## Building
 

--- a/Guide/src/dev_guide/getting_started/linux.md
+++ b/Guide/src/dev_guide/getting_started/linux.md
@@ -43,6 +43,23 @@ over to it.
 
 Please follow the [official instructions](https://www.rust-lang.org/tools/install) to do so.
 
+## \[Linux] Additional Dependencies
+
+On Linux, there are various other dependencies you will need depending on what
+you're working on. On Debian-based distros such as Ubuntu, running the following
+command within WSL will install these dependencies.
+
+In the future, it is likely that this step will be folded into the
+`cargo xflowey restore-packages` command.
+
+```bash
+$ sudo apt install \
+  binutils              \
+  build-essential       \
+  gcc-aarch64-linux-gnu \
+  libssl-dev
+```
+
 ## Cloning the OpenVMM source
 
 **If using WSL2:** Do NOT clone the repo into Windows then try to access said


### PR DESCRIPTION
This is a collection of several small changes to the OpenVMM developer guide. I am setting up a new clone of this environment and following the instructions in linear order. What prompted me to first make this change is that I encountered an error running `cargo xflowey restore-packages`: it seemed to need a linker. I found going "out of order" a bit jarring. Since the same core dependencies are required to build OpenVMM and OpenHCL (I think), and we expect contributors to set up their environment first, I moved this up. And, I noticed a broken link.

* Fix broken link to the contributing guide.
* Move the Linux compiler / linker prereqs to the Linux / WSL2 setup page. These are necessary before the xflowey restore.
* Use the fancy new admonish plugin for the cross compile tip.