### PR TITLE
get: add event_log_fatal()

### DIFF
--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -367,7 +367,7 @@ pub async fn initialize_platform_security(
     )
     .await
     {
-        get.event_log_and_flush(guest_emulation_transport::api::EventLogId::ATTESTATION_FAILED)
+        get.event_log_fatal(guest_emulation_transport::api::EventLogId::ATTESTATION_FAILED)
             .await;
 
         Err(ErrorInner::UnlockVmgsDataStore(e))?
@@ -589,7 +589,7 @@ async fn get_derived_keys(
                         | GetKeysFromKeyProtectorError::IngressDekRsaUnwrap(_)
                 ) =>
             {
-                get.event_log_and_flush(
+                get.event_log_fatal(
                     guest_emulation_transport::api::EventLogId::DEK_DECRYPTION_FAILED,
                 )
                 .await;

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -367,8 +367,8 @@ pub async fn initialize_platform_security(
     )
     .await
     {
-        get.event_log(guest_emulation_transport::api::EventLogId::ATTESTATION_FAILED);
-        get.event_log_flush().await;
+        get.event_log_and_flush(guest_emulation_transport::api::EventLogId::ATTESTATION_FAILED)
+            .await;
 
         Err(ErrorInner::UnlockVmgsDataStore(e))?
     }
@@ -589,8 +589,10 @@ async fn get_derived_keys(
                         | GetKeysFromKeyProtectorError::IngressDekRsaUnwrap(_)
                 ) =>
             {
-                get.event_log(guest_emulation_transport::api::EventLogId::DEK_DECRYPTION_FAILED);
-                get.event_log_flush().await;
+                get.event_log_and_flush(
+                    guest_emulation_transport::api::EventLogId::DEK_DECRYPTION_FAILED,
+                )
+                .await;
 
                 return Err(GetDerivedKeysError::GetKeysFromKeyProtector(e));
             }

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -188,8 +188,8 @@ pub async fn request_vmgs_encryption_keys(
     } else {
         tracing::warn!(CVM_ALLOWED, "tenant vmgs ingress key is not released");
 
-        get.event_log(guest_emulation_transport::api::EventLogId::KEY_NOT_RELEASED);
-        get.event_log_flush().await;
+        get.event_log_and_flush(guest_emulation_transport::api::EventLogId::KEY_NOT_RELEASED)
+            .await;
 
         None
     };

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -188,7 +188,7 @@ pub async fn request_vmgs_encryption_keys(
     } else {
         tracing::warn!(CVM_ALLOWED, "tenant vmgs ingress key is not released");
 
-        get.event_log_and_flush(guest_emulation_transport::api::EventLogId::KEY_NOT_RELEASED)
+        get.event_log_fatal(guest_emulation_transport::api::EventLogId::KEY_NOT_RELEASED)
             .await;
 
         None

--- a/openhcl/underhill_core/src/emuplat/watchdog.rs
+++ b/openhcl/underhill_core/src/emuplat/watchdog.rs
@@ -42,8 +42,8 @@ impl WatchdogPlatform for UnderhillWatchdog {
         // FUTURE: consider emitting different events for the UEFI watchdog vs.
         // the guest watchdog
         self.get
-            .event_log(get_protocol::EventLogId::WATCHDOG_TIMEOUT_RESET);
-        self.get.event_log_flush().await;
+            .event_log_and_flush(get_protocol::EventLogId::WATCHDOG_TIMEOUT_RESET)
+            .await;
 
         (self.on_timeout)()
     }

--- a/openhcl/underhill_core/src/emuplat/watchdog.rs
+++ b/openhcl/underhill_core/src/emuplat/watchdog.rs
@@ -42,7 +42,7 @@ impl WatchdogPlatform for UnderhillWatchdog {
         // FUTURE: consider emitting different events for the UEFI watchdog vs.
         // the guest watchdog
         self.get
-            .event_log_and_flush(get_protocol::EventLogId::WATCHDOG_TIMEOUT_RESET)
+            .event_log_fatal(get_protocol::EventLogId::WATCHDOG_TIMEOUT_RESET)
             .await;
 
         (self.on_timeout)()

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1356,7 +1356,7 @@ async fn new_underhill_vm(
                             _ => EventLogId::VMGS_INIT_FAILED,
                         };
 
-                        get_client.event_log_and_flush(event_log_id).await;
+                        get_client.event_log_fatal(event_log_id).await;
                         return Err(err).context("fatal VMGS initialization error")?;
                     }
                 }
@@ -1895,7 +1895,7 @@ async fn new_underhill_vm(
                         Err(e) => {
                             tracing::error!("Failed to load custom UEFI vars");
                             get_client
-                                .event_log_and_flush(EventLogId::BOOT_FAILURE_SECURE_BOOT_FAILED)
+                                .event_log_fatal(EventLogId::BOOT_FAILURE_SECURE_BOOT_FAILED)
                                 .await;
                             return Err(e).context("failed to load custom UEFI variables");
                         }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1356,8 +1356,7 @@ async fn new_underhill_vm(
                             _ => EventLogId::VMGS_INIT_FAILED,
                         };
 
-                        get_client.event_log(event_log_id);
-                        get_client.event_log_flush().await;
+                        get_client.event_log_and_flush(event_log_id).await;
                         return Err(err).context("fatal VMGS initialization error")?;
                     }
                 }
@@ -1895,8 +1894,9 @@ async fn new_underhill_vm(
                         Ok(vars) => vars,
                         Err(e) => {
                             tracing::error!("Failed to load custom UEFI vars");
-                            get_client.event_log(EventLogId::BOOT_FAILURE_SECURE_BOOT_FAILED);
-                            get_client.event_log_flush().await;
+                            get_client
+                                .event_log_and_flush(EventLogId::BOOT_FAILURE_SECURE_BOOT_FAILED)
+                                .await;
                             return Err(e).context("failed to load custom UEFI variables");
                         }
                     }

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -448,7 +448,7 @@ impl GuestEmulationTransportClient {
     /// This function is non-blocking and does not wait for a response from the
     /// host.
     ///
-    /// When reporting fatal events (i.e: events which terminate underhill
+    /// When reporting fatal events (i.e: events which terminate OpenHCL
     /// execution entirely), the caller must also await-on
     /// [`event_log_flush`](Self::event_log_flush) in order to ensure all queued
     /// events has actually been sent to the host.
@@ -465,8 +465,9 @@ impl GuestEmulationTransportClient {
         self.control.call(msg::Msg::FlushWrites, ()).await
     }
 
-    /// Report the event to host and flush the event queue.
-    pub async fn event_log_and_flush(&self, event_log_id: crate::api::EventLogId) {
+    /// Report the fatal event to the host and flush the event queue. This ensures all the
+    /// relevant events are sent to the host prior to OpenHCL teardown.
+    pub async fn event_log_fatal(&self, event_log_id: crate::api::EventLogId) {
         self.control.notify(msg::Msg::EventLog(event_log_id));
         self.control.call(msg::Msg::FlushWrites, ()).await
     }

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -465,6 +465,12 @@ impl GuestEmulationTransportClient {
         self.control.call(msg::Msg::FlushWrites, ()).await
     }
 
+    /// Report the event to host and flush the event queue.
+    pub async fn event_log_and_flush(&self, event_log_id: crate::api::EventLogId) {
+        self.control.notify(msg::Msg::EventLog(event_log_id));
+        self.control.call(msg::Msg::FlushWrites, ()).await
+    }
+
     /// Retrieves the current time from the host.
     pub async fn host_time(&self) -> crate::api::Time {
         let response = self.control.call(msg::Msg::HostTime, ()).await;

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -465,8 +465,14 @@ impl GuestEmulationTransportClient {
         self.control.call(msg::Msg::FlushWrites, ()).await
     }
 
-    /// Report the fatal event to the host and flush the event queue. This ensures all the
-    /// relevant events are sent to the host prior to OpenHCL teardown.
+    /// Report the fatal event to the host and flush the event queue.
+    ///
+    /// This function is asynchronous and is equivalent to the combination of
+    /// [`event_log`](Self::event_log) and [`event_log_flush`](Self::event_log_flush).
+    ///
+    /// Use this function to ensure all the events prior to the fatal event are sent to
+    /// the host before the OpenHCL tears down. For non-fatal event, use
+    /// [`event_log`](Self::event_log).
     pub async fn event_log_fatal(&self, event_log_id: crate::api::EventLogId) {
         self.control.notify(msg::Msg::EventLog(event_log_id));
         self.control.call(msg::Msg::FlushWrites, ()).await


### PR DESCRIPTION
This PR adds ` event_log_fatal()` that simplifies the two-call (`event_log()` + `event_log_flush()`) pattern. The PR still retains the two APIs for firmware code that does the log and flush separately.