### PR TITLE
guest_emulation_log: rename tracing target to paravisor_log

### DIFF
--- a/openvmm/hvlite_entry/src/tracing_init.rs
+++ b/openvmm/hvlite_entry/src/tracing_init.rs
@@ -24,9 +24,9 @@ pub fn enable_tracing() -> anyhow::Result<()> {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
-    // Enable tracing for underhill_log by default since this is passed through
+    // Enable tracing for paravisor_log by default since this is passed through
     // from the guest (but still allow it to be disabled via OPENVMM_LOG).
-    let base = "underhill_log=trace";
+    let base = "paravisor_log=trace";
     let filter = if let Ok(filter) = legacy_openvmm_env("OPENVMM_LOG") {
         tracing_subscriber::EnvFilter::try_new(format!("{base},{filter}"))
             .context("invalid OPENVMM_LOG")?

--- a/vm/devices/get/guest_emulation_log/src/lib.rs
+++ b/vm/devices/get/guest_emulation_log/src/lib.rs
@@ -196,7 +196,7 @@ impl<T: RingMem + Unpin> GelChannel<T> {
                 Ok(data) => match &*data.level {
                     "ERROR" => {
                         tracing::error!(
-                            target: "underhill_log",
+                            target: "paravisor_log",
                             inner_target = &*data.target,
                             message = data.fields.message.as_deref(),
                             fields = %data.fields.extra,
@@ -205,7 +205,7 @@ impl<T: RingMem + Unpin> GelChannel<T> {
                     }
                     "WARN" => {
                         tracing::warn!(
-                            target: "underhill_log",
+                            target: "paravisor_log",
                             inner_target = &*data.target,
                             message = data.fields.message.as_deref(),
                             fields = %data.fields.extra,
@@ -214,7 +214,7 @@ impl<T: RingMem + Unpin> GelChannel<T> {
                     }
                     "INFO" => {
                         tracing::info!(
-                            target: "underhill_log",
+                            target: "paravisor_log",
                             inner_target = &*data.target,
                             message = data.fields.message.as_deref(),
                             fields = %data.fields.extra,
@@ -223,7 +223,7 @@ impl<T: RingMem + Unpin> GelChannel<T> {
                     }
                     "DEBUG" => {
                         tracing::debug!(
-                            target: "underhill_log",
+                            target: "paravisor_log",
                             inner_target = &*data.target,
                             message = data.fields.message.as_deref(),
                             fields = %data.fields.extra,
@@ -232,7 +232,7 @@ impl<T: RingMem + Unpin> GelChannel<T> {
                     }
                     "TRACE" => {
                         tracing::trace!(
-                            target: "underhill_log",
+                            target: "paravisor_log",
                             inner_target = &*data.target,
                             message = data.fields.message.as_deref(),
                             fields = %data.fields.extra,
@@ -241,7 +241,7 @@ impl<T: RingMem + Unpin> GelChannel<T> {
                     }
                     some_level => {
                         tracing::info!(
-                            target: "underhill_log",
+                            target: "paravisor_log",
                             inner_level = some_level,
                             inner_target = &*data.target,
                             message = data.fields.message.as_deref(),
@@ -252,7 +252,7 @@ impl<T: RingMem + Unpin> GelChannel<T> {
                 },
                 Err(err) => {
                     tracing::warn!(
-                        target: "underhill_log",
+                        target: "paravisor_log",
                         inner_level = ?header.level,
                         error = &err as &dyn std::error::Error,
                         message = String::from_utf8_lossy(message).as_ref(),


### PR DESCRIPTION
Rename the trace target `underhill_log` to `paravisor_log` to be more generic.