### PR TITLE
CI: Add --fail flag to invocations of curl to make http errors more obvious

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -29,7 +29,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -38,7 +38,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -46,7 +46,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -219,7 +219,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -228,7 +228,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -236,7 +236,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -421,7 +421,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -430,7 +430,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -438,7 +438,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -781,7 +781,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -790,7 +790,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -798,7 +798,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -1204,7 +1204,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1213,7 +1213,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -1221,7 +1221,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -1618,7 +1618,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1627,7 +1627,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -1635,7 +1635,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2205,7 +2205,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2214,7 +2214,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2222,7 +2222,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2526,7 +2526,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2535,7 +2535,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2543,7 +2543,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2895,7 +2895,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2904,7 +2904,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2912,7 +2912,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -4136,7 +4136,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4145,7 +4145,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -4153,7 +4153,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -4352,7 +4352,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4361,7 +4361,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -4369,7 +4369,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -4562,7 +4562,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4571,7 +4571,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -4579,7 +4579,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -4751,7 +4751,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4760,7 +4760,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -4768,7 +4768,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -4952,7 +4952,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4961,7 +4961,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -4969,7 +4969,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5227,7 +5227,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5236,7 +5236,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5244,7 +5244,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5514,7 +5514,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5523,7 +5523,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5531,7 +5531,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5792,7 +5792,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5801,7 +5801,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5809,7 +5809,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -32,7 +32,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -41,7 +41,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -49,7 +49,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -222,7 +222,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -231,7 +231,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -239,7 +239,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -424,7 +424,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -433,7 +433,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -441,7 +441,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -847,7 +847,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -856,7 +856,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -864,7 +864,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -1261,7 +1261,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1270,7 +1270,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -1278,7 +1278,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -1848,7 +1848,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -1857,7 +1857,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -1865,7 +1865,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2169,7 +2169,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2178,7 +2178,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2186,7 +2186,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2538,7 +2538,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -2547,7 +2547,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2555,7 +2555,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -3779,7 +3779,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3788,7 +3788,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -3796,7 +3796,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -3909,7 +3909,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -3918,7 +3918,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -3926,7 +3926,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -4174,7 +4174,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4183,7 +4183,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -4191,7 +4191,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -4363,7 +4363,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4372,7 +4372,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -4380,7 +4380,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -4564,7 +4564,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4573,7 +4573,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -4581,7 +4581,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -4839,7 +4839,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -4848,7 +4848,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -4856,7 +4856,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5126,7 +5126,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5135,7 +5135,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5143,7 +5143,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5404,7 +5404,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5413,7 +5413,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5421,7 +5421,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5699,7 +5699,7 @@ jobs:
         set -x
         i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
         sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
+        curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain=1.82.0 -y
         . "$HOME/.cargo/env"
         echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
         rustup show
@@ -5708,7 +5708,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5716,7 +5716,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
         ./rustup-init.exe -y --default-toolchain=1.82.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
@@ -20,7 +20,7 @@
     set -x
     i=0; while [ $i -lt 5 ] && ! sudo apt-get update; do let "i=i+1"; sleep 1; done;
     sudo apt-get -o DPkg::Lock::Timeout=60 install gcc -y
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain={{RUSTUP_TOOLCHAIN}} -y
+    curl --fail --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain={{RUSTUP_TOOLCHAIN}} -y
     . "$HOME/.cargo/env"
     echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
     rustup show
@@ -32,7 +32,7 @@
 # but that currently needs to be preinstalled on the actions runner.
 - run: |
     set -x
-    curl -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+    curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
     ./rustup-init.exe -y --default-toolchain={{RUSTUP_TOOLCHAIN}}
     echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
   if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -41,7 +41,7 @@
 
 - run: |
     set -x
-    curl -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+    curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
     ./rustup-init.exe -y --default-toolchain={{RUSTUP_TOOLCHAIN}}
     echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
   if: runner.os == 'Windows' && runner.arch == 'ARM64'

--- a/flowey/flowey_lib_common/src/download_azcopy.rs
+++ b/flowey/flowey_lib_common/src/download_azcopy.rs
@@ -107,7 +107,7 @@ impl FlowNode for Node {
                     };
                     match rt.platform().kind() {
                         FlowPlatformKind::Windows => {
-                            xshell::cmd!(sh, "curl -L https://azcopyvnext.azureedge.net/releases/release-{version_with_date}/azcopy_windows_{arch}_{version_without_date}.zip -o azcopy.zip").run()?;
+                            xshell::cmd!(sh, "curl --fail -L https://azcopyvnext.azureedge.net/releases/release-{version_with_date}/azcopy_windows_{arch}_{version_without_date}.zip -o azcopy.zip").run()?;
 
                             let bsdtar = crate::_util::bsdtar_name(rt);
                             xshell::cmd!(sh, "{bsdtar} -xf azcopy.zip --strip-components=1").run()?;
@@ -118,7 +118,7 @@ impl FlowNode for Node {
                                 FlowPlatform::MacOs => "darwin",
                                 platform => anyhow::bail!("unhandled platform {platform}"),
                             };
-                            xshell::cmd!(sh, "curl -L https://azcopyvnext.azureedge.net/releases/release-{version_with_date}/azcopy_{os}_{arch}_{version_without_date}.tar.gz -o azcopy.tar.gz").run()?;
+                            xshell::cmd!(sh, "curl --fail -L https://azcopyvnext.azureedge.net/releases/release-{version_with_date}/azcopy_{os}_{arch}_{version_without_date}.tar.gz -o azcopy.tar.gz").run()?;
                             xshell::cmd!(sh, "tar -xf azcopy.tar.gz --strip-components=1").run()?;
                         }
                     };

--- a/flowey/flowey_lib_common/src/download_gh_cli.rs
+++ b/flowey/flowey_lib_common/src/download_gh_cli.rs
@@ -91,15 +91,15 @@ impl FlowNode for Node {
                     let sh = xshell::Shell::new()?;
                     match rt.platform() {
                         FlowPlatform::Windows => {
-                            xshell::cmd!(sh, "curl -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_windows_{gh_arch}.zip -o gh.zip").run()?;
+                            xshell::cmd!(sh, "curl --fail -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_windows_{gh_arch}.zip -o gh.zip").run()?;
                             xshell::cmd!(sh, "tar -xf gh.zip").run()?;
                         },
                         FlowPlatform::Linux(_) => {
-                            xshell::cmd!(sh, "curl -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_{gh_arch}.tar.gz -o gh.tar.gz").run()?;
+                            xshell::cmd!(sh, "curl --fail -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_{gh_arch}.tar.gz -o gh.tar.gz").run()?;
                             xshell::cmd!(sh, "tar -xf gh.tar.gz --strip-components=1").run()?;
                         },
                         FlowPlatform::MacOs => {
-                            xshell::cmd!(sh, "curl -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_macOS_{gh_arch}.zip -o gh.zip").run()?;
+                            xshell::cmd!(sh, "curl --fail -L https://github.com/cli/cli/releases/download/v{version}/gh_{version}_macOS_{gh_arch}.zip -o gh.zip").run()?;
                             xshell::cmd!(sh, "tar -xf gh.zip --strip-components=1").run()?;
                         }
                         platform => anyhow::bail!("unsupported platform {platform}"),

--- a/flowey/flowey_lib_common/src/download_gh_release.rs
+++ b/flowey/flowey_lib_common/src/download_gh_release.rs
@@ -247,7 +247,7 @@ fn download_all_reqs(
         } else {
             // FUTURE: parallelize curl invocations across all download_reqs
             for file in files.keys() {
-                xshell::cmd!(sh, "curl -L https://github.com/{repo_owner}/{repo_name}/releases/download/{tag}/{file} -o {file}").run()?;
+                xshell::cmd!(sh, "curl --fail -L https://github.com/{repo_owner}/{repo_name}/releases/download/{tag}/{file} -o {file}").run()?;
             }
         }
     }

--- a/flowey/flowey_lib_common/src/download_nuget_exe.rs
+++ b/flowey/flowey_lib_common/src/download_nuget_exe.rs
@@ -171,8 +171,11 @@ impl Node {
                 if !nuget_exe_path.exists() {
                     let nuget_install_latest_url =
                         "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe";
-                    xshell::cmd!(sh, "curl -o {nuget_exe_path} {nuget_install_latest_url}")
-                        .run()?;
+                    xshell::cmd!(
+                        sh,
+                        "curl --fail -o {nuget_exe_path} {nuget_install_latest_url}"
+                    )
+                    .run()?;
                 }
 
                 let write_mono_shim = || {

--- a/flowey/flowey_lib_common/src/install_azure_cli.rs
+++ b/flowey/flowey_lib_common/src/install_azure_cli.rs
@@ -132,7 +132,7 @@ impl FlowNode for Node {
                                 sh.change_dir(&az_dir);
                                 xshell::cmd!(
                                     sh,
-                                    "curl -L https://aka.ms/installazurecliwindowszipx64 -o az.zip"
+                                    "curl --fail -L https://aka.ms/installazurecliwindowszipx64 -o az.zip"
                                 )
                                 .run()?;
                                 xshell::cmd!(sh, "tar -xf az.zip").run()?;
@@ -141,7 +141,7 @@ impl FlowNode for Node {
                             FlowPlatform::Linux(_) => {
                                 xshell::cmd!(
                                     sh,
-                                    "curl -sL https://aka.ms/InstallAzureCLIDeb -o InstallAzureCLIDeb.sh"
+                                    "curl --fail -sL https://aka.ms/InstallAzureCLIDeb -o InstallAzureCLIDeb.sh"
                                 )
                                 .run()?;
                                 xshell::cmd!(sh, "chmod +x ./InstallAzureCLIDeb.sh").run()?;

--- a/flowey/flowey_lib_common/src/install_rust.rs
+++ b/flowey/flowey_lib_common/src/install_rust.rs
@@ -201,7 +201,7 @@ impl FlowNode for Node {
 
                                     xshell::cmd!(
                                         sh,
-                                        "curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh"
+                                        "curl --fail --proto =https --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh"
                                     )
                                     .run()?;
                                     xshell::cmd!(sh, "chmod +x ./rustup-init.sh").run()?;
@@ -227,7 +227,7 @@ impl FlowNode for Node {
 
                                     xshell::cmd!(
                                         sh,
-                                        "curl -sSfLo rustup-init.exe https://win.rustup.rs/{arch} --output rustup-init"
+                                        "curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/{arch} --output rustup-init"
                                     ).run()?;
                                     xshell::cmd!(
                                         sh,


### PR DESCRIPTION
While updating to the latest version of the OHCL kernel I noticed that the invocations of curl are currently returning a zero status code when http errors occur. This change adds the [--fail](https://curl.se/docs/manpage.html#-f) flag to all invocations of curl so the curl command itself will fail instead of some future command that relies on the output.
