### PR TITLE
Trace less during crash reporting

### DIFF
--- a/vm/devices/vmbus/vmbus_user_channel/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_user_channel/src/lib.rs
@@ -163,10 +163,10 @@ pub fn open_uio_device(instance_id: &Guid) -> Result<File, Error> {
         .map_err(ErrorInner::Exist)?;
 
     let uio_dev_path = Path::new("/dev").join(uio_path.file_name());
-    tracing::info!(
-        "opening device {} for {}",
-        uio_dev_path.display(),
-        instance_id
+    tracing::debug!(
+        dev_path = %uio_dev_path.display(),
+        %instance_id,
+        "opening device"
     );
 
     let file = fs_err::OpenOptions::new()


### PR DESCRIPTION
One of our core crash diagnostics is that we send a chunk of kmsg output to the host to log. It is ideal if that output contains the panic message that caused the crash, but that isn't guaranteed. Since we have a fixed size buffer, it is possible that output that occurs after the panic message could push the useful details off the end of the buffer. This PR reduces the amount of tracing we emit during the crash dump process to hopefully help with this.