### PR TITLE
openhcl: add magic field to measured header in loader info and validate

### DIFF
--- a/openhcl/underhill_core/src/loader/vtl0_config.rs
+++ b/openhcl/underhill_core/src/loader/vtl0_config.rs
@@ -80,6 +80,9 @@ impl MeasuredVtl0Info {
             .map_err(Error::GuestMemoryAccess)?;
         config_pages.push(PV_CONFIG_BASE_PAGE);
 
+        // Verify the magic field is set.
+        assert_eq!(measured_config.magic, ParavisorMeasuredVtl0Config::MAGIC);
+
         let supports_pcat = measured_config.supported_vtl0.pcat_supported();
 
         let supports_uefi = if measured_config.supported_vtl0.uefi_supported() {

--- a/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
+++ b/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
@@ -159,7 +159,6 @@ impl Drop for Vtl2ParamsMap<'_> {
             .start();
 
         for range in self.ranges {
-            tracing::error!(?range, "zeroing");
             self.mapping
                 .fill_at((range.start() - base) as usize, 0, range.len() as usize)
                 .unwrap();

--- a/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
+++ b/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
@@ -89,12 +89,15 @@ impl MeasuredVtl2Info {
 
 #[derive(Debug)]
 /// Map of the portion of memory that contains the VTL2 parameters.
-struct Vtl2ParamsMap {
+///
+/// On drop, this mapping zeroes out the specified config ranges.
+struct Vtl2ParamsMap<'a> {
     mapping: SparseMapping,
+    ranges: &'a [MemoryRange],
 }
 
-impl Vtl2ParamsMap {
-    fn new(config_ranges: &[MemoryRange]) -> anyhow::Result<Self> {
+impl<'a> Vtl2ParamsMap<'a> {
+    fn new(config_ranges: &'a [MemoryRange]) -> anyhow::Result<Self> {
         // No overlaps.
         // TODO: Move this check to host_fdt_parser?
         if let Some((l, r)) = config_ranges
@@ -124,12 +127,15 @@ impl Vtl2ParamsMap {
                     range.len() as usize,
                     dev_mem.file(),
                     range.start(),
-                    false,
+                    true,
                 )
                 .context("failed to memory map igvm parameters")?;
         }
 
-        Ok(Self { mapping })
+        Ok(Self {
+            mapping,
+            ranges: config_ranges,
+        })
     }
 
     fn read_at(&self, offset: usize, buf: &mut [u8]) -> anyhow::Result<()> {
@@ -138,6 +144,23 @@ impl Vtl2ParamsMap {
 
     fn read_plain<T: AsBytes + zerocopy::FromBytes>(&self, offset: usize) -> anyhow::Result<T> {
         Ok(self.mapping.read_plain(offset)?)
+    }
+}
+
+impl Drop for Vtl2ParamsMap<'_> {
+    fn drop(&mut self) {
+        let base = self
+            .ranges
+            .first()
+            .expect("already checked that there is at least one range")
+            .start();
+
+        for range in self.ranges {
+            tracing::error!(?range, "zeroing");
+            self.mapping
+                .fill_at((range.start() - base) as usize, 0, range.len() as usize)
+                .unwrap();
+        }
     }
 }
 
@@ -227,6 +250,10 @@ pub fn read_vtl2_params() -> anyhow::Result<(RuntimeParameters, MeasuredVtl2Info
             (PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_INDEX * HV_PAGE_SIZE) as usize,
         )
         .context("failed to read measured vtl2 config")?;
+
+    drop(mapping);
+
+    assert_eq!(measured_config.magic, ParavisorMeasuredVtl2Config::MAGIC);
 
     let vtom_offset_bit = if measured_config.vtom_offset_bit == 0 {
         None

--- a/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
+++ b/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
@@ -119,7 +119,10 @@ impl<'a> Vtl2ParamsMap<'a> {
         let mapping =
             SparseMapping::new(size as usize).context("failed to create a sparse mapping")?;
 
-        let dev_mem = fs_err::File::open("/dev/mem")?;
+        let dev_mem = fs_err::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/mem")?;
         for range in config_ranges {
             mapping
                 .map_file(

--- a/vm/loader/loader_defs/src/paravisor.rs
+++ b/vm/loader/loader_defs/src/paravisor.rs
@@ -368,8 +368,6 @@ pub struct ParavisorMeasuredVtl2Config {
     /// Magic value. Must be [`Self::MAGIC`].
     pub magic: u64,
     /// The bit offset of vTOM, if non-zero.
-    ///
-    /// TODO: Only set on SNP, but should also be used for TDX.
     pub vtom_offset_bit: u8,
     /// Padding.
     pub padding: [u8; 7],

--- a/vm/loader/loader_defs/src/paravisor.rs
+++ b/vm/loader/loader_defs/src/paravisor.rs
@@ -332,12 +332,19 @@ pub struct SupportedVtl0LoadInfo {
 #[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
 #[cfg_attr(feature = "inspect", derive(Inspect))]
 pub struct ParavisorMeasuredVtl0Config {
+    /// Magic value. Must be [`Self::MAGIC`].
+    pub magic: u64,
     /// Supported VTL0 images.
     pub supported_vtl0: SupportedVtl0LoadInfo,
     /// If UEFI is supported, information about UEFI for VTL0.
     pub uefi_info: UefiInfo,
     /// If Linux is supported, information about Linux for VTL0.
     pub linux_info: LinuxInfo,
+}
+
+impl ParavisorMeasuredVtl0Config {
+    /// Magic value for the measured config, which is "OHCLVTL0".
+    pub const MAGIC: u64 = 0x4F48434C56544C30;
 }
 
 /// The physical page number for where the vtl 0 measured config is stored, x86_64.
@@ -358,8 +365,17 @@ pub const PARAVISOR_VTL0_MEASURED_CONFIG_BASE_PAGE_AARCH64: u64 = 16 << (20 - 12
 #[derive(Copy, Clone, Debug, AsBytes, FromBytes, FromZeroes)]
 #[cfg_attr(feature = "inspect", derive(Inspect))]
 pub struct ParavisorMeasuredVtl2Config {
+    /// Magic value. Must be [`Self::MAGIC`].
+    pub magic: u64,
     /// The bit offset of vTOM, if non-zero.
     ///
     /// TODO: Only set on SNP, but should also be used for TDX.
     pub vtom_offset_bit: u8,
+    /// Padding.
+    pub padding: [u8; 7],
+}
+
+impl ParavisorMeasuredVtl2Config {
+    /// Magic value for the measured config, which is "OHCLVTL2".
+    pub const MAGIC: u64 = 0x4F48434C56544C32;
 }

--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -1268,6 +1268,22 @@ where
     )?;
     importer.import_parameter(dt_parameter_area, 0, IgvmParameterType::DeviceTree)?;
 
+    let vtl2_measured_config = ParavisorMeasuredVtl2Config {
+        magic: ParavisorMeasuredVtl2Config::MAGIC,
+        vtom_offset_bit: 0,
+        padding: [0; 7],
+    };
+
+    importer
+        .import_pages(
+            config_region_page_base + PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_INDEX,
+            PARAVISOR_MEASURED_VTL2_CONFIG_SIZE_PAGES,
+            "underhill-vtl2-measured-config",
+            BootPageAcceptance::Exclusive,
+            vtl2_measured_config.as_bytes(),
+        )
+        .map_err(Error::Importer)?;
+
     let imported_region_base =
         config_region_page_base + PARAVISOR_MEASURED_VTL2_CONFIG_ACCEPTED_MEMORY_PAGE_INDEX;
 

--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -658,6 +658,7 @@ where
     // The measured config is at page 0. Free pages start at page 1.
     let mut free_page = 1;
     let mut measured_config = ParavisorMeasuredVtl0Config {
+        magic: ParavisorMeasuredVtl0Config::MAGIC,
         ..FromZeroes::new_zeroed()
     };
 
@@ -759,7 +760,9 @@ where
         .map_err(Error::Importer)?;
 
     let vtl2_measured_config = ParavisorMeasuredVtl2Config {
+        magic: ParavisorMeasuredVtl2Config::MAGIC,
         vtom_offset_bit: shared_gpa_boundary_bits.unwrap_or(0),
+        padding: [0; 7],
     };
 
     importer
@@ -1038,6 +1041,7 @@ where
         .map_err(Error::Importer)?;
 
     let mut measured_config = ParavisorMeasuredVtl0Config {
+        magic: ParavisorMeasuredVtl0Config::MAGIC,
         ..FromZeroes::new_zeroed()
     };
 


### PR DESCRIPTION
Add a magic header to measured information that should be loaded by the host. Additionally, zero out the VTL2 boot data range, to validate that on servicing operations, the host actually deposits new data. 

This fixes the issue on ARM64 where this data was not actually written. Thus, on a cold boot where memory is zeroed, the correct value of vtom = 0 was read, but during a servicing operation because this memory was not part of the launch context, the value could be garbage and cause failures later during initialization. 

In the future, we should just have the bootloader parse the information here, but getting the SLIT and PPTT info reconstructed is a bit trickier. Tracked by #263 