### PR TITLE
underhill_mem: register memory with proper private/shared bit

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -651,9 +651,14 @@ pub struct MshvVtl {
 
 impl MshvVtl {
     /// Adds the VTL0 memory as a ZONE_DEVICE memory (I/O) to support DMA from the guest.
-    pub fn add_vtl0_memory(&self, mem_range: MemoryRange) -> Result<(), Error> {
+    pub fn add_vtl0_memory(&self, mem_range: MemoryRange, shared: bool) -> Result<(), Error> {
+        let flags = if shared {
+            MshvVtlLow::SHARED_MEMORY_FLAG / HV_PAGE_SIZE
+        } else {
+            0
+        };
         let ram_disposition = protocol::hcl_pfn_range_t {
-            start_pfn: mem_range.start_4k_gpn(),
+            start_pfn: mem_range.start_4k_gpn() | flags,
             last_pfn: mem_range.end_4k_gpn(),
         };
 

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -288,6 +288,7 @@ mod mapping {
                     MshvVtlWithPolicy {
                         mshv_vtl,
                         ignore_registration_failure: self.ignore_registration_failure,
+                        shared: self.shared,
                     },
                 ))
             } else {
@@ -308,6 +309,7 @@ mod mapping {
     struct MshvVtlWithPolicy {
         mshv_vtl: MshvVtl,
         ignore_registration_failure: bool,
+        shared: bool,
     }
 
     impl crate::registrar::RegisterMemory for MshvVtlWithPolicy {
@@ -315,7 +317,7 @@ mod mapping {
             &self,
             range: MemoryRange,
         ) -> Result<(), impl 'static + std::error::Error> {
-            match self.mshv_vtl.add_vtl0_memory(range) {
+            match self.mshv_vtl.add_vtl0_memory(range, self.shared) {
                 Ok(()) => Ok(()),
                 // TODO: remove this once the kernel driver tracks registration
                 Err(err) if self.ignore_registration_failure => {

--- a/openhcl/underhill_mem/src/registrar.rs
+++ b/openhcl/underhill_mem/src/registrar.rs
@@ -19,7 +19,6 @@
 //! initial registration for a chunk small. We track whether a given chunk has
 //! been registered via a small bitmap.
 
-use hcl::ioctl::MshvVtl;
 use inspect::Inspect;
 use memory_range::overlapping_ranges;
 use memory_range::MemoryRange;
@@ -99,12 +98,6 @@ impl Bitmap {
 
 pub trait RegisterMemory {
     fn register_range(&self, range: MemoryRange) -> Result<(), impl 'static + std::error::Error>;
-}
-
-impl RegisterMemory for MshvVtl {
-    fn register_range(&self, range: MemoryRange) -> Result<(), impl 'static + std::error::Error> {
-        self.add_vtl0_memory(range)
-    }
 }
 
 impl<T: Fn(MemoryRange) -> Result<(), E>, E: 'static + std::error::Error> RegisterMemory for T {


### PR DESCRIPTION
At some point, we stopped passing the shared bit down when registering kernel memory. Fix this.

This fixes kernel-mode DMA from TDX VMs.

Note that there are still problems with the overall scenario: the kernel will double buffer through the swiotlb even when the target pages are already shared, and swiotlb is sized by openhcl_boot such that there's not enough memory for all the IO that we may have in flight concurrently.