### PR TITLE
net_consomme: support setting the NAT network from the command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3921,6 +3921,7 @@ dependencies = [
  "net_backend_resources",
  "pal_async",
  "parking_lot",
+ "thiserror",
  "tracing",
  "vm_resource",
 ]

--- a/openvmm/hvlite_entry/src/cli_args.rs
+++ b/openvmm/hvlite_entry/src/cli_args.rs
@@ -794,7 +794,7 @@ impl FromStr for SerialConfigCli {
 #[derive(Clone)]
 pub enum EndpointConfigCli {
     None,
-    Consomme,
+    Consomme { cidr: Option<String> },
     Dio { id: Option<String> },
     Tap { name: String },
 }
@@ -805,7 +805,9 @@ impl FromStr for EndpointConfigCli {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let ret = match s.split(':').collect::<Vec<_>>().as_slice() {
             ["none"] => EndpointConfigCli::None,
-            ["consomme"] => EndpointConfigCli::Consomme,
+            ["consomme", s @ ..] => EndpointConfigCli::Consomme {
+                cidr: s.first().map(|&s| s.to_owned()),
+            },
             ["dio", s @ ..] => EndpointConfigCli::Dio {
                 id: s.first().map(|s| (*s).to_owned()),
             },

--- a/openvmm/hvlite_entry/src/lib.rs
+++ b/openvmm/hvlite_entry/src/lib.rs
@@ -519,7 +519,7 @@ fn vm_config_from_command_line(
         let nic_config = parse_endpoint(
             &NicConfigCli {
                 vtl: DeviceVtl::Vtl0,
-                endpoint: EndpointConfigCli::Consomme,
+                endpoint: EndpointConfigCli::Consomme { cidr: None },
                 max_queues: None,
                 underhill: false,
             },
@@ -1279,8 +1279,8 @@ fn parse_endpoint(
 ) -> anyhow::Result<NicConfig> {
     let _ = resources;
     let endpoint = match &cli_cfg.endpoint {
-        EndpointConfigCli::Consomme => {
-            net_backend_resources::consomme::ConsommeHandle.into_resource()
+        EndpointConfigCli::Consomme { cidr } => {
+            net_backend_resources::consomme::ConsommeHandle { cidr: cidr.clone() }.into_resource()
         }
         EndpointConfigCli::None => net_backend_resources::null::NullHandle.into_resource(),
         EndpointConfigCli::Dio { id } => {

--- a/vm/devices/net/net_backend_resources/src/lib.rs
+++ b/vm/devices/net/net_backend_resources/src/lib.rs
@@ -34,7 +34,10 @@ pub mod consomme {
 
     /// Handle to a Consomme network endpoint.
     #[derive(MeshPayload)]
-    pub struct ConsommeHandle;
+    pub struct ConsommeHandle {
+        /// The CIDR of the network to use.
+        pub cidr: Option<String>,
+    }
 
     impl ResourceId<NetEndpointHandleKind> for ConsommeHandle {
         const ID: &'static str = "consomme";

--- a/vm/devices/net/net_consomme/Cargo.toml
+++ b/vm/devices/net/net_consomme/Cargo.toml
@@ -16,6 +16,7 @@ vm_resource.workspace = true
 inspect.workspace = true
 inspect_counters.workspace = true
 pal_async.workspace = true
+thiserror.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -175,9 +175,9 @@ impl ConsommeState {
     pub fn new() -> Result<Self, Error> {
         let nameservers = dns::nameservers()?;
         Ok(Self {
-            gateway_ip: Ipv4Address::new(10, 1, 0, 1),
+            gateway_ip: Ipv4Address::new(10, 0, 0, 1),
             gateway_mac: EthernetAddress([0x52, 0x55, 10, 0, 0, 1]),
-            client_ip: Ipv4Address::new(10, 1, 0, 2),
+            client_ip: Ipv4Address::new(10, 0, 0, 2),
             client_mac: EthernetAddress([0x0, 0x0, 0x0, 0x0, 0x1, 0x0]),
             net_mask: Ipv4Address::new(255, 255, 255, 0),
             nameservers,

--- a/vm/devices/net/net_consomme/src/resolver.rs
+++ b/vm/devices/net/net_consomme/src/resolver.rs
@@ -6,6 +6,7 @@ use consomme::ConsommeState;
 use net_backend::resolve::ResolveEndpointParams;
 use net_backend::resolve::ResolvedEndpoint;
 use net_backend_resources::consomme::ConsommeHandle;
+use thiserror::Error;
 use vm_resource::declare_static_resolver;
 use vm_resource::kind::NetEndpointHandleKind;
 use vm_resource::ResolveResource;
@@ -17,17 +18,30 @@ declare_static_resolver! {
     (NetEndpointHandleKind, ConsommeHandle),
 }
 
+#[derive(Debug, Error)]
+pub enum ResolveConsommeError {
+    #[error(transparent)]
+    Consomme(consomme::Error),
+    #[error(transparent)]
+    InvalidCidr(consomme::InvalidCidr),
+}
+
 impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver {
     type Output = ResolvedEndpoint;
-    type Error = consomme::Error;
+    type Error = ResolveConsommeError;
 
     fn resolve(
         &self,
-        ConsommeHandle: ConsommeHandle,
+        resource: ConsommeHandle,
         input: ResolveEndpointParams,
     ) -> Result<Self::Output, Self::Error> {
-        let mut state = ConsommeState::new()?;
+        let mut state = ConsommeState::new().map_err(ResolveConsommeError::Consomme)?;
         state.client_mac.0 = input.mac_address.to_bytes();
+        if let Some(cidr) = &resource.cidr {
+            state
+                .set_cidr(cidr)
+                .map_err(ResolveConsommeError::InvalidCidr)?;
+        }
         let endpoint = ConsommeEndpoint::new_with_state(state);
         Ok(endpoint.into())
     }

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -46,7 +46,8 @@ async fn boot_openhcl_linux_mana_nic(config: PetriVmConfig) -> Result<(), anyhow
                 resource: GdmaDeviceHandle {
                     vports: vec![VportDefinition {
                         mac_address: [0x00, 0x15, 0x5D, 0x12, 0x12, 0x12].into(),
-                        endpoint: net_backend_resources::consomme::ConsommeHandle.into_resource(),
+                        endpoint: net_backend_resources::consomme::ConsommeHandle { cidr: None }
+                            .into_resource(),
                     }],
                 }
                 .into_resource(),


### PR DESCRIPTION
Now you can say:

```
cargo run -- --net consomme:192.168.0.0/24
```

to set the network used by the consomme NAT. This is useful when the default network (10.0.0.0/24) conflicts with your host.