### PR TITLE
igvmfilegen: refactor VTL0 image configuration

### DIFF
--- a/Guide/src/reference/openhcl/diag/ohcldiag_dev/perf.md
+++ b/Guide/src/reference/openhcl/diag/ohcldiag_dev/perf.md
@@ -22,8 +22,8 @@ configuration file (openhcl-x64-dev.json). E.g. increase it to 524288 like:
 
 ```json
 {
-    "vtl2": {
-        "underhill": {
+    "image": {
+        "openhcl": {
             ....................
             "memory_page_count": 524288
         }

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -101,7 +101,6 @@ pub struct IgvmLoader<R: VbsRegister + GuestArch> {
     directives: Vec<IgvmDirectiveHeader>,
     page_data_directives: Vec<IgvmDirectiveHeader>,
     vp_context: Option<Box<dyn VpContextBuilder<Register = R>>>,
-    lower_vtl_context: Option<VbsVpContext<R>>,
     max_vtl: Vtl,
     parameter_areas: BTreeMap<(u64, u32), u32>,
     isolation_type: LoaderIsolationType,
@@ -112,11 +111,31 @@ pub struct IgvmLoader<R: VbsRegister + GuestArch> {
 pub struct IgvmVtlLoader<'a, R: VbsRegister + GuestArch> {
     loader: &'a mut IgvmLoader<R>,
     vtl: Vtl,
+    vp_context: Option<VbsVpContext<R>>,
 }
 
 impl<R: VbsRegister + GuestArch> IgvmVtlLoader<'_, R> {
     pub fn loader(&self) -> &IgvmLoader<R> {
         self.loader
+    }
+
+    /// Returns a loader for importing an inner image as part of the actual
+    /// (paravisor) image to load.
+    ///
+    /// Use `take_vp_context` on the returned loader to get the VP context that
+    /// the paravisor should load.
+    pub fn nested_loader(&mut self) -> IgvmVtlLoader<'_, R> {
+        IgvmVtlLoader {
+            loader: &mut *self.loader,
+            vtl: Vtl::Vtl0,
+            vp_context: Some(VbsVpContext::new(self.vtl.into())),
+        }
+    }
+
+    pub fn take_vp_context(&mut self) -> Vec<u8> {
+        self.vp_context
+            .take()
+            .map_or_else(Vec::new, |vp| vp.as_page())
     }
 }
 
@@ -502,12 +521,6 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             }
         }
 
-        let lower_vtl_context_builder = if with_paravisor {
-            Some(VbsVpContext::new(Vtl::Vtl0.into()))
-        } else {
-            None
-        };
-
         IgvmLoader {
             accepted_ranges: RangeMap::new(),
             relocatable_regions: RangeMap::new(),
@@ -518,7 +531,6 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             directives: Vec::new(),
             page_data_directives: Vec::new(),
             vp_context: vp_context_builder,
-            lower_vtl_context: lower_vtl_context_builder,
             max_vtl,
             parameter_areas: BTreeMap::new(),
             isolation_type,
@@ -570,9 +582,6 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
         // Finalize any VP state.
         let mut state = Vec::new();
         self.vp_context.take().unwrap().finalize(&mut state);
-        if let Some(mut context) = self.lower_vtl_context.take() {
-            context.finalize(&mut state);
-        }
 
         for context in state {
             match context {
@@ -765,10 +774,12 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
         }
     }
 
-    pub fn for_vtl(&mut self, vtl: Vtl) -> IgvmVtlLoader<'_, R> {
-        assert!(vtl <= self.max_vtl);
-        assert!(vtl == Vtl::Vtl0 || vtl == Vtl::Vtl2);
-        IgvmVtlLoader { loader: self, vtl }
+    pub fn loader(&mut self) -> IgvmVtlLoader<'_, R> {
+        IgvmVtlLoader {
+            vtl: self.max_vtl,
+            loader: self,
+            vp_context: None,
+        }
     }
 
     fn import_pages(
@@ -1010,19 +1021,14 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmVtlLoader
     }
 
     fn import_vp_register(&mut self, register: R) -> anyhow::Result<()> {
-        if self.vtl == self.loader.max_vtl {
+        if let Some(vp_context) = &mut self.vp_context {
+            vp_context.import_vp_register(register)
+        } else {
             self.loader
                 .vp_context
                 .as_mut()
                 .unwrap()
                 .import_vp_register(register);
-        } else {
-            assert_eq!(self.vtl, Vtl::Vtl0);
-            self.loader
-                .lower_vtl_context
-                .as_mut()
-                .unwrap()
-                .import_vp_register(register)
         }
 
         Ok(())
@@ -1077,18 +1083,6 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmVtlLoader
             .as_mut()
             .unwrap()
             .set_vp_context_memory(page_base);
-
-        Ok(())
-    }
-
-    fn set_lower_vtl_context_page(&mut self, page_base: u64) -> anyhow::Result<()> {
-        if self.vtl != Vtl::Vtl0 {
-            self.loader
-                .lower_vtl_context
-                .as_mut()
-                .unwrap()
-                .set_vp_context_memory(page_base);
-        }
 
         Ok(())
     }
@@ -1340,7 +1334,7 @@ mod tests {
             },
         );
         {
-            let mut loader = loader.for_vtl(Vtl::Vtl0);
+            let mut loader = loader.loader();
 
             let data = vec![0, 5];
             loader

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -128,7 +128,7 @@ impl<R: VbsRegister + GuestArch> IgvmVtlLoader<'_, R> {
         IgvmVtlLoader {
             loader: &mut *self.loader,
             vtl: Vtl::Vtl0,
-            vp_context: Some(VbsVpContext::new(self.vtl.into())),
+            vp_context: Some(VbsVpContext::new(self.vtl)),
         }
     }
 
@@ -498,7 +498,7 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
 
         match isolation_type {
             LoaderIsolationType::None | LoaderIsolationType::Vbs { .. } => {
-                vp_context_builder = Some(Box::new(VbsVpContext::<R>::new(max_vtl.into())));
+                vp_context_builder = Some(Box::new(VbsVpContext::<R>::new(max_vtl)));
 
                 // Add VBS platform header
                 let info = IGVM_VHS_SUPPORTED_PLATFORM {

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -684,9 +684,9 @@ fn load_uefi<R: IgvmfilegenRegister + GuestArch + 'static>(
     Ok(load_info)
 }
 
-fn load_linux<'a, R: IgvmfilegenRegister + GuestArch + 'static>(
+fn load_linux<R: IgvmfilegenRegister + GuestArch + 'static>(
     loader: &mut IgvmVtlLoader<'_, R>,
-    config: &'a LinuxImage,
+    config: &LinuxImage,
     resources: &Resources,
 ) -> Result<loader::linux::LoadInfo, anyhow::Error> {
     let LinuxImage {

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -15,18 +15,18 @@ use anyhow::Context;
 use clap::Parser;
 use file_loader::IgvmLoaderRegister;
 use file_loader::IgvmVtlLoader;
-use hvdef::Vtl;
 use igvm::IgvmFile;
 use igvm_defs::SnpPolicy;
 use igvm_defs::TdxPolicy;
 use igvm_defs::IGVM_FIXED_HEADER;
 use igvmfilegen_config::Config;
 use igvmfilegen_config::ConfigIsolationType;
+use igvmfilegen_config::Image;
+use igvmfilegen_config::LinuxImage;
 use igvmfilegen_config::ResourceType;
 use igvmfilegen_config::Resources;
 use igvmfilegen_config::SnpInjectionType;
 use igvmfilegen_config::UefiConfigType;
-use igvmfilegen_config::VtlConfig;
 use loader::importer::Aarch64Register;
 use loader::importer::GuestArch;
 use loader::importer::GuestArchKind;
@@ -36,7 +36,6 @@ use loader::linux::InitrdConfig;
 use loader::paravisor::CommandLineType;
 use loader::paravisor::Vtl0Config;
 use loader::paravisor::Vtl0Linux;
-use std::ffi::CString;
 use std::io::Write;
 use std::path::PathBuf;
 use tracing_subscriber::filter::LevelFilter;
@@ -168,11 +167,6 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
             bail!("max_vtl must be 2 or 0");
         }
 
-        // If max VTL is 0, then VTL2 config must be none.
-        if config.max_vtl == 0 && !matches!(config.vtl2, VtlConfig::None) {
-            bail!("vtl2 must be none if max vtl is 0");
-        }
-
         let isolation_string = match config.isolation_type {
             ConfigIsolationType::None => "none",
             ConfigIsolationType::Vbs { .. } => "vbs",
@@ -212,22 +206,7 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
 
         let mut loader = IgvmLoader::<R>::new(with_paravisor, loader_isolation_type);
 
-        // Load VTL0, then VTL2, if present.
-        let vtl0_load_info = load_image(
-            &mut loader.for_vtl(Vtl::Vtl0),
-            &config.vtl0,
-            &resources,
-            Vtl0LoadInfo::None,
-        )?;
-
-        if config.max_vtl == 2 {
-            load_image(
-                &mut loader.for_vtl(Vtl::Vtl2),
-                &config.vtl2,
-                &resources,
-                vtl0_load_info,
-            )?;
-        }
+        load_image(&mut loader.loader(), &config.image, &resources)?;
 
         let igvm_output = loader
             .finalize(config.guest_svn)
@@ -410,13 +389,6 @@ fn debug_validate_igvm_file(igvm_file: &IgvmFile, binary_file: &[u8]) {
     }
 }
 
-#[derive(Debug)]
-enum Vtl0LoadInfo<'a> {
-    None,
-    Uefi(loader::uefi::LoadInfo),
-    Linux(&'a CString, loader::linux::LoadInfo),
-}
-
 /// A trait to specialize behavior of the file builder based on different
 /// register types for different architectures. Different methods may need to be
 /// called depending on the register type that represents the given architecture.
@@ -438,7 +410,7 @@ trait IgvmfilegenRegister: IgvmLoaderRegister + 'static {
         F: std::io::Read + std::io::Seek,
         Self: GuestArch;
 
-    fn load_underhill<F>(
+    fn load_openhcl<F>(
         importer: &mut dyn ImageLoad<Self>,
         kernel_image: &mut F,
         shim: &mut F,
@@ -480,7 +452,7 @@ impl IgvmfilegenRegister for X86Register {
         )
     }
 
-    fn load_underhill<F>(
+    fn load_openhcl<F>(
         importer: &mut dyn ImageLoad<Self>,
         kernel_image: &mut F,
         shim: &mut F,
@@ -494,7 +466,7 @@ impl IgvmfilegenRegister for X86Register {
     where
         F: std::io::Read + std::io::Seek,
     {
-        loader::paravisor::load_underhill_x64(
+        loader::paravisor::load_openhcl_x64(
             importer,
             kernel_image,
             shim,
@@ -536,7 +508,7 @@ impl IgvmfilegenRegister for Aarch64Register {
         )
     }
 
-    fn load_underhill<F>(
+    fn load_openhcl<F>(
         importer: &mut dyn ImageLoad<Self>,
         kernel_image: &mut F,
         shim: &mut F,
@@ -550,7 +522,7 @@ impl IgvmfilegenRegister for Aarch64Register {
     where
         F: std::io::Read + std::io::Seek,
     {
-        loader::paravisor::load_underhill_arm64(
+        loader::paravisor::load_openhcl_arm64(
             importer,
             kernel_image,
             shim,
@@ -566,75 +538,33 @@ impl IgvmfilegenRegister for Aarch64Register {
 /// Load an image.
 fn load_image<'a, R: IgvmfilegenRegister + GuestArch + 'static>(
     loader: &mut IgvmVtlLoader<'_, R>,
-    config: &'a VtlConfig,
+    config: &'a Image,
     resources: &'a Resources,
-    vtl0_load_info: Vtl0LoadInfo<'_>,
-) -> anyhow::Result<Vtl0LoadInfo<'a>> {
+) -> anyhow::Result<()> {
     tracing::debug!(?config, "loading into VTL0");
 
-    let load_info = match config {
-        VtlConfig::None => {
+    match *config {
+        Image::None => {
             // Nothing is loaded.
-            Vtl0LoadInfo::None
         }
-        VtlConfig::Uefi { config_type } => {
-            let image_path = resources
-                .get(ResourceType::Uefi)
-                .expect("validated present");
-            let image = fs_err::read(image_path)
-                .context(format!("reading uefi image at {}", image_path.display()))?;
-            let config = match config_type {
-                UefiConfigType::None => loader::uefi::ConfigType::None,
-                UefiConfigType::Igvm => loader::uefi::ConfigType::Igvm,
-            };
-
-            let load_info = R::load_uefi(loader, &image, config).context("uefi loader")?;
-            Vtl0LoadInfo::Uefi(load_info)
+        Image::Uefi { config_type } => {
+            load_uefi(loader, resources, config_type)?;
         }
-        VtlConfig::Linux {
-            command_line,
-            use_initrd,
-        } => {
-            let kernel_path = resources
-                .get(ResourceType::LinuxKernel)
-                .expect("validated present");
-            let mut kernel = fs_err::File::open(kernel_path).context(format!(
-                "reading vtl0 kernel image at {}",
-                kernel_path.display()
-            ))?;
-
-            let initrd_vec = if *use_initrd {
-                let initrd_path = resources
-                    .get(ResourceType::LinuxInitrd)
-                    .expect("validated present");
-                fs_err::read(initrd_path)
-                    .context(format!("reading vtl0 initrd at {}", initrd_path.display()))?
-            } else {
-                Vec::new()
-            };
-
-            let initrd = if initrd_vec.is_empty() {
-                None
-            } else {
-                Some(InitrdConfig {
-                    initrd_address: loader::linux::InitrdAddressType::AfterKernel,
-                    initrd: &initrd_vec,
-                })
-            };
-
-            // NOTE: The kernel is allowed to load at address 0, but if it actually attempts to load at address 0,
-            //       underhill will fail to load due to overlapping with ACPI tables and additional config.
-            let load_info = R::load_linux_kernel_and_initrd(loader, &mut kernel, 0, initrd, None)
-                .context("loading linux kernel and initrd")?;
-
-            Vtl0LoadInfo::Linux(command_line, load_info)
+        Image::Linux(ref linux) => {
+            load_linux(loader, linux, resources)?;
         }
-        VtlConfig::Underhill {
-            command_line,
+        Image::Openhcl {
+            ref command_line,
             static_command_line,
             memory_page_base,
             memory_page_count,
+            uefi,
+            ref linux,
         } => {
+            if uefi && linux.is_some() {
+                anyhow::bail!("cannot include both UEFI and Linux images in OpenHCL image");
+            }
+
             let kernel_path = resources
                 .get(ResourceType::UnderhillKernel)
                 .expect("validated present");
@@ -675,25 +605,31 @@ fn load_image<'a, R: IgvmfilegenRegister + GuestArch + 'static>(
             // Since the host performs PCAT loading, each image that supports
             // UEFI also supports PCAT boot. A future file builder config change
             // will make this more explicit.
-            let vtl0_load_config = match vtl0_load_info {
-                Vtl0LoadInfo::None => Vtl0Config {
-                    supports_pcat: false,
-                    supports_uefi: None,
-                    supports_linux: None,
-                },
-                Vtl0LoadInfo::Uefi(load_info) => Vtl0Config {
+            let vtl0_load_config = if uefi {
+                let mut inner_loader = loader.nested_loader();
+                let load_info = load_uefi(&mut inner_loader, resources, UefiConfigType::None)?;
+                let vp_context = inner_loader.take_vp_context();
+                Vtl0Config {
                     supports_pcat: loader.loader().arch() == GuestArchKind::X86_64,
-                    supports_uefi: Some(load_info),
+                    supports_uefi: Some((load_info, vp_context)),
                     supports_linux: None,
-                },
-                Vtl0LoadInfo::Linux(command_line, load_info) => Vtl0Config {
+                }
+            } else if let Some(linux) = linux {
+                let load_info = load_linux(&mut loader.nested_loader(), linux, resources)?;
+                Vtl0Config {
                     supports_pcat: false,
                     supports_uefi: None,
                     supports_linux: Some(Vtl0Linux {
-                        command_line,
+                        command_line: &linux.command_line,
                         load_info,
                     }),
-                },
+                }
+            } else {
+                Vtl0Config {
+                    supports_pcat: false,
+                    supports_uefi: None,
+                    supports_linux: None,
+                }
             };
 
             let command_line = if loader.loader().confidential_debug() {
@@ -706,28 +642,82 @@ fn load_image<'a, R: IgvmfilegenRegister + GuestArch + 'static>(
                 command_line.to_string()
             };
 
-            let command_line = if *static_command_line {
+            let command_line = if static_command_line {
                 CommandLineType::Static(&command_line)
             } else {
                 CommandLineType::HostAppendable(&command_line)
             };
 
-            R::load_underhill(
+            R::load_openhcl(
                 loader,
                 &mut kernel,
                 &mut shim,
                 sidecar.as_mut(),
                 command_line,
                 initrd_slice,
-                *memory_page_base,
-                *memory_page_count,
+                memory_page_base,
+                memory_page_count,
                 vtl0_load_config,
             )
             .context("underhill kernel loader")?;
-
-            Vtl0LoadInfo::None
         }
     };
 
+    Ok(())
+}
+
+fn load_uefi<R: IgvmfilegenRegister + GuestArch + 'static>(
+    loader: &mut IgvmVtlLoader<'_, R>,
+    resources: &Resources,
+    config_type: UefiConfigType,
+) -> Result<loader::uefi::LoadInfo, anyhow::Error> {
+    let image_path = resources
+        .get(ResourceType::Uefi)
+        .expect("validated present");
+    let image = fs_err::read(image_path)
+        .context(format!("reading uefi image at {}", image_path.display()))?;
+    let config = match config_type {
+        UefiConfigType::None => loader::uefi::ConfigType::None,
+        UefiConfigType::Igvm => loader::uefi::ConfigType::Igvm,
+    };
+    let load_info = R::load_uefi(loader, &image, config).context("uefi loader")?;
+    Ok(load_info)
+}
+
+fn load_linux<'a, R: IgvmfilegenRegister + GuestArch + 'static>(
+    loader: &mut IgvmVtlLoader<'_, R>,
+    config: &'a LinuxImage,
+    resources: &Resources,
+) -> Result<loader::linux::LoadInfo, anyhow::Error> {
+    let LinuxImage {
+        use_initrd,
+        command_line: _,
+    } = *config;
+    let kernel_path = resources
+        .get(ResourceType::LinuxKernel)
+        .expect("validated present");
+    let mut kernel = fs_err::File::open(kernel_path).context(format!(
+        "reading vtl0 kernel image at {}",
+        kernel_path.display()
+    ))?;
+    let initrd_vec = if use_initrd {
+        let initrd_path = resources
+            .get(ResourceType::LinuxInitrd)
+            .expect("validated present");
+        fs_err::read(initrd_path)
+            .context(format!("reading vtl0 initrd at {}", initrd_path.display()))?
+    } else {
+        Vec::new()
+    };
+    let initrd = if initrd_vec.is_empty() {
+        None
+    } else {
+        Some(InitrdConfig {
+            initrd_address: loader::linux::InitrdAddressType::AfterKernel,
+            initrd: &initrd_vec,
+        })
+    };
+    let load_info = R::load_linux_kernel_and_initrd(loader, &mut kernel, 0, initrd, None)
+        .context("loading linux kernel and initrd")?;
     Ok(load_info)
 }

--- a/vm/loader/manifests/openhcl-aarch64-dev.json
+++ b/vm/loader/manifests/openhcl-aarch64-dev.json
@@ -6,7 +6,7 @@
             "max_vtl": 2,
             "isolation_type": "none",
             "image": {
-                "underhill": {
+                "openhcl": {
                     "memory_page_count": 24576,
                     "command_line": "console=null",
                     "uefi": true

--- a/vm/loader/manifests/openhcl-aarch64-dev.json
+++ b/vm/loader/manifests/openhcl-aarch64-dev.json
@@ -5,15 +5,11 @@
             "guest_svn": 1,
             "max_vtl": 2,
             "isolation_type": "none",
-            "vtl0": {
-                "uefi": {
-                    "config_type": "none"
-                }
-            },
-            "vtl2": {
+            "image": {
                 "underhill": {
                     "memory_page_count": 24576,
-                    "command_line": "console=null"
+                    "command_line": "console=null",
+                    "uefi": true
                 }
             }
         }

--- a/vm/loader/manifests/openhcl-aarch64-release.json
+++ b/vm/loader/manifests/openhcl-aarch64-release.json
@@ -5,15 +5,11 @@
             "guest_svn": 1,
             "max_vtl": 2,
             "isolation_type": "none",
-            "vtl0": {
-                "uefi": {
-                    "config_type": "none"
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "memory_page_count": 12288,
-                    "command_line": "console=null"
+                    "command_line": "console=null",
+                    "uefi": true
                 }
             }
         }

--- a/vm/loader/manifests/openhcl-x64-cvm-dev.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-dev.json
@@ -12,16 +12,12 @@
                     "injection_type": "normal"
                 }
             },
-            "vtl0": {
-                "uefi": {
-                    "config_type": "none"
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "command_line": "",
                     "memory_page_count": 163840,
-                    "memory_page_base": 32768
+                    "memory_page_base": 32768,
+                    "uefi": true
                 }
             }
         },
@@ -34,16 +30,12 @@
                     "sept_ve_disable": true
                 }
             },
-            "vtl0": {
-                "uefi": {
-                    "config_type": "none"
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "command_line": "",
                     "memory_page_count": 163840,
-                    "memory_page_base": 32768
+                    "memory_page_base": 32768,
+                    "uefi": true
                 }
             }
         },
@@ -55,16 +47,12 @@
                     "enable_debug": true
                 }
             },
-            "vtl0": {
-                "uefi": {
-                    "config_type": "none"
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "command_line": "",
                     "memory_page_count": 163840,
-                    "memory_page_base": 32768
+                    "memory_page_base": 32768,
+                    "uefi": true
                 }
             }
         }

--- a/vm/loader/manifests/openhcl-x64-cvm-release.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-release.json
@@ -12,16 +12,12 @@
                     "injection_type": "normal"
                 }
             },
-            "vtl0": {
-                "uefi": {
-                    "config_type": "none"
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "command_line": "",
                     "memory_page_count": 163840,
-                    "memory_page_base": 32768
+                    "memory_page_base": 32768,
+                    "uefi": true
                 }
             }
         },
@@ -34,16 +30,12 @@
                     "sept_ve_disable": true
                 }
             },
-            "vtl0": {
-                "uefi": {
-                    "config_type": "none"
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "command_line": "",
                     "memory_page_count": 32768,
-                    "memory_page_base": 32768
+                    "memory_page_base": 32768,
+                    "uefi": true
                 }
             }
         },
@@ -55,16 +47,12 @@
                     "enable_debug": true
                 }
             },
-            "vtl0": {
-                "uefi": {
-                    "config_type": "none"
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "command_line": "",
                     "memory_page_count": 32768,
-                    "memory_page_base": 32768
+                    "memory_page_base": 32768,
+                    "uefi": true
                 }
             }
         }

--- a/vm/loader/manifests/openhcl-x64-dev.json
+++ b/vm/loader/manifests/openhcl-x64-dev.json
@@ -5,15 +5,11 @@
             "guest_svn": 1,
             "max_vtl": 2,
             "isolation_type": "none",
-            "vtl0": {
-                "uefi": {
-                    "config_type": "none"
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "command_line": "OPENHCL_BOOT_LOG=com3",
-                    "memory_page_count": 126976
+                    "memory_page_count": 126976,
+                    "uefi": true
                 }
             }
         }

--- a/vm/loader/manifests/openhcl-x64-direct-dev.json
+++ b/vm/loader/manifests/openhcl-x64-direct-dev.json
@@ -5,16 +5,14 @@
             "guest_svn": 1,
             "max_vtl": 2,
             "isolation_type": "none",
-            "vtl0": {
-                "linux": {
-                    "command_line": "panic=-1 root=/dev/sda3 debug console=ttyS0,115200 nokasrl",
-                    "use_initrd": true
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "command_line": "OPENHCL_FORCE_LOAD_VTL0_IMAGE=linux OPENHCL_BOOT_LOG=com3",
-                    "memory_page_count": 245760
+                    "memory_page_count": 245760,
+                    "linux": {
+                        "command_line": "panic=-1 root=/dev/sda3 debug console=ttyS0,115200 nokasrl",
+                        "use_initrd": true
+                    }
                 }
             }
         }

--- a/vm/loader/manifests/openhcl-x64-direct-release.json
+++ b/vm/loader/manifests/openhcl-x64-direct-release.json
@@ -5,16 +5,14 @@
             "guest_svn": 1,
             "max_vtl": 2,
             "isolation_type": "none",
-            "vtl0": {
-                "linux": {
-                    "command_line": "panic=-1 root=/dev/sda3 debug console=ttyS0,115200 nokasrl",
-                    "use_initrd": true
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "command_line": "OPENHCL_FORCE_LOAD_VTL0_IMAGE=linux OPENHCL_BOOT_LOG=com3",
-                    "memory_page_count": 245760
+                    "memory_page_count": 245760,
+                    "linux": {
+                        "command_line": "panic=-1 root=/dev/sda3 debug console=ttyS0,115200 nokasrl",
+                        "use_initrd": true
+                    }
                 }
             }
         }

--- a/vm/loader/manifests/openhcl-x64-release.json
+++ b/vm/loader/manifests/openhcl-x64-release.json
@@ -5,16 +5,12 @@
             "guest_svn": 1,
             "max_vtl": 2,
             "isolation_type": "none",
-            "vtl0": {
-                "uefi": {
-                    "config_type": "none"
-                }
-            },
-            "vtl2": {
-                "underhill": {
+            "image": {
+                "openhcl": {
                     "initrd_path": "./underhill.cpio.gz",
                     "command_line": "",
-                    "memory_page_count": 16384
+                    "memory_page_count": 16384,
+                    "uefi": true
                 }
             }
         }

--- a/vm/loader/manifests/uefi-aarch64.json
+++ b/vm/loader/manifests/uefi-aarch64.json
@@ -5,12 +5,11 @@
             "guest_svn": 1,
             "max_vtl": 0,
             "isolation_type": "none",
-            "vtl0": {
+            "image": {
                 "uefi": {
                    "config_type": "none"
                 }
-            },
-            "vtl2": "none"
+            }
         }
     ]
 }

--- a/vm/loader/manifests/uefi-x64.json
+++ b/vm/loader/manifests/uefi-x64.json
@@ -10,12 +10,11 @@
                     "sept_ve_disable": true
                 }
             },
-            "vtl0": {
+            "image": {
                 "uefi": {
                     "config_type": "igvm"
                 }
-            },
-            "vtl2": "none"
+            }
         },
         {
             "guest_svn": 1,
@@ -28,12 +27,11 @@
                     "injection_type": "restricted"
                 }
             },
-            "vtl0": {
+            "image": {
                 "uefi": {
                     "config_type": "igvm"
                 }
-            },
-            "vtl2": "none"
+            }
         }
     ]
 }

--- a/vm/loader/src/importer.rs
+++ b/vm/loader/src/importer.rs
@@ -488,9 +488,6 @@ where
     /// TODO: It probably makes sense to use a different acceptance type than the default one?
     fn set_vp_context_page(&mut self, page_base: u64) -> anyhow::Result<()>;
 
-    /// Notify the loader to deposit lower VTL context information at the given page.
-    fn set_lower_vtl_context_page(&mut self, page_base: u64) -> anyhow::Result<()>;
-
     /// Specify this region as relocatable.
     fn relocation_region(
         &mut self,

--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -58,7 +58,8 @@ pub struct Vtl0Linux<'a> {
 #[derive(Debug)]
 pub struct Vtl0Config<'a> {
     pub supports_pcat: bool,
-    pub supports_uefi: Option<crate::uefi::LoadInfo>,
+    /// The load info and the VP context page.
+    pub supports_uefi: Option<(crate::uefi::LoadInfo, Vec<u8>)>,
     pub supports_linux: Option<Vtl0Linux<'a>>,
 }
 
@@ -100,7 +101,7 @@ pub enum CommandLineType<'a> {
 ///
 /// An optional `memory_page_base` may be specified. This will disable
 /// relocation support for underhill.
-pub fn load_underhill_x64<F>(
+pub fn load_openhcl_x64<F>(
     importer: &mut dyn ImageLoad<X86Register>,
     kernel_image: &mut F,
     shim: &mut F,
@@ -671,7 +672,7 @@ where
         measured_config.supported_vtl0.set_pcat_supported(true);
     }
 
-    if let Some(uefi) = supports_uefi {
+    if let Some((uefi, vp_context)) = &supports_uefi {
         measured_config.supported_vtl0.set_uefi_supported(true);
         let vp_context_page = free_page;
         free_page += 1;
@@ -686,15 +687,14 @@ where
             },
         };
 
-        // Tell the loader to deposit VTL0 vp context for UEFI at the allocated
-        // page.
-        //
-        // TODO: It might be better to have UEFI's LoadInfo contain the vp
-        // state? Right now, UEFI is the only thing that actually sets VTL0 vp
-        // context, but if PCAT/Linux did, this wouldn't work.
-        importer
-            .set_lower_vtl_context_page(vp_context_page)
-            .map_err(Error::Importer)?;
+        // Deposit the UEFI vp context.
+        importer.import_pages(
+            vp_context_page,
+            1,
+            "openhcl-uefi-vp-context",
+            BootPageAcceptance::Exclusive,
+            vp_context,
+        )?;
     }
 
     if let Some(linux) = supports_linux {
@@ -810,7 +810,7 @@ fn create_snp_cpuid_page() -> HV_PSP_CPUID_PAGE {
 ///
 /// An optional `memory_page_base` may be specified. This will disable
 /// relocation support for underhill.
-pub fn load_underhill_arm64<F>(
+pub fn load_openhcl_arm64<F>(
     importer: &mut dyn ImageLoad<Aarch64Register>,
     kernel_image: &mut F,
     shim: &mut F,
@@ -1041,7 +1041,7 @@ where
         ..FromZeroes::new_zeroed()
     };
 
-    if let Some(uefi) = supports_uefi {
+    if let Some((uefi, vp_context)) = &supports_uefi {
         measured_config.supported_vtl0.set_uefi_supported(true);
         let vp_context_page = PARAVISOR_VTL0_MEASURED_CONFIG_BASE_PAGE_AARCH64 + 1;
         measured_config.uefi_info = UefiInfo {
@@ -1055,15 +1055,14 @@ where
             },
         };
 
-        // Tell the loader to deposit VTL0 vp context for UEFI at the allocated
-        // page.
-        //
-        // TODO: It might be better to have UEFI's LoadInfo contain the vp
-        // state? Right now, UEFI is the only thing that actually sets VTL0 vp
-        // context, but if PCAT/Linux did, this wouldn't work.
-        importer
-            .set_lower_vtl_context_page(vp_context_page)
-            .map_err(Error::Importer)?;
+        // Deposit the UEFI vp context.
+        importer.import_pages(
+            vp_context_page,
+            1,
+            "openhcl-uefi-vp-context",
+            BootPageAcceptance::Exclusive,
+            vp_context,
+        )?;
     }
 
     importer

--- a/vmm_core/vm_loader/src/lib.rs
+++ b/vmm_core/vm_loader/src/lib.rs
@@ -265,10 +265,6 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
         unimplemented!()
     }
 
-    fn set_lower_vtl_context_page(&mut self, _page_base: u64) -> anyhow::Result<()> {
-        unimplemented!()
-    }
-
     fn create_parameter_area(
         &mut self,
         _page_base: u64,


### PR DESCRIPTION
Instead of having separate VTL0 and VTL2 fields in the igvmfilegen configuration, have a single "image" field specifying the actual boot image to load. Then, for the case of embedding UEFI firmware or a Linux kernel for OpenHCL to load, have explicit fields within the "openhcl" type of image.

This has a few advantages:

1. It allows a UEFI firmware to be provided even if OpenHCL is being loaded into VTL0 (i.e., for the nested virtualization configuration).

2. It acknowledges that the paravisor needs to understand the nested image type--it's not enough that igvmfilegen knows how to load something into VTL0, because (except for the UEFI case), the paravisor is still quite involved in the load process.

3. It is more flexible for the future. With this model, we can experiment with different, more powerful approaches to loading firmwares:

   * We can ship firmwares uninterpreted, e.g. just embed the UEFI firmware .fd file directly and do a full load from within OpenHCL.

   * Or we can continue to partially load them, but at an offset from where they eventually need to load.

   * We can ship multiple firmwares in a single IGVM file. This would be most interesting for supporting SeaBIOS and mu_mshv in a single image, or both the test Linux kernel and mu_mshv.

   * Or we can load externally provided firmwares, e.g. via vmbfs or fw_cfg.

   Admittedly, most of these are possible with the existing VTL0/VTL2 split, but they are less natural.