### PR TITLE
openhcl/tdx: implement wbinvd exits

### DIFF
--- a/openhcl/hcl/src/protocol.rs
+++ b/openhcl/hcl/src/protocol.rs
@@ -216,6 +216,17 @@ pub struct tdx_tdg_vp_enter_exit_info {
     pub r13: u64,
 }
 
+#[bitfield(u64)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
+pub struct tdx_vp_state_flags {
+    /// Issue a cache flush for a WBINVD before calling VP.ENTER.
+    pub wbinvd: bool,
+    /// Issue a cache flush for a WBNOINVD before calling VP.ENTER.
+    pub wbnoinvd: bool,
+    #[bits(62)]
+    reserved: u64,
+}
+
 /// Additional VP state that is save/restored across TDG.VP.ENTER.
 #[repr(C)]
 #[derive(Debug, AsBytes, FromBytes, FromZeroes)]
@@ -227,6 +238,7 @@ pub struct tdx_vp_state {
     pub msr_xss: u64,
     pub cr2: u64,
     pub msr_tsc_aux: u64,
+    pub flags: tdx_vp_state_flags,
 }
 
 #[repr(C)]
@@ -235,7 +247,7 @@ pub struct tdx_vp_context {
     pub exit_info: tdx_tdg_vp_enter_exit_info,
     pub pad1: [u8; 48],
     pub vp_state: tdx_vp_state,
-    pub pad2: [u8; 40],
+    pub pad2: [u8; 32],
     pub entry_rcx: x86defs::tdx::TdxVmFlags,
     pub gpr_list: x86defs::tdx::TdxL2EnterGuestState,
     pub pad3: [u8; 96],

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1529,8 +1529,14 @@ impl UhProcessor<'_, TdxBacked> {
                 &mut self.backing.exit_stats.xsetbv
             }
             VmxExit::WBINVD_INSTRUCTION => {
-                // TODO TDX: forward the request to the host via TD.VMCALL
-                // see HvlRequestCacheFlush
+                // Ask the kernel to flush the cache before issuing VP.ENTER.
+                let no_invalidate = exit_info.qualification() != 0;
+                if no_invalidate {
+                    self.runner.tdx_vp_state_mut().flags.set_wbnoinvd(true);
+                } else {
+                    self.runner.tdx_vp_state_mut().flags.set_wbinvd(true);
+                }
+
                 self.advance_to_next_instruction();
                 &mut self.backing.exit_stats.wbinvd
             }


### PR DESCRIPTION
Implement WBINVD exits by signalling to the kernel to issue the corresponding flush before calling VP.ENTER.