### PR TITLE
Begin working towards Rust 2024 compatibility

### DIFF
--- a/.github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py
+++ b/.github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py
@@ -15,7 +15,8 @@ def main(repo_path: str, target_branch: str, token: str, pull_request: str, team
             return False
 
         with open(f'{repo_path}/{change.a_path}') as fd:
-            return 'unsafe ' in fd.read()
+            content = fd.read()
+            return 'unsafe ' in content or 'unsafe(' in content
 
     # Look for modified / added files
     repo = Repo(repo_path)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -567,7 +567,7 @@ nonstandard_style = { level = "deny", priority = -2 }
 rust_2018_idioms = { level = "deny", priority = -2 }
 
 rust-2024-compatibility = { level = "warn", priority = -1 }
-# TODO: Fix all of the below
+# TODO: Fix all of the below, https://github.com/microsoft/openvmm/issues/288
 edition_2024_expr_fragment_specifier = "allow"
 impl_trait_overcaptures = "allow"
 deprecated-safe-2024 = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -562,9 +562,17 @@ pbjson-build = { git = "https://github.com/jstarks/pbjson", branch = "aliases" }
 
 [workspace.lints.rust]
 # Lint groups need a priority lower than individual lints so they get applied first.
-future_incompatible = { level = "deny", priority = -1 }
-nonstandard_style = { level = "deny", priority = -1 }
-rust_2018_idioms = { level = "deny", priority = -1 }
+future_incompatible = { level = "deny", priority = -2 }
+nonstandard_style = { level = "deny", priority = -2 }
+rust_2018_idioms = { level = "deny", priority = -2 }
+
+rust-2024-compatibility = { level = "warn", priority = -1 }
+# TODO: Fix all of the below
+edition_2024_expr_fragment_specifier = "allow"
+impl_trait_overcaptures = "allow"
+deprecated-safe-2024 = "allow"
+# Needed for linkme compatibility for now, https://github.com/dtolnay/linkme/issues/101
+unsafe-attr-outside-unsafe = "allow"
 
 unused_qualifications = "warn"
 

--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -62,8 +62,8 @@ impl BuildInfo {
 
 // UNSAFETY: link_section and export_name are considered unsafe.
 #[allow(unsafe_code)]
-#[link_section = ".build_info"]
-#[export_name = "BUILD_INFO"]
+#[unsafe(link_section = ".build_info")]
+#[unsafe(export_name = "BUILD_INFO")]
 static BUILD_INFO: BuildInfo = BuildInfo::new();
 
 pub fn get() -> &'static BuildInfo {

--- a/openhcl/minimal_rt/src/arch/aarch64/intrinsics.rs
+++ b/openhcl/minimal_rt/src/arch/aarch64/intrinsics.rs
@@ -5,7 +5,7 @@
 
 /// Hand rolled implementation of memcpy.
 #[cfg(minimal_rt)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *mut u8 {
     // SAFETY: the caller guarantees the pointers and length are correct.
     unsafe {
@@ -31,7 +31,7 @@ unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *m
 
 /// Hand rolled implementation of memset.
 #[cfg(minimal_rt)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
     // SAFETY: the caller guarantees the pointer and length are correct.
     unsafe {

--- a/openhcl/minimal_rt/src/arch/x86_64/hypercall.rs
+++ b/openhcl/minimal_rt/src/arch/x86_64/hypercall.rs
@@ -5,7 +5,7 @@
 //!
 //! The hypercall ABI for x64 is well documented in the TLFS.
 
-extern "C" {
+unsafe extern "C" {
     /// The hypercall page. The actual hypercall page must be mapped on top of
     /// this page before it is used.
     pub static mut HYPERCALL_PAGE: [u8; 4096];

--- a/openhcl/minimal_rt/src/arch/x86_64/intrinsics.rs
+++ b/openhcl/minimal_rt/src/arch/x86_64/intrinsics.rs
@@ -5,7 +5,7 @@
 
 /// Hand rolled implementation of memset.
 #[cfg(minimal_rt)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
     // SAFETY: The caller guarantees that the pointer and length are correct.
     unsafe {
@@ -22,7 +22,7 @@ unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
 
 /// Hand rolled implementation of memcpy.
 #[cfg(minimal_rt)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *mut u8 {
     // SAFETY: The caller guarantees that the pointers and length are correct.
     unsafe {

--- a/openhcl/minimal_rt/src/rt.rs
+++ b/openhcl/minimal_rt/src/rt.rs
@@ -19,12 +19,12 @@ mod instead_of_builtins {
         }
     }
 
-    extern "C" {
+    unsafe extern "C" {
         fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
     }
 
     /// Implementation cribbed from compiler_builtins.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
         let delta = (dest as usize).wrapping_sub(src as usize);
         if delta >= n {
@@ -47,7 +47,7 @@ mod instead_of_builtins {
     /// This implementation is cribbed from compiler_builtins. It would be nice to
     /// use those implementation for all the above functions, but those require
     /// nightly as these are not yet stabilized.
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
         // SAFETY: The caller guarantees that the pointers and length are correct.
         unsafe {

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -266,7 +266,7 @@ struct Fdt {
 /// where the shim is loaded. Return a ShimParams structure based on the raw
 /// offset based RawShimParams.
 fn shim_parameters(shim_params_raw_offset: isize) -> ShimParams {
-    extern "C" {
+    unsafe extern "C" {
         static __ehdr_start: u8;
     }
 

--- a/openhcl/sidecar/src/arch/x86_64/init.rs
+++ b/openhcl/sidecar/src/arch/x86_64/init.rs
@@ -55,7 +55,7 @@ use x86defs::IdtEntry64;
 use x86defs::Pte;
 use zerocopy::FromZeroes;
 
-extern "C" {
+unsafe extern "C" {
     static IMAGE_PDE: Pte;
     fn irq_entry();
     fn exc_gpf();

--- a/openhcl/sidecar/src/arch/x86_64/mod.rs
+++ b/openhcl/sidecar/src/arch/x86_64/mod.rs
@@ -38,7 +38,7 @@ mod addr_space {
 
     const PAGE_SIZE: u64 = 0x1000;
 
-    extern "C" {
+    unsafe extern "C" {
         static __ehdr_start: u8;
     }
 

--- a/support/openssl_crypto_only/src/lib.rs
+++ b/support/openssl_crypto_only/src/lib.rs
@@ -13,7 +13,7 @@
 use core::ffi::c_int;
 use core::ffi::c_void;
 
-extern "C" {
+unsafe extern "C" {
     #[doc(hidden)]
     pub fn OPENSSL_init_crypto(opts: u64, settings: *const c_void) -> c_int;
 }
@@ -33,7 +33,7 @@ macro_rules! openssl_crypto_only {
         /// # Safety
         ///
         /// The caller must call as documented for `OPENSSL_init_ssl`.
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         unsafe extern "C" fn OPENSSL_init_ssl(
             opts: u64,
             settings: *const ::core::ffi::c_void,

--- a/support/openssl_kdf/src/sys/evp.rs
+++ b/support/openssl_kdf/src/sys/evp.rs
@@ -19,7 +19,7 @@ pub enum KDF {}
 
 pub enum KDF_CTX {}
 
-extern "C" {
+unsafe extern "C" {
     pub fn EVP_MD_get0_name(md: *const EVP_MD) -> *const c_char;
 }
 
@@ -31,7 +31,7 @@ pub const OSSL_PARAM_OCTET_STRING: c_uchar = 5;
 pub const OSSL_PARAM_UTF8_PTR: c_uchar = 6;
 pub const OSSL_PARAM_OCTET_PTR: c_uchar = 7;
 
-extern "C" {
+unsafe extern "C" {
     pub fn EVP_KDF_fetch(
         libctx: *mut OSSL_LIB_CTX,
         algorithm: *const c_char,

--- a/support/openssl_kdf/src/sys/params.rs
+++ b/support/openssl_kdf/src/sys/params.rs
@@ -18,7 +18,7 @@ use libc::time_t;
 use openssl_sys::BIGNUM;
 use std::ffi::CStr;
 
-extern "C" {
+unsafe extern "C" {
     pub fn OSSL_PARAM_get_int(p: *const OSSL_PARAM, val: *mut c_int) -> c_int;
     pub fn OSSL_PARAM_get_uint(p: *const OSSL_PARAM, val: *mut c_uint) -> c_int;
     pub fn OSSL_PARAM_get_long(p: *const OSSL_PARAM, val: *mut c_long) -> c_int;

--- a/support/pal/src/windows/alpc.rs
+++ b/support/pal/src/windows/alpc.rs
@@ -57,7 +57,7 @@ mod ntlpcapi {
     pub const OB_ALL_OBJECT_TYPE_CODES: u32 = 0x00000ffd;
 
     // This is defined incorrectly in ntapi 0.3.6.
-    extern "C" {
+    unsafe extern "C" {
         pub fn AlpcInitializeMessageAttribute(
             AttributeFlags: u32,
             Buffer: PALPC_MESSAGE_ATTRIBUTES,

--- a/support/pal/src/windows/security.rs
+++ b/support/pal/src/windows/security.rs
@@ -318,7 +318,7 @@ impl SecurityDescriptor {
 }
 
 #[link(name = "api-ms-win-security-base-private-l1-1-1")]
-extern "C" {
+unsafe extern "C" {
     fn CreateAppContainerToken(
         token: HANDLE,
         caps: LPSECURITY_CAPABILITIES,

--- a/support/sparse_mmap/src/lib.rs
+++ b/support/sparse_mmap/src/lib.rs
@@ -47,7 +47,7 @@ pub fn initialize_try_copy() {
     }
 }
 
-extern "C" {
+unsafe extern "C" {
     #[cfg(unix)]
     fn install_signal_handlers() -> i32;
 

--- a/support/win_prng_support/src/lib.rs
+++ b/support/win_prng_support/src/lib.rs
@@ -25,7 +25,7 @@ macro_rules! use_win10_prng_apis {
         $($crate::use_win10_prng_apis!(@x $lib);)*
     };
     (@x advapi32) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "system" fn SystemFunction036(data: *mut u8, len: u32) -> u8 {
             // SAFETY: passing through guarantees.
             unsafe { $crate::private::SystemFunction036(data, len) }
@@ -33,12 +33,12 @@ macro_rules! use_win10_prng_apis {
 
         /// If a call to SystemFunction036 is marked as a dllimport, then it may be an indirect call
         /// through __imp_SystemFunction036 instead.
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub static __imp_SystemFunction036: unsafe extern "system" fn(*mut u8, u32) -> u8 =
             SystemFunction036;
     };
     (@x bcrypt) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "system" fn BCryptOpenAlgorithmProvider(
             handle: *mut ::core::ffi::c_void,
             psz_alg_id: *mut u16,
@@ -56,7 +56,7 @@ macro_rules! use_win10_prng_apis {
             }
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "system" fn BCryptCloseAlgorithmProvider(
             handle: *mut ::core::ffi::c_void,
             flags: u32,
@@ -65,7 +65,7 @@ macro_rules! use_win10_prng_apis {
             unsafe { $crate::private::BCryptCloseAlgorithmProvider(handle, flags) }
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub unsafe extern "system" fn BCryptGenRandom(
             algorithm: usize,
             data: *mut u8,
@@ -78,7 +78,7 @@ macro_rules! use_win10_prng_apis {
 
         /// If a call to BCryptGenRandom is marked as a dllimport, then it may be an indirect call
         /// through __imp_BCryptGenRandom instead.
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub static __imp_BCryptGenRandom: unsafe extern "system" fn(
             usize,
             *mut u8,
@@ -86,7 +86,7 @@ macro_rules! use_win10_prng_apis {
             u32,
         ) -> u32 = BCryptGenRandom;
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub static __imp_BCryptOpenAlgorithmProvider: unsafe extern "system" fn(
             *mut ::core::ffi::c_void,
             *mut u16,
@@ -94,7 +94,7 @@ macro_rules! use_win10_prng_apis {
             u32,
         ) -> u32 = BCryptOpenAlgorithmProvider;
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         pub static __imp_BCryptCloseAlgorithmProvider: unsafe extern "system" fn(
             *mut ::core::ffi::c_void,
             u32,
@@ -115,7 +115,7 @@ pub mod private {
     const BCRYPT_MAGIC_ALGORITHM_HANDLE: usize = 0x1234abcd;
 
     #[link(name = "ext-ms-win-cng-rng-l1-1-0")]
-    extern "C" {
+    unsafe extern "C" {
         /// The lowest-level PRNG API in Windows.
         fn ProcessPrng(data: *mut u8, len: usize) -> u32;
     }

--- a/vm/devices/net/linux_net_bindings/src/gen_if.rs
+++ b/vm/devices/net/linux_net_bindings/src/gen_if.rs
@@ -653,7 +653,7 @@ pub struct fd_set {
     pub __fds_bits: [__fd_mask; 16usize],
 }
 pub type fd_mask = __fd_mask;
-extern "C" {
+unsafe extern "C" {
     pub fn select(
         __nfds: ::std::os::raw::c_int,
         __readfds: *mut fd_set,
@@ -662,7 +662,7 @@ extern "C" {
         __timeout: *mut timeval,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn pselect(
         __nfds: ::std::os::raw::c_int,
         __readfds: *mut fd_set,
@@ -1017,7 +1017,7 @@ pub struct cmsghdr {
     pub cmsg_type: ::std::os::raw::c_int,
     pub __cmsg_data: __IncompleteArrayField<::std::os::raw::c_uchar>,
 }
-extern "C" {
+unsafe extern "C" {
     pub fn __cmsg_nxthdr(__mhdr: *mut msghdr, __cmsg: *mut cmsghdr) -> *mut cmsghdr;
 }
 pub const SCM_RIGHTS: ::std::os::raw::c_uint = 1;
@@ -1038,14 +1038,14 @@ pub const SHUT_RD: ::std::os::raw::c_uint = 0;
 pub const SHUT_WR: ::std::os::raw::c_uint = 1;
 pub const SHUT_RDWR: ::std::os::raw::c_uint = 2;
 pub type _bindgen_ty_3 = ::std::os::raw::c_uint;
-extern "C" {
+unsafe extern "C" {
     pub fn socket(
         __domain: ::std::os::raw::c_int,
         __type: ::std::os::raw::c_int,
         __protocol: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn socketpair(
         __domain: ::std::os::raw::c_int,
         __type: ::std::os::raw::c_int,
@@ -1053,35 +1053,35 @@ extern "C" {
         __fds: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn bind(
         __fd: ::std::os::raw::c_int,
         __addr: *const sockaddr,
         __len: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn getsockname(
         __fd: ::std::os::raw::c_int,
         __addr: *mut sockaddr,
         __len: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn connect(
         __fd: ::std::os::raw::c_int,
         __addr: *const sockaddr,
         __len: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn getpeername(
         __fd: ::std::os::raw::c_int,
         __addr: *mut sockaddr,
         __len: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn send(
         __fd: ::std::os::raw::c_int,
         __buf: *const ::std::os::raw::c_void,
@@ -1089,7 +1089,7 @@ extern "C" {
         __flags: ::std::os::raw::c_int,
     ) -> ssize_t;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn recv(
         __fd: ::std::os::raw::c_int,
         __buf: *mut ::std::os::raw::c_void,
@@ -1097,7 +1097,7 @@ extern "C" {
         __flags: ::std::os::raw::c_int,
     ) -> ssize_t;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn sendto(
         __fd: ::std::os::raw::c_int,
         __buf: *const ::std::os::raw::c_void,
@@ -1107,7 +1107,7 @@ extern "C" {
         __addr_len: socklen_t,
     ) -> ssize_t;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn recvfrom(
         __fd: ::std::os::raw::c_int,
         __buf: *mut ::std::os::raw::c_void,
@@ -1117,21 +1117,21 @@ extern "C" {
         __addr_len: *mut socklen_t,
     ) -> ssize_t;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn sendmsg(
         __fd: ::std::os::raw::c_int,
         __message: *const msghdr,
         __flags: ::std::os::raw::c_int,
     ) -> ssize_t;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn recvmsg(
         __fd: ::std::os::raw::c_int,
         __message: *mut msghdr,
         __flags: ::std::os::raw::c_int,
     ) -> ssize_t;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn getsockopt(
         __fd: ::std::os::raw::c_int,
         __level: ::std::os::raw::c_int,
@@ -1140,7 +1140,7 @@ extern "C" {
         __optlen: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn setsockopt(
         __fd: ::std::os::raw::c_int,
         __level: ::std::os::raw::c_int,
@@ -1149,27 +1149,27 @@ extern "C" {
         __optlen: socklen_t,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn listen(__fd: ::std::os::raw::c_int, __n: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn accept(
         __fd: ::std::os::raw::c_int,
         __addr: *mut sockaddr,
         __addr_len: *mut socklen_t,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn shutdown(
         __fd: ::std::os::raw::c_int,
         __how: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn sockatmark(__fd: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn isfdtype(
         __fd: ::std::os::raw::c_int,
         __fdtype: ::std::os::raw::c_int,

--- a/vm/devices/serial/vmbus_serial_guest/src/lib.rs
+++ b/vm/devices/serial/vmbus_serial_guest/src/lib.rs
@@ -208,7 +208,7 @@ impl VmbusSerialDriver {
     pub async fn drain_rx(&mut self) -> Result<(), Error> {
         poll_fn(|cx| {
             while self.rx_in_flight {
-                ready!(self.poll(cx))?;
+                ready!(self.poll_outer(cx))?;
             }
             Poll::Ready(Ok(()))
         })
@@ -246,12 +246,12 @@ impl VmbusSerialDriver {
         }
 
         // Poll once to get modem status, which the host should send right away.
-        poll_fn(|cx| self.poll(cx)).await?;
+        poll_fn(|cx| self.poll_outer(cx)).await?;
 
         Ok(())
     }
 
-    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ErrorInner>> {
+    fn poll_outer(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ErrorInner>> {
         if self.failed {
             Poll::Ready(Err(ErrorInner::FailedDevice))
         } else {
@@ -361,14 +361,14 @@ impl SerialIo for VmbusSerialDriver {
 
     fn poll_connect(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         while !self.connected {
-            ready!(self.poll(cx))?;
+            ready!(self.poll_outer(cx))?;
         }
         Poll::Ready(Ok(()))
     }
 
     fn poll_disconnect(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         while self.connected {
-            ready!(self.poll(cx))?;
+            ready!(self.poll_outer(cx))?;
         }
         Poll::Ready(Ok(()))
     }
@@ -385,7 +385,7 @@ impl AsyncRead for VmbusSerialDriver {
                 return Poll::Ready(Ok(0));
             }
             self.rx_waker = Some(cx.waker().clone());
-            ready!(self.poll(cx))?;
+            ready!(self.poll_outer(cx))?;
         }
         let n = buf.len().min(self.rx_buffer.len());
         for (s, d) in self.rx_buffer.drain(..n).zip(buf) {
@@ -403,7 +403,7 @@ impl AsyncWrite for VmbusSerialDriver {
     ) -> Poll<io::Result<usize>> {
         while self.tx_in_flight || self.failed {
             self.tx_waker = Some(cx.waker().clone());
-            ready!(self.poll(cx))?;
+            ready!(self.poll_outer(cx))?;
         }
         let buf = &buf[..buf.len().min(UART_MSG_MAX_PAYLOAD)];
         let mut request = protocol::TxDataAvailableMessage {
@@ -425,7 +425,7 @@ impl AsyncWrite for VmbusSerialDriver {
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         while self.tx_in_flight || self.failed {
-            ready!(self.poll(cx))?;
+            ready!(self.poll_outer(cx))?;
         }
         Poll::Ready(Ok(()))
     }

--- a/vm/devices/storage/disk_vhdmp/src/lib.rs
+++ b/vm/devices/storage/disk_vhdmp/src/lib.rs
@@ -202,7 +202,7 @@ mod virtdisk {
     }
 
     #[link(name = "virtdisk")]
-    extern "system" {
+    unsafe extern "system" {
         pub fn OpenVirtualDisk(
             virtual_storage_type: &mut VIRTUAL_STORAGE_TYPE,
             path: *const u16,

--- a/vm/devices/storage/nvme/src/namespace/reservations.rs
+++ b/vm/devices/storage/nvme/src/namespace/reservations.rs
@@ -76,7 +76,7 @@ impl Namespace {
 
         let report_header = nvm::ReservationReportExtended {
             report: nvm::ReservationReport {
-                gen: report.generation,
+                generation: report.generation,
                 rtype: report
                     .reservation_type
                     .map_or(nvm::ReservationType(0), to_nvme_reservation_type),

--- a/vm/devices/storage/nvme_common/src/lib.rs
+++ b/vm/devices/storage/nvme_common/src/lib.rs
@@ -97,7 +97,7 @@ pub fn from_nvme_reservation_report(
         .collect();
 
     let report = pr::ReservationReport {
-        generation: report_header.gen,
+        generation: report_header.generation,
         reservation_type,
         controllers,
         persist_through_power_loss: report_header.ptpls != 0,

--- a/vm/devices/storage/nvme_spec/src/nvm.rs
+++ b/vm/devices/storage/nvme_spec/src/nvm.rs
@@ -349,7 +349,7 @@ pub struct Cdw11ReservationReport {
 #[derive(Debug, Copy, Clone, AsBytes, FromBytes, FromZeroes)]
 pub struct ReservationReport {
     /// Generation
-    pub gen: u32,
+    pub generation: u32,
     /// Reservation type
     pub rtype: ReservationType,
     /// Number of registered controllers

--- a/vm/devices/support/fs/plan9/src/protocol.rs
+++ b/vm/devices/support/fs/plan9/src/protocol.rs
@@ -29,7 +29,7 @@ p9_protocol_messages! {
     15 Rlcreate qid[q] iounit[4];
     24 Tgetattr fid[4] request_mask[8];
     25 Rgetattr valid[8] qid[q] mode[4] uid[4] gid[4] nlink[8] rdev[8] size[8] blksize[8] blocks[8] atime_sec[8] atime_nsec[8]
-        mtime_sec[8] mtime_nsec[8] ctime_sec[8] ctime_nsec[8] btime_sec[8] btime_nsec[8] gen[8] data_version[8];
+        mtime_sec[8] mtime_nsec[8] ctime_sec[8] ctime_nsec[8] btime_sec[8] btime_nsec[8] r#gen[8] data_version[8];
     26 Tsetattr fid[4] valid[4] mode[4] uid[4] gid[4] size[8] atime_sec[8] atime_nsec[8] mtime_sec[8] mtime_nsec[8];
     27 Rsetattr;
     40 Treaddir fid[4] offset[8] count[4];

--- a/vm/vmgs/vmgs_lib/src/lib.rs
+++ b/vm/vmgs/vmgs_lib/src/lib.rs
@@ -47,7 +47,7 @@ pub enum VmgsError {
 ///
 /// `file_path` must point to a valid null-terminated utf-8 string.
 /// `in_len` must be the size of `in_buf` in bytes and match the value returned from query_size_vmgs
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn read_vmgs(
     file_path: *const c_char,
     file_id: FileId,
@@ -144,7 +144,7 @@ async fn do_read(
 ///
 /// `file_path` and `data_path` must point to valid null-terminated utf-8 strings.
 /// `encryption_key` must be null-terminated and nonnull if using encryption
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn write_vmgs(
     file_path: *const c_char,
     data_path: *const c_char,
@@ -236,7 +236,7 @@ async fn do_write(
 /// # Safety
 ///
 /// `path` must point to a valid null-terminated utf-8 string.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn create_vmgs(
     path: *const c_char,
     file_size: u64,
@@ -324,7 +324,7 @@ async fn do_create(
 ///
 /// `path` pointer must point to a valid, null-terminated utf-8 string.
 /// `out_size` pointer must be nonnull
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn query_size_vmgs(
     path: *const c_char,
     file_id: FileId,

--- a/vm/whp/src/api.rs
+++ b/vm/whp/src/api.rs
@@ -73,7 +73,7 @@ pub const WHV_E_UNKNOWN_CAPABILITY: HRESULT = 0x80370300u32 as HRESULT;
 pub const WHV_E_INSUFFICIENT_BUFFER: HRESULT = 0x80370301u32 as HRESULT;
 
 #[link(name = "WinHvPlatform")]
-extern "stdcall" {
+unsafe extern "stdcall" {
     pub fn WHvGetCapability(
         CapabilityCode: WHV_CAPABILITY_CODE,
         CapabilityBuffer: *mut u8,

--- a/vmm_core/virt_hvf/src/abi.rs
+++ b/vmm_core/virt_hvf/src/abi.rs
@@ -65,7 +65,7 @@ impl HvfResult {
 }
 
 #[link(name = "Hypervisor", kind = "framework")]
-extern "C" {
+unsafe extern "C" {
     pub fn hv_vm_create(config: *const ()) -> HvfResult;
     pub fn hv_vm_destroy() -> HvfResult;
     pub fn hv_vm_map(addr: *mut c_void, ipa: u64, size: usize, flags: u64) -> HvfResult;

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -449,7 +449,7 @@ enum Generation {
     Gen2,
 }
 
-fn parse_vhd(input: ParseStream<'_>, gen: Generation) -> syn::Result<ImageInfo> {
+fn parse_vhd(input: ParseStream<'_>, generation: Generation) -> syn::Result<ImageInfo> {
     let word = input.parse::<Ident>()?;
 
     macro_rules! image_info {
@@ -464,7 +464,7 @@ fn parse_vhd(input: ParseStream<'_>, gen: Generation) -> syn::Result<ImageInfo> 
     }
 
     match &*word.to_string() {
-        "freebsd_13_2_x64" => match gen {
+        "freebsd_13_2_x64" => match generation {
             Generation::Gen1 => Ok(image_info!(
                 ::petri_artifacts_vmm_test::artifacts::test_vhd::FREE_BSD_13_2_X64
             )),
@@ -473,7 +473,7 @@ fn parse_vhd(input: ParseStream<'_>, gen: Generation) -> syn::Result<ImageInfo> 
                 "FreeBSD 13.2 is not available for UEFI",
             )),
         },
-        "windows_datacenter_core_2022_x64" => match gen {
+        "windows_datacenter_core_2022_x64" => match generation {
             Generation::Gen1 => Ok(image_info!(
                 ::petri_artifacts_vmm_test::artifacts::test_vhd::GEN1_WINDOWS_DATA_CENTER_CORE2022_X64
             )),


### PR DESCRIPTION
This PR fixes up the easy issues with Rust 2024 compatibility and enables the lint for it. However it also scopes out some allows for the things that need some more work and focus. #288 is tracking them.

Changes in this PR:

- extern blocks are now unsafe
- `gen` is becoming a reserved keyword, rename variables
- mark unsafe attributes other than linkme's
- resolve the ambiguity of `fn poll` in VmbusSerialDriver 