### PR TITLE
vtl2 config: Don't zero the VTL 2 params map for isolated VMs

### DIFF
--- a/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
+++ b/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
@@ -94,11 +94,10 @@ impl MeasuredVtl2Info {
 struct Vtl2ParamsMap<'a> {
     mapping: SparseMapping,
     ranges: &'a [MemoryRange],
-    is_isolated: bool,
 }
 
 impl<'a> Vtl2ParamsMap<'a> {
-    fn new(config_ranges: &'a [MemoryRange], is_isolated: bool) -> anyhow::Result<Self> {
+    fn new(config_ranges: &'a [MemoryRange]) -> anyhow::Result<Self> {
         // No overlaps.
         // TODO: Move this check to host_fdt_parser?
         if let Some((l, r)) = config_ranges
@@ -139,7 +138,6 @@ impl<'a> Vtl2ParamsMap<'a> {
         Ok(Self {
             mapping,
             ranges: config_ranges,
-            is_isolated,
         })
     }
 
@@ -154,10 +152,9 @@ impl<'a> Vtl2ParamsMap<'a> {
 
 impl Drop for Vtl2ParamsMap<'_> {
     fn drop(&mut self) {
-        // The zeroing is only for servicing validation, so this is only needed
-        // for non-isolated VMs. Currently it breaks SNP-isolated VMs, so skip
-        // it for all isolated VMs for now.
-        if !self.is_isolated {
+        // This currently doesn't work on SNP. Revive this when it works on all
+        // platforms.
+        if false {
             let base = self
                 .ranges
                 .first()
@@ -177,11 +174,8 @@ impl Drop for Vtl2ParamsMap<'_> {
 pub fn read_vtl2_params() -> anyhow::Result<(RuntimeParameters, MeasuredVtl2Info)> {
     let parsed_openhcl_boot = ParsedBootDtInfo::new().context("failed to parse openhcl_boot dt")?;
 
-    let mapping = Vtl2ParamsMap::new(
-        &parsed_openhcl_boot.config_ranges,
-        parsed_openhcl_boot.isolation != IsolationType::None,
-    )
-    .context("failed to map igvm parameters")?;
+    let mapping = Vtl2ParamsMap::new(&parsed_openhcl_boot.config_ranges)
+        .context("failed to map igvm parameters")?;
 
     // For the various ACPI tables, read the header to see how big the table
     // is, then read the exact table.

--- a/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
+++ b/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
@@ -94,10 +94,11 @@ impl MeasuredVtl2Info {
 struct Vtl2ParamsMap<'a> {
     mapping: SparseMapping,
     ranges: &'a [MemoryRange],
+    is_isolated: bool,
 }
 
 impl<'a> Vtl2ParamsMap<'a> {
-    fn new(config_ranges: &'a [MemoryRange]) -> anyhow::Result<Self> {
+    fn new(config_ranges: &'a [MemoryRange], is_isolated: bool) -> anyhow::Result<Self> {
         // No overlaps.
         // TODO: Move this check to host_fdt_parser?
         if let Some((l, r)) = config_ranges
@@ -138,6 +139,7 @@ impl<'a> Vtl2ParamsMap<'a> {
         Ok(Self {
             mapping,
             ranges: config_ranges,
+            is_isolated,
         })
     }
 
@@ -152,16 +154,21 @@ impl<'a> Vtl2ParamsMap<'a> {
 
 impl Drop for Vtl2ParamsMap<'_> {
     fn drop(&mut self) {
-        let base = self
-            .ranges
-            .first()
-            .expect("already checked that there is at least one range")
-            .start();
+        // The zeroing is only for servicing validation, so this is only needed
+        // for non-isolated VMs. Currently it breaks SNP-isolated VMs, so skip
+        // it for all isolated VMs for now.
+        if !self.is_isolated {
+            let base = self
+                .ranges
+                .first()
+                .expect("already checked that there is at least one range")
+                .start();
 
-        for range in self.ranges {
-            self.mapping
-                .fill_at((range.start() - base) as usize, 0, range.len() as usize)
-                .unwrap();
+            for range in self.ranges {
+                self.mapping
+                    .fill_at((range.start() - base) as usize, 0, range.len() as usize)
+                    .unwrap();
+            }
         }
     }
 }
@@ -170,8 +177,11 @@ impl Drop for Vtl2ParamsMap<'_> {
 pub fn read_vtl2_params() -> anyhow::Result<(RuntimeParameters, MeasuredVtl2Info)> {
     let parsed_openhcl_boot = ParsedBootDtInfo::new().context("failed to parse openhcl_boot dt")?;
 
-    let mapping = Vtl2ParamsMap::new(&parsed_openhcl_boot.config_ranges)
-        .context("failed to map igvm parameters")?;
+    let mapping = Vtl2ParamsMap::new(
+        &parsed_openhcl_boot.config_ranges,
+        parsed_openhcl_boot.isolation != IsolationType::None,
+    )
+    .context("failed to map igvm parameters")?;
 
     // For the various ACPI tables, read the header to see how big the table
     // is, then read the exact table.

--- a/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
+++ b/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
@@ -91,12 +91,14 @@ impl MeasuredVtl2Info {
 /// Map of the portion of memory that contains the VTL2 parameters.
 ///
 /// On drop, this mapping zeroes out the specified config ranges.
-struct Vtl2ParamsMap {
+struct Vtl2ParamsMap<'a> {
     mapping: SparseMapping,
+    ranges: &'a [MemoryRange],
+    is_isolated: bool,
 }
 
-impl<'a> Vtl2ParamsMap {
-    fn new(config_ranges: &'a [MemoryRange]) -> anyhow::Result<Self> {
+impl<'a> Vtl2ParamsMap<'a> {
+    fn new(config_ranges: &'a [MemoryRange], is_isolated: bool) -> anyhow::Result<Self> {
         // No overlaps.
         // TODO: Move this check to host_fdt_parser?
         if let Some((l, r)) = config_ranges
@@ -134,7 +136,11 @@ impl<'a> Vtl2ParamsMap {
                 .context("failed to memory map igvm parameters")?;
         }
 
-        Ok(Self { mapping })
+        Ok(Self {
+            mapping,
+            ranges: config_ranges,
+            is_isolated,
+        })
     }
 
     fn read_at(&self, offset: usize, buf: &mut [u8]) -> anyhow::Result<()> {
@@ -146,12 +152,36 @@ impl<'a> Vtl2ParamsMap {
     }
 }
 
+impl Drop for Vtl2ParamsMap<'_> {
+    fn drop(&mut self) {
+        // The zeroing is only for servicing validation, so this is only needed
+        // for non-isolated VMs. Currently it breaks SNP-isolated VMs, so skip
+        // it for all isolated VMs for now.
+        if !self.is_isolated {
+            let base = self
+                .ranges
+                .first()
+                .expect("already checked that there is at least one range")
+                .start();
+
+            for range in self.ranges {
+                self.mapping
+                    .fill_at((range.start() - base) as usize, 0, range.len() as usize)
+                    .unwrap();
+            }
+        }
+    }
+}
+
 /// Reads the VTL 2 parameters from the vtl-boot-data region.
 pub fn read_vtl2_params() -> anyhow::Result<(RuntimeParameters, MeasuredVtl2Info)> {
     let parsed_openhcl_boot = ParsedBootDtInfo::new().context("failed to parse openhcl_boot dt")?;
 
-    let mapping = Vtl2ParamsMap::new(&parsed_openhcl_boot.config_ranges)
-        .context("failed to map igvm parameters")?;
+    let mapping = Vtl2ParamsMap::new(
+        &parsed_openhcl_boot.config_ranges,
+        parsed_openhcl_boot.isolation != IsolationType::None,
+    )
+    .context("failed to map igvm parameters")?;
 
     // For the various ACPI tables, read the header to see how big the table
     // is, then read the exact table.
@@ -232,6 +262,8 @@ pub fn read_vtl2_params() -> anyhow::Result<(RuntimeParameters, MeasuredVtl2Info
             (PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_INDEX * HV_PAGE_SIZE) as usize,
         )
         .context("failed to read measured vtl2 config")?;
+
+    drop(mapping);
 
     assert_eq!(measured_config.magic, ParavisorMeasuredVtl2Config::MAGIC);
 


### PR DESCRIPTION
Zeroing the VTL 2 params map via dev/mem seems to fail on SNP. Since SNP doesn't support servicing, and this was being done for servicing validation, skip the zeroing for isolated VMs for now.