### PR TITLE
openvmm: support adding openhcl devices to VTL0

### DIFF
--- a/openvmm/hvlite_entry/src/cli_args.rs
+++ b/openvmm/hvlite_entry/src/cli_args.rs
@@ -83,13 +83,14 @@ pub struct Options {
 
     /// enable vtl2 - only supported in WHP and simulated without hypervisor support currently
     ///
-    /// Currently implies --openhcl-devices.
+    /// Currently implies --get.
     #[clap(long, requires("hv"))]
     pub vtl2: bool,
 
-    /// Add devices for using the OpenHCL paravisor to the highest enabled VTL.
-    #[clap(long)]
-    pub openhcl_devices: bool,
+    /// Add GET and related devices for using the OpenHCL paravisor to the
+    /// highest enabled VTL.
+    #[clap(long, requires("hv"))]
+    pub get: bool,
 
     /// disable the VTL0 alias map presented to VTL2 by default
     #[clap(long, requires("vtl2"))]

--- a/openvmm/hvlite_entry/src/cli_args.rs
+++ b/openvmm/hvlite_entry/src/cli_args.rs
@@ -82,8 +82,14 @@ pub struct Options {
     pub hv: bool,
 
     /// enable vtl2 - only supported in WHP and simulated without hypervisor support currently
+    ///
+    /// Currently implies --openhcl-devices.
     #[clap(long, requires("hv"))]
     pub vtl2: bool,
+
+    /// Add devices for using the OpenHCL paravisor to the highest enabled VTL.
+    #[clap(long)]
+    pub openhcl_devices: bool,
 
     /// disable the VTL0 alias map presented to VTL2 by default
     #[clap(long, requires("vtl2"))]

--- a/openvmm/hvlite_entry/src/lib.rs
+++ b/openvmm/hvlite_entry/src/lib.rs
@@ -2613,7 +2613,7 @@ async fn connect_diag(
     Ok(diag_client)
 }
 
-/// An object that implements [`Inspect`] by sending an inspect request over
+/// An object that implements [`InspectMut`] by sending an inspect request over
 /// TTRPC to the guest (typically the paravisor running in VTL2), then stitching
 /// the response back into the inspect tree.
 ///


### PR DESCRIPTION
This is useful for testing openvmm boot with non-VSM configurations.