### PR TITLE
loader: simplify handling of multiple VTLs

### DIFF
--- a/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
@@ -89,6 +89,8 @@ pub enum Error {
     UnsupportedGuestArch,
     #[error("igvm file does not support vbs")]
     NoVbsSupport,
+    #[error("vp context for lower VTL not supported")]
+    LowerVtlContext,
 }
 
 fn from_memory_range(range: &MemoryRange) -> IGVM_VHS_MEMORY_RANGE {
@@ -995,6 +997,10 @@ fn load_igvm_x86(
                 ref registers,
                 compatibility_mask: _,
             } => {
+                if from_igvm_vtl(vtl) != max_vtl {
+                    return Err(Error::LowerVtlContext);
+                }
+
                 let mut cr3: Option<u64> = None;
                 let mut cr4: Option<u64> = None;
 
@@ -1097,7 +1103,7 @@ fn load_igvm_x86(
                     };
 
                     loader
-                        .import_vp_register(from_igvm_vtl(vtl), reloc_reg)
+                        .import_vp_register(reloc_reg)
                         .map_err(Error::Loader)?;
                 }
 

--- a/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
@@ -421,7 +421,7 @@ pub fn load_linux_arm64(
 
     // Set the registers separately so they won't conflict with the UEFI boot when
     // `load_kernel_and_initrd_arm64` is used for VTL2 direct kernel boot.
-    loader::linux::set_direct_boot_registers_arm64(&mut loader, &load_info, hvdef::Vtl::Vtl0)
+    loader::linux::set_direct_boot_registers_arm64(&mut loader, &load_info)
         .map_err(Error::Loader)?;
 
     Ok(loader.initial_regs())

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -11,10 +11,10 @@ use crate::signed_measurement::generate_snp_measurement;
 use crate::signed_measurement::generate_tdx_measurement;
 use crate::signed_measurement::generate_vbs_measurement;
 use crate::vp_context_builder::snp::InjectionType;
-use crate::vp_context_builder::snp::SnpVpContextBuilder;
-use crate::vp_context_builder::tdx::TdxVpContextBuilder;
+use crate::vp_context_builder::snp::SnpHardwareContext;
+use crate::vp_context_builder::tdx::TdxHardwareContext;
 use crate::vp_context_builder::vbs::VbsRegister;
-use crate::vp_context_builder::vbs::VbsVpContextBuilder;
+use crate::vp_context_builder::vbs::VbsVpContext;
 use crate::vp_context_builder::VpContextBuilder;
 use crate::vp_context_builder::VpContextPageState;
 use crate::vp_context_builder::VpContextState;
@@ -57,7 +57,6 @@ use std::fmt::Display;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 
-pub const HV_NUM_VTLS: usize = 3;
 pub const DEFAULT_COMPATIBILITY_MASK: u32 = 0x1;
 
 const TDX_SHARED_GPA_BOUNDARY_BITS: u8 = 47;
@@ -101,12 +100,24 @@ pub struct IgvmLoader<R: VbsRegister + GuestArch> {
     initialization_headers: Vec<IgvmInitializationHeader>,
     directives: Vec<IgvmDirectiveHeader>,
     page_data_directives: Vec<IgvmDirectiveHeader>,
-    vp_context_builder: Option<Box<dyn VpContextBuilder<Register = R>>>,
+    vp_context: Option<Box<dyn VpContextBuilder<Register = R>>>,
+    lower_vtl_context: Option<VbsVpContext<R>>,
     max_vtl: Vtl,
     parameter_areas: BTreeMap<(u64, u32), u32>,
     isolation_type: LoaderIsolationType,
     paravisor_present: bool,
     imported_regions_config_page: Option<u64>,
+}
+
+pub struct IgvmVtlLoader<'a, R: VbsRegister + GuestArch> {
+    loader: &'a mut IgvmLoader<R>,
+    vtl: Vtl,
+}
+
+impl<R: VbsRegister + GuestArch> IgvmVtlLoader<'_, R> {
+    pub fn loader(&self) -> &IgvmLoader<R> {
+        self.loader
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -192,15 +203,12 @@ impl IgvmLoaderRegister for X86Register {
                     compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
                 };
 
-                let vp_context_builder = Box::new(
-                    SnpVpContextBuilder::new(
-                        max_vtl,
-                        !with_paravisor,
-                        shared_gpa_boundary,
-                        injection_type,
-                    )
-                    .expect("must be valid"),
-                );
+                let vp_context_builder = Box::new(SnpHardwareContext::new(
+                    max_vtl,
+                    !with_paravisor,
+                    shared_gpa_boundary,
+                    injection_type,
+                ));
 
                 (platform_header, vec![init_header], vp_context_builder)
             }
@@ -224,9 +232,7 @@ impl IgvmLoaderRegister for X86Register {
                     });
                 }
 
-                let vp_context_builder = Box::new(
-                    TdxVpContextBuilder::new(max_vtl, !with_paravisor).expect("must be valid"),
-                );
+                let vp_context_builder = Box::new(TdxHardwareContext::new(!with_paravisor));
 
                 (platform_header, init_headers, vp_context_builder)
             }
@@ -473,7 +479,7 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
 
         match isolation_type {
             LoaderIsolationType::None | LoaderIsolationType::Vbs { .. } => {
-                vp_context_builder = Some(Box::new(VbsVpContextBuilder::<R>::new()));
+                vp_context_builder = Some(Box::new(VbsVpContext::<R>::new(max_vtl.into())));
 
                 // Add VBS platform header
                 let info = IGVM_VHS_SUPPORTED_PLATFORM {
@@ -496,6 +502,12 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             }
         }
 
+        let lower_vtl_context_builder = if with_paravisor {
+            Some(VbsVpContext::new(Vtl::Vtl0.into()))
+        } else {
+            None
+        };
+
         IgvmLoader {
             accepted_ranges: RangeMap::new(),
             relocatable_regions: RangeMap::new(),
@@ -505,7 +517,8 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             initialization_headers,
             directives: Vec::new(),
             page_data_directives: Vec::new(),
-            vp_context_builder,
+            vp_context: vp_context_builder,
+            lower_vtl_context: lower_vtl_context_builder,
             max_vtl,
             parameter_areas: BTreeMap::new(),
             isolation_type,
@@ -555,13 +568,13 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
     /// Finalize the loader state, returning an IGVM file.
     pub fn finalize(mut self, guest_svn: u32) -> anyhow::Result<IgvmOutput> {
         // Finalize any VP state.
-        for context in self
-            .vp_context_builder
-            .take()
-            .expect("should never be none")
-            .finalize()
-            .into_iter()
-        {
+        let mut state = Vec::new();
+        self.vp_context.take().unwrap().finalize(&mut state);
+        if let Some(mut context) = self.lower_vtl_context.take() {
+            context.finalize(&mut state);
+        }
+
+        for context in state {
             match context {
                 VpContextState::Page(VpContextPageState {
                     page_base,
@@ -751,128 +764,11 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             _ => false,
         }
     }
-}
 
-impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R> {
-    fn isolation_config(&self) -> IsolationConfig {
-        match self.isolation_type {
-            LoaderIsolationType::None => IsolationConfig {
-                paravisor_present: self.paravisor_present,
-                isolation_type: IsolationType::None,
-                shared_gpa_boundary_bits: None,
-            },
-            LoaderIsolationType::Vbs { .. } => IsolationConfig {
-                paravisor_present: self.paravisor_present,
-                isolation_type: IsolationType::Vbs,
-                shared_gpa_boundary_bits: None,
-            },
-            LoaderIsolationType::Snp {
-                shared_gpa_boundary_bits,
-                policy: _,
-                injection_type: _,
-            } => IsolationConfig {
-                paravisor_present: self.paravisor_present,
-                isolation_type: IsolationType::Snp,
-                shared_gpa_boundary_bits,
-            },
-            LoaderIsolationType::Tdx { .. } => IsolationConfig {
-                paravisor_present: self.paravisor_present,
-                isolation_type: IsolationType::Tdx,
-                shared_gpa_boundary_bits: Some(TDX_SHARED_GPA_BOUNDARY_BITS),
-            },
-        }
-    }
-
-    fn create_parameter_area(
-        &mut self,
-        page_base: u64,
-        page_count: u32,
-        debug_tag: &str,
-    ) -> anyhow::Result<ParameterAreaIndex> {
-        self.create_parameter_area_with_data(page_base, page_count, debug_tag, &[])
-    }
-
-    fn create_parameter_area_with_data(
-        &mut self,
-        page_base: u64,
-        page_count: u32,
-        debug_tag: &str,
-        initial_data: &[u8],
-    ) -> anyhow::Result<ParameterAreaIndex> {
-        let area_id = (page_base, page_count);
-
-        // Allocate a new parameter area, that must not overlap other accepted ranges.
-        self.accept_new_range(
-            page_base,
-            page_count as u64,
-            debug_tag,
-            BootPageAcceptance::ExclusiveUnmeasured,
-        )?;
-
-        let index: u32 = self
-            .parameter_areas
-            .len()
-            .try_into()
-            .expect("parameter area greater than u32");
-        self.parameter_areas.insert(area_id, index);
-
-        // Add the newly allocated parameter area index to headers.
-        self.directives.push(IgvmDirectiveHeader::ParameterArea {
-            number_of_bytes: page_count as u64 * PAGE_SIZE_4K,
-            parameter_area_index: index,
-            initial_data: initial_data.to_vec(),
-        });
-
-        tracing::debug!(
-            index,
-            page_base,
-            page_count,
-            initial_data_len = initial_data.len(),
-            "Creating new parameter area",
-        );
-
-        Ok(ParameterAreaIndex(index))
-    }
-
-    fn import_parameter(
-        &mut self,
-        parameter_area: ParameterAreaIndex,
-        byte_offset: u32,
-        parameter_type: IgvmParameterType,
-    ) -> anyhow::Result<()> {
-        let index = parameter_area.0;
-
-        if index >= self.parameter_areas.len() as u32 {
-            anyhow::bail!("invalid parameter area index: {:x}", index);
-        }
-
-        tracing::debug!(
-            ?parameter_type,
-            parameter_area_index = parameter_area.0,
-            byte_offset,
-            "Importing parameter",
-        );
-
-        let info = IGVM_VHS_PARAMETER {
-            parameter_area_index: index,
-            byte_offset,
-        };
-
-        let header = match parameter_type {
-            IgvmParameterType::VpCount => IgvmDirectiveHeader::VpCount(info),
-            IgvmParameterType::Srat => IgvmDirectiveHeader::Srat(info),
-            IgvmParameterType::Madt => IgvmDirectiveHeader::Madt(info),
-            IgvmParameterType::Slit => IgvmDirectiveHeader::Slit(info),
-            IgvmParameterType::Pptt => IgvmDirectiveHeader::Pptt(info),
-            IgvmParameterType::MmioRanges => IgvmDirectiveHeader::MmioRanges(info),
-            IgvmParameterType::MemoryMap => IgvmDirectiveHeader::MemoryMap(info),
-            IgvmParameterType::CommandLine => IgvmDirectiveHeader::CommandLine(info),
-            IgvmParameterType::DeviceTree => IgvmDirectiveHeader::DeviceTree(info),
-        };
-
-        self.directives.push(header);
-
-        Ok(())
+    pub fn for_vtl(&mut self, vtl: Vtl) -> IgvmVtlLoader<'_, R> {
+        assert!(vtl <= self.max_vtl);
+        assert!(vtl == Vtl::Vtl0 || vtl == Vtl::Vtl2);
+        IgvmVtlLoader { loader: self, vtl }
     }
 
     fn import_pages(
@@ -882,7 +778,7 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
         debug_tag: &str,
         acceptance: BootPageAcceptance,
         mut data: &[u8],
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), anyhow::Error> {
         tracing::debug!(
             page_base,
             ?acceptance,
@@ -974,19 +870,159 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
 
         Ok(())
     }
+}
 
-    fn import_vp_register(&mut self, vtl: Vtl, register: R) -> anyhow::Result<()> {
-        if vtl > self.max_vtl {
-            anyhow::bail!(
-                "vtl specified {vtl:?} is greater than max enabled vtl {:?}",
-                self.max_vtl
-            );
+impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmVtlLoader<'_, R> {
+    fn isolation_config(&self) -> IsolationConfig {
+        match self.loader.isolation_type {
+            LoaderIsolationType::None => IsolationConfig {
+                paravisor_present: self.loader.paravisor_present,
+                isolation_type: IsolationType::None,
+                shared_gpa_boundary_bits: None,
+            },
+            LoaderIsolationType::Vbs { .. } => IsolationConfig {
+                paravisor_present: self.loader.paravisor_present,
+                isolation_type: IsolationType::Vbs,
+                shared_gpa_boundary_bits: None,
+            },
+            LoaderIsolationType::Snp {
+                shared_gpa_boundary_bits,
+                policy: _,
+                injection_type: _,
+            } => IsolationConfig {
+                paravisor_present: self.loader.paravisor_present,
+                isolation_type: IsolationType::Snp,
+                shared_gpa_boundary_bits,
+            },
+            LoaderIsolationType::Tdx { .. } => IsolationConfig {
+                paravisor_present: self.loader.paravisor_present,
+                isolation_type: IsolationType::Tdx,
+                shared_gpa_boundary_bits: Some(TDX_SHARED_GPA_BOUNDARY_BITS),
+            },
+        }
+    }
+
+    fn create_parameter_area(
+        &mut self,
+        page_base: u64,
+        page_count: u32,
+        debug_tag: &str,
+    ) -> anyhow::Result<ParameterAreaIndex> {
+        self.create_parameter_area_with_data(page_base, page_count, debug_tag, &[])
+    }
+
+    fn create_parameter_area_with_data(
+        &mut self,
+        page_base: u64,
+        page_count: u32,
+        debug_tag: &str,
+        initial_data: &[u8],
+    ) -> anyhow::Result<ParameterAreaIndex> {
+        let area_id = (page_base, page_count);
+
+        // Allocate a new parameter area, that must not overlap other accepted ranges.
+        self.loader.accept_new_range(
+            page_base,
+            page_count as u64,
+            debug_tag,
+            BootPageAcceptance::ExclusiveUnmeasured,
+        )?;
+
+        let index: u32 = self
+            .loader
+            .parameter_areas
+            .len()
+            .try_into()
+            .expect("parameter area greater than u32");
+        self.loader.parameter_areas.insert(area_id, index);
+
+        // Add the newly allocated parameter area index to headers.
+        self.loader
+            .directives
+            .push(IgvmDirectiveHeader::ParameterArea {
+                number_of_bytes: page_count as u64 * PAGE_SIZE_4K,
+                parameter_area_index: index,
+                initial_data: initial_data.to_vec(),
+            });
+
+        tracing::debug!(
+            index,
+            page_base,
+            page_count,
+            initial_data_len = initial_data.len(),
+            "Creating new parameter area",
+        );
+
+        Ok(ParameterAreaIndex(index))
+    }
+
+    fn import_parameter(
+        &mut self,
+        parameter_area: ParameterAreaIndex,
+        byte_offset: u32,
+        parameter_type: IgvmParameterType,
+    ) -> anyhow::Result<()> {
+        let index = parameter_area.0;
+
+        if index >= self.loader.parameter_areas.len() as u32 {
+            anyhow::bail!("invalid parameter area index: {:x}", index);
         }
 
-        self.vp_context_builder
-            .as_mut()
-            .expect("option should always be some")
-            .import_vp_register(vtl, register);
+        tracing::debug!(
+            ?parameter_type,
+            parameter_area_index = parameter_area.0,
+            byte_offset,
+            "Importing parameter",
+        );
+
+        let info = IGVM_VHS_PARAMETER {
+            parameter_area_index: index,
+            byte_offset,
+        };
+
+        let header = match parameter_type {
+            IgvmParameterType::VpCount => IgvmDirectiveHeader::VpCount(info),
+            IgvmParameterType::Srat => IgvmDirectiveHeader::Srat(info),
+            IgvmParameterType::Madt => IgvmDirectiveHeader::Madt(info),
+            IgvmParameterType::Slit => IgvmDirectiveHeader::Slit(info),
+            IgvmParameterType::Pptt => IgvmDirectiveHeader::Pptt(info),
+            IgvmParameterType::MmioRanges => IgvmDirectiveHeader::MmioRanges(info),
+            IgvmParameterType::MemoryMap => IgvmDirectiveHeader::MemoryMap(info),
+            IgvmParameterType::CommandLine => IgvmDirectiveHeader::CommandLine(info),
+            IgvmParameterType::DeviceTree => IgvmDirectiveHeader::DeviceTree(info),
+        };
+
+        self.loader.directives.push(header);
+
+        Ok(())
+    }
+
+    fn import_pages(
+        &mut self,
+        page_base: u64,
+        page_count: u64,
+        debug_tag: &str,
+        acceptance: BootPageAcceptance,
+        data: &[u8],
+    ) -> anyhow::Result<()> {
+        self.loader
+            .import_pages(page_base, page_count, debug_tag, acceptance, data)
+    }
+
+    fn import_vp_register(&mut self, register: R) -> anyhow::Result<()> {
+        if self.vtl < self.loader.max_vtl {
+            self.loader
+                .vp_context
+                .as_mut()
+                .unwrap()
+                .import_vp_register(register);
+        } else {
+            self.loader
+                .lower_vtl_context
+                .as_mut()
+                .unwrap()
+                .import_vp_register(register)
+        }
 
         Ok(())
     }
@@ -1017,14 +1053,16 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
         let vtl2_protectable =
             memory_type == loader::importer::StartupMemoryType::Vtl2ProtectableRam;
 
-        self.directives.push(IgvmDirectiveHeader::RequiredMemory {
-            gpa,
-            compatibility_mask,
-            number_of_bytes,
-            vtl2_protectable,
-        });
+        self.loader
+            .directives
+            .push(IgvmDirectiveHeader::RequiredMemory {
+                gpa,
+                compatibility_mask,
+                number_of_bytes,
+                vtl2_protectable,
+            });
 
-        self.required_memory.push(RequiredMemory {
+        self.loader.required_memory.push(RequiredMemory {
             range: MemoryRange::new(gpa..gpa + number_of_bytes as u64),
             vtl2_protectable,
         });
@@ -1032,39 +1070,26 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
         Ok(())
     }
 
-    fn set_vp_context_page(
-        &mut self,
-        vtl: Vtl,
-        page_base: u64,
-        acceptance: BootPageAcceptance,
-    ) -> anyhow::Result<()> {
-        if vtl > self.max_vtl {
-            anyhow::bail!(
-                "vtl specified {vtl:?} is greater than max enabled vtl {:?}",
-                self.max_vtl
-            );
-        }
-
-        self.vp_context_builder
+    fn set_vp_context_page(&mut self, page_base: u64) -> anyhow::Result<()> {
+        self.loader
+            .vp_context
             .as_mut()
-            .expect("option should always be some")
-            .set_vp_context_memory(vtl, page_base, acceptance);
+            .unwrap()
+            .set_vp_context_memory(page_base);
 
         Ok(())
     }
 
-    fn vp_context_page(&self, vtl: Vtl) -> anyhow::Result<u64> {
-        if vtl > self.max_vtl {
-            anyhow::bail!(
-                "vtl specified {vtl:?} is greater than max enabled vtl {:?}",
-                self.max_vtl
-            );
+    fn set_lower_vtl_context_page(&mut self, page_base: u64) -> anyhow::Result<()> {
+        if self.vtl != Vtl::Vtl0 {
+            self.loader
+                .lower_vtl_context
+                .as_mut()
+                .unwrap()
+                .set_vp_context_memory(page_base);
         }
 
-        self.vp_context_builder
-            .as_ref()
-            .expect("option should always be some")
-            .vp_context_page(vtl)
+        Ok(())
     }
 
     fn relocation_region(
@@ -1074,13 +1099,12 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
         relocation_alignment: u64,
         minimum_relocation_gpa: u64,
         maximum_relocation_gpa: u64,
-        is_vtl2: bool,
         apply_rip_offset: bool,
         apply_gdtr_offset: bool,
         vp_index: u16,
-        vtl: Vtl,
     ) -> anyhow::Result<()> {
         if let Some(overlap) = self
+            .loader
             .relocatable_regions
             .get_range(gpa..=(gpa + size_bytes - 1))
         {
@@ -1116,7 +1140,8 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
             );
         }
 
-        self.initialization_headers
+        self.loader
+            .initialization_headers
             .push(IgvmInitializationHeader::RelocatableRegion {
                 compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
                 relocation_alignment,
@@ -1124,14 +1149,14 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
                 relocation_region_size: size_bytes,
                 minimum_relocation_gpa,
                 maximum_relocation_gpa,
-                is_vtl2,
+                is_vtl2: self.vtl == Vtl::Vtl2,
                 apply_rip_offset,
                 apply_gdtr_offset,
                 vp_index,
-                vtl: to_igvm_vtl(vtl),
+                vtl: to_igvm_vtl(self.vtl),
             });
 
-        self.relocatable_regions.insert(
+        self.loader.relocatable_regions.insert(
             gpa..=gpa + size_bytes - 1,
             RelocationType::Normal(IgvmRelocatableRegion {
                 base_gpa: gpa,
@@ -1139,11 +1164,11 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
                 minimum_relocation_gpa,
                 maximum_relocation_gpa,
                 relocation_alignment,
-                is_vtl2,
+                is_vtl2: self.vtl == Vtl::Vtl2,
                 apply_rip_offset,
                 apply_gdtr_offset,
                 vp_index,
-                vtl: to_igvm_vtl(vtl),
+                vtl: to_igvm_vtl(self.vtl),
             }),
         );
 
@@ -1156,10 +1181,9 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
         size_pages: u64,
         used_size_pages: u64,
         vp_index: u16,
-        vtl: Vtl,
     ) -> anyhow::Result<()> {
         // can only be one set
-        if let Some(region) = &self.page_table_region {
+        if let Some(region) = &self.loader.page_table_region {
             anyhow::bail!("page table relocation already set {:?}", region)
         }
 
@@ -1172,22 +1196,27 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
         let end_gpa = page_table_gpa + size_pages * PAGE_SIZE_4K - 1;
 
         // cannot override other relocatable regions
-        if let Some(overlap) = self.relocatable_regions.get_range(page_table_gpa..=end_gpa) {
+        if let Some(overlap) = self
+            .loader
+            .relocatable_regions
+            .get_range(page_table_gpa..=end_gpa)
+        {
             anyhow::bail!(
                 "new page table relocation region overlaps existing region {:?}",
                 overlap
             );
         }
 
-        self.initialization_headers
-            .push(IgvmInitializationHeader::PageTableRelocationRegion {
+        self.loader.initialization_headers.push(
+            IgvmInitializationHeader::PageTableRelocationRegion {
                 compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
                 gpa: page_table_gpa,
                 size: size_pages * PAGE_SIZE_4K,
                 used_size: used_size_pages * PAGE_SIZE_4K,
                 vp_index,
-                vtl: to_igvm_vtl(vtl),
-            });
+                vtl: to_igvm_vtl(self.vtl),
+            },
+        );
 
         let region = PageTableRegion {
             gpa: page_table_gpa,
@@ -1195,18 +1224,18 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmLoader<R>
             used_size_pages,
         };
 
-        self.relocatable_regions.insert(
+        self.loader.relocatable_regions.insert(
             page_table_gpa..=end_gpa,
             RelocationType::PageTable(region.clone()),
         );
 
-        self.page_table_region = Some(region);
+        self.loader.page_table_region = Some(region);
 
         Ok(())
     }
 
     fn set_imported_regions_config_page(&mut self, page_base: u64) {
-        self.imported_regions_config_page = Some(page_base);
+        self.loader.imported_regions_config_page = Some(page_base);
     }
 }
 
@@ -1309,20 +1338,23 @@ mod tests {
                 enable_debug: false,
             },
         );
+        {
+            let mut loader = loader.for_vtl(Vtl::Vtl0);
 
-        let data = vec![0, 5];
-        loader
-            .import_pages(0, 5, "data", BootPageAcceptance::Exclusive, &data)
-            .unwrap();
-        loader
-            .import_pages(5, 5, "data", BootPageAcceptance::ExclusiveUnmeasured, &data)
-            .unwrap();
-        loader
-            .import_pages(10, 1, "data", BootPageAcceptance::Exclusive, &data)
-            .unwrap();
-        loader
-            .import_pages(20, 1, "data", BootPageAcceptance::Shared, &data)
-            .unwrap();
+            let data = vec![0, 5];
+            loader
+                .import_pages(0, 5, "data", BootPageAcceptance::Exclusive, &data)
+                .unwrap();
+            loader
+                .import_pages(5, 5, "data", BootPageAcceptance::ExclusiveUnmeasured, &data)
+                .unwrap();
+            loader
+                .import_pages(10, 1, "data", BootPageAcceptance::Exclusive, &data)
+                .unwrap();
+            loader
+                .import_pages(20, 1, "data", BootPageAcceptance::Shared, &data)
+                .unwrap();
+        }
 
         let igvm_output = loader.finalize(1).unwrap();
         let doc = igvm_output.doc.expect("doc");

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -1017,6 +1017,7 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmVtlLoader
                 .unwrap()
                 .import_vp_register(register);
         } else {
+            assert_eq!(self.vtl, Vtl::Vtl0);
             self.loader
                 .lower_vtl_context
                 .as_mut()

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -1010,7 +1010,7 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmVtlLoader
     }
 
     fn import_vp_register(&mut self, register: R) -> anyhow::Result<()> {
-        if self.vtl < self.loader.max_vtl {
+        if self.vtl == self.loader.max_vtl {
             self.loader
                 .vp_context
                 .as_mut()

--- a/vm/loader/igvmfilegen/src/vp_context_builder/mod.rs
+++ b/vm/loader/igvmfilegen/src/vp_context_builder/mod.rs
@@ -7,7 +7,6 @@ pub mod snp;
 pub mod tdx;
 pub mod vbs;
 
-use hvdef::Vtl;
 use igvm::IgvmDirectiveHeader;
 use loader::importer::BootPageAcceptance;
 
@@ -33,15 +32,12 @@ pub trait VpContextBuilder {
     type Register;
 
     /// Import a register to the BSP at the given vtl.
-    fn import_vp_register(&mut self, vtl: Vtl, register: Self::Register);
+    fn import_vp_register(&mut self, register: Self::Register);
 
     /// Define the base of the GPA range to be used for architecture-specific VP context data.
-    fn set_vp_context_memory(&mut self, vtl: Vtl, page_base: u64, acceptance: BootPageAcceptance);
-
-    /// Obtain the page base of the GPA range to be used for architecture specific VP context data.
-    fn vp_context_page(&self, vtl: Vtl) -> anyhow::Result<u64>;
+    fn set_vp_context_memory(&mut self, page_base: u64);
 
     /// Finalize all VP context data. Returns architecture specific data that should be either imported
     /// into guest memory space or added directly to the IGVM file.
-    fn finalize(self: Box<Self>) -> Vec<VpContextState>;
+    fn finalize(&mut self, state: &mut Vec<VpContextState>);
 }

--- a/vm/loader/src/common.rs
+++ b/vm/loader/src/common.rs
@@ -8,7 +8,6 @@ use crate::importer::ImageLoad;
 use crate::importer::SegmentRegister;
 use crate::importer::TableRegister;
 use crate::importer::X86Register;
-use hvdef::Vtl;
 use hvdef::HV_PAGE_SIZE;
 use vm_topology::memory::MemoryLayout;
 use x86defs::GdtEntry;
@@ -63,7 +62,7 @@ pub fn import_default_gdt(
     )?;
 
     // Import GDTR and selectors.
-    let mut import_reg = |register| importer.import_vp_register(Vtl::Vtl0, register);
+    let mut import_reg = |register| importer.import_vp_register(register);
     import_reg(X86Register::Gdtr(TableRegister {
         base: gdt_page_base * HV_PAGE_SIZE,
         limit: (size_of::<GdtEntry>() * DEFAULT_GDT_COUNT - 1) as u16,

--- a/vm/loader/src/importer.rs
+++ b/vm/loader/src/importer.rs
@@ -9,8 +9,6 @@ pub use Aarch64Register as Register;
 #[cfg(guest_arch = "x86_64")]
 pub use X86Register as Register;
 
-use hvdef::Vtl;
-
 /// The page acceptance used for importing pages into the initial launch context
 /// of the guest.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -474,8 +472,8 @@ where
         data: &[u8],
     ) -> anyhow::Result<()>;
 
-    /// Import a register into the BSP at the given VTL.
-    fn import_vp_register(&mut self, vtl: Vtl, register: R) -> anyhow::Result<()>;
+    /// Import a register into the BSP.
+    fn import_vp_register(&mut self, register: R) -> anyhow::Result<()>;
 
     /// Verify with the loader that memory is available in guest address space with the given type.
     fn verify_startup_memory_available(
@@ -488,15 +486,10 @@ where
     /// Notify the loader to deposit architecture specific VP context information at the given page.
     ///
     /// TODO: It probably makes sense to use a different acceptance type than the default one?
-    fn set_vp_context_page(
-        &mut self,
-        vtl: Vtl,
-        page_base: u64,
-        acceptance: BootPageAcceptance,
-    ) -> anyhow::Result<()>;
+    fn set_vp_context_page(&mut self, page_base: u64) -> anyhow::Result<()>;
 
-    /// Obtain the page base of the GPA range to be used for architecture specific VP context data.
-    fn vp_context_page(&self, vtl: Vtl) -> anyhow::Result<u64>;
+    /// Notify the loader to deposit lower VTL context information at the given page.
+    fn set_lower_vtl_context_page(&mut self, page_base: u64) -> anyhow::Result<()>;
 
     /// Specify this region as relocatable.
     fn relocation_region(
@@ -506,11 +499,9 @@ where
         relocation_alignment: u64,
         minimum_relocation_gpa: u64,
         maximum_relocation_gpa: u64,
-        is_vtl2: bool,
         apply_rip_offset: bool,
         apply_gdtr_offset: bool,
         vp_index: u16,
-        vtl: Vtl,
     ) -> anyhow::Result<()>;
 
     /// Specify a region as relocatable page table memory.
@@ -520,7 +511,6 @@ where
         size_pages: u64,
         used_pages: u64,
         vp_index: u16,
-        vtl: Vtl,
     ) -> anyhow::Result<()>;
 
     /// Lets the loader know what the base page of where the config page

--- a/vm/loader/src/linux.rs
+++ b/vm/loader/src/linux.rs
@@ -18,7 +18,6 @@ use aarch64defs::TranslationControlEl1;
 use aarch64defs::TranslationGranule0;
 use aarch64defs::TranslationGranule1;
 use bitfield_struct::bitfield;
-use hvdef::Vtl;
 use hvdef::HV_PAGE_SIZE;
 use loader_defs::linux as defs;
 use page_table::x64::align_up_to_large_page_size;
@@ -392,7 +391,7 @@ pub fn load_config(
     // Set common X64 registers. Segments already set by default gdt.
     let mut import_reg = |register| {
         importer
-            .import_vp_register(Vtl::Vtl0, register)
+            .import_vp_register(register)
             .map_err(Error::Importer)
     };
 
@@ -672,13 +671,10 @@ where
 pub fn set_direct_boot_registers_arm64(
     importer: &mut impl ImageLoad<Aarch64Register>,
     load_info: &LoadInfo,
-    vtl: Vtl,
 ) -> Result<(), Error> {
-    assert!(vtl == Vtl::Vtl0);
-
     let mut import_reg = |register| {
         importer
-            .import_vp_register(vtl, register)
+            .import_vp_register(register)
             .map_err(Error::Importer)
     };
 

--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -407,9 +407,7 @@ where
             1 << 48,
             true,
             true,
-            true,
             0, // BSP
-            Vtl::Vtl2,
         )?;
 
         // Tell the loader page table relocation information.
@@ -418,7 +416,6 @@ where
             page_table_region_size / HV_PAGE_SIZE,
             page_table.len() as u64 / HV_PAGE_SIZE,
             0,
-            Vtl::Vtl2,
         )?;
     }
 
@@ -519,7 +516,7 @@ where
 
     let mut import_reg = |register| {
         importer
-            .import_vp_register(Vtl::Vtl2, register)
+            .import_vp_register(register)
             .map_err(Error::Importer)
     };
 
@@ -652,7 +649,7 @@ where
         )?;
 
         let vmsa_page_base = config_region_page_base + PARAVISOR_CONFIG_VMSA_PAGE_INDEX;
-        importer.set_vp_context_page(Vtl::Vtl2, vmsa_page_base, BootPageAcceptance::VpContext)?;
+        importer.set_vp_context_page(vmsa_page_base)?;
     }
 
     // Load measured config.
@@ -694,7 +691,7 @@ where
         // state? Right now, UEFI is the only thing that actually sets VTL0 vp
         // context, but if PCAT/Linux did, this wouldn't work.
         importer
-            .set_vp_context_page(Vtl::Vtl0, vp_context_page, BootPageAcceptance::Exclusive)
+            .set_lower_vtl_context_page(vp_context_page)
             .map_err(Error::Importer)?;
     }
 
@@ -1057,7 +1054,7 @@ where
         // state? Right now, UEFI is the only thing that actually sets VTL0 vp
         // context, but if PCAT/Linux did, this wouldn't work.
         importer
-            .set_vp_context_page(Vtl::Vtl0, vp_context_page, BootPageAcceptance::Exclusive)
+            .set_lower_vtl_context_page(vp_context_page)
             .map_err(Error::Importer)?;
     }
 
@@ -1104,10 +1101,8 @@ where
             PARAVISOR_DEFAULT_MEMORY_BASE_ADDRESS,
             1 << 48,
             true,
-            true,
             false,
             0, // BSP
-            Vtl::Vtl2,
         )?;
 
         // Tell the loader page table relocation information.
@@ -1116,7 +1111,6 @@ where
             page_table_region_size / HV_PAGE_SIZE,
             page_tables.len() as u64 / HV_PAGE_SIZE,
             0,
-            Vtl::Vtl2,
         )?;
     }
 
@@ -1132,7 +1126,7 @@ where
 
     let mut import_reg = |register| {
         importer
-            .import_vp_register(Vtl::Vtl2, register)
+            .import_vp_register(register)
             .map_err(Error::Importer)
     };
 

--- a/vm/loader/src/pcat.rs
+++ b/vm/loader/src/pcat.rs
@@ -7,7 +7,6 @@ use crate::importer::BootPageAcceptance;
 use crate::importer::ImageLoad;
 use crate::importer::SegmentRegister;
 use crate::importer::X86Register;
-use hvdef::Vtl;
 use hvdef::HV_PAGE_SIZE;
 use thiserror::Error;
 
@@ -97,7 +96,7 @@ pub fn load(
     // Enable MTRRs, default MTRR is uncached, and set lowest 640KB and highest 128KB as WB
     let mut import_reg = |register| {
         importer
-            .import_vp_register(Vtl::Vtl0, register)
+            .import_vp_register(register)
             .map_err(Error::Importer)
     };
     import_reg(X86Register::MtrrDefType(0xc00))?;

--- a/vmm_core/vm_loader/src/lib.rs
+++ b/vmm_core/vm_loader/src/lib.rs
@@ -176,16 +176,7 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
             .context("unable to zero remaining import")
     }
 
-    fn import_vp_register(&mut self, vtl: Vtl, register: R) -> anyhow::Result<()> {
-        // Only importing to the max VTL for registers is currently allowed, as
-        // only one set of registers is stored.
-        if vtl != self.max_vtl {
-            anyhow::bail!(
-                "vtl specified {vtl:?} is not the max enabled vtl {:?}",
-                self.max_vtl
-            );
-        }
-
+    fn import_vp_register(&mut self, register: R) -> anyhow::Result<()> {
         let entry = self.regs.entry(std::mem::discriminant(&register));
         match entry {
             std::collections::hash_map::Entry::Occupied(_) => {
@@ -270,16 +261,11 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
         }
     }
 
-    fn set_vp_context_page(
-        &mut self,
-        _vtl: Vtl,
-        _page_base: u64,
-        _acceptance: BootPageAcceptance,
-    ) -> anyhow::Result<()> {
+    fn set_vp_context_page(&mut self, _page_base: u64) -> anyhow::Result<()> {
         unimplemented!()
     }
 
-    fn vp_context_page(&self, _vtl: Vtl) -> anyhow::Result<u64> {
+    fn set_lower_vtl_context_page(&mut self, _page_base: u64) -> anyhow::Result<()> {
         unimplemented!()
     }
 
@@ -318,11 +304,9 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
         _relocation_alignment: u64,
         _minimum_relocation_gpa: u64,
         _maximum_relocation_gpa: u64,
-        _is_vtl2: bool,
         _apply_rip_offset: bool,
         _apply_gdtr_offset: bool,
         _vp_index: u16,
-        _vtl: Vtl,
     ) -> anyhow::Result<()> {
         unimplemented!()
     }
@@ -333,7 +317,6 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
         _size_pages: u64,
         _used_pages: u64,
         _vp_index: u16,
-        _vtl: Vtl,
     ) -> anyhow::Result<()> {
         unimplemented!()
     }


### PR DESCRIPTION
The individual firmware loaders generally do not need to be VTL aware. Remove VTL awareness from most of the code. This will soon allow OpenHCL to be loaded into VTL0.

The remaining exception is the VTL0 VP context. Simplify the handling of this, so that the CVM-specific code doesn't have to know about this.

A future change should consider whether we really need this at all: it seems that it's just so that OpenVMM in OpenHCL doesn't have to replay the UEFI register state. But OpenVMM already knows so much about how to load UEFI, so it seems kind of silly to pretend that it doesn't know how to set the register state appropriately.