### PR TITLE
virt_mshv_vtl: Move hv and untrusted_synic into backings

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -42,6 +42,7 @@ use hcl::ioctl::Hcl;
 use hcl::ioctl::SetVsmPartitionConfigError;
 use hcl::GuestVtl;
 use hv1_emulator::hv::GlobalHv;
+use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::hv::VtlProtectHypercallOverlay;
 use hv1_emulator::message_queues::MessageQueues;
 use hv1_emulator::synic::GlobalSynic;
@@ -309,15 +310,18 @@ pub struct UhCvmVpState {
     vtls_tlb_waiting: VtlArray<bool, 2>,
     /// Used in VTL 2 exit code to determine which VTL to exit to.
     exit_vtl: GuestVtl,
+    /// Hypervisor enlightenment emulator state.
+    hv: VtlArray<ProcessorVtlHv, 2>,
 }
 
 #[cfg(guest_arch = "x86_64")]
 impl UhCvmVpState {
     /// Creates a new CVM VP state.
-    pub fn new() -> Self {
+    pub fn new(hv: VtlArray<ProcessorVtlHv, 2>) -> Self {
         Self {
             vtls_tlb_waiting: VtlArray::new(false),
             exit_vtl: GuestVtl::Vtl0,
+            hv,
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -19,6 +19,7 @@ cfg_if::cfg_if!(
         pub use processor::tdx::TdxBacked;
         pub use crate::processor::mshv::x64::HypervisorBackedX86 as HypervisorBacked;
         use devmsr::MsrDevice;
+        use hv1_emulator::hv::ProcessorVtlHv;
         use processor::snp::SnpBackedShared;
         use processor::tdx::TdxBackedShared;
         use std::arch::x86_64::CpuidResult;
@@ -42,7 +43,6 @@ use hcl::ioctl::Hcl;
 use hcl::ioctl::SetVsmPartitionConfigError;
 use hcl::GuestVtl;
 use hv1_emulator::hv::GlobalHv;
-use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::hv::VtlProtectHypercallOverlay;
 use hv1_emulator::message_queues::MessageQueues;
 use hv1_emulator::synic::GlobalSynic;

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -37,9 +37,7 @@ use crate::GuestVtl;
 use crate::WakeReason;
 use hcl::ioctl;
 use hcl::ioctl::ProcessorRunner;
-use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::message_queues::MessageQueues;
-use hv1_emulator::synic::ProcessorSynic;
 use hvdef::hypercall::HostVisibilityType;
 use hvdef::HvError;
 use hvdef::HvMessage;
@@ -96,8 +94,6 @@ pub struct UhProcessor<'a, T: Backing> {
     crash_reg: [u64; hvdef::HV_X64_GUEST_CRASH_PARAMETER_MSRS],
     #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
     crash_control: hvdef::GuestCrashCtl,
-    hv: VtlArray<Option<ProcessorVtlHv>, 2>,
-    untrusted_synic: Option<ProcessorSynic>,
     vmtime: VmTimeAccess,
     #[inspect(skip)]
     timer: PollImpl<dyn PollTimer>,
@@ -166,6 +162,8 @@ mod private {
     use crate::GuestVtl;
     use crate::UhPartitionInner;
     use hcl::ioctl::ProcessorRunner;
+    use hv1_emulator::hv::ProcessorVtlHv;
+    use hv1_emulator::synic::ProcessorSynic;
     use inspect::InspectMut;
     use std::future::Future;
     use virt::io::CpuIo;
@@ -173,11 +171,13 @@ mod private {
     use virt::StopVp;
     use virt::VpHaltReason;
     use vm_topology::processor::TargetVpInfo;
+    use vtl_array::VtlArray;
 
     pub struct BackingParams<'a, 'b, T: BackingPrivate> {
         pub(crate) partition: &'a UhPartitionInner,
         #[cfg(guest_arch = "x86_64")]
-        pub(crate) lapics: Option<vtl_array::VtlArray<super::LapicState, 2>>,
+        pub(crate) lapics: Option<VtlArray<super::LapicState, 2>>,
+        pub(crate) hv: Option<VtlArray<ProcessorVtlHv, 2>>,
         pub(crate) vp_info: &'a TargetVpInfo,
         pub(crate) runner: &'a mut ProcessorRunner<'b, T::HclBacking>,
         pub(crate) backing_shared: &'a BackingShared,
@@ -241,6 +241,16 @@ mod private {
         }
 
         fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}
+
+        fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv>;
+        fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv>;
+
+        fn untrusted_synic(&self) -> Option<&ProcessorSynic> {
+            None
+        }
+        fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
+            None
+        }
     }
 }
 
@@ -456,12 +466,12 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
 
     fn update_synic(&mut self, vtl: GuestVtl, untrusted_synic: bool) {
         loop {
-            let hv = self.hv[vtl].as_mut().unwrap();
+            let hv = self.backing.hv_mut(vtl).unwrap();
 
             let ref_time_now = hv.ref_time_now();
             let synic = if untrusted_synic {
                 debug_assert_eq!(vtl, GuestVtl::Vtl0);
-                self.untrusted_synic.as_mut().unwrap()
+                self.backing.untrusted_synic_mut().unwrap()
             } else {
                 &mut hv.synic
             };
@@ -655,13 +665,13 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                     [false, false].into()
                 };
 
-                if self.untrusted_synic.is_some() {
+                if self.backing.untrusted_synic().is_some() {
                     self.update_synic(GuestVtl::Vtl0, true);
                 }
 
                 for vtl in [GuestVtl::Vtl1, GuestVtl::Vtl0] {
                     // Process interrupts.
-                    if self.hv[vtl].is_some() {
+                    if self.backing.hv(vtl).is_some() {
                         self.update_synic(vtl, false);
                     }
 
@@ -779,30 +789,21 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
             lapic_states.into()
         });
 
+        let hv = partition.hv.as_ref().map(|hv| {
+            VtlArray::from_fn(|vtl| {
+                hv.add_vp(partition.gm[vtl].clone(), vp_info.base.vp_index, vtl)
+            })
+        });
+
         let backing = T::new(private::BackingParams {
             partition,
             #[cfg(guest_arch = "x86_64")]
             lapics,
+            hv,
             vp_info: &vp_info,
             runner: &mut runner,
             backing_shared,
         })?;
-
-        let hv = {
-            let vtl0_hv = partition.hv.as_ref().map(|hv| {
-                hv.add_vp(
-                    partition.gm[GuestVtl::Vtl0].clone(),
-                    vp_info.base.vp_index,
-                    Vtl::Vtl0,
-                )
-            });
-            VtlArray::from([vtl0_hv, None])
-        };
-
-        let untrusted_synic = partition
-            .untrusted_synic
-            .as_ref()
-            .map(|synic| synic.add_vp(vp_info.base.vp_index));
 
         let mut vp = Self {
             partition,
@@ -814,8 +815,6 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
             crash_control: hvdef::GuestCrashCtl::new()
                 .with_crash_notify(true)
                 .with_crash_message(true),
-            hv,
-            untrusted_synic,
             _not_send: PhantomData,
             backing,
             vmtime: partition
@@ -854,7 +853,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                         if pending_sints & (1 << sint) == 0 {
                             continue;
                         }
-                        let sint_msr = if let Some(hv) = self.hv[vtl].as_ref() {
+                        let sint_msr = if let Some(hv) = self.backing.hv(vtl).as_ref() {
                             hv.synic.sint(sint)
                         } else {
                             #[cfg(guest_arch = "x86_64")]
@@ -897,20 +896,8 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
 
                     if vtl == GuestVtl::Vtl1 {
                         assert!(self.partition.isolation.is_hardware_isolated());
-                        // Should not have already initialized the hv emulator for this vtl
-                        assert!(self.hv[vtl].is_none());
-
-                        self.hv[vtl] = Some(
-                            self.partition
-                                .hv
-                                .as_ref()
-                                .expect("has an hv emulator")
-                                .add_vp(
-                                    self.partition.gm[GuestVtl::Vtl1].clone(),
-                                    self.vp_index(),
-                                    Vtl::Vtl1,
-                                ),
-                        );
+                        // Should have already initialized the hv emulator for this vtl
+                        assert!(self.backing.hv(vtl).is_some());
 
                         // TODO CVM GUEST VSM: Revisit during AP startup if we need to exit to VTL 1 here
                     }
@@ -927,7 +914,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         }
 
         // Send the SINT notifications to the local synic for non-proxied SINTs.
-        let untrusted_sints = if let Some(hv) = &mut self.hv[vtl] {
+        let untrusted_sints = if let Some(hv) = self.backing.hv_mut(vtl).as_mut() {
             let proxied_sints = hv.synic.proxied_sints();
             hv.synic.request_sint_readiness(sints & !proxied_sints);
             proxied_sints
@@ -947,7 +934,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     #[cfg(guest_arch = "x86_64")]
     fn write_msr(&mut self, msr: u32, value: u64, vtl: GuestVtl) -> Result<(), MsrError> {
         if msr & 0xf0000000 == 0x40000000 {
-            if let Some(hv) = self.hv[vtl].as_mut() {
+            if let Some(hv) = self.backing.hv_mut(vtl).as_mut() {
                 let r = hv.msr_write(msr, value);
                 if !matches!(r, Err(MsrError::Unknown)) {
                     return r;
@@ -983,7 +970,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     #[cfg(guest_arch = "x86_64")]
     fn read_msr(&mut self, msr: u32, vtl: GuestVtl) -> Result<u64, MsrError> {
         if msr & 0xf0000000 == 0x40000000 {
-            if let Some(hv) = self.hv[vtl].as_ref() {
+            if let Some(hv) = self.backing.hv(vtl).as_ref() {
                 let r = hv.msr_read(msr);
                 if !matches!(r, Err(MsrError::Unknown)) {
                     return r;
@@ -1064,13 +1051,15 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     fn deliver_synic_messages(&mut self, vtl: GuestVtl, sints: u16) {
-        let proxied_sints = self.hv[vtl]
+        let proxied_sints = self
+            .backing
+            .hv(vtl)
             .as_ref()
             .map_or(!0, |hv| hv.synic.proxied_sints());
         let pending_sints =
             self.inner.message_queues[vtl].post_pending_messages(sints, |sint, message| {
                 if proxied_sints & (1 << sint) != 0 {
-                    if let Some(synic) = &mut self.untrusted_synic {
+                    if let Some(synic) = self.backing.untrusted_synic_mut().as_mut() {
                         synic.post_message(
                             &self.partition.gm[vtl],
                             sint,
@@ -1087,14 +1076,19 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                         )
                     }
                 } else {
-                    self.hv[vtl].as_mut().unwrap().synic.post_message(
-                        &self.partition.gm[vtl],
-                        sint,
-                        message,
-                        &mut self
-                            .partition
-                            .synic_interrupt(self.inner.vp_info.base.vp_index, vtl),
-                    )
+                    self.backing
+                        .hv_mut(vtl)
+                        .as_mut()
+                        .unwrap()
+                        .synic
+                        .post_message(
+                            &self.partition.gm[vtl],
+                            sint,
+                            message,
+                            &mut self
+                                .partition
+                                .synic_interrupt(self.inner.vp_info.base.vp_index, vtl),
+                        )
                 }
             });
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -245,12 +245,8 @@ mod private {
         fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv>;
         fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv>;
 
-        fn untrusted_synic(&self) -> Option<&ProcessorSynic> {
-            None
-        }
-        fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
-            None
-        }
+        fn untrusted_synic(&self) -> Option<&ProcessorSynic>;
+        fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic>;
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -26,6 +26,8 @@ use hcl::ioctl::aarch64::MshvArm64;
 use hcl::ioctl::ProcessorRunner;
 use hcl::GuestVtl;
 use hcl::UnsupportedGuestVtl;
+use hv1_emulator::hv::ProcessorVtlHv;
+use hv1_emulator::synic::ProcessorSynic;
 use hvdef::hypercall;
 use hvdef::HvAarch64PendingEvent;
 use hvdef::HvArm64RegisterName;
@@ -108,6 +110,7 @@ impl BackingPrivate for HypervisorBackedArm64 {
     fn new(params: BackingParams<'_, '_, Self>) -> Result<Self, Error> {
         vp::Registers::at_reset(&params.partition.caps, params.vp_info);
         let _ = (params.runner, &params.backing_shared);
+        assert!(params.hv.is_none());
         Ok(Self {
             deliverability_notifications: Default::default(),
             next_deliverability_notifications: Default::default(),
@@ -220,6 +223,22 @@ impl BackingPrivate for HypervisorBackedArm64 {
     }
 
     fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}
+
+    fn hv(&self, _vtl: GuestVtl) -> Option<&ProcessorVtlHv> {
+        None
+    }
+
+    fn hv_mut(&mut self, _vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
+        None
+    }
+
+    fn untrusted_synic(&self) -> Option<&ProcessorSynic> {
+        None
+    }
+
+    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
+        None
+    }
 }
 
 impl UhProcessor<'_, HypervisorBackedArm64> {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -33,6 +33,7 @@ use hcl::ioctl::ApplyVtlProtectionsError;
 use hcl::ioctl::ProcessorRunner;
 use hcl::protocol;
 use hv1_emulator::hv::ProcessorVtlHv;
+use hv1_emulator::synic::ProcessorSynic;
 use hvdef::hypercall;
 use hvdef::HvDeliverabilityNotificationsRegister;
 use hvdef::HvError;
@@ -380,6 +381,14 @@ impl BackingPrivate for HypervisorBackedX86 {
 
     fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
         self.hv.as_mut().map(|arr| &mut arr[vtl])
+    }
+
+    fn untrusted_synic(&self) -> Option<&ProcessorSynic> {
+        None
+    }
+
+    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
+        None
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -25,6 +25,7 @@ use crate::UhPartitionInner;
 use crate::WakeReason;
 use guestmem::GuestMemory;
 use hcl::vmsa::VmsaWrapper;
+use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_hypercall::HypercallIo;
 use hvdef::hypercall::HvFlushFlags;
 use hvdef::hypercall::HvGvaRange;
@@ -216,7 +217,7 @@ impl BackingPrivate for SnpBacked {
             hv_sint_notifications: 0,
             general_stats: Default::default(),
             exit_stats: Default::default(),
-            cvm: UhCvmVpState::new(),
+            cvm: UhCvmVpState::new(params.hv.unwrap()),
             shared: shared.clone(),
         })
     }
@@ -472,6 +473,14 @@ impl BackingPrivate for SnpBacked {
                     }
                 });
         });
+    }
+
+    fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv> {
+        Some(&self.cvm.hv[vtl])
+    }
+
+    fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
+        Some(&mut self.cvm.hv[vtl])
     }
 }
 
@@ -894,11 +903,10 @@ impl UhProcessor<'_, SnpBacked> {
 
     #[must_use]
     fn sync_lazy_eoi(&mut self, vtl: GuestVtl) -> bool {
-        if let Some(hv) = &mut self.hv[vtl] {
-            if self.backing.lapics[vtl].lapic.is_lazy_eoi_pending() {
-                return hv.set_lazy_eoi();
-            }
+        if self.backing.lapics[vtl].lapic.is_lazy_eoi_pending() {
+            return self.backing.cvm.hv[vtl].set_lazy_eoi();
         }
+
         false
     }
 
@@ -978,12 +986,7 @@ impl UhProcessor<'_, SnpBacked> {
         vmsa.v_intr_cntrl_mut().set_irq(false);
 
         // Clear lazy EOI before processing the exit.
-        if lazy_eoi
-            && self.hv[entered_from_vtl]
-                .as_mut()
-                .map(|hv| hv.clear_lazy_eoi())
-                .unwrap_or(false)
-        {
+        if lazy_eoi && self.backing.cvm.hv[entered_from_vtl].clear_lazy_eoi() {
             self.backing.lapics[entered_from_vtl]
                 .lapic
                 .access(&mut SnpApicClient {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -26,6 +26,7 @@ use crate::WakeReason;
 use guestmem::GuestMemory;
 use hcl::vmsa::VmsaWrapper;
 use hv1_emulator::hv::ProcessorVtlHv;
+use hv1_emulator::synic::ProcessorSynic;
 use hv1_hypercall::HypercallIo;
 use hvdef::hypercall::HvFlushFlags;
 use hvdef::hypercall::HvGvaRange;
@@ -481,6 +482,14 @@ impl BackingPrivate for SnpBacked {
 
     fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
         Some(&mut self.cvm.hv[vtl])
+    }
+
+    fn untrusted_synic(&self) -> Option<&ProcessorSynic> {
+        None
+    }
+
+    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
+        None
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -24,6 +24,8 @@ use crate::WakeReason;
 use hcl::ioctl::tdx::Tdx;
 use hcl::ioctl::ProcessorRunner;
 use hcl::protocol::tdx_tdg_vp_enter_exit_info;
+use hv1_emulator::hv::ProcessorVtlHv;
+use hv1_emulator::synic::ProcessorSynic;
 use hv1_hypercall::AsHandler;
 use hv1_hypercall::HypercallIo;
 use hvdef::hypercall::HvFlushFlags;
@@ -394,6 +396,7 @@ pub struct TdxBacked {
     direct_overlay_pfns_handle: shared_pool_alloc::SharedPoolHandle,
 
     lapic: LapicState,
+    untrusted_synic: Option<ProcessorSynic>,
     #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
     eoi_exit_bitmap: [u64; 4],
     tpr_threshold: u8,
@@ -641,6 +644,12 @@ impl BackingPrivate for TdxBacked {
         // TODO TDX GUEST VSM
         let [lapic, _] = params.lapics.unwrap().into_inner();
 
+        let untrusted_synic = params
+            .partition
+            .untrusted_synic
+            .as_ref()
+            .map(|synic| synic.add_vp(params.vp_info.base.vp_index));
+
         Ok(Self {
             efer: regs.efer,
             cr0: VirtualRegister::new(ShadowedRegister::Cr0, regs.cr0, None),
@@ -648,6 +657,7 @@ impl BackingPrivate for TdxBacked {
             direct_overlays_pfns: overlays.try_into().unwrap(),
             direct_overlay_pfns_handle: pfns_handle,
             lapic,
+            untrusted_synic,
             eoi_exit_bitmap: [0; 4],
             tpr_threshold: 0,
             processor_controls,
@@ -659,7 +669,7 @@ impl BackingPrivate for TdxBacked {
             flush_page,
             enter_stats: Default::default(),
             exit_stats: Default::default(),
-            cvm: UhCvmVpState::new(),
+            cvm: UhCvmVpState::new(params.hv.unwrap()),
             shared: shared.clone(),
         })
     }
@@ -700,7 +710,7 @@ impl BackingPrivate for TdxBacked {
             ),
         ];
 
-        let reg_count = if let Some(synic) = &mut this.untrusted_synic {
+        let reg_count = if let Some(synic) = &mut this.backing.untrusted_synic {
             synic.set_simp(
                 &this.partition.gm[GuestVtl::Vtl0],
                 reg(pfns[UhDirectOverlay::Sipp as usize]),
@@ -758,7 +768,7 @@ impl BackingPrivate for TdxBacked {
     }
 
     fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16) {
-        if let Some(synic) = &mut this.untrusted_synic {
+        if let Some(synic) = &mut this.backing.untrusted_synic {
             synic.request_sint_readiness(sints);
         } else {
             tracelimit::error_ratelimited!("untrusted synic is not configured");
@@ -771,6 +781,22 @@ impl BackingPrivate for TdxBacked {
         _target_vtl: GuestVtl,
     ) {
         todo!()
+    }
+
+    fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv> {
+        Some(&self.cvm.hv[vtl])
+    }
+
+    fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
+        Some(&mut self.cvm.hv[vtl])
+    }
+
+    fn untrusted_synic(&self) -> Option<&ProcessorSynic> {
+        self.untrusted_synic.as_ref()
+    }
+
+    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
+        self.untrusted_synic.as_mut()
     }
 }
 
@@ -1615,7 +1641,7 @@ impl UhProcessor<'_, TdxBacked> {
             VmxExit::TDCALL => {
                 // If the proxy synic is local, then the host did not get this
                 // instruction, and we need to handle it.
-                if self.untrusted_synic.is_some() {
+                if self.backing.untrusted_synic.is_some() {
                     self.handle_tdvmcall(dev, intercepted_vtl);
                 }
                 &mut self.backing.exit_stats.tdcall
@@ -1728,9 +1754,10 @@ impl UhProcessor<'_, TdxBacked> {
     fn read_tdvmcall_msr(&mut self, msr: u32, intercepted_vtl: GuestVtl) -> Result<u64, MsrError> {
         match msr {
             msr @ (hvdef::HV_X64_MSR_GUEST_OS_ID | hvdef::HV_X64_MSR_VP_INDEX) => {
-                self.hv[intercepted_vtl].as_ref().unwrap().msr_read(msr)
+                self.backing.cvm.hv[intercepted_vtl].msr_read(msr)
             }
             _ => self
+                .backing
                 .untrusted_synic
                 .as_mut()
                 .unwrap()
@@ -1745,16 +1772,15 @@ impl UhProcessor<'_, TdxBacked> {
         intercepted_vtl: GuestVtl,
     ) -> Result<(), MsrError> {
         match msr {
-            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => self.hv[intercepted_vtl]
-                .as_mut()
-                .unwrap()
-                .msr_write(msr, value)?,
+            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => {
+                self.backing.cvm.hv[intercepted_vtl].msr_write(msr, value)?
+            }
             _ => {
-                self.untrusted_synic.as_mut().unwrap().write_nontimer_msr(
-                    &self.partition.gm[GuestVtl::Vtl0],
-                    msr,
-                    value,
-                )?;
+                self.backing
+                    .untrusted_synic
+                    .as_mut()
+                    .unwrap()
+                    .write_nontimer_msr(&self.partition.gm[GuestVtl::Vtl0], msr, value)?;
                 // Propagate sint MSR writes to the hypervisor as well
                 // so that the hypervisor can directly inject events.
                 if matches!(msr, hvdef::HV_X64_MSR_SINT0..=hvdef::HV_X64_MSR_SINT15) {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1776,6 +1776,9 @@ impl UhProcessor<'_, TdxBacked> {
                 self.backing.cvm.hv[intercepted_vtl].msr_write(msr, value)?
             }
             _ => {
+                // If we get here we must have an untrusted synic, as otherwise
+                // we wouldn't be handling the TDVMCALL that ends up here. Therefore
+                // this is fine to unwrap.
                 self.backing
                     .untrusted_synic
                     .as_mut()


### PR DESCRIPTION
This removes two more options from UhProcessor, replacing them with getters on Backing. This results in the removal of unwraps in backing-specific code. While it also results in slightly wordier backing-agnostic code, it should optimize better, as each backing can now specialize on whether certain variables are guaranteed to be present or not.

This does not move the equivalent state from UhPartition to BackingShared types, as since UhPartition is not generic I'd expect there to be no meaningful optimization gains from doing so. We could still do so for the sake of organization and self-documentation if we wanted to though.