### PR TITLE
vmbus_client: eliminate extra text in inspect output

### DIFF
--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -472,9 +472,8 @@ impl Channel {
     }
 
     fn inspect(&self, resp: &mut inspect::Response<'_>) {
-        let name = format!("host relay channel - {}", self.interface_id_to_string());
         resp.display("state", &self.state)
-            .field("interface_name", name)
+            .field_with("interface_name", || self.interface_id_to_string())
             .display("instance_id", &self.offer.instance_id)
             .display("interface_id", &self.offer.interface_id)
             .field("mmio_megabytes", self.offer.mmio_megabytes)


### PR DESCRIPTION
Before:
```
    interface_name: "host relay channel - vpci",
```

After:
```
    interface_name: "vpci",
```

This is not ambiguous, so I'm not sure why we had the extra text to begin with.