### PR TITLE
Upgrade azcopy and use large disk linux test runners

### DIFF
--- a/.github/workflows/openvmm-ci.json
+++ b/.github/workflows/openvmm-ci.json
@@ -15,7 +15,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"debug_label\":\"guide\",\"done\":{\"backing_var\":\"start1\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_guide::publish:0:flowey_lib_hvlite/src/artifact_guide.rs:34:40\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -128,7 +128,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"debug_label\":\"rustdoc\",\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_rustdoc::publish:1:flowey_lib_hvlite/src/artifact_rustdoc.rs:48:33\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -260,7 +260,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"debug_label\":\"rustdoc\",\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_rustdoc::publish:1:flowey_lib_hvlite/src/artifact_rustdoc.rs:48:33\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -384,7 +384,7 @@
         "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -477,7 +477,7 @@
         "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -599,7 +599,7 @@
         "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -731,7 +731,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start7\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -902,7 +902,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start13\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -1071,7 +1071,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start14\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -1244,7 +1244,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start20\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -1414,7 +1414,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start22\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -1638,7 +1638,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start33\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -1870,7 +1870,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-musl-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start35\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -2083,7 +2083,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start37\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -2330,7 +2330,7 @@
         "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -2513,7 +2513,7 @@
         "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -2719,7 +2719,7 @@
         "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -2919,7 +2919,7 @@
     },
     "17": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.26.0-20240731\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
@@ -2930,7 +2930,7 @@
       ],
       "flowey_lib_common::download_azcopy": [
         "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -3068,7 +3068,7 @@
     },
     "18": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.26.0-20240731\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
@@ -3079,7 +3079,7 @@
       ],
       "flowey_lib_common::download_azcopy": [
         "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -3217,7 +3217,7 @@
     },
     "19": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.26.0-20240731\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
@@ -3228,7 +3228,7 @@
       ],
       "flowey_lib_common::download_azcopy": [
         "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -3367,7 +3367,7 @@
         "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -4129,6 +4129,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
+    - 1ES.ImageOverride=MMSUbuntu20.04-1TB-2
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-pr.json
+++ b/.github/workflows/openvmm-pr.json
@@ -15,7 +15,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"debug_label\":\"guide\",\"done\":{\"backing_var\":\"start1\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_guide::publish:0:flowey_lib_hvlite/src/artifact_guide.rs:34:40\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -128,7 +128,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"debug_label\":\"rustdoc\",\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_rustdoc::publish:1:flowey_lib_hvlite/src/artifact_rustdoc.rs:48:33\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -260,7 +260,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"debug_label\":\"rustdoc\",\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_rustdoc::publish:1:flowey_lib_hvlite/src/artifact_rustdoc.rs:48:33\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -389,7 +389,7 @@
         "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -511,7 +511,7 @@
         "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -643,7 +643,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start6\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -814,7 +814,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start12\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -983,7 +983,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start13\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -1156,7 +1156,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start19\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -1326,7 +1326,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start21\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -1550,7 +1550,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start32\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -1782,7 +1782,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-musl-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start34\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -1995,7 +1995,7 @@
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start36\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -2242,7 +2242,7 @@
         "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -2425,7 +2425,7 @@
         "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -2631,7 +2631,7 @@
         "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -2831,7 +2831,7 @@
     },
     "16": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.26.0-20240731\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
@@ -2842,7 +2842,7 @@
       ],
       "flowey_lib_common::download_azcopy": [
         "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -2980,7 +2980,7 @@
     },
     "17": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.26.0-20240731\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
@@ -2991,7 +2991,7 @@
       ],
       "flowey_lib_common::download_azcopy": [
         "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -3129,7 +3129,7 @@
     },
     "18": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.26.0-20240731\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
@@ -3140,7 +3140,7 @@
       ],
       "flowey_lib_common::download_azcopy": [
         "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -3279,7 +3279,7 @@
         "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"
@@ -3363,7 +3363,7 @@
         "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
       ],
       "flowey_lib_common::download_azcopy": [
-        "{\"Version\":\"10.26.0-20240731\"}"
+        "{\"Version\":\"10.27.0-20241030\"}"
       ],
       "flowey_lib_common::download_cargo_fuzz": [
         "{\"Version\":\"0.12.0\"}"

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3752,6 +3752,7 @@ jobs:
     runs-on:
     - self-hosted
     - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
+    - 1ES.ImageOverride=MMSUbuntu20.04-1TB-2
     permissions:
       contents: read
       id-token: write

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -869,7 +869,7 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Linux,
                 arch: FlowArch::X86_64,
-                gh_pool: crate::pipelines_shared::gh_pools::linux_self_hosted(),
+                gh_pool: crate::pipelines_shared::gh_pools::linux_self_hosted_largedisk(),
                 label: "x64-linux",
                 target: CommonTriple::X86_64_LINUX_GNU,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_linux_x86,

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -67,6 +67,14 @@ pub fn linux_self_hosted() -> GhRunner {
     ])
 }
 
+pub fn linux_self_hosted_largedisk() -> GhRunner {
+    GhRunner::SelfHosted(vec![
+        "self-hosted".to_string(),
+        "1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3".to_string(),
+        "1ES.ImageOverride=MMSUbuntu20.04-1TB-2".to_string(),
+    ])
+}
+
 pub fn gh_hosted_windows() -> GhRunner {
     GhRunner::GhHosted(GhRunnerOsLabel::WindowsLatest)
 }

--- a/flowey/flowey_lib_common/src/download_azcopy.rs
+++ b/flowey/flowey_lib_common/src/download_azcopy.rs
@@ -90,9 +90,14 @@ impl FlowNode for Node {
                     cached
                 } else {
                     let sh = xshell::Shell::new()?;
+                    let arch = match rt.arch() {
+                        FlowArch::X86_64 => "amd64",
+                        FlowArch::Aarch64 => "arm64",
+                        arch => anyhow::bail!("unhandled arch {arch}"),
+                    };
                     match rt.platform().kind() {
                         FlowPlatformKind::Windows => {
-                            xshell::cmd!(sh, "curl -L https://azcopyvnext.azureedge.net/releases/release-{version_with_date}/azcopy_windows_amd64_{version_without_date}.zip -o azcopy.zip").run()?;
+                            xshell::cmd!(sh, "curl -L https://azcopyvnext.azureedge.net/releases/release-{version_with_date}/azcopy_windows_{arch}_{version_without_date}.zip -o azcopy.zip").run()?;
 
                             let bsdtar = crate::_util::bsdtar_name(rt);
                             xshell::cmd!(sh, "{bsdtar} -xf azcopy.zip --strip-components=1").run()?;
@@ -103,7 +108,7 @@ impl FlowNode for Node {
                                 FlowPlatform::MacOs => "darwin",
                                 platform => anyhow::bail!("unhandled platform {platform}"),
                             };
-                            xshell::cmd!(sh, "curl -L https://azcopyvnext.azureedge.net/releases/release-{version_with_date}/azcopy_{os}_amd64_{version_without_date}.tar.gz -o azcopy.tar.gz").run()?;
+                            xshell::cmd!(sh, "curl -L https://azcopyvnext.azureedge.net/releases/release-{version_with_date}/azcopy_{os}_{arch}_{version_without_date}.tar.gz -o azcopy.tar.gz").run()?;
                             xshell::cmd!(sh, "tar -xf azcopy.tar.gz --strip-components=1").run()?;
                         }
                     };

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -14,7 +14,7 @@ use flowey::node::prelude::*;
 //
 // This would require nodes that currently accept a `Version(String)` to accept
 // a `Version(ReadVar<String>)`, but that shouldn't be a serious blocker.
-pub const AZCOPY: &str = "10.26.0-20240731";
+pub const AZCOPY: &str = "10.27.0-20241030";
 pub const AZURE_CLI: &str = "2.56.0";
 pub const FUZZ: &str = "0.12.0";
 pub const GH_CLI: &str = "2.52.0";


### PR DESCRIPTION
Upgrade azcopy to version 10.27.0 and use large disk linux test runners so that the downloaded VHDs fit. Also makes the flowey download azcopy node arm64 native capable.