### PR TITLE
consomme: fix connections across guest reset

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -442,6 +442,14 @@ impl<T: Client> Access<'_, T> {
         self.poll_message(cx);
     }
 
+    /// Update all sockets to use the new client's IO driver. This must be
+    /// called if the previous driver is no longer usable or if the client
+    /// otherwise wants existing connections to be polled on a new IO driver.
+    pub fn refresh_driver(&mut self) {
+        self.refresh_tcp_driver();
+        self.refresh_udp_driver();
+    }
+
     /// Sends an Ethernet frame to the network.
     ///
     /// If `checksum.ipv4`, `checksum.tcp`, or `checksum.udp` are set, then

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -79,7 +79,7 @@ impl net_backend::Endpoint for ConsommeEndpoint {
     ) -> anyhow::Result<()> {
         assert_eq!(config.len(), 1);
         let config = config.into_iter().next().unwrap();
-        let queue = Box::new(ConsommeQueue {
+        let mut queue = Box::new(ConsommeQueue {
             slot: self.consomme.clone(),
             consomme: self.consomme.lock().take(),
             state: QueueState {
@@ -92,6 +92,7 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             stats: Default::default(),
             driver: config.driver,
         });
+        queue.with_consomme(|c| c.refresh_driver());
         queues.push(queue);
         Ok(())
     }


### PR DESCRIPTION
Network connections that were established before guest reset are left in a bad state after reset because their old IO driver is no longer functional.

Add a method to reset the IO driver for all connections, and call it in net_consomme when the consomme queue moves into the active state.

In particular, this fixes kdnet after a guest reset.

Thanks @neerajsi-msft for the report.