### PR TITLE
netvsp: Use NDIS Offload rev3 to support Windows CVM.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4029,6 +4029,7 @@ dependencies = [
  "pal_async",
  "parking_lot",
  "safeatomic",
+ "static_assertions",
  "task_control",
  "test_with_tracing",
  "thiserror",

--- a/vm/devices/net/netvsp/Cargo.toml
+++ b/vm/devices/net/netvsp/Cargo.toml
@@ -35,6 +35,7 @@ bitfield-struct.workspace = true
 futures.workspace = true
 futures-concurrency.workspace = true
 parking_lot.workspace = true
+static_assertions.workspace = true
 thiserror.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -726,8 +726,8 @@ impl OffloadConfig {
         rndisprot::NdisOffload {
             header: rndisprot::NdisObjectHeader {
                 object_type: rndisprot::NdisObjectType::OFFLOAD,
-                revision: 1,
-                size: rndisprot::NDIS_SIZEOF_NDIS_OFFLOAD_REVISION_1 as u16,
+                revision: 3,
+                size: rndisprot::NDIS_SIZEOF_NDIS_OFFLOAD_REVISION_3 as u16,
             },
             checksum,
             lso_v2,

--- a/vm/devices/net/netvsp/src/rndisprot.rs
+++ b/vm/devices/net/netvsp/src/rndisprot.rs
@@ -5,6 +5,7 @@
 
 use bitfield_struct::bitfield;
 use open_enum::open_enum;
+use static_assertions::const_assert_eq;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
@@ -897,7 +898,13 @@ pub struct NdisOffload {
     pub padding: [u8; 3],
 }
 
-pub const NDIS_SIZEOF_NDIS_OFFLOAD_REVISION_1: usize = 112;
+pub const NDIS_SIZEOF_NDIS_OFFLOAD_REVISION_1: usize =
+    std::mem::offset_of!(NdisOffload, flags) + size_of::<u32>();
+const_assert_eq!(NDIS_SIZEOF_NDIS_OFFLOAD_REVISION_1, 112);
+
+pub const NDIS_SIZEOF_NDIS_OFFLOAD_REVISION_3: usize =
+    std::mem::offset_of!(NdisOffload, encapsulated_packet_task_offload_gre) + size_of::<[u32; 2]>();
+const_assert_eq!(NDIS_SIZEOF_NDIS_OFFLOAD_REVISION_3, 156);
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, AsBytes, FromBytes, FromZeroes)]


### PR DESCRIPTION
Windows guests running isolated expect at least a rev3 response to the hardware offload capabilities query.
Make the constant size derivations easier to understand via offset_of and size_of.