### PR TITLE
consomme: recycle UDP connections on receive error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,6 +687,7 @@ dependencies = [
  "futures",
  "getrandom",
  "inspect",
+ "inspect_counters",
  "libc",
  "mesh",
  "pal_async",

--- a/support/inspect/src/defer.rs
+++ b/support/inspect/src/defer.rs
@@ -269,8 +269,7 @@ impl DeferredUpdate {
     }
 
     /// Report that the update failed, with the reason in `err`.
-    #[cfg(feature = "std")]
-    pub fn fail<E: Into<alloc::boxed::Box<dyn std::error::Error + Send + Sync>>>(self, err: E) {
+    pub fn fail<E: Into<alloc::boxed::Box<dyn core::error::Error + Send + Sync>>>(self, err: E) {
         self.node.send(InternalNode::failed(err.into()));
     }
 }

--- a/support/inspect/src/initiate.rs
+++ b/support/inspect/src/initiate.rs
@@ -282,7 +282,7 @@ impl Node {
         self.compute_since(last, duration.as_secs_f64())
     }
 
-    /// Returns an object that implements [`std::fmt::Display`] to output JSON.
+    /// Returns an object that implements [`Display`](core::fmt::Display) to output JSON.
     pub fn json(&self) -> impl '_ + fmt::Display {
         JsonDisplay(self)
     }
@@ -408,7 +408,7 @@ impl<'a> InspectionBuilder<'a> {
 /// ```rust
 /// # use inspect::{Inspect, Request, Node, inspect, Value, ValueKind};
 /// # use futures::executor::block_on;
-/// # use std::time::Duration;
+/// # use core::time::Duration;
 /// struct Obj;
 /// impl Inspect for Obj {
 ///     fn inspect(&self, req: Request) {

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -295,36 +295,32 @@ pub use initiate::*;
 /// * `flatten`: calls [`Response::merge`] with `&mut field`.
 /// * `transparent` (struct attribute): calls [`InspectMut::inspect_mut`] on the
 ///   sole unskipped field.
-#[cfg_attr(
-    feature = "std",
-    doc = r##"
-## Example
-
-```no_run
-# use inspect::{Inspect, InspectMut};
-# use std::sync::Arc;
-# use std::path::PathBuf;
-#[derive(InspectMut)]
-struct Outer {
-    #[inspect(hex)]
-    id: u32,                // will be displayed as hex
-    count: usize,
-    #[inspect(mut)]
-    max_buffers: usize,     // can be changed via `update()`
-    #[inspect(skip)]
-    signal: Box<dyn Send>,  // won't be present in inspect output
-    #[inspect(flatten)]
-    inner: Arc<Inner>,      // contents will be merged in
-}
-
-#[derive(Inspect)]
-struct Inner {
-    #[inspect(format = "{:016x}")]
-    uuid: u128,             // will be displayed as a 0-padded hex string
-}
-```
-"##
-)]
+/// ## Example
+///
+/// ```no_run
+/// # use inspect::{Inspect, InspectMut};
+/// # use std::sync::Arc;
+/// # use std::path::PathBuf;
+/// #[derive(InspectMut)]
+/// struct Outer {
+///     #[inspect(hex)]
+///     id: u32,                // will be displayed as hex
+///     count: usize,
+///     #[inspect(mut)]
+///     max_buffers: usize,     // can be changed via `update()`
+///     #[inspect(skip)]
+///     signal: Box<dyn Send>,  // won't be present in inspect output
+///     #[inspect(flatten)]
+///     inner: Arc<Inner>,      // contents will be merged in
+/// }
+///
+/// #[derive(Inspect)]
+/// struct Inner {
+///     #[inspect(format = "{:016x}")]
+///     uuid: u128,             // will be displayed as a 0-padded hex string
+/// }
+/// ```
+///
 /// # Unit-only enums
 ///
 /// The macro supports enums, with multiple different output formats:
@@ -791,12 +787,11 @@ impl Response<'_> {
     }
 
     /// Adds a mutable field with custom get/update function.
-    #[cfg(feature = "std")]
     pub fn field_mut_with<F, V, E>(&mut self, name: &str, f: F) -> &mut Self
     where
         F: FnOnce(Option<&str>) -> Result<V, E>,
         V: Into<Value>,
-        E: Into<Box<dyn std::error::Error + Send + Sync>>,
+        E: Into<Box<dyn core::error::Error + Send + Sync>>,
     {
         self.child(name, |req| match req.update() {
             Ok(req) => match (f)(Some(req.new_value())) {
@@ -1126,8 +1121,7 @@ impl UpdateRequest<'_> {
     }
 
     /// Report that the update failed, with the reason in `err`.
-    #[cfg(feature = "std")]
-    pub fn fail<E: Into<Box<dyn std::error::Error + Send + Sync>>>(self, err: E) {
+    pub fn fail<E: Into<Box<dyn core::error::Error + Send + Sync>>>(self, err: E) {
         *self.node = InternalNode::failed(err.into());
     }
 }
@@ -1438,7 +1432,6 @@ macro_rules! inspect_value {
         inspect_value_immut!($($ty,)*);
         $(
         $(#[$attr])*
-        #[cfg(feature = "std")]
         impl InspectMut for $ty {
             fn inspect_mut(&mut self, req: Request<'_>) {
                 match req.update() {
@@ -1519,7 +1512,6 @@ macro_rules! inspect_atomic_value {
         // reference to the Atomic, it's most likely that type didn't need to be
         // atomic in the first place.
 
-        #[cfg(feature = "std")]
         impl Inspect for AtomicMut<&core::sync::atomic::$ty> {
             fn inspect(&self, req: Request<'_>) {
                 let mut value = self.0.load(core::sync::atomic::Ordering::Relaxed);
@@ -1904,8 +1896,7 @@ enum InternalError {
 }
 
 impl InternalNode {
-    #[cfg(feature = "std")]
-    fn failed(err: Box<dyn std::error::Error + Send + Sync>) -> Self {
+    fn failed(err: Box<dyn core::error::Error + Send + Sync>) -> Self {
         use core::fmt::Write;
 
         let mut s = err.to_string();

--- a/vm/devices/net/net_consomme/consomme/Cargo.toml
+++ b/vm/devices/net/net_consomme/consomme/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 inspect.workspace = true
+inspect_counters.workspace = true
 mesh.workspace = true
 pal_async.workspace = true
 

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -25,7 +25,7 @@ mod tcp;
 mod udp;
 mod windows;
 
-use inspect::Inspect;
+use inspect::InspectMut;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use pal_async::driver::Driver;
@@ -136,11 +136,11 @@ pub struct Consomme {
     udp: udp::Udp,
 }
 
-impl Inspect for Consomme {
-    fn inspect(&self, req: inspect::Request<'_>) {
+impl InspectMut for Consomme {
+    fn inspect_mut(&mut self, req: inspect::Request<'_>) {
         req.respond()
             .field("tcp", &self.tcp)
-            .field("udp", &self.udp);
+            .field_mut("udp", &mut self.udp);
     }
 }
 

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -10,6 +10,8 @@ use super::SocketAddress;
 use crate::ChecksumState;
 use crate::Ipv4Addresses;
 use inspect::Inspect;
+use inspect::InspectMut;
+use inspect_counters::Counter;
 use pal_async::interest::InterestSlot;
 use pal_async::interest::PollEvents;
 use pal_async::socket::PolledSocket;
@@ -47,24 +49,32 @@ impl Udp {
     }
 }
 
-impl Inspect for Udp {
-    fn inspect(&self, req: inspect::Request<'_>) {
+impl InspectMut for Udp {
+    fn inspect_mut(&mut self, req: inspect::Request<'_>) {
         let mut resp = req.respond();
-        for (addr, conn) in &self.connections {
-            resp.field(&format!("{}:{}", addr.ip, addr.port), conn);
+        for (addr, conn) in &mut self.connections {
+            resp.field_mut(&format!("{}:{}", addr.ip, addr.port), conn);
         }
     }
 }
 
+#[derive(InspectMut)]
 struct UdpConnection {
+    #[inspect(skip)]
     socket: Option<PolledSocket<UdpSocket>>,
+    #[inspect(display)]
     guest_mac: EthernetAddress,
+    stats: Stats,
+    #[inspect(mut)]
+    recycle: bool,
 }
 
-impl Inspect for UdpConnection {
-    fn inspect(&self, req: inspect::Request<'_>) {
-        req.respond();
-    }
+#[derive(Inspect, Default)]
+struct Stats {
+    tx_packets: Counter,
+    tx_dropped: Counter,
+    tx_errors: Counter,
+    rx_packets: Counter,
 }
 
 impl UdpConnection {
@@ -74,14 +84,21 @@ impl UdpConnection {
         dst_addr: &SocketAddress,
         state: &mut ConsommeState,
         client: &mut impl Client,
-    ) {
+    ) -> bool {
+        if self.recycle {
+            return false;
+        }
+
         let mut eth = EthernetFrame::new_unchecked(&mut state.buffer);
-        // Receive UDP packets while there are receive buffers available. This
-        // means we won't drop UDP packets at this level--instead, we only drop
-        // UDP packets if the kernel socket's receive buffer fills up. If this
-        // results in latency problems, then we could try sizing this buffer
-        // more carefully.
-        while client.rx_mtu() > 0 {
+        loop {
+            // Receive UDP packets while there are receive buffers available. This
+            // means we won't drop UDP packets at this level--instead, we only drop
+            // UDP packets if the kernel socket's receive buffer fills up. If this
+            // results in latency problems, then we could try sizing this buffer
+            // more carefully.
+            if client.rx_mtu() == 0 {
+                break true;
+            }
             match self.socket.as_mut().unwrap().poll_io(
                 cx,
                 InterestSlot::Read,
@@ -117,12 +134,13 @@ impl UdpConnection {
                     udp.fill_checksum(&src_ip.into(), &dst_addr.ip.into());
                     let len = ETHERNET_HEADER_LEN + ipv4.total_len() as usize;
                     client.recv(&eth.as_ref()[..len], &ChecksumState::UDP4);
+                    self.stats.rx_packets.increment();
                 }
                 Poll::Ready(Err(err)) => {
                     tracing::error!(error = &err as &dyn std::error::Error, "recv error");
-                    break;
+                    break false;
                 }
-                Poll::Pending => break,
+                Poll::Pending => break true,
             }
         }
     }
@@ -130,9 +148,9 @@ impl UdpConnection {
 
 impl<T: Client> Access<'_, T> {
     pub(crate) fn poll_udp(&mut self, cx: &mut Context<'_>) {
-        for (dst_addr, conn) in &mut self.inner.udp.connections {
-            conn.poll_conn(cx, dst_addr, &mut self.inner.state, self.client);
-        }
+        self.inner.udp.connections.retain(|dst_addr, conn| {
+            conn.poll_conn(cx, dst_addr, &mut self.inner.state, self.client)
+        });
     }
 
     pub(crate) fn refresh_udp_driver(&mut self) {
@@ -169,6 +187,10 @@ impl<T: Client> Access<'_, T> {
             &checksum.caps(),
         )?;
 
+        if udp.src_port == 50015 {
+            tracing::info!(src = %addresses.src_addr, src_port = udp.src_port, dest = %addresses.dst_addr, dest_port = udp.dst_port, "packet");
+        }
+
         if addresses.dst_addr == self.inner.state.gateway_ip || addresses.dst_addr.is_broadcast() {
             if self.handle_gateway_udp(&udp_packet)? {
                 return Ok(());
@@ -185,9 +207,18 @@ impl<T: Client> Access<'_, T> {
             udp_packet.payload(),
             (Ipv4Addr::from(addresses.dst_addr), udp.dst_port),
         ) {
-            Ok(_) => Ok(()),
-            Err(err) if err.kind() == ErrorKind::WouldBlock => Err(DropReason::SendBufferFull),
-            Err(err) => Err(DropReason::Io(err)),
+            Ok(_) => {
+                conn.stats.tx_packets.increment();
+                Ok(())
+            }
+            Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                conn.stats.tx_dropped.increment();
+                Err(DropReason::SendBufferFull)
+            }
+            Err(err) => {
+                conn.stats.tx_errors.increment();
+                Err(DropReason::Io(err))
+            }
         }
     }
 
@@ -208,6 +239,8 @@ impl<T: Client> Access<'_, T> {
                 let conn = UdpConnection {
                     socket: Some(socket),
                     guest_mac: guest_mac.unwrap_or(self.inner.state.client_mac),
+                    stats: Default::default(),
+                    recycle: false,
                 };
                 Ok(e.insert(conn))
             }

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -187,10 +187,6 @@ impl<T: Client> Access<'_, T> {
             &checksum.caps(),
         )?;
 
-        if udp.src_port == 50015 {
-            tracing::info!(src = %addresses.src_addr, src_port = udp.src_port, dest = %addresses.dst_addr, dest_port = udp.dst_port, "packet");
-        }
-
         if addresses.dst_addr == self.inner.state.gateway_ip || addresses.dst_addr.is_broadcast() {
             if self.handle_gateway_udp(&udp_packet)? {
                 return Ok(());

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -59,8 +59,8 @@ impl ConsommeEndpoint {
 
 impl InspectMut for ConsommeEndpoint {
     fn inspect_mut(&mut self, req: inspect::Request<'_>) {
-        if let Some(consomme) = &*self.consomme.lock() {
-            consomme.inspect(req);
+        if let Some(consomme) = &mut *self.consomme.lock() {
+            consomme.inspect_mut(req);
         }
     }
 }
@@ -126,7 +126,7 @@ pub struct ConsommeQueue {
 impl InspectMut for ConsommeQueue {
     fn inspect_mut(&mut self, req: inspect::Request<'_>) {
         req.respond()
-            .merge(self.consomme.as_ref().unwrap())
+            .merge(self.consomme.as_mut().unwrap())
             .field("rx_avail", self.state.rx_avail.len())
             .field("rx_ready", self.state.rx_ready.len())
             .field("tx_avail", self.state.tx_avail.len())


### PR DESCRIPTION
Also add in a way to manually recycle a connection via inspect, and add per-connection stats.

As part of this, remove the `std` requirement for failing in `InspectMut` implementations. This is now possible since `Error` is in `core`.