### PR TITLE
Vtl1 interrupt preemption handling

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -307,6 +307,8 @@ impl From<EnterMode> for hcl::protocol::EnterMode {
 pub struct UhCvmVpState {
     /// The VTLs on this VP waiting for TLB locks on other VPs.
     vtls_tlb_waiting: VtlArray<bool, 2>,
+    /// Used in VTL 2 exit code to determine which VTL to exit to.
+    exit_vtl: GuestVtl,
 }
 
 #[cfg(guest_arch = "x86_64")]
@@ -315,6 +317,7 @@ impl UhCvmVpState {
     pub fn new() -> Self {
         Self {
             vtls_tlb_waiting: VtlArray::new(false),
+            exit_vtl: GuestVtl::Vtl0,
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -307,8 +307,6 @@ impl From<EnterMode> for hcl::protocol::EnterMode {
 pub struct UhCvmVpState {
     /// The VTLs on this VP waiting for TLB locks on other VPs.
     vtls_tlb_waiting: VtlArray<bool, 2>,
-    /// Used in VTL 2 exit code to determine which VTL to exit to.
-    exit_vtl: GuestVtl,
 }
 
 #[cfg(guest_arch = "x86_64")]
@@ -317,7 +315,6 @@ impl UhCvmVpState {
     pub fn new() -> Self {
         Self {
             vtls_tlb_waiting: VtlArray::new(false),
-            exit_vtl: GuestVtl::Vtl0,
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -410,20 +410,13 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlCall for UhHypercallHandle
         tracing::trace!("handling vtl call");
 
         B::switch_vtl_state(self.vp, self.intercepted_vtl, GuestVtl::Vtl1);
-        self.vp.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl1;
+        self.vp.exit_vtl = GuestVtl::Vtl1;
 
-        // TODO GUEST VSM: reevaluate if the return reason should be set here or
-        // during VTL 2 exit handling
         self.vp.hv[GuestVtl::Vtl1]
             .as_ref()
             .unwrap()
             .set_return_reason(HvVtlEntryReason::VTL_CALL)
             .expect("setting return reason cannot fail");
-
-        // TODO GUEST_VSM: Force reevaluation of the VTL 1 APIC in case delivery of
-        // low-priority interrupts was suppressed while in VTL 0.
-
-        // TODO GUEST_VSM: Track which VTLs are runnable and mark VTL as runnable
     }
 }
 
@@ -441,7 +434,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlReturn for UhHypercallHand
         self.vp.unlock_tlb_lock(Vtl::Vtl1);
 
         B::switch_vtl_state(self.vp, self.intercepted_vtl, GuestVtl::Vtl0);
-        self.vp.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl0;
+        self.vp.exit_vtl = GuestVtl::Vtl0;
 
         // TODO CVM GUEST_VSM:
         // - rewind interrupts

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -683,7 +683,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                     }
                 }
 
-                // TODO WHP GUEST VSM This should be next_vtl
+                // TODO WHP GUEST VSM: This should be next_vtl
                 if T::halt_in_usermode(self, GuestVtl::Vtl0) {
                     break Poll::Pending;
                 } else {

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -44,7 +44,6 @@ use hvdef::hypercall::HostVisibilityType;
 use hvdef::HvError;
 use hvdef::HvMessage;
 use hvdef::HvSynicSint;
-use hvdef::HvVtlEntryReason;
 use hvdef::Vtl;
 use hvdef::NUM_SINTS;
 use inspect::Inspect;
@@ -106,8 +105,6 @@ pub struct UhProcessor<'a, T: Backing> {
     force_exit_sidecar: bool,
     /// The VTLs on this VP that are currently locked, per requesting VTL.
     vtls_tlb_locked: VtlsTlbLocked,
-    /// Used in VTL 2 exit code to determine which VTL to exit to.
-    exit_vtl: GuestVtl,
 
     // Put the runner and backing at the end so that monomorphisms of functions
     // that don't access backing-specific state are more likely to be folded
@@ -176,11 +173,12 @@ mod private {
     use virt::StopVp;
     use virt::VpHaltReason;
     use vm_topology::processor::TargetVpInfo;
+    use vtl_array::VtlArray;
 
     pub struct BackingParams<'a, 'b, T: BackingPrivate> {
         pub(crate) partition: &'a UhPartitionInner,
         #[cfg(guest_arch = "x86_64")]
-        pub(crate) lapics: Option<vtl_array::VtlArray<super::LapicState, 2>>,
+        pub(crate) lapics: Option<VtlArray<super::LapicState, 2>>,
         pub(crate) vp_info: &'a TargetVpInfo,
         pub(crate) runner: &'a mut ProcessorRunner<'b, T::HclBacking>,
         pub(crate) backing_shared: &'a BackingShared,
@@ -207,6 +205,7 @@ mod private {
             this: &mut UhProcessor<'_, Self>,
             dev: &impl CpuIo,
             stop: &mut StopVp<'_>,
+            interrupt_pending: VtlArray<Option<u8>, 2>,
         ) -> impl Future<Output = Result<(), VpHaltReason<UhRunVpError>>>;
 
         /// Process any pending APIC work. Returns the vector of the next
@@ -228,14 +227,6 @@ mod private {
         ///
         /// This is used for hypervisor-managed and untrusted SINTs.
         fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16);
-
-        /// Copies shared registers (per VSM TLFS spec) from the source VTL to
-        /// the target VTL that will become active.
-        fn switch_vtl_state(
-            this: &mut UhProcessor<'_, Self>,
-            source_vtl: GuestVtl,
-            target_vtl: GuestVtl,
-        );
 
         /// Returns whether this VP should be put to sleep in usermode, or
         /// whether it's ready to proceed into the kernel.
@@ -264,6 +255,13 @@ pub trait HardwareIsolatedBacking: Backing {
     fn cvm_state_mut(&mut self) -> &mut crate::UhCvmVpState;
     /// Gets CVM specific partition state.
     fn cvm_partition_state(&self) -> &crate::UhCvmPartitionState;
+    /// Copies shared registers (per VSM TLFS spec) from the source VTL to
+    /// the target VTL that will become active.
+    fn switch_vtl_state(
+        this: &mut UhProcessor<'_, Self>,
+        source_vtl: GuestVtl,
+        target_vtl: GuestVtl,
+    );
 }
 
 #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
@@ -633,6 +631,8 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
         let mut first_scan_irr = true;
 
         loop {
+            let mut interrupt_pending: VtlArray<_, 2> = VtlArray::new(None);
+
             // Process VP activity and wait for the VP to be ready.
             poll_fn(|cx| loop {
                 stop.check()?;
@@ -663,7 +663,6 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                     self.update_synic(GuestVtl::Vtl0, true);
                 }
 
-                let mut interrupt_pending: VtlArray<_, 2> = VtlArray::new(None);
                 for vtl in [GuestVtl::Vtl1, GuestVtl::Vtl0] {
                     // Process interrupts.
                     if self.hv[vtl].is_some() {
@@ -684,29 +683,8 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                     }
                 }
 
-                match self.exit_vtl {
-                    GuestVtl::Vtl0 => {
-                        // Check for VTL preemption
-                        if let Some(vector) = interrupt_pending[GuestVtl::Vtl1] {
-                            let priority = vector >> 4;
-                            // TODO actually check priority registers
-                            if priority > 0 {
-                                T::switch_vtl_state(self, GuestVtl::Vtl0, GuestVtl::Vtl1);
-                                self.exit_vtl = GuestVtl::Vtl1;
-                                self.hv[GuestVtl::Vtl1]
-                                    .as_ref()
-                                    .unwrap()
-                                    .set_return_reason(HvVtlEntryReason::INTERRUPT)
-                                    .unwrap();
-                            }
-                        }
-                    }
-                    GuestVtl::Vtl1 => {
-                        // TODO: Check for VINA
-                    }
-                }
-
-                if T::halt_in_usermode(self, self.exit_vtl) {
+                // TODO WHP GUEST VSM This should be next_vtl
+                if T::halt_in_usermode(self, GuestVtl::Vtl0) {
                     break Poll::Pending;
                 } else {
                     return <Result<_, VpHaltReason<_>>>::Ok(()).into();
@@ -730,7 +708,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                     .into();
             }
 
-            T::run_vp(self, dev, &mut stop).await?;
+            T::run_vp(self, dev, &mut stop, interrupt_pending).await?;
             self.kernel_returns += 1;
         }
     }
@@ -854,7 +832,6 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                 vtl1: VtlArray::new(false),
                 vtl2: VtlArray::new(false),
             },
-            exit_vtl: GuestVtl::Vtl0,
         };
 
         T::init(&mut vp);

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -50,6 +50,7 @@ use virt_support_aarch64emu::emulate::EmuCheckVtlAccessError;
 use virt_support_aarch64emu::emulate::EmuTranslateError;
 use virt_support_aarch64emu::emulate::EmuTranslateResult;
 use virt_support_aarch64emu::emulate::EmulatorSupport;
+use vtl_array::VtlArray;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
@@ -131,6 +132,7 @@ impl BackingPrivate for HypervisorBackedArm64 {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         _stop: &mut virt::StopVp<'_>,
+        _interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         if this.backing.deliverability_notifications
             != this.backing.next_deliverability_notifications
@@ -193,8 +195,8 @@ impl BackingPrivate for HypervisorBackedArm64 {
         _this: &mut UhProcessor<'_, Self>,
         _vtl: GuestVtl,
         _scan_irr: bool,
-    ) -> Result<(), UhRunVpError> {
-        Ok(())
+    ) -> Result<Option<u8>, UhRunVpError> {
+        Ok(None)
     }
 
     fn request_extint_readiness(this: &mut UhProcessor<'_, Self>) {
@@ -207,16 +209,6 @@ impl BackingPrivate for HypervisorBackedArm64 {
         this.backing
             .next_deliverability_notifications
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
-    }
-
-    /// Copies shared registers (per VSM TLFS spec) from the last VTL to
-    /// the target VTL that will become active.
-    fn switch_vtl_state(
-        _this: &mut UhProcessor<'_, Self>,
-        _source_vtl: GuestVtl,
-        _target_vtl: GuestVtl,
-    ) {
-        unreachable!("vtl switching should be managed by the hypervisor");
     }
 
     fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -178,6 +178,7 @@ impl BackingPrivate for HypervisorBackedX86 {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         stop: &mut StopVp<'_>,
+        _interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         if this.backing.deliverability_notifications
             != this.backing.next_deliverability_notifications
@@ -366,14 +367,6 @@ impl BackingPrivate for HypervisorBackedX86 {
         this.backing
             .next_deliverability_notifications
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
-    }
-
-    fn switch_vtl_state(
-        _this: &mut UhProcessor<'_, Self>,
-        _source_vtl: GuestVtl,
-        _target_vtl: GuestVtl,
-    ) {
-        unreachable!("vtl switching should be managed by the hypervisor");
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -914,7 +914,7 @@ impl UhProcessor<'_, SnpBacked> {
         interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         self.hcvm_handle_cross_vtl_interrupts(interrupt_pending);
-        let next_vtl = self.backing.cvm_state_mut().exit_vtl;
+        let next_vtl = self.backing.cvm.exit_vtl;
 
         let mut vmsa = self.runner.vmsa_mut(next_vtl);
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -319,7 +319,7 @@ impl BackingPrivate for SnpBacked {
         this: &mut UhProcessor<'_, Self>,
         vtl: GuestVtl,
         scan_irr: bool,
-    ) -> Result<(), UhRunVpError> {
+    ) -> Result<Option<u8>, UhRunVpError> {
         // Check for interrupt requests from the host.
         // TODO SNP GUEST VSM supporting VTL 1 proxy irrs requires kernel changes
         if vtl == GuestVtl::Vtl0 {
@@ -332,6 +332,7 @@ impl BackingPrivate for SnpBacked {
         // Clear any pending interrupt.
         this.runner.vmsa_mut(vtl).v_intr_cntrl_mut().set_irq(false);
 
+        let mut ret = None;
         let ApicWork {
             init,
             extint,
@@ -344,10 +345,14 @@ impl BackingPrivate for SnpBacked {
 
         if nmi {
             this.handle_nmi(vtl);
+            ret = Some(u8::MAX);
         }
 
         if let Some(vector) = interrupt {
             this.handle_interrupt(vtl, vector);
+            if ret.is_none() {
+                ret = Some(vector);
+            }
         }
 
         if extint {
@@ -369,7 +374,7 @@ impl BackingPrivate for SnpBacked {
             }
         }
 
-        Ok(())
+        Ok(ret)
     }
 
     fn request_extint_readiness(_this: &mut UhProcessor<'_, Self>) {
@@ -903,9 +908,7 @@ impl UhProcessor<'_, SnpBacked> {
     }
 
     async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        // TODO CVM GUEST VSM: actually check if there is an interrupt waiting
-        // for VTL 1 and switch to it if there is
-        let next_vtl = self.backing.cvm.exit_vtl;
+        let next_vtl = self.exit_vtl;
 
         let mut vmsa = self.runner.vmsa_mut(next_vtl);
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();
@@ -929,8 +932,6 @@ impl UhProcessor<'_, SnpBacked> {
 
         // Set the lazy EOI bit just before running.
         let lazy_eoi = self.sync_lazy_eoi(next_vtl);
-
-        // TODO GUEST VSM: update next_vtl based on interrupts
 
         let mut has_intercept = self
             .runner

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -913,7 +913,18 @@ impl UhProcessor<'_, SnpBacked> {
         dev: &impl CpuIo,
         interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        self.hcvm_handle_cross_vtl_interrupts(interrupt_pending);
+        self.hcvm_handle_cross_vtl_interrupts(interrupt_pending, |this, vtl, msr| {
+            this.backing.lapics[vtl]
+                .lapic
+                .access(&mut SnpApicClient {
+                    partition: this.partition,
+                    vmsa: this.runner.vmsa_mut(vtl),
+                    dev,
+                    vmtime: &this.vmtime,
+                    vtl,
+                })
+                .msr_read(msr)
+        });
         let next_vtl = self.backing.cvm.exit_vtl;
 
         let mut vmsa = self.runner.vmsa_mut(next_vtl);

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1103,7 +1103,18 @@ impl UhProcessor<'_, TdxBacked> {
         dev: &impl CpuIo,
         interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        self.hcvm_handle_cross_vtl_interrupts(interrupt_pending);
+        self.hcvm_handle_cross_vtl_interrupts(interrupt_pending, |this, _vtl, msr| {
+            this.backing
+                .lapic
+                .lapic
+                .access(&mut TdxApicClient {
+                    partition: this.partition,
+                    dev,
+                    apic_page: zerocopy::transmute_mut!(this.runner.tdx_apic_page_mut()),
+                    vmtime: &this.vmtime,
+                })
+                .msr_read(msr)
+        });
         let next_vtl = self.backing.cvm.exit_vtl;
 
         if self.backing.interruption_information.valid() {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1104,7 +1104,7 @@ impl UhProcessor<'_, TdxBacked> {
         interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         self.hcvm_handle_cross_vtl_interrupts(interrupt_pending);
-        let next_vtl = self.backing.cvm_state_mut().exit_vtl;
+        let next_vtl = self.backing.cvm.exit_vtl;
 
         if self.backing.interruption_information.valid() {
             tracing::debug!(


### PR DESCRIPTION
When VTL 1 has an interrupt pending, and we're planning on running VTL 0, check to see if we should preempt that and run VTL 1 to deliver the interrupt instead.