### PR TITLE
Update pyopenssl to version 24.2.1

### DIFF
--- a/.github/scripts/add_unsafe_reviewers/requirements.txt
+++ b/.github/scripts/add_unsafe_reviewers/requirements.txt
@@ -3,4 +3,4 @@ click==8.1.3
 azure-devops==7.1.0b4
 GitPython==3.1.42
 pygithub==2.2.0
-pyopenssl==24.1.0
+pyopenssl==24.2.1


### PR DESCRIPTION
This change updates pyopenssl to the latest available version.

NOTE: the pipeline that currently uses this is currently disabled.