### PR TITLE
ged: don't panic if the local timezone can't be discovered

### DIFF
--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -603,8 +603,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
 
         // time_zone is in minutes between UTC and local time (as stored
         // in a windows TIME_ZONE_INFORMATION struct)
-        let local_offset = time::UtcOffset::current_local_offset()
-            .expect("could not determine local timezone offset");
+        let local_offset = time::UtcOffset::current_local_offset().unwrap_or(time::UtcOffset::UTC);
         let time_zone = local_offset.whole_minutes();
         let response = get_protocol::TimeResponse::new(0, since_win_epoch, time_zone, false);
 


### PR DESCRIPTION
The `time` crate refuses to return the current timezone in Linux due to some soundness concerns with calling `localtime_r` concurrently with `std::env::set_var`.

Switching to `jiff` would resolve this, since `jiff` doesn't use `localtime_r` to get the current timezone (and it's just generally better than `time`). But for now, just fall back to UTC when we can't get the timezone (which I suppose could happen for any number of other reasons, anyway).