### PR TITLE
shared_pool_alloc: zero out allocated DMA buffers

### DIFF
--- a/openhcl/shared_pool_alloc/src/lib.rs
+++ b/openhcl/shared_pool_alloc/src/lib.rs
@@ -266,6 +266,11 @@ impl user_driver::vfio::VfioDmaBuffer for SharedPoolAllocator {
             .map_file(0, len, gpa_fd.get(), file_offset, true)
             .context("unable to map allocation")?;
 
+        // It is a requirement of the VfioDmaBuffer trait that all allocated buffers be zeroed out
+        mapping
+            .fill_at(0, 0, len)
+            .context("failed to zero shared memory")?;
+
         let pfns: Vec<_> = (alloc.base_pfn()..alloc.base_pfn() + alloc.size_pages).collect();
 
         Ok(user_driver::memory::MemoryBlock::new(SharedDmaBuffer {

--- a/vm/devices/user_driver/src/vfio.rs
+++ b/vm/devices/user_driver/src/vfio.rs
@@ -36,7 +36,7 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 
 pub trait VfioDmaBuffer: 'static + Send + Sync {
-    /// Create a new dma buffer with the given `len` in bytes. This buffer must be zeroed out.
+    /// Create a new DMA buffer of the given `len` bytes. Guaranteed to be zero-initialized.
     fn create_dma_buffer(&self, len: usize) -> anyhow::Result<MemoryBlock>;
 }
 

--- a/vm/devices/user_driver/src/vfio.rs
+++ b/vm/devices/user_driver/src/vfio.rs
@@ -36,7 +36,7 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 
 pub trait VfioDmaBuffer: 'static + Send + Sync {
-    /// Create a new dma buffer with the given `len` in bytes.
+    /// Create a new dma buffer with the given `len` in bytes. This buffer must be zeroed out.
     fn create_dma_buffer(&self, len: usize) -> anyhow::Result<MemoryBlock>;
 }
 


### PR DESCRIPTION
DMA buffers are expected to be zeroed out upon allocation

MSFT#53036590