### PR TITLE
Doc updates: vmm tests, vscode settings

### DIFF
--- a/Guide/src/dev_guide/getting_started/suggested_dev_env.md
+++ b/Guide/src/dev_guide/getting_started/suggested_dev_env.md
@@ -197,8 +197,9 @@ cargo xtask install-git-hooks --pre-push --with-fmt=yes
 And you'll be all set!
 
 ```admonish success
-If you're worried about time, the `pre-push` hook should only takes ~5
-seconds to run locally. That's far better than sinking ~20+ mins of CI time!
+If you're worried about time, the `pre-push` hook should only take ~5
+seconds to run locally. That's far better than waiting ~20+ minutes only
+for CI to fail on your pull request.
 ```
 
 # \[WSL2] Cross Compiling from WSL2 to Windows

--- a/Guide/src/dev_guide/getting_started/suggested_dev_env.md
+++ b/Guide/src/dev_guide/getting_started/suggested_dev_env.md
@@ -21,6 +21,24 @@ If you're using a different development environment, we nonetheless suggest
 reading through this section, so you can enable similar settings in whatever
 editor / IDE you happen to be using.
 
+```admonish tip
+Just want the recommended editor settings? Put this in `openvmm/.vscode/settings.json`:
+
+```json
+{
+    "rust-analyzer.linkedProjects": [
+        "Cargo.toml",
+    ],
+    "rust-analyzer.cargo.targetDir": true,
+    "rust-analyzer.imports.granularity.group": "item",
+    "rust-analyzer.imports.group.enable": false,
+    "[rust]": {
+        "editor.formatOnSave": true
+    },
+}
+```
+```
+
 ### \[WSL2] Connecting to WSL using VSCode
 
 When using Visual Studio Code with WSL, be sure to use the


### PR DESCRIPTION
Minor updates to the dev guide to provide "quick mode" integration tests + vscode setup. I had ambitions of further refactoring the dev environment docs, but think this incremental update is still useful.