### PR TITLE
openvmm: support TCP listener for serial ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5643,6 +5643,7 @@ dependencies = [
  "pal",
  "pal_async",
  "serial_core",
+ "socket2",
  "tracing",
  "unix_socket",
  "vm_resource",

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -29,10 +29,13 @@ as well as the generated CLI help (via `cargo run -- --help`).
 
 And serial devices can each be configured to be relayed to different endpoints:
 
-* `--com1/com2/virtio-serial <none|console|stderr|listen=PATH>`
+* `--com1/com2/virtio-serial <none|console|stderr|listen=PATH|listen=tcp:IP:PORT>`
     * `none`: Serial output is dropped.
     * `console`: Serial input is read and output is written to the console.
     * `stderr`: Serial output is written to stderr.
     * `listen=PATH`: A named pipe (on Windows) or Unix socket (on Linux) is set
       up to listen on the given path. Serial input and output is relayed to this
       pipe/socket.
+    * `listen=tcp:IP:PORT`: As with `listen=PATH`, but listen for TCP
+      connections on the given IP address and port. Typically IP will be
+      127.0.0.1, to restrict connections to the current host.

--- a/openvmm/hvlite_entry/src/lib.rs
+++ b/openvmm/hvlite_entry/src/lib.rs
@@ -238,6 +238,9 @@ fn vm_config_from_command_line(
             SerialConfigCli::Pipe(path) => {
                 Some(serial_io::bind_serial(&path).context("failed to bind serial")?)
             }
+            SerialConfigCli::Tcp(addr) => {
+                Some(serial_io::bind_tcp_serial(&addr).context("failed to bind serial")?)
+            }
             SerialConfigCli::NewConsole(app) => {
                 let path = console::random_console_path();
                 let config =
@@ -281,6 +284,7 @@ fn vm_config_from_command_line(
                     .detach();
                 Some(io.config)
             }
+            SerialConfigCli::Tcp(_addr) => anyhow::bail!("TCP virtio serial not supported"),
             SerialConfigCli::NewConsole(app) => {
                 let path = console::random_console_path();
 

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -30,7 +30,7 @@ vm_resource::register_static_resolvers! {
     serial_core::disconnected::resolver::DisconnectedSerialBackendResolver,
     #[cfg(windows)]
     serial_socket::windows::WindowsPipeSerialResolver,
-    serial_socket::unix::UnixStreamSerialResolver,
+    serial_socket::net::SocketSerialResolver,
 
     // Network backends
     net_backend::null::NullResolver,

--- a/petri/src/vm/construct.rs
+++ b/petri/src/vm/construct.rs
@@ -66,7 +66,7 @@ use scsidisk_resources::SimpleScsiDiskHandle;
 use scsidisk_resources::SimpleScsiDvdHandle;
 use serial_16550_resources::ComPort;
 use serial_core::resources::DisconnectedSerialBackendHandle;
-use serial_socket::unix::OpenUnixStreamSerialConfig;
+use serial_socket::net::OpenSocketSerialConfig;
 use sparse_mmap::alloc_shared_memory;
 use std::fmt::Write as _;
 use std::io::Write;
@@ -541,7 +541,7 @@ impl PetriVmConfigSetupCore<'_> {
     )> {
         let (host_side, guest_side) = UnixStream::pair()?;
         let host_side = PolledSocket::new(self.driver, host_side)?;
-        let serial = OpenUnixStreamSerialConfig::from(guest_side).into_resource();
+        let serial = OpenSocketSerialConfig::from(guest_side).into_resource();
         Ok((host_side, Some(serial)))
     }
 

--- a/support/mesh/mesh_protobuf/src/encoding.rs
+++ b/support/mesh/mesh_protobuf/src/encoding.rs
@@ -1834,6 +1834,9 @@ mod windows {
     os_resource!(std::net::TcpListener, OwnedSocket);
     os_resource!(std::net::TcpStream, OwnedSocket);
     os_resource!(std::net::UdpSocket, OwnedSocket);
+
+    #[cfg(feature = "socket2")]
+    os_resource!(socket2::Socket, OwnedSocket);
 }
 
 #[cfg(unix)]

--- a/vm/devices/serial/serial_socket/Cargo.toml
+++ b/vm/devices/serial/serial_socket/Cargo.toml
@@ -11,11 +11,12 @@ serial_core.workspace = true
 vm_resource.workspace = true
 
 inspect.workspace = true
-mesh.workspace = true
+mesh = { workspace = true, features = ["socket2"] }
 pal.workspace = true
 unix_socket = { workspace = true, features = ["mesh"] }
 pal_async.workspace = true
 futures.workspace = true
+socket2.workspace = true
 tracing.workspace = true
 
 [lints]

--- a/vm/devices/serial/serial_socket/src/lib.rs
+++ b/vm/devices/serial/serial_socket/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Serial port backends based on Unix sockets and Windows named pipes.
+//! Serial port backends based on sockets and Windows named pipes.
 
-pub mod unix;
+pub mod net;
 #[cfg(windows)]
 pub mod windows;


### PR DESCRIPTION
Add support for serial ports listening on TCP sockets instead of just Unix sockets and Windows named pipes.

This is useful for interacting with tools that only support TCP. For example, windbg's EXDI support (used to debug the UEFI firmware) currently only supports TCP. This eliminates the need to use a separate tool to relay Unix sockets/named pipes to TCP sockets.

To use, append something like `--com1 listen=tcp:127.0.0.1:4000` to the command line.