### PR TITLE
RFC: enable openhcl to run in VTL0, use nested virtualization

### DIFF
--- a/.github/workflows/openvmm-ci.json
+++ b/.github/workflows/openvmm-ci.json
@@ -1,0 +1,3430 @@
+{
+  "flow_backend": "Github",
+  "var_db_backend_kind": "Json",
+  "job_reqs": {
+    "0": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fdc019ee4bc3ad94\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"debug_label\":\"guide\",\"done\":{\"backing_var\":\"start1\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_guide::publish:0:flowey_lib_hvlite/src/artifact_guide.rs:34:40\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"mdbook-mermaid-v0.14.0-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:0:flowey_lib_common/src/download_mdbook_mermaid.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-mermaid\",\"repo_owner\":\"badboy\",\"tag\":\"v0.14.0\"}",
+        "{\"file_name\":\"mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook:0:flowey_lib_common/src/download_mdbook.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdBook\",\"repo_owner\":\"rust-lang\",\"tag\":\"v0.4.40\"}",
+        "{\"file_name\":\"mdbook-admonish-v1.18.0-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:0:flowey_lib_common/src/download_mdbook_admonish.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-admonish\",\"repo_owner\":\"tommilligan\",\"tag\":\"v1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"GetMdbook\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:0:flowey_lib_hvlite/src/build_guide.rs:28:30\",\"is_secret\":false}}",
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"GetMdbookAdmonish\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:1:flowey_lib_hvlite/src/build_guide.rs:30:17\",\"is_secret\":false}}",
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"GetMdbookMermaid\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:2:flowey_lib_hvlite/src/build_guide.rs:32:17\",\"is_secret\":false}}",
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook:1:flowey_lib_common/src/download_mdbook.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:1:flowey_lib_common/src/download_mdbook_admonish.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:1:flowey_lib_common/src/download_mdbook_mermaid.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:6:flowey_lib_hvlite/src/build_guide.rs:38:37\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_guide": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start1\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_guide::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start1\",\"is_secret\":false},\"rendered_guide\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_guide:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guide.rs:30:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_guide": [
+        "{\"built_guide\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_guide:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guide.rs:30:34\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:3:flowey_lib_hvlite/src/build_guide.rs:35:14\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ]
+    },
+    "1": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:1:flowey_lib_common/src/run_cargo_doc.rs:115:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"debug_label\":\"rustdoc\",\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_rustdoc::publish:1:flowey_lib_hvlite/src/artifact_rustdoc.rs:48:33\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:0:flowey_lib_common/src/run_cargo_doc.rs:114:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_doc": [
+        "{\"cargo_cmd\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:3:flowey_lib_hvlite/src/build_rustdoc.rs:84:33\",\"is_secret\":false},\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\"},\"is_secret\":false},\"packages\":[{\"document_private_items\":false,\"kind\":{\"Workspace\":{\"exclude\":[\"vmfirmwareigvm_dll\"]}},\"no_deps\":true},{\"document_private_items\":false,\"kind\":{\"NoStdCrate\":\"guest_test_uefi\"},\"no_deps\":true}],\"target_triple\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"target_triple\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_rustdoc::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"rustdocs_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_rustdoc:0:flowey_lib_hvlite/src/_jobs/build_and_publish_rustdoc.rs:34:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_rustdoc": [
+        "{\"Doc\":{\"docs_dir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_rustdoc:0:flowey_lib_hvlite/src/_jobs/build_and_publish_rustdoc.rs:34:32\",\"is_secret\":false},\"target_triple\":\"x86_64-pc-windows-msvc\"}}",
+        "{\"SetDenyWarnings\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:2:flowey_lib_hvlite/src/build_rustdoc.rs:79:42\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:0:flowey_lib_hvlite/src/build_rustdoc.rs:60:37\",\"is_secret\":false}"
+      ]
+    },
+    "2": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:1:flowey_lib_common/src/run_cargo_doc.rs:115:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"debug_label\":\"rustdoc\",\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_rustdoc::publish:1:flowey_lib_hvlite/src/artifact_rustdoc.rs:48:33\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:0:flowey_lib_common/src/run_cargo_doc.rs:114:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_doc": [
+        "{\"cargo_cmd\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:3:flowey_lib_hvlite/src/build_rustdoc.rs:84:33\",\"is_secret\":false},\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\"},\"is_secret\":false},\"packages\":[{\"document_private_items\":false,\"kind\":{\"Workspace\":{\"exclude\":[\"vmfirmwareigvm_dll\"]}},\"no_deps\":true},{\"document_private_items\":false,\"kind\":{\"NoStdCrate\":\"guest_test_uefi\"},\"no_deps\":true}],\"target_triple\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"target_triple\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_rustdoc::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"rustdocs_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_rustdoc:0:flowey_lib_hvlite/src/_jobs/build_and_publish_rustdoc.rs:34:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_rustdoc": [
+        "{\"Doc\":{\"docs_dir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_rustdoc:0:flowey_lib_hvlite/src/_jobs/build_and_publish_rustdoc.rs:34:32\",\"is_secret\":false},\"target_triple\":\"x86_64-unknown-linux-gnu\"}}",
+        "{\"SetDenyWarnings\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:2:flowey_lib_hvlite/src/build_rustdoc.rs:79:42\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:0:flowey_lib_hvlite/src/build_rustdoc.rs:60:37\",\"is_secret\":false}"
+      ]
+    },
+    "3": {
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages": [
+        "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start4\",\"is_secret\":false},\"guide\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_guide\"},\"is_secret\":false},\"rustdoc_linux\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-rustdoc\"},\"is_secret\":false},\"rustdoc_windows\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-rustdoc\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_guide::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_guide\"},\"is_secret\":false},\"rendered_guide\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages:0:flowey_lib_hvlite/src/_jobs/consolidate_and_publish_gh_pages.rs:43:34\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_rustdoc::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-rustdoc\"},\"is_secret\":false},\"rustdocs_dir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages:2:flowey_lib_hvlite/src/_jobs/consolidate_and_publish_gh_pages.rs:53:33\",\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-rustdoc\"},\"is_secret\":false},\"rustdocs_dir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages:1:flowey_lib_hvlite/src/_jobs/consolidate_and_publish_gh_pages.rs:48:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ]
+    },
+    "4": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::check_xtask_fmt": [
+        "{\"done\":{\"backing_var\":\"start5\",\"is_secret\":false},\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::build_xtask": [
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_xtask_fmt:1:flowey_lib_hvlite/src/_jobs/check_xtask_fmt.rs:31:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_xtask_fmt:0:flowey_lib_hvlite/src/_jobs/check_xtask_fmt.rs:29:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:0:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ]
+    },
+    "5": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-185fb9aa857d6110\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::check_xtask_fmt": [
+        "{\"done\":{\"backing_var\":\"start6\",\"is_secret\":false},\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::build_xtask": [
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_xtask_fmt:1:flowey_lib_hvlite/src/_jobs/check_xtask_fmt.rs:31:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_xtask_fmt:0:flowey_lib_hvlite/src/_jobs/check_xtask_fmt.rs:29:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:0:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "6": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-igvmfilegen\"},\"is_secret\":false},\"debug_label\":\"igvmfilegen\",\"done\":{\"backing_var\":\"start9\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_igvmfilegen::publish:0:flowey_lib_hvlite/src/artifact_igvmfilegen.rs:37:37\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-ohcldiag-dev\"},\"is_secret\":false},\"debug_label\":\"ohcldiag-dev\",\"done\":{\"backing_var\":\"start10\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_ohcldiag_dev::publish:0:flowey_lib_hvlite/src/artifact_ohcldiag_dev.rs:37:38\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgs_lib\"},\"is_secret\":false},\"debug_label\":\"vmgs_lib\",\"done\":{\"backing_var\":\"start8\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgs_lib::publish:0:flowey_lib_hvlite/src/artifact_vmgs_lib.rs:37:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start7\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"encryption_win\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start9\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start10\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start8\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgstool": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start7\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_igvmfilegen::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start9\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_ohcldiag_dev::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start10\",\"is_secret\":false},\"ohcldiag_dev\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgs_lib::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start8\",\"is_secret\":false},\"vmgs_lib\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgstool::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start7\",\"is_secret\":false},\"vmgstool\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_and_test_vmgs_lib": [
+        "{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}},\"vmgs_lib\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_ohcldiag_dev": [
+        "{\"ohcldiag_dev\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::build_vmgstool": [
+        "{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}},\"vmgstool\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\",\"is_secret\":false},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_ohcldiag_dev:0:flowey_lib_hvlite/src/build_ohcldiag_dev.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"crate_type\":\"DynamicLib\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:1:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:61:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgstool\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"encryption_win\"],\"no_split_dbg_info\":false,\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:1:flowey_lib_hvlite/src/build_vmgstool.rs:55:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ]
+    },
+    "7": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-6fd9989180c5ad5c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:0:flowey_lib_common/src/run_cargo_nextest_archive.rs:40:31\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start12\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start13\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:1:flowey_lib_common/src/run_cargo_nextest_archive.rs:42:37\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:2:flowey_lib_common/src/run_cargo_nextest_archive.rs:44:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"openvmm\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_archive": [
+        "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:3:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:157:29\",\"is_secret\":false},\"build_params\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\"},\"is_secret\":false},\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start13\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openvmm": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start11\",\"is_secret\":false},\"features\":[],\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_pipette": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start12\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start13\",\"is_secret\":false},\"vmm_tests\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start11\",\"is_secret\":false},\"openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start12\",\"is_secret\":false},\"pipette\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_nextest_vmm_tests": [
+        "{\"build_mode\":{\"Archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\",\"is_secret\":false}},\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::build_openvmm": [
+        "{\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\",\"is_secret\":false},\"params\":{\"features\":[],\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}}"
+      ],
+      "flowey_lib_hvlite::build_pipette": [
+        "{\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"openvmm\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:98:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"pipette\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_pipette:0:flowey_lib_hvlite/src/build_pipette.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ]
+    },
+    "8": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-igvmfilegen\"},\"is_secret\":false},\"debug_label\":\"igvmfilegen\",\"done\":{\"backing_var\":\"start16\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_igvmfilegen::publish:0:flowey_lib_hvlite/src/artifact_igvmfilegen.rs:37:37\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-ohcldiag-dev\"},\"is_secret\":false},\"debug_label\":\"ohcldiag-dev\",\"done\":{\"backing_var\":\"start17\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_ohcldiag_dev::publish:0:flowey_lib_hvlite/src/artifact_ohcldiag_dev.rs:37:38\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgs_lib\"},\"is_secret\":false},\"debug_label\":\"vmgs_lib\",\"done\":{\"backing_var\":\"start15\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgs_lib::publish:0:flowey_lib_hvlite/src/artifact_vmgs_lib.rs:37:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start14\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:3:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:103:21\",\"is_secret\":false},\"package_names\":[\"clang\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"encryption_win\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start16\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start17\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start15\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgstool": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start14\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_igvmfilegen::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start16\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_ohcldiag_dev::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start17\",\"is_secret\":false},\"ohcldiag_dev\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgs_lib::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start15\",\"is_secret\":false},\"vmgs_lib\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgstool::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start14\",\"is_secret\":false},\"vmgstool\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_and_test_vmgs_lib": [
+        "{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"vmgs_lib\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_ohcldiag_dev": [
+        "{\"ohcldiag_dev\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::build_vmgstool": [
+        "{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"vmgstool\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\",\"is_secret\":false},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:4:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:108:41\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_ohcldiag_dev:0:flowey_lib_hvlite/src/build_ohcldiag_dev.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"crate_type\":\"DynamicLib\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:1:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:61:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgstool\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"encryption_win\"],\"no_split_dbg_info\":false,\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:1:flowey_lib_hvlite/src/build_vmgstool.rs:55:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ]
+    },
+    "9": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:0:flowey_lib_common/src/run_cargo_nextest_archive.rs:40:31\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start19\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start20\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:1:flowey_lib_common/src/run_cargo_nextest_archive.rs:42:37\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:2:flowey_lib_common/src/run_cargo_nextest_archive.rs:44:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"openvmm\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_archive": [
+        "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:3:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:157:29\",\"is_secret\":false},\"build_params\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\"},\"is_secret\":false},\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start20\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openvmm": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start18\",\"is_secret\":false},\"features\":[],\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_pipette": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start19\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start20\",\"is_secret\":false},\"vmm_tests\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start18\",\"is_secret\":false},\"openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start19\",\"is_secret\":false},\"pipette\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_nextest_vmm_tests": [
+        "{\"build_mode\":{\"Archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\",\"is_secret\":false}},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::build_openvmm": [
+        "{\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\",\"is_secret\":false},\"params\":{\"features\":[],\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}}"
+      ],
+      "flowey_lib_hvlite::build_pipette": [
+        "{\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"openvmm\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:98:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"pipette\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_pipette:0:flowey_lib_hvlite/src/build_pipette.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ]
+    },
+    "10": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-82559e949fe64647\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-guest_test_uefi\"},\"is_secret\":false},\"debug_label\":\"guest_test_uefi\",\"done\":{\"backing_var\":\"start26\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_guest_test_uefi::publish:0:flowey_lib_hvlite/src/artifact_guest_test_uefi.rs:36:41\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-igvmfilegen\"},\"is_secret\":false},\"debug_label\":\"igvmfilegen\",\"done\":{\"backing_var\":\"start24\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_igvmfilegen::publish:0:flowey_lib_hvlite/src/artifact_igvmfilegen.rs:37:37\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-ohcldiag-dev\"},\"is_secret\":false},\"debug_label\":\"ohcldiag-dev\",\"done\":{\"backing_var\":\"start25\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_ohcldiag_dev::publish:0:flowey_lib_hvlite/src/artifact_ohcldiag_dev.rs:37:38\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgs_lib\"},\"is_secret\":false},\"debug_label\":\"vmgs_lib\",\"done\":{\"backing_var\":\"start23\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgs_lib::publish:0:flowey_lib_hvlite/src/artifact_vmgs_lib.rs:37:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start22\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\",\"is_secret\":false},\"package_names\":[\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:0:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:2:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:4:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:6:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:8:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-uefi\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"guest_test_uefi\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"guest_test_uefi\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-uefi\"}",
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:13:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openvmm\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:27:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"encryption_ossl\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:30:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
+        "{\"arch\":\"Aarch64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start26\",\"is_secret\":false},\"profile\":\"Release\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start24\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start25\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openvmm": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start21\",\"is_secret\":false},\"features\":[\"Tpm\"],\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start23\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgstool": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start22\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_guest_test_uefi::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start26\",\"is_secret\":false},\"guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guest_test_uefi.rs:38:35\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_igvmfilegen::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start24\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_ohcldiag_dev::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start25\",\"is_secret\":false},\"ohcldiag_dev\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start21\",\"is_secret\":false},\"openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgs_lib::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start23\",\"is_secret\":false},\"vmgs_lib\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgstool::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start22\",\"is_secret\":false},\"vmgstool\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_and_test_vmgs_lib": [
+        "{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}},\"vmgs_lib\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_guest_test_uefi": [
+        "{\"arch\":\"Aarch64\",\"guest_test_uefi\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guest_test_uefi.rs:38:35\",\"is_secret\":false},\"profile\":\"Release\"}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_ohcldiag_dev": [
+        "{\"ohcldiag_dev\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::build_openvmm": [
+        "{\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\",\"is_secret\":false},\"params\":{\"features\":[\"Tpm\"],\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}}"
+      ],
+      "flowey_lib_hvlite::build_vmgstool": [
+        "{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}},\"vmgstool\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\",\"is_secret\":false},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_guest_test_uefi:1:flowey_lib_hvlite/src/build_guest_test_uefi.rs:75:41\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-uefi\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"guest_test_uefi\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"guest_test_uefi\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_guest_test_uefi:0:flowey_lib_hvlite/src/build_guest_test_uefi.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"aarch64-unknown-uefi\"}",
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_ohcldiag_dev:0:flowey_lib_hvlite/src/build_ohcldiag_dev.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openvmm\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"tpm\"],\"no_split_dbg_info\":false,\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:3:flowey_lib_hvlite/src/build_openvmm.rs:98:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"crate_type\":\"DynamicLib\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:1:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:61:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgstool\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"encryption_ossl\"],\"no_split_dbg_info\":false,\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:1:flowey_lib_hvlite/src/build_vmgstool.rs:55:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:14:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:31:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:33:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:34:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "11": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:0:flowey_lib_common/src/run_cargo_nextest_archive.rs:40:31\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-guest_test_uefi\"},\"is_secret\":false},\"debug_label\":\"guest_test_uefi\",\"done\":{\"backing_var\":\"start32\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_guest_test_uefi::publish:0:flowey_lib_hvlite/src/artifact_guest_test_uefi.rs:36:41\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-igvmfilegen\"},\"is_secret\":false},\"debug_label\":\"igvmfilegen\",\"done\":{\"backing_var\":\"start30\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_igvmfilegen::publish:0:flowey_lib_hvlite/src/artifact_igvmfilegen.rs:37:37\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-ohcldiag-dev\"},\"is_secret\":false},\"debug_label\":\"ohcldiag-dev\",\"done\":{\"backing_var\":\"start31\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_ohcldiag_dev::publish:0:flowey_lib_hvlite/src/artifact_ohcldiag_dev.rs:37:38\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgs_lib\"},\"is_secret\":false},\"debug_label\":\"vmgs_lib\",\"done\":{\"backing_var\":\"start29\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgs_lib::publish:0:flowey_lib_hvlite/src/artifact_vmgs_lib.rs:37:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start28\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start33\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:1:flowey_lib_common/src/run_cargo_nextest_archive.rs:42:37\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\",\"is_secret\":false},\"package_names\":[\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:3:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:103:21\",\"is_secret\":false},\"package_names\":[\"clang\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:2:flowey_lib_common/src/run_cargo_nextest_archive.rs:44:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-uefi\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"guest_test_uefi\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"guest_test_uefi\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-uefi\"}",
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:13:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openvmm\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:27:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"encryption_ossl\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:30:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_archive": [
+        "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:3:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:157:29\",\"is_secret\":false},\"build_params\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\"},\"is_secret\":false},\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
+        "{\"arch\":\"X86_64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start32\",\"is_secret\":false},\"profile\":\"Release\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start30\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start33\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start31\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openvmm": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start27\",\"is_secret\":false},\"features\":[\"Tpm\"],\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start29\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgstool": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start28\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_guest_test_uefi::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start32\",\"is_secret\":false},\"guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guest_test_uefi.rs:38:35\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_igvmfilegen::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start30\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start33\",\"is_secret\":false},\"vmm_tests\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_ohcldiag_dev::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start31\",\"is_secret\":false},\"ohcldiag_dev\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start27\",\"is_secret\":false},\"openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgs_lib::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start29\",\"is_secret\":false},\"vmgs_lib\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgstool::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start28\",\"is_secret\":false},\"vmgstool\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_and_test_vmgs_lib": [
+        "{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"vmgs_lib\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_guest_test_uefi": [
+        "{\"arch\":\"X86_64\",\"guest_test_uefi\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guest_test_uefi.rs:38:35\",\"is_secret\":false},\"profile\":\"Release\"}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_nextest_vmm_tests": [
+        "{\"build_mode\":{\"Archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\",\"is_secret\":false}},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::build_ohcldiag_dev": [
+        "{\"ohcldiag_dev\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::build_openvmm": [
+        "{\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\",\"is_secret\":false},\"params\":{\"features\":[\"Tpm\"],\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}}"
+      ],
+      "flowey_lib_hvlite::build_vmgstool": [
+        "{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"vmgstool\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\",\"is_secret\":false},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:4:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:108:41\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_guest_test_uefi:1:flowey_lib_hvlite/src/build_guest_test_uefi.rs:75:41\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-uefi\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"guest_test_uefi\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"guest_test_uefi\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_guest_test_uefi:0:flowey_lib_hvlite/src/build_guest_test_uefi.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-unknown-uefi\"}",
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_ohcldiag_dev:0:flowey_lib_hvlite/src/build_ohcldiag_dev.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openvmm\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"tpm\"],\"no_split_dbg_info\":false,\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:3:flowey_lib_hvlite/src/build_openvmm.rs:98:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"crate_type\":\"DynamicLib\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:1:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:61:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgstool\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"encryption_ossl\"],\"no_split_dbg_info\":false,\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:1:flowey_lib_hvlite/src/build_vmgstool.rs:55:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:14:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:31:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:33:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:34:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "12": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-54d538eb47bfa81c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm-extras\"},\"is_secret\":false},\"debug_label\":\"OpenHCL igvm extras\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:23:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:107:30\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm\"},\"is_secret\":false},\"debug_label\":\"OpenHCL igvm files\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:22:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:99:30\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-musl-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start35\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-arm64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
+        "{\"file_name\":\"RELEASE-AARCH64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:111:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:8:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:0:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:2:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:4:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:0:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:0:flowey_lib_hvlite/src/build_openhcl_initrd.rs:63:17\",\"is_secret\":false},\"package_names\":[\"python3\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openhcl_boot\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:13:flowey_lib_hvlite/src/run_cargo_build.rs:367:22\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:15:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"boot-release\"},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"openvmm_hcl\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:22:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"underhill-ship\"},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:27:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
+        "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start34\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"Aarch64\"},{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"Aarch64Devkern\"}]}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_pipette": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-musl-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start35\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxMusl\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:22:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:99:30\",\"is_secret\":false},\"openhcl_igvm_files\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:3:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:14:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:23:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:107:30\",\"is_secret\":false},\"extras\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:9:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:20:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-musl-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start35\",\"is_secret\":false},\"pipette\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:32:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}",
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:4:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_boot": [
+        "{\"build_params\":{\"arch\":\"Aarch64\",\"profile\":\"Release\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:33:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}",
+        "{\"build_params\":{\"arch\":\"Aarch64\",\"profile\":\"Release\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:5:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_igvm_from_recipe": [
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"Aarch64\"}",
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:12:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:13:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:11:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"Aarch64Devkern\"}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_initrd": [
+        "{\"arch\":\"Aarch64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:18:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:20:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":false,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:16:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}",
+        "{\"arch\":\"Aarch64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:46:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:48:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":false,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:29:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:44:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::build_openvmm_hcl": [
+        "{\"build_params\":{\"features\":[\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"OpenvmmHclShip\",\"target\":{\"Custom\":\"aarch64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:31:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}",
+        "{\"build_params\":{\"features\":[\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"OpenvmmHclShip\",\"target\":{\"Custom\":\"aarch64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:3:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_pipette": [
+        "{\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxMusl\"}}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:0:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"kind\":\"Dev\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:29:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetOpenhclCpioShell\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:2:flowey_lib_hvlite/src/build_openhcl_initrd.rs:99:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioShell\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:4:flowey_lib_hvlite/src/build_openhcl_initrd.rs:99:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclSysroot\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:1:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:52:46\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"GetMsvmFd\":{\"arch\":\"Aarch64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:405:21\",\"is_secret\":false}}}",
+        "{\"GetMsvmFd\":{\"arch\":\"Aarch64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:30:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:405:21\",\"is_secret\":false}}}",
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:0:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:28:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:1:flowey_lib_hvlite/src/build_openhcl_initrd.rs:70:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:22:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot": [
+        "{\"arch\":\"Aarch64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openhcl_boot\",\"crate_type\":\"Bin\",\"extra_env\":{\"backing_var\":{\"Inline\":{\"MINIMAL_RT_BUILD\":\"1\"}},\"is_secret\":false},\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_boot:0:flowey_lib_hvlite/src/build_openhcl_boot.rs:82:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"BootRelease\",\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"openvmm_hcl\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"tpm\"],\"no_split_dbg_info\":true,\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm_hcl:1:flowey_lib_hvlite/src/build_openvmm_hcl.rs:104:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\"},\"is_secret\":false}],\"profile\":\"UnderhillShip\",\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"pipette\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_pipette:0:flowey_lib_hvlite/src/build_pipette.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::run_igvmfilegen": [
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:24:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:26:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:23:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:13:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:52:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:54:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:51:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:37:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:35:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:36:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:9:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:7:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:8:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:28:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:30:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:31:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "13": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-b130c166bdbdc2a8\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm-extras\"},\"is_secret\":false},\"debug_label\":\"OpenHCL igvm extras\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:56:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:107:30\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm\"},\"is_secret\":false},\"debug_label\":\"OpenHCL igvm files\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:55:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:99:30\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start37\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:5:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-cvm-x64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-x64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:10:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:12:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:14:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:8:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:0:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:0:flowey_lib_hvlite/src/build_openhcl_initrd.rs:63:17\",\"is_secret\":false},\"package_names\":[\"python3\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-none\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openhcl_boot\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:367:22\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:14:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"boot-release\"},\"target\":\"x86_64-unknown-none\"}",
+        "{\"crate_name\":\"openvmm_hcl\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:22:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"underhill-ship\"},\"target\":\"x86_64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
+        "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start36\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64Devkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64TestLinuxDirect\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64TestLinuxDirectDevkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64Cvm\"}]}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_pipette": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start37\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxMusl\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:55:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:99:30\",\"is_secret\":false},\"openhcl_igvm_files\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:3:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:14:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:25:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:36:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:47:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:56:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:107:30\",\"is_secret\":false},\"extras\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:9:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:20:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:31:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:42:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:53:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start37\",\"is_secret\":false},\"pipette\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:118:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}",
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:32:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}",
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:4:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}",
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:60:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}",
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:89:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_boot": [
+        "{\"build_params\":{\"arch\":\"X86_64\",\"profile\":\"Release\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:119:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}",
+        "{\"build_params\":{\"arch\":\"X86_64\",\"profile\":\"Release\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:33:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}",
+        "{\"build_params\":{\"arch\":\"X86_64\",\"profile\":\"Release\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:5:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}",
+        "{\"build_params\":{\"arch\":\"X86_64\",\"profile\":\"Release\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:61:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}",
+        "{\"build_params\":{\"arch\":\"X86_64\",\"profile\":\"Release\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:90:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_igvm_from_recipe": [
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64\"}",
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:45:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:46:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:44:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64Cvm\"}",
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:12:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:13:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:11:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64Devkern\"}",
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:23:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:24:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:22:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64TestLinuxDirect\"}",
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:34:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:35:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:33:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"OpenvmmHclShip\",\"recipe\":\"X64TestLinuxDirectDevkern\"}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_initrd": [
+        "{\"arch\":\"X86_64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:103:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:105:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":false,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:85:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:101:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}",
+        "{\"arch\":\"X86_64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:132:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:134:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":false,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:114:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:130:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}",
+        "{\"arch\":\"X86_64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:18:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:20:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":false,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:16:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}",
+        "{\"arch\":\"X86_64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:46:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:48:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":false,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:29:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:44:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}",
+        "{\"arch\":\"X86_64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:74:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:76:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":false,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:57:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:72:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::build_openvmm_hcl": [
+        "{\"build_params\":{\"features\":[\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"OpenvmmHclShip\",\"target\":{\"Custom\":\"x86_64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:117:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}",
+        "{\"build_params\":{\"features\":[\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"OpenvmmHclShip\",\"target\":{\"Custom\":\"x86_64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:31:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}",
+        "{\"build_params\":{\"features\":[\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"OpenvmmHclShip\",\"target\":{\"Custom\":\"x86_64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:3:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}",
+        "{\"build_params\":{\"features\":[\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"OpenvmmHclShip\",\"target\":{\"Custom\":\"x86_64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:59:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}",
+        "{\"build_params\":{\"features\":[\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"OpenvmmHclShip\",\"target\":{\"Custom\":\"x86_64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:88:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_pipette": [
+        "{\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\",\"is_secret\":false},\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxMusl\"}}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:0:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Cvm\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:29:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Dev\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:114:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Dev\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:57:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:85:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:116:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:433:30\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:87:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:433:30\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestKernel\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:115:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:420:52\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestKernel\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:86:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:420:52\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioShell\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:10:flowey_lib_hvlite/src/build_openhcl_initrd.rs:99:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioShell\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:2:flowey_lib_hvlite/src/build_openhcl_initrd.rs:99:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioShell\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:4:flowey_lib_hvlite/src/build_openhcl_initrd.rs:99:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioShell\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:6:flowey_lib_hvlite/src/build_openhcl_initrd.rs:99:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioShell\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:8:flowey_lib_hvlite/src/build_openhcl_initrd.rs:99:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclSysroot\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:1:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:52:46\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:405:21\",\"is_secret\":false}}}",
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:30:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:405:21\",\"is_secret\":false}}}",
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:58:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:405:21\",\"is_secret\":false}}}",
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:0:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:113:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:28:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:56:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:84:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:1:flowey_lib_hvlite/src/build_openhcl_initrd.rs:70:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-none\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot": [
+        "{\"arch\":\"X64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\",\"is_secret\":false}}",
+        "{\"arch\":\"X64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\",\"is_secret\":false}}",
+        "{\"arch\":\"X64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openhcl_boot\",\"crate_type\":\"Bin\",\"extra_env\":{\"backing_var\":{\"Inline\":{\"MINIMAL_RT_BUILD\":\"1\"}},\"is_secret\":false},\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_boot:0:flowey_lib_hvlite/src/build_openhcl_boot.rs:82:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"BootRelease\",\"target\":\"x86_64-unknown-none\"}",
+        "{\"crate_name\":\"openvmm_hcl\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"tpm\"],\"no_split_dbg_info\":true,\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm_hcl:1:flowey_lib_hvlite/src/build_openvmm_hcl.rs:104:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\"},\"is_secret\":false}],\"profile\":\"UnderhillShip\",\"target\":\"x86_64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"pipette\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_pipette:0:flowey_lib_hvlite/src/build_pipette.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::run_igvmfilegen": [
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:24:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:109:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:111:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:108:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:35:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:138:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:140:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:137:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:24:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:26:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:23:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:46:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:52:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:54:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:51:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:13:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:80:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:82:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:79:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:123:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:121:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:122:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:37:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:35:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:36:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:65:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:63:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:64:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:94:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:92:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:93:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:9:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:7:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:8:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:15:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:27:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:30:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "14": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-38b54383c2832bcf\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:1:flowey_lib_common/src/run_cargo_clippy.rs:48:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:187:43\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:1:flowey_lib_common/src/run_cargo_nextest_run.rs:190:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:9:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:0:flowey_lib_common/src/run_cargo_clippy.rs:47:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:2:flowey_lib_common/src/run_cargo_nextest_run.rs:192:46\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:3:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:69:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:68:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-windows-unit-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_common::run_cargo_clippy": [
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:9:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:10:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\",\"tests\":true}",
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:7:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:5:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\",\"tests\":true}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":{\"Specific\":[\"ci\"]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_doc_tests": [
+        "{\"done\":{\"backing_var\":\"start41\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
+        "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start40\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-windows-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::check_clippy": [
+        "{\"also_check_misc_nostd_crates\":false,\"done\":{\"backing_var\":\"start39\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"also_check_misc_nostd_crates\":false,\"done\":{\"backing_var\":\"start38\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::build_nextest_unit_tests": [
+        "{\"build_mode\":{\"ImmediatelyRun\":{\"nextest_profile\":\"Ci\",\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false}}},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::build_xtask": [
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:0:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:88:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:2:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:40:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:5:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:1:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:93:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:39:34\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:10:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:0:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:2:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:4:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":null,\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":{\"Specific\":[\"ci\"]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}}}"
+      ]
+    },
+    "15": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-763048f92183c49f\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:1:flowey_lib_common/src/run_cargo_clippy.rs:48:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:187:43\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:1:flowey_lib_common/src/run_cargo_nextest_run.rs:190:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:0:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:16:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:0:flowey_lib_common/src/run_cargo_clippy.rs:47:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:2:flowey_lib_common/src/run_cargo_nextest_run.rs:192:46\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-apple-darwin\"}",
+        "{\"InstallTargetTriple\":\"aarch64-apple-darwin\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:3:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:69:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:68:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-linux-unit-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_common::run_cargo_clippy": [
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:7:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:9:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:10:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\",\"tests\":true}",
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:22:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:21:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:20:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:16:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:18:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\",\"tests\":true}",
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:5:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":[[\"SPARSE_MMAP_NO_BUILD\",\"1\"]],\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-apple-darwin\",\"tests\":true}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_doc_tests": [
+        "{\"done\":{\"backing_var\":\"start46\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
+        "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start45\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::check_clippy": [
+        "{\"also_check_misc_nostd_crates\":false,\"done\":{\"backing_var\":\"start44\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"aarch64-apple-darwin\"}",
+        "{\"also_check_misc_nostd_crates\":false,\"done\":{\"backing_var\":\"start43\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"also_check_misc_nostd_crates\":false,\"done\":{\"backing_var\":\"start42\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::build_nextest_unit_tests": [
+        "{\"build_mode\":{\"ImmediatelyRun\":{\"nextest_profile\":\"Ci\",\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false}}},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::build_xtask": [
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:19:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:0:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:88:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:2:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:40:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:20:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:1:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:93:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:10:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:18:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:7:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:39:34\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:9:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:0:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:2:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:4:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:6:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":null,\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}}}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:13:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:14:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:27:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:28:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "16": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-776396c93f9413c8\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:1:flowey_lib_common/src/run_cargo_clippy.rs:48:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:187:43\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:1:flowey_lib_common/src/run_cargo_nextest_run.rs:190:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:2:flowey_lib_hvlite/src/download_openvmm_deps.rs:111:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:0:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:0:flowey_lib_common/src/run_cargo_clippy.rs:47:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:2:flowey_lib_common/src/run_cargo_nextest_run.rs:192:46\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-uefi\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-uefi\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-none\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-none\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-uefi\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-uefi\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:3:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:69:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:68:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-linux-musl-unit-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_common::run_cargo_clippy": [
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:19:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:18:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\",\"tests\":true}",
+        "{\"all_targets\":false,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:21:flowey_lib_hvlite/src/_jobs/check_clippy.rs:249:27\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"Inline\":null},\"is_secret\":false},\"extra_env\":null,\"features\":null,\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":{\"Crate\":\"guest_test_uefi\"},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-uefi\",\"tests\":false}",
+        "{\"all_targets\":false,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:20:flowey_lib_hvlite/src/_jobs/check_clippy.rs:233:27\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"Inline\":null},\"is_secret\":false},\"extra_env\":[[\"MINIMAL_RT_BUILD\",\"1\"]],\"features\":null,\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":{\"Crate\":\"openhcl_boot\"},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-none\",\"tests\":false}",
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:7:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-musl\",\"tests\":true}",
+        "{\"all_targets\":false,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:10:flowey_lib_hvlite/src/_jobs/check_clippy.rs:249:27\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"Inline\":null},\"is_secret\":false},\"extra_env\":null,\"features\":null,\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":{\"Crate\":\"guest_test_uefi\"},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-uefi\",\"tests\":false}",
+        "{\"all_targets\":false,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:9:flowey_lib_hvlite/src/_jobs/check_clippy.rs:233:27\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"Inline\":null},\"is_secret\":false},\"extra_env\":[[\"MINIMAL_RT_BUILD\",\"1\"]],\"features\":null,\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":{\"Crate\":\"openhcl_boot\"},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-musl\",\"tests\":false}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:186:25\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:6:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_doc_tests": [
+        "{\"done\":{\"backing_var\":\"start50\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
+        "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start49\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-musl-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::check_clippy": [
+        "{\"also_check_misc_nostd_crates\":true,\"done\":{\"backing_var\":\"start48\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"also_check_misc_nostd_crates\":true,\"done\":{\"backing_var\":\"start47\",\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::build_nextest_unit_tests": [
+        "{\"build_mode\":{\"ImmediatelyRun\":{\"nextest_profile\":\"Ci\",\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false}}},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::build_xtask": [
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:16:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:5:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:0:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:88:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:2:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:0:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetOpenhclSysroot\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:1:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:52:46\",\"is_secret\":false}]}",
+        "{\"GetOpenhclSysroot\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:3:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:52:46\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:40:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:1:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:93:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:6:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot": [
+        "{\"arch\":\"Aarch64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\",\"is_secret\":false}}",
+        "{\"arch\":\"X64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\",\"is_secret\":false}}",
+        "{\"arch\":\"X64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:186:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:39:34\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:0:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:2:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:4:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":null,\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:186:25\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:6:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}}}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:13:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:14:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "17": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallStandalone\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:207:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_azcopy:2:flowey_lib_common/src/download_azcopy.rs:68:36\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{\"crash-dumps\":[{\"backing_var\":{\"Inline\":\"C:\\\\Users\\\\cloudtest\\\\AppData\\\\Local\\\\CrashDumps\"},\"is_secret\":false},true],\"logs\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\"},\"is_secret\":false},false],\"openhcl-dumps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\"},\"is_secret\":false},false]},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:15:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:210:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:13:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:209:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-windows-intel-vmm-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":null,\"dep_artifact_dirs\":{\"artifact_dir_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_files\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-openvmm\"},\"is_secret\":false},\"artifact_dir_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"artifact_dir_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false}},\"done\":{\"backing_var\":\"start51\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-windows-intel-vmm-tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"target\":\"x86_64-pc-windows-msvc\",\"vmm_tests_artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_guest_test_uefi::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"guest_test_uefi\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"nextest_archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-openhcl-igvm\"},\"is_secret\":false},\"igvm_files\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:124:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-openvmm\"},\"is_secret\":false},\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\",\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:1:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:59:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestKernel\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:1:flowey_lib_hvlite/src/init_vmm_tests_env.rs:88:37\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_vmm_tests_vhds": [
+        "{\"DownloadIsos\":[\"FreeBsd13_2\"]}",
+        "{\"DownloadVhds\":[\"FreeBsd13_2\",\"Gen1WindowsDataCenterCore2022\",\"Gen2WindowsDataCenterCore2022\",\"Ubuntu2204Server\"]}",
+        "{\"GetDownloadFolder\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:0:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:49:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:2:flowey_lib_hvlite/src/init_vmm_tests_env.rs:92:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_vmm_tests_env": [
+        "{\"disk_images_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\"},\"is_secret\":false},\"get_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\",\"is_secret\":false},\"get_openhcl_dump_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\",\"is_secret\":false},\"get_test_log_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\",\"is_secret\":false},\"register_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\"},\"is_secret\":false},\"register_openhcl_igvm_files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:124:17\"},\"is_secret\":false},\"register_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\"},\"is_secret\":false},\"register_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\"},\"is_secret\":false},\"register_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\"},\"is_secret\":false},\"test_content_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:1:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"vmm_tests_target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::test_nextest_vmm_tests_archive": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"nextest_archive_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\"},\"is_secret\":false},\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false}}"
+      ]
+    },
+    "18": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallStandalone\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:207:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_azcopy:2:flowey_lib_common/src/download_azcopy.rs:68:36\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{\"crash-dumps\":[{\"backing_var\":{\"Inline\":\"C:\\\\Users\\\\cloudtest\\\\AppData\\\\Local\\\\CrashDumps\"},\"is_secret\":false},true],\"logs\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\"},\"is_secret\":false},false],\"openhcl-dumps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\"},\"is_secret\":false},false]},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:15:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:210:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:13:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:209:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-windows-amd-vmm-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":null,\"dep_artifact_dirs\":{\"artifact_dir_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_files\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-openvmm\"},\"is_secret\":false},\"artifact_dir_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"artifact_dir_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false}},\"done\":{\"backing_var\":\"start52\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-windows-amd-vmm-tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"target\":\"x86_64-pc-windows-msvc\",\"vmm_tests_artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_guest_test_uefi::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"guest_test_uefi\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"nextest_archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-openhcl-igvm\"},\"is_secret\":false},\"igvm_files\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:124:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-openvmm\"},\"is_secret\":false},\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\",\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:1:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:59:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestKernel\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:1:flowey_lib_hvlite/src/init_vmm_tests_env.rs:88:37\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_vmm_tests_vhds": [
+        "{\"DownloadIsos\":[\"FreeBsd13_2\"]}",
+        "{\"DownloadVhds\":[\"FreeBsd13_2\",\"Gen1WindowsDataCenterCore2022\",\"Gen2WindowsDataCenterCore2022\",\"Ubuntu2204Server\"]}",
+        "{\"GetDownloadFolder\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:0:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:49:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:2:flowey_lib_hvlite/src/init_vmm_tests_env.rs:92:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_vmm_tests_env": [
+        "{\"disk_images_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\"},\"is_secret\":false},\"get_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\",\"is_secret\":false},\"get_openhcl_dump_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\",\"is_secret\":false},\"get_test_log_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\",\"is_secret\":false},\"register_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\"},\"is_secret\":false},\"register_openhcl_igvm_files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:124:17\"},\"is_secret\":false},\"register_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\"},\"is_secret\":false},\"register_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\"},\"is_secret\":false},\"register_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\"},\"is_secret\":false},\"test_content_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:1:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"vmm_tests_target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::test_nextest_vmm_tests_archive": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"nextest_archive_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\"},\"is_secret\":false},\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false}}"
+      ]
+    },
+    "19": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallStandalone\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:207:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_azcopy:2:flowey_lib_common/src/download_azcopy.rs:68:36\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{\"crash-dumps\":[{\"backing_var\":{\"Inline\":\"/will/not/exist\"},\"is_secret\":false},true],\"logs\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\"},\"is_secret\":false},false],\"openhcl-dumps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\"},\"is_secret\":false},false]},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:14:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:210:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:209:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-linux-vmm-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all() and not test(openhcl) and not test(pcat_x64)\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"auto_se:flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_core/src/node.rs:852:34\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:1:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":null,\"dep_artifact_dirs\":{\"artifact_dir_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_files\":null,\"artifact_dir_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-openvmm\"},\"is_secret\":false},\"artifact_dir_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"artifact_dir_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false}},\"done\":{\"backing_var\":\"start53\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-vmm-tests\",\"nextest_filter_expr\":\"all() and not test(openhcl) and not test(pcat_x64)\",\"nextest_profile\":\"Ci\",\"target\":\"x86_64-unknown-linux-gnu\",\"vmm_tests_artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_guest_test_uefi::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"guest_test_uefi\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false},\"nextest_archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-openvmm\"},\"is_secret\":false},\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\",\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:1:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:59:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestKernel\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:1:flowey_lib_hvlite/src/init_vmm_tests_env.rs:88:37\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_vmm_tests_vhds": [
+        "{\"DownloadIsos\":[\"FreeBsd13_2\"]}",
+        "{\"DownloadVhds\":[\"FreeBsd13_2\",\"Gen1WindowsDataCenterCore2022\",\"Gen2WindowsDataCenterCore2022\",\"Ubuntu2204Server\"]}",
+        "{\"GetDownloadFolder\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:0:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:49:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:2:flowey_lib_hvlite/src/init_vmm_tests_env.rs:92:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_vmm_tests_env": [
+        "{\"disk_images_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\"},\"is_secret\":false},\"get_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\",\"is_secret\":false},\"get_openhcl_dump_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\",\"is_secret\":false},\"get_test_log_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\",\"is_secret\":false},\"register_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\"},\"is_secret\":false},\"register_openhcl_igvm_files\":null,\"register_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\"},\"is_secret\":false},\"register_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\"},\"is_secret\":false},\"register_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\"},\"is_secret\":false},\"test_content_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:1:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"vmm_tests_target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all() and not test(openhcl) and not test(pcat_x64)\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"auto_se:flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_core/src/node.rs:852:34\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:1:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::test_nextest_vmm_tests_archive": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"nextest_archive_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\"},\"is_secret\":false},\"nextest_filter_expr\":\"all() and not test(openhcl) and not test(pcat_x64)\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false}}"
+      ]
+    },
+    "20": {
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:1:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:31:32\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm": [
+        "{\"base_recipe\":\"X64\",\"done\":{\"backing_var\":\"start54\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:0:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:30:31\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ]
+    }
+  }
+}

--- a/.github/workflows/openvmm-pr.json
+++ b/.github/workflows/openvmm-pr.json
@@ -1,0 +1,3423 @@
+{
+  "flow_backend": "Github",
+  "var_db_backend_kind": "Json",
+  "job_reqs": {
+    "0": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fdc019ee4bc3ad94\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"debug_label\":\"guide\",\"done\":{\"backing_var\":\"start1\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_guide::publish:0:flowey_lib_hvlite/src/artifact_guide.rs:34:40\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"mdbook-mermaid-v0.14.0-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:0:flowey_lib_common/src/download_mdbook_mermaid.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-mermaid\",\"repo_owner\":\"badboy\",\"tag\":\"v0.14.0\"}",
+        "{\"file_name\":\"mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook:0:flowey_lib_common/src/download_mdbook.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdBook\",\"repo_owner\":\"rust-lang\",\"tag\":\"v0.4.40\"}",
+        "{\"file_name\":\"mdbook-admonish-v1.18.0-x86_64-unknown-linux-gnu.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:0:flowey_lib_common/src/download_mdbook_admonish.rs:61:30\",\"is_secret\":false},\"repo_name\":\"mdbook-admonish\",\"repo_owner\":\"tommilligan\",\"tag\":\"v1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"GetMdbook\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:0:flowey_lib_hvlite/src/build_guide.rs:28:30\",\"is_secret\":false}}",
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"GetMdbookAdmonish\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:1:flowey_lib_hvlite/src/build_guide.rs:30:17\",\"is_secret\":false}}",
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"GetMdbookMermaid\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:2:flowey_lib_hvlite/src/build_guide.rs:32:17\",\"is_secret\":false}}",
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook:1:flowey_lib_common/src/download_mdbook.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_admonish:1:flowey_lib_common/src/download_mdbook_admonish.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_mdbook_mermaid:1:flowey_lib_common/src/download_mdbook_mermaid.rs:70:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:6:flowey_lib_hvlite/src/build_guide.rs:38:37\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_guide": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start1\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_guide::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_guide\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start1\",\"is_secret\":false},\"rendered_guide\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_guide:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guide.rs:30:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_guide": [
+        "{\"built_guide\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_guide:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guide.rs:30:34\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_guide:3:flowey_lib_hvlite/src/build_guide.rs:35:14\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ]
+    },
+    "1": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:1:flowey_lib_common/src/run_cargo_doc.rs:115:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"debug_label\":\"rustdoc\",\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_rustdoc::publish:1:flowey_lib_hvlite/src/artifact_rustdoc.rs:48:33\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:0:flowey_lib_common/src/run_cargo_doc.rs:114:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_doc": [
+        "{\"cargo_cmd\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:3:flowey_lib_hvlite/src/build_rustdoc.rs:84:33\",\"is_secret\":false},\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\"},\"is_secret\":false},\"packages\":[{\"document_private_items\":false,\"kind\":{\"Workspace\":{\"exclude\":[\"vmfirmwareigvm_dll\"]}},\"no_deps\":true},{\"document_private_items\":false,\"kind\":{\"NoStdCrate\":\"guest_test_uefi\"},\"no_deps\":true}],\"target_triple\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"target_triple\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_rustdoc::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start2\",\"is_secret\":false},\"rustdocs_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_rustdoc:0:flowey_lib_hvlite/src/_jobs/build_and_publish_rustdoc.rs:34:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_rustdoc": [
+        "{\"Doc\":{\"docs_dir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_rustdoc:0:flowey_lib_hvlite/src/_jobs/build_and_publish_rustdoc.rs:34:32\",\"is_secret\":false},\"target_triple\":\"x86_64-pc-windows-msvc\"}}",
+        "{\"SetDenyWarnings\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:2:flowey_lib_hvlite/src/build_rustdoc.rs:79:42\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:0:flowey_lib_hvlite/src/build_rustdoc.rs:60:37\",\"is_secret\":false}"
+      ]
+    },
+    "2": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:1:flowey_lib_common/src/run_cargo_doc.rs:115:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"debug_label\":\"rustdoc\",\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_rustdoc::publish:1:flowey_lib_hvlite/src/artifact_rustdoc.rs:48:33\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_doc:0:flowey_lib_common/src/run_cargo_doc.rs:114:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_doc": [
+        "{\"cargo_cmd\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:3:flowey_lib_hvlite/src/build_rustdoc.rs:84:33\",\"is_secret\":false},\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\"},\"is_secret\":false},\"packages\":[{\"document_private_items\":false,\"kind\":{\"Workspace\":{\"exclude\":[\"vmfirmwareigvm_dll\"]}},\"no_deps\":true},{\"document_private_items\":false,\"kind\":{\"NoStdCrate\":\"guest_test_uefi\"},\"no_deps\":true}],\"target_triple\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_rustdoc": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"target_triple\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_rustdoc::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-rustdoc\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start3\",\"is_secret\":false},\"rustdocs_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_rustdoc:0:flowey_lib_hvlite/src/_jobs/build_and_publish_rustdoc.rs:34:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_rustdoc": [
+        "{\"Doc\":{\"docs_dir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_rustdoc:0:flowey_lib_hvlite/src/_jobs/build_and_publish_rustdoc.rs:34:32\",\"is_secret\":false},\"target_triple\":\"x86_64-unknown-linux-gnu\"}}",
+        "{\"SetDenyWarnings\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:1:flowey_lib_hvlite/src/build_rustdoc.rs:62:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:2:flowey_lib_hvlite/src/build_rustdoc.rs:79:42\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::build_rustdoc:0:flowey_lib_hvlite/src/build_rustdoc.rs:60:37\",\"is_secret\":false}"
+      ]
+    },
+    "3": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::check_xtask_fmt": [
+        "{\"done\":{\"backing_var\":\"start4\",\"is_secret\":false},\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::build_xtask": [
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_xtask_fmt:1:flowey_lib_hvlite/src/_jobs/check_xtask_fmt.rs:31:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_xtask_fmt:0:flowey_lib_hvlite/src/_jobs/check_xtask_fmt.rs:29:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:0:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ]
+    },
+    "4": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-185fb9aa857d6110\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::check_xtask_fmt": [
+        "{\"done\":{\"backing_var\":\"start5\",\"is_secret\":false},\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::build_xtask": [
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_xtask_fmt:1:flowey_lib_hvlite/src/_jobs/check_xtask_fmt.rs:31:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_xtask_fmt:0:flowey_lib_hvlite/src/_jobs/check_xtask_fmt.rs:29:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:0:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "5": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-igvmfilegen\"},\"is_secret\":false},\"debug_label\":\"igvmfilegen\",\"done\":{\"backing_var\":\"start8\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_igvmfilegen::publish:0:flowey_lib_hvlite/src/artifact_igvmfilegen.rs:37:37\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-ohcldiag-dev\"},\"is_secret\":false},\"debug_label\":\"ohcldiag-dev\",\"done\":{\"backing_var\":\"start9\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_ohcldiag_dev::publish:0:flowey_lib_hvlite/src/artifact_ohcldiag_dev.rs:37:38\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgs_lib\"},\"is_secret\":false},\"debug_label\":\"vmgs_lib\",\"done\":{\"backing_var\":\"start7\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgs_lib::publish:0:flowey_lib_hvlite/src/artifact_vmgs_lib.rs:37:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start6\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"encryption_win\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start8\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start9\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start7\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgstool": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start6\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_igvmfilegen::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start8\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_ohcldiag_dev::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start9\",\"is_secret\":false},\"ohcldiag_dev\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgs_lib::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start7\",\"is_secret\":false},\"vmgs_lib\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgstool::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start6\",\"is_secret\":false},\"vmgstool\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_and_test_vmgs_lib": [
+        "{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}},\"vmgs_lib\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_ohcldiag_dev": [
+        "{\"ohcldiag_dev\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::build_vmgstool": [
+        "{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}},\"vmgstool\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\",\"is_secret\":false},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_ohcldiag_dev:0:flowey_lib_hvlite/src/build_ohcldiag_dev.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"crate_type\":\"DynamicLib\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:1:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:61:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgstool\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"encryption_win\"],\"no_split_dbg_info\":false,\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:1:flowey_lib_hvlite/src/build_vmgstool.rs:55:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ]
+    },
+    "6": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-6fd9989180c5ad5c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:0:flowey_lib_common/src/run_cargo_nextest_archive.rs:40:31\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start11\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start12\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:1:flowey_lib_common/src/run_cargo_nextest_archive.rs:42:37\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:2:flowey_lib_common/src/run_cargo_nextest_archive.rs:44:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"openvmm\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_archive": [
+        "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:3:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:157:29\",\"is_secret\":false},\"build_params\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\"},\"is_secret\":false},\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start12\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openvmm": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start10\",\"is_secret\":false},\"features\":[],\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_pipette": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start11\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start12\",\"is_secret\":false},\"vmm_tests\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start10\",\"is_secret\":false},\"openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-windows-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start11\",\"is_secret\":false},\"pipette\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_nextest_vmm_tests": [
+        "{\"build_mode\":{\"Archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\",\"is_secret\":false}},\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::build_openvmm": [
+        "{\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\",\"is_secret\":false},\"params\":{\"features\":[],\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}}"
+      ],
+      "flowey_lib_hvlite::build_pipette": [
+        "{\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"openvmm\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:98:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"pipette\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_pipette:0:flowey_lib_hvlite/src/build_pipette.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}"
+      ]
+    },
+    "7": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-fa1a19ce1953e79c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-igvmfilegen\"},\"is_secret\":false},\"debug_label\":\"igvmfilegen\",\"done\":{\"backing_var\":\"start15\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_igvmfilegen::publish:0:flowey_lib_hvlite/src/artifact_igvmfilegen.rs:37:37\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-ohcldiag-dev\"},\"is_secret\":false},\"debug_label\":\"ohcldiag-dev\",\"done\":{\"backing_var\":\"start16\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_ohcldiag_dev::publish:0:flowey_lib_hvlite/src/artifact_ohcldiag_dev.rs:37:38\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgs_lib\"},\"is_secret\":false},\"debug_label\":\"vmgs_lib\",\"done\":{\"backing_var\":\"start14\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgs_lib::publish:0:flowey_lib_hvlite/src/artifact_vmgs_lib.rs:37:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start13\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:3:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:103:21\",\"is_secret\":false},\"package_names\":[\"clang\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"encryption_win\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start15\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start16\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start14\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgstool": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start13\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_igvmfilegen::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start15\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_ohcldiag_dev::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start16\",\"is_secret\":false},\"ohcldiag_dev\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgs_lib::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start14\",\"is_secret\":false},\"vmgs_lib\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgstool::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start13\",\"is_secret\":false},\"vmgstool\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_and_test_vmgs_lib": [
+        "{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"vmgs_lib\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_ohcldiag_dev": [
+        "{\"ohcldiag_dev\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::build_vmgstool": [
+        "{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"vmgstool\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\",\"is_secret\":false},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:4:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:108:41\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_ohcldiag_dev:0:flowey_lib_hvlite/src/build_ohcldiag_dev.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"crate_type\":\"DynamicLib\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:1:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:61:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"vmgstool\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"encryption_win\"],\"no_split_dbg_info\":false,\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:1:flowey_lib_hvlite/src/build_vmgstool.rs:55:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ]
+    },
+    "8": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-967eeac5d4f6b742\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:0:flowey_lib_common/src/run_cargo_nextest_archive.rs:40:31\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start18\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start19\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:1:flowey_lib_common/src/run_cargo_nextest_archive.rs:42:37\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:2:flowey_lib_common/src/run_cargo_nextest_archive.rs:44:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"openvmm\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_archive": [
+        "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:3:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:157:29\",\"is_secret\":false},\"build_params\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\"},\"is_secret\":false},\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start19\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openvmm": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start17\",\"is_secret\":false},\"features\":[],\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_pipette": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start18\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start19\",\"is_secret\":false},\"vmm_tests\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start17\",\"is_secret\":false},\"openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-windows-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start18\",\"is_secret\":false},\"pipette\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_nextest_vmm_tests": [
+        "{\"build_mode\":{\"Archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\",\"is_secret\":false}},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::build_openvmm": [
+        "{\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\",\"is_secret\":false},\"params\":{\"features\":[],\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}}"
+      ],
+      "flowey_lib_hvlite::build_pipette": [
+        "{\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"openvmm\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:98:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"pipette\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_pipette:0:flowey_lib_hvlite/src/build_pipette.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ]
+    },
+    "9": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-82559e949fe64647\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-guest_test_uefi\"},\"is_secret\":false},\"debug_label\":\"guest_test_uefi\",\"done\":{\"backing_var\":\"start25\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_guest_test_uefi::publish:0:flowey_lib_hvlite/src/artifact_guest_test_uefi.rs:36:41\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-igvmfilegen\"},\"is_secret\":false},\"debug_label\":\"igvmfilegen\",\"done\":{\"backing_var\":\"start23\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_igvmfilegen::publish:0:flowey_lib_hvlite/src/artifact_igvmfilegen.rs:37:37\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-ohcldiag-dev\"},\"is_secret\":false},\"debug_label\":\"ohcldiag-dev\",\"done\":{\"backing_var\":\"start24\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_ohcldiag_dev::publish:0:flowey_lib_hvlite/src/artifact_ohcldiag_dev.rs:37:38\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgs_lib\"},\"is_secret\":false},\"debug_label\":\"vmgs_lib\",\"done\":{\"backing_var\":\"start22\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgs_lib::publish:0:flowey_lib_hvlite/src/artifact_vmgs_lib.rs:37:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start21\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\",\"is_secret\":false},\"package_names\":[\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:0:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:2:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:4:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:6:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:8:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-uefi\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"guest_test_uefi\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"guest_test_uefi\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-uefi\"}",
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:13:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openvmm\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:27:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"encryption_ossl\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:30:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
+        "{\"arch\":\"Aarch64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start25\",\"is_secret\":false},\"profile\":\"Debug\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start23\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start24\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openvmm": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start20\",\"is_secret\":false},\"features\":[\"Tpm\"],\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start22\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgstool": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start21\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_guest_test_uefi::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start25\",\"is_secret\":false},\"guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guest_test_uefi.rs:38:35\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_igvmfilegen::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start23\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_ohcldiag_dev::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start24\",\"is_secret\":false},\"ohcldiag_dev\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start20\",\"is_secret\":false},\"openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgs_lib::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start22\",\"is_secret\":false},\"vmgs_lib\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgstool::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start21\",\"is_secret\":false},\"vmgstool\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_and_test_vmgs_lib": [
+        "{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}},\"vmgs_lib\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_guest_test_uefi": [
+        "{\"arch\":\"Aarch64\",\"guest_test_uefi\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guest_test_uefi.rs:38:35\",\"is_secret\":false},\"profile\":\"Debug\"}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_ohcldiag_dev": [
+        "{\"ohcldiag_dev\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::build_openvmm": [
+        "{\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\",\"is_secret\":false},\"params\":{\"features\":[\"Tpm\"],\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}}}}"
+      ],
+      "flowey_lib_hvlite::build_vmgstool": [
+        "{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxGnu\"}},\"vmgstool\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\",\"is_secret\":false},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_guest_test_uefi:1:flowey_lib_hvlite/src/build_guest_test_uefi.rs:75:41\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-uefi\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"guest_test_uefi\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"guest_test_uefi\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_guest_test_uefi:0:flowey_lib_hvlite/src/build_guest_test_uefi.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-uefi\"}",
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_ohcldiag_dev:0:flowey_lib_hvlite/src/build_ohcldiag_dev.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openvmm\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"tpm\"],\"no_split_dbg_info\":false,\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:3:flowey_lib_hvlite/src/build_openvmm.rs:98:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"crate_type\":\"DynamicLib\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:1:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:61:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgstool\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"encryption_ossl\"],\"no_split_dbg_info\":false,\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:1:flowey_lib_hvlite/src/build_vmgstool.rs:55:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:14:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:31:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:33:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:34:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "10": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-e0511fec3dac278b\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:0:flowey_lib_common/src/run_cargo_nextest_archive.rs:40:31\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-guest_test_uefi\"},\"is_secret\":false},\"debug_label\":\"guest_test_uefi\",\"done\":{\"backing_var\":\"start31\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_guest_test_uefi::publish:0:flowey_lib_hvlite/src/artifact_guest_test_uefi.rs:36:41\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-igvmfilegen\"},\"is_secret\":false},\"debug_label\":\"igvmfilegen\",\"done\":{\"backing_var\":\"start29\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_igvmfilegen::publish:0:flowey_lib_hvlite/src/artifact_igvmfilegen.rs:37:37\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-ohcldiag-dev\"},\"is_secret\":false},\"debug_label\":\"ohcldiag-dev\",\"done\":{\"backing_var\":\"start30\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_ohcldiag_dev::publish:0:flowey_lib_hvlite/src/artifact_ohcldiag_dev.rs:37:38\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgs_lib\"},\"is_secret\":false},\"debug_label\":\"vmgs_lib\",\"done\":{\"backing_var\":\"start28\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgs_lib::publish:0:flowey_lib_hvlite/src/artifact_vmgs_lib.rs:37:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgstool\"},\"is_secret\":false},\"debug_label\":\"vmgstool\",\"done\":{\"backing_var\":\"start27\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_vmgstool::publish:0:flowey_lib_hvlite/src/artifact_vmgstool.rs:37:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false},\"debug_label\":\"vmm_tests\",\"done\":{\"backing_var\":\"start32\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish:0:flowey_lib_hvlite/src/artifact_nextest_vmm_tests_archive.rs:39:35\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:1:flowey_lib_common/src/run_cargo_nextest_archive.rs:42:37\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\",\"is_secret\":false},\"package_names\":[\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:3:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:103:21\",\"is_secret\":false},\"package_names\":[\"clang\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\",\"build-essential\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_archive:2:flowey_lib_common/src/run_cargo_nextest_archive.rs:44:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-uefi\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"guest_test_uefi\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"guest_test_uefi\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-uefi\"}",
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:13:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openvmm\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:27:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"DynamicLib\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgstool\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"encryption_ossl\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:30:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_archive": [
+        "{\"archive_file\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:3:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:157:29\",\"is_secret\":false},\"build_params\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\"},\"is_secret\":false},\"features\":{\"Specific\":[]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"Inline\":{\"Crates\":{\"crates\":[\"vmm_tests\"]}}},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null},\"friendly_label\":\"vmm_tests\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\"},\"is_secret\":false}],\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi": [
+        "{\"arch\":\"X86_64\",\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start31\",\"is_secret\":false},\"profile\":\"Debug\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start29\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start32\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start30\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openvmm": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start26\",\"is_secret\":false},\"features\":[\"Tpm\"],\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start28\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_vmgstool": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start27\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_guest_test_uefi::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-guest_test_uefi\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start31\",\"is_secret\":false},\"guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guest_test_uefi.rs:38:35\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_igvmfilegen::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-igvmfilegen\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start29\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start32\",\"is_secret\":false},\"vmm_tests\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_ohcldiag_dev::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-ohcldiag-dev\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start30\",\"is_secret\":false},\"ohcldiag_dev\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-openvmm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start26\",\"is_secret\":false},\"openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgs_lib::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgs_lib\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start28\",\"is_secret\":false},\"vmgs_lib\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_vmgstool::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-vmgstool\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start27\",\"is_secret\":false},\"vmgstool\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_and_test_vmgs_lib": [
+        "{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"vmgs_lib\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgs_lib:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgs_lib.rs:38:28\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_guest_test_uefi": [
+        "{\"arch\":\"X86_64\",\"guest_test_uefi\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_guest_test_uefi:0:flowey_lib_hvlite/src/_jobs/build_and_publish_guest_test_uefi.rs:38:35\",\"is_secret\":false},\"profile\":\"Debug\"}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_igvmfilegen:0:flowey_lib_hvlite/src/_jobs/build_and_publish_igvmfilegen.rs:38:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_nextest_vmm_tests": [
+        "{\"build_mode\":{\"Archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/build_and_publish_nextest_vmm_tests_archive.rs:40:29\",\"is_secret\":false}},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::build_ohcldiag_dev": [
+        "{\"ohcldiag_dev\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_ohcldiag_dev:0:flowey_lib_hvlite/src/_jobs/build_and_publish_ohcldiag_dev.rs:38:32\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}"
+      ],
+      "flowey_lib_hvlite::build_openvmm": [
+        "{\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openvmm:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openvmm.rs:41:27\",\"is_secret\":false},\"params\":{\"features\":[\"Tpm\"],\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}}}"
+      ],
+      "flowey_lib_hvlite::build_vmgstool": [
+        "{\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"vmgstool\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_vmgstool:0:flowey_lib_hvlite/src/_jobs/build_and_publish_vmgstool.rs:40:28\",\"is_secret\":false},\"with_crypto\":true}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:4:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:108:41\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_guest_test_uefi:1:flowey_lib_hvlite/src/build_guest_test_uefi.rs:75:41\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:2:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:154:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:1:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:107:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-uefi\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_vmm_tests:0:flowey_lib_hvlite/src/build_nextest_vmm_tests.rs:74:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"guest_test_uefi\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"guest_test_uefi\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_guest_test_uefi:0:flowey_lib_hvlite/src/build_guest_test_uefi.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-uefi\"}",
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"ohcldiag-dev\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"ohcldiag-dev\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_ohcldiag_dev:0:flowey_lib_hvlite/src/build_ohcldiag_dev.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openvmm\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"tpm\"],\"no_split_dbg_info\":false,\"out_name\":\"openvmm\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm:3:flowey_lib_hvlite/src/build_openvmm.rs:98:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:0:flowey_lib_hvlite/src/build_openvmm.rs:51:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:1:flowey_lib_hvlite/src/build_openvmm.rs:76:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm:2:flowey_lib_hvlite/src/build_openvmm.rs:89:68\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgs_lib\",\"crate_type\":\"DynamicLib\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"vmgs_lib\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:1:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:61:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_and_test_vmgs_lib:0:flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs:54:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"vmgstool\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"encryption_ossl\"],\"no_split_dbg_info\":false,\"out_name\":\"vmgstool\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_vmgstool:1:flowey_lib_hvlite/src/build_vmgstool.rs:55:26\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_vmgstool:0:flowey_lib_hvlite/src/build_vmgstool.rs:47:37\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:14:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:31:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:33:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:34:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "11": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-54d538eb47bfa81c\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm-extras\"},\"is_secret\":false},\"debug_label\":\"OpenHCL igvm extras\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:23:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:107:30\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm\"},\"is_secret\":false},\"debug_label\":\"OpenHCL igvm files\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:22:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:99:30\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-musl-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start34\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-arm64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-arm64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
+        "{\"file_name\":\"RELEASE-AARCH64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:111:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:8:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:0:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:2:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:4:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:0:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:0:flowey_lib_hvlite/src/build_openhcl_initrd.rs:63:17\",\"is_secret\":false},\"package_names\":[\"python3\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openhcl_boot\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:13:flowey_lib_hvlite/src/run_cargo_build.rs:367:22\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:15:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"boot-dev\"},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"openvmm_hcl\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:22:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"gdb\",\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:27:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
+        "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start33\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"Aarch64\"},{\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"Aarch64Devkern\"}]}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_pipette": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-musl-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start34\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxMusl\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:22:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:99:30\",\"is_secret\":false},\"openhcl_igvm_files\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:3:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:14:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:23:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:107:30\",\"is_secret\":false},\"extras\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:9:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:20:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_aarch64-linux-musl-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start34\",\"is_secret\":false},\"pipette\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:32:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}",
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:4:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_boot": [
+        "{\"build_params\":{\"arch\":\"Aarch64\",\"profile\":\"Debug\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:33:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}",
+        "{\"build_params\":{\"arch\":\"Aarch64\",\"profile\":\"Debug\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:5:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_igvm_from_recipe": [
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"Aarch64\"}",
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:12:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:13:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:11:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"aarch64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"Aarch64Devkern\"}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_initrd": [
+        "{\"arch\":\"Aarch64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:18:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:20:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":true,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:16:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}",
+        "{\"arch\":\"Aarch64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:46:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:48:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":true,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:29:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:44:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::build_openvmm_hcl": [
+        "{\"build_params\":{\"features\":[\"Gdb\",\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"Debug\",\"target\":{\"Custom\":\"aarch64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:31:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}",
+        "{\"build_params\":{\"features\":[\"Gdb\",\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"Debug\",\"target\":{\"Custom\":\"aarch64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:3:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_pipette": [
+        "{\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"Aarch64\",\"platform\":\"LinuxMusl\"}}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:0:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"kind\":\"Dev\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:29:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetOpenhclCpioDbgrd\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:2:flowey_lib_hvlite/src/build_openhcl_initrd.rs:95:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioDbgrd\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:4:flowey_lib_hvlite/src/build_openhcl_initrd.rs:95:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclSysroot\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:1:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:52:46\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"GetMsvmFd\":{\"arch\":\"Aarch64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:405:21\",\"is_secret\":false}}}",
+        "{\"GetMsvmFd\":{\"arch\":\"Aarch64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:30:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:405:21\",\"is_secret\":false}}}",
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:0:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:28:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:1:flowey_lib_hvlite/src/build_openhcl_initrd.rs:70:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:22:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot": [
+        "{\"arch\":\"Aarch64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openhcl_boot\",\"crate_type\":\"Bin\",\"extra_env\":{\"backing_var\":{\"Inline\":{\"MINIMAL_RT_BUILD\":\"1\"}},\"is_secret\":false},\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_boot:0:flowey_lib_hvlite/src/build_openhcl_boot.rs:82:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"BootDev\",\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"openvmm_hcl\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"gdb\",\"tpm\"],\"no_split_dbg_info\":true,\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm_hcl:1:flowey_lib_hvlite/src/build_openvmm_hcl.rs:104:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"pipette\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_pipette:0:flowey_lib_hvlite/src/build_pipette.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::run_igvmfilegen": [
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:24:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:26:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:23:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:13:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:52:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:54:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:51:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:37:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:35:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:36:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:9:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:7:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:8:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:19:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:28:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:30:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:31:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "12": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-b130c166bdbdc2a8\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::copy_to_artifact_dir": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm-extras\"},\"is_secret\":false},\"debug_label\":\"OpenHCL igvm extras\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:56:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:107:30\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm\"},\"is_secret\":false},\"debug_label\":\"OpenHCL igvm files\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:55:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:99:30\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"debug_label\":\"pipette\",\"done\":{\"backing_var\":\"start36\",\"is_secret\":false},\"files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::artifact_pipette::publish:0:flowey_lib_hvlite/src/artifact_pipette.rs:37:33\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.6-dev-x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:5:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-dev/6.6.51.6\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-cvm-x64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:3:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
+        "{\"file_name\":\"Microsoft.OHCL.Kernel.6.6.51.7-main-x64.tar.gz\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:1:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:114:21\",\"is_secret\":false},\"repo_name\":\"OHCL-Linux-Kernel\",\"repo_owner\":\"microsoft\",\"tag\":\"rolling-lts/hcl-main/6.6.51.7\"}",
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:10:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:12:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:14:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:8:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openhcl_kernel_package:0:flowey_lib_hvlite/src/download_openhcl_kernel_package.rs:77:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:0:flowey_lib_hvlite/src/build_openhcl_initrd.rs:63:17\",\"is_secret\":false},\"package_names\":[\"python3\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-none\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openhcl_boot\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:12:flowey_lib_hvlite/src/run_cargo_build.rs:367:22\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:14:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"boot-dev\"},\"target\":\"x86_64-unknown-none\"}",
+        "{\"crate_name\":\"openvmm_hcl\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[\"gdb\",\"tpm\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:22:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"pipette\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:26:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe": [
+        "{\"artifact_dir_openhcl_igvm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_extras\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start35\",\"is_secret\":false},\"igvm_files\":[{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64Devkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64TestLinuxDirect\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64TestLinuxDirectDevkern\"},{\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64Cvm\"}]}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_publish_pipette": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start36\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxMusl\"}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm\"},\"is_secret\":false},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:55:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:99:30\",\"is_secret\":false},\"openhcl_igvm_files\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:3:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:14:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:25:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:36:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:47:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:75:59\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-openhcl-igvm-extras\"},\"is_secret\":false},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:56:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:107:30\",\"is_secret\":false},\"extras\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:9:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:20:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:31:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:42:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:53:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:84:22\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::publish": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_publish_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"done\":{\"backing_var\":\"start36\",\"is_secret\":false},\"pipette\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_igvmfilegen": [
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:118:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}",
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:32:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}",
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:4:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}",
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:60:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}",
+        "{\"build_params\":{\"profile\":\"Release\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}}},\"igvmfilegen\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:89:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:506:31\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_boot": [
+        "{\"build_params\":{\"arch\":\"X86_64\",\"profile\":\"Debug\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:119:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}",
+        "{\"build_params\":{\"arch\":\"X86_64\",\"profile\":\"Debug\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:33:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}",
+        "{\"build_params\":{\"arch\":\"X86_64\",\"profile\":\"Debug\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:5:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}",
+        "{\"build_params\":{\"arch\":\"X86_64\",\"profile\":\"Debug\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:61:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}",
+        "{\"build_params\":{\"arch\":\"X86_64\",\"profile\":\"Debug\"},\"openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:90:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:533:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_igvm_from_recipe": [
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:0:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64\"}",
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:45:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:46:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:44:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64Cvm\"}",
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:12:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:13:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:11:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64Devkern\"}",
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:23:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:24:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:22:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64TestLinuxDirect\"}",
+        "{\"built_openhcl_boot\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:34:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:63:69\",\"is_secret\":false},\"built_openhcl_igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:35:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"built_openvmm_hcl\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:33:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:62:67\",\"is_secret\":false},\"built_sidecar\":null,\"custom_target\":{\"Custom\":\"x86_64-unknown-linux-musl\"},\"profile\":\"Debug\",\"recipe\":\"X64TestLinuxDirectDevkern\"}"
+      ],
+      "flowey_lib_hvlite::build_openhcl_initrd": [
+        "{\"arch\":\"X86_64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:103:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:105:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":true,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:85:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:101:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}",
+        "{\"arch\":\"X86_64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:132:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:134:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":true,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:114:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:130:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}",
+        "{\"arch\":\"X86_64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:18:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:20:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":true,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:16:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}",
+        "{\"arch\":\"X86_64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:46:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:48:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":true,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:29:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:44:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}",
+        "{\"arch\":\"X86_64\",\"bin_openhcl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:74:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:598:51\"},\"is_secret\":false},\"extra_env\":null,\"extra_params\":null,\"initrd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:76:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:600:17\",\"is_secret\":false},\"interactive\":true,\"kernel_package_root\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:57:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\"},\"is_secret\":false},\"rootfs_config\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:72:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:592:43\"},\"is_secret\":false}]}"
+      ],
+      "flowey_lib_hvlite::build_openvmm_hcl": [
+        "{\"build_params\":{\"features\":[\"Gdb\",\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"Debug\",\"target\":{\"Custom\":\"x86_64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:117:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}",
+        "{\"build_params\":{\"features\":[\"Gdb\",\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"Debug\",\"target\":{\"Custom\":\"x86_64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:31:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}",
+        "{\"build_params\":{\"features\":[\"Gdb\",\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"Debug\",\"target\":{\"Custom\":\"x86_64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:3:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}",
+        "{\"build_params\":{\"features\":[\"Gdb\",\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"Debug\",\"target\":{\"Custom\":\"x86_64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:59:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}",
+        "{\"build_params\":{\"features\":[\"Gdb\",\"Tpm\"],\"no_split_dbg_info\":true,\"profile\":\"Debug\",\"target\":{\"Custom\":\"x86_64-unknown-linux-musl\"}},\"openvmm_hcl_output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:88:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:486:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::build_pipette": [
+        "{\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_pipette:0:flowey_lib_hvlite/src/_jobs/build_and_publish_pipette.rs:38:27\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxMusl\"}}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:0:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Cvm\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:29:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Dev\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:114:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Dev\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:57:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:1:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"kind\":\"Main\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:85:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:390:25\",\"is_secret\":false}}}",
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:116:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:433:30\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:87:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:433:30\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestKernel\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:115:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:420:52\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestKernel\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:86:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:420:52\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioDbgrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:10:flowey_lib_hvlite/src/build_openhcl_initrd.rs:95:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioDbgrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:2:flowey_lib_hvlite/src/build_openhcl_initrd.rs:95:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioDbgrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:4:flowey_lib_hvlite/src/build_openhcl_initrd.rs:95:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioDbgrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:6:flowey_lib_hvlite/src/build_openhcl_initrd.rs:95:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclCpioDbgrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:8:flowey_lib_hvlite/src/build_openhcl_initrd.rs:95:21\",\"is_secret\":false}]}",
+        "{\"GetOpenhclSysroot\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:1:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:52:46\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:405:21\",\"is_secret\":false}}}",
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:30:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:405:21\",\"is_secret\":false}}}",
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:58:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:405:21\",\"is_secret\":false}}}",
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:0:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:113:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:28:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:56:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:84:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:358:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_initrd:1:flowey_lib_hvlite/src/build_openhcl_initrd.rs:70:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-none\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot": [
+        "{\"arch\":\"X64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\",\"is_secret\":false}}",
+        "{\"arch\":\"X64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\",\"is_secret\":false}}",
+        "{\"arch\":\"X64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:351:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"igvmfilegen\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"igvmfilegen\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_igvmfilegen:0:flowey_lib_hvlite/src/build_igvmfilegen.rs:53:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Release\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"openhcl_boot\",\"crate_type\":\"Bin\",\"extra_env\":{\"backing_var\":{\"Inline\":{\"MINIMAL_RT_BUILD\":\"1\"}},\"is_secret\":false},\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"openhcl_boot\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_boot:0:flowey_lib_hvlite/src/build_openhcl_boot.rs:82:30\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"BootDev\",\"target\":\"x86_64-unknown-none\"}",
+        "{\"crate_name\":\"openvmm_hcl\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[\"gdb\",\"tpm\"],\"no_split_dbg_info\":true,\"out_name\":\"openvmm_hcl\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_openvmm_hcl:1:flowey_lib_hvlite/src/build_openvmm_hcl.rs:104:30\",\"is_secret\":false},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openvmm_hcl:0:flowey_lib_hvlite/src/build_openvmm_hcl.rs:93:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\"}",
+        "{\"crate_name\":\"pipette\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"pipette\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_pipette:0:flowey_lib_hvlite/src/build_pipette.rs:40:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::run_igvmfilegen": [
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:24:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:109:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:111:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:108:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:35:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:138:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:140:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:137:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:2:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:24:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:26:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:23:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:46:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:52:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:54:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:51:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}",
+        "{\"igvm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe:13:flowey_lib_hvlite/src/_jobs/build_and_publish_openhcl_igvm_from_recipe.rs:64:69\",\"is_secret\":false},\"igvmfilegen\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:80:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:649:39\"},\"is_secret\":false},\"manifest\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:82:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:656:35\"},\"is_secret\":false},\"resources\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:79:flowey_core/src/node.rs:896:34\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:123:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:121:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:122:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:37:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:35:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:36:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:65:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:63:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:64:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:94:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:92:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:93:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:9:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:566:42\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:7:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:563:37\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::build_openhcl_igvm_from_recipe:8:flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs:564:45\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:15:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:27:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:29:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:30:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "13": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-38b54383c2832bcf\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:1:flowey_lib_common/src/run_cargo_clippy.rs:48:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:187:43\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:1:flowey_lib_common/src/run_cargo_nextest_run.rs:190:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-win64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:9:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:0:flowey_lib_common/src/run_cargo_clippy.rs:47:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:2:flowey_lib_common/src/run_cargo_nextest_run.rs:192:46\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"aarch64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"InstallTargetTriple\":\"x86_64-pc-windows-msvc\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:3:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:69:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:68:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-windows-unit-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_common::run_cargo_clippy": [
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:9:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:10:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\",\"tests\":true}",
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:7:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:5:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\",\"tests\":true}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":{\"Specific\":[\"ci\"]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_doc_tests": [
+        "{\"done\":{\"backing_var\":\"start40\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
+        "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start39\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-windows-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::check_clippy": [
+        "{\"also_check_misc_nostd_crates\":false,\"done\":{\"backing_var\":\"start38\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"also_check_misc_nostd_crates\":false,\"done\":{\"backing_var\":\"start37\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::build_nextest_unit_tests": [
+        "{\"build_mode\":{\"ImmediatelyRun\":{\"nextest_profile\":\"Ci\",\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false}}},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::build_xtask": [
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"WindowsMsvc\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:0:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:88:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:2:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:40:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:5:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:1:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:93:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"aarch64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:5:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:8:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:39:34\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:10:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:0:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:2:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-pc-windows-msvc\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:4:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":null,\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":{\"Specific\":[\"ci\"]},\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-pc-windows-msvc\",\"unstable_panic_abort_tests\":null}}}"
+      ]
+    },
+    "14": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-763048f92183c49f\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:1:flowey_lib_common/src/run_cargo_clippy.rs:48:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:187:43\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:1:flowey_lib_common/src/run_cargo_nextest_run.rs:190:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:6:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:0:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:16:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:0:flowey_lib_common/src/run_cargo_clippy.rs:47:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:2:flowey_lib_common/src/run_cargo_nextest_run.rs:192:46\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-apple-darwin\"}",
+        "{\"InstallTargetTriple\":\"aarch64-apple-darwin\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:3:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:69:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:68:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-linux-unit-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:24:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_common::run_cargo_clippy": [
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:7:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:9:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:10:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\",\"tests\":true}",
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:22:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:21:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:20:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:16:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:18:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\",\"tests\":true}",
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:5:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":[[\"SPARSE_MMAP_NO_BUILD\",\"1\"]],\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-apple-darwin\",\"tests\":true}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_doc_tests": [
+        "{\"done\":{\"backing_var\":\"start45\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
+        "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start44\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::check_clippy": [
+        "{\"also_check_misc_nostd_crates\":false,\"done\":{\"backing_var\":\"start43\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"aarch64-apple-darwin\"}",
+        "{\"also_check_misc_nostd_crates\":false,\"done\":{\"backing_var\":\"start42\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"also_check_misc_nostd_crates\":false,\"done\":{\"backing_var\":\"start41\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::build_nextest_unit_tests": [
+        "{\"build_mode\":{\"ImmediatelyRun\":{\"nextest_profile\":\"Ci\",\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false}}},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::build_xtask": [
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:19:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:0:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:88:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:2:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:40:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:20:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:1:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:93:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:10:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:18:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:23:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:7:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:39:34\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:9:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:0:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:2:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:4:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:6:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":null,\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-gnu\",\"unstable_panic_abort_tests\":null}}}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:13:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:14:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:25:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:27:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:28:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "15": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-776396c93f9413c8\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:1:flowey_lib_common/src/run_cargo_build.rs:102:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:1:flowey_lib_common/src/run_cargo_clippy.rs:48:25\",\"is_secret\":false}}",
+        "{\"GetFlags\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:187:43\",\"is_secret\":false}}",
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::cfg_persistent_dir_cargo_install": [
+        "{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:2:flowey_lib_common/src/download_cargo_nextest.rs:79:21\",\"is_secret\":false}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallWithCargo\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:1:flowey_lib_common/src/run_cargo_nextest_run.rs:190:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"openvmm-deps.aarch64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:2:flowey_lib_hvlite/src/download_openvmm_deps.rs:111:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.AARCH64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:3:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"Microsoft.WSL.LxUtil.x64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:1:flowey_lib_hvlite/src/download_lxutil.rs:82:34\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release\"}",
+        "{\"file_name\":\"protoc-27.1-linux-x86_64.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_common::download_protoc:0:flowey_lib_common/src/download_protoc.rs:69:30\",\"is_secret\":false},\"repo_name\":\"protobuf\",\"repo_owner\":\"protocolbuffers\",\"tag\":\"v27.1\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Get\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:0:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:24:30\",\"is_secret\":false}}",
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:0:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:2:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::run_split_debug_info:4:flowey_lib_hvlite/src/run_split_debug_info.rs:36:17\",\"is_secret\":false},\"package_names\":[\"binutils-x86-64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::init_cross_build:0:flowey_lib_hvlite/src/init_cross_build.rs:76:49\",\"is_secret\":false},\"package_names\":[\"gcc-aarch64-linux-gnu\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_protoc:1:flowey_lib_common/src/download_protoc.rs:78:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_lxutil:0:flowey_lib_hvlite/src/download_lxutil.rs:67:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\",\"is_secret\":false},\"package_names\":[\"libssl-dev\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:2:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:35:17\",\"is_secret\":false}}",
+        "{\"GetCargoHome\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:4:flowey_lib_common/src/download_cargo_nextest.rs:83:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:3:flowey_lib_common/src/download_cargo_nextest.rs:81:38\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_build:0:flowey_lib_common/src/run_cargo_build.rs:101:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_clippy:0:flowey_lib_common/src/run_cargo_clippy.rs:47:34\",\"is_secret\":false}}",
+        "{\"GetRustupToolchain\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:2:flowey_lib_common/src/run_cargo_nextest_run.rs:192:46\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-uefi\"}",
+        "{\"InstallTargetTriple\":\"aarch64-unknown-uefi\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-linux-musl\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-none\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-none\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-uefi\"}",
+        "{\"InstallTargetTriple\":\"x86_64-unknown-uefi\"}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:3:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:69:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:68:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-linux-musl-unit-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:17:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:3:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\"},\"is_secret\":false},\"features\":[],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\"},\"is_secret\":false},\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:10:flowey_lib_hvlite/src/run_cargo_build.rs:375:35\",\"is_secret\":false},\"output_kind\":\"Bin\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\"},\"is_secret\":false}],\"profile\":{\"Custom\":\"xtask\"},\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_common::run_cargo_clippy": [
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:19:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:18:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\",\"tests\":true}",
+        "{\"all_targets\":false,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:21:flowey_lib_hvlite/src/_jobs/check_clippy.rs:249:27\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"Inline\":null},\"is_secret\":false},\"extra_env\":null,\"features\":null,\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":{\"Crate\":\"guest_test_uefi\"},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-uefi\",\"tests\":false}",
+        "{\"all_targets\":false,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:20:flowey_lib_hvlite/src/_jobs/check_clippy.rs:233:27\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"Inline\":null},\"is_secret\":false},\"extra_env\":[[\"MINIMAL_RT_BUILD\",\"1\"]],\"features\":null,\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":{\"Crate\":\"openhcl_boot\"},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:13:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"x86_64-unknown-none\",\"tests\":false}",
+        "{\"all_targets\":true,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:8:flowey_lib_hvlite/src/_jobs/check_clippy.rs:217:33\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:7:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"extra_env\":null,\"features\":[\"ci\"],\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":\"Workspace\",\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-musl\",\"tests\":true}",
+        "{\"all_targets\":false,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:10:flowey_lib_hvlite/src/_jobs/check_clippy.rs:249:27\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"Inline\":null},\"is_secret\":false},\"extra_env\":null,\"features\":null,\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":{\"Crate\":\"guest_test_uefi\"},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-uefi\",\"tests\":false}",
+        "{\"all_targets\":false,\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:9:flowey_lib_hvlite/src/_jobs/check_clippy.rs:233:27\",\"is_secret\":false},\"exclude\":{\"backing_var\":{\"Inline\":null},\"is_secret\":false},\"extra_env\":[[\"MINIMAL_RT_BUILD\",\"1\"]],\"features\":null,\"in_folder\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\"},\"is_secret\":false},\"keep_going\":true,\"package\":{\"Crate\":\"openhcl_boot\"},\"pre_build_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:2:flowey_lib_hvlite/src/_jobs/check_clippy.rs:106:17\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\"},\"is_secret\":false}],\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-musl\",\"tests\":false}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"Inline\":{\"OPENVMM_LOG\":\"debug,mesh_node=info\",\"RUST_LOG\":\"trace,mesh_node=info\"}},\"is_secret\":false},\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:186:25\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:6:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_doc_tests": [
+        "{\"done\":{\"backing_var\":\"start49\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests": [
+        "{\"artifact_dir\":null,\"done\":{\"backing_var\":\"start48\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-musl-unit-tests\",\"nextest_profile\":\"Ci\",\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::check_clippy": [
+        "{\"also_check_misc_nostd_crates\":true,\"done\":{\"backing_var\":\"start47\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"also_check_misc_nostd_crates\":true,\"done\":{\"backing_var\":\"start46\",\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::build_nextest_unit_tests": [
+        "{\"build_mode\":{\"ImmediatelyRun\":{\"nextest_profile\":\"Ci\",\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false}}},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}"
+      ],
+      "flowey_lib_hvlite::build_xtask": [
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:16:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:5:flowey_lib_hvlite/src/_jobs/check_clippy.rs:143:25\",\"is_secret\":false}}",
+        "{\"target\":{\"Common\":{\"arch\":\"X86_64\",\"platform\":\"LinuxGnu\"}},\"xtask\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:0:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:88:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:2:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:0:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:49:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_protoc:1:flowey_lib_hvlite/src/init_openvmm_magicpath_protoc.rs:25:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"GetPackage\":{\"arch\":\"Aarch64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:1:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"GetPackage\":{\"arch\":\"X86_64\",\"pkg\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_lxutil:0:flowey_lib_hvlite/src/init_openvmm_magicpath_lxutil.rs:42:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetOpenhclSysroot\":[\"Aarch64\",{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:1:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:52:46\",\"is_secret\":false}]}",
+        "{\"GetOpenhclSysroot\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot:3:flowey_lib_hvlite/src/init_openvmm_magicpath_openhcl_sysroot.rs:52:46\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:1:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:40:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:17:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:6:flowey_lib_hvlite/src/_jobs/check_clippy.rs:153:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:1:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:93:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings:0:flowey_lib_hvlite/src/init_openvmm_cargo_config_deny_warnings.rs:51:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:1:flowey_lib_hvlite/src/run_cargo_build.rs:315:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_cross_build": [
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:4:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"aarch64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:16:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:2:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:9:flowey_lib_hvlite/src/run_cargo_build.rs:359:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:15:flowey_lib_hvlite/src/_jobs/check_clippy.rs:121:21\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-musl\"}",
+        "{\"injected_env\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:6:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\",\"is_secret\":false},\"target\":\"x86_64-unknown-linux-musl\"}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}",
+        "{\"Done\":{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:0:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:33:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_lxutil": [
+        "{\"arch\":\"Aarch64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:1:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:12:flowey_lib_hvlite/src/_jobs/check_clippy.rs:86:33\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot": [
+        "{\"arch\":\"Aarch64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:0:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\",\"is_secret\":false}}",
+        "{\"arch\":\"X64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:11:flowey_lib_hvlite/src/_jobs/check_clippy.rs:77:21\",\"is_secret\":false}}",
+        "{\"arch\":\"X64\",\"path\":{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:186:25\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_protoc": [
+        "{\"backing_var\":\"flowey_lib_hvlite::install_openvmm_rust_build_essential:1:flowey_lib_hvlite/src/install_openvmm_rust_build_essential.rs:34:17\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::install_openvmm_rust_build_essential": [
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_doc_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_doc_tests.rs:39:34\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:14:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::_jobs::check_clippy:3:flowey_lib_hvlite/src/_jobs/check_clippy.rs:112:33\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\",\"is_secret\":false}",
+        "{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:0:flowey_lib_hvlite/src/run_cargo_build.rs:313:18\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::run_cargo_build": [
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:0:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:2:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}",
+        "{\"crate_name\":\"xtask\",\"crate_type\":\"Bin\",\"extra_env\":null,\"features\":[],\"no_split_dbg_info\":false,\"out_name\":\"xtask\",\"output\":{\"backing_var\":\"flowey_lib_hvlite::build_xtask:4:flowey_lib_hvlite/src/build_xtask.rs:36:26\",\"is_secret\":false},\"pre_build_deps\":[],\"profile\":\"Xtask\",\"target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":null,\"friendly_name\":\"unit-tests\",\"nextest_filter_expr\":null,\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:2:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:97:37\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:4:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:176:35\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:5:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:186:25\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests:0:flowey_lib_hvlite/src/_jobs/build_and_run_nextest_unit_tests.rs:56:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"BuildAndRun\":{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:6:flowey_lib_hvlite/src/build_nextest_unit_tests.rs:212:36\"},\"is_secret\":false},\"features\":\"All\",\"no_default_features\":false,\"packages\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::build_nextest_unit_tests:3:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"profile\":\"Debug\",\"target\":\"x86_64-unknown-linux-musl\",\"unstable_panic_abort_tests\":null}}}"
+      ],
+      "flowey_lib_hvlite::run_split_debug_info": [
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:11:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:13:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:14:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:18:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:20:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:21:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}",
+        "{\"arch\":\"X86_64\",\"in_bin\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_build:4:flowey_lib_hvlite/src/run_cargo_build.rs:407:51\"},\"is_secret\":false},\"out_bin\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:6:flowey_lib_hvlite/src/run_cargo_build.rs:412:52\",\"is_secret\":false},\"out_dbg_info\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_build:7:flowey_lib_hvlite/src/run_cargo_build.rs:413:52\",\"is_secret\":false}}"
+      ]
+    },
+    "16": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallStandalone\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:207:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_azcopy:2:flowey_lib_common/src/download_azcopy.rs:68:36\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{\"crash-dumps\":[{\"backing_var\":{\"Inline\":\"C:\\\\Users\\\\cloudtest\\\\AppData\\\\Local\\\\CrashDumps\"},\"is_secret\":false},true],\"logs\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\"},\"is_secret\":false},false],\"openhcl-dumps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\"},\"is_secret\":false},false]},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:15:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:210:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:13:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:209:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-windows-intel-vmm-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":null,\"dep_artifact_dirs\":{\"artifact_dir_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_files\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-openvmm\"},\"is_secret\":false},\"artifact_dir_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"artifact_dir_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false}},\"done\":{\"backing_var\":\"start50\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-windows-intel-vmm-tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"target\":\"x86_64-pc-windows-msvc\",\"vmm_tests_artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_guest_test_uefi::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"guest_test_uefi\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"nextest_archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-openhcl-igvm\"},\"is_secret\":false},\"igvm_files\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:124:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-openvmm\"},\"is_secret\":false},\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\",\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:1:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:59:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestKernel\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:1:flowey_lib_hvlite/src/init_vmm_tests_env.rs:88:37\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_vmm_tests_vhds": [
+        "{\"DownloadIsos\":[\"FreeBsd13_2\"]}",
+        "{\"DownloadVhds\":[\"FreeBsd13_2\",\"Gen1WindowsDataCenterCore2022\",\"Gen2WindowsDataCenterCore2022\",\"Ubuntu2204Server\"]}",
+        "{\"GetDownloadFolder\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:0:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:49:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:2:flowey_lib_hvlite/src/init_vmm_tests_env.rs:92:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_vmm_tests_env": [
+        "{\"disk_images_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\"},\"is_secret\":false},\"get_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\",\"is_secret\":false},\"get_openhcl_dump_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\",\"is_secret\":false},\"get_test_log_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\",\"is_secret\":false},\"register_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\"},\"is_secret\":false},\"register_openhcl_igvm_files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:124:17\"},\"is_secret\":false},\"register_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\"},\"is_secret\":false},\"register_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\"},\"is_secret\":false},\"register_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\"},\"is_secret\":false},\"test_content_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:1:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"vmm_tests_target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::test_nextest_vmm_tests_archive": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"nextest_archive_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\"},\"is_secret\":false},\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false}}"
+      ]
+    },
+    "17": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallStandalone\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:207:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_azcopy:2:flowey_lib_common/src/download_azcopy.rs:68:36\",\"is_secret\":false},\"package_names\":[]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{\"crash-dumps\":[{\"backing_var\":{\"Inline\":\"C:\\\\Users\\\\cloudtest\\\\AppData\\\\Local\\\\CrashDumps\"},\"is_secret\":false},true],\"logs\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\"},\"is_secret\":false},false],\"openhcl-dumps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\"},\"is_secret\":false},false]},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:15:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:210:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:13:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:209:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-windows-amd-vmm-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":null,\"dep_artifact_dirs\":{\"artifact_dir_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_files\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-openhcl-igvm\"},\"is_secret\":false},\"artifact_dir_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-openvmm\"},\"is_secret\":false},\"artifact_dir_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"artifact_dir_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false}},\"done\":{\"backing_var\":\"start51\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-windows-amd-vmm-tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"target\":\"x86_64-pc-windows-msvc\",\"vmm_tests_artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_guest_test_uefi::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"guest_test_uefi\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-vmm-tests-archive\"},\"is_secret\":false},\"nextest_archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-openhcl-igvm\"},\"is_secret\":false},\"igvm_files\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:124:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-openvmm\"},\"is_secret\":false},\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\",\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:1:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:59:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestKernel\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:1:flowey_lib_hvlite/src/init_vmm_tests_env.rs:88:37\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_vmm_tests_vhds": [
+        "{\"DownloadIsos\":[\"FreeBsd13_2\"]}",
+        "{\"DownloadVhds\":[\"FreeBsd13_2\",\"Gen1WindowsDataCenterCore2022\",\"Gen2WindowsDataCenterCore2022\",\"Ubuntu2204Server\"]}",
+        "{\"GetDownloadFolder\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:0:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:49:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:2:flowey_lib_hvlite/src/init_vmm_tests_env.rs:92:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_vmm_tests_env": [
+        "{\"disk_images_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\"},\"is_secret\":false},\"get_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\",\"is_secret\":false},\"get_openhcl_dump_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\",\"is_secret\":false},\"get_test_log_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\",\"is_secret\":false},\"register_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\"},\"is_secret\":false},\"register_openhcl_igvm_files\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:124:17\"},\"is_secret\":false},\"register_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\"},\"is_secret\":false},\"register_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\"},\"is_secret\":false},\"register_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\"},\"is_secret\":false},\"test_content_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:1:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"vmm_tests_target\":\"x86_64-pc-windows-msvc\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::test_nextest_vmm_tests_archive": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"nextest_archive_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\"},\"is_secret\":false},\"nextest_filter_expr\":\"all()\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false}}"
+      ]
+    },
+    "18": {
+      "flowey_lib_common::cache": [
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_azcopy:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_azcopy:1:flowey_lib_common/src/download_azcopy.rs:58:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"azcopy-10.27.0-20241030\"},\"is_secret\":false},\"label\":\"azcopy\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_cargo_nextest:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_cargo_nextest:1:flowey_lib_common/src/download_cargo_nextest.rs:66:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"cargo-nextest-0.9.74\"},\"is_secret\":false},\"label\":\"cargo-nextest\",\"restore_keys\":null}",
+        "{\"dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_common::download_gh_release:0:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"hitvar\":{\"HitVar\":{\"backing_var\":\"flowey_lib_common::download_gh_release:1:flowey_lib_common/src/download_gh_release.rs:177:26\",\"is_secret\":false}},\"key\":{\"backing_var\":{\"Inline\":\"gh-release-download-cece0abc200568d6\"},\"is_secret\":false},\"label\":\"gh-release-download\",\"restore_keys\":null}"
+      ],
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"GetAzCopy\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_vmm_tests_vhds:0:flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs:113:30\",\"is_secret\":false}}",
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"InstallStandalone\":{\"backing_var\":\"flowey_lib_common::run_cargo_nextest_run:0:flowey_lib_common/src/run_cargo_nextest_run.rs:207:29\",\"is_secret\":false}}",
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_gh_release": [
+        "{\"file_name\":\"RELEASE-X64-artifacts.zip\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:1:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:64:35\",\"is_secret\":false},\"repo_name\":\"mu_msvm\",\"repo_owner\":\"microsoft\",\"tag\":\"v24.0.2\"}",
+        "{\"file_name\":\"openvmm-deps.x86_64.0.1.0-20241014.2.tar.bz2\",\"needs_auth\":false,\"path\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:1:flowey_lib_hvlite/src/download_openvmm_deps.rs:90:21\",\"is_secret\":false},\"repo_name\":\"openvmm-deps\",\"repo_owner\":\"microsoft\",\"tag\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_dist_pkg": [
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_openvmm_deps:0:flowey_lib_hvlite/src/download_openvmm_deps.rs:81:13\",\"is_secret\":false},\"package_names\":[\"lbzip2\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_common::download_azcopy:2:flowey_lib_common/src/download_azcopy.rs:68:36\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}",
+        "{\"Install\":{\"done\":{\"backing_var\":\"flowey_lib_hvlite::download_uefi_mu_msvm:0:flowey_lib_hvlite/src/download_uefi_mu_msvm.rs:56:32\",\"is_secret\":false},\"package_names\":[\"libarchive-tools\"]}}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_common::publish_test_results": [
+        "{\"attachments\":{\"crash-dumps\":[{\"backing_var\":{\"Inline\":\"/will/not/exist\"},\"is_secret\":false},true],\"logs\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\"},\"is_secret\":false},false],\"openhcl-dumps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\"},\"is_secret\":false},false]},\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:14:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:210:36\",\"is_secret\":false},\"junit_xml\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:12:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:209:33\"},\"is_secret\":false},\"output_dir\":null,\"test_label\":\"x64-linux-vmm-tests\"}"
+      ],
+      "flowey_lib_common::run_cargo_nextest_run": [
+        "{\"Run\":{\"config_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:1:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:58:31\"},\"is_secret\":false},\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:3:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:83:26\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all() and not test(openhcl) and not test(pcat_x64)\",\"nextest_profile\":\"ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"auto_se:flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_core/src/node.rs:852:34\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:1:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}},\"tool_config_files\":[],\"with_rlimit_unlimited_core_size\":true,\"working_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive": [
+        "{\"artifact_dir\":null,\"dep_artifact_dirs\":{\"artifact_dir_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"artifact_dir_openhcl_igvm_files\":null,\"artifact_dir_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-openvmm\"},\"is_secret\":false},\"artifact_dir_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"artifact_dir_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false}},\"done\":{\"backing_var\":\"start52\",\"is_secret\":false},\"fail_job_on_test_fail\":true,\"junit_test_label\":\"x64-linux-vmm-tests\",\"nextest_filter_expr\":\"all() and not test(openhcl) and not test(pcat_x64)\",\"nextest_profile\":\"Ci\",\"target\":\"x86_64-unknown-linux-gnu\",\"vmm_tests_artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_guest_test_uefi::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-guest_test_uefi\"},\"is_secret\":false},\"guest_test_uefi\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-vmm-tests-archive\"},\"is_secret\":false},\"nextest_archive\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_openvmm::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-openvmm\"},\"is_secret\":false},\"openvmm\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::artifact_pipette::resolve": [
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-linux-musl-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\",\"is_secret\":false}}",
+        "{\"artifact_dir\":{\"backing_var\":{\"RuntimeVar\":\"artifact_use_from_x64-windows-pipette\"},\"is_secret\":false},\"pipette\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::cfg_openvmm_magicpath": [
+        "{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:1:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:59:37\",\"is_secret\":false}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"GetLinuxTestInitrd\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:0:flowey_lib_hvlite/src/init_vmm_tests_env.rs:85:37\",\"is_secret\":false}]}",
+        "{\"GetLinuxTestKernel\":[\"X86_64\",{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:1:flowey_lib_hvlite/src/init_vmm_tests_env.rs:88:37\",\"is_secret\":false}]}",
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_vmm_tests_vhds": [
+        "{\"DownloadIsos\":[\"FreeBsd13_2\"]}",
+        "{\"DownloadVhds\":[\"FreeBsd13_2\",\"Gen1WindowsDataCenterCore2022\",\"Gen2WindowsDataCenterCore2022\",\"Ubuntu2204Server\"]}",
+        "{\"GetDownloadFolder\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"GetMsvmFd\":{\"arch\":\"X86_64\",\"msvm_fd\":{\"backing_var\":\"flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm:0:flowey_lib_hvlite/src/init_openvmm_magicpath_uefi_mu_msvm.rs:49:29\",\"is_secret\":false}}}",
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::cfg_openvmm_magicpath:0:flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs:27:29\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::init_vmm_tests_env:2:flowey_lib_hvlite/src/init_vmm_tests_env.rs:92:37\",\"is_secret\":false}}",
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::run_cargo_nextest_run:0:flowey_lib_hvlite/src/run_cargo_nextest_run.rs:55:37\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm": [
+        "{\"arch\":\"X86_64\",\"done\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_vmm_tests_env": [
+        "{\"disk_images_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:6:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:155:17\"},\"is_secret\":false},\"get_env\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\",\"is_secret\":false},\"get_openhcl_dump_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:9:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:178:62\",\"is_secret\":false},\"get_test_log_path\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:8:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:177:54\",\"is_secret\":false},\"register_guest_test_uefi\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:5:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:117:17\"},\"is_secret\":false},\"register_openhcl_igvm_files\":null,\"register_openvmm\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:2:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:96:17\"},\"is_secret\":false},\"register_pipette_linux_musl\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:4:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:110:17\"},\"is_secret\":false},\"register_pipette_windows\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:3:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:103:17\"},\"is_secret\":false},\"test_content_dir\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:1:flowey_core/src/node.rs:896:34\"},\"is_secret\":false},\"vmm_tests_target\":\"x86_64-unknown-linux-gnu\"}"
+      ],
+      "flowey_lib_hvlite::run_cargo_nextest_run": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"friendly_name\":\"vmm_tests\",\"nextest_filter_expr\":\"all() and not test(openhcl) and not test(pcat_x64)\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false},{\"backing_var\":{\"RuntimeVar\":\"auto_se:flowey_lib_hvlite::test_nextest_vmm_tests_archive:0:flowey_core/src/node.rs:852:34\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false},\"run_ignored\":false,\"run_kind\":{\"RunFromArchive\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::test_nextest_vmm_tests_archive:1:flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs:68:52\"},\"is_secret\":false}}}"
+      ],
+      "flowey_lib_hvlite::test_nextest_vmm_tests_archive": [
+        "{\"extra_env\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:10:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:180:29\"},\"is_secret\":false},\"nextest_archive_file\":{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:75:17\"},\"is_secret\":false},\"nextest_filter_expr\":\"all() and not test(openhcl) and not test(pcat_x64)\",\"nextest_profile\":\"Ci\",\"pre_run_deps\":[{\"backing_var\":{\"RuntimeVar\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:7:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:171:21\"},\"is_secret\":false}],\"results\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:11:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs:194:27\",\"is_secret\":false}}"
+      ]
+    },
+    "19": {
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"CheckoutRepo\":{\"persist_credentials\":false,\"repo_id\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false},\"repo_path\":{\"backing_var\":\"flowey_lib_hvlite::git_checkout_openvmm_repo:0:flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs:48:24\",\"is_secret\":false}}}",
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"EnsureInstalled\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:1:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:31:32\",\"is_secret\":false}}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm": [
+        "{\"base_recipe\":\"X64\",\"done\":{\"backing_var\":\"start53\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"GetRepoDir\":{\"backing_var\":\"flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:0:flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs:30:31\",\"is_secret\":false}}",
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ]
+    },
+    "20": {
+      "flowey_lib_common::cfg_cargo_common_flags": [
+        "{\"SetLocked\":true}",
+        "{\"SetVerbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_common::download_azcopy": [
+        "{\"Version\":\"10.27.0-20241030\"}"
+      ],
+      "flowey_lib_common::download_cargo_fuzz": [
+        "{\"Version\":\"0.12.0\"}"
+      ],
+      "flowey_lib_common::download_cargo_nextest": [
+        "{\"Version\":\"0.9.74\"}"
+      ],
+      "flowey_lib_common::download_gh_cli": [
+        "{\"Version\":\"2.52.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook": [
+        "{\"Version\":\"0.4.40\"}"
+      ],
+      "flowey_lib_common::download_mdbook_admonish": [
+        "{\"Version\":\"1.18.0\"}"
+      ],
+      "flowey_lib_common::download_mdbook_mermaid": [
+        "{\"Version\":\"0.14.0\"}"
+      ],
+      "flowey_lib_common::download_protoc": [
+        "{\"Version\":\"27.1\"}"
+      ],
+      "flowey_lib_common::git_checkout": [
+        "{\"RegisterRepo\":{\"allow_persist_credentials\":false,\"depth\":1,\"pre_run_deps\":[],\"repo_id\":\"hvlite\",\"repo_src\":\"GithubSelf\"}}"
+      ],
+      "flowey_lib_common::install_azure_cli": [
+        "{\"AutoInstall\":true}",
+        "{\"Version\":\"2.56.0\"}"
+      ],
+      "flowey_lib_common::install_nodejs": [
+        "{\"Version\":\"18.x\"}"
+      ],
+      "flowey_lib_common::install_rust": [
+        "{\"AutoInstall\":true}",
+        "{\"IgnoreVersion\":false}",
+        "{\"Version\":\"1.82.0\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::all_good_job": [
+        "{\"did_fail_env_var\":\"ANY_JOBS_FAILED\",\"done\":{\"backing_var\":\"start54\",\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_common": [
+        "{\"deny_warnings\":true,\"local_only\":null,\"locked\":true,\"verbose\":{\"backing_var\":{\"RuntimeVar\":\"param0\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_hvlite_reposource": [
+        "{\"hvlite_repo_source\":\"GithubSelf\"}"
+      ],
+      "flowey_lib_hvlite::_jobs::cfg_versions": [
+        "{}"
+      ],
+      "flowey_lib_hvlite::download_lxutil": [
+        "{\"Version\":\"10.0.26100.1-240331-1435.ge-release\"}"
+      ],
+      "flowey_lib_hvlite::download_openhcl_kernel_package": [
+        "{\"Version\":[\"Cvm\",\"6.6.51.7\"]}",
+        "{\"Version\":[\"CvmDev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Dev\",\"6.6.51.6\"]}",
+        "{\"Version\":[\"Main\",\"6.6.51.7\"]}"
+      ],
+      "flowey_lib_hvlite::download_openvmm_deps": [
+        "{\"Version\":\"0.1.0-20241014.2\"}"
+      ],
+      "flowey_lib_hvlite::download_uefi_mu_msvm": [
+        "{\"Version\":\"24.0.2\"}"
+      ],
+      "flowey_lib_hvlite::git_checkout_openvmm_repo": [
+        "{\"SetRepoId\":{\"backing_var\":{\"Inline\":\"hvlite\"},\"is_secret\":false}}"
+      ],
+      "flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings": [
+        "{\"DenyWarnings\":true}"
+      ]
+    }
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6829,6 +6829,7 @@ dependencies = [
  "vga_proxy",
  "video_core",
  "virt",
+ "virt_kvm",
  "virt_mshv_vtl",
  "vm_loader",
  "vm_manifest_builder",
@@ -6912,9 +6913,11 @@ dependencies = [
  "libc",
  "log",
  "nix 0.26.4",
+ "safe_intrinsics",
  "underhill_confidentiality",
  "vergen",
  "walkdir",
+ "x86defs",
 ]
 
 [[package]]
@@ -6923,6 +6926,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "build_rs_guest_arch",
+ "fs-err",
  "futures",
  "guestmem",
  "hcl",

--- a/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_igvm.rs
@@ -30,6 +30,9 @@ pub enum OpenhclRecipeCli {
     X64,
     /// X64 OpenHCL, using the dev kernel in VTL2
     X64Devkern,
+    /// X64 OpenHCL running in VTL0, using KVM and nested virtualization to run
+    /// the guest. Uses the dev kernel.
+    X64Nested,
 }
 
 /// Build OpenHCL IGVM files for local development. DO NOT USE IN CI.
@@ -293,6 +296,7 @@ impl IntoPipeline for BuildIgvmCli {
                     OpenhclRecipeCli::X64CvmDevkern => OpenhclIgvmRecipe::X64CvmDevkern,
                     OpenhclRecipeCli::Aarch64 => OpenhclIgvmRecipe::Aarch64,
                     OpenhclRecipeCli::Aarch64Devkern => OpenhclIgvmRecipe::Aarch64Devkern,
+                    OpenhclRecipeCli::X64Nested => OpenhclIgvmRecipe::X64Nested,
                 },
                 release,
 

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_igvm.rs
@@ -7,6 +7,7 @@ use flowey::node::prelude::*;
 
 use crate::build_openhcl_boot::OpenhclBootOutput;
 use crate::build_openhcl_igvm_from_recipe::IgvmManifestPath;
+use crate::build_openhcl_igvm_from_recipe::InitrdRootfsPath;
 use crate::build_openhcl_igvm_from_recipe::OpenhclIgvmRecipe;
 use crate::build_openhcl_igvm_from_recipe::OpenhclIgvmRecipeDetails;
 use crate::build_openhcl_igvm_from_recipe::OpenhclIgvmRecipeDetailsLocalOnly;
@@ -115,6 +116,7 @@ impl SimpleFlowNode for Node {
                 with_uefi,
                 with_interactive,
                 with_sidecar_details,
+                initrd_rootfs,
             } = &mut recipe_details;
 
             if custom_kernel.is_some() {
@@ -149,11 +151,11 @@ impl SimpleFlowNode for Node {
                 custom_uefi: custom_uefi.map(|p| p.absolute()).transpose()?,
                 custom_kernel: custom_kernel.map(|p| p.absolute()).transpose()?,
                 custom_sidecar: custom_sidecar.map(|p| p.absolute()).transpose()?,
-                custom_extra_rootfs: custom_extra_rootfs
-                    .into_iter()
-                    .map(|p| p.absolute())
-                    .collect::<Result<_, _>>()?,
             });
+
+            for p in custom_extra_rootfs.iter() {
+                initrd_rootfs.push(InitrdRootfsPath::LocalOnlyCustom(p.absolute()?));
+            }
 
             if let Some(p) = override_manifest {
                 *igvm_manifest = IgvmManifestPath::LocalOnlyCustom(p.absolute()?);
@@ -309,6 +311,7 @@ pub fn non_production_build_igvm_tool_out_name(recipe: &OpenhclIgvmRecipe) -> &'
         OpenhclIgvmRecipe::X64CvmDevkern => "x64-cvm-devkern",
         OpenhclIgvmRecipe::Aarch64 => "aarch64",
         OpenhclIgvmRecipe::Aarch64Devkern => "aarch64-devkern",
+        OpenhclIgvmRecipe::X64Nested => "x64-nested",
         OpenhclIgvmRecipe::LocalOnlyCustom(_) => unreachable!(),
     }
 }

--- a/flowey/flowey_lib_hvlite/src/artifact_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/artifact_openhcl_igvm_from_recipe.rs
@@ -14,6 +14,7 @@ pub(crate) fn recipe_to_filename(flavor: &OpenhclIgvmRecipe) -> &str {
         OpenhclIgvmRecipe::X64TestLinuxDirectDevkern => "openhcl-direct-dev",
         OpenhclIgvmRecipe::X64Cvm => "openhcl-cvm",
         OpenhclIgvmRecipe::X64CvmDevkern => "openhcl-cvm-dev",
+        OpenhclIgvmRecipe::X64Nested => "openhcl-nested",
         OpenhclIgvmRecipe::Aarch64 => "openhcl-aarch64",
         OpenhclIgvmRecipe::Aarch64Devkern => "openhcl-aarch64-dev",
         OpenhclIgvmRecipe::LocalOnlyCustom(_) => unreachable!(),

--- a/flowey/flowey_lib_hvlite/src/build_openvmm_hcl.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm_hcl.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeSet;
 pub enum OpenvmmHclFeature {
     Gdb,
     Tpm,
+    VirtKvm,
     LocalOnlyCustom(String),
 }
 
@@ -119,6 +120,7 @@ impl FlowNode for Node {
                         match f {
                             OpenvmmHclFeature::Gdb => "gdb",
                             OpenvmmHclFeature::Tpm => "tpm",
+                            OpenvmmHclFeature::VirtKvm => "virt_kvm",
                             OpenvmmHclFeature::LocalOnlyCustom(s) => s,
                         }
                         .into()

--- a/openhcl/openvmm_hcl/Cargo.toml
+++ b/openhcl/openvmm_hcl/Cargo.toml
@@ -19,6 +19,9 @@ uidevices = ["openvmm_hcl_resources/uidevices", "openvmm_hcl_resources/vnc_worke
 # Enable NVMe emulation.
 nvme = ["openvmm_hcl_resources/nvme", "underhill_entry/vpci"]
 
+# Enable KVM and nested virtualization support.
+virt_kvm = ["underhill_entry/virt_kvm"]
+
 [target.'cfg(target_os = "linux")'.dependencies]
 underhill_entry.workspace = true
 openvmm_hcl_resources.workspace = true

--- a/openhcl/rootfs.config
+++ b/openhcl/rootfs.config
@@ -25,16 +25,17 @@ dir /lib/modules 0755 0 0
 # Kernel modules are loaded in sort order; put them in directories appropriately
 # to ensure they are loaded in dependency order.
 
-dir /lib/modules/000    0755 0 0
-dir /lib/modules/001    0755 0 0
-dir /lib/modules/999    0755 0 0
+dir /lib/modules/auto        0755 0 0
+dir /lib/modules/auto/000    0755 0 0
+dir /lib/modules/auto/001    0755 0 0
+dir /lib/modules/auto/999    0755 0 0
 
-file /lib/modules/000/pci-hyperv-intf.ko    ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/pci/controller/pci-hyperv-intf.ko  0644 0 0
-file /lib/modules/001/pci-hyperv.ko         ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/pci/controller/pci-hyperv.ko       0644 0 0
+file /lib/modules/auto/000/pci-hyperv-intf.ko    ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/pci/controller/pci-hyperv-intf.ko  0644 0 0
+file /lib/modules/auto/001/pci-hyperv.ko         ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/pci/controller/pci-hyperv.ko       0644 0 0
 
 # Storvsc is last because it sometimes takes a long time to load and should not
 # block other device startup.
-file /lib/modules/999/hv_storvsc.ko         ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/scsi/hv_storvsc.ko      0644 0 0
+file /lib/modules/auto/999/hv_storvsc.ko         ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/drivers/scsi/hv_storvsc.ko      0644 0 0
 
 # These nodes are needed for early logging before devfs is mounted.
 nod /dev/null      0666 0 0 c 1  3

--- a/openhcl/rootfs.kvm.config
+++ b/openhcl/rootfs.kvm.config
@@ -1,0 +1,3 @@
+file /lib/modules/kvm.ko        ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/arch/x86/kvm/kvm.ko         0644 0 0
+file /lib/modules/kvm-amd.ko    ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/arch/x86/kvm/kvm-amd.ko     0644 0 0
+file /lib/modules/kvm-intel.ko  ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/modules/kernel/arch/x86/kvm/kvm-intel.ko   0644 0 0

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -20,6 +20,11 @@ openssl-vendored = ["underhill_attestation/openssl-vendored"]
 # Enable VPCI device support
 vpci = []
 
+# Enable support for running the guest OS via nested virtualization with KVM.
+# (Note that the virt_kvm crate is always a dependency just to avoid build
+# breaks.)
+virt_kvm = []
+
 [target.'cfg(target_os = "linux")'.dependencies]
 vmotherboard = { workspace = true, features = [
     "encryption",
@@ -93,6 +98,7 @@ underhill_threadpool.workspace = true
 bootloader_fdt_parser.workspace = true
 vga_proxy.workspace = true
 video_core.workspace = true
+virt_kvm.workspace = true
 virt_mshv_vtl.workspace = true
 vm_manifest_builder.workspace = true
 vmbus_async.workspace = true

--- a/openhcl/underhill_core/src/emuplat/firmware.rs
+++ b/openhcl/underhill_core/src/emuplat/firmware.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::partition::OpenhclPartition;
 #[cfg(guest_arch = "x86_64")]
 use firmware_pcat::PcatEvent;
 #[cfg(guest_arch = "x86_64")]
@@ -10,7 +11,6 @@ use firmware_uefi::platform::logger::UefiLogger;
 use guest_emulation_transport::api::EventLogId;
 use guest_emulation_transport::GuestEmulationTransportClient;
 use std::sync::Weak;
-use virt_mshv_vtl::UhPartition;
 
 /// An Underhill specific logger used to log UEFI and PCAT events.
 #[derive(Debug)]
@@ -54,7 +54,7 @@ impl PcatLogger for UnderhillLogger {
 
 #[derive(Debug)]
 pub struct UnderhillVsmConfig {
-    pub partition: Weak<UhPartition>,
+    pub partition: Weak<dyn OpenhclPartition>,
 }
 
 impl firmware_uefi::platform::nvram::VsmConfig for UnderhillVsmConfig {
@@ -62,7 +62,7 @@ impl firmware_uefi::platform::nvram::VsmConfig for UnderhillVsmConfig {
         if let Some(partition) = self.partition.upgrade() {
             if let Err(err) = partition.revoke_guest_vsm() {
                 tracing::warn!(
-                    error = &err as &dyn std::error::Error,
+                    error = err.as_ref() as &dyn std::error::Error,
                     "failed to revoke guest vsm"
                 );
             }

--- a/openhcl/underhill_core/src/emuplat/vga_proxy.rs
+++ b/openhcl/underhill_core/src/emuplat/vga_proxy.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::partition::OpenhclPartition;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
-use virt_mshv_vtl::UhPartition;
 
-pub struct UhRegisterHostIoFastPath(pub Arc<UhPartition>);
+pub struct UhRegisterHostIoFastPath(pub Arc<dyn OpenhclPartition>);
 
 impl vga_proxy::RegisterHostIoPortFastPath for UhRegisterHostIoFastPath {
     fn register(&self, range: RangeInclusive<u16>) -> Box<dyn Send> {

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -16,6 +16,7 @@ mod inspect_proc;
 mod loader;
 mod nvme_manager;
 mod options;
+mod partition;
 mod reference_time;
 mod servicing;
 mod threadpool_vm_task_backend;
@@ -322,6 +323,7 @@ async fn launch_workers(
         no_sidecar_hotplug: opt.no_sidecar_hotplug,
         gdbstub: opt.gdbstub,
         hide_isolation: opt.hide_isolation,
+        kvm: opt.kvm,
     };
 
     let (mut remote_console_cfg, framebuffer_access) =

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -113,6 +113,10 @@ pub struct Options {
     /// (OPENHCL_NO_SIDECAR_HOTPLUG=1) Leave sidecar VPs remote even if they
     /// hit exits.
     pub no_sidecar_hotplug: bool,
+
+    /// (OPENHCL_KVM=1) Use KVM and nested virtualization to run the guest OS
+    /// instead of using the mshv_vtl driver.
+    pub kvm: bool,
 }
 
 impl Options {
@@ -181,6 +185,7 @@ impl Options {
         let no_sidecar_hotplug = parse_legacy_env_bool("OPENHCL_NO_SIDECAR_HOTPLUG");
         let gdbstub = parse_legacy_env_bool("OPENHCL_GDBSTUB");
         let gdbstub_port = parse_legacy_env_number("OPENHCL_GDBSTUB_PORT")?.map(|x| x as u32);
+        let kvm = parse_env_bool("OPENHCL_KVM");
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.
@@ -234,6 +239,7 @@ impl Options {
             hide_isolation,
             halt_on_guest_halt,
             no_sidecar_hotplug,
+            kvm,
         })
     }
 

--- a/openhcl/underhill_core/src/partition.rs
+++ b/openhcl/underhill_core/src/partition.rs
@@ -1,0 +1,285 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Partition abstraction allowing different virtualization backends within
+//! OpenHCL.
+//!
+//! This abstraction is similar to `HvlitePartition`, and should be merged with
+//! it at some point. Right now, there are enough differences in requirements
+//! that this is not practical.
+
+#![warn(missing_docs)]
+
+use core::ops::RangeInclusive;
+use inspect::Inspect;
+use inspect::InspectMut;
+use std::sync::Arc;
+use virt::Partition;
+use vmcore::save_restore::SaveRestore;
+use vmcore::save_restore::SavedStateNotSupported;
+
+/// The VM partition.
+pub trait OpenhclPartition: Send + Sync + Inspect {
+    /// The current paravisor reference time.
+    ///
+    /// This is only here because we use an `Hcl` method to get it today. It
+    /// should be moved elsewhere in the future, since this isn't really a
+    /// partition concept.
+    fn reference_time(&self) -> u64;
+
+    /// The current VTL0 guest OS ID.
+    fn vtl0_guest_os_id(&self) -> hvdef::hypercall::HvGuestOsId;
+
+    /// Registers the range to be intercepted by the host directly, without the
+    /// exit flowing through the paravisor.
+    ///
+    /// This is best effort. Exits for this range may still flow through the paravisor.
+    fn register_host_io_port_fast_path(&self, range: RangeInclusive<u16>) -> Box<dyn Send>;
+
+    /// Revokes support for guest VSM (i.e., VTL1) after the guest has started
+    /// running.
+    fn revoke_guest_vsm(&self) -> anyhow::Result<()>;
+
+    /// Requests an MSI be delivered to the guest interrupt controller.
+    fn request_msi(&self, vtl: hvdef::Vtl, request: virt::irqcon::MsiRequest);
+
+    /// Returns the partition's capabilities.
+    fn caps(&self) -> &virt::PartitionCapabilities;
+
+    /// Returns the trait object for accessing the synic.
+    fn into_synic(self: Arc<Self>) -> Arc<dyn virt::Synic>;
+
+    /// Gets a line set target to trigger local APIC LINTs.
+    ///
+    /// The line number is the VP index times 2, plus the LINT number (0 or 1).
+    #[cfg(guest_arch = "x86_64")]
+    fn into_lint_target(
+        self: Arc<Self>,
+        vtl: hvdef::Vtl,
+    ) -> Arc<dyn vmcore::line_interrupt::LineSetTarget>;
+
+    /// Returns the interface for IO APIC routing.
+    #[cfg(guest_arch = "x86_64")]
+    fn ioapic_routing(&self) -> Arc<dyn virt::irqcon::IoApicRouting>;
+
+    /// Returns the interface for VTL memory protection changes.
+    fn into_vtl_memory_protection(
+        self: Arc<Self>,
+    ) -> Arc<dyn virt::VtlMemoryProtection + Send + Sync>;
+
+    /// Sets the port to use for the PM timer assist. Reads of this port will be
+    /// implemented by the hypervisor, using the reference time scaled to the
+    /// appropriate frequency.
+    ///
+    /// This is best effort. Exits for reads of this port may still flow through
+    /// the paravisor.
+    fn set_pm_timer_assist(&self, port: Option<u16>) -> anyhow::Result<()>;
+
+    /// Reads from an MMIO address by calling into the host.
+    ///
+    /// FUTURE: remove from the partition interface
+    fn host_mmio_read(&self, addr: u64, data: &mut [u8]);
+
+    /// Writes to an MMIO address by calling into the host.
+    ///
+    /// FUTURE: remove from the partition interface
+    fn host_mmio_write(&self, addr: u64, data: &[u8]);
+
+    /// Gets an interface for cancelling VPs.
+    fn into_request_yield(self: Arc<Self>) -> Arc<dyn vmm_core::partition_unit::RequestYield>;
+}
+
+impl OpenhclPartition for virt_mshv_vtl::UhPartition {
+    fn reference_time(&self) -> u64 {
+        self.reference_time()
+    }
+
+    fn vtl0_guest_os_id(&self) -> hvdef::hypercall::HvGuestOsId {
+        self.vtl0_guest_os_id()
+    }
+
+    fn register_host_io_port_fast_path(&self, range: RangeInclusive<u16>) -> Box<dyn Send> {
+        Box::new(self.register_host_io_port_fast_path(range))
+    }
+
+    fn revoke_guest_vsm(&self) -> anyhow::Result<()> {
+        self.revoke_guest_vsm()?;
+        Ok(())
+    }
+
+    fn request_msi(&self, vtl: hvdef::Vtl, request: virt::irqcon::MsiRequest) {
+        Partition::request_msi(self, vtl, request)
+    }
+
+    fn caps(&self) -> &virt::PartitionCapabilities {
+        Partition::caps(self)
+    }
+
+    fn into_synic(self: Arc<Self>) -> Arc<dyn virt::Synic> {
+        self
+    }
+
+    fn into_lint_target(
+        self: Arc<Self>,
+        vtl: hvdef::Vtl,
+    ) -> Arc<dyn vmcore::line_interrupt::LineSetTarget> {
+        Arc::new(virt::irqcon::ApicLintLineTarget::new(self, vtl))
+    }
+
+    fn ioapic_routing(&self) -> Arc<dyn virt::irqcon::IoApicRouting> {
+        virt::X86Partition::ioapic_routing(self)
+    }
+
+    fn into_vtl_memory_protection(
+        self: Arc<Self>,
+    ) -> Arc<dyn virt::VtlMemoryProtection + Send + Sync> {
+        self
+    }
+
+    fn set_pm_timer_assist(&self, port: Option<u16>) -> anyhow::Result<()> {
+        self.set_pm_timer_assist(port)?;
+        Ok(())
+    }
+
+    fn host_mmio_read(&self, addr: u64, data: &mut [u8]) {
+        self.host_mmio_read(addr, data);
+    }
+
+    fn host_mmio_write(&self, addr: u64, data: &[u8]) {
+        self.host_mmio_write(addr, data);
+    }
+
+    fn into_request_yield(self: Arc<Self>) -> Arc<dyn vmm_core::partition_unit::RequestYield> {
+        self
+    }
+}
+
+impl OpenhclPartition for virt_kvm::KvmPartition {
+    fn reference_time(&self) -> u64 {
+        // TODO. This is just used for logging, so it's not critical.
+        0
+    }
+
+    fn vtl0_guest_os_id(&self) -> hvdef::hypercall::HvGuestOsId {
+        hvdef::hypercall::HvGuestOsId::new()
+    }
+
+    fn register_host_io_port_fast_path(&self, _range: RangeInclusive<u16>) -> Box<dyn Send> {
+        Box::new(())
+    }
+
+    fn revoke_guest_vsm(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn request_msi(&self, vtl: hvdef::Vtl, request: virt::irqcon::MsiRequest) {
+        Partition::request_msi(self, vtl, request)
+    }
+
+    fn caps(&self) -> &virt::PartitionCapabilities {
+        Partition::caps(self)
+    }
+
+    fn into_synic(self: Arc<Self>) -> Arc<dyn virt::Synic> {
+        self
+    }
+
+    fn into_lint_target(
+        self: Arc<Self>,
+        vtl: hvdef::Vtl,
+    ) -> Arc<dyn vmcore::line_interrupt::LineSetTarget> {
+        Arc::new(virt::irqcon::ApicLintLineTarget::new(self, vtl))
+    }
+
+    fn ioapic_routing(&self) -> Arc<dyn virt::irqcon::IoApicRouting> {
+        virt::X86Partition::ioapic_routing(self)
+    }
+
+    fn into_vtl_memory_protection(
+        self: Arc<Self>,
+    ) -> Arc<dyn virt::VtlMemoryProtection + Send + Sync> {
+        Arc::new(IgnoreProtectionChanges)
+    }
+
+    fn set_pm_timer_assist(&self, _port: Option<u16>) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn host_mmio_read(&self, _addr: u64, _data: &mut [u8]) {
+        unimplemented!()
+    }
+
+    fn host_mmio_write(&self, _addr: u64, _data: &[u8]) {
+        unimplemented!()
+    }
+
+    fn into_request_yield(self: Arc<Self>) -> Arc<dyn vmm_core::partition_unit::RequestYield> {
+        self
+    }
+}
+
+struct IgnoreProtectionChanges;
+
+impl virt::VtlMemoryProtection for IgnoreProtectionChanges {
+    fn modify_vtl_page_setting(
+        &self,
+        _pfn: u64,
+        _flags: hvdef::HvMapGpaFlags,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+/// A wrapper around a `virt::Processor` that does not support save/restore.
+#[derive(InspectMut)]
+#[inspect(transparent, bound = "T: InspectMut")]
+pub struct NoSaveVp<T>(#[inspect(mut)] pub T);
+
+impl<T: virt::Processor> virt::Processor for NoSaveVp<T> {
+    type Error = T::Error;
+    type RunVpError = T::RunVpError;
+
+    type StateAccess<'a> = T::StateAccess<'a>
+    where
+        Self: 'a
+    ;
+
+    fn set_debug_state(
+        &mut self,
+        vtl: hvdef::Vtl,
+        state: Option<&virt::x86::DebugState>,
+    ) -> Result<(), Self::Error> {
+        self.0.set_debug_state(vtl, state)
+    }
+
+    async fn run_vp(
+        &mut self,
+        stop: virt::StopVp<'_>,
+        dev: &impl virt::io::CpuIo,
+    ) -> Result<std::convert::Infallible, virt::VpHaltReason<Self::RunVpError>> {
+        self.0.run_vp(stop, dev).await
+    }
+
+    fn flush_async_requests(&mut self) -> Result<(), Self::RunVpError> {
+        self.0.flush_async_requests()
+    }
+
+    fn access_state(&mut self, vtl: hvdef::Vtl) -> Self::StateAccess<'_> {
+        self.0.access_state(vtl)
+    }
+}
+
+impl<T> SaveRestore for NoSaveVp<T> {
+    type SavedState = SavedStateNotSupported;
+
+    fn save(&mut self) -> Result<Self::SavedState, vmcore::save_restore::SaveError> {
+        Err(vmcore::save_restore::SaveError::NotSupported)
+    }
+
+    fn restore(
+        &mut self,
+        state: Self::SavedState,
+    ) -> Result<(), vmcore::save_restore::RestoreError> {
+        match state {}
+    }
+}

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -42,6 +42,7 @@ use crate::loader::LoadKind;
 use crate::nvme_manager::NvmeDiskConfig;
 use crate::nvme_manager::NvmeDiskResolver;
 use crate::nvme_manager::NvmeManager;
+use crate::partition::OpenhclPartition;
 use crate::reference_time::ReferenceTime;
 use crate::servicing;
 use crate::servicing::transposed::OptionServicingInitState;
@@ -112,15 +113,13 @@ use tpm_resources::TpmRegisterLayout;
 use tracing::instrument;
 use tracing::Instrument;
 use uevent::UeventListener;
+use underhill_mem::AccessGuestMemory;
 use underhill_threadpool::AffinitizedThreadpool;
 use underhill_threadpool::ThreadpoolBuilder;
 use user_driver::lockmem::LockedMemorySpawner;
 use user_driver::vfio::VfioDmaBuffer;
 use virt::state::HvRegisterState;
-use virt::Partition;
 use virt::VpIndex;
-use virt::X86Partition;
-use virt_mshv_vtl::UhPartition;
 use virt_mshv_vtl::UhPartitionNewParams;
 use virt_mshv_vtl::UhProtoPartition;
 use vm_loader::initial_regs::initial_regs;
@@ -294,6 +293,8 @@ pub struct UnderhillEnvCfg {
     pub gdbstub: bool,
     /// Hide the isolation mode from the guest.
     pub hide_isolation: bool,
+    /// Use KVM instead of mshv_vtl.
+    pub kvm: bool,
 }
 
 /// Bundle of config + runtime objects for hooking into the underhill remote
@@ -723,7 +724,7 @@ impl UhVmNetworkSettings {
         uevent_listener: &UeventListener,
         servicing_netvsp_state: &Option<Vec<crate::emuplat::netvsp::SavedState>>,
         shared_vis_pages_pool: &Option<SharedPool>,
-        partition: Arc<UhPartition>,
+        partition: Arc<dyn OpenhclPartition>,
         state_units: &StateUnits,
         tp: &AffinitizedThreadpool,
         vmbus_server: &Option<VmbusServerHandle>,
@@ -854,7 +855,7 @@ impl LoadedVmNetworkSettings for UhVmNetworkSettings {
         uevent_listener: &UeventListener,
         servicing_netvsp_state: &Option<Vec<crate::emuplat::netvsp::SavedState>>,
         shared_vis_pages_pool: &Option<SharedPool>,
-        partition: Arc<UhPartition>,
+        partition: Arc<dyn OpenhclPartition>,
         state_units: &StateUnits,
         vmbus_server: &Option<VmbusServerHandle>,
     ) -> anyhow::Result<RuntimeSavedState> {
@@ -1317,7 +1318,7 @@ async fn new_underhill_vm(
     )
     .context("failed to construct the processor topology")?;
 
-    let mut with_vmbus: bool = false;
+    let mut with_vmbus: bool = env_cfg.kvm;
     let mut with_vmbus_relay = false;
     if dps.general.vmbus_redirection_enabled {
         with_vmbus = true;
@@ -1420,62 +1421,56 @@ async fn new_underhill_vm(
 
     // Construct the underhill partition instance. This contains much of the configuration of the guest deposited by
     // the host, along with additional device configuration and transports.
-    let params = UhPartitionNewParams {
-        lower_vtl_memory_layout: &mem_layout,
-        isolation,
-        topology: &processor_topology,
-        cvm_cpuid_info: runtime_params.cvm_cpuid_info(),
-        snp_secrets: runtime_params.snp_secrets(),
-        env_cvm_guest_vsm: env_cfg.cvm_guest_vsm,
-        vtom,
-        handle_synic: with_vmbus,
-        no_sidecar_hotplug: env_cfg.no_sidecar_hotplug,
-        use_mmio_hypercalls,
-        intercept_debug_exceptions: env_cfg.gdbstub,
-        hide_isolation,
+    let proto_partition = if env_cfg.kvm {
+        None
+    } else {
+        let params = UhPartitionNewParams {
+            lower_vtl_memory_layout: &mem_layout,
+            isolation,
+            topology: &processor_topology,
+            cvm_cpuid_info: runtime_params.cvm_cpuid_info(),
+            snp_secrets: runtime_params.snp_secrets(),
+            env_cvm_guest_vsm: env_cfg.cvm_guest_vsm,
+            vtom,
+            handle_synic: with_vmbus,
+            no_sidecar_hotplug: env_cfg.no_sidecar_hotplug,
+            use_mmio_hypercalls,
+            intercept_debug_exceptions: env_cfg.gdbstub,
+            hide_isolation,
+        };
+
+        let proto_partition = UhProtoPartition::new(params, |cpu| tp.driver(cpu).clone())
+            .context("failed to create prototype partition")?;
+        Some(proto_partition)
     };
 
-    let proto_partition = UhProtoPartition::new(params, |cpu| tp.driver(cpu).clone())
-        .context("failed to create prototype partition")?;
-
-    let gm = underhill_mem::init(&underhill_mem::Init {
-        tp,
-        processor_topology: &processor_topology,
-        isolation,
-        vtl0_alias_map_bit,
-        vtom,
-        mem_layout: &mem_layout,
-        complete_memory_layout: &complete_memory_layout,
-        boot_init,
-        shared_pool: &shared_pool,
-        maximum_vtl: if proto_partition.guest_vsm_available() {
-            Vtl::Vtl1
-        } else {
-            Vtl::Vtl0
-        },
-        vtl2_memory: runtime_params.vtl2_memory_map(),
-        accepted_regions: measured_vtl2_info.accepted_regions(),
-    })
-    .await
-    .context("failed to initialize memory")?;
-
-    // Devices in hardware isolated VMs default to accessing only shared memory,
-    // since that is what the guest expects--it will double buffer memory to be
-    // DMAed through a shared memory pool.
-    //
-    // When hiding isolation, allow devices to access all memory, since that's
-    // the only option: the guest won't and can't transition anything to shared.
-    //
-    // For non-isolated VMs, there is no shared/private distinction, so devices
-    // access the same memory as the guest. For software-isolated VMs, the
-    // hypervisor does not allow the paravisor to observe changes to
-    // shared/private state, so we have no choice but to allow devices to access
-    // both.
-    let device_memory = if hide_isolation || !isolation.is_hardware_isolated() {
-        gm.vtl0()
+    let mut gm: Box<dyn AccessGuestMemory> = if let Some(proto_partition) = &proto_partition {
+        Box::new(
+            underhill_mem::init(&underhill_mem::Init {
+                tp,
+                processor_topology: &processor_topology,
+                isolation,
+                vtl0_alias_map_bit,
+                vtom,
+                mem_layout: &mem_layout,
+                complete_memory_layout: &complete_memory_layout,
+                boot_init,
+                shared_pool: &shared_pool,
+                maximum_vtl: if proto_partition.guest_vsm_available() {
+                    Vtl::Vtl1
+                } else {
+                    Vtl::Vtl0
+                },
+                vtl2_memory: runtime_params.vtl2_memory_map(),
+                accepted_regions: measured_vtl2_info.accepted_regions(),
+            })
+            .await
+            .context("failed to initialize memory")?,
+        )
     } else {
-        gm.shared_memory()
-            .expect("isolated VMs should have shared memory")
+        // KVM configurations do not yet support the driver for full
+        // underhill_mem support, so fall back to /dev/mem.
+        Box::new(underhill_mem::DevMemMemory::new(&mem_layout)?)
     };
 
     let shared_vis_pages_pool = if shared_pool_size != 0 {
@@ -1653,7 +1648,7 @@ async fn new_underhill_vm(
 
     // Only advertise extended IOAPIC on non-PCAT systems.
     #[cfg(guest_arch = "x86_64")]
-    let cpuid = {
+    let mut cpuid = {
         let extended_ioapic_rte = !matches!(firmware_type, FirmwareType::Pcat);
         vmm_core::cpuid::hyperv_cpuid_leaves(extended_ioapic_rte).collect::<Vec<_>>()
     };
@@ -1679,29 +1674,140 @@ async fn new_underhill_vm(
         })
         .unwrap();
 
-    let late_params = virt_mshv_vtl::UhLateParams {
-        gm: [
-            gm.vtl0().clone(),
-            gm.vtl1().cloned().unwrap_or(GuestMemory::empty()),
-        ]
-        .into(),
-        shared_memory: gm.shared_memory().cloned(),
-        #[cfg(guest_arch = "x86_64")]
-        cpuid,
-        crash_notification_send,
-        emulate_apic,
-        vmtime: &vmtime_source,
-        isolated_memory_protector: gm.isolated_memory_protector()?,
-        shared_vis_pages_pool: shared_vis_pages_pool.as_ref().map(|p| p.allocator()),
-    };
+    let (partition, spawn_vps): (
+        Arc<dyn OpenhclPartition>,
+        Box<
+            dyn FnOnce(
+                _,
+                _,
+            )
+                -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>>>>,
+        >,
+    ) = if let Some(proto_partition) = proto_partition {
+        let late_params = virt_mshv_vtl::UhLateParams {
+            gm: [
+                gm.vtl0().clone(),
+                gm.vtl1().cloned().unwrap_or(GuestMemory::empty()),
+            ]
+            .into(),
+            shared_memory: gm.shared_memory().cloned(),
+            #[cfg(guest_arch = "x86_64")]
+            cpuid,
+            crash_notification_send,
+            emulate_apic,
+            vmtime: &vmtime_source,
+            isolated_memory_protector: gm.isolated_memory_protector()?,
+            shared_vis_pages_pool: shared_vis_pages_pool.as_ref().map(|p| p.allocator()),
+        };
 
-    let (partition, vps) = proto_partition
-        .build(late_params)
-        .instrument(tracing::info_span!("new_uh_partition"))
-        .await
+        let (partition, vps) = proto_partition
+            .build(late_params)
+            .instrument(tracing::info_span!("new_uh_partition"))
+            .await
+            .context("failed to create partition")?;
+
+        let spawn_vps = Box::new(move |vp_runners, chipset| {
+            Box::pin(crate::vp::spawn_vps(
+                tp, vps, vp_runners, chipset, isolation,
+            )) as _
+        });
+
+        (Arc::new(partition) as _, spawn_vps)
+    } else {
+        if !cfg!(feature = "virt_kvm") {
+            anyhow::bail!("not compiled with support for KVM");
+        }
+
+        let mut kvm = virt_kvm::Kvm;
+        let proto = virt::Hypervisor::new_partition(
+            &mut kvm,
+            virt::ProtoPartitionConfig {
+                processor_topology: &processor_topology,
+                hv_config: Some(virt::HvConfig {
+                    offload_enlightenments: true,
+                    allow_device_assignment: false,
+                    vtl2: None,
+                }),
+                vmtime: &vmtime_source,
+                user_mode_apic: false,
+                isolation,
+            },
+        )
+        .context("failed to create proto partition")?;
+
+        // Add in topology CPUID leaves.
+        #[cfg(guest_arch = "x86_64")]
+        vmm_core::cpuid::topology::topology_cpuid(
+            &processor_topology,
+            &|eax, ecx| virt::ProtoPartition::cpuid(&proto, eax, ecx),
+            &mut cpuid,
+        )
+        .context("failed to compute topology cpuid")?;
+
+        let (partition, vps) = virt::ProtoPartition::build(
+            proto,
+            virt::PartitionConfig {
+                mem_layout: &mem_layout,
+                guest_memory: gm.vtl0(),
+                cpuid: &cpuid,
+            },
+        )
         .context("failed to create partition")?;
 
-    let partition = Arc::new(partition);
+        let partition = Arc::new(partition);
+
+        gm.map_partition(partition.as_ref())
+            .context("failed to map partition")?;
+
+        // virt_kvm is not currently compatible with using the thread pool, so
+        // spawn a thread for each VP.
+        let p = partition.clone();
+        let spawn_vps = Box::new(
+            move |vp_runners: Vec<vmm_core::partition_unit::VpRunner>,
+                  chipset: &vmm_core::vmotherboard_adapter::ChipsetPlusSynic| {
+                let chipset = chipset.clone();
+                Box::pin(async move {
+                    futures::future::try_join_all(vps.into_iter().zip(vp_runners).enumerate().map(
+                        |(vp_index, (mut vp, mut runner))| {
+                            let partition = p.clone().into_request_yield();
+                            let chipset = chipset.clone();
+                            let (send, recv) = mesh::oneshot();
+                            std::thread::Builder::new()
+                                .name(format!("vp-{}", vp_index))
+                                .spawn(move || match virt::BindProcessor::bind(&mut vp) {
+                                    Ok(vp) => {
+                                        send.send(Ok(()));
+                                        vmm_core::partition_unit::block_on_vp(
+                                            partition,
+                                            VpIndex::new(vp_index as u32),
+                                            async {
+                                                let mut vp = crate::partition::NoSaveVp(vp);
+                                                while runner.run(&mut vp, &chipset).await.is_err() {
+                                                }
+                                            },
+                                        )
+                                    }
+                                    Err(err) => {
+                                        send.send(Err(err));
+                                    }
+                                })
+                                .unwrap();
+
+                            async move {
+                                recv.await
+                                    .unwrap()
+                                    .with_context(|| format!("failed to bind vp {vp_index}"))
+                            }
+                        },
+                    ))
+                    .await
+                    .map(drop)
+                }) as _
+            },
+        );
+
+        (partition, spawn_vps)
+    };
 
     // By default, scale the max QD by the number of VPs to save memory
     // on smaller VMs, up to a QD of 256.
@@ -1765,7 +1871,9 @@ async fn new_underhill_vm(
     // Similarly, when hiding isolation from the guest, we must bounce because
     // the guest buffers are in private memory, which the kernel does not have
     // access to.
-    let always_bounce = cfg!(guest_arch = "aarch64") || hide_isolation;
+    //
+    // KVM always bounces because its memory is not registered with the kernel.
+    let always_bounce = cfg!(guest_arch = "aarch64") || hide_isolation || env_cfg.kvm;
     resolver.add_async_resolver::<DiskHandleKind, _, OpenBlockDeviceConfig, _>(
         BlockDeviceResolver::new(
             Arc::new(tp.clone()),
@@ -2132,7 +2240,7 @@ async fn new_underhill_vm(
 
     let emuplat_adjust_gpa_range;
 
-    let synic = Arc::new(SynicPorts::new(partition.clone()));
+    let synic = Arc::new(SynicPorts::new(partition.clone().into_synic()));
 
     let mut chipset = vm_manifest_builder::VmManifestBuilder::new(
         match firmware_type {
@@ -2475,6 +2583,25 @@ async fn new_underhill_vm(
         })) as Arc<CloseableMutex<dyn ChipsetDevice>>
     });
 
+    // Devices in hardware isolated VMs default to accessing only shared memory,
+    // since that is what the guest expects--it will double buffer memory to be
+    // DMAed through a shared memory pool.
+    //
+    // When hiding isolation, allow devices to access all memory, since that's
+    // the only option: the guest won't and can't transition anything to shared.
+    //
+    // For non-isolated VMs, there is no shared/private distinction, so devices
+    // access the same memory as the guest. For software-isolated VMs, the
+    // hypervisor does not allow the paravisor to observe changes to
+    // shared/private state, so we have no choice but to allow devices to access
+    // both.
+    let device_memory = if hide_isolation || !isolation.is_hardware_isolated() {
+        gm.vtl0()
+    } else {
+        gm.shared_memory()
+            .expect("isolated VMs should have shared memory")
+    };
+
     #[cfg_attr(not(feature = "vpci"), allow(unused_mut))]
     let BaseChipsetBuilderOutput {
         mut chipset_builder,
@@ -2508,10 +2635,7 @@ async fn new_underhill_vm(
         0..=1,
         0,
         "bsp",
-        Arc::new(virt::irqcon::ApicLintLineTarget::new(
-            partition.clone(),
-            Vtl::Vtl0,
-        )),
+        partition.clone().into_lint_target(Vtl::Vtl0),
     );
 
     // Add the GIC.
@@ -2663,7 +2787,7 @@ async fn new_underhill_vm(
         nics: Vec::new(),
         vf_managers: HashMap::new(),
         get_client: get_client.clone(),
-        vp_count: vps.len(),
+        vp_count: processor_topology.vp_count() as usize,
         dma_mode: if hide_isolation {
             net_mana::GuestDmaMode::BounceBuffer
         } else {
@@ -2747,7 +2871,7 @@ async fn new_underhill_vm(
 
         let shutdown_guest = SimpleVmbusClientDeviceWrapper::new(
             driver_source.simple(),
-            partition.clone(),
+            partition.clone().into_vtl_memory_protection(),
             shutdown_guest,
         )?;
         vmbus_intercept_devices
@@ -2814,7 +2938,7 @@ async fn new_underhill_vm(
     .context("failed to create partition unit")?;
 
     // Start the VP tasks on the thread pool.
-    crate::vp::spawn_vps(tp, vps, vp_runners, &chipset, isolation)
+    spawn_vps(vp_runners, &chipset)
         .await
         .context("failed to spawn vps")?;
 
@@ -2826,7 +2950,7 @@ async fn new_underhill_vm(
             &processor_topology,
             &vtl0_memory_map,
             &mut partition_unit,
-            &partition,
+            partition.as_ref(),
             env_cfg.cmdline_append.as_deref(),
             vtl0_info,
             &runtime_params,
@@ -3112,7 +3236,7 @@ async fn load_firmware(
     processor_topology: &ProcessorTopology,
     vtl0_memory_map: &[(MemoryRangeWithNode, MemoryMapEntryType)],
     partition_unit: &mut PartitionUnit,
-    partition: &UhPartition,
+    partition: &dyn OpenhclPartition,
     cmdline_append: Option<&str>,
     vtl0_info: MeasuredVtl0Info,
     runtime_params: &RuntimeParameters,
@@ -3171,7 +3295,7 @@ async fn load_firmware(
 }
 
 pub struct UnderhillPmTimerAssist {
-    pub partition: std::sync::Weak<UhPartition>,
+    pub partition: std::sync::Weak<dyn OpenhclPartition>,
 }
 
 impl chipset::pm::PmTimerAssist for UnderhillPmTimerAssist {
@@ -3179,7 +3303,7 @@ impl chipset::pm::PmTimerAssist for UnderhillPmTimerAssist {
         if let Some(partition) = self.partition.upgrade() {
             if let Err(err) = partition.set_pm_timer_assist(port) {
                 tracing::warn!(
-                    error = &err as &dyn std::error::Error,
+                    error = err.as_ref() as &dyn std::error::Error,
                     ?port,
                     "failed to set PM timer assist"
                 );
@@ -3192,7 +3316,7 @@ impl chipset::pm::PmTimerAssist for UnderhillPmTimerAssist {
 // forwarding them to the host. It needs to implement the ChipsetDevice and
 // MmioIntercept traits.
 struct FallbackMmioDevice {
-    partition: std::sync::Weak<UhPartition>,
+    partition: std::sync::Weak<dyn OpenhclPartition>,
     mmio_ranges: Vec<MemoryRange>,
 }
 

--- a/openhcl/underhill_core/src/wrapped_partition.rs
+++ b/openhcl/underhill_core/src/wrapped_partition.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::partition::OpenhclPartition;
 use async_trait::async_trait;
 use hvdef::Vtl;
 use inspect::InspectMut;
 use memory_range::MemoryRange;
 use std::sync::Arc;
 use virt::PageVisibility;
-use virt_mshv_vtl::UhPartition;
 use vmcore::save_restore::NoSavedState;
 use vmcore::save_restore::RestoreError;
 use vmcore::save_restore::SaveError;
@@ -17,7 +17,7 @@ use vmm_core::partition_unit::VmPartition;
 /// Wraps `Arc<UhPartition>` and implements [`VmPartition`].
 #[derive(InspectMut)]
 #[inspect(transparent)]
-pub struct WrappedPartition(pub Arc<UhPartition>);
+pub struct WrappedPartition(pub Arc<dyn OpenhclPartition>);
 
 #[async_trait]
 impl VmPartition for WrappedPartition {

--- a/openhcl/underhill_entry/Cargo.toml
+++ b/openhcl/underhill_entry/Cargo.toml
@@ -16,6 +16,9 @@ profiler = ["underhill_core/profiler"]
 # Enable vpci support.
 vpci = ["underhill_core/vpci"]
 
+# Enable KVM and nested virtualization support.
+virt_kvm = ["underhill_core/virt_kvm"]
+
 [target.'cfg(target_os = "linux")'.dependencies]
 underhill_core.workspace = true
 underhill_init.workspace = true

--- a/openhcl/underhill_init/Cargo.toml
+++ b/openhcl/underhill_init/Cargo.toml
@@ -18,6 +18,10 @@ log = { workspace = true, features = ["std"] }
 nix = { workspace = true, features = ["ioctl"] }
 walkdir.workspace = true
 
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
+safe_intrinsics.workspace = true
+x86defs.workspace = true
+
 [build-dependencies]
 vergen = { workspace = true, features = ["git", "gitcl"] }
 

--- a/openhcl/underhill_mem/Cargo.toml
+++ b/openhcl/underhill_mem/Cargo.toml
@@ -24,6 +24,7 @@ pal_async.workspace = true
 sparse_mmap.workspace = true
 
 anyhow.workspace = true
+fs-err.workspace = true
 futures.workspace = true
 parking_lot.workspace = true
 thiserror.workspace = true

--- a/openhcl/underhill_mem/src/devmem.rs
+++ b/openhcl/underhill_mem/src/devmem.rs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// UNSAFETY: required for mapping memory to a partition.
+#![allow(unsafe_code)]
+
+use crate::AccessGuestMemory;
+use anyhow::Context;
+use guestmem::GuestMemory;
+use inspect::Inspect;
+use std::sync::Arc;
+use std::sync::Weak;
+use vm_topology::memory::MemoryLayout;
+
+/// Guest OS memory accessed via /dev/mem.
+///
+/// This is less efficient than using [`MemoryMappings`](crate::MemoryMappings),
+/// but it works without extra driver support.
+#[derive(Inspect)]
+pub struct DevMemMemory {
+    #[inspect(skip)]
+    mapping: Arc<sparse_mmap::SparseMapping>,
+    mem: GuestMemory,
+    layout: MemoryLayout,
+    #[inspect(skip)]
+    partition: Option<Weak<dyn virt::PartitionMemoryMap>>,
+}
+
+impl DevMemMemory {
+    /// Opens and maps ranges from /dev/mem.
+    pub fn new(layout: &MemoryLayout) -> anyhow::Result<Self> {
+        let mmap = sparse_mmap::SparseMapping::new(layout.end_of_ram() as usize)
+            .context("failed to allocate VA space")?;
+        let ram = fs_err::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/mem")?;
+        for range in layout.ram() {
+            let range = range.range;
+            mmap.map_file(
+                range.start() as usize,
+                range.len() as usize,
+                ram.file(),
+                range.start(),
+                true,
+            )
+            .with_context(|| format!("failed to map range {range}"))?;
+        }
+        let mmap = Arc::new(mmap);
+        Ok(Self {
+            mapping: mmap.clone(),
+            mem: GuestMemory::new("guest", mmap),
+            layout: layout.clone(),
+            partition: None,
+        })
+    }
+}
+
+impl AccessGuestMemory for DevMemMemory {
+    fn vtl0(&self) -> &GuestMemory {
+        &self.mem
+    }
+
+    fn vtl1(&self) -> Option<&GuestMemory> {
+        None
+    }
+
+    fn shared_memory(&self) -> Option<&GuestMemory> {
+        None
+    }
+
+    fn private_vtl0_memory(&self) -> Option<&GuestMemory> {
+        None
+    }
+
+    fn isolated_memory_protector(
+        &self,
+    ) -> anyhow::Result<Option<Arc<dyn virt_mshv_vtl::ProtectIsolatedMemory>>> {
+        Ok(None)
+    }
+
+    fn map_partition(&mut self, partition: &dyn virt::PartitionMemoryMapper) -> anyhow::Result<()> {
+        let map = partition.memory_mapper(hvdef::Vtl::Vtl0);
+        for range in self.layout.ram() {
+            let range = range.range;
+            // SAFETY: the VA range is valid until `drop`, which unmaps the
+            // memory from the partition.
+            unsafe {
+                map.map_range(
+                    self.mapping
+                        .as_ptr()
+                        .byte_add(range.start() as usize)
+                        .cast(),
+                    range.len() as usize,
+                    range.start(),
+                    true,
+                    true,
+                )
+                .with_context(|| format!("failed to map range {range}"))?;
+            }
+        }
+        self.partition = Some(Arc::downgrade(&map));
+        Ok(())
+    }
+}
+
+impl Drop for DevMemMemory {
+    fn drop(&mut self) {
+        let Some(partition) = self.partition.take().and_then(|p| p.upgrade()) else {
+            return;
+        };
+        for range in self.layout.ram() {
+            let range = range.range;
+            partition.unmap_range(range.start(), range.len()).unwrap();
+        }
+    }
+}

--- a/vm/loader/manifests/openhcl-x64-nested.json
+++ b/vm/loader/manifests/openhcl-x64-nested.json
@@ -1,0 +1,18 @@
+{
+    "guest_arch": "x64",
+    "guest_configs": [
+        {
+            "guest_svn": 1,
+            "max_vtl": 0,
+            "isolation_type": "none",
+            "image": {
+                "openhcl": {
+                    "command_line": "OPENHCL_KVM=1",
+                    "memory_page_count": 163840,
+                    "memory_page_base": 131072,
+                    "uefi": true
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This change enables OpenHCL to be launched in a non-VSM capable partition (i.e., in VTL0) and to use nested virtualization to run the target guest OS.

To achieve this, we build the existing `virt_kvm` backend into the paravisor openvmm build. So this has all the same limitations as `virt_kvm` has on the host.

With this, it becomes possible to do some basic OpenHCL testing on a Linux platform, with no Windows dependencies. Of course, since we are using nested virtualization, there are some limitations:

* The host is not aware of the L2 guest, so it cannot offer vmbus or assigned devices directly to it. All devices must be emulated in the paravisor. There is no support for an interactive graphics console or anything else we haven't built a relay for yet.

* Performance is pretty bad in my testing. Of course, I tested this with 3x nested virtualization, so that is not too surprising. I expect this to be much better on a native Linux host.

Currently, we still depend on the GET and other Hyper-V HCL devices, so this can really only be used in conjunction with openvmm on the host. Future changes can support alternate configuration mechanisms so that this would be able to run in qemu or another VMM.

Also, virt_whp and virt_hvf do not yet support nested virtualization (even though WHP and HVF do), so even with openvmm, this only works on Linux.

Finally, I only built and tested this on x64, because I do not have a KVM ARM64 environment that supports nested virtualization.