### PR TITLE
serial: add debugcon device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,6 +2749,7 @@ dependencies = [
  "rustyline",
  "scsidisk_resources",
  "serial_16550_resources",
+ "serial_core",
  "serial_socket",
  "shell-words",
  "sparse_mmap",
@@ -4470,6 +4471,7 @@ dependencies = [
  "scsidisk",
  "serial_16550",
  "serial_core",
+ "serial_debugcon",
  "serial_pl011",
  "serial_socket",
  "storvsp",
@@ -5571,6 +5573,32 @@ dependencies = [
  "mesh",
  "pal_async",
  "parking_lot",
+ "vm_resource",
+]
+
+[[package]]
+name = "serial_debugcon"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "chipset_device",
+ "chipset_device_resources",
+ "futures",
+ "inspect",
+ "serial_core",
+ "serial_debugcon_resources",
+ "thiserror 2.0.0",
+ "tracelimit",
+ "tracing",
+ "vm_resource",
+ "vmcore",
+]
+
+[[package]]
+name = "serial_debugcon_resources"
+version = "0.0.0"
+dependencies = [
+ "mesh",
  "vm_resource",
 ]
 
@@ -7454,6 +7482,7 @@ dependencies = [
  "missing_dev_resources",
  "serial_16550_resources",
  "serial_core",
+ "serial_debugcon_resources",
  "serial_pl011_resources",
  "thiserror 2.0.0",
  "vm_resource",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,6 +264,8 @@ plan9 = { path = "vm/devices/support/fs/plan9" }
 power_resources = { path = "vm/power_resources" }
 serial_16550 = { path = "vm/devices/serial/serial_16550" }
 serial_16550_resources = { path = "vm/devices/serial/serial_16550_resources" }
+serial_debugcon = { path = "vm/devices/serial/serial_debugcon" }
+serial_debugcon_resources = { path = "vm/devices/serial/serial_debugcon_resources" }
 serial_core = { path = "vm/devices/serial/serial_core" }
 serial_pl011 = { path = "vm/devices/serial/serial_pl011" }
 serial_pl011_resources = { path = "vm/devices/serial/serial_pl011_resources" }

--- a/openvmm/hvlite_entry/Cargo.toml
+++ b/openvmm/hvlite_entry/Cargo.toml
@@ -46,6 +46,7 @@ net_backend_resources.workspace = true
 netvsp_resources.workspace = true
 nvme_resources.workspace = true
 scsidisk_resources.workspace = true
+serial_core.workspace = true
 serial_16550_resources.workspace = true
 serial_socket.workspace = true
 storvsp_resources.workspace = true

--- a/openvmm/openvmm_resources/Cargo.toml
+++ b/openvmm/openvmm_resources/Cargo.toml
@@ -41,6 +41,7 @@ disk_vhd1.workspace = true
 chipset.workspace = true
 missing_dev.workspace = true
 serial_16550.workspace = true
+serial_debugcon.workspace = true
 serial_pl011.workspace = true
 tpm = { workspace = true, optional = true, features = ["tpm"] }
 

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -17,6 +17,8 @@ vm_resource::register_static_resolvers! {
     tpm::resolver::TpmDeviceResolver,
     #[cfg(guest_arch = "x86_64")]
     serial_16550::resolver::Serial16550Resolver,
+    #[cfg(guest_arch = "x86_64")]
+    serial_debugcon::resolver::SerialDebugconResolver,
     #[cfg(guest_arch = "aarch64")]
     serial_pl011::resolver::SerialPl011Resolver,
     chipset::battery::resolver::BatteryResolver,

--- a/vm/devices/serial/serial_debugcon/Cargo.toml
+++ b/vm/devices/serial/serial_debugcon/Cargo.toml
@@ -2,24 +2,25 @@
 # Licensed under the MIT License.
 
 [package]
-name = "vm_manifest_builder"
+name = "serial_debugcon"
 edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-chipset_resources.workspace = true
-input_core.workspace = true
-missing_dev_resources.workspace = true
-serial_16550_resources.workspace = true
+chipset_device.workspace = true
+chipset_device_resources.workspace = true
 serial_core.workspace = true
 serial_debugcon_resources.workspace = true
-serial_pl011_resources.workspace = true
+vmcore.workspace = true
 vm_resource.workspace = true
-vmotherboard.workspace = true
 
-mesh.workspace = true
+inspect.workspace = true
 
+async-trait.workspace = true
+futures.workspace = true
 thiserror.workspace = true
+tracelimit.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/vm/devices/serial/serial_debugcon/src/lib.rs
+++ b/vm/devices/serial/serial_debugcon/src/lib.rs
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Implementation of the bochs / QEMU debugcon device.
+//!
+//! This is a zero-configuration, output-only serial device, which should only
+//! be used for debugging (hence the name). It offers no flow control
+//! mechanisms, or any method of reading data into the Guest.
+
+#![warn(missing_docs)]
+
+pub mod resolver;
+
+use chipset_device::io::IoError;
+use chipset_device::io::IoResult;
+use chipset_device::pio::PortIoIntercept;
+use chipset_device::poll_device::PollDevice;
+use chipset_device::ChipsetDevice;
+use futures::AsyncWrite;
+use inspect::InspectMut;
+use serial_core::SerialIo;
+use std::collections::VecDeque;
+use std::io::ErrorKind;
+use std::ops::RangeInclusive;
+use std::pin::Pin;
+use std::task::ready;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
+use vmcore::device_state::ChangeDeviceState;
+
+/// A Debugcon serial port emulator.
+#[derive(InspectMut)]
+pub struct SerialDebugcon {
+    // Fixed configuration
+    io_port: u16,
+    #[inspect(skip)]
+    io_region: (&'static str, RangeInclusive<u16>),
+
+    // Runtime glue
+    #[inspect(mut)]
+    io: Box<dyn SerialIo>,
+
+    // Volatile state
+    #[inspect(with = "VecDeque::len")]
+    tx_buffer: VecDeque<u8>,
+    #[inspect(skip)]
+    tx_waker: Option<Waker>,
+}
+
+impl SerialDebugcon {
+    /// Returns a new emulator instance.
+    pub fn new(port: u16, io: Box<dyn SerialIo>) -> Self {
+        Self {
+            io_port: port,
+            io_region: ("debugcon", port..=port),
+            io,
+            tx_buffer: VecDeque::new(),
+            tx_waker: None,
+        }
+    }
+
+    /// Synchronize interrupt and waker state with device state.
+    fn sync(&mut self) {
+        // Wake to poll if there are any bytes to write.
+        if !self.tx_buffer.is_empty() {
+            if let Some(waker) = self.tx_waker.take() {
+                waker.wake();
+            }
+        }
+    }
+
+    fn poll_tx(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        while !self.tx_buffer.is_empty() {
+            let (buf, _) = self.tx_buffer.as_slices();
+            match ready!(Pin::new(&mut self.io).poll_write(cx, buf)) {
+                Ok(n) => {
+                    assert_ne!(n, 0);
+                    self.tx_buffer.drain(..n);
+                }
+                Err(err) if err.kind() == ErrorKind::BrokenPipe => {
+                    tracing::info!("debugcon output broken pipe");
+                }
+                Err(err) => {
+                    tracelimit::error_ratelimited!(
+                        len = buf.len(),
+                        error = &err as &dyn std::error::Error,
+                        "debugcon write failed, dropping data"
+                    );
+                    self.tx_buffer.drain(..buf.len());
+                }
+            }
+        }
+        // Wait for more bytes to write.
+        self.tx_waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+impl ChangeDeviceState for SerialDebugcon {
+    fn start(&mut self) {}
+
+    async fn stop(&mut self) {}
+
+    async fn reset(&mut self) {
+        self.tx_buffer.clear();
+    }
+}
+
+impl ChipsetDevice for SerialDebugcon {
+    fn supports_pio(&mut self) -> Option<&mut dyn PortIoIntercept> {
+        Some(self)
+    }
+
+    fn supports_poll_device(&mut self) -> Option<&mut dyn PollDevice> {
+        Some(self)
+    }
+}
+
+impl PollDevice for SerialDebugcon {
+    fn poll_device(&mut self, cx: &mut Context<'_>) {
+        let _ = self.poll_tx(cx);
+        self.sync();
+    }
+}
+
+impl PortIoIntercept for SerialDebugcon {
+    fn io_read(&mut self, io_port: u16, data: &mut [u8]) -> IoResult {
+        if io_port != self.io_port {
+            return IoResult::Err(IoError::InvalidRegister);
+        }
+
+        if data.len() != 1 {
+            return IoResult::Err(IoError::InvalidAccessSize);
+        }
+
+        // this is a magic constant which the guest can use to detect the
+        // presence of the debugcon device. Its value is fixed, and matches the
+        // value set by the original debugcon implementation in bochs.
+        data[0] = 0xe9;
+
+        IoResult::Ok
+    }
+
+    fn io_write(&mut self, io_port: u16, data: &[u8]) -> IoResult {
+        if io_port != self.io_port {
+            return IoResult::Err(IoError::InvalidRegister);
+        }
+
+        if data.len() != 1 {
+            return IoResult::Err(IoError::InvalidAccessSize);
+        }
+
+        self.tx_buffer.push_back(data[0]);
+
+        // HACK: work around the fact that in openvmm, the console is in raw mode.
+        //
+        // FUTURE: this should be configurable, in case folks need 1:1 faithful
+        // debugcon output.
+        if data[0] == b'\n' {
+            self.tx_buffer.push_back(b'\r')
+        }
+
+        self.sync();
+
+        IoResult::Ok
+    }
+
+    fn get_static_regions(&mut self) -> &[(&str, RangeInclusive<u16>)] {
+        std::slice::from_ref(&self.io_region)
+    }
+}
+
+mod save_restore {
+    use crate::SerialDebugcon;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+    use vmcore::save_restore::SavedStateNotSupported;
+
+    impl SaveRestore for SerialDebugcon {
+        // This device should be constructed with `omit_saved_state`.
+        type SavedState = SavedStateNotSupported;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Err(SaveError::NotSupported)
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            match state {}
+        }
+    }
+}

--- a/vm/devices/serial/serial_debugcon/src/resolver.rs
+++ b/vm/devices/serial/serial_debugcon/src/resolver.rs
@@ -57,9 +57,6 @@ impl AsyncResolveResource<ChipsetDeviceHandleKind, SerialDebugconDeviceHandle>
             .map_err(ResolveDebugconError::ResolveBackend)?;
 
         let device = SerialDebugcon::new(resource.port, io.0.into_io());
-
-        input.configure.omit_saved_state();
-
         Ok(device.into())
     }
 }

--- a/vm/devices/serial/serial_debugcon/src/resolver.rs
+++ b/vm/devices/serial/serial_debugcon/src/resolver.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resource resolver for a serial debugcon chipset device.
+
+use crate::SerialDebugcon;
+use async_trait::async_trait;
+use chipset_device_resources::ResolveChipsetDeviceHandleParams;
+use chipset_device_resources::ResolvedChipsetDevice;
+use serial_core::resources::ResolveSerialBackendParams;
+use serial_debugcon_resources::SerialDebugconDeviceHandle;
+use thiserror::Error;
+use vm_resource::declare_static_async_resolver;
+use vm_resource::kind::ChipsetDeviceHandleKind;
+use vm_resource::AsyncResolveResource;
+use vm_resource::ResolveError;
+use vm_resource::ResourceResolver;
+
+/// The resource resolver for [`SerialDebugcon`].
+pub struct SerialDebugconResolver;
+
+declare_static_async_resolver! {
+    SerialDebugconResolver,
+    (ChipsetDeviceHandleKind, SerialDebugconDeviceHandle),
+}
+
+/// An error resolving a [`SerialDebugconDeviceHandle`].
+#[allow(missing_docs)]
+#[derive(Debug, Error)]
+pub enum ResolveDebugconError {
+    #[error("failed to resolve io backend")]
+    ResolveBackend(#[source] ResolveError),
+}
+
+#[async_trait]
+impl AsyncResolveResource<ChipsetDeviceHandleKind, SerialDebugconDeviceHandle>
+    for SerialDebugconResolver
+{
+    type Output = ResolvedChipsetDevice;
+    type Error = ResolveDebugconError;
+
+    async fn resolve(
+        &self,
+        resolver: &ResourceResolver,
+        resource: SerialDebugconDeviceHandle,
+        input: ResolveChipsetDeviceHandleParams<'_>,
+    ) -> Result<Self::Output, Self::Error> {
+        let io = resolver
+            .resolve(
+                resource.io,
+                ResolveSerialBackendParams {
+                    driver: Box::new(input.task_driver_source.simple()),
+                    _async_trait_workaround: &(),
+                },
+            )
+            .await
+            .map_err(ResolveDebugconError::ResolveBackend)?;
+
+        let device = SerialDebugcon::new(resource.port, io.0.into_io());
+
+        input.configure.omit_saved_state();
+
+        Ok(device.into())
+    }
+}

--- a/vm/devices/serial/serial_debugcon_resources/Cargo.toml
+++ b/vm/devices/serial/serial_debugcon_resources/Cargo.toml
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "serial_debugcon_resources"
+edition = "2021"
+rust-version.workspace = true
+
+[dependencies]
+vm_resource.workspace = true
+
+mesh.workspace = true
+
+[lints]
+workspace = true

--- a/vm/devices/serial/serial_debugcon_resources/src/lib.rs
+++ b/vm/devices/serial/serial_debugcon_resources/src/lib.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Resource definitions for the debugcon serial device.
+
+#![warn(missing_docs)]
+#![forbid(unsafe_code)]
+
+use mesh::MeshPayload;
+use vm_resource::kind::ChipsetDeviceHandleKind;
+use vm_resource::kind::SerialBackendHandle;
+use vm_resource::Resource;
+use vm_resource::ResourceId;
+
+/// A handle to a 16550A serial device.
+#[derive(MeshPayload)]
+pub struct SerialDebugconDeviceHandle {
+    /// Which IO port to put the single-byte debugcon register.
+    pub port: u16,
+    /// The IO backend.
+    pub io: Resource<SerialBackendHandle>,
+}
+
+impl ResourceId<ChipsetDeviceHandleKind> for SerialDebugconDeviceHandle {
+    const ID: &'static str = "debugcon";
+}

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -22,6 +22,7 @@ use input_core::MultiplexedInputHandle;
 use missing_dev_resources::MissingDevHandle;
 use serial_16550_resources::Serial16550DeviceHandle;
 use serial_core::resources::DisconnectedSerialBackendHandle;
+use serial_debugcon_resources::SerialDebugconDeviceHandle;
 use serial_pl011_resources::SerialPl011DeviceHandle;
 use std::iter::zip;
 use thiserror::Error;
@@ -43,6 +44,7 @@ pub struct VmManifestBuilder {
     framebuffer: bool,
     guest_watchdog: bool,
     psp: bool,
+    debugcon: Option<(Resource<SerialBackendHandle>, u16)>,
 }
 
 /// The VM's base chipset type, which determines the set of core devices (such
@@ -93,6 +95,8 @@ enum ErrorInner {
     UnsupportedArch,
     #[error("unsupported serial port count")]
     UnsupportedSerialCount,
+    #[error("unsupported debugcon architecture")]
+    UnsupportedDebugconArch,
     #[error("wait for RTS not supported with this serial type")]
     WaitForRtsNotSupported,
 }
@@ -112,6 +116,7 @@ impl VmManifestBuilder {
             framebuffer: false,
             guest_watchdog: false,
             psp: false,
+            debugcon: None,
         }
     }
 
@@ -134,6 +139,15 @@ impl VmManifestBuilder {
     /// until the guest has raised the RTS line.
     pub fn with_serial_wait_for_rts(mut self) -> Self {
         self.serial_wait_for_rts = true;
+        self
+    }
+
+    /// Enable the debugcon output-only serial device at the specified port,
+    /// backed by the given serial backend.
+    ///
+    /// Only supported on x86
+    pub fn with_debugcon(mut self, serial: Resource<SerialBackendHandle>, port: u16) -> Self {
+        self.debugcon = Some((serial, port));
         self
     }
 
@@ -195,6 +209,15 @@ impl VmManifestBuilder {
             chipset_devices: Vec::new(),
             chipset: BaseChipsetManifest::empty(),
         };
+
+        if let Some((backend, port)) = self.debugcon {
+            if matches!(self.arch, MachineArch::X86_64) {
+                result.attach_debugcon(port, backend);
+            } else {
+                return Err(ErrorInner::UnsupportedDebugconArch.into());
+            }
+        }
+
         match self.ty {
             BaseChipsetType::HypervGen1 => {
                 if self.arch != MachineArch::X86_64 {
@@ -402,6 +425,14 @@ impl VmChipsetResult {
             });
         }
         Ok(self)
+    }
+
+    fn attach_debugcon(&mut self, port: u16, backend: Resource<SerialBackendHandle>) -> &mut Self {
+        self.chipset_devices.push(ChipsetDeviceHandle {
+            name: format!("debugcon-{port:#x?}"),
+            resource: SerialDebugconDeviceHandle { port, io: backend }.into_resource(),
+        });
+        self
     }
 
     fn attach_serial_16550(


### PR DESCRIPTION
Ahh, the joys of open-source!
I can finally work on fun openvmm stuff on the weekend from my personal PC 😄

This PR adds simple `debugcon` serial device, originally implemented in bochs, but now widely supported in other VMMs such as QEMU, crosvm, cloud-hypervisor, etc...

It is a no-frills, relocatable, single IO-port mechanism for a Guest to write a steam of bytes to the host. It can be instantiated by passing `--debugcon=port:serialmode` to the CLI (e.g: `--debugcon=0x402,stderr`).

For context: I am playing around with standing up SeaBIOS support in OpenVMM (on the weekends, just for kicks), and SeaBIOS writes a lot of useful debug info to a debugcon at port 0x402. Also, IIUC, OVMF can also be configured to use a debugcon for early-boot debugging, so this device might come in handy later as well.

