### PR TITLE
misc: Reduce mesh and kernel logging on crashes

### DIFF
--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -128,7 +128,7 @@ fn build_kernel_command_line(
         // this information doesn't seem useful without a dump anyways.
         // Additionally it may push important logs off the end of the kmsg
         // page logged by the host.
-        "print_fatal_signals=0",
+        //"print_fatal_signals=0",
         // RELIABILITY: Unlimited logging to /dev/kmsg from userspace.
         "printk.devkmsg=on",
         // RELIABILITY: Reboot using a triple fault as the fastest method.

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -123,8 +123,12 @@ fn build_kernel_command_line(
         "panic_print=0",
         // RELIABILITY: Reboot immediately on panic, no timeout.
         "panic=-1",
-        // RELIABILITY: Print processor context information on a fatal signal.
-        "print_fatal_signals=1",
+        // RELIABILITY: Don't print processor context information on a fatal
+        // signal. Our crash dump collection infrastructure seems reliable, and
+        // this information doesn't seem useful without a dump anyways.
+        // Additionally it may push important logs off the end of the kmsg
+        // page logged by the host.
+        "print_fatal_signals=0",
         // RELIABILITY: Unlimited logging to /dev/kmsg from userspace.
         "printk.devkmsg=on",
         // RELIABILITY: Reboot using a triple fault as the fastest method.

--- a/support/mesh/mesh_remote/src/unix_node.rs
+++ b/support/mesh/mesh_remote/src/unix_node.rs
@@ -296,7 +296,7 @@ async fn run_leader(
             },
             Err(err) => {
                 if let RecvError::Error(err) = err {
-                    tracing::warn!(
+                    tracing::debug!(
                         ?remote_id,
                         error = &err as &dyn std::error::Error,
                         "leader connection to remote failed"


### PR DESCRIPTION
See #261 for the reasoning behind this change. This removes two more sources of logs that we don't feel are useful.