### PR TITLE
flowey: use `curl` download public GitHub artifacts (instead of `gh` CLI)

### DIFF
--- a/.github/workflows/openvmm-ci.json
+++ b/.github/workflows/openvmm-ci.json
@@ -4,8 +4,7 @@
   "job_reqs": {
     "0": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fdc019ee4bc3ad94\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fdc019ee4bc3ad94\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"SetLocked\":true}",
@@ -24,13 +23,12 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"mdbook-mermaid-v0.14.0-x86_64-unknown-linux-gnu.tar.gz\",\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:0:flowey_lib_common/src/download_mdbook_mermaid.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-mermaid\",\"repo_owner\":\"badboy\",\"tag\":\"v0.14.0\"}",
-        "{\"file_name\":\"mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz\",\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook:0:flowey_lib_common/src/download_mdbook.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdBook\",\"repo_owner\":\"rust-lang\",\"tag\":\"v0.4.40\"}",
-        "{\"file_name\":\"mdbook-admonish-v1.18.0-x86_64-unknown-linux-gnu.tar.gz\",\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:0:flowey_lib_common/src/download_mdbook_admonish.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-admonish\",\"repo_owner\":\"tommilligan\",\"tag\":\"v1.18.0\"}"
+        "{\"file_name\":\"mdbook-mermaid-v0.14.0-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:0:flowey_lib_common/src/download_mdbook_mermaid.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-mermaid\",\"repo_owner\":\"badboy\",\"tag\":\"v0.14.0\"}",
+        "{\"file_name\":\"mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook:0:flowey_lib_common/src/download_mdbook.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdBook\",\"repo_owner\":\"rust-lang\",\"tag\":\"v0.4.40\"}",
+        "{\"file_name\":\"mdbook-admonish-v1.18.0-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:0:flowey_lib_common/src/download_mdbook_admonish.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-admonish\",\"repo_owner\":\"tommilligan\",\"tag\":\"v1.18.0\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"GetMdbook\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:0:flowey_lib_hvlite/src/build_guide.rs:28:30\",\"is_secret\":false}}",
@@ -52,9 +50,9 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook:1:flowey_lib_common/src/download_mdbook.rs:69:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:1:flowey_lib_common/src/download_mdbook_admonish.rs:69:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:1:flowey_lib_common/src/download_mdbook_mermaid.rs:69:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook:1:flowey_lib_common/src/download_mdbook.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:1:flowey_lib_common/src/download_mdbook_admonish.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:1:flowey_lib_common/src/download_mdbook_mermaid.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
@@ -68,10 +66,6 @@
         "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:6:flowey_lib_hvlite/src/build_guide.rs:38:37\",\"is_secret\":false}}",
         "{\"IgnoreVersion\":false}",
         "{\"Version\":\"1.82.0\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guide": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start1\",\"is_secret\":false}}"
@@ -116,8 +110,7 @@
     },
     "1": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:1:flowey_lib_common/src/run_cargo_doc.rs:115:25\",\"is_secret\":false}}",
@@ -137,12 +130,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -162,7 +154,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
@@ -182,10 +174,6 @@
       ],
       "flowey_lib_common::run_cargo_doc": [
         "{\"cargo_cmd\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:3:flowey_lib_hvlite/src/build_rustdoc.rs:84:33\",\"is_secret\":false},\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\"},\"is_secret\":false},\"packages\":[{\"document_private_items\":false,\"kind\":{\"Workspace\":{\"exclude\":[\"vmfirmwareigvm_dll\"]}},\"no_deps\":true},{\"document_private_items\":false,\"kind\":{\"NoStdCrate\":\"guest_test_uefi\"},\"no_deps\":true}],\"target_triple\":\"x86_64-pc-windows-msvc\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"target_triple\":\"x86_64-pc-windows-msvc\"}"
@@ -248,8 +236,7 @@
     },
     "2": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:1:flowey_lib_common/src/run_cargo_doc.rs:115:25\",\"is_secret\":false}}",
@@ -269,12 +256,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -294,7 +280,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
@@ -314,10 +300,6 @@
       ],
       "flowey_lib_common::run_cargo_doc": [
         "{\"cargo_cmd\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:3:flowey_lib_hvlite/src/build_rustdoc.rs:84:33\",\"is_secret\":false},\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\"},\"is_secret\":false},\"packages\":[{\"document_private_items\":false,\"kind\":{\"Workspace\":{\"exclude\":[\"vmfirmwareigvm_dll\"]}},\"no_deps\":true},{\"document_private_items\":false,\"kind\":{\"NoStdCrate\":\"guest_test_uefi\"},\"no_deps\":true}],\"target_triple\":\"x86_64-unknown-linux-gnu\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"target_triple\":\"x86_64-unknown-linux-gnu\"}"
@@ -422,9 +404,6 @@
         "{\"IgnoreVersion\":false}",
         "{\"Version\":\"1.82.0\"}"
       ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
-      ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
       ],
@@ -468,8 +447,7 @@
     },
     "4": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -486,11 +464,10 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -510,7 +487,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
@@ -529,10 +506,6 @@
       ],
       "flowey_lib_common::run_cargo_build": [
         "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-pc-windows-msvc\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -590,8 +563,7 @@
     },
     "5": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-185fb9aa857d6110\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-185fb9aa857d6110\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -608,11 +580,10 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -633,7 +604,7 @@
       ],
       "flowey_lib_common::install_apt_pkg": [
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
@@ -652,10 +623,6 @@
       ],
       "flowey_lib_common::run_cargo_build": [
         "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -716,8 +683,7 @@
     },
     "6": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -740,11 +706,10 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -764,7 +729,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
       ],
@@ -791,10 +756,6 @@
         "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
         "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
         "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[\"encryption_win\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start9\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
@@ -885,8 +846,7 @@
     "7": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-6fd9989180c5ad5c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-6fd9989180c5ad5c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -912,12 +872,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -937,7 +896,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}"
       ],
@@ -967,10 +926,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_archive": [
         "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:141:29\",\"is_secret\":false},\"build_params\":{\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:73:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:138:29\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start13\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}"
@@ -1056,8 +1011,7 @@
     },
     "8": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1080,11 +1034,10 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -1105,7 +1058,7 @@
       ],
       "flowey_lib_common::install_apt_pkg": [
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:3:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:100:21\",\"is_secret\":false},\"package_names\":[\"clang\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
       ],
@@ -1132,10 +1085,6 @@
         "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}",
         "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}",
         "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[\"encryption_win\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start16\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
@@ -1227,8 +1176,7 @@
     "9": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1254,12 +1202,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -1279,7 +1226,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}"
       ],
@@ -1309,10 +1256,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_archive": [
         "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:141:29\",\"is_secret\":false},\"build_params\":{\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:73:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:138:29\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start20\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
@@ -1398,8 +1341,7 @@
     },
     "10": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-82559e949fe64647\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-82559e949fe64647\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1423,12 +1365,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -1458,7 +1399,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:28:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
@@ -1491,10 +1432,6 @@
         "{\"crate_name\":\"openvmm\",\"extra_env\":{\"backing_var\":{\"Inline\":{\"CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER\":\"aarch64-linux-gnu-gcc\"}},\"is_secret\":false},\"features\":[\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
         "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"Inline\":{\"CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER\":\"aarch64-linux-gnu-gcc\"}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
         "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"Inline\":{\"CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER\":\"aarch64-linux-gnu-gcc\"}},\"is_secret\":false},\"features\":[\"encryption_ossl\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:28:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
         "{\"arch\":\"Aarch64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start26\",\"is_secret\":false},\"profile\":\"Release\"}"
@@ -1617,8 +1554,7 @@
     "11": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1648,12 +1584,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -1679,7 +1614,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\",\"is_secret\":false},\"package_names\":[\"build-essential\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:3:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:100:21\",\"is_secret\":false},\"package_names\":[\"clang\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
@@ -1719,10 +1654,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_archive": [
         "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:141:29\",\"is_secret\":false},\"build_params\":{\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:73:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:138:29\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
         "{\"arch\":\"X86_64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start32\",\"is_secret\":false},\"profile\":\"Release\"}"
@@ -1856,8 +1787,7 @@
     },
     "12": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e27197f6b5dd16ab\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e27197f6b5dd16ab\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1879,16 +1809,15 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-arm64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-arm64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
-        "{\"file_name\":\"RELEASE-AARCH64-artifacts.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
-        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:2:flowey_lib_hvlite/src/download_openvmm_deps.rs:110:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
+        "{\"file_name\":\"RELEASE-AARCH64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:2:flowey_lib_hvlite/src/download_openvmm_deps.rs:111:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -1917,7 +1846,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:22:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:0:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:0:flowey_lib_hvlite/src/build_openhcl_initrd.rs:62:26\",\"is_secret\":false},\"package_names\":[\"python3\"]}}"
@@ -1945,10 +1874,6 @@
         "{\"crate_name\":\"openhcl_boot\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:397:27\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:387:25\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"boot-release\"},\"target\":\"aarch64-unknown-linux-musl\"}",
         "{\"crate_name\":\"openvmm_hcl\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:92:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:387:25\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"underhill-ship\"},\"target\":\"aarch64-unknown-linux-musl\"}",
         "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:22:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:387:25\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-musl\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
         "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start34\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"Aarch64\"},{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"Aarch64Devkern\"}]}"
@@ -2069,8 +1994,7 @@
     },
     "13": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-69bfa92774c5940b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-69bfa92774c5940b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -2092,16 +2016,15 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:5:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-cvm-x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
-        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:5:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-cvm-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -2130,7 +2053,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:8:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:0:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:0:flowey_lib_hvlite/src/build_openhcl_initrd.rs:62:26\",\"is_secret\":false},\"package_names\":[\"python3\"]}}"
@@ -2158,10 +2081,6 @@
         "{\"crate_name\":\"openhcl_boot\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:397:27\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"boot-release\"},\"target\":\"x86_64-unknown-none\"}",
         "{\"crate_name\":\"openvmm_hcl\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:92:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:387:25\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"underhill-ship\"},\"target\":\"x86_64-unknown-linux-musl\"}",
         "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:387:25\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
         "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start36\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64Devkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64TestLinuxDirect\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64TestLinuxDirectDevkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64Cvm\"}]}"
@@ -2316,8 +2235,7 @@
     "14": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-38b54383c2832bcf\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-38b54383c2832bcf\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -2340,13 +2258,12 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -2366,7 +2283,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
@@ -2409,10 +2326,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:55:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"features\":{\"Specific\":[\"ci\"]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start40\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-windows-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}"
@@ -2499,8 +2412,7 @@
     "15": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-763048f92183c49f\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-763048f92183c49f\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -2523,13 +2435,12 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -2553,7 +2464,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:110:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"gcc-aarch64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:110:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"gcc-aarch64-linux-gnu\"]}}"
@@ -2603,10 +2514,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:55:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start44\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}"
@@ -2705,8 +2612,7 @@
     "16": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-776396c93f9413c8\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-776396c93f9413c8\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -2729,15 +2635,14 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:2:flowey_lib_hvlite/src/download_openvmm_deps.rs:110:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:2:flowey_lib_hvlite/src/download_openvmm_deps.rs:111:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -2761,7 +2666,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:110:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"gcc-aarch64-linux-gnu\"]}}"
       ],
@@ -2817,10 +2722,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:186:25\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:55:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start47\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-musl-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}"
@@ -2921,8 +2822,7 @@
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"SetLocked\":true}",
@@ -2940,12 +2840,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -2985,10 +2884,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:167:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:187:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3070,8 +2965,7 @@
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"SetLocked\":true}",
@@ -3089,12 +2983,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -3134,10 +3027,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:167:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:187:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3219,8 +3108,7 @@
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"SetLocked\":true}",
@@ -3238,12 +3126,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -3283,10 +3170,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all() and not test(openhcl) and not test(pcat_x64)\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:167:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"auto_se:flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_core/src/node.rs:840:34\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:187:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:1:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3406,9 +3289,6 @@
         "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:1:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:31:32\",\"is_secret\":false}}",
         "{\"IgnoreVersion\":false}",
         "{\"Version\":\"1.82.0\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -111,32 +111,6 @@ jobs:
       run: flowey e 0 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 0 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 0 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey v 0 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 0 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 0 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 0 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 0 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -152,21 +126,12 @@ jobs:
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 0 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 0 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 0 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 0 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 0 flowey_lib_common::download_gh_release 1
@@ -231,9 +196,6 @@ jobs:
       run: flowey e 0 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 0 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
       run: flowey e 0 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish guide
@@ -343,16 +305,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -371,32 +333,6 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 1 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 1 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 1 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 1 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 1 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -412,21 +348,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 1 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 1 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 1 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 1 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 1 flowey_lib_common::download_gh_release 1
@@ -470,11 +397,8 @@ jobs:
     - name: copying rustdoc to artifact dir
       run: flowey.exe e 1 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 1 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 1 flowey_lib_common::cache 7
+      run: flowey.exe e 1 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-windows-rustdoc
       uses: actions/upload-artifact@v4
@@ -604,32 +528,6 @@ jobs:
       run: flowey e 10 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 10 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 10 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 10 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 10 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -645,21 +543,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 10 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 10 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 10 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 10 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 10 flowey_lib_common::download_gh_release 1
@@ -675,16 +564,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -825,11 +714,8 @@ jobs:
     - name: copying guest_test_uefi to artifact dir
       run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 10 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 10 flowey_lib_common::cache 7
+      run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish aarch64-guest_test_uefi
       uses: actions/upload-artifact@v4
@@ -986,32 +872,6 @@ jobs:
       run: flowey e 11 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 11 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey v 11 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - run: |
-        flowey v 11 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey v 11 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 11 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 11 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -1027,21 +887,12 @@ jobs:
       with:
         key: ${{ env.floweyvar3 }}
         path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 11 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey e 11 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 11 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 11 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 11 flowey_lib_common::download_gh_release 1
@@ -1057,16 +908,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -1260,11 +1111,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 11 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 11 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 11 flowey_lib_common::cache 11
+      run: flowey e 11 flowey_lib_common::cache 7
       shell: bash
     - name: 🌼📦 Publish x64-guest_test_uefi
       uses: actions/upload-artifact@v4
@@ -1409,32 +1257,6 @@ jobs:
       run: flowey e 12 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 12 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 12 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 12 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 12 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -1450,21 +1272,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 12 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 12 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 12 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 12 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 12 flowey_lib_common::download_gh_release 1
@@ -1489,16 +1302,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -1720,11 +1533,8 @@ jobs:
     - name: copying pipette to artifact dir
       run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 2
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 12 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 12 flowey_lib_common::cache 7
+      run: flowey e 12 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v4
@@ -1849,32 +1659,6 @@ jobs:
       run: flowey e 13 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 13 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 13 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 13 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 13 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -1890,21 +1674,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 13 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 13 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 13 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 13 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 13 flowey_lib_common::download_gh_release 1
@@ -1929,16 +1704,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -2322,11 +2097,8 @@ jobs:
     - name: copying pipette to artifact dir
       run: flowey e 13 flowey_lib_common::copy_to_artifact_dir 2
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 13 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 13 flowey_lib_common::cache 7
+      run: flowey e 13 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v4
@@ -2488,32 +2260,6 @@ jobs:
       run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 14 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey.exe v 14 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - run: |
-        flowey.exe v 14 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 14 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 14 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 14 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 14 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -2529,21 +2275,12 @@ jobs:
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 14 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 14 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 14 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 14 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 14 flowey_lib_common::download_gh_release 1
@@ -2669,15 +2406,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 14 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar6'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-unit-tests
-        path: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar6 }}
       name: 'publish JUnit test results: x64-windows-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -2686,11 +2423,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 14 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 14 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 14 flowey_lib_common::cache 11
+      run: flowey.exe e 14 flowey_lib_common::cache 7
       shell: bash
   job15:
     name: clippy [linux, macos], unit tests [x64-linux]
@@ -2803,32 +2537,6 @@ jobs:
       run: flowey e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 15 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey v 15 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - run: |
-        flowey v 15 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey v 15 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 15 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 15 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 15 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -2844,21 +2552,12 @@ jobs:
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 15 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey e 15 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 15 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 15 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 15 flowey_lib_common::download_gh_release 1
@@ -3055,15 +2754,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 15 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 15 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar6'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-unit-tests
-        path: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar6 }}
       name: 'publish JUnit test results: x64-linux-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -3072,11 +2771,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 15 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 15 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 15 flowey_lib_common::cache 11
+      run: flowey e 15 flowey_lib_common::cache 7
       shell: bash
   job16:
     name: clippy [linux-musl, misc nostd], unit tests [x64-linux-musl]
@@ -3221,32 +2917,6 @@ jobs:
       run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 16 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey v 16 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - run: |
-        flowey v 16 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey v 16 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 16 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 16 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 16 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -3262,21 +2932,12 @@ jobs:
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 16 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey e 16 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 16 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 16 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 16 flowey_lib_common::download_gh_release 1
@@ -3441,15 +3102,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 16 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 16 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar6'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-musl-unit-tests
-        path: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar6 }}
       name: 'publish JUnit test results: x64-linux-musl-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -3458,11 +3119,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 16 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 16 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 16 flowey_lib_common::cache 11
+      run: flowey e 16 flowey_lib_common::cache 7
       shell: bash
   job17:
     name: run vmm-tests [x64-windows-intel]
@@ -3573,32 +3231,6 @@ jobs:
       run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 17 flowey_lib_common::cache 12
-      shell: bash
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::cache:26:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::cache:25:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar10'
-    - id: flowey_lib_common__cache__13
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__13.outputs.cache-hit }}
-      shell: flowey.exe v 17 'flowey_lib_common::cache:28:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__13.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 17 flowey_lib_common::cache 14
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 17 flowey_lib_common::cache 8
       shell: bash
     - run: |
@@ -3614,21 +3246,12 @@ jobs:
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey.exe v 17 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 17 flowey_lib_common::cache 10
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 17 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 17 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 17 flowey_lib_common::download_gh_release 1
@@ -3783,16 +3406,13 @@ jobs:
       run: flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 17 flowey_lib_common::cache 15
+      run: flowey.exe e 17 flowey_lib_common::cache 11
       shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 17 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 17 flowey_lib_common::cache 11
       shell: bash
   job18:
     name: run vmm-tests [x64-windows-amd]
@@ -3903,32 +3523,6 @@ jobs:
       run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 18 flowey_lib_common::cache 12
-      shell: bash
-    - run: |
-        flowey.exe v 18 'flowey_lib_common::cache:26:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
-        flowey.exe v 18 'flowey_lib_common::cache:25:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar10'
-    - id: flowey_lib_common__cache__13
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__13.outputs.cache-hit }}
-      shell: flowey.exe v 18 'flowey_lib_common::cache:28:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__13.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 18 flowey_lib_common::cache 14
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 18 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 18 flowey_lib_common::cache 8
       shell: bash
     - run: |
@@ -3944,21 +3538,12 @@ jobs:
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 18 flowey_lib_common::cache 10
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 18 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 18 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 18 flowey_lib_common::download_gh_release 1
@@ -4113,16 +3698,13 @@ jobs:
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 18 flowey_lib_common::cache 15
+      run: flowey.exe e 18 flowey_lib_common::cache 11
       shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 18 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 18 flowey_lib_common::cache 11
       shell: bash
   job19:
     name: run vmm-tests [x64-linux]
@@ -4235,32 +3817,6 @@ jobs:
       run: flowey e 19 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 19 flowey_lib_common::cache 12
-      shell: bash
-    - run: |
-        flowey v 19 'flowey_lib_common::cache:26:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
-        flowey v 19 'flowey_lib_common::cache:25:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar10'
-    - id: flowey_lib_common__cache__13
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__13.outputs.cache-hit }}
-      shell: flowey v 19 'flowey_lib_common::cache:28:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__13.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 19 flowey_lib_common::cache 14
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 19 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 19 flowey_lib_common::cache 8
       shell: bash
     - run: |
@@ -4276,21 +3832,12 @@ jobs:
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 19 flowey_lib_common::cache 10
-      shell: bash
-    - name: installing gh
-      run: flowey e 19 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 19 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 19 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 19 flowey_lib_common::download_gh_release 1
@@ -4442,16 +3989,13 @@ jobs:
       run: flowey e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 19 flowey_lib_common::cache 15
+      run: flowey e 19 flowey_lib_common::cache 11
       shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 19 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 19 flowey_lib_common::cache 11
       shell: bash
   job2:
     name: build and check docs [x64-linux]
@@ -4555,16 +4099,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -4583,32 +4127,6 @@ jobs:
       run: flowey e 2 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 2 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 2 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 2 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 2 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 2 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 2 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 2 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -4624,21 +4142,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 2 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 2 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 2 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 2 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 2 flowey_lib_common::download_gh_release 1
@@ -4688,11 +4197,8 @@ jobs:
     - name: copying rustdoc to artifact dir
       run: flowey e 2 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 2 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 2 flowey_lib_common::cache 7
+      run: flowey e 2 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-linux-rustdoc
       uses: actions/upload-artifact@v4
@@ -5054,32 +4560,6 @@ jobs:
       run: flowey.exe e 4 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 4 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey.exe v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey.exe v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 4 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 4 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 4 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 4 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -5095,21 +4575,12 @@ jobs:
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 4 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 4 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 4 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 4 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 4 flowey_lib_common::download_gh_release 1
@@ -5135,11 +4606,8 @@ jobs:
     - name: run xtask fmt
       run: flowey.exe e 4 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 4 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 4 flowey_lib_common::cache 7
+      run: flowey.exe e 4 flowey_lib_common::cache 3
       shell: bash
   job5:
     name: xtask fmt (linux)
@@ -5278,32 +4746,6 @@ jobs:
       run: flowey e 5 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 5 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 5 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 5 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 5 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -5319,21 +4761,12 @@ jobs:
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 5 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 5 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 5 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 5 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 5 flowey_lib_common::download_gh_release 1
@@ -5371,11 +4804,8 @@ jobs:
     - name: run xtask fmt
       run: flowey e 5 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 5 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 5 flowey_lib_common::cache 7
+      run: flowey e 5 flowey_lib_common::cache 3
       shell: bash
   job6:
     name: build artifacts (not for VMM tests) [aarch64-windows]
@@ -5494,16 +4924,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -5522,32 +4952,6 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 6 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 6 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 6 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 6 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -5563,21 +4967,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 6 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 6 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 6 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 6 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 6 flowey_lib_common::download_gh_release 1
@@ -5654,11 +5049,8 @@ jobs:
     - name: copying igvmfilegen to artifact dir
       run: flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 6 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 6 flowey_lib_common::cache 7
+      run: flowey.exe e 6 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish aarch64-windows-igvmfilegen
       uses: actions/upload-artifact@v4
@@ -5789,32 +5181,6 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 7 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 7 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 7 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 7 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 7 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -5830,21 +5196,12 @@ jobs:
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 7 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 7 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 7 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 7 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 7 flowey_lib_common::download_gh_release 1
@@ -5973,11 +5330,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 7 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 7 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 7 flowey_lib_common::cache 11
+      run: flowey.exe e 7 flowey_lib_common::cache 7
       shell: bash
     - name: 🌼📦 Publish aarch64-windows-openvmm
       uses: actions/upload-artifact@v4
@@ -6111,16 +5465,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -6139,32 +5493,6 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 8 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 8 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 8 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 8 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -6180,21 +5508,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 8 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 8 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 8 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 8 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 8 flowey_lib_common::download_gh_release 1
@@ -6274,11 +5593,8 @@ jobs:
     - name: copying ohcldiag-dev to artifact dir
       run: flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 1
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 8 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 8 flowey_lib_common::cache 7
+      run: flowey.exe e 8 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-windows-igvmfilegen
       uses: actions/upload-artifact@v4
@@ -6409,32 +5725,6 @@ jobs:
       run: flowey.exe e 9 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 9 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey.exe v 9 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - run: |
-        flowey.exe v 9 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 9 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 9 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 9 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 9 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -6450,21 +5740,12 @@ jobs:
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 9 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 9 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 9 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 9 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 9 flowey_lib_common::download_gh_release 1
@@ -6593,11 +5874,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 9 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 9 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 9 flowey_lib_common::cache 11
+      run: flowey.exe e 9 flowey_lib_common::cache 7
       shell: bash
     - name: 🌼📦 Publish x64-windows-openvmm
       uses: actions/upload-artifact@v4

--- a/.github/workflows/openvmm-pr.json
+++ b/.github/workflows/openvmm-pr.json
@@ -4,8 +4,7 @@
   "job_reqs": {
     "0": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fdc019ee4bc3ad94\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fdc019ee4bc3ad94\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"SetLocked\":true}",
@@ -24,13 +23,12 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"mdbook-mermaid-v0.14.0-x86_64-unknown-linux-gnu.tar.gz\",\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:0:flowey_lib_common/src/download_mdbook_mermaid.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-mermaid\",\"repo_owner\":\"badboy\",\"tag\":\"v0.14.0\"}",
-        "{\"file_name\":\"mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz\",\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook:0:flowey_lib_common/src/download_mdbook.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdBook\",\"repo_owner\":\"rust-lang\",\"tag\":\"v0.4.40\"}",
-        "{\"file_name\":\"mdbook-admonish-v1.18.0-x86_64-unknown-linux-gnu.tar.gz\",\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:0:flowey_lib_common/src/download_mdbook_admonish.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-admonish\",\"repo_owner\":\"tommilligan\",\"tag\":\"v1.18.0\"}"
+        "{\"file_name\":\"mdbook-mermaid-v0.14.0-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:0:flowey_lib_common/src/download_mdbook_mermaid.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-mermaid\",\"repo_owner\":\"badboy\",\"tag\":\"v0.14.0\"}",
+        "{\"file_name\":\"mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook:0:flowey_lib_common/src/download_mdbook.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdBook\",\"repo_owner\":\"rust-lang\",\"tag\":\"v0.4.40\"}",
+        "{\"file_name\":\"mdbook-admonish-v1.18.0-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:0:flowey_lib_common/src/download_mdbook_admonish.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-admonish\",\"repo_owner\":\"tommilligan\",\"tag\":\"v1.18.0\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"GetMdbook\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:0:flowey_lib_hvlite/src/build_guide.rs:28:30\",\"is_secret\":false}}",
@@ -52,9 +50,9 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook:1:flowey_lib_common/src/download_mdbook.rs:69:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:1:flowey_lib_common/src/download_mdbook_admonish.rs:69:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:1:flowey_lib_common/src/download_mdbook_mermaid.rs:69:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook:1:flowey_lib_common/src/download_mdbook.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:1:flowey_lib_common/src/download_mdbook_admonish.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:1:flowey_lib_common/src/download_mdbook_mermaid.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
@@ -68,10 +66,6 @@
         "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:6:flowey_lib_hvlite/src/build_guide.rs:38:37\",\"is_secret\":false}}",
         "{\"IgnoreVersion\":false}",
         "{\"Version\":\"1.82.0\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guide": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start1\",\"is_secret\":false}}"
@@ -116,8 +110,7 @@
     },
     "1": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:1:flowey_lib_common/src/run_cargo_doc.rs:115:25\",\"is_secret\":false}}",
@@ -137,12 +130,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -162,7 +154,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
@@ -182,10 +174,6 @@
       ],
       "flowey_lib_common::run_cargo_doc": [
         "{\"cargo_cmd\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:3:flowey_lib_hvlite/src/build_rustdoc.rs:84:33\",\"is_secret\":false},\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\"},\"is_secret\":false},\"packages\":[{\"document_private_items\":false,\"kind\":{\"Workspace\":{\"exclude\":[\"vmfirmwareigvm_dll\"]}},\"no_deps\":true},{\"document_private_items\":false,\"kind\":{\"NoStdCrate\":\"guest_test_uefi\"},\"no_deps\":true}],\"target_triple\":\"x86_64-pc-windows-msvc\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"target_triple\":\"x86_64-pc-windows-msvc\"}"
@@ -248,8 +236,7 @@
     },
     "2": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:1:flowey_lib_common/src/run_cargo_doc.rs:115:25\",\"is_secret\":false}}",
@@ -269,12 +256,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -294,7 +280,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
@@ -314,10 +300,6 @@
       ],
       "flowey_lib_common::run_cargo_doc": [
         "{\"cargo_cmd\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:3:flowey_lib_hvlite/src/build_rustdoc.rs:84:33\",\"is_secret\":false},\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\"},\"is_secret\":false},\"packages\":[{\"document_private_items\":false,\"kind\":{\"Workspace\":{\"exclude\":[\"vmfirmwareigvm_dll\"]}},\"no_deps\":true},{\"document_private_items\":false,\"kind\":{\"NoStdCrate\":\"guest_test_uefi\"},\"no_deps\":true}],\"target_triple\":\"x86_64-unknown-linux-gnu\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"target_triple\":\"x86_64-unknown-linux-gnu\"}"
@@ -380,8 +362,7 @@
     },
     "3": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -398,11 +379,10 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -422,7 +402,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
@@ -441,10 +421,6 @@
       ],
       "flowey_lib_common::run_cargo_build": [
         "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-pc-windows-msvc\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -502,8 +478,7 @@
     },
     "4": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-185fb9aa857d6110\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-185fb9aa857d6110\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -520,11 +495,10 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -545,7 +519,7 @@
       ],
       "flowey_lib_common::install_apt_pkg": [
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
         "{\"AutoInstall\":true}",
@@ -564,10 +538,6 @@
       ],
       "flowey_lib_common::run_cargo_build": [
         "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -628,8 +598,7 @@
     },
     "5": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -652,11 +621,10 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -676,7 +644,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
       ],
@@ -703,10 +671,6 @@
         "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
         "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
         "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[\"encryption_win\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start8\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
@@ -797,8 +761,7 @@
     "6": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-6fd9989180c5ad5c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-6fd9989180c5ad5c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -824,12 +787,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -849,7 +811,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}"
       ],
@@ -879,10 +841,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_archive": [
         "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:141:29\",\"is_secret\":false},\"build_params\":{\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:73:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:138:29\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start12\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}"
@@ -968,8 +926,7 @@
     },
     "7": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -992,11 +949,10 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -1017,7 +973,7 @@
       ],
       "flowey_lib_common::install_apt_pkg": [
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:3:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:100:21\",\"is_secret\":false},\"package_names\":[\"clang\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
       ],
@@ -1044,10 +1000,6 @@
         "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}",
         "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}",
         "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[\"encryption_win\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start15\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
@@ -1139,8 +1091,7 @@
     "8": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1166,12 +1117,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -1191,7 +1141,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}"
       ],
@@ -1221,10 +1171,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_archive": [
         "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:141:29\",\"is_secret\":false},\"build_params\":{\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:73:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:138:29\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
         "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start19\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
@@ -1310,8 +1256,7 @@
     },
     "9": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-82559e949fe64647\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-82559e949fe64647\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1335,12 +1280,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -1370,7 +1314,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:28:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
@@ -1403,10 +1347,6 @@
         "{\"crate_name\":\"openvmm\",\"extra_env\":{\"backing_var\":{\"Inline\":{\"CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER\":\"aarch64-linux-gnu-gcc\"}},\"is_secret\":false},\"features\":[\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
         "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"Inline\":{\"CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER\":\"aarch64-linux-gnu-gcc\"}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
         "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"Inline\":{\"CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER\":\"aarch64-linux-gnu-gcc\"}},\"is_secret\":false},\"features\":[\"encryption_ossl\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:28:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
         "{\"arch\":\"Aarch64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start25\",\"is_secret\":false},\"profile\":\"Debug\"}"
@@ -1529,8 +1469,7 @@
     "10": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1560,12 +1499,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -1591,7 +1529,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\",\"is_secret\":false},\"package_names\":[\"build-essential\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:3:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:100:21\",\"is_secret\":false},\"package_names\":[\"clang\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:53:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
@@ -1631,10 +1569,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_archive": [
         "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:141:29\",\"is_secret\":false},\"build_params\":{\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:73:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:138:29\"},\"is_secret\":false}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
         "{\"arch\":\"X86_64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start31\",\"is_secret\":false},\"profile\":\"Debug\"}"
@@ -1768,8 +1702,7 @@
     },
     "11": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e27197f6b5dd16ab\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e27197f6b5dd16ab\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1791,16 +1724,15 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-arm64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-arm64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
-        "{\"file_name\":\"RELEASE-AARCH64-artifacts.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
-        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:2:flowey_lib_hvlite/src/download_openvmm_deps.rs:110:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
+        "{\"file_name\":\"RELEASE-AARCH64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:2:flowey_lib_hvlite/src/download_openvmm_deps.rs:111:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -1829,7 +1761,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:22:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:0:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:0:flowey_lib_hvlite/src/build_openhcl_initrd.rs:62:26\",\"is_secret\":false},\"package_names\":[\"python3\"]}}"
@@ -1857,10 +1789,6 @@
         "{\"crate_name\":\"openhcl_boot\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:397:27\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:387:25\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"boot-dev\"},\"target\":\"aarch64-unknown-linux-musl\"}",
         "{\"crate_name\":\"openvmm_hcl\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[\"gdb\",\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:92:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:387:25\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-musl\"}",
         "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:22:flowey_lib_hvlite/src/run_cargo_build.rs:355:41\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:387:25\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-musl\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
         "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start33\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"Aarch64\"},{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"Aarch64Devkern\"}]}"
@@ -1981,8 +1909,7 @@
     },
     "12": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-69bfa92774c5940b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-69bfa92774c5940b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -2004,16 +1931,15 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:5:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-cvm-x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
-        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:5:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-cvm-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -2042,7 +1968,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:8:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:0:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:0:flowey_lib_hvlite/src/build_openhcl_initrd.rs:62:26\",\"is_secret\":false},\"package_names\":[\"python3\"]}}"
@@ -2070,10 +1996,6 @@
         "{\"crate_name\":\"openhcl_boot\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:397:27\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"boot-dev\"},\"target\":\"x86_64-unknown-none\"}",
         "{\"crate_name\":\"openvmm_hcl\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[\"gdb\",\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:92:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:387:25\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\"}",
         "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"Inline\":{}},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:311:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:405:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:309:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:387:25\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
         "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start35\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64Devkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64TestLinuxDirect\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64TestLinuxDirectDevkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64Cvm\"}]}"
@@ -2228,8 +2150,7 @@
     "13": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-38b54383c2832bcf\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-38b54383c2832bcf\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -2252,13 +2173,12 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-win64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -2278,7 +2198,7 @@
         "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
       ],
       "flowey_lib_common::install_apt_pkg": [
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
       ],
       "flowey_lib_common::install_azure_cli": [
@@ -2321,10 +2241,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:55:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"features\":{\"Specific\":[\"ci\"]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start39\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-windows-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}"
@@ -2411,8 +2327,7 @@
     "14": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-763048f92183c49f\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-763048f92183c49f\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -2435,13 +2350,12 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -2465,7 +2379,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:110:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"gcc-aarch64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:110:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"gcc-aarch64-linux-gnu\"]}}"
@@ -2515,10 +2429,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:55:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start43\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}"
@@ -2617,8 +2527,7 @@
     "15": {
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-776396c93f9413c8\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-776396c93f9413c8\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -2641,15 +2550,14 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:2:flowey_lib_hvlite/src/download_openvmm_deps.rs:110:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
-        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:2:flowey_lib_hvlite/src/download_openvmm_deps.rs:111:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -2673,7 +2581,7 @@
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
-        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
         "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:110:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"gcc-aarch64-linux-gnu\"]}}"
       ],
@@ -2729,10 +2637,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:186:25\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:55:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
         "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start46\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-musl-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}"
@@ -2833,8 +2737,7 @@
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"SetLocked\":true}",
@@ -2852,12 +2755,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -2897,10 +2799,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:167:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:187:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -2982,8 +2880,7 @@
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"SetLocked\":true}",
@@ -3001,12 +2898,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -3046,10 +2942,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:167:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:187:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3131,8 +3023,7 @@
       "flowey_lib_common::cache": [
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
         "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_cli:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_cli:1:flowey_lib_common/src/download_gh_cli.rs:65:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-cli-2.52.0\"},\"is_secret\":false},\"label\":\"gh-cli\",\"restore_keys\":null}",
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:151:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:884:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"SetLocked\":true}",
@@ -3150,12 +3041,11 @@
         "{\"Version\":\"0.9.74\"}"
       ],
       "flowey_lib_common::download_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::use_gh_cli:0:flowey_lib_common/src/use_gh_cli.rs:93:31\",\"is_secret\":false}}",
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
-        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
       ],
       "flowey_lib_common::download_mdbook": [
         "{\"Version\":\"0.4.40\"}"
@@ -3195,10 +3085,6 @@
       ],
       "flowey_lib_common::run_cargo_nextest_run": [
         "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all() and not test(openhcl) and not test(pcat_x64)\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:167:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"auto_se:flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_core/src/node.rs:840:34\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:187:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:1:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"Get\":{\"backing_var\":\"flowey_lib_common::download_gh_release:2:flowey_lib_common/src/download_gh_release.rs:161:26\",\"is_secret\":false}}",
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
@@ -3319,9 +3205,6 @@
         "{\"IgnoreVersion\":false}",
         "{\"Version\":\"1.82.0\"}"
       ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
-      ],
       "flowey_lib_hvlite::_jobs::cfg_common": [
         "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
       ],
@@ -3400,9 +3283,6 @@
         "{\"AutoInstall\":true}",
         "{\"IgnoreVersion\":false}",
         "{\"Version\":\"1.82.0\"}"
-      ],
-      "flowey_lib_common::use_gh_cli": [
-        "{\"WithAuth\":{\"AuthToken\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36\"},\"is_secret\":true}}}"
       ],
       "flowey_lib_hvlite::_jobs::all_good_job": [
         "{\"did_fail_env_var\":\"ANY_JOBS_FAILED\",\"done\":{\"backing_var\":\"start51\",\"is_secret\":false}}"

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -114,32 +114,6 @@ jobs:
       run: flowey e 0 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 0 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 0 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey v 0 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 0 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 0 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 0 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 0 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -155,21 +129,12 @@ jobs:
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 0 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 0 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 0 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 0 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 0 flowey_lib_common::download_gh_release 1
@@ -234,9 +199,6 @@ jobs:
       run: flowey e 0 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 0 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
       run: flowey e 0 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish guide
@@ -346,16 +308,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -374,32 +336,6 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 1 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 1 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 1 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 1 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 1 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -415,21 +351,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 1 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 1 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 1 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 1 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 1 flowey_lib_common::download_gh_release 1
@@ -473,11 +400,8 @@ jobs:
     - name: copying rustdoc to artifact dir
       run: flowey.exe e 1 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 1 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 1 flowey_lib_common::cache 7
+      run: flowey.exe e 1 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-windows-rustdoc
       uses: actions/upload-artifact@v4
@@ -609,32 +533,6 @@ jobs:
       run: flowey e 10 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 10 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey v 10 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - run: |
-        flowey v 10 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey v 10 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 10 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 10 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 10 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -650,21 +548,12 @@ jobs:
       with:
         key: ${{ env.floweyvar3 }}
         path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 10 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey e 10 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 10 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 10 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 10 flowey_lib_common::download_gh_release 1
@@ -680,16 +569,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar7'
+      name: 🌼 Write to 'floweyvar5'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar7 }}
+        persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -883,11 +772,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 10 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 10 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 10 flowey_lib_common::cache 11
+      run: flowey e 10 flowey_lib_common::cache 7
       shell: bash
     - name: 🌼📦 Publish x64-guest_test_uefi
       uses: actions/upload-artifact@v4
@@ -1032,32 +918,6 @@ jobs:
       run: flowey e 11 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 11 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 11 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 11 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 11 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -1073,21 +933,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 11 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 11 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 11 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 11 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 11 flowey_lib_common::download_gh_release 1
@@ -1112,16 +963,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -1343,11 +1194,8 @@ jobs:
     - name: copying pipette to artifact dir
       run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 2
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 11 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 11 flowey_lib_common::cache 7
+      run: flowey e 11 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish aarch64-linux-musl-pipette
       uses: actions/upload-artifact@v4
@@ -1472,32 +1320,6 @@ jobs:
       run: flowey e 12 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 12 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 12 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 12 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 12 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -1513,21 +1335,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 12 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 12 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 12 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 12 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 12 flowey_lib_common::download_gh_release 1
@@ -1552,16 +1365,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -1945,11 +1758,8 @@ jobs:
     - name: copying pipette to artifact dir
       run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 2
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 12 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 12 flowey_lib_common::cache 7
+      run: flowey e 12 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-linux-musl-pipette
       uses: actions/upload-artifact@v4
@@ -2111,32 +1921,6 @@ jobs:
       run: flowey.exe e 13 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 13 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - run: |
-        flowey.exe v 13 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 13 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 13 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 13 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 13 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -2152,21 +1936,12 @@ jobs:
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 13 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 13 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 13 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 13 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 13 flowey_lib_common::download_gh_release 1
@@ -2292,15 +2067,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 13 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar6'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-unit-tests
-        path: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar6 }}
       name: 'publish JUnit test results: x64-windows-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -2309,11 +2084,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 13 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 13 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 13 flowey_lib_common::cache 11
+      run: flowey.exe e 13 flowey_lib_common::cache 7
       shell: bash
   job14:
     name: clippy [linux, macos], unit tests [x64-linux]
@@ -2426,32 +2198,6 @@ jobs:
       run: flowey e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 14 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey v 14 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - run: |
-        flowey v 14 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey v 14 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 14 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 14 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 14 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -2467,21 +2213,12 @@ jobs:
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 14 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey e 14 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 14 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 14 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 14 flowey_lib_common::download_gh_release 1
@@ -2678,15 +2415,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 14 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 14 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar6'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-unit-tests
-        path: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar6 }}
       name: 'publish JUnit test results: x64-linux-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -2695,11 +2432,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 14 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 14 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 14 flowey_lib_common::cache 11
+      run: flowey e 14 flowey_lib_common::cache 7
       shell: bash
   job15:
     name: clippy [linux-musl, misc nostd], unit tests [x64-linux-musl]
@@ -2844,32 +2578,6 @@ jobs:
       run: flowey e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 15 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey v 15 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - run: |
-        flowey v 15 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey v 15 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 15 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 15 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 15 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -2885,21 +2593,12 @@ jobs:
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 15 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey e 15 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 15 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 15 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 15 flowey_lib_common::download_gh_release 1
@@ -3064,15 +2763,15 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 15 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 15 'flowey_lib_common::junit_publish_test_results:2:flowey_lib_common/src/junit_publish_test_results.rs:105:42' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
+      name: 🌼 Write to 'floweyvar6'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__junit_publish_test_results__2
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-musl-unit-tests
-        path: ${{ env.floweyvar8 }}
+        path: ${{ env.floweyvar6 }}
       name: 'publish JUnit test results: x64-linux-musl-unit-tests'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
@@ -3081,11 +2780,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 15 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 15 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 15 flowey_lib_common::cache 11
+      run: flowey e 15 flowey_lib_common::cache 7
       shell: bash
   job16:
     name: run vmm-tests [x64-windows-intel]
@@ -3196,32 +2892,6 @@ jobs:
       run: flowey.exe e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 16 flowey_lib_common::cache 12
-      shell: bash
-    - run: |
-        flowey.exe v 16 'flowey_lib_common::cache:26:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
-        flowey.exe v 16 'flowey_lib_common::cache:25:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar10'
-    - id: flowey_lib_common__cache__13
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__13.outputs.cache-hit }}
-      shell: flowey.exe v 16 'flowey_lib_common::cache:28:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__13.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 16 flowey_lib_common::cache 14
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 16 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 16 flowey_lib_common::cache 8
       shell: bash
     - run: |
@@ -3237,21 +2907,12 @@ jobs:
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey.exe v 16 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 16 flowey_lib_common::cache 10
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 16 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 16 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 16 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 16 flowey_lib_common::download_gh_release 1
@@ -3406,16 +3067,13 @@ jobs:
       run: flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 16 flowey_lib_common::cache 15
+      run: flowey.exe e 16 flowey_lib_common::cache 11
       shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 16 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 16 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 16 flowey_lib_common::cache 11
       shell: bash
   job17:
     name: run vmm-tests [x64-windows-amd]
@@ -3526,32 +3184,6 @@ jobs:
       run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 17 flowey_lib_common::cache 12
-      shell: bash
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::cache:26:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::cache:25:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar10'
-    - id: flowey_lib_common__cache__13
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__13.outputs.cache-hit }}
-      shell: flowey.exe v 17 'flowey_lib_common::cache:28:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__13.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 17 flowey_lib_common::cache 14
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 17 flowey_lib_common::cache 8
       shell: bash
     - run: |
@@ -3567,21 +3199,12 @@ jobs:
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey.exe v 17 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 17 flowey_lib_common::cache 10
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 17 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 17 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 17 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 17 flowey_lib_common::download_gh_release 1
@@ -3736,16 +3359,13 @@ jobs:
       run: flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 17 flowey_lib_common::cache 15
+      run: flowey.exe e 17 flowey_lib_common::cache 11
       shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 17 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 17 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 17 flowey_lib_common::cache 11
       shell: bash
   job18:
     name: run vmm-tests [x64-linux]
@@ -3858,32 +3478,6 @@ jobs:
       run: flowey e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 18 flowey_lib_common::cache 12
-      shell: bash
-    - run: |
-        flowey v 18 'flowey_lib_common::cache:26:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
-        flowey v 18 'flowey_lib_common::cache:25:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar10'
-    - id: flowey_lib_common__cache__13
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar9 }}
-        path: ${{ env.floweyvar10 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__13.outputs.cache-hit }}
-      shell: flowey v 18 'flowey_lib_common::cache:28:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__13.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 18 flowey_lib_common::cache 14
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 18 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 18 flowey_lib_common::cache 8
       shell: bash
     - run: |
@@ -3899,21 +3493,12 @@ jobs:
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
       shell: flowey v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 18 flowey_lib_common::cache 10
-      shell: bash
-    - name: installing gh
-      run: flowey e 18 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 18 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 18 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 18 flowey_lib_common::download_gh_release 1
@@ -4065,16 +3650,13 @@ jobs:
       run: flowey e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 18 flowey_lib_common::cache 15
+      run: flowey e 18 flowey_lib_common::cache 11
       shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 18 flowey_lib_common::cache 7
-      shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 18 flowey_lib_common::cache 11
       shell: bash
   job19:
     name: test flowey local backend
@@ -4308,16 +3890,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -4336,32 +3918,6 @@ jobs:
       run: flowey e 2 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 2 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 2 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 2 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 2 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 2 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 2 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 2 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -4377,21 +3933,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 2 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 2 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 2 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 2 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 2 flowey_lib_common::download_gh_release 1
@@ -4441,11 +3988,8 @@ jobs:
     - name: copying rustdoc to artifact dir
       run: flowey e 2 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 2 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 2 flowey_lib_common::cache 7
+      run: flowey e 2 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-linux-rustdoc
       uses: actions/upload-artifact@v4
@@ -4646,32 +4190,6 @@ jobs:
       run: flowey.exe e 3 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 3 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 3 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 3 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 3 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 3 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -4687,21 +4205,12 @@ jobs:
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 3 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 3 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 3 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 3 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 3 flowey_lib_common::download_gh_release 1
@@ -4727,11 +4236,8 @@ jobs:
     - name: run xtask fmt
       run: flowey.exe e 3 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 3 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 3 flowey_lib_common::cache 7
+      run: flowey.exe e 3 flowey_lib_common::cache 3
       shell: bash
   job4:
     name: xtask fmt (linux)
@@ -4870,32 +4376,6 @@ jobs:
       run: flowey e 4 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 4 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 4 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
-        flowey v 4 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 4 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 4 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 4 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 4 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -4911,21 +4391,12 @@ jobs:
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 4 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 4 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 4 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 4 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 4 flowey_lib_common::download_gh_release 1
@@ -4963,11 +4434,8 @@ jobs:
     - name: run xtask fmt
       run: flowey e 4 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 4 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 4 flowey_lib_common::cache 7
+      run: flowey e 4 flowey_lib_common::cache 3
       shell: bash
   job5:
     name: build artifacts (not for VMM tests) [aarch64-windows]
@@ -5086,16 +4554,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -5114,32 +4582,6 @@ jobs:
       run: flowey.exe e 5 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 5 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 5 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 5 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 5 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -5155,21 +4597,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 5 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 5 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 5 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 5 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 5 flowey_lib_common::download_gh_release 1
@@ -5246,11 +4679,8 @@ jobs:
     - name: copying ohcldiag-dev to artifact dir
       run: flowey.exe e 5 flowey_lib_common::copy_to_artifact_dir 1
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 5 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 5 flowey_lib_common::cache 7
+      run: flowey.exe e 5 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish aarch64-windows-igvmfilegen
       uses: actions/upload-artifact@v4
@@ -5381,32 +4811,6 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 6 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 6 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 6 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 6 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 6 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -5422,21 +4826,12 @@ jobs:
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 6 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 6 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 6 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 6 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 6 flowey_lib_common::download_gh_release 1
@@ -5565,11 +4960,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 6 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 6 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 6 flowey_lib_common::cache 11
+      run: flowey.exe e 6 flowey_lib_common::cache 7
       shell: bash
     - name: 🌼📦 Publish aarch64-windows-openvmm
       uses: actions/upload-artifact@v4
@@ -5703,16 +5095,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -5731,32 +5123,6 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 7 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 7 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 7 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 7 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -5772,21 +5138,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 7 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 7 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 7 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 7 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 7 flowey_lib_common::download_gh_release 1
@@ -5866,11 +5223,8 @@ jobs:
     - name: copying ohcldiag-dev to artifact dir
       run: flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 1
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 7 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 7 flowey_lib_common::cache 7
+      run: flowey.exe e 7 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish x64-windows-igvmfilegen
       uses: actions/upload-artifact@v4
@@ -6001,32 +5355,6 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 8 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - id: flowey_lib_common__cache__9
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar6 }}
-        path: ${{ env.floweyvar7 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 8 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 8 flowey_lib_common::cache 10
-      shell: bash
-    - name: create gh cache dir
-      run: flowey.exe e 8 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey.exe e 8 flowey_lib_common::cache 4
       shell: bash
     - run: |
@@ -6042,21 +5370,12 @@ jobs:
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
       shell: flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey.exe e 8 flowey_lib_common::cache 6
-      shell: bash
-    - name: installing gh
-      run: flowey.exe e 8 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey.exe v 8 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey.exe e 8 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey.exe e 8 flowey_lib_common::download_gh_release 1
@@ -6185,11 +5504,8 @@ jobs:
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 8 flowey_lib_common::cache 3
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey.exe e 8 flowey_lib_common::cache 7
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 8 flowey_lib_common::cache 11
+      run: flowey.exe e 8 flowey_lib_common::cache 7
       shell: bash
     - name: 🌼📦 Publish x64-windows-openvmm
       uses: actions/upload-artifact@v4
@@ -6337,32 +5653,6 @@ jobs:
       run: flowey e 9 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 9 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
-        flowey v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
-        flowey v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - id: flowey_lib_common__cache__5
-      uses: actions/cache@v4
-      with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
-      name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 9 flowey_lib_common::cache 6
-      shell: bash
-    - name: create gh cache dir
-      run: flowey e 9 flowey_lib_common::download_gh_cli 0
-      shell: bash
-    - name: Pre-processing cache vars
       run: flowey e 9 flowey_lib_common::cache 0
       shell: bash
     - run: |
@@ -6378,21 +5668,12 @@ jobs:
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
-      name: 'Restore cache: gh-cli'
+      name: 'Restore cache: gh-release-download'
     - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
       shell: flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
       name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
     - name: map Github cache-hit to flowey
       run: flowey e 9 flowey_lib_common::cache 2
-      shell: bash
-    - name: installing gh
-      run: flowey e 9 flowey_lib_common::download_gh_cli 1
-      shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 9 'flowey_lib_hvlite::_jobs::cfg_common:0:flowey_lib_hvlite/src/_jobs/cfg_common.rs:92:36' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
-    - name: setup gh cli
-      run: flowey e 9 flowey_lib_common::use_gh_cli 0
       shell: bash
     - name: download artifacts from github releases
       run: flowey e 9 flowey_lib_common::download_gh_release 1
@@ -6408,16 +5689,16 @@ jobs:
       shell: bash
       name: 🌼❓ Write to 'FLOWEY_CONDITION'
     - run: |
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
+      name: 🌼 Write to 'floweyvar3'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar5 }}
+        persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo hvlite
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
@@ -6558,11 +5839,8 @@ jobs:
     - name: copying guest_test_uefi to artifact dir
       run: flowey e 9 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
-    - name: 'validate cache entry: gh-cli'
-      run: flowey e 9 flowey_lib_common::cache 3
-      shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 9 flowey_lib_common::cache 7
+      run: flowey e 9 flowey_lib_common::cache 3
       shell: bash
     - name: 🌼📦 Publish aarch64-guest_test_uefi
       uses: actions/upload-artifact@v4

--- a/flowey/flowey_lib_common/src/download_gh_release.rs
+++ b/flowey/flowey_lib_common/src/download_gh_release.rs
@@ -8,10 +8,25 @@ use std::collections::BTreeMap;
 
 flowey_request! {
     pub struct Request {
+        /// First component of a github repo path
+        ///
+        /// e.g: the "foo" in "github.com/foo/bar"
         pub repo_owner: String,
+        /// Second component of a github repo path
+        ///
+        /// e.g: the "bar" in "github.com/foo/bar"
         pub repo_name: String,
+        /// Whether this repo requires authentication.
+        ///
+        /// If true, downloads will be routed through the `gh` CLI client, which
+        /// will require auth to be set up. See
+        /// [`use_gh_cli`](crate::use_gh_cli).
+        pub needs_auth: bool,
+        /// Tag associated with the release artifact.
         pub tag: String,
+        /// Specific filename to download.
         pub file_name: String,
+        /// Path to downloaded artifact.
         pub path: WriteVar<PathBuf>,
     }
 }
@@ -31,15 +46,21 @@ impl FlowNode for Node {
             (String, String, String),
             BTreeMap<String, Vec<WriteVar<PathBuf>>>,
         > = BTreeMap::new();
+        let mut use_gh_cli = false;
 
         for req in requests {
             let Request {
                 repo_owner,
                 repo_name,
+                needs_auth,
                 tag,
                 file_name,
                 path,
             } = req;
+
+            // if any package needs auth, we might as well download every
+            // package using the GH cli.
+            use_gh_cli |= needs_auth;
 
             download_reqs
                 .entry((repo_owner, repo_name, tag))
@@ -49,9 +70,15 @@ impl FlowNode for Node {
                 .push(path)
         }
 
+        if download_reqs.is_empty() {
+            return Ok(());
+        }
+
+        let gh_cli = use_gh_cli.then(|| ctx.reqv(crate::use_gh_cli::Request::Get));
+
         match ctx.persistent_dir() {
-            Some(dir) => Self::with_local_cache(ctx, dir, download_reqs),
-            None => Self::with_ci_cache(ctx, download_reqs),
+            Some(dir) => Self::with_local_cache(ctx, dir, download_reqs, gh_cli),
+            None => Self::with_ci_cache(ctx, download_reqs, gh_cli),
         }
 
         Ok(())
@@ -64,16 +91,14 @@ impl Node {
         ctx: &mut NodeCtx<'_>,
         persistent_dir: ReadVar<PathBuf>,
         download_reqs: BTreeMap<(String, String, String), BTreeMap<String, Vec<WriteVar<PathBuf>>>>,
+        gh_cli: Option<ReadVar<PathBuf>>,
     ) {
-        let gh_cli = ctx.reqv(crate::use_gh_cli::Request::Get);
-
         ctx.emit_rust_step("download artifacts from github releases", |ctx| {
             let gh_cli = gh_cli.claim(ctx);
             let persistent_dir = persistent_dir.claim(ctx);
             let download_reqs = download_reqs.claim(ctx);
             move |rt| {
                 let persistent_dir = rt.read(persistent_dir);
-                let gh_cli = rt.read(gh_cli);
 
                 // first - check what reqs are already present in the local cache
                 let mut remaining_download_reqs: BTreeMap<
@@ -104,7 +129,7 @@ impl Node {
                     return Ok(());
                 }
 
-                download_all_reqs(&remaining_download_reqs, &persistent_dir, &gh_cli)?;
+                download_all_reqs(rt, &remaining_download_reqs, &persistent_dir, gh_cli)?;
 
                 for ((repo_owner, repo_name, tag), files) in remaining_download_reqs {
                     for (file, vars) in files {
@@ -128,6 +153,7 @@ impl Node {
     fn with_ci_cache(
         ctx: &mut NodeCtx<'_>,
         download_reqs: BTreeMap<(String, String, String), BTreeMap<String, Vec<WriteVar<PathBuf>>>>,
+        gh_cli: Option<ReadVar<PathBuf>>,
     ) {
         let cache_dir = ctx.emit_rust_stepv("create gh-release-download cache dir", |_| {
             |_| Ok(std::env::current_dir()?.absolute()?)
@@ -158,8 +184,6 @@ impl Node {
             }
         });
 
-        let gh_cli = ctx.reqv(crate::use_gh_cli::Request::Get);
-
         ctx.emit_rust_step("download artifacts from github releases", |ctx| {
             let cache_dir = cache_dir.claim(ctx);
             let hitvar = hitvar.claim(ctx);
@@ -168,10 +192,9 @@ impl Node {
             move |rt| {
                 let cache_dir = rt.read(cache_dir);
                 let hitvar = rt.read(hitvar);
-                let gh_cli = rt.read(gh_cli);
 
                 if !matches!(hitvar, crate::cache::CacheHit::Hit) {
-                    download_all_reqs(&download_reqs, &cache_dir, &gh_cli)?;
+                    download_all_reqs(rt, &download_reqs, &cache_dir, gh_cli)?;
                 }
 
                 for ((repo_owner, repo_name, tag), files) in download_reqs {
@@ -191,31 +214,42 @@ impl Node {
 }
 
 fn download_all_reqs(
+    rt: &mut RustRuntimeServices<'_>,
     download_reqs: &BTreeMap<
         (String, String, String),
         BTreeMap<String, Vec<WriteVar<PathBuf, VarClaimed>>>,
     >,
     cache_dir: &Path,
-    gh_cli: &Path,
+    gh_cli: Option<ReadVar<PathBuf, VarClaimed>>,
 ) -> anyhow::Result<()> {
     let sh = xshell::Shell::new()?;
 
-    // FUTURE: while the gh cli takes care of doing simultaneous downloads in
-    // the context of a single (repo, tag), we might want to have flowey spawn
-    // multiple processes to saturate the network connection in cases where
-    // multiple (repo, tag) pairs are being pulled at the same time.
+    let gh_cli = gh_cli.map(|x| rt.read(x));
+
     for ((repo_owner, repo_name, tag), files) in download_reqs {
         let repo = format!("{repo_owner}/{repo_name}");
-        let patterns = files.keys().flat_map(|k| ["--pattern".into(), k.clone()]);
 
         let out_dir = cache_dir.join(format!("{repo_owner}/{repo_name}/{tag}"));
         fs_err::create_dir_all(&out_dir)?;
         sh.change_dir(&out_dir);
-        xshell::cmd!(
-            sh,
-            "{gh_cli} release download -R {repo} {tag} {patterns...} --skip-existing"
-        )
-        .run()?;
+
+        if let Some(gh_cli) = &gh_cli {
+            // FUTURE: while the gh cli takes care of doing simultaneous downloads in
+            // the context of a single (repo, tag), we might want to have flowey spawn
+            // multiple processes to saturate the network connection in cases where
+            // multiple (repo, tag) pairs are being pulled at the same time.
+            let patterns = files.keys().flat_map(|k| ["--pattern".into(), k.clone()]);
+            xshell::cmd!(
+                sh,
+                "{gh_cli} release download -R {repo} {tag} {patterns...} --skip-existing"
+            )
+            .run()?;
+        } else {
+            // FUTURE: parallelize curl invocations across all download_reqs
+            for file in files.keys() {
+                xshell::cmd!(sh, "curl -L https://github.com/{repo_owner}/{repo_name}/releases/download/{tag}/{file} -o {file}").run()?;
+            }
+        }
     }
 
     Ok(())

--- a/flowey/flowey_lib_common/src/download_mdbook.rs
+++ b/flowey/flowey_lib_common/src/download_mdbook.rs
@@ -61,6 +61,7 @@ impl FlowNode for Node {
         let mdbook_zip = ctx.reqv(|v| crate::download_gh_release::Request {
             repo_owner: "rust-lang".into(),
             repo_name: "mdBook".into(),
+            needs_auth: false,
             tag: tag.clone(),
             file_name: file_name.clone(),
             path: v,

--- a/flowey/flowey_lib_common/src/download_mdbook_admonish.rs
+++ b/flowey/flowey_lib_common/src/download_mdbook_admonish.rs
@@ -61,6 +61,7 @@ impl FlowNode for Node {
         let mdbook_zip = ctx.reqv(|v| crate::download_gh_release::Request {
             repo_owner: "tommilligan".into(),
             repo_name: "mdbook-admonish".into(),
+            needs_auth: false,
             tag: tag.clone(),
             file_name: file_name.clone(),
             path: v,

--- a/flowey/flowey_lib_common/src/download_mdbook_mermaid.rs
+++ b/flowey/flowey_lib_common/src/download_mdbook_mermaid.rs
@@ -61,6 +61,7 @@ impl FlowNode for Node {
         let mdbook_zip = ctx.reqv(|v| crate::download_gh_release::Request {
             repo_owner: "badboy".into(),
             repo_name: "mdbook-mermaid".into(),
+            needs_auth: false,
             tag: tag.clone(),
             file_name: file_name.clone(),
             path: v,

--- a/flowey/flowey_lib_common/src/download_protoc.rs
+++ b/flowey/flowey_lib_common/src/download_protoc.rs
@@ -69,6 +69,7 @@ impl FlowNode for Node {
         let protoc_zip = ctx.reqv(|v| crate::download_gh_release::Request {
             repo_owner: "protocolbuffers".into(),
             repo_name: "protobuf".into(),
+            needs_auth: false,
             tag: tag.clone(),
             file_name: file_name.clone(),
             path: v,

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_common.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_common.rs
@@ -87,14 +87,6 @@ impl SimpleFlowNode for Node {
             ctx.req(flowey_lib_common::install_rust::Request::IgnoreVersion(
                 false,
             ));
-
-            {
-                let gh_token = ctx.get_gh_context_var(GhContextVar::GITHUB__TOKEN);
-
-                ctx.req(flowey_lib_common::use_gh_cli::Request::WithAuth(
-                    flowey_lib_common::use_gh_cli::GhCliAuth::AuthToken(gh_token),
-                ));
-            }
         } else if matches!(ctx.backend(), FlowBackend::Ado) {
             if local_only.is_some() {
                 anyhow::bail!("can only set `local_only` params when using Local backend");

--- a/flowey/flowey_lib_hvlite/src/download_lxutil.rs
+++ b/flowey/flowey_lib_hvlite/src/download_lxutil.rs
@@ -82,6 +82,7 @@ impl FlowNode for Node {
             let lxutil_zip = ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
                 repo_owner: "microsoft".into(),
                 repo_name: "openvmm-deps".into(),
+                needs_auth: false,
                 tag: tag.clone(),
                 file_name: file_name.clone(),
                 path: v,

--- a/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
@@ -106,6 +106,7 @@ impl FlowNode for Node {
                 ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
                     repo_owner: "microsoft".into(),
                     repo_name: "OHCL-Linux-Kernel".into(),
+                    needs_auth: false,
                     tag,
                     file_name: file_name.clone(),
                     path: v,

--- a/flowey/flowey_lib_hvlite/src/download_openvmm_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openvmm_deps.rs
@@ -90,6 +90,7 @@ impl FlowNode for Node {
                 ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
                     repo_owner: "microsoft".into(),
                     repo_name: "openvmm-deps".into(),
+                    needs_auth: false,
                     tag: version.clone(),
                     file_name: format!("openvmm-deps.x86_64.{version}.tar.bz2"),
                     path: v,
@@ -110,6 +111,7 @@ impl FlowNode for Node {
                 ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
                     repo_owner: "microsoft".into(),
                     repo_name: "openvmm-deps".into(),
+                    needs_auth: false,
                     tag: version.clone(),
                     file_name: format!("openvmm-deps.aarch64.{version}.tar.bz2"),
                     path: v,

--- a/flowey/flowey_lib_hvlite/src/download_uefi_mu_msvm.rs
+++ b/flowey/flowey_lib_hvlite/src/download_uefi_mu_msvm.rs
@@ -64,6 +64,7 @@ impl FlowNode for Node {
             let mu_msvm_zip = ctx.reqv(|v| flowey_lib_common::download_gh_release::Request {
                 repo_owner: "microsoft".into(),
                 repo_name: "mu_msvm".into(),
+                needs_auth: false,
                 tag: format!("v{version}"),
                 file_name: file_name.into(),
                 path: v,


### PR DESCRIPTION
Closes #151 

In the brief window where OpenVMM was on github, but was still closed-source, we used the `gh` CLI in order to properly authenticate with private repos in order to download various artifacts (e.g: the mu_msvm UEFI package, via `xflowey restore-packages` and `xflowey build-igvm`).

Now that we are open-source, we can sidestep the `gh` CLI entirely, and pull public github releases down using `curl`.

This is nice, as it avoids needing uses to log-in to the `gh` CLI tool, making `cargo xflowey restore-packages` a truly "hands off" dev-ex.