### PR TITLE
Clean up use of no_std in crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "inspect",
  "pal_async",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
 ]
 
@@ -42,7 +42,7 @@ dependencies = [
  "bitfield-struct",
  "open_enum",
  "static_assertions",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
 ]
 
@@ -178,7 +178,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -271,7 +271,7 @@ checksum = "6c2ce686adbebce0ee484a502c440b4657739adbad65eadf06d64f5816ee9765"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -388,7 +388,7 @@ name = "cache_topology"
 version = "0.0.0"
 dependencies = [
  "fs-err",
- "thiserror",
+ "thiserror 2.0.0",
  "windows-sys 0.52.0",
 ]
 
@@ -399,7 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -453,7 +453,7 @@ dependencies = [
  "pal_async",
  "power_resources",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "time",
  "tracelimit",
  "tracing",
@@ -471,7 +471,7 @@ dependencies = [
  "closeable_mutex",
  "parking_lot",
  "range_map_vec",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
 ]
 
@@ -527,7 +527,7 @@ dependencies = [
  "pal_async",
  "pci_bus",
  "pci_core",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vmcore",
@@ -618,7 +618,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -694,7 +694,7 @@ dependencies = [
  "resolv-conf",
  "smoltcp",
  "socket2",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -920,7 +920,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -951,7 +951,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -973,7 +973,7 @@ dependencies = [
  "mesh_rpc",
  "pal_async",
  "socket2",
- "thiserror",
+ "thiserror 2.0.0",
  "unix_socket",
  "vmsocket",
  "windows-sys 0.52.0",
@@ -1068,7 +1068,7 @@ dependencies = [
  "inspect",
  "scsi_buffers",
  "stackfuture",
- "thiserror",
+ "thiserror 2.0.0",
  "vm_resource",
 ]
 
@@ -1099,7 +1099,7 @@ dependencies = [
  "once_cell",
  "scsi_buffers",
  "stackfuture",
- "thiserror",
+ "thiserror 2.0.0",
  "tokio",
  "vhd1_defs",
  "vm_resource",
@@ -1135,7 +1135,7 @@ dependencies = [
  "scsi_buffers",
  "stackfuture",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "uevent",
  "vm_resource",
@@ -1201,7 +1201,7 @@ dependencies = [
  "parking_lot",
  "scsi_buffers",
  "stackfuture",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vm_resource",
  "zerocopy",
@@ -1223,7 +1223,7 @@ dependencies = [
  "pal_async",
  "scsi_buffers",
  "stackfuture",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vm_resource",
@@ -1243,7 +1243,7 @@ dependencies = [
  "scsi_buffers",
  "stackfuture",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.0",
  "vhd1_defs",
  "vm_resource",
  "zerocopy",
@@ -1263,7 +1263,7 @@ dependencies = [
  "scsi_buffers",
  "stackfuture",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.0",
  "vm_resource",
  "winapi",
 ]
@@ -1283,7 +1283,7 @@ dependencies = [
  "libc",
  "nix 0.26.4",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
  "zerocopy",
 ]
@@ -1349,7 +1349,7 @@ checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1458,6 +1458,7 @@ dependencies = [
 name = "fdt"
 version = "0.0.0"
 dependencies = [
+ "thiserror 2.0.0",
  "zerocopy",
  "zerocopy_helpers",
 ]
@@ -1486,7 +1487,7 @@ dependencies = [
  "mesh",
  "open_enum",
  "static_assertions",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vm_topology",
@@ -1514,7 +1515,7 @@ dependencies = [
  "openssl",
  "pal_async",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "time",
  "tracelimit",
  "tracing",
@@ -1534,7 +1535,7 @@ version = "0.0.0"
 dependencies = [
  "guid",
  "mesh_protobuf",
- "thiserror",
+ "thiserror 2.0.0",
  "uefi_specs",
 ]
 
@@ -1567,7 +1568,7 @@ dependencies = [
  "mesh",
  "open_enum",
  "scsi_buffers",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vmcore",
@@ -1768,7 +1769,7 @@ dependencies = [
  "parking_lot",
  "tempfile",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "zerocopy",
 ]
@@ -1852,7 +1853,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2051,7 +2052,7 @@ dependencies = [
  "pci_resources",
  "slab",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vm_resource",
  "vmcore",
@@ -2129,7 +2130,7 @@ name = "get_resources"
 version = "0.0.0"
 dependencies = [
  "mesh",
- "thiserror",
+ "thiserror 2.0.0",
  "vm_resource",
 ]
 
@@ -2179,7 +2180,7 @@ dependencies = [
  "crc",
  "nix 0.26.4",
  "serde",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -2255,7 +2256,7 @@ dependencies = [
  "power_resources",
  "serde_json",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "time",
  "tracing",
  "video_core",
@@ -2279,7 +2280,7 @@ dependencies = [
  "serde",
  "serde_json",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vm_resource",
  "vmbus_async",
@@ -2312,7 +2313,7 @@ dependencies = [
  "serde_json",
  "shared_pool_alloc",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "tracing_helpers",
  "underhill_config",
@@ -2353,7 +2354,7 @@ dependencies = [
  "inspect",
  "pal_event",
  "sparse_mmap",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
 ]
 
@@ -2364,7 +2365,7 @@ dependencies = [
  "getrandom",
  "inspect",
  "mesh_protobuf",
- "thiserror",
+ "thiserror 2.0.0",
  "winapi",
  "windows-sys 0.52.0",
  "zerocopy",
@@ -2421,7 +2422,7 @@ dependencies = [
  "sidecar_client",
  "signal-hook",
  "tdcall",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vtl_array",
@@ -2440,7 +2441,7 @@ dependencies = [
  "open_enum",
  "pal_async",
  "static_assertions",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "ucs2 0.0.0",
  "uefi_nvram_storage",
@@ -2566,7 +2567,7 @@ dependencies = [
  "open_enum",
  "sparse_mmap",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "zerocopy",
@@ -2639,7 +2640,7 @@ dependencies = [
  "sparse_mmap",
  "state_unit",
  "storvsp",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "tracing_helpers",
  "uefi_nvram_storage",
@@ -2686,7 +2687,7 @@ dependencies = [
  "mesh",
  "mesh_worker",
  "net_backend_resources",
- "thiserror",
+ "thiserror 2.0.0",
  "unix_socket",
  "virt",
  "virt_whp",
@@ -2753,7 +2754,7 @@ dependencies = [
  "sparse_mmap",
  "storvsp_resources",
  "term",
- "thiserror",
+ "thiserror 2.0.0",
  "tpm_resources",
  "tracelimit",
  "tracing",
@@ -2893,7 +2894,7 @@ dependencies = [
  "inspect",
  "mesh",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vm_resource",
  "vmbus_async",
@@ -2913,7 +2914,7 @@ dependencies = [
  "inspect",
  "mesh",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vmbus_async",
@@ -2963,7 +2964,7 @@ dependencies = [
  "serde",
  "serde_helpers",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
 ]
 
@@ -3000,7 +3001,7 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "tracing_helpers",
@@ -3046,7 +3047,7 @@ dependencies = [
  "igvm_defs",
  "open-enum",
  "range_map_vec",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
  "zerocopy",
 ]
@@ -3082,7 +3083,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "tracing-subscriber",
  "underhill_confidentiality",
@@ -3144,7 +3145,7 @@ dependencies = [
  "mesh",
  "pal_async",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -3161,7 +3162,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3184,7 +3185,7 @@ dependencies = [
  "cfg-if",
  "inspect",
  "libc",
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -3244,7 +3245,7 @@ dependencies = [
 name = "kmsg"
 version = "0.0.0"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -3261,7 +3262,7 @@ dependencies = [
  "pal",
  "parking_lot",
  "signal-hook",
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -3278,7 +3279,7 @@ checksum = "9baa9eeb6e315942429397e617a190f4fdc696ef1ee0342939d641029cbb4ea7"
 dependencies = [
  "enumflags2",
  "libc",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -3342,7 +3343,7 @@ checksum = "04e542a18c94a9b6fcc7adb090fa3ba6b79ee220a16404f325672729f32a66ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3375,7 +3376,7 @@ dependencies = [
  "object",
  "open_enum",
  "page_table",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vm_topology",
  "x86defs",
@@ -3423,7 +3424,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 name = "lx"
 version = "0.0.0"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -3505,7 +3506,7 @@ dependencies = [
  "bitvec",
  "serde",
  "serde-big-array",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -3532,7 +3533,7 @@ dependencies = [
  "parking_lot",
  "slab",
  "sparse_mmap",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "virt",
  "vm_topology",
@@ -3560,7 +3561,7 @@ version = "0.0.0"
 dependencies = [
  "inspect",
  "mesh_protobuf",
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -3581,7 +3582,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3598,7 +3599,7 @@ dependencies = [
  "pal_event",
  "parking_lot",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
 ]
 
@@ -3609,7 +3610,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3625,7 +3626,7 @@ dependencies = [
  "pal_async",
  "parking_lot",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "zerocopy",
 ]
@@ -3663,7 +3664,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "socket2",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
 ]
 
@@ -3685,7 +3686,7 @@ dependencies = [
  "parking_lot",
  "socket2",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "tracing_helpers",
  "unicycle",
@@ -3712,7 +3713,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tokio",
  "tracing",
  "unicycle",
@@ -3905,7 +3906,7 @@ dependencies = [
  "guid",
  "inspect",
  "mesh",
- "thiserror",
+ "thiserror 2.0.0",
  "vm_resource",
 ]
 
@@ -3922,7 +3923,7 @@ dependencies = [
  "net_backend_resources",
  "pal_async",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vm_resource",
 ]
@@ -4000,7 +4001,7 @@ dependencies = [
  "net_backend_resources",
  "pal_async",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vm_resource",
 ]
@@ -4031,7 +4032,7 @@ dependencies = [
  "safeatomic",
  "task_control",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vm_resource",
@@ -4161,7 +4162,7 @@ dependencies = [
  "pci_resources",
  "scsi_buffers",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "unicycle",
@@ -4177,7 +4178,7 @@ version = "0.0.0"
 dependencies = [
  "disk_backend",
  "nvme_spec",
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -4204,7 +4205,7 @@ dependencies = [
  "slab",
  "task_control",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "user_driver",
  "vmcore",
@@ -4260,7 +4261,7 @@ dependencies = [
  "pal_async",
  "socket2",
  "term",
- "thiserror",
+ "thiserror 2.0.0",
  "unicycle",
 ]
 
@@ -4293,7 +4294,7 @@ checksum = "8d1296fab5231654a5aec8bf9e87ba4e3938c502fc4c3c0425a00084c78944be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4348,7 +4349,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4390,7 +4391,7 @@ dependencies = [
  "libc",
  "openssl",
  "openssl-sys",
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -4520,7 +4521,7 @@ dependencies = [
  "pal_event",
  "seccompiler",
  "socket2",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "widestring",
  "win_import_lib",
@@ -4560,7 +4561,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4671,7 +4672,7 @@ checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
 dependencies = [
  "byteorder_slice",
  "derive-into-owned",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4682,7 +4683,7 @@ dependencies = [
  "chipset_device",
  "inspect",
  "mesh",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vmcore",
@@ -4700,7 +4701,7 @@ dependencies = [
  "mesh",
  "open_enum",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vmcore",
@@ -4843,7 +4844,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4979,9 +4980,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -5148,7 +5149,7 @@ checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -5284,7 +5285,7 @@ checksum = "e5af959c8bf6af1aff6d2b463a57f71aae53d1332da58419e30ad8dc7011d951"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5318,7 +5319,7 @@ name = "save_restore_derive"
 version = "0.0.0"
 dependencies = [
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5399,7 +5400,7 @@ dependencies = [
  "scsi_defs",
  "scsidisk_resources",
  "stackfuture",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "tracing_helpers",
@@ -5482,7 +5483,7 @@ checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5543,7 +5544,7 @@ dependencies = [
  "open_enum",
  "serial_16550_resources",
  "serial_core",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vm_resource",
@@ -5586,7 +5587,7 @@ dependencies = [
  "pal_async",
  "serial_core",
  "serial_pl011_resources",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vm_resource",
@@ -5623,7 +5624,7 @@ dependencies = [
  "bitfield-struct",
  "nix 0.26.4",
  "static_assertions",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
 ]
 
@@ -5657,7 +5658,7 @@ dependencies = [
  "inspect",
  "parking_lot",
  "sparse_mmap",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "user_driver",
  "vm_topology",
@@ -5694,7 +5695,7 @@ dependencies = [
  "pal_async",
  "parking_lot",
  "sidecar_defs",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "zerocopy",
 ]
@@ -5797,7 +5798,7 @@ dependencies = [
  "libc",
  "pal",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
  "windows-sys 0.52.0",
  "zerocopy",
 ]
@@ -5821,7 +5822,7 @@ dependencies = [
  "pal_async",
  "parking_lot",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vmcore",
 ]
@@ -5838,7 +5839,7 @@ version = "0.0.0"
 dependencies = [
  "inspect",
  "mesh_protobuf",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
 ]
 
@@ -5871,7 +5872,7 @@ dependencies = [
  "storvsp_resources",
  "task_control",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "tracing_helpers",
@@ -5913,9 +5914,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5964,7 +5965,7 @@ version = "0.0.0"
 dependencies = [
  "nix 0.26.4",
  "static_assertions",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
 ]
 
@@ -5975,7 +5976,7 @@ dependencies = [
  "sev_guest_device",
  "static_assertions",
  "tdx_guest_device",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
 ]
 
@@ -6033,27 +6034,47 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15291287e9bff1bc6f9ff3409ed9af665bec7a5fc8ac079ea96be07bca0e2668"
+dependencies = [
+ "thiserror-impl 2.0.0",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22efd00f33f93fa62848a7cab956c3d38c8d43095efda1decfc2b3a5dc0b8972"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6226,7 +6247,7 @@ dependencies = [
  "open_enum",
  "pal_async",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
  "tpm_resources",
  "tracelimit",
  "tracing",
@@ -6272,7 +6293,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6370,7 +6391,7 @@ name = "ucs2"
 version = "0.0.0"
 dependencies = [
  "mesh_protobuf",
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -6406,7 +6427,7 @@ checksum = "c19ee3a01d435eda42cb9931269b349d28a1762f91ddf01c68d276f74b957cc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6425,7 +6446,7 @@ name = "uefi_nvram_specvars"
 version = "0.0.0"
 dependencies = [
  "guid",
- "thiserror",
+ "thiserror 2.0.0",
  "ucs2 0.0.0",
  "uefi_specs",
  "zerocopy",
@@ -6440,7 +6461,7 @@ dependencies = [
  "guid",
  "inspect",
  "pal_async",
- "thiserror",
+ "thiserror 2.0.0",
  "ucs2 0.0.0",
  "uefi_specs",
  "wchar",
@@ -6473,7 +6494,7 @@ dependencies = [
  "mesh",
  "pal_async",
  "socket2",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
 ]
 
@@ -6499,7 +6520,7 @@ dependencies = [
  "static_assertions",
  "task_control",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "tracing_helpers",
@@ -6545,7 +6566,7 @@ dependencies = [
  "static_assertions",
  "tdx_guest_device",
  "tee_call",
- "thiserror",
+ "thiserror 2.0.0",
  "time",
  "tracing",
  "vmgs",
@@ -6566,7 +6587,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.0",
  "vtl2_settings_proto",
 ]
 
@@ -6664,7 +6685,7 @@ dependencies = [
  "storvsp",
  "storvsp_resources",
  "tee_call",
- "thiserror",
+ "thiserror 2.0.0",
  "time",
  "tpm",
  "tpm_resources",
@@ -6723,7 +6744,7 @@ dependencies = [
  "guid",
  "libc",
  "pal_async",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "tracing-subscriber",
  "vergen",
@@ -6787,7 +6808,7 @@ dependencies = [
  "pal_async",
  "parking_lot",
  "sparse_mmap",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "underhill_threadpool",
  "virt",
@@ -6807,7 +6828,7 @@ dependencies = [
  "pal_async",
  "pal_uring",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
 ]
 
@@ -6977,7 +6998,7 @@ dependencies = [
  "parking_lot",
  "pci_core",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "video_core",
  "vmcore",
@@ -7030,7 +7051,7 @@ dependencies = [
  "parking_lot",
  "pci_core",
  "slab",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vm_topology",
@@ -7053,7 +7074,7 @@ dependencies = [
  "memory_range",
  "open_enum",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "virt",
@@ -7081,7 +7102,7 @@ dependencies = [
  "parking_lot",
  "pci_core",
  "safe_x86_intrinsics",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "virt",
@@ -7110,7 +7131,7 @@ dependencies = [
  "parking_lot",
  "signal-hook",
  "static_assertions",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "virt",
@@ -7152,7 +7173,7 @@ dependencies = [
  "safe_x86_intrinsics",
  "shared_pool_alloc",
  "sidecar_client",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "virt",
@@ -7175,7 +7196,7 @@ dependencies = [
  "aarch64emu",
  "guestmem",
  "hvdef",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "virt",
  "vm_topology",
@@ -7191,7 +7212,7 @@ dependencies = [
  "inspect",
  "inspect_counters",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "virt",
@@ -7219,7 +7240,7 @@ dependencies = [
  "hvdef",
  "iced-x86",
  "pal_async",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "virt",
@@ -7251,7 +7272,7 @@ dependencies = [
  "pci_core",
  "range_map_vec",
  "sparse_mmap",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "tracing_helpers",
@@ -7289,7 +7310,7 @@ dependencies = [
  "pci_core",
  "task_control",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vm_resource",
@@ -7316,7 +7337,7 @@ dependencies = [
  "pal_async",
  "parking_lot",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "virtio",
  "virtio_resources",
@@ -7431,7 +7452,7 @@ dependencies = [
  "serial_16550_resources",
  "serial_core",
  "serial_pl011_resources",
- "thiserror",
+ "thiserror 2.0.0",
  "vm_resource",
  "vmotherboard",
 ]
@@ -7445,7 +7466,7 @@ dependencies = [
  "linkme",
  "mesh",
  "pal_async",
- "thiserror",
+ "thiserror 2.0.0",
 ]
 
 [[package]]
@@ -7459,7 +7480,7 @@ dependencies = [
  "memory_range",
  "mesh_protobuf",
  "safe_x86_intrinsics",
- "thiserror",
+ "thiserror 2.0.0",
  "x86defs",
 ]
 
@@ -7473,7 +7494,7 @@ dependencies = [
  "inspect",
  "open_enum",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vm_resource",
  "vmbfs_resources",
@@ -7502,7 +7523,7 @@ dependencies = [
  "inspect_counters",
  "pal_async",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.0",
  "vmbus_channel",
  "vmbus_ring",
  "zerocopy",
@@ -7523,7 +7544,7 @@ dependencies = [
  "pal_event",
  "parking_lot",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vm_resource",
@@ -7543,7 +7564,7 @@ dependencies = [
  "mesh",
  "pal_async",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vmbus_async",
  "vmbus_channel",
@@ -7563,7 +7584,7 @@ dependencies = [
  "mesh",
  "open_enum",
  "static_assertions",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
  "zerocopy_helpers",
 ]
@@ -7647,7 +7668,7 @@ dependencies = [
  "inspect",
  "safeatomic",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
 ]
 
@@ -7665,7 +7686,7 @@ dependencies = [
  "pal_async",
  "serial_core",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "unix_socket",
  "vm_resource",
@@ -7686,7 +7707,7 @@ dependencies = [
  "inspect_counters",
  "serial_core",
  "task_control",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vm_resource",
  "vmbus_async",
@@ -7735,7 +7756,7 @@ dependencies = [
  "safeatomic",
  "slab",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "unicycle",
@@ -7762,7 +7783,7 @@ dependencies = [
  "parking_lot",
  "safeatomic",
  "sparse_mmap",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vmbus_async",
  "vmbus_channel",
@@ -7787,7 +7808,7 @@ dependencies = [
  "parking_lot",
  "save_restore_derive",
  "slab",
- "thiserror",
+ "thiserror 2.0.0",
  "time",
  "tracelimit",
  "tracing",
@@ -7818,7 +7839,7 @@ dependencies = [
  "openssl",
  "pal_async",
  "tempfile_helpers",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vhd1_defs",
  "vmgs_format",
@@ -7834,7 +7855,7 @@ dependencies = [
  "inspect",
  "mesh_channel",
  "pal_async",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vm_resource",
  "vmcore",
@@ -7887,7 +7908,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.0",
  "ucs2 0.0.0",
  "uefi_nvram_specvars",
  "uefi_nvram_storage",
@@ -7935,7 +7956,7 @@ dependencies = [
  "power_resources",
  "slab",
  "state_unit",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "virt",
  "virt_support_x86emu",
@@ -7977,7 +7998,7 @@ dependencies = [
  "petri_artifacts_vmm_test",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8057,7 +8078,7 @@ dependencies = [
  "pci_bus",
  "range_map_vec",
  "state_unit",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "uefi_nvram_storage",
@@ -8091,7 +8112,7 @@ dependencies = [
  "pal",
  "pal_async",
  "pal_event",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "widestring",
  "winapi",
@@ -8106,7 +8127,7 @@ dependencies = [
  "futures",
  "pal_async",
  "socket2",
- "thiserror",
+ "thiserror 2.0.0",
  "zerocopy",
 ]
 
@@ -8162,7 +8183,7 @@ dependencies = [
  "pci_core",
  "task_control",
  "test_with_tracing",
- "thiserror",
+ "thiserror 2.0.0",
  "tracelimit",
  "tracing",
  "vmbus_async",
@@ -8256,7 +8277,7 @@ dependencies = [
  "inspect",
  "mesh",
  "pal_async",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "vmcore",
 ]
@@ -8265,7 +8286,7 @@ dependencies = [
 name = "watchdog_vmgs_format"
 version = "0.0.0"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.0",
  "vmcore",
 ]
 
@@ -8443,7 +8464,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8454,7 +8475,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8661,7 +8682,7 @@ dependencies = [
  "arbitrary",
  "futures",
  "iced-x86",
- "thiserror",
+ "thiserror 2.0.0",
  "tracing",
  "x86defs",
  "zerocopy",
@@ -8739,7 +8760,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -479,7 +479,7 @@ static_assertions = "1.1"
 syn = "2"
 target-lexicon = "0.12.13"
 tempfile = "3.2"
-thiserror = "1.0"
+thiserror = { version = "2", default-features = false }
 time = "0.3"
 toml_edit = "0.21"
 tracing = "0.1"

--- a/openhcl/bootloader_fdt_parser/Cargo.toml
+++ b/openhcl/bootloader_fdt_parser/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-fdt = { workspace = true, features = ["std"] }
+fdt.workspace = true
 inspect.workspace = true
 loader_defs = { workspace = true, features = ["inspect"] }
 memory_range = { workspace = true, features = ["inspect"] }

--- a/openhcl/diag_server/Cargo.toml
+++ b/openhcl/diag_server/Cargo.toml
@@ -32,7 +32,7 @@ net_packet_capture.workspace = true
 profiler_worker = { workspace = true, optional = true }
 socket2.workspace = true
 safe_x86_intrinsics.workspace = true
-hvdef = { workspace = true, features = ["std"] }
+hvdef.workspace = true
 
 [features]
 profiler = ["dep:profiler_worker"]

--- a/openhcl/hcl/Cargo.toml
+++ b/openhcl/hcl/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-hvdef = { workspace = true, features = ["std"] }
+hvdef.workspace = true
 pal.workspace = true
 memory_range.workspace = true
 sidecar_client.workspace = true

--- a/openhcl/host_fdt_parser/Cargo.toml
+++ b/openhcl/host_fdt_parser/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 rust-version.workspace = true
 
 [features]
-std = ["fdt/std", "dep:tracing", "memory_range/std"]
-inspect = ["std", "dep:inspect", "memory_range/inspect"]
+tracing = ["dep:tracing"]
+inspect = ["dep:inspect", "memory_range/inspect"]
 
 [dependencies]
 hvdef.workspace = true

--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -1068,7 +1068,12 @@ mod inspect_helpers {
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
     use super::*;
+    use alloc::format;
+    use alloc::vec;
+    use alloc::vec::Vec;
     use fdt::builder::Builder;
     use fdt::builder::BuilderConfig;
     use fdt::builder::Nest;

--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -8,7 +8,7 @@
 //! Notably, we search for IGVM specific extensions to nodes, defined here:
 //! [`igvm_defs::dt`].
 
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![no_std]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
@@ -66,9 +66,7 @@ impl<'a> Display for Error<'a> {
     }
 }
 
-// TODO: Once core::error::Error is stablized, we can remove this feature gate.
-#[cfg(feature = "std")]
-impl<'a> std::error::Error for Error<'a> {}
+impl<'a> core::error::Error for Error<'a> {}
 
 #[derive(Debug)]
 enum ErrorKind<'a> {
@@ -501,7 +499,7 @@ impl<
                                     .data;
 
                                 if host_entropy.len() > MAX_ENTROPY_SIZE {
-                                    #[cfg(feature = "std")]
+                                    #[cfg(feature = "tracing")]
                                     tracing::warn!(
                                         entropy_len = host_entropy.len(),
                                         "Truncating host-provided entropy",
@@ -515,7 +513,7 @@ impl<
                                 storage.entropy = Some(entropy);
                             }
                             _ => {
-                                #[cfg(feature = "std")]
+                                #[cfg(feature = "tracing")]
                                 tracing::warn!(?openhcl_child.name, "Unrecognized OpenHCL child node");
                             }
                         }
@@ -733,7 +731,7 @@ fn parse_compatible<'a>(
     } else if compatible == "x86-pio-bus" {
         parse_io_bus(node, com3_serial)?;
     } else {
-        #[cfg(feature = "std")]
+        #[cfg(feature = "tracing")]
         tracing::warn!(?compatible, ?node.name,
             "Unrecognized compatible field",
         );
@@ -977,7 +975,7 @@ fn parse_io_bus<'a>(
         if compatible == "ns16550" && reg_base == COM3_REG_BASE {
             *com3_serial = true
         } else {
-            #[cfg(feature = "std")]
+            #[cfg(feature = "tracing")]
             tracing::warn!(?node.name, ?compatible, ?reg_base,
                 "unrecognized io bus child"
             );

--- a/openhcl/sidecar_client/Cargo.toml
+++ b/openhcl/sidecar_client/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-hvdef = { workspace = true, features = ["std"] }
+hvdef.workspace = true
 sidecar_defs.workspace = true
 
 pal_async.workspace = true

--- a/openhcl/underhill_confidentiality/src/lib.rs
+++ b/openhcl/underhill_confidentiality/src/lib.rs
@@ -5,8 +5,10 @@
 
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
+#[cfg(feature = "std")]
+extern crate std;
 #[cfg(feature = "std")]
 mod getters;
 #[cfg(feature = "std")]

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -158,7 +158,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_helpers.workspace = true
 serde_json.workspace = true
 socket2.workspace = true
-thiserror.workspace = true
+thiserror = { workspace = true, features = ["std"] }
 time = { workspace = true, features = ["macros"] }
 tracing-subscriber = { workspace = true, features = ["registry"] }
 tracing.workspace = true

--- a/support/fdt/Cargo.toml
+++ b/support/fdt/Cargo.toml
@@ -6,11 +6,8 @@ name = "fdt"
 edition = "2021"
 rust-version.workspace = true
 
-[features]
-default = []
-std = []
-
 [dependencies]
+thiserror.workspace = true
 zerocopy.workspace = true
 zerocopy_helpers.workspace = true
 

--- a/support/fdt/src/builder.rs
+++ b/support/fdt/src/builder.rs
@@ -6,6 +6,7 @@
 use crate::spec;
 use core::marker::PhantomData;
 use core::mem::size_of;
+use thiserror::Error;
 use zerocopy::AsBytes;
 use zerocopy::FromZeroes;
 
@@ -40,40 +41,21 @@ struct Inner<'a> {
 pub struct StringId(spec::U32b);
 
 /// Errors returned by the FDT builder.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Error)]
 pub enum Error {
     /// No space left in buffer.
+    #[error("out of space")]
     OutOfSpace,
     /// Memory reservations overlap.
+    #[error("memory reservations overlap: {0:?} and {1:?}")]
     OverlappingMemoryReservations(spec::ReserveEntry, spec::ReserveEntry),
     /// Duplicate memory reservation.
+    #[error("duplicate memory reservation: {0:?}")]
     DuplicateMemoryReservations(spec::ReserveEntry),
     /// Zero-sized memory reservation.
+    #[error("zero-sized memory reservation")]
     ZeroMemoryReservation,
 }
-
-impl core::fmt::Display for Error {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Error::OutOfSpace => write!(f, "out of space"),
-            Error::OverlappingMemoryReservations(entry1, entry2) => {
-                write!(
-                    f,
-                    "memory reservations overlap: {:?} and {:?}",
-                    entry1, entry2
-                )
-            }
-            Error::DuplicateMemoryReservations(entry) => {
-                write!(f, "duplicate memory reservation: {:?}", entry)
-            }
-            Error::ZeroMemoryReservation => write!(f, "zero-sized memory reservation"),
-        }
-    }
-}
-
-// TODO: Once core::error::Error is stablized, we can remove this feature gate.
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
 
 /// Type used to track node nesting level.
 #[derive(Debug)]

--- a/support/fdt/src/lib.rs
+++ b/support/fdt/src/lib.rs
@@ -4,7 +4,7 @@
 //! This crate contains utilities to interact with Flattened DeviceTree binary
 //! blobs. Included is a builder and parser, both available as no_std.
 
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![no_std]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 

--- a/support/fdt/src/parser.rs
+++ b/support/fdt/src/parser.rs
@@ -18,13 +18,12 @@ pub struct Error<'a>(ErrorKind<'a>);
 
 impl<'a> Display for Error<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_fmt(format_args!("{}", self.0))
+        self.0.fmt(f)
     }
 }
 
 // TODO: Once core::error::Error is stablized, we can remove this feature gate.
-#[cfg(feature = "std")]
-impl<'a> std::error::Error for Error<'a> {}
+impl<'a> core::error::Error for Error<'a> {}
 
 /// Types of errors when parsing a FDT.
 #[derive(Debug)]
@@ -736,9 +735,7 @@ impl<'a> Iterator for MemoryReserveIter<'a> {
     }
 }
 
-#[cfg(feature = "std")]
-// TODO: Once core::error::Error is stablized, we can remove this feature gate.
-impl std::error::Error for StringError {}
+impl core::error::Error for StringError {}
 
 /// Extract a string from bytes treated as a C String, stopping at the first null terminator.
 fn extract_str_from_bytes(bytes: &[u8]) -> Result<&str, StringError> {

--- a/support/fdt/src/parser.rs
+++ b/support/fdt/src/parser.rs
@@ -751,12 +751,17 @@ fn extract_str_from_bytes(bytes: &[u8]) -> Result<&str, StringError> {
 
 #[cfg(test)]
 mod test {
+    extern crate alloc;
+
     use super::*;
     use crate::builder::Builder;
     use crate::builder::BuilderConfig;
     use crate::builder::StringId;
     use crate::spec::ReserveEntry;
-    use std::vec;
+    use alloc::format;
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum DtProp {

--- a/vm/acpi_spec/Cargo.toml
+++ b/vm/acpi_spec/Cargo.toml
@@ -10,14 +10,14 @@ rust-version.workspace = true
 default = []
 
 alloc = []
-std = ["alloc", "dep:thiserror"]
+std = ["alloc"]
 
 [dependencies]
 open_enum.workspace = true
 
 bitfield-struct.workspace = true
 static_assertions.workspace = true
-thiserror = { optional = true, workspace = true }
+thiserror.workspace = true
 zerocopy.workspace = true
 
 [lints]

--- a/vm/acpi_spec/src/lib.rs
+++ b/vm/acpi_spec/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! ACPI types.
 
-#![cfg_attr(not(any(test, feature = "std")), no_std)]
+#![no_std]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/vm/acpi_spec/src/srat.rs
+++ b/vm/acpi_spec/src/srat.rs
@@ -232,8 +232,7 @@ impl core::fmt::Display for ParseSratError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseSratError {}
+impl core::error::Error for ParseSratError {}
 
 pub fn parse_srat<'a>(
     raw_srat: &'a [u8],

--- a/vm/chipset_arc_mutex_device/src/device.rs
+++ b/vm/chipset_arc_mutex_device/src/device.rs
@@ -41,9 +41,9 @@ pub(crate) enum AddDeviceErrorKind {
     #[error("could not construct device")]
     DeviceError(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    #[error("device attmpted to use {0:?} services without overriding supports_{}", .0.supports_fn())]
+    #[error("device attmpted to use {0:?} services without overriding supports_{sup}", sup = .0.supports_fn())]
     DeviceMissingSupports(ServiceKind),
-    #[error("chipset does not support {0:?} services (`ChipsetServices::supports_{}` returned `None`)", .0.supports_fn())]
+    #[error("chipset does not support {0:?} services (`ChipsetServices::supports_{sup}` returned `None`)", sup = .0.supports_fn())]
     ChipsetMissingSupports(ServiceKind),
 
     #[error("no pci bus address provided")]

--- a/vm/devices/support/fs/lx/src/lib.rs
+++ b/vm/devices/support/fs/lx/src/lib.rs
@@ -110,7 +110,7 @@ pub const XATTR_REPLACE: i32 = 0x2;
 
 /// Wraps a Linux error code in a strongly-typed struct.
 #[derive(Copy, Clone, Error, Eq, PartialEq)]
-#[error("{} ({0})", str_error(*.0))]
+#[error("{err} ({0})", err = str_error(*.0))]
 pub struct Error(i32);
 
 impl From<io::Error> for Error {

--- a/vm/hv1/hv1_emulator/Cargo.toml
+++ b/vm/hv1/hv1_emulator/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-hvdef = { workspace = true, features = ["std"] }
+hvdef.workspace = true
 vm_topology.workspace = true
 guestmem.workspace = true
 virt.workspace = true

--- a/vm/hv1/hvdef/Cargo.toml
+++ b/vm/hv1/hvdef/Cargo.toml
@@ -6,10 +6,6 @@ name = "hvdef"
 edition = "2021"
 rust-version.workspace = true
 
-[features]
-default = []
-std = []
-
 [dependencies]
 open_enum.workspace = true
 bitfield-struct.workspace = true

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -5,9 +5,6 @@
 
 #![no_std]
 
-#[cfg(feature = "std")]
-extern crate std;
-
 use bitfield_struct::bitfield;
 use core::fmt::Debug;
 use core::mem::size_of;
@@ -480,9 +477,7 @@ impl core::fmt::Display for HvError {
     }
 }
 
-#[cfg(feature = "std")]
-// TODO: Once core::error::Error is stablized, can remove this feature gate.
-impl std::error::Error for HvError {}
+impl core::error::Error for HvError {}
 
 /// Hypervisor result type for simple hypercalls, or code where only an HV_STATUS is to be returned.
 /// The error is an `HvError` and the success value `T` is the output data of the hypercall.

--- a/vm/loader/loader_defs/Cargo.toml
+++ b/vm/loader/loader_defs/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [features]
-std = []
-inspect = ["std", "dep:inspect"]
+inspect = ["dep:inspect"]
 
 [dependencies]
 hvdef.workspace = true

--- a/vm/loader/loader_defs/src/lib.rs
+++ b/vm/loader/loader_defs/src/lib.rs
@@ -4,7 +4,7 @@
 //! Type definitions for loading guest firmware, available as no_std if no features are defined.
 
 #![warn(missing_docs)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 pub mod linux;
 pub mod paravisor;

--- a/vm/vmcore/memory_range/Cargo.toml
+++ b/vm/vmcore/memory_range/Cargo.toml
@@ -7,15 +7,14 @@ edition = "2021"
 rust-version.workspace = true
 
 [features]
-inspect = ["dep:inspect", "std"]
-mesh = ["dep:mesh_protobuf", "std"]
-std = ["dep:thiserror"]
+inspect = ["dep:inspect"]
+mesh = ["dep:mesh_protobuf"]
 
 [dependencies]
 inspect = { workspace = true, optional = true }
 mesh_protobuf = { workspace = true, optional = true }
 
-thiserror = { workspace = true, optional = true }
+thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/vm/vmcore/memory_range/src/lib.rs
+++ b/vm/vmcore/memory_range/src/lib.rs
@@ -8,9 +8,6 @@
 #![forbid(unsafe_code)]
 #![no_std]
 
-#[cfg(feature = "std")]
-extern crate std;
-
 use core::iter::Iterator;
 use core::iter::Peekable;
 use core::ops::Range;
@@ -61,13 +58,8 @@ impl TryFrom<Range<usize>> for MemoryRange {
 }
 
 /// Error returned by [`MemoryRange::try_new`].
-#[derive(Debug)]
-#[cfg_attr(
-    feature = "std",
-    derive(thiserror::Error),
-    error("unaligned or invalid memory range: {start:#x}-{end:#x}")
-)]
-#[cfg_attr(not(feature = "std"), allow(dead_code))]
+#[derive(Debug, thiserror::Error)]
+#[error("unaligned or invalid memory range: {start:#x}-{end:#x}")]
 pub struct InvalidMemoryRange {
     start: u64,
     end: u64,

--- a/vm/x86/tdcall/Cargo.toml
+++ b/vm/x86/tdcall/Cargo.toml
@@ -8,8 +8,7 @@ rust-version.workspace = true
 
 [features]
 default = []
-std = []
-tracing = ["std", "dep:tracing"]
+tracing = ["dep:tracing"]
 
 [dependencies]
 hvdef.workspace = true

--- a/vm/x86/tdcall/src/lib.rs
+++ b/vm/x86/tdcall/src/lib.rs
@@ -6,9 +6,6 @@
 #![no_std]
 #![warn(missing_docs)]
 
-#[cfg(feature = "std")]
-extern crate std;
-
 use hvdef::HV_PAGE_SIZE;
 use memory_range::MemoryRange;
 use x86defs::tdx::TdCallLeaf;

--- a/vmm_core/virt_hvf/Cargo.toml
+++ b/vmm_core/virt_hvf/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 
 [target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
 aarch64defs.workspace = true
-hvdef = { workspace = true, features = ["std"] }
+hvdef.workspace = true
 hv1_emulator.workspace = true
 hv1_hypercall.workspace = true
 virt.workspace = true

--- a/vmm_core/virt_whp/Cargo.toml
+++ b/vmm_core/virt_whp/Cargo.toml
@@ -14,7 +14,7 @@ aarch64defs.workspace = true
 chipset_device.workspace = true
 hv1_emulator.workspace = true
 hv1_hypercall.workspace = true
-hvdef = { workspace = true, features = ["std"] }
+hvdef.workspace = true
 pci_core.workspace = true
 memory_range = { workspace = true, features = ["inspect"] }
 vm_topology = { workspace = true, features = ["inspect"] }


### PR DESCRIPTION
Now that `Error` is in `core` and `thiserror` 2.0 supports `no_std`, remove a bunch of `std` features across the codebase.