### PR TITLE
virt_mshv_vtl: Add VTL 1 interrupt preemption and VINA support

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -308,8 +308,6 @@ impl From<EnterMode> for hcl::protocol::EnterMode {
 pub struct UhCvmVpState {
     /// The VTLs on this VP waiting for TLB locks on other VPs.
     vtls_tlb_waiting: VtlArray<bool, 2>,
-    /// Used in VTL 2 exit code to determine which VTL to exit to.
-    exit_vtl: GuestVtl,
     /// Hypervisor enlightenment emulator state.
     hv: VtlArray<ProcessorVtlHv, 2>,
 }
@@ -320,7 +318,6 @@ impl UhCvmVpState {
     pub fn new(hv: VtlArray<ProcessorVtlHv, 2>) -> Self {
         Self {
             vtls_tlb_waiting: VtlArray::new(false),
-            exit_vtl: GuestVtl::Vtl0,
             hv,
         }
     }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -308,10 +308,10 @@ impl From<EnterMode> for hcl::protocol::EnterMode {
 pub struct UhCvmVpState {
     /// The VTLs on this VP waiting for TLB locks on other VPs.
     vtls_tlb_waiting: VtlArray<bool, 2>,
-    /// Hypervisor enlightenment emulator state.
-    hv: VtlArray<ProcessorVtlHv, 2>,
     /// Used in VTL 2 exit code to determine which VTL to exit to.
     exit_vtl: GuestVtl,
+    /// Hypervisor enlightenment emulator state.
+    hv: VtlArray<ProcessorVtlHv, 2>,
 }
 
 #[cfg(guest_arch = "x86_64")]
@@ -320,8 +320,8 @@ impl UhCvmVpState {
     pub fn new(hv: VtlArray<ProcessorVtlHv, 2>) -> Self {
         Self {
             vtls_tlb_waiting: VtlArray::new(false),
-            hv,
             exit_vtl: GuestVtl::Vtl0,
+            hv,
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -310,6 +310,8 @@ pub struct UhCvmVpState {
     vtls_tlb_waiting: VtlArray<bool, 2>,
     /// Hypervisor enlightenment emulator state.
     hv: VtlArray<ProcessorVtlHv, 2>,
+    /// Used in VTL 2 exit code to determine which VTL to exit to.
+    exit_vtl: GuestVtl,
 }
 
 #[cfg(guest_arch = "x86_64")]
@@ -319,6 +321,7 @@ impl UhCvmVpState {
         Self {
             vtls_tlb_waiting: VtlArray::new(false),
             hv,
+            exit_vtl: GuestVtl::Vtl0,
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -598,7 +598,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
     /// Handle checking for cross-VTL interrupts, preempting VTL 0, and setting
     /// VINA when appropriate. The `is_interrupt_pending` function should return
     /// true if an interrupt of appropriate priority, or an NMI, is pending for
-    /// the given VTL.
+    /// the given VTL. Returns true if interrupt reprocessing is required.
     pub(crate) fn hcvm_handle_cross_vtl_interrupts(
         &mut self,
         is_interrupt_pending: impl Fn(&mut Self, GuestVtl) -> bool,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -25,6 +25,7 @@ use std::iter::zip;
 use virt::io::CpuIo;
 use virt::vp::AccessVpState;
 use virt::Processor;
+use vtl_array::VtlArray;
 use zerocopy::FromZeroes;
 
 impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
@@ -403,7 +404,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlCall for UhHypercallHandle
         tracing::trace!("handling vtl call");
 
         B::switch_vtl_state(self.vp, self.intercepted_vtl, GuestVtl::Vtl1);
-        self.vp.exit_vtl = GuestVtl::Vtl1;
+        self.vp.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl1;
 
         self.vp.backing.cvm_state_mut().hv[GuestVtl::Vtl1]
             .set_return_reason(HvVtlEntryReason::VTL_CALL)
@@ -425,7 +426,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlReturn for UhHypercallHand
         self.vp.unlock_tlb_lock(Vtl::Vtl1);
 
         B::switch_vtl_state(self.vp, self.intercepted_vtl, GuestVtl::Vtl0);
-        self.vp.exit_vtl = GuestVtl::Vtl0;
+        self.vp.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl0;
 
         // TODO CVM GUEST_VSM:
         // - rewind interrupts
@@ -588,6 +589,33 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         guest_vsm.deny_lower_vtl_startup = value.deny_lower_vtl_startup();
 
         Ok(())
+    }
+
+    pub(crate) fn hcvm_handle_cross_vtl_interrupts(
+        &mut self,
+        interrupt_pending: VtlArray<Option<u8>, 2>,
+    ) {
+        match self.backing.cvm_state_mut().exit_vtl {
+            GuestVtl::Vtl0 => {
+                // Check for VTL preemption
+                if let Some(vector) = interrupt_pending[GuestVtl::Vtl1] {
+                    let priority = vector >> 4;
+                    // TODO actually check priority registers
+                    if priority > 0 {
+                        B::switch_vtl_state(self, GuestVtl::Vtl0, GuestVtl::Vtl1);
+                        self.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl1;
+                        self.hv[GuestVtl::Vtl1]
+                            .as_ref()
+                            .unwrap()
+                            .set_return_reason(HvVtlEntryReason::INTERRUPT)
+                            .unwrap();
+                    }
+                }
+            }
+            GuestVtl::Vtl1 => {
+                // TODO: Check for VINA
+            }
+        }
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -652,6 +652,10 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                                         hv.synic.vina().vector().into(),
                                         hv.synic.vina().auto_eoi(),
                                     );
+                                // We're about to return to the guest, so we need to
+                                // process the interrupt now. We're already past the update
+                                // loop in run_vp.
+                                self.update_synic(GuestVtl::Vtl1, false);
                             }
                         }
                     }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -403,18 +403,11 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlCall for UhHypercallHandle
         tracing::trace!("handling vtl call");
 
         B::switch_vtl_state(self.vp, self.intercepted_vtl, GuestVtl::Vtl1);
-        self.vp.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl1;
+        self.vp.exit_vtl = GuestVtl::Vtl1;
 
-        // TODO GUEST VSM: reevaluate if the return reason should be set here or
-        // during VTL 2 exit handling
         self.vp.backing.cvm_state_mut().hv[GuestVtl::Vtl1]
             .set_return_reason(HvVtlEntryReason::VTL_CALL)
             .expect("setting return reason cannot fail");
-
-        // TODO GUEST_VSM: Force reevaluation of the VTL 1 APIC in case delivery of
-        // low-priority interrupts was suppressed while in VTL 0.
-
-        // TODO GUEST_VSM: Track which VTLs are runnable and mark VTL as runnable
     }
 }
 
@@ -432,7 +425,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlReturn for UhHypercallHand
         self.vp.unlock_tlb_lock(Vtl::Vtl1);
 
         B::switch_vtl_state(self.vp, self.intercepted_vtl, GuestVtl::Vtl0);
-        self.vp.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl0;
+        self.vp.exit_vtl = GuestVtl::Vtl0;
 
         // TODO CVM GUEST_VSM:
         // - rewind interrupts

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -614,7 +614,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                 self.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl1;
                 self.backing.cvm_state_mut().hv[GuestVtl::Vtl1]
                     .set_return_reason(HvVtlEntryReason::INTERRUPT)
-                    .map_err(UhRunVpError::HypercallAssistPage)?;
+                    .map_err(UhRunVpError::VpAssistPage)?;
             }
         }
 
@@ -624,12 +624,10 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                 let vp_index = self.vp_index();
                 let hv = &mut self.backing.cvm_state_mut().hv[GuestVtl::Vtl1];
                 if hv.synic.vina().enabled()
-                    && !hv
-                        .vina_asserted()
-                        .map_err(UhRunVpError::HypercallAssistPage)?
+                    && !hv.vina_asserted().map_err(UhRunVpError::VpAssistPage)?
                 {
                     hv.set_vina_asserted(true)
-                        .map_err(UhRunVpError::HypercallAssistPage)?;
+                        .map_err(UhRunVpError::VpAssistPage)?;
                     self.partition
                         .synic_interrupt(vp_index, GuestVtl::Vtl1)
                         .request_interrupt(

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -24,8 +24,10 @@ use hvdef::Vtl;
 use std::iter::zip;
 use virt::io::CpuIo;
 use virt::vp::AccessVpState;
+use virt::x86::MsrError;
 use virt::Processor;
 use vtl_array::VtlArray;
+use x86defs::apic::ApicRegister;
 use zerocopy::FromZeroes;
 
 impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
@@ -594,21 +596,30 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
     pub(crate) fn hcvm_handle_cross_vtl_interrupts(
         &mut self,
         interrupt_pending: VtlArray<Option<u8>, 2>,
+        lapic_msr_read: impl FnOnce(&mut Self, GuestVtl, u32) -> Result<u64, MsrError>,
     ) {
         match self.backing.cvm_state_mut().exit_vtl {
             GuestVtl::Vtl0 => {
                 // Check for VTL preemption
                 if let Some(vector) = interrupt_pending[GuestVtl::Vtl1] {
                     let priority = vector >> 4;
-                    // TODO actually check priority registers
                     if priority > 0 {
-                        B::switch_vtl_state(self, GuestVtl::Vtl0, GuestVtl::Vtl1);
-                        self.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl1;
-                        self.hv[GuestVtl::Vtl1]
-                            .as_ref()
-                            .unwrap()
-                            .set_return_reason(HvVtlEntryReason::INTERRUPT)
-                            .unwrap();
+                        let ppr = lapic_msr_read(
+                            self,
+                            GuestVtl::Vtl1,
+                            ApicRegister::PPR.0 as u32 + x86defs::apic::X2APIC_MSR_BASE,
+                        )
+                        .expect("reading PPR should never fail");
+                        let ppr_priority = ppr >> 4;
+                        if priority as u64 > ppr_priority {
+                            B::switch_vtl_state(self, GuestVtl::Vtl0, GuestVtl::Vtl1);
+                            self.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl1;
+                            self.hv[GuestVtl::Vtl1]
+                                .as_ref()
+                                .unwrap()
+                                .set_return_reason(HvVtlEntryReason::INTERRUPT)
+                                .unwrap();
+                        }
                     }
                 }
             }

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -403,8 +403,8 @@ pub enum UhRunVpError {
     InvalidVmcb,
     #[error("unknown exit {0:#x?}")]
     UnknownVmxExit(x86defs::vmx::VmxExit),
-    #[error("failed to access hypercall assist page")]
-    HypercallAssistPage(#[source] guestmem::GuestMemoryError),
+    #[error("failed to access VP assist page")]
+    VpAssistPage(#[source] guestmem::GuestMemoryError),
     #[error("failed to read hypercall parameters")]
     HypercallParameters(#[source] guestmem::GuestMemoryError),
     #[error("failed to write hypercall result")]

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -688,7 +688,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                     }
                 }
 
-                // TODO WHP GUEST VSM This should be next_vtl
+                // TODO WHP GUEST VSM: This should be next_vtl
                 if T::halt_in_usermode(self, GuestVtl::Vtl0) {
                     break Poll::Pending;
                 } else {

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -42,6 +42,7 @@ use hvdef::hypercall::HostVisibilityType;
 use hvdef::HvError;
 use hvdef::HvMessage;
 use hvdef::HvSynicSint;
+use hvdef::HvVtlEntryReason;
 use hvdef::Vtl;
 use hvdef::NUM_SINTS;
 use inspect::Inspect;
@@ -101,6 +102,8 @@ pub struct UhProcessor<'a, T: Backing> {
     force_exit_sidecar: bool,
     /// The VTLs on this VP that are currently locked, per requesting VTL.
     vtls_tlb_locked: VtlsTlbLocked,
+    /// Used in VTL 2 exit code to determine which VTL to exit to.
+    exit_vtl: GuestVtl,
 
     // Put the runner and backing at the end so that monomorphisms of functions
     // that don't access backing-specific state are more likely to be folded
@@ -206,12 +209,13 @@ mod private {
             stop: &mut StopVp<'_>,
         ) -> impl Future<Output = Result<(), VpHaltReason<UhRunVpError>>>;
 
-        /// Process any pending APIC work.
+        /// Process any pending APIC work. Returns the vector of the next
+        /// pending interrupt if there is one, or u8::MAX for an NMI.
         fn poll_apic(
             this: &mut UhProcessor<'_, Self>,
             vtl: GuestVtl,
             scan_irr: bool,
-        ) -> Result<(), UhRunVpError>;
+        ) -> Result<Option<u8>, UhRunVpError>;
 
         /// Requests the VP to exit when an external interrupt is ready to be
         /// delivered.
@@ -665,14 +669,16 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                     self.update_synic(GuestVtl::Vtl0, true);
                 }
 
+                let mut interrupt_pending: VtlArray<_, 2> = VtlArray::new(None);
                 for vtl in [GuestVtl::Vtl1, GuestVtl::Vtl0] {
                     // Process interrupts.
                     if self.backing.hv(vtl).is_some() {
                         self.update_synic(vtl, false);
                     }
 
-                    T::poll_apic(self, vtl, scan_irr[vtl] || first_scan_irr)
-                        .map_err(VpHaltReason::Hypervisor)?;
+                    interrupt_pending[vtl] =
+                        T::poll_apic(self, vtl, scan_irr[vtl] || first_scan_irr)
+                            .map_err(VpHaltReason::Hypervisor)?;
                 }
                 first_scan_irr = false;
 
@@ -684,8 +690,29 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                     }
                 }
 
-                // TODO WHP GUEST VSM: This should be next_vtl
-                if T::halt_in_usermode(self, GuestVtl::Vtl0) {
+                match self.exit_vtl {
+                    GuestVtl::Vtl0 => {
+                        // Check for VTL preemption
+                        if let Some(vector) = interrupt_pending[GuestVtl::Vtl1] {
+                            let priority = vector >> 4;
+                            // TODO actually check priority registers
+                            if priority > 0 {
+                                T::switch_vtl_state(self, GuestVtl::Vtl0, GuestVtl::Vtl1);
+                                self.exit_vtl = GuestVtl::Vtl1;
+                                self.hv[GuestVtl::Vtl1]
+                                    .as_ref()
+                                    .unwrap()
+                                    .set_return_reason(HvVtlEntryReason::INTERRUPT)
+                                    .unwrap();
+                            }
+                        }
+                    }
+                    GuestVtl::Vtl1 => {
+                        // TODO: Check for VINA
+                    }
+                }
+
+                if T::halt_in_usermode(self, self.exit_vtl) {
                     break Poll::Pending;
                 } else {
                     return <Result<_, VpHaltReason<_>>>::Ok(()).into();
@@ -822,6 +849,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                 vtl1: VtlArray::new(false),
                 vtl2: VtlArray::new(false),
             },
+            exit_vtl: GuestVtl::Vtl0,
         };
 
         T::init(&mut vp);

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -135,7 +135,6 @@ impl BackingPrivate for HypervisorBackedArm64 {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         _stop: &mut virt::StopVp<'_>,
-        _interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         if this.backing.deliverability_notifications
             != this.backing.next_deliverability_notifications
@@ -198,8 +197,8 @@ impl BackingPrivate for HypervisorBackedArm64 {
         _this: &mut UhProcessor<'_, Self>,
         _vtl: GuestVtl,
         _scan_irr: bool,
-    ) -> Result<Option<u8>, UhRunVpError> {
-        Ok(None)
+    ) -> Result<(), UhRunVpError> {
+        Ok(())
     }
 
     fn request_extint_readiness(this: &mut UhProcessor<'_, Self>) {
@@ -212,6 +211,11 @@ impl BackingPrivate for HypervisorBackedArm64 {
         this.backing
             .next_deliverability_notifications
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
+    }
+
+    fn handle_cross_vtl_interrupts(_this: &mut UhProcessor<'_, Self>, _dev: &impl CpuIo) -> bool {
+        // TODO WHP ARM GUEST VSM
+        false
     }
 
     fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -52,6 +52,7 @@ use virt_support_aarch64emu::emulate::EmuCheckVtlAccessError;
 use virt_support_aarch64emu::emulate::EmuTranslateError;
 use virt_support_aarch64emu::emulate::EmuTranslateResult;
 use virt_support_aarch64emu::emulate::EmulatorSupport;
+use vtl_array::VtlArray;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
@@ -134,6 +135,7 @@ impl BackingPrivate for HypervisorBackedArm64 {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         _stop: &mut virt::StopVp<'_>,
+        _interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         if this.backing.deliverability_notifications
             != this.backing.next_deliverability_notifications
@@ -196,8 +198,8 @@ impl BackingPrivate for HypervisorBackedArm64 {
         _this: &mut UhProcessor<'_, Self>,
         _vtl: GuestVtl,
         _scan_irr: bool,
-    ) -> Result<(), UhRunVpError> {
-        Ok(())
+    ) -> Result<Option<u8>, UhRunVpError> {
+        Ok(None)
     }
 
     fn request_extint_readiness(this: &mut UhProcessor<'_, Self>) {
@@ -210,16 +212,6 @@ impl BackingPrivate for HypervisorBackedArm64 {
         this.backing
             .next_deliverability_notifications
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
-    }
-
-    /// Copies shared registers (per VSM TLFS spec) from the last VTL to
-    /// the target VTL that will become active.
-    fn switch_vtl_state(
-        _this: &mut UhProcessor<'_, Self>,
-        _source_vtl: GuestVtl,
-        _target_vtl: GuestVtl,
-    ) {
-        unreachable!("vtl switching should be managed by the hypervisor");
     }
 
     fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -212,9 +212,12 @@ impl BackingPrivate for HypervisorBackedArm64 {
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
     }
 
-    fn handle_cross_vtl_interrupts(_this: &mut UhProcessor<'_, Self>, _dev: &impl CpuIo) -> bool {
+    fn handle_cross_vtl_interrupts(
+        _this: &mut UhProcessor<'_, Self>,
+        _dev: &impl CpuIo,
+    ) -> Result<bool, UhRunVpError> {
         // TODO WHP ARM GUEST VSM
-        false
+        Ok(false)
     }
 
     fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -52,7 +52,6 @@ use virt_support_aarch64emu::emulate::EmuCheckVtlAccessError;
 use virt_support_aarch64emu::emulate::EmuTranslateError;
 use virt_support_aarch64emu::emulate::EmuTranslateResult;
 use virt_support_aarch64emu::emulate::EmulatorSupport;
-use vtl_array::VtlArray;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -182,6 +182,7 @@ impl BackingPrivate for HypervisorBackedX86 {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         stop: &mut StopVp<'_>,
+        _interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         if this.backing.deliverability_notifications
             != this.backing.next_deliverability_notifications
@@ -370,14 +371,6 @@ impl BackingPrivate for HypervisorBackedX86 {
         this.backing
             .next_deliverability_notifications
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
-    }
-
-    fn switch_vtl_state(
-        _this: &mut UhProcessor<'_, Self>,
-        _source_vtl: GuestVtl,
-        _target_vtl: GuestVtl,
-    ) {
-        unreachable!("vtl switching should be managed by the hypervisor");
     }
 
     fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv> {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -307,11 +307,12 @@ impl BackingPrivate for HypervisorBackedX86 {
         this: &mut UhProcessor<'_, Self>,
         vtl: GuestVtl,
         scan_irr: bool,
-    ) -> Result<(), UhRunVpError> {
+    ) -> Result<Option<u8>, UhRunVpError> {
         let Some(lapics) = this.backing.lapics.as_mut() else {
-            return Ok(());
+            return Ok(None);
         };
 
+        let mut ret = None;
         let lapic = &mut lapics[vtl];
         let ApicWork {
             init,
@@ -324,10 +325,14 @@ impl BackingPrivate for HypervisorBackedX86 {
         if nmi || lapic.nmi_pending {
             lapic.nmi_pending = true;
             this.handle_nmi(vtl)?;
+            ret = Some(u8::MAX);
         }
 
         if let Some(vector) = interrupt {
             this.handle_interrupt(vector, vtl)?;
+            if ret.is_none() {
+                ret = Some(vector);
+            }
         }
 
         if extint {
@@ -343,7 +348,7 @@ impl BackingPrivate for HypervisorBackedX86 {
             this.handle_sipi(vtl, vector)?;
         }
 
-        Ok(())
+        Ok(ret)
     }
 
     fn halt_in_usermode(this: &mut UhProcessor<'_, Self>, target_vtl: GuestVtl) -> bool {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -355,9 +355,12 @@ impl BackingPrivate for HypervisorBackedX86 {
         false
     }
 
-    fn handle_cross_vtl_interrupts(_this: &mut UhProcessor<'_, Self>, _dev: &impl CpuIo) -> bool {
+    fn handle_cross_vtl_interrupts(
+        _this: &mut UhProcessor<'_, Self>,
+        _dev: &impl CpuIo,
+    ) -> Result<bool, UhRunVpError> {
         // TODO WHP GUEST VSM
-        false
+        Ok(false)
     }
 
     fn request_extint_readiness(this: &mut UhProcessor<'_, Self>) {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -931,7 +931,7 @@ impl UhProcessor<'_, SnpBacked> {
         interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         self.hcvm_handle_cross_vtl_interrupts(interrupt_pending);
-        let next_vtl = self.backing.cvm_state_mut().exit_vtl;
+        let next_vtl = self.backing.cvm.exit_vtl;
 
         let mut vmsa = self.runner.vmsa_mut(next_vtl);
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -446,7 +446,10 @@ impl BackingPrivate for SnpBacked {
             .expect("requesting deliverability is not a fallable operation");
     }
 
-    fn handle_cross_vtl_interrupts(this: &mut UhProcessor<'_, Self>, dev: &impl CpuIo) -> bool {
+    fn handle_cross_vtl_interrupts(
+        this: &mut UhProcessor<'_, Self>,
+        dev: &impl CpuIo,
+    ) -> Result<bool, UhRunVpError> {
         this.hcvm_handle_cross_vtl_interrupts(|this, vtl, check_rflags| {
             let vmsa = this.runner.vmsa_mut(vtl);
             if vmsa.event_inject().valid()

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -155,6 +155,58 @@ impl HardwareIsolatedBacking for SnpBacked {
     fn cvm_partition_state(&self) -> &UhCvmPartitionState {
         &self.shared.cvm
     }
+
+    fn switch_vtl_state(
+        this: &mut UhProcessor<'_, Self>,
+        source_vtl: GuestVtl,
+        target_vtl: GuestVtl,
+    ) {
+        let [vmsa0, vmsa1] = this.runner.vmsas_mut();
+        let (current_vmsa, mut target_vmsa) = match (source_vtl, target_vtl) {
+            (GuestVtl::Vtl0, GuestVtl::Vtl1) => (vmsa0, vmsa1),
+            (GuestVtl::Vtl1, GuestVtl::Vtl0) => (vmsa1, vmsa0),
+            _ => unreachable!(),
+        };
+
+        target_vmsa.set_rax(current_vmsa.rax());
+        target_vmsa.set_rbx(current_vmsa.rbx());
+        target_vmsa.set_rcx(current_vmsa.rcx());
+        target_vmsa.set_rdx(current_vmsa.rdx());
+        target_vmsa.set_rbp(current_vmsa.rbp());
+        target_vmsa.set_rsi(current_vmsa.rsi());
+        target_vmsa.set_rdi(current_vmsa.rdi());
+        target_vmsa.set_r8(current_vmsa.r8());
+        target_vmsa.set_r9(current_vmsa.r9());
+        target_vmsa.set_r10(current_vmsa.r10());
+        target_vmsa.set_r11(current_vmsa.r11());
+        target_vmsa.set_r12(current_vmsa.r12());
+        target_vmsa.set_r13(current_vmsa.r13());
+        target_vmsa.set_r14(current_vmsa.r14());
+        target_vmsa.set_r15(current_vmsa.r15());
+        target_vmsa.set_xcr0(current_vmsa.xcr0());
+
+        target_vmsa.set_cr2(current_vmsa.cr2());
+
+        // DR6 not shared on AMD
+        target_vmsa.set_dr0(current_vmsa.dr0());
+        target_vmsa.set_dr1(current_vmsa.dr1());
+        target_vmsa.set_dr2(current_vmsa.dr2());
+        target_vmsa.set_dr3(current_vmsa.dr3());
+
+        target_vmsa.set_pl0_ssp(current_vmsa.pl0_ssp());
+        target_vmsa.set_pl1_ssp(current_vmsa.pl1_ssp());
+        target_vmsa.set_pl2_ssp(current_vmsa.pl2_ssp());
+        target_vmsa.set_pl3_ssp(current_vmsa.pl3_ssp());
+        target_vmsa.set_u_cet(current_vmsa.u_cet());
+
+        target_vmsa.set_x87_registers(&current_vmsa.x87_registers());
+
+        let vec_reg_count = 16;
+        for i in 0..vec_reg_count {
+            target_vmsa.set_xmm_registers(i, current_vmsa.xmm_registers(i));
+            target_vmsa.set_ymm_registers(i, current_vmsa.ymm_registers(i));
+        }
+    }
 }
 
 /// Partition-wide shared data for SNP VPs.
@@ -313,8 +365,9 @@ impl BackingPrivate for SnpBacked {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         _stop: &mut virt::StopVp<'_>,
+        interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        this.run_vp_snp(dev).await
+        this.run_vp_snp(dev, interrupt_pending).await
     }
 
     fn poll_apic(
@@ -397,58 +450,6 @@ impl BackingPrivate for SnpBacked {
                 u64::from(notifications).into(),
             )
             .expect("requesting deliverability is not a fallable operation");
-    }
-
-    fn switch_vtl_state(
-        this: &mut UhProcessor<'_, Self>,
-        source_vtl: GuestVtl,
-        target_vtl: GuestVtl,
-    ) {
-        let [vmsa0, vmsa1] = this.runner.vmsas_mut();
-        let (current_vmsa, mut target_vmsa) = match (source_vtl, target_vtl) {
-            (GuestVtl::Vtl0, GuestVtl::Vtl1) => (vmsa0, vmsa1),
-            (GuestVtl::Vtl1, GuestVtl::Vtl0) => (vmsa1, vmsa0),
-            _ => unreachable!(),
-        };
-
-        target_vmsa.set_rax(current_vmsa.rax());
-        target_vmsa.set_rbx(current_vmsa.rbx());
-        target_vmsa.set_rcx(current_vmsa.rcx());
-        target_vmsa.set_rdx(current_vmsa.rdx());
-        target_vmsa.set_rbp(current_vmsa.rbp());
-        target_vmsa.set_rsi(current_vmsa.rsi());
-        target_vmsa.set_rdi(current_vmsa.rdi());
-        target_vmsa.set_r8(current_vmsa.r8());
-        target_vmsa.set_r9(current_vmsa.r9());
-        target_vmsa.set_r10(current_vmsa.r10());
-        target_vmsa.set_r11(current_vmsa.r11());
-        target_vmsa.set_r12(current_vmsa.r12());
-        target_vmsa.set_r13(current_vmsa.r13());
-        target_vmsa.set_r14(current_vmsa.r14());
-        target_vmsa.set_r15(current_vmsa.r15());
-        target_vmsa.set_xcr0(current_vmsa.xcr0());
-
-        target_vmsa.set_cr2(current_vmsa.cr2());
-
-        // DR6 not shared on AMD
-        target_vmsa.set_dr0(current_vmsa.dr0());
-        target_vmsa.set_dr1(current_vmsa.dr1());
-        target_vmsa.set_dr2(current_vmsa.dr2());
-        target_vmsa.set_dr3(current_vmsa.dr3());
-
-        target_vmsa.set_pl0_ssp(current_vmsa.pl0_ssp());
-        target_vmsa.set_pl1_ssp(current_vmsa.pl1_ssp());
-        target_vmsa.set_pl2_ssp(current_vmsa.pl2_ssp());
-        target_vmsa.set_pl3_ssp(current_vmsa.pl3_ssp());
-        target_vmsa.set_u_cet(current_vmsa.u_cet());
-
-        target_vmsa.set_x87_registers(&current_vmsa.x87_registers());
-
-        let vec_reg_count = 16;
-        for i in 0..vec_reg_count {
-            target_vmsa.set_xmm_registers(i, current_vmsa.xmm_registers(i));
-            target_vmsa.set_ymm_registers(i, current_vmsa.ymm_registers(i));
-        }
     }
 
     fn inspect_extra(this: &mut UhProcessor<'_, Self>, resp: &mut inspect::Response<'_>) {
@@ -924,8 +925,13 @@ impl UhProcessor<'_, SnpBacked> {
         false
     }
 
-    async fn run_vp_snp(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let next_vtl = self.exit_vtl;
+    async fn run_vp_snp(
+        &mut self,
+        dev: &impl CpuIo,
+        interrupt_pending: VtlArray<Option<u8>, 2>,
+    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+        self.hcvm_handle_cross_vtl_interrupts(interrupt_pending);
+        let next_vtl = self.backing.cvm_state_mut().exit_vtl;
 
         let mut vmsa = self.runner.vmsa_mut(next_vtl);
         let last_interrupt_ctrl = vmsa.v_intr_cntrl();

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1130,7 +1130,7 @@ impl UhProcessor<'_, TdxBacked> {
         interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
         self.hcvm_handle_cross_vtl_interrupts(interrupt_pending);
-        let next_vtl = self.backing.cvm_state_mut().exit_vtl;
+        let next_vtl = self.backing.cvm.exit_vtl;
 
         if self.backing.interruption_information.valid() {
             tracing::debug!(

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -785,7 +785,7 @@ impl BackingPrivate for TdxBacked {
 
     fn handle_cross_vtl_interrupts(this: &mut UhProcessor<'_, Self>, _dev: &impl CpuIo) -> bool {
         // TODO TDX GUEST VSM
-        this.hcvm_handle_cross_vtl_interrupts(|_this, _vtl| false)
+        this.hcvm_handle_cross_vtl_interrupts(|_this, _vtl, _check_rflags| false)
     }
 
     fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv> {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -749,7 +749,7 @@ impl BackingPrivate for TdxBacked {
         this: &mut UhProcessor<'_, Self>,
         _vtl: GuestVtl,
         scan_irr: bool,
-    ) -> Result<(), UhRunVpError> {
+    ) -> Result<Option<u8>, UhRunVpError> {
         if !this.try_poll_apic(scan_irr)? {
             tracing::info!("disabling APIC offload due to auto EOI");
             let page = zerocopy::transmute_mut!(this.runner.tdx_apic_page_mut());
@@ -760,7 +760,8 @@ impl BackingPrivate for TdxBacked {
             this.try_poll_apic(false)?;
         }
 
-        Ok(())
+        // TODO TDX GUEST VSM
+        Ok(None)
     }
 
     fn request_extint_readiness(_this: &mut UhProcessor<'_, Self>) {
@@ -1123,7 +1124,7 @@ impl UhProcessor<'_, TdxBacked> {
     }
 
     async fn run_vp_tdx(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let next_vtl = self.backing.cvm.exit_vtl;
+        let next_vtl = self.exit_vtl;
 
         if self.backing.interruption_information.valid() {
             tracing::debug!(

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -472,6 +472,14 @@ impl HardwareIsolatedBacking for TdxBacked {
     fn cvm_partition_state(&self) -> &UhCvmPartitionState {
         &self.shared.cvm
     }
+
+    fn switch_vtl_state(
+        _this: &mut UhProcessor<'_, Self>,
+        _source_vtl: GuestVtl,
+        _target_vtl: GuestVtl,
+    ) {
+        todo!()
+    }
 }
 
 /// Partition-wide shared data for TDX VPs.
@@ -740,8 +748,9 @@ impl BackingPrivate for TdxBacked {
         this: &mut UhProcessor<'_, Self>,
         dev: &impl CpuIo,
         _stop: &mut virt::StopVp<'_>,
+        interrupt_pending: VtlArray<Option<u8>, 2>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        this.run_vp_tdx(dev).await
+        this.run_vp_tdx(dev, interrupt_pending).await
     }
 
     // TODO TDX GUEST VSM
@@ -774,14 +783,6 @@ impl BackingPrivate for TdxBacked {
         } else {
             tracelimit::error_ratelimited!("untrusted synic is not configured");
         }
-    }
-
-    fn switch_vtl_state(
-        _this: &mut UhProcessor<'_, Self>,
-        _source_vtl: GuestVtl,
-        _target_vtl: GuestVtl,
-    ) {
-        todo!()
     }
 
     fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv> {
@@ -1123,8 +1124,13 @@ impl UhProcessor<'_, TdxBacked> {
         }
     }
 
-    async fn run_vp_tdx(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let next_vtl = self.exit_vtl;
+    async fn run_vp_tdx(
+        &mut self,
+        dev: &impl CpuIo,
+        interrupt_pending: VtlArray<Option<u8>, 2>,
+    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+        self.hcvm_handle_cross_vtl_interrupts(interrupt_pending);
+        let next_vtl = self.backing.cvm_state_mut().exit_vtl;
 
         if self.backing.interruption_information.valid() {
             tracing::debug!(

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -783,7 +783,10 @@ impl BackingPrivate for TdxBacked {
         }
     }
 
-    fn handle_cross_vtl_interrupts(this: &mut UhProcessor<'_, Self>, _dev: &impl CpuIo) -> bool {
+    fn handle_cross_vtl_interrupts(
+        this: &mut UhProcessor<'_, Self>,
+        _dev: &impl CpuIo,
+    ) -> Result<bool, UhRunVpError> {
         // TODO TDX GUEST VSM
         this.hcvm_handle_cross_vtl_interrupts(|_this, _vtl, _check_rflags| false)
     }

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -468,6 +468,15 @@ impl ProcessorVtlHv {
         self.guest_memory.read_plain(gpa)
     }
 
+    /// Set the reason for the vtl return into the vp assist page
+    pub fn set_return_reason(&self, reason: HvVtlEntryReason) -> Result<(), GuestMemoryError> {
+        let gpa = (self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE)
+            + offset_of!(hvdef::HvVpAssistPage, vtl_control) as u64
+            + offset_of!(HvVpVtlControl, entry_reason) as u64;
+
+        self.guest_memory.write_plain(gpa, &(reason.0))
+    }
+
     /// Gets whether VINA is currently asserted.
     pub fn vina_asserted(&self) -> Result<bool, GuestMemoryError> {
         let gpa = (self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE)
@@ -484,15 +493,6 @@ impl ProcessorVtlHv {
             + offset_of!(HvVpVtlControl, vina_status) as u64;
 
         self.guest_memory.write_plain(gpa, &(value as u8))
-    }
-
-    /// Set the reason for the vtl return into the vp assist page
-    pub fn set_return_reason(&self, reason: HvVtlEntryReason) -> Result<(), GuestMemoryError> {
-        let gpa = (self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE)
-            + offset_of!(hvdef::HvVpAssistPage, vtl_control) as u64
-            + offset_of!(HvVpVtlControl, entry_reason) as u64;
-
-        self.guest_memory.write_plain(gpa, &(reason.0))
     }
 }
 

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -462,11 +462,28 @@ impl ProcessorVtlHv {
     /// Get the register values to restore on vtl return
     pub fn return_registers(&self) -> Result<[u64; 2], GuestMemoryError> {
         let gpa = (self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE)
-            + offset_of!(hvdef::HvVpAssistPage, vtl_control) as u64;
+            + offset_of!(hvdef::HvVpAssistPage, vtl_control) as u64
+            + offset_of!(HvVpVtlControl, registers) as u64;
 
-        let v: HvVpVtlControl = self.guest_memory.read_plain(gpa)?;
+        self.guest_memory.read_plain(gpa)
+    }
 
-        Ok(v.registers)
+    /// Gets whether VINA is currently asserted.
+    pub fn vina_asserted(&self) -> Result<bool, GuestMemoryError> {
+        let gpa = (self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE)
+            + offset_of!(hvdef::HvVpAssistPage, vtl_control) as u64
+            + offset_of!(HvVpVtlControl, vina_status) as u64;
+
+        self.guest_memory.read_plain(gpa).map(|v: u8| v != 0)
+    }
+
+    /// Sets whether VINA is currently asserted.
+    pub fn set_vina_asserted(&self, value: bool) -> Result<(), GuestMemoryError> {
+        let gpa = (self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE)
+            + offset_of!(hvdef::HvVpAssistPage, vtl_control) as u64
+            + offset_of!(HvVpVtlControl, vina_status) as u64;
+
+        self.guest_memory.write_plain(gpa, &(value as u8))
     }
 
     /// Set the reason for the vtl return into the vp assist page

--- a/vm/hv1/hv1_emulator/src/synic.rs
+++ b/vm/hv1/hv1_emulator/src/synic.rs
@@ -9,6 +9,7 @@ use hvdef::HvError;
 use hvdef::HvMessage;
 use hvdef::HvMessageHeader;
 use hvdef::HvMessageType;
+use hvdef::HvRegisterVsmVina;
 use hvdef::HvSynicSimpSiefp;
 use hvdef::HvSynicStimerConfig;
 use hvdef::TimerMessagePayload;
@@ -33,6 +34,8 @@ pub struct ProcessorSynic {
     timers: [Timer; hvdef::NUM_TIMERS],
     #[inspect(skip)]
     shared: Arc<RwLock<SharedProcessorState>>,
+    #[inspect(debug)]
+    vina: HvRegisterVsmVina,
 }
 
 #[derive(Inspect)]
@@ -256,6 +259,7 @@ impl GlobalSynic {
             sints: SintState::AT_RESET,
             timers: array::from_fn(|_| Timer::default()),
             shared,
+            vina: HvRegisterVsmVina::new(),
         }
     }
 }
@@ -267,10 +271,12 @@ impl ProcessorSynic {
             sints,
             timers,
             shared,
+            vina,
         } = self;
         *sints = SintState::AT_RESET;
         *timers = array::from_fn(|_| Timer::default());
         *shared.write() = SharedProcessorState::AT_RESET;
+        *vina = HvRegisterVsmVina::new();
     }
 
     /// Returns the event flags page register.
@@ -320,6 +326,11 @@ impl ProcessorSynic {
     /// Returns the specified synthetic timer count register.
     pub fn stimer_count(&self, n: usize) -> u64 {
         self.timers[n].count
+    }
+
+    /// Returns the value of the VINA register.
+    pub fn vina(&self) -> HvRegisterVsmVina {
+        self.vina
     }
 
     /// Sets the event flags page register.

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -2362,6 +2362,17 @@ pub struct HvVpVtlControl {
     pub registers: [u64; 2],
 }
 
+#[bitfield(u64)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
+pub struct HvRegisterVsmVina {
+    pub vector: u8,
+    pub enabled: bool,
+    pub auto_reset: bool,
+    pub auto_eoi: bool,
+    #[bits(53)]
+    pub reserved: u64,
+}
+
 #[repr(C)]
 #[derive(Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct HvVpAssistPage {

--- a/vmm_core/virt_support_apic/src/lib.rs
+++ b/vmm_core/virt_support_apic/src/lib.rs
@@ -844,12 +844,7 @@ impl<T: ApicClient> LocalApicAccess<'_, T> {
             ApicRegister::ID => self.apic.id_register(),
             ApicRegister::VERSION => self.apic.version,
             ApicRegister::TPR => self.client.cr8() << 4,
-            ApicRegister::PPR => {
-                self.ensure_state_local();
-                let task_pri = self.client.cr8();
-                let isr_pri = priority(self.apic.isr.top().unwrap_or(0));
-                task_pri.max(isr_pri.into()) << 4
-            }
+            ApicRegister::PPR => self.get_ppr(),
             ApicRegister::LDR => self.apic.ldr_register(),
             ApicRegister::DFR if !self.apic.x2apic_enabled() => {
                 if self.apic.cluster_mode {
@@ -1043,6 +1038,14 @@ impl<T: ApicClient> LocalApicAccess<'_, T> {
             }
         }
         true
+    }
+
+    /// Computes and returns the current effective PPR value.
+    pub fn get_ppr(&mut self) -> u32 {
+        self.ensure_state_local();
+        let task_pri = self.client.cr8();
+        let isr_pri = priority(self.apic.isr.top().unwrap_or(0));
+        task_pri.max(isr_pri.into()) << 4
     }
 
     fn ensure_state_local(&mut self) {


### PR DESCRIPTION
When VTL 1 has an interrupt pending, and we're planning on running VTL 0, check to see if we should preempt that and run VTL 1 to deliver the interrupt instead. Also, sets VINA when VTL 0 has a high enough priority interrupt and we're running VTL 1. Also resets VINA if auto reset is asked for. 

Note that since we don't have a way for the guest to set its VINA configuration yet that portion of the code is functionally dead (enabled will never be true). That's coming soon.