### PR TITLE
disk_blockdevice: always bounce block device IO for arm64

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1719,11 +1719,13 @@ async fn new_underhill_vm(
         ))
     };
 
+    let always_bounce = cfg!(guest_arch = "aarch64");
     resolver.add_async_resolver::<DiskHandleKind, _, OpenBlockDeviceConfig, _>(
         BlockDeviceResolver::new(
             Arc::new(tp.clone()),
             Some(uevent_listener.clone()),
             bounce_buffer_tracker,
+            always_bounce,
         ),
     );
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1719,6 +1719,8 @@ async fn new_underhill_vm(
         ))
     };
 
+    // ARM64 always bounces, as the OpenHCL kernel does not
+    // have access to VTL0 pages. Necessary until #273 is resolved.
     let always_bounce = cfg!(guest_arch = "aarch64");
     resolver.add_async_resolver::<DiskHandleKind, _, OpenBlockDeviceConfig, _>(
         BlockDeviceResolver::new(


### PR DESCRIPTION
Work around kernel limitations for ARM64 OpenHCL: always bounce external data in the block device. This prevents the need from the kernel to have visibility into the pages used for VTL0 memory.