### PR TITLE
Kernel: Update the OHCL stable kernel to 6.6.51.7

### DIFF
--- a/.github/workflows/openvmm-ci.json
+++ b/.github/workflows/openvmm-ci.json
@@ -89,10 +89,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -203,10 +203,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -329,10 +329,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -427,10 +427,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -529,10 +529,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -649,10 +649,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -815,10 +815,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -984,10 +984,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -1155,10 +1155,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -1325,10 +1325,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -1533,10 +1533,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -1772,10 +1772,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -1832,7 +1832,7 @@
     },
     "12": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-56d8e0c0c8bbe627\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-54d538eb47bfa81c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1857,8 +1857,8 @@
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-arm64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
         "{\"file_name\":\"RELEASE-AARCH64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
         "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:111:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
         "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
@@ -1976,10 +1976,10 @@
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
         "{\"GetPackage\":{\"arch\":\"Aarch64\",\"kind\":\"Dev\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:29:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:349:25\",\"is_secret\":false}}}",
         "{\"GetPackage\":{\"arch\":\"Aarch64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:349:25\",\"is_secret\":false}}}",
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetOpenhclCpioShell\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:2:flowey_lib_hvlite/src/build_openhcl_initrd.rs:99:21\",\"is_secret\":false}]}",
@@ -2043,7 +2043,7 @@
     },
     "13": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-69bfa92774c5940b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-b130c166bdbdc2a8\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -2068,9 +2068,9 @@
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:5:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-cvm-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:5:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-cvm-x64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-x64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
         "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
         "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
         "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
@@ -2206,10 +2206,10 @@
         "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Dev\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:57:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:349:25\",\"is_secret\":false}}}",
         "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:349:25\",\"is_secret\":false}}}",
         "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:85:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:349:25\",\"is_secret\":false}}}",
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:116:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:392:30\",\"is_secret\":false}]}",
@@ -2418,10 +2418,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -2618,10 +2618,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -2836,10 +2836,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetOpenhclSysroot\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:1:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:52:46\",\"is_secret\":false}]}",
@@ -3006,10 +3006,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
@@ -3149,10 +3149,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
@@ -3289,10 +3289,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
@@ -3392,10 +3392,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1494,7 +1494,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.2-main-arm64.zip
+    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-arm64.tar.gz
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -1908,7 +1908,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.2-main-x64.zip
+    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-x64.tar.gz
       run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -2010,7 +2010,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.2-main-cvm-x64.zip
+    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-cvm-x64.tar.gz
       run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var

--- a/.github/workflows/openvmm-pr.json
+++ b/.github/workflows/openvmm-pr.json
@@ -89,10 +89,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -203,10 +203,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -329,10 +329,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -444,10 +444,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -564,10 +564,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -730,10 +730,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -899,10 +899,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -1070,10 +1070,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -1240,10 +1240,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -1448,10 +1448,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -1687,10 +1687,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -1747,7 +1747,7 @@
     },
     "11": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-56d8e0c0c8bbe627\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-54d538eb47bfa81c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1772,8 +1772,8 @@
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-arm64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
         "{\"file_name\":\"RELEASE-AARCH64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
         "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:111:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
         "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
@@ -1891,10 +1891,10 @@
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
         "{\"GetPackage\":{\"arch\":\"Aarch64\",\"kind\":\"Dev\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:29:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:349:25\",\"is_secret\":false}}}",
         "{\"GetPackage\":{\"arch\":\"Aarch64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:349:25\",\"is_secret\":false}}}",
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetOpenhclCpioDbgrd\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:2:flowey_lib_hvlite/src/build_openhcl_initrd.rs:95:21\",\"is_secret\":false}]}",
@@ -1958,7 +1958,7 @@
     },
     "12": {
       "flowey_lib_common::cache": [
-        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-69bfa92774c5940b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-b130c166bdbdc2a8\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
       ],
       "flowey_lib_common::cfg_cargo_common_flags": [
         "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
@@ -1983,9 +1983,9 @@
         "{\"Version\":\"2.52.0\"}"
       ],
       "flowey_lib_common::download_gh_release": [
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:5:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-cvm-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
-        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.2-main-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:106:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.2\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:5:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-cvm-x64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-x64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
         "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
         "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
         "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
@@ -2121,10 +2121,10 @@
         "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Dev\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:57:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:349:25\",\"is_secret\":false}}}",
         "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:349:25\",\"is_secret\":false}}}",
         "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:85:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:349:25\",\"is_secret\":false}}}",
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:116:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:392:30\",\"is_secret\":false}]}",
@@ -2333,10 +2333,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -2533,10 +2533,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -2751,10 +2751,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetOpenhclSysroot\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:1:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:52:46\",\"is_secret\":false}]}",
@@ -2921,10 +2921,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
@@ -3064,10 +3064,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
@@ -3204,10 +3204,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
@@ -3307,10 +3307,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"
@@ -3386,10 +3386,10 @@
         "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
       ],
       "flowey_lib_hvlite::download_openhcl_kernel_package": [
-        "{\"Version\":[\"Cvm\",\"6.6.51.2\"]}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
         "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
         "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
-        "{\"Version\":[\"Main\",\"6.6.51.2\"]}"
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
       ],
       "flowey_lib_hvlite::download_openvmm_deps": [
         "{\"Version\":\"0.1.0-20241014.2\"}"

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1137,7 +1137,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.2-main-arm64.zip
+    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-arm64.tar.gz
       run: flowey e 11 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -1551,7 +1551,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.2-main-x64.zip
+    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-x64.tar.gz
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -1653,7 +1653,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.2-main-cvm-x64.zip
+    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-cvm-x64.tar.gz
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -27,7 +27,7 @@ pub const MU_MSVM: &str = "24.0.2";
 pub const NEXTEST: &str = "0.9.74";
 pub const NODEJS: &str = "18.x";
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.6.51.6";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.6.51.2";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.6.51.7";
 pub const OPENVMM_DEPS: &str = "0.1.0-20241014.2";
 pub const PROTOC: &str = "27.1";
 

--- a/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
@@ -86,7 +86,7 @@ impl FlowNode for Node {
             let tag = format!("rolling-lts/hcl-{kind_string}/{version}");
 
             let file_name = format!(
-                "Microsoft.OHCL.Kernel.{}-{}-{}.zip",
+                "Microsoft.OHCL.Kernel.{}-{}-{}.{}",
                 version,
                 match kind {
                     OpenhclKernelPackageKind::Main | OpenhclKernelPackageKind::Dev => {
@@ -99,7 +99,15 @@ impl FlowNode for Node {
                 match arch {
                     OpenhclKernelPackageArch::X86_64 => "x64",
                     OpenhclKernelPackageArch::Aarch64 => "arm64",
-                }
+                },
+                match kind {
+                    OpenhclKernelPackageKind::Main | OpenhclKernelPackageKind::Cvm => {
+                        "tar.gz"
+                    }
+                    OpenhclKernelPackageKind::Dev | OpenhclKernelPackageKind::CvmDev => {
+                        "zip"
+                    }
+                },
             );
 
             let kernel_package_zip =


### PR DESCRIPTION
This change updates the stable version of the OHCL kernel to the latest version: https://github.com/microsoft/OHCL-Linux-Kernel/releases/tag/rolling-lts%2Fhcl-main%2F6.6.51.7

The only difference with this kernel is that it contains a patch to add tdx support for handling wbinvd.