### PR TITLE
virt_hvf: Add PSCI support and extend GIC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7111,6 +7111,7 @@ dependencies = [
  "tracing",
  "virt",
  "virt_support_gic",
+ "vm_topology",
  "vmcore",
 ]
 
@@ -7257,9 +7258,11 @@ dependencies = [
 name = "virt_support_gic"
 version = "0.0.0"
 dependencies = [
+ "aarch64defs",
  "inspect",
- "open_enum",
+ "memory_range",
  "parking_lot",
+ "tracelimit",
  "tracing",
  "vm_topology",
 ]

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1107,13 +1107,11 @@ fn new_aarch64_topology(
     TopologyBuilder::new_aarch64(gic)
         .vps_per_socket(cpus.len() as u32)
         .build_with_vp_info(cpus.iter().enumerate().map(|(vp_index, cpu)| {
-            let mpidr = aarch64defs::MpidrEl1::new()
-                .with_res1_31(true)
-                .with_u(cpus.len() == 1)
-                .with_aff0((cpu.reg & 0xFF) as u8)
-                .with_aff1(((cpu.reg >> 8) & 0xFF) as u8)
-                .with_aff2(((cpu.reg >> 16) & 0xFF) as u8)
-                .with_aff3(((cpu.reg >> 32) & 0xFF) as u8);
+            let mpidr = aarch64defs::MpidrEl1::from(
+                cpu.reg & u64::from(aarch64defs::MpidrEl1::AFFINITY_MASK),
+            )
+            .with_res1_31(true)
+            .with_u(cpus.len() == 1);
             vm_topology::processor::aarch64::Aarch64VpInfo {
                 base: VpInfo {
                     vp_index: VpIndex::new(vp_index as u32),

--- a/vm/aarch64/aarch64defs/src/gic.rs
+++ b/vm/aarch64/aarch64defs/src/gic.rs
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Definitions for the Generic Interrupt Controller (GIC) registers.
+
+use bitfield_struct::bitfield;
+use core::ops::Range;
+use open_enum::open_enum;
+
+open_enum! {
+    pub enum GicdRegister: u16 {
+        CTLR = 0x0000,
+        TYPER = 0x0004,
+        IIDR = 0x0008,
+        TYPER2 = 0x000c,
+        STATUSR = 0x0010,
+        SETSPI_NSR = 0x0040,
+        CLRSPI_NSR = 0x0048,
+        SETSPI_SR = 0x0050,
+        CLRSPI_SR = 0x0058,
+        IGROUPR0 = 0x0080,       // 0x80
+        ISENABLER0 = 0x0100,     // 0x80
+        ICENABLER0 = 0x0180,     // 0x80
+        ISPENDR0 = 0x0200,       // 0x80
+        ICPENDR0 = 0x0280,       // 0x80
+        ISACTIVER0 = 0x0300,     // 0x80
+        ICACTIVER0 = 0x0380,     // 0x80
+        IPRIORITYR0 = 0x0400,    // 0x400
+        ITARGETSR0 = 0x0800,     // 0x400
+        ICFGR0 = 0x0c00,         // 0x100
+        IGRPMODR0 = 0x0d00,      // 0x100
+        NSACR0 = 0x0e00,         // 0x100
+        SGIR = 0x0f00,
+        CPENDSGIR0 = 0x0f10,     // 0x10
+        SPENDSGIR0 = 0x0f20,     // 0x10
+        INMIR0 = 0x0f80,         // 0x80
+        IROUTER0 = 0x6000,       // 0x2000, skip first 0x100,
+        PIDR2 = 0xffe8,
+    }
+}
+
+impl GicdRegister {
+    pub const IGROUPR: Range<u16> = Self::IGROUPR0.0..Self::IGROUPR0.0 + 0x80;
+    pub const ISENABLER: Range<u16> = Self::ISENABLER0.0..Self::ISENABLER0.0 + 0x80;
+    pub const ICENABLER: Range<u16> = Self::ICENABLER0.0..Self::ICENABLER0.0 + 0x80;
+    pub const ISPENDR: Range<u16> = Self::ISPENDR0.0..Self::ISPENDR0.0 + 0x80;
+    pub const ICPENDR: Range<u16> = Self::ICPENDR0.0..Self::ICPENDR0.0 + 0x80;
+    pub const ISACTIVER: Range<u16> = Self::ISACTIVER0.0..Self::ISACTIVER0.0 + 0x80;
+    pub const ICACTIVER: Range<u16> = Self::ICACTIVER0.0..Self::ICACTIVER0.0 + 0x80;
+    pub const ICFGR: Range<u16> = Self::ICFGR0.0..Self::ICFGR0.0 + 0x100;
+    pub const IPRIORITYR: Range<u16> = Self::IPRIORITYR0.0..Self::IPRIORITYR0.0 + 0x400;
+    pub const IROUTER: Range<u16> = Self::IROUTER0.0..Self::IROUTER0.0 + 0x2000;
+}
+
+#[bitfield(u32)]
+pub struct GicdTyper {
+    #[bits(5)]
+    pub it_lines_number: u8,
+    #[bits(3)]
+    pub cpu_number: u8,
+    pub espi: bool,
+    pub nmi: bool,
+    pub security_extn: bool,
+    #[bits(5)]
+    pub num_lpis: u8,
+    pub mbis: bool,
+    pub lpis: bool,
+    pub dvis: bool,
+    #[bits(5)]
+    pub id_bits: u8,
+    pub a3v: bool,
+    pub no1n: bool,
+    pub rss: bool,
+    #[bits(5)]
+    pub espi_range: u8,
+}
+
+#[bitfield(u32)]
+pub struct GicdTyper2 {
+    #[bits(5)]
+    pub vid: u8,
+    #[bits(2)]
+    _res5_6: u8,
+    pub vil: bool,
+    pub n_assgi_cap: bool,
+    #[bits(23)]
+    _res9_31: u32,
+}
+
+#[bitfield(u32)]
+pub struct GicdCtlr {
+    pub enable_grp0: bool,
+    pub enable_grp1: bool,
+    #[bits(2)]
+    _res_2_3: u8,
+    pub are: bool,
+    _res_5: bool,
+    pub ds: bool,
+    pub e1nwf: bool,
+    pub n_assgi_req: bool,
+    #[bits(22)]
+    _res_9_30: u32,
+    pub rwp: bool,
+}
+
+open_enum! {
+    pub enum GicrRdRegister: u16 {
+        CTLR = 0x0000,
+        IIDR = 0x0004,
+        TYPER = 0x0008,     // 64 bit
+        STATUSR = 0x0010,
+        WAKER = 0x0014,
+        MPAMIDR = 0x0018,
+        PARTIDR = 0x001c,
+        SETLPIR = 0x0040,   // 64 bit
+        CLRLPIR = 0x0048,   // 64 bit
+        PROPBASER = 0x0070, // 64 bit
+        PENDBASER = 0x0078, // 64 bit
+        INVLPIR = 0x00A0,   // 64 bit
+        SYNCR = 0x00C0,     // 64 bit
+        PIDR2 = 0xffe8,
+    }
+}
+
+open_enum! {
+    pub enum GicrSgiRegister: u16 {
+        IGROUPR0 = 0x0080,
+        ISENABLER0 = 0x0100,
+        ICENABLER0 = 0x0180,
+        ISPENDR0 = 0x0200,
+        ICPENDR0 = 0x0280,
+        ISACTIVER0 = 0x0300,
+        ICACTIVER0 = 0x0380,
+        IPRIORITYR0 = 0x0400, // 0x20
+        ICFGR0 = 0x0c00,
+        ICFGR1 = 0x0c04,
+        IGRPMODR0 = 0x0d00,
+    }
+}
+
+impl GicrSgiRegister {
+    pub const IPRIORITYR: Range<u16> = Self::IPRIORITYR0.0..Self::IPRIORITYR0.0 + 0x20;
+}
+
+#[bitfield(u64)]
+pub struct GicrTyper {
+    pub plpis: bool,
+    pub vlpis: bool,
+    pub dirty: bool,
+    pub direct_lpi: bool,
+    pub last: bool,
+    pub dpgs: bool,
+    pub mpam: bool,
+    pub rvpeid: bool,
+    pub processor_number: u16,
+    #[bits(2)]
+    pub common_lpi_aff: u8,
+    pub vsgi: bool,
+    #[bits(5)]
+    pub ppi_num: u8,
+    pub aff0: u8,
+    pub aff1: u8,
+    pub aff2: u8,
+    pub aff3: u8,
+}
+
+#[bitfield(u32)]
+pub struct GicrCtlr {
+    pub enable_lpis: bool,
+    pub ces: bool,
+    pub ir: bool,
+    pub rwp: bool,
+    #[bits(20)]
+    _res_4_23: u32,
+    pub dpg0: bool,
+    pub dpg1ns: bool,
+    pub dpg1s: bool,
+    #[bits(4)]
+    _res_27_30: u32,
+    pub uwp: bool,
+}
+
+#[bitfield(u32)]
+pub struct GicrWaker {
+    /// Implementation defined.
+    pub bit_0: bool,
+    pub processor_sleep: bool,
+    pub children_asleep: bool,
+    #[bits(28)]
+    _res_3_30: u32,
+    /// Implementation defined.
+    pub bit_31: bool,
+}
+
+#[bitfield(u64)]
+pub struct GicrSgi {
+    pub target_list: u16,
+    pub aff1: u8,
+    #[bits(4)]
+    pub intid: u32,
+    #[bits(4)]
+    _res_28_31: u16,
+    pub aff2: u8,
+    pub irm: bool,
+    #[bits(3)]
+    _res_41_43: u8,
+    #[bits(4)]
+    pub rs: u8,
+    pub aff3: u8,
+    _res_56_63: u8,
+}

--- a/vm/aarch64/aarch64defs/src/lib.rs
+++ b/vm/aarch64/aarch64defs/src/lib.rs
@@ -5,6 +5,9 @@
 
 #![no_std]
 
+pub mod gic;
+pub mod psci;
+
 use bitfield_struct::bitfield;
 use open_enum::open_enum;
 use zerocopy::AsBytes;
@@ -600,6 +603,14 @@ pub struct MpidrEl1 {
     pub aff3: u8,
     #[bits(24)]
     pub res0_40_63: u32,
+}
+
+impl MpidrEl1 {
+    pub const AFFINITY_MASK: Self = Self::new()
+        .with_aff0(0xff)
+        .with_aff1(0xff)
+        .with_aff2(0xff)
+        .with_aff3(0xff);
 }
 
 open_enum! {

--- a/vm/aarch64/aarch64defs/src/psci.rs
+++ b/vm/aarch64/aarch64defs/src/psci.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Definitions for the Power State Coordination Interface (PSCI).
+
+use bitfield_struct::bitfield;
+use open_enum::open_enum;
+
+pub const PSCI: u8 = 0x4;
+
+#[bitfield(u32)]
+#[derive(PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct FastCall {
+    pub number: u16,
+    pub hint: bool,
+    #[bits(7)]
+    pub mbz: u8,
+    #[bits(6)]
+    pub service: u8,
+    pub smc64: bool,
+    pub fast: bool,
+}
+
+open_enum! {
+    pub enum PsciCall: FastCall {
+        PSCI_VERSION = FastCall(0x8400_0000),
+        CPU_SUSPEND = FastCall(0x8400_0001),
+        CPU_OFF = FastCall(0x8400_0002),
+        CPU_ON = FastCall(0x8400_0003),
+        AFFINITY_INFO = FastCall(0x8400_0004),
+        MIGRATE = FastCall(0x8400_0005),
+        MIGRATE_INFO_TYPE = FastCall(0x8400_0006),
+        MIGRATE_INFO_UP_CPU = FastCall(0x8400_0007),
+        SYSTEM_OFF = FastCall(0x8400_0008),
+        SYSTEM_OFF2 = FastCall(0x8400_0015),
+        SYSTEM_RESET = FastCall(0x8400_0009),
+        SYSTEM_RESET2 = FastCall(0x8400_0012),
+        MEM_PROTECT = FastCall(0x8400_0013),
+        MEM_PROTECT_CHECK_RANGE = FastCall(0x8400_0014),
+        PSCI_FEATURES = FastCall(0x8400_000a),
+        CPU_FREEZE = FastCall(0x8400_000b),
+        CPU_DEFAULT_SUSPEND = FastCall(0x8400_000c),
+        NODE_HW_STATE = FastCall(0x8400_000d),
+        SYSTEM_SUSPEND = FastCall(0x8400_000e),
+        PSCI_SET_SUSPEND_MODE = FastCall(0x8400_000f),
+        PSCI_STAT_RESIDENCY = FastCall(0x8400_0010),
+        PSCI_STAT_COUNT = FastCall(0x8400_0011),
+    }
+}
+
+open_enum! {
+    pub enum PsciError: i32 {
+        SUCCESS = 0,
+        NOT_SUPPORTED = -1,
+        INVALID_PARAMETERS = -2,
+        DENIED = -3,
+        ALREADY_ON = -4,
+        ON_PENDING = -5,
+        INTERNAL_FAILURE = -6,
+        NOT_PRESENT = -7,
+        DISABLED = -8,
+        INVALID_ADDRESS = -9,
+    }
+}

--- a/vmm_core/virt_hvf/Cargo.toml
+++ b/vmm_core/virt_hvf/Cargo.toml
@@ -15,6 +15,7 @@ virt.workspace = true
 virt_support_gic.workspace = true
 guestmem.workspace = true
 vmcore.workspace = true
+vm_topology.workspace = true
 memory_range.workspace = true
 
 inspect.workspace = true

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -12,11 +12,15 @@ mod hypercall;
 mod vp_state;
 
 use crate::hypercall::HvfHypercallHandler;
+use aarch64defs::psci::FastCall;
+use aarch64defs::psci::PsciCall;
+use aarch64defs::psci::PsciError;
+use aarch64defs::psci::PSCI;
 use aarch64defs::Cpsr64;
 use aarch64defs::ExceptionClass;
 use aarch64defs::IssDataAbort;
 use aarch64defs::IssSystem;
-use aarch64defs::SystemReg;
+use aarch64defs::MpidrEl1;
 use abi::HvfError;
 use anyhow::Context;
 use guestmem::GuestMemory;
@@ -40,25 +44,30 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Weak;
 use std::task::ready;
+use std::task::Poll;
+use std::task::Waker;
 use std::time::Duration;
 use thiserror::Error;
 use virt::aarch64::vm::AccessVmState;
 use virt::aarch64::Aarch64PartitionCapabilities;
 use virt::io::CpuIo;
+use virt::state::StateElement;
+use virt::vp::AccessVpState;
 use virt::BindProcessor;
 use virt::NeedsYield;
+use virt::Processor;
 use virt::StopVp;
 use virt::VpHaltReason;
 use virt::VpIndex;
-use virt::VpInfo;
 use virt_support_gic as gic;
+use vm_topology::processor::aarch64::Aarch64VpInfo;
 use vmcore::interrupt::Interrupt;
 use vmcore::synic::GuestEventPort;
 use vmcore::vmtime::VmTimeAccess;
 
 const PPI_VTIMER: u32 = 20;
 
-const HV_ARM64_HVC_SMCCC_IDENTIFIER: u64 = (1 << 30) | (6 << 24) | 1;
+const HV_ARM64_HVC_SMCCC_IDENTIFIER: u32 = (1 << 30) | (6 << 24) | 1;
 
 #[derive(Debug)]
 pub struct HvfHypervisor;
@@ -117,12 +126,21 @@ impl virt::ProtoPartition for HvfProtoPartition<'_> {
             .map(|vp_info| hv1.synic.add_vp(vp_info.vp_index))
             .collect::<Vec<_>>();
 
-        let mut gicd = gic::Distributor::new(256);
+        let mut gicd = gic::Distributor::new(
+            self.config.processor_topology.gic_distributor_base(),
+            MemoryRange::new(
+                self.config.processor_topology.gic_redistributors_base()
+                    ..self.config.processor_topology.gic_redistributors_base()
+                        + aarch64defs::GIC_REDISTRIBUTOR_SIZE
+                            * self.config.processor_topology.vp_count() as u64,
+            ),
+            256,
+        );
         let gicrs = self
             .config
             .processor_topology
-            .vps()
-            .map(|_| gicd.add_redistributor())
+            .vps_arch()
+            .map(|vp_info| gicd.add_redistributor(vp_info.mpidr.into(), true))
             .collect::<Vec<_>>();
 
         let inner = Arc::new(HvfPartitionInner {
@@ -130,11 +148,14 @@ impl virt::ProtoPartition for HvfProtoPartition<'_> {
             vps: self
                 .config
                 .processor_topology
-                .vps()
-                .map(|_| HvfVpInner {
+                .vps_arch()
+                .map(|vp_info| HvfVpInner {
                     needs_yield: NeedsYield::new(),
                     vcpu: (!0).into(),
                     message_queues: hv1_emulator::message_queues::MessageQueues::new(),
+                    waker: Default::default(),
+                    vp_info,
+                    cpu_on: Default::default(),
                 })
                 .collect(),
             gicd,
@@ -142,9 +163,6 @@ impl virt::ProtoPartition for HvfProtoPartition<'_> {
             vmtime: self.config.vmtime.access("hvf"),
             hv1,
             mappings: Default::default(),
-            gicd_range: self.config.processor_topology.gic_distributor_base()
-                ..self.config.processor_topology.gic_distributor_base()
-                    + aarch64defs::GIC_DISTRIBUTOR_SIZE,
         });
 
         let mut vps = Vec::new();
@@ -157,8 +175,8 @@ impl virt::ProtoPartition for HvfProtoPartition<'_> {
         {
             vps.push(HvfProcessorBinder {
                 partition: inner.clone(),
+                vp_index: vp.base.vp_index,
                 state: Some(VpInitState {
-                    info: vp.base,
                     gicr,
                     hv1,
                     vmtime: self
@@ -224,12 +242,20 @@ impl virt::Aarch64Partition for HvfPartition {
 
 impl virt::Hv1 for HvfPartition {
     type Error = Error;
-    type Device = virt::UnimplementedDevice;
+    type Device = virt::aarch64::gic_software_device::GicSoftwareDevice;
 
     fn new_virtual_device(
         &self,
     ) -> Option<&dyn virt::DeviceBuilder<Device = Self::Device, Error = Self::Error>> {
-        None
+        Some(self)
+    }
+}
+
+impl virt::DeviceBuilder for HvfPartition {
+    fn build(&self, _vtl: Vtl, _device_id: u64) -> Result<Self::Device, Self::Error> {
+        Ok(virt::aarch64::gic_software_device::GicSoftwareDevice::new(
+            self.inner.clone(),
+        ))
     }
 }
 
@@ -237,7 +263,7 @@ impl virt::irqcon::ControlGic for HvfPartitionInner {
     fn set_spi_irq(&self, irq_id: u32, high: bool) {
         if let Some(vp) = self.gicd.set_pending(irq_id, high) {
             if let Some(vp) = self.vps.get(vp as usize) {
-                vp.cancel_run();
+                vp.wake();
             }
         }
     }
@@ -250,7 +276,7 @@ impl virt::Synic for HvfPartition {
                 .message_queues
                 .enqueue_message(sint, &HvMessage::new(HvMessageType(typ), 0, payload))
             {
-                vp.cancel_run();
+                vp.wake();
             }
         }
     }
@@ -288,7 +314,7 @@ impl GuestEventPort for HvfEventPort {
                         &mut |vector, _auto_eoi| {
                             if partition.gicd.raise_ppi(vp, vector) {
                                 tracing::debug!(vector, "ppi from event");
-                                partition.vps[vp.index() as usize].cancel_run();
+                                partition.vps[vp.index() as usize].wake();
                             }
                         },
                     );
@@ -393,8 +419,6 @@ struct HvfPartitionInner {
     hv1: HvfHv1State,
     #[inspect(with = "|x| inspect::adhoc(|req| inspect::iter_by_index(&*x.lock()).inspect(req))")]
     mappings: Mutex<Vec<MemoryRange>>,
-    #[inspect(debug)]
-    gicd_range: Range<u64>,
 }
 
 #[derive(Inspect)]
@@ -416,9 +440,19 @@ impl HvfHv1State {
 struct HvfVpInner {
     #[inspect(skip)]
     needs_yield: NeedsYield,
+    vp_info: Aarch64VpInfo,
     #[inspect(skip)]
     vcpu: AtomicU64,
     message_queues: hv1_emulator::message_queues::MessageQueues,
+    #[inspect(skip)]
+    waker: RwLock<Option<Waker>>,
+    cpu_on: Mutex<Option<CpuOnState>>,
+}
+
+#[derive(Debug, Inspect)]
+struct CpuOnState {
+    pc: u64,
+    x0: u64,
 }
 
 impl HvfVpInner {
@@ -429,16 +463,22 @@ impl HvfVpInner {
             unsafe { abi::hv_vcpus_exit(&vcpu, 1) }.chk().unwrap();
         }
     }
+
+    fn wake(&self) {
+        if let Some(waker) = &*self.waker.read() {
+            waker.wake_by_ref();
+        }
+    }
 }
 
 pub struct HvfProcessorBinder {
     partition: Arc<HvfPartitionInner>,
+    vp_index: VpIndex,
     state: Option<VpInitState>,
 }
 
 #[derive(Inspect)]
 struct VpInitState {
-    info: VpInfo,
     gicr: gic::Redistributor,
     hv1: ProcessorSynic,
     vmtime: VmTimeAccess,
@@ -453,29 +493,39 @@ impl BindProcessor for HvfProcessorBinder {
     fn bind(&mut self) -> Result<Self::Processor<'_>, Self::Error> {
         let mut vcpu = HvfVcpu::new()?;
 
+        let state = self.state.take().unwrap();
+        let inner = &self.partition.vps[self.vp_index.index() as usize];
+
         // Initialize configuration registers.
         // Set 40 bit physical address width.
         vcpu.set_sys_reg(abi::HvSysReg::ID_AA64MMFR0_EL1, 2)?;
         // Enable GICv3 system registers.
         vcpu.set_sys_reg(abi::HvSysReg::ID_AA64PFR0_EL1, 1 << 24)?;
-
-        let state = self.state.take().unwrap();
-        let inner = &self.partition.vps[state.info.vp_index.index() as usize];
+        // Set the MPIDR.
+        vcpu.set_sys_reg(abi::HvSysReg::MPIDR_EL1, inner.vp_info.mpidr.into())?;
 
         // Store the vcpu index in the partition.
         inner.vcpu.store(vcpu.vcpu, Ordering::Relaxed);
 
-        let vp = HvfProcessor {
-            info: state.info,
+        let mut vp = HvfProcessor {
             partition: &self.partition,
             inner,
             vcpu,
             wfi: false,
+            on: inner.vp_info.base.vp_index.is_bsp(),
             gicr: state.gicr,
             hv1: state.hv1,
             vmtime: state.vmtime,
-            gicr_range: state.gicr_range,
         };
+
+        // Set initial register state.
+        let mut state = vp.access_state(Vtl::Vtl0);
+        state
+            .set_registers(&StateElement::at_reset(
+                &self.partition.caps,
+                &inner.vp_info,
+            ))
+            .unwrap();
 
         Ok(vp)
     }
@@ -485,7 +535,6 @@ impl BindProcessor for HvfProcessorBinder {
 pub struct HvfProcessor<'a> {
     #[inspect(skip)]
     partition: &'a HvfPartitionInner,
-    info: VpInfo,
     #[inspect(flatten)]
     inner: &'a HvfVpInner,
     gicr: gic::Redistributor,
@@ -494,8 +543,7 @@ pub struct HvfProcessor<'a> {
     #[inspect(flatten)]
     vcpu: HvfVcpu,
     wfi: bool,
-    #[inspect(debug)]
-    gicr_range: Range<u64>,
+    on: bool,
 }
 
 #[derive(Debug, Inspect)]
@@ -626,9 +674,71 @@ impl HvfProcessor<'_> {
                 )
             });
     }
+
+    fn psci(&mut self, fc: FastCall) -> Result<(), VpHaltReason<Error>> {
+        let mask = if fc.smc64() {
+            u64::MAX
+        } else {
+            u32::MAX as u64
+        };
+        let r = match PsciCall(fc.with_smc64(false).with_hint(false)) {
+            PsciCall::PSCI_VERSION => (1 << 16) | 0,
+            PsciCall::PSCI_FEATURES => {
+                let feature_bits = match PsciCall(
+                    FastCall::from(self.vcpu.gp(1).unwrap() as u32).with_smc64(false),
+                ) {
+                    PsciCall::CPU_SUSPEND => Some(0),
+                    PsciCall::CPU_ON => Some(0),
+                    PsciCall::CPU_OFF => Some(0),
+                    PsciCall::AFFINITY_INFO => Some(0),
+                    PsciCall::SYSTEM_OFF => Some(0),
+                    PsciCall::SYSTEM_RESET => Some(0),
+                    PsciCall::PSCI_FEATURES => Some(0),
+                    _ => None,
+                };
+                feature_bits.unwrap_or(PsciError::NOT_SUPPORTED.0)
+            }
+            PsciCall::CPU_SUSPEND => PsciError::INVALID_PARAMETERS.0,
+            PsciCall::CPU_ON => {
+                let target_cpu = self.vcpu.gp(1).unwrap() & mask;
+                let entry_point = self.vcpu.gp(2).unwrap() & mask;
+                let context_id = self.vcpu.gp(3).unwrap() & mask;
+                if let Some(vp) = self.partition.vps.iter().find(|vp| {
+                    u64::from(vp.vp_info.mpidr) & u64::from(MpidrEl1::AFFINITY_MASK) == target_cpu
+                }) {
+                    let mut cpu_on = vp.cpu_on.lock();
+                    if cpu_on.is_some() {
+                        PsciError::ON_PENDING.0
+                    } else {
+                        // TODO check already on
+                        *cpu_on = Some(CpuOnState {
+                            pc: entry_point,
+                            x0: context_id,
+                        });
+                        drop(cpu_on);
+                        vp.wake();
+                        PsciError::SUCCESS.0
+                    }
+                } else {
+                    PsciError::INVALID_PARAMETERS.0
+                }
+            }
+            PsciCall::CPU_OFF => PsciError::DENIED.0,
+            PsciCall::AFFINITY_INFO => PsciError::INVALID_PARAMETERS.0,
+            PsciCall::SYSTEM_RESET => return Err(VpHaltReason::Reset),
+            PsciCall::SYSTEM_OFF => return Err(VpHaltReason::PowerOff),
+            PsciCall::MIGRATE_INFO_TYPE => PsciError::NOT_SUPPORTED.0,
+            call => {
+                tracelimit::warn_ratelimited!(?call, "ignoring unknown PSCI32 call");
+                PsciError::NOT_SUPPORTED.0
+            }
+        };
+        self.vcpu.set_gp(0, r as u64).expect("BUGBUG");
+        Ok(())
+    }
 }
 
-impl<'p> virt::Processor for HvfProcessor<'p> {
+impl<'p> Processor for HvfProcessor<'p> {
     type Error = Error;
     type RunVpError = Error;
 
@@ -646,73 +756,97 @@ impl<'p> virt::Processor for HvfProcessor<'p> {
 
     async fn run_vp(
         &mut self,
-        mut stop: StopVp<'_>,
+        stop: StopVp<'_>,
         dev: &impl CpuIo,
     ) -> Result<Infallible, VpHaltReason<Error>> {
+        let vp_index = self.inner.vp_info.base.vp_index;
+        let mut last_waker = None;
         loop {
             self.inner.needs_yield.maybe_yield().await;
 
-            stop.check()?;
+            poll_fn(|cx| loop {
+                stop.check()?;
 
-            let vp_index = self.info.vp_index;
-
-            self.hv1
-                .request_sint_readiness(self.inner.message_queues.pending_sints());
-
-            let ref_time_now = self.vmtime.now().as_100ns();
-            let (ready_sints, next_ref_time) = self.hv1.scan(
-                ref_time_now,
-                &self.partition.guest_memory,
-                &mut |ppi, _auto_eoi| {
-                    tracing::debug!(ppi, "ppi from message");
-                    self.gicr.raise(ppi);
-                },
-            );
-
-            if let Some(next_ref_time) = next_ref_time {
-                // Convert from reference timer basis to vmtime basis via
-                // difference of programmed timer and current reference time.
-                const NUM_100NS_IN_SEC: u64 = 10 * 1000 * 1000;
-                let ref_diff = next_ref_time.saturating_sub(ref_time_now);
-                let ref_duration = Duration::new(
-                    ref_diff / NUM_100NS_IN_SEC,
-                    (ref_diff % NUM_100NS_IN_SEC) as u32 * 100,
-                );
-                let timeout = self.vmtime.now().wrapping_add(ref_duration);
-                self.vmtime.set_timeout_if_before(timeout);
-            }
-
-            if ready_sints != 0 {
-                self.deliver_sints(ready_sints);
-                continue;
-            }
-
-            if self.gicr.irq_pending() || self.partition.gicd.irq_pending() {
-                // SAFETY: no requirements.
-                unsafe {
-                    abi::hv_vcpu_set_pending_interrupt(
-                        self.vcpu.vcpu,
-                        abi::HvInterruptType::IRQ,
-                        true,
-                    )
+                if !last_waker
+                    .as_ref()
+                    .map_or(false, |waker| cx.waker().will_wake(waker))
+                {
+                    last_waker = Some(cx.waker().clone());
+                    self.inner.waker.write().clone_from(&last_waker);
                 }
-                .chk()
-                .map_err(|err| VpHaltReason::Hypervisor(err.into()))?;
-                self.wfi = false;
-            }
 
-            if self.wfi {
-                self.vmtime.set_timeout_if_before(
-                    self.vmtime.now().wrapping_add(Duration::from_millis(2)),
+                if let Some(cpu_on) = self.inner.cpu_on.lock().take() {
+                    if self.on {
+                        todo!("block this");
+                    } else {
+                        tracing::debug!(x0 = cpu_on.x0, pc = cpu_on.pc, "cpu on");
+                        self.vcpu.set_gp(0, cpu_on.x0).unwrap();
+                        self.vcpu.set_reg(abi::HvReg::PC, cpu_on.pc).unwrap();
+                        self.on = true;
+                    }
+                }
+
+                if !self.on {
+                    break Poll::Pending;
+                }
+
+                self.hv1
+                    .request_sint_readiness(self.inner.message_queues.pending_sints());
+
+                let ref_time_now = self.vmtime.now().as_100ns();
+                let (ready_sints, next_ref_time) = self.hv1.scan(
+                    ref_time_now,
+                    &self.partition.guest_memory,
+                    &mut |ppi, _auto_eoi| {
+                        tracing::debug!(ppi, "ppi from message");
+                        self.gicr.raise(ppi);
+                    },
                 );
-                let timeout = poll_fn(|cx| {
+
+                if let Some(next_ref_time) = next_ref_time {
+                    // Convert from reference timer basis to vmtime basis via
+                    // difference of programmed timer and current reference time.
+                    const NUM_100NS_IN_SEC: u64 = 10 * 1000 * 1000;
+                    let ref_diff = next_ref_time.saturating_sub(ref_time_now);
+                    let ref_duration = Duration::new(
+                        ref_diff / NUM_100NS_IN_SEC,
+                        (ref_diff % NUM_100NS_IN_SEC) as u32 * 100,
+                    );
+                    let timeout = self.vmtime.now().wrapping_add(ref_duration);
+                    self.vmtime.set_timeout_if_before(timeout);
+                }
+
+                if ready_sints != 0 {
+                    self.deliver_sints(ready_sints);
+                    continue;
+                }
+
+                if self.partition.gicd.irq_pending(&mut self.gicr) {
+                    // SAFETY: no requirements.
+                    unsafe {
+                        abi::hv_vcpu_set_pending_interrupt(
+                            self.vcpu.vcpu,
+                            abi::HvInterruptType::IRQ,
+                            true,
+                        )
+                    }
+                    .chk()
+                    .map_err(|err| VpHaltReason::Hypervisor(err.into()))?;
+                    self.wfi = false;
+                }
+
+                if self.wfi {
+                    self.vmtime.set_timeout_if_before(
+                        self.vmtime.now().wrapping_add(Duration::from_millis(2)),
+                    );
                     ready!(self.vmtime.poll_timeout(cx));
                     self.gicr.raise(PPI_VTIMER);
-                    ().into()
-                });
-                stop.until_stop(timeout).await?;
-                continue;
-            }
+                    continue;
+                }
+
+                break Poll::Ready(Result::<_, VpHaltReason<_>>::Ok(()));
+            })
+            .await?;
 
             if !self.gicr.is_pending_or_active(PPI_VTIMER) {
                 // SAFETY: no requirements.
@@ -779,20 +913,11 @@ impl<'p> virt::Processor for HvfProcessor<'p> {
                                     _ => unreachable!(),
                                 }
                                 .to_ne_bytes();
-                                if self
+                                if !self
                                     .partition
-                                    .gicd_range
-                                    .contains(&exception.physical_address)
+                                    .gicd
+                                    .write(exception.physical_address, &data[..len])
                                 {
-                                    self.partition
-                                        .gicd
-                                        .write(exception.physical_address, &data[..len]);
-                                } else if self.gicr_range.contains(&exception.physical_address) {
-                                    self.gicr.write(
-                                        exception.physical_address - self.gicr_range.start,
-                                        &data[..len],
-                                    );
-                                } else {
                                     dev.write_mmio(
                                         vp_index,
                                         exception.physical_address,
@@ -802,20 +927,11 @@ impl<'p> virt::Processor for HvfProcessor<'p> {
                                 }
                             } else if reg != 31 {
                                 let mut data = [0; 8];
-                                if self
+                                if !self
                                     .partition
-                                    .gicd_range
-                                    .contains(&exception.physical_address)
+                                    .gicd
+                                    .read(exception.physical_address, &mut data[..len])
                                 {
-                                    self.partition
-                                        .gicd
-                                        .read(exception.physical_address, &mut data[..len]);
-                                } else if self.gicr_range.contains(&exception.physical_address) {
-                                    self.gicr.read(
-                                        exception.physical_address - self.gicr_range.start,
-                                        &mut data[..len],
-                                    );
-                                } else {
                                     dev.read_mmio(
                                         vp_index,
                                         exception.physical_address,
@@ -837,74 +953,78 @@ impl<'p> virt::Processor for HvfProcessor<'p> {
                         }
                         ExceptionClass::SYSTEM => {
                             let iss = IssSystem::from(exception.syndrome.iss());
+                            let reg = iss.system_reg();
                             if iss.direction() {
-                                let value = match iss.system_reg() {
-                                    SystemReg::ICC_IAR1_EL1 => {
-                                        let mut intid = self.gicr.ack_group1();
-                                        if intid == 1023 {
-                                            intid = self.partition.gicd.ack();
-                                        }
-                                        intid.into()
-                                    }
-                                    reg => {
+                                let value = self
+                                    .partition
+                                    .gicd
+                                    .read_sysreg(&mut self.gicr, reg)
+                                    .unwrap_or_else(|| {
                                         tracing::warn!(
                                             ?reg,
                                             "returning zero for unknown system register"
                                         );
                                         0
-                                    }
-                                };
+                                    });
                                 self.vcpu.set_gp(iss.rt(), value).expect("BUGBUG");
                             } else {
                                 let value = self.vcpu.gp(iss.rt()).expect("BUGBUG");
-                                match iss.system_reg() {
-                                    SystemReg::ICC_EOIR1_EL1 => {
-                                        let intid = value as u32;
-                                        if intid < 32 {
-                                            self.gicr.eoi_group1(intid);
-                                        } else {
-                                            self.partition.gicd.eoi(intid);
-                                        }
-                                    }
-                                    reg => {
-                                        tracing::warn!(
-                                            ?reg,
-                                            value,
-                                            "ignoring write to unknown system register"
-                                        );
-                                    }
+                                if !self.partition.gicd.write_sysreg(
+                                    &mut self.gicr,
+                                    reg,
+                                    value,
+                                    |index| self.partition.vps[index].wake(),
+                                ) {
+                                    tracing::warn!(
+                                        ?reg,
+                                        value,
+                                        "ignoring write to unknown system register"
+                                    );
                                 }
                             }
                             advance(&mut self.vcpu);
                         }
-                        ExceptionClass::HVC => {
+                        ec @ (ExceptionClass::HVC | ExceptionClass::SMC) => {
+                            // HVC automatically advances pc.
+                            let mut advance_pc = ec == ExceptionClass::SMC;
                             match exception.syndrome.iss() as u16 {
                                 0 => {
-                                    let x0 = self.vcpu.gp(0).expect("BUGBUG");
-                                    match x0 {
-                                        HV_ARM64_HVC_SMCCC_IDENTIFIER => self.hypercall(dev, true),
-                                        _ => {
-                                            let x0 = self.vcpu.gp(0).expect("BUGBUG");
-                                            tracing::warn!(x0, "ignoring SMCCC HVC");
-                                            // Set not supported error.
-                                            self.vcpu.set_gp(0, !0).expect("BUGBUG");
+                                    let x0 = self.vcpu.gp(0).expect("BUGBUG") as u32;
+                                    let fc = FastCall::from(x0);
+                                    let handled = 'handle: {
+                                        if fc.fast() {
+                                            match fc.service() {
+                                                PSCI => self.psci(fc)?,
+                                                _ => break 'handle false,
+                                            }
+                                        } else {
+                                            match x0 {
+                                                HV_ARM64_HVC_SMCCC_IDENTIFIER
+                                                    if ec == ExceptionClass::HVC =>
+                                                {
+                                                    self.hypercall(dev, true);
+                                                    advance_pc = false;
+                                                }
+                                                _ => break 'handle false,
+                                            }
                                         }
+                                        true
+                                    };
+                                    if !handled {
+                                        tracing::warn!(x0, ?ec, "ignoring SMCCC HVC/SMC");
+                                        // Set not supported error.
+                                        self.vcpu.set_gp(0, !0).expect("BUGBUG");
                                     }
                                 }
                                 1 => self.hypercall(dev, false),
                                 immed => {
-                                    tracing::warn!(immed, "ignoring HVC");
+                                    tracing::warn!(immed, ?ec, "ignoring HVC/SMC");
                                     self.vcpu.set_gp(0, !0).expect("BUGBUG");
-                                    // HVC automatically advances pc.
                                 }
                             }
-                        }
-                        ExceptionClass::SMC => {
-                            let x0 = self.vcpu.gp(0).expect("BUGBUG");
-                            tracing::warn!(immed = exception.syndrome.iss(), x0, "ignoring SMC");
-                            // Set not supported error.
-                            self.vcpu.set_gp(0, !0).expect("BUGBUG");
-                            advance(&mut self.vcpu);
+                            if advance_pc {
+                                advance(&mut self.vcpu);
+                            }
                         }
                         ExceptionClass::WFI => {
                             self.wfi = true;

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -682,7 +682,7 @@ impl HvfProcessor<'_> {
             u32::MAX as u64
         };
         let r = match PsciCall(fc.with_smc64(false).with_hint(false)) {
-            PsciCall::PSCI_VERSION => (1 << 16) | 0,
+            PsciCall::PSCI_VERSION => 1 << 16,
             PsciCall::PSCI_FEATURES => {
                 let feature_bits = match PsciCall(
                     FastCall::from(self.vcpu.gp(1).unwrap() as u32).with_smc64(false),
@@ -821,7 +821,7 @@ impl<'p> Processor for HvfProcessor<'p> {
                     continue;
                 }
 
-                if self.partition.gicd.irq_pending(&mut self.gicr) {
+                if self.partition.gicd.irq_pending(&self.gicr) {
                     // SAFETY: no requirements.
                     unsafe {
                         abi::hv_vcpu_set_pending_interrupt(

--- a/vmm_core/virt_support_gic/Cargo.toml
+++ b/vmm_core/virt_support_gic/Cargo.toml
@@ -7,10 +7,12 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
+memory_range.workspace = true
 vm_topology.workspace = true
 
+aarch64defs.workspace = true
 inspect.workspace = true
-open_enum.workspace = true
+tracelimit.workspace = true
 
 parking_lot.workspace = true
 tracing.workspace = true

--- a/vmm_core/virt_support_gic/Cargo.toml
+++ b/vmm_core/virt_support_gic/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-memory_range.workspace = true
+memory_range = { workspace = true, features = ["inspect"] }
 vm_topology.workspace = true
 
 aarch64defs.workspace = true

--- a/vmm_core/virt_support_gic/src/lib.rs
+++ b/vmm_core/virt_support_gic/src/lib.rs
@@ -682,13 +682,12 @@ mod gicr {
         }
 
         fn rd_read64(&self, address: GicrRdRegister) -> Option<u64> {
-            let mpidr = MpidrEl1::from(self.mpidr);
             let v = match address {
                 GicrRdRegister::TYPER => GicrTyper::new()
-                    .with_aff0(mpidr.aff0())
-                    .with_aff1(mpidr.aff1())
-                    .with_aff2(mpidr.aff2())
-                    .with_aff3(mpidr.aff3())
+                    .with_aff0(self.mpidr.aff0())
+                    .with_aff1(self.mpidr.aff1())
+                    .with_aff2(self.mpidr.aff2())
+                    .with_aff3(self.mpidr.aff3())
                     .with_last(self.last)
                     .into(),
                 _ => return None,

--- a/vmm_core/virt_support_gic/src/lib.rs
+++ b/vmm_core/virt_support_gic/src/lib.rs
@@ -13,82 +13,94 @@ pub use gicr::Redistributor;
 mod gicd {
     use super::gicr::SharedState;
     use super::Redistributor;
+    use aarch64defs::gic::GicdCtlr;
+    use aarch64defs::gic::GicdRegister;
+    use aarch64defs::gic::GicdTyper;
+    use aarch64defs::gic::GicdTyper2;
+    use aarch64defs::gic::GicrSgi;
+    use aarch64defs::MpidrEl1;
+    use aarch64defs::SystemReg;
     use inspect::Inspect;
-    use open_enum::open_enum;
+    use memory_range::MemoryRange;
     use parking_lot::Mutex;
     use std::sync::Arc;
     use vm_topology::processor::VpIndex;
 
-    open_enum! {
-        enum Register: u16 {
-            CTLR = 0x0000,
-            TYPER = 0x0004,
-            IIDR = 0x0008,
-            TYPER2 = 0x000c,
-            STATUSR = 0x0010,
-            SETSPI_NSR = 0x0040,
-            CLRSPI_NSR = 0x0048,
-            SETSPI_SR = 0x0050,
-            CLRSPI_SR = 0x0058,
-            IGROUPR = 0x0080,       // 0x80
-            ISENABLER = 0x0100,     // 0x80
-            ICENABLER = 0x0180,     // 0x80
-            ISPENDR = 0x0200,       // 0x80
-            ICPENDR = 0x0280,       // 0x80
-            ISACTIVER = 0x0300,     // 0x80
-            ICACTIVER = 0x0380,     // 0x80
-            IPRIORITYR = 0x0400,    // 0x400
-            ITARGETSR = 0x0800,     // 0x400
-            ICFGR = 0x0c00,         // 0x100
-            IGRPMODR = 0x0d00,      // 0x100
-            NSACR = 0x0e00,         // 0x100
-            SGIR = 0x0f00,
-            CPENDSGIR = 0x0f10,     // 0x10
-            SPENDSGIR = 0x0f20,     // 0x10
-            INMIR = 0x0f80,         // 0x80
-            IROUTER = 0x6000,       // 0x2000, skip first 0x100,
-            PIDR2 = 0xffe8,
-        }
-    }
-
     #[derive(Debug, Inspect)]
     pub struct Distributor {
-        #[inspect(skip)]
         state: Mutex<DistributorState>,
         max_spi_intid: u32,
         #[inspect(skip)]
-        gicr: Arc<SharedState>,
+        gicr: Vec<Arc<SharedState>>,
+        gicd_range: MemoryRange,
+        gicr_range: MemoryRange,
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Inspect)]
     struct DistributorState {
+        #[inspect(iter_by_index)]
         pending: Vec<u32>,
+        #[inspect(iter_by_index)]
         active: Vec<u32>,
+        #[inspect(iter_by_index)]
+        group: Vec<u32>,
+        #[inspect(iter_by_index)]
+        enable: Vec<u32>,
+        #[inspect(iter_by_index)]
+        cfg: Vec<u32>,
+        #[inspect(iter_by_index)]
+        priority: Vec<u32>,
+        #[inspect(iter_by_index)]
+        route: Vec<u64>,
+        enable_grp0: bool,
+        enable_grp1: bool,
     }
 
     impl Distributor {
-        pub fn new(max_spis: u32) -> Self {
+        pub fn new(gicd_base: u64, gicr_range: MemoryRange, max_spis: u32) -> Self {
             let n = (max_spis as usize + 1) / 32;
             Self {
                 state: Mutex::new(DistributorState {
                     pending: vec![0; n],
                     active: vec![0; n],
+                    group: vec![0; n],
+                    enable: vec![0; n],
+                    cfg: vec![0; n * 2],
+                    priority: vec![0; n * 8],
+                    route: vec![0; n * 64],
+                    enable_grp0: false,
+                    enable_grp1: false,
                 }),
                 max_spi_intid: 32 + max_spis - 1,
                 gicr: Default::default(),
+                gicd_range: MemoryRange::new(
+                    gicd_base..gicd_base + aarch64defs::GIC_DISTRIBUTOR_SIZE,
+                ),
+                gicr_range,
             }
         }
 
-        pub fn add_redistributor(&mut self) -> Redistributor {
-            Redistributor::new(self.gicr.clone())
+        pub fn add_redistributor(&mut self, mpidr: u64, last: bool) -> Redistributor {
+            let mpidr = mpidr & u64::from(MpidrEl1::AFFINITY_MASK);
+            let (gicr, state) = Redistributor::new(self.gicr.len(), mpidr, last);
+            self.gicr.push(state);
+            assert!(
+                (self.gicr.len() as u64)
+                    <= self.gicr_range.len() / aarch64defs::GIC_REDISTRIBUTOR_SIZE
+            );
+            gicr
         }
 
-        pub fn raise_ppi(&self, _vp: VpIndex, intid: u32) -> bool {
-            self.gicr.raise(intid)
+        pub fn raise_ppi(&self, vp: VpIndex, intid: u32) -> bool {
+            if let Some(gicr) = self.gicr.get(vp.index() as usize) {
+                gicr.raise(intid)
+            } else {
+                false
+            }
         }
 
         pub fn set_pending(&self, intid: u32, pending: bool) -> Option<u32> {
-            let v = &mut self.state.lock().pending[intid as usize / 32 - 1];
+            let v = &mut self.state.lock().pending[intid as usize / 32];
             let mask = 1 << (intid & 31);
             if (*v & mask != 0) != pending {
                 tracing::debug!(intid, pending, "set pending");
@@ -102,16 +114,29 @@ mod gicd {
             }
         }
 
-        pub fn irq_pending(&self) -> bool {
+        pub fn irq_pending(&self, gicr: &Redistributor) -> bool {
+            if gicr.irq_pending() {
+                return true;
+            }
+            if gicr.index != 0 {
+                return false;
+            }
             let state = self.state.lock();
             state
                 .pending
                 .iter()
                 .zip(&state.active)
-                .any(|(&p, &a)| p & !a != 0)
+                .zip(&state.enable)
+                .any(|((&p, &a), e)| p & !a & e != 0)
         }
 
-        pub fn ack(&self) -> u32 {
+        pub fn ack(&self, gicr: &mut Redistributor, group1: bool) -> u32 {
+            if let Some(intid) = gicr.ack(group1) {
+                return intid;
+            }
+            if gicr.index != 0 {
+                return 1023;
+            }
             let mut state = self.state.lock();
             let state = &mut *state;
             if let Some((i, (p, a))) = state
@@ -124,7 +149,7 @@ mod gicd {
                 let v = 31 - (*p & !*a).leading_zeros();
                 *p &= !(1 << v);
                 *a |= 1 << v;
-                let intid = (i as u32 + 1) * 32 + v;
+                let intid = i as u32 * 32 + v;
                 tracing::debug!(intid, "gicd ack");
                 intid
             } else {
@@ -132,119 +157,388 @@ mod gicd {
             }
         }
 
-        pub fn eoi(&self, intid: u32) {
+        pub fn write_sysreg(
+            &self,
+            gicr: &mut Redistributor,
+            reg: SystemReg,
+            value: u64,
+            wake: impl FnMut(usize),
+        ) -> bool {
+            match reg {
+                SystemReg::ICC_EOIR0_EL1 => self.eoi(gicr, false, value as u32),
+                SystemReg::ICC_EOIR1_EL1 => self.eoi(gicr, true, value as u32),
+                SystemReg::ICC_SGI0R_EL1 => self.sgi(gicr, false, value, wake),
+                SystemReg::ICC_SGI1R_EL1 => self.sgi(gicr, true, value, wake),
+                _ => return false,
+            }
+            true
+        }
+
+        fn sgi(
+            &self,
+            this: &mut Redistributor,
+            _group1: bool,
+            value: u64,
+            mut wake: impl FnMut(usize),
+        ) {
+            let value = GicrSgi::from(value);
+            for (index, gicr) in self.gicr.iter().enumerate() {
+                if (value.irm() && !Arc::ptr_eq(&this.shared, gicr))
+                    || (!value.irm()
+                        && gicr.mpidr.aff3() == value.aff3()
+                        && gicr.mpidr.aff2() == value.aff2()
+                        && gicr.mpidr.aff1() == value.aff1()
+                        && (1 << gicr.mpidr.aff0()) & value.target_list() != 0)
+                {
+                    if gicr.raise(value.intid()) {
+                        wake(index);
+                    }
+                }
+            }
+        }
+
+        pub fn read_sysreg(&self, gicr: &mut Redistributor, reg: SystemReg) -> Option<u64> {
+            let v = match reg {
+                SystemReg::ICC_IAR0_EL1 => self.ack(gicr, false).into(),
+                SystemReg::ICC_IAR1_EL1 => self.ack(gicr, true).into(),
+                _ => return None,
+            };
+            Some(v)
+        }
+
+        fn eoi(&self, gicr: &mut Redistributor, group1: bool, intid: u32) {
+            if intid < 32 {
+                gicr.eoi(group1, intid);
+                return;
+            }
+            if gicr.index != 0 {
+                return;
+            }
             tracing::debug!(intid, "gicd eoi");
-            let v = &mut self.state.lock().active[intid as usize / 32 - 1];
+            let v = &mut self.state.lock().active[intid as usize / 32];
             *v &= !(1 << (intid & 31));
         }
 
-        fn write32(&self, address: u16, value: u32) {
-            assert!(address & 3 == 0);
-            match Register(address) {
-                address => {
-                    tracing::warn!(?address, value, "unsupported 4-byte gicd register write");
+        fn write32(&self, address: GicdRegister, value: u32) -> bool {
+            assert!(address.0 & 3 == 0);
+            match address {
+                GicdRegister::CTLR => {
+                    let ctlr = GicdCtlr::from(value);
+                    let mut state = self.state.lock();
+                    let state = &mut *state;
+                    state.enable_grp0 = ctlr.enable_grp0();
+                    state.enable_grp1 = ctlr.enable_grp1();
                 }
+                r if GicdRegister::IGROUPR.contains(&r.0) => {
+                    let n = (r.0 & 0x7f) / 4;
+                    if n != 0 {
+                        if let Some(group) = self.state.lock().group.get_mut(n as usize) {
+                            *group = value;
+                        }
+                    }
+                }
+                r if GicdRegister::ISENABLER.contains(&r.0) => {
+                    let n = (r.0 & 0x7f) / 4;
+                    if n != 0 {
+                        if let Some(enable) = self.state.lock().enable.get_mut(n as usize) {
+                            *enable |= value;
+                        }
+                    }
+                }
+                r if GicdRegister::ICENABLER.contains(&r.0) => {
+                    let n = (r.0 & 0x7f) / 4;
+                    if n != 0 {
+                        if let Some(enable) = self.state.lock().enable.get_mut(n as usize) {
+                            *enable &= !value;
+                        }
+                    }
+                }
+                r if GicdRegister::ICFGR.contains(&r.0) => {
+                    let n = (r.0 & 0xff) / 4;
+                    if n >= 2 {
+                        if let Some(cfg) = self.state.lock().cfg.get_mut(n as usize) {
+                            // The low bit of each bit pair is res0.
+                            *cfg = value & 0xaaaaaaaa;
+                        }
+                    }
+                }
+                r if GicdRegister::IPRIORITYR.contains(&r.0) => {
+                    let n = (r.0 & 0x3ff) / 4;
+                    if n >= 8 {
+                        if let Some(cfg) = self.state.lock().cfg.get_mut(n as usize) {
+                            *cfg = value;
+                        }
+                    }
+                }
+                r if GicdRegister::ISACTIVER.contains(&r.0) => {
+                    let n = (r.0 & 0x7f) / 4;
+                    if n != 0 {
+                        if let Some(active) = self.state.lock().active.get_mut(n as usize) {
+                            *active |= value;
+                        }
+                    }
+                }
+                r if GicdRegister::ICACTIVER.contains(&r.0) => {
+                    let n = (r.0 & 0x7f) / 4;
+                    if n != 0 {
+                        if let Some(active) = self.state.lock().active.get_mut(n as usize) {
+                            *active &= !value;
+                        }
+                    }
+                }
+                _ => return false,
             }
+            true
         }
 
-        fn read32(&self, address: u16) -> u32 {
-            assert!(address & 3 == 0);
-            match Register(address) {
-                Register::PIDR2 => {
+        fn read32(&self, address: GicdRegister) -> Option<u32> {
+            assert!(address.0 & 3 == 0);
+            let v = match address {
+                GicdRegister::PIDR2 => {
                     // GICv3
                     3 << 4
                 }
-                address => {
-                    tracing::warn!(?address, "unsupported 4-byte gicd register read");
-                    0
+                GicdRegister::TYPER => GicdTyper::new()
+                    .with_it_lines_number(31)
+                    .with_id_bits(5)
+                    .into(),
+                GicdRegister::IIDR => 0,
+                GicdRegister::TYPER2 => GicdTyper2::new().into(),
+                GicdRegister::CTLR => {
+                    let state = self.state.lock();
+                    GicdCtlr::new()
+                        .with_enable_grp0(state.enable_grp0)
+                        .with_enable_grp1(state.enable_grp1)
+                        .with_ds(true)
+                        .with_are(true)
+                        .into()
                 }
-            }
+                r if GicdRegister::IGROUPR.contains(&r.0) => {
+                    let n = (r.0 & 0x7f) / 4;
+                    self.state
+                        .lock()
+                        .group
+                        .get(n as usize)
+                        .copied()
+                        .unwrap_or(0)
+                }
+                r if GicdRegister::ICENABLER.contains(&r.0)
+                    || GicdRegister::ISENABLER.contains(&r.0) =>
+                {
+                    let n = (r.0 & 0x7f) / 4;
+                    self.state
+                        .lock()
+                        .enable
+                        .get(n as usize)
+                        .copied()
+                        .unwrap_or(0)
+                }
+                r if GicdRegister::ICFGR.contains(&r.0) => {
+                    let n = (r.0 & 0xff) / 4;
+                    self.state.lock().cfg.get(n as usize).copied().unwrap_or(0)
+                }
+                r if GicdRegister::IPRIORITYR.contains(&r.0) => {
+                    let n = (r.0 & 0x3ff) / 4;
+                    self.state
+                        .lock()
+                        .priority
+                        .get(n as usize)
+                        .copied()
+                        .unwrap_or(0)
+                }
+                r if GicdRegister::ICACTIVER.contains(&r.0)
+                    || GicdRegister::ISACTIVER.contains(&r.0) =>
+                {
+                    let n = (r.0 & 0x7f) / 4;
+                    self.state
+                        .lock()
+                        .active
+                        .get(n as usize)
+                        .copied()
+                        .unwrap_or(0)
+                }
+                r if GicdRegister::ICPENDR.contains(&r.0)
+                    || GicdRegister::ISPENDR.contains(&r.0) =>
+                {
+                    let n = (r.0 & 0x7f) / 4;
+                    self.state
+                        .lock()
+                        .pending
+                        .get(n as usize)
+                        .copied()
+                        .unwrap_or(0)
+                }
+                _ => return None,
+            };
+            Some(v)
         }
 
-        pub fn read(&self, address: u64, data: &mut [u8]) {
+        fn write64(&self, address: GicdRegister, value: u64) -> bool {
+            assert!(address.0 & 7 == 0);
+            match address {
+                r if GicdRegister::IROUTER.contains(&r.0) => {
+                    let n = (r.0 & 0x1fff) / 8;
+                    if n >= 32 {
+                        if let Some(route) = self.state.lock().route.get_mut(n as usize) {
+                            *route = value;
+                        }
+                    }
+                }
+                _ => return false,
+            }
+            true
+        }
+
+        fn read64(&self, address: GicdRegister) -> Option<u64> {
+            assert!(address.0 & 7 == 0);
+            let v = match address {
+                r if GicdRegister::IROUTER.contains(&r.0) => {
+                    let n = (r.0 & 0x1fff) / 8;
+                    self.state
+                        .lock()
+                        .route
+                        .get(n as usize)
+                        .copied()
+                        .unwrap_or(0)
+                }
+                _ => return None,
+            };
+            Some(v)
+        }
+
+        pub fn read(&self, address: u64, data: &mut [u8]) -> bool {
+            if self.gicd_range.contains_addr(address) {
+                self.read_gicd(address - self.gicd_range.start(), data);
+            } else if self.gicr_range.contains_addr(address) {
+                let vp = (address - self.gicr_range.start()) / aarch64defs::GIC_REDISTRIBUTOR_SIZE;
+                if let Some(gicr) = self.gicr.get(vp as usize) {
+                    gicr.read(address - self.gicr_range.start(), data);
+                } else {
+                    tracelimit::warn_ratelimited!(
+                        address,
+                        ?data,
+                        "gicr read unallocated redistributor"
+                    );
+                    data.fill(0);
+                }
+            } else {
+                return false;
+            }
+            true
+        }
+
+        fn read_gicd(&self, address: u64, data: &mut [u8]) {
             if address & (data.len() as u64 - 1) != 0 {
                 data.fill(!0);
                 tracing::warn!(address, ?data, "gicd read unaligned access");
                 return;
             }
-            match data.len() {
-                4 => data.copy_from_slice(&self.read32(address as u16).to_ne_bytes()),
-                _ => {
-                    data.fill(0);
-                    tracing::warn!(address, ?data, "unsupported n-byte gicd register read");
+            let address = GicdRegister(address as u16);
+            let handled = match data.len() {
+                4 => {
+                    if let Some(v) = self.read32(address) {
+                        data.copy_from_slice(&v.to_ne_bytes());
+                        true
+                    } else {
+                        false
+                    }
                 }
+                8 => {
+                    if let Some(v) = self.read64(address) {
+                        data.copy_from_slice(&v.to_ne_bytes());
+                        true
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            };
+            if !handled {
+                data.fill(0);
+                tracelimit::warn_ratelimited!(?address, ?data, "unsupported gicd register read");
             }
         }
 
-        pub fn write(&self, address: u64, data: &[u8]) {
+        pub fn write(&self, address: u64, data: &[u8]) -> bool {
+            if self.gicd_range.contains_addr(address) {
+                self.write_gicd(address - self.gicd_range.start(), data);
+            } else if self.gicr_range.contains_addr(address) {
+                let vp = (address - self.gicr_range.start()) / aarch64defs::GIC_REDISTRIBUTOR_SIZE;
+                if let Some(gicr) = self.gicr.get(vp as usize) {
+                    gicr.write(address - self.gicr_range.start(), data);
+                } else {
+                    tracelimit::warn_ratelimited!(
+                        address,
+                        ?data,
+                        "gicr write unallocated redistributor"
+                    );
+                }
+            } else {
+                return false;
+            }
+            true
+        }
+
+        fn write_gicd(&self, address: u64, data: &[u8]) {
             if address & (data.len() as u64 - 1) != 0 {
                 tracing::warn!(address, ?data, "gicd write unaligned access");
                 return;
             }
-
-            match data.len() {
-                4 => {
-                    self.write32(address as u16, u32::from_ne_bytes(data.try_into().unwrap()));
-                }
-                _ => {
-                    tracing::warn!(address, ?data, "unsupported n-byte gicd register write");
-                }
+            let address = GicdRegister(address as u16);
+            let handled = match data.len() {
+                4 => self.write32(address, u32::from_ne_bytes(data.try_into().unwrap())),
+                8 => self.write64(address, u64::from_ne_bytes(data.try_into().unwrap())),
+                _ => false,
+            };
+            if !handled {
+                tracelimit::warn_ratelimited!(?address, ?data, "unsupported gicd register write");
             }
         }
     }
 }
 
 mod gicr {
+    use aarch64defs::gic::GicrCtlr;
+    use aarch64defs::gic::GicrRdRegister;
+    use aarch64defs::gic::GicrSgiRegister;
+    use aarch64defs::gic::GicrTyper;
+    use aarch64defs::gic::GicrWaker;
+    use aarch64defs::MpidrEl1;
     use inspect::Inspect;
-    use open_enum::open_enum;
+    use parking_lot::Mutex;
     use std::sync::atomic::AtomicU32;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
 
-    open_enum! {
-        enum RdRegister: u16 {
-            CTLR = 0x0000,
-            IIDR = 0x0004,
-            TYPER = 0x0008,     // 64 bit
-            STATUSR = 0x0010,
-            WAKER = 0x0014,
-            MPAMIDR = 0x0018,
-            PARTIDR = 0x001c,
-            SETLPIR = 0x0040,   // 64 bit
-            CLRLPIR = 0x0048,   // 64 bit
-            PROPBASER = 0x0070, // 64 bit
-            PENDBASER = 0x0078, // 64 bit
-            INVLPIR = 0x00A0,   // 64 bit
-            SYNCR = 0x00C0,     // 64 bit
-            PIDR2 = 0xffe8,
-        }
-    }
-
-    open_enum! {
-        enum SgiRegister: u16 {
-            IGROUPR0 = 0x0080,
-            ISENABLER0 = 0x0100,
-            ICENABLER0 = 0x0180,
-            ISPENDR0 = 0x0200,
-            ICPENDR0 = 0x0280,
-            ISACTIVER0 = 0x0300,
-            ICACTIVER0 = 0x0380,
-            IPRIORITYR = 0x0400, // 0x20
-            ICFGR0 = 0x0c00,
-            ICFGR1 = 0x0c04,
-            IGRPMODR0 = 0x0d00,
-        }
+    #[derive(Debug, Inspect)]
+    pub struct Redistributor {
+        #[inspect(flatten)]
+        pub(super) shared: Arc<SharedState>,
+        pub(super) index: usize,
     }
 
     #[derive(Debug, Inspect)]
-    pub struct Redistributor {
-        shared: Arc<SharedState>,
-        active: u32,
+    pub(crate) struct SharedState {
+        pub(super) pending: AtomicU32,
+        #[inspect(with = "|&x| u64::from(x)")]
+        pub(super) mpidr: MpidrEl1,
+        last: bool,
+        mutable: Mutex<SharedMutState>,
     }
 
-    #[derive(Default, Debug, Inspect)]
-    pub struct SharedState {
-        pending: AtomicU32,
+    #[derive(Debug, Inspect)]
+    struct SharedMutState {
+        #[inspect(hex)]
+        active: u32,
+        #[inspect(hex)]
+        group: u32,
+        #[inspect(hex)]
+        enable: u32,
+        #[inspect(hex)]
+        ppi_cfg: u32,
+        #[inspect(iter_by_index)]
+        priority: [u32; 8],
+        sleep: bool,
     }
 
     impl SharedState {
@@ -252,135 +546,271 @@ mod gicr {
             let mask = 1 << intid;
             self.pending.fetch_or(mask, Ordering::Relaxed) & mask == 0
         }
-    }
 
-    impl Redistributor {
-        pub(crate) fn new(shared: Arc<SharedState>) -> Self {
-            Self { shared, active: 0 }
-        }
-
-        pub fn read(&mut self, address: u64, data: &mut [u8]) {
+        pub fn read(&self, address: u64, data: &mut [u8]) {
             if address & (data.len() as u64 - 1) != 0 {
                 data.fill(!0);
                 tracing::warn!(address, ?data, "gicr read unaligned access");
                 return;
             }
 
-            let rd = address & 0x10000 == 0;
-
-            match data.len() {
-                4 => {
-                    let v = if rd {
-                        self.rd_read32(address as u16)
-                    } else {
-                        self.sgi_read32(address as u16)
-                    };
-                    data.copy_from_slice(&v.to_ne_bytes())
-                }
-                _ => {
+            if address & 0x10000 == 0 {
+                let address = GicrRdRegister(address as u16);
+                let handled = match data.len() {
+                    4 => {
+                        if let Some(v) = self.rd_read32(address) {
+                            data.copy_from_slice(&v.to_ne_bytes());
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    8 => {
+                        if let Some(v) = self.rd_read64(address) {
+                            data.copy_from_slice(&v.to_ne_bytes());
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    _ => false,
+                };
+                if !handled {
                     data.fill(0);
-                    tracing::warn!(?address, ?data, "unsupported n-byte gicr register read");
+                    tracelimit::warn_ratelimited!(?address, "unsupported gicr rd register read");
+                }
+            } else {
+                let address = GicrSgiRegister(address as u16);
+                let handled = match data.len() {
+                    4 => {
+                        if let Some(v) = self.sgi_read32(address) {
+                            data.copy_from_slice(&v.to_ne_bytes());
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                    _ => false,
+                };
+                if !handled {
+                    data.fill(0);
+                    tracelimit::warn_ratelimited!(
+                        ?address,
+                        ?data,
+                        "unsupported gicr sgi register read"
+                    );
                 }
             }
         }
 
-        pub fn write(&mut self, address: u64, data: &[u8]) {
+        pub fn write(&self, address: u64, data: &[u8]) {
             if address & (data.len() as u64 - 1) != 0 {
                 tracing::warn!(address, ?data, "gicr write unaligned access");
                 return;
             }
 
-            let rd = address & 0x10000 == 0;
-
-            match data.len() {
-                4 => {
-                    let data = u32::from_ne_bytes(data.try_into().unwrap());
-                    if rd {
-                        self.rd_write32(address as u16, data);
-                    } else {
-                        self.sgi_write32(address as u16, data);
+            if address & 0x10000 == 0 {
+                let address = GicrRdRegister(address as u16);
+                let handled = match data.len() {
+                    4 => {
+                        let data = u32::from_ne_bytes(data.try_into().unwrap());
+                        self.rd_write32(address, data)
                     }
+                    8 => {
+                        let data = u64::from_ne_bytes(data.try_into().unwrap());
+                        self.rd_write64(address, data)
+                    }
+                    _ => false,
+                };
+                if !handled {
+                    tracelimit::warn_ratelimited!(
+                        ?address,
+                        ?data,
+                        "unsupported gicr rd register write"
+                    );
                 }
-                address => {
-                    tracing::warn!(?address, ?data, "unsupported n-byte gicr register write");
+            } else {
+                let address = GicrSgiRegister(address as u16);
+                let handled = match data.len() {
+                    4 => {
+                        let data = u32::from_ne_bytes(data.try_into().unwrap());
+                        self.sgi_write32(address, data)
+                    }
+                    _ => false,
+                };
+                if !handled {
+                    tracelimit::warn_ratelimited!(
+                        ?address,
+                        ?data,
+                        "unsupported gicr sgi register write"
+                    );
                 }
             }
         }
 
-        fn rd_read32(&mut self, address: u16) -> u32 {
-            match RdRegister(address) {
-                RdRegister::PIDR2 => {
+        fn rd_read32(&self, address: GicrRdRegister) -> Option<u32> {
+            let v = match address {
+                GicrRdRegister::PIDR2 => {
                     // GICv3
                     3 << 4
                 }
-                address => {
-                    tracing::warn!(?address, "unsupported 4-byte gicr rd register read");
-                    0
+                GicrRdRegister::CTLR => GicrCtlr::new().into(),
+                GicrRdRegister::WAKER => {
+                    let sleep = self.mutable.lock().sleep;
+                    GicrWaker::new()
+                        .with_processor_sleep(sleep)
+                        .with_children_asleep(sleep)
+                        .into()
                 }
-            }
+                _ => return None,
+            };
+            tracing::debug!(?address, v, "gicr rd read32");
+            Some(v)
         }
 
-        fn rd_write32(&mut self, address: u16, data: u32) {
-            match RdRegister(address) {
-                address => {
-                    tracing::warn!(?address, data, "unsupported 4-byte gicr rd register write");
+        fn rd_write32(&self, address: GicrRdRegister, data: u32) -> bool {
+            match address {
+                GicrRdRegister::CTLR => {}
+                GicrRdRegister::WAKER => {
+                    let v = GicrWaker::from(data);
+                    self.mutable.lock().sleep = v.processor_sleep();
                 }
+                _ => return false,
             }
+            tracing::debug!(?address, data, "gicr rd write32");
+            true
         }
 
-        fn sgi_read32(&mut self, address: u16) -> u32 {
-            match SgiRegister(address) {
-                address => {
-                    tracing::warn!(?address, "unsupported 4-byte gicr sgi register read");
-                    0
-                }
-            }
+        fn rd_read64(&self, address: GicrRdRegister) -> Option<u64> {
+            let mpidr = MpidrEl1::from(self.mpidr);
+            let v = match address {
+                GicrRdRegister::TYPER => GicrTyper::new()
+                    .with_aff0(mpidr.aff0())
+                    .with_aff1(mpidr.aff1())
+                    .with_aff2(mpidr.aff2())
+                    .with_aff3(mpidr.aff3())
+                    .with_last(self.last)
+                    .into(),
+                _ => return None,
+            };
+            Some(v)
         }
 
-        fn sgi_write32(&mut self, address: u16, data: u32) {
-            match SgiRegister(address) {
-                address => {
-                    tracing::warn!(?address, data, "unsupported 4-byte gicr sgi register write");
+        fn rd_write64(&self, _address: GicrRdRegister, _data: u64) -> bool {
+            false
+        }
+
+        fn sgi_read32(&self, address: GicrSgiRegister) -> Option<u32> {
+            let v = match address {
+                GicrSgiRegister::IGROUPR0 => self.mutable.lock().group,
+                GicrSgiRegister::ICACTIVER0 | GicrSgiRegister::ISACTIVER0 => {
+                    self.mutable.lock().active
                 }
+                GicrSgiRegister::ICENABLER0 | GicrSgiRegister::ISENABLER0 => {
+                    self.mutable.lock().enable
+                }
+                GicrSgiRegister::ICPENDR0 | GicrSgiRegister::ISPENDR0 => {
+                    self.pending.load(Ordering::Relaxed)
+                }
+                GicrSgiRegister::ICFGR0 => {
+                    // SGIs are always edge triggered.
+                    0xaaaaaaaa
+                }
+                GicrSgiRegister::ICFGR1 => self.mutable.lock().ppi_cfg,
+                r if GicrSgiRegister::IPRIORITYR.contains(&r.0) => {
+                    let n = (r.0 & 0x1f) / 4;
+                    self.mutable.lock().priority[n as usize]
+                }
+                _ => return None,
+            };
+            tracing::debug!(?address, v, "gicr sgi read32");
+            Some(v)
+        }
+
+        fn sgi_write32(&self, address: GicrSgiRegister, data: u32) -> bool {
+            match address {
+                GicrSgiRegister::IGROUPR0 => self.mutable.lock().group = data,
+                GicrSgiRegister::ISACTIVER0 => self.mutable.lock().active |= data,
+                GicrSgiRegister::ICACTIVER0 => self.mutable.lock().active &= !data,
+                GicrSgiRegister::ISENABLER0 => self.mutable.lock().enable |= data,
+                GicrSgiRegister::ICENABLER0 => self.mutable.lock().enable &= !data,
+                GicrSgiRegister::ICFGR0 => {
+                    // Cannot change trigger mode for SGIs.
+                }
+                GicrSgiRegister::ICFGR1 => self.mutable.lock().ppi_cfg = data,
+                r if GicrSgiRegister::IPRIORITYR.contains(&r.0) => {
+                    let n = (r.0 & 0x1f) / 4;
+                    self.mutable.lock().priority[n as usize] = data;
+                }
+                _ => return false,
             }
+            tracing::debug!(?address, data, "gicr sgi write32");
+            true
+        }
+    }
+
+    impl Redistributor {
+        pub(crate) fn new(index: usize, mpidr: u64, last: bool) -> (Self, Arc<SharedState>) {
+            let shared = Arc::new(SharedState {
+                pending: AtomicU32::new(0),
+                mpidr: mpidr.into(),
+                last,
+                mutable: Mutex::new(SharedMutState {
+                    active: 0,
+                    group: 0,
+                    enable: 0,
+                    ppi_cfg: 0,
+                    priority: [0; 8],
+                    sleep: false,
+                }),
+            });
+            (
+                Self {
+                    index,
+                    shared: shared.clone(),
+                },
+                shared,
+            )
         }
 
         pub fn raise(&mut self, intid: u32) {
             self.shared.pending.fetch_or(1 << intid, Ordering::Relaxed);
         }
 
-        pub fn irq_pending(&self) -> bool {
-            (self.shared.pending.load(Ordering::Relaxed) & !self.active) != 0
-        }
-
-        pub fn fiq_pending(&self) -> bool {
-            false
+        pub(crate) fn irq_pending(&self) -> bool {
+            let pending = self.shared.pending.load(Ordering::Relaxed);
+            if pending == 0 {
+                return false;
+            }
+            let state = self.shared.mutable.lock();
+            (pending & !state.active & state.enable & state.group) != 0
         }
 
         pub fn is_pending_or_active(&self, intid: u32) -> bool {
-            (self.shared.pending.load(Ordering::Relaxed) | self.active) & (1 << intid) != 0
+            let state = self.shared.mutable.lock();
+            (self.shared.pending.load(Ordering::Relaxed) | state.active) & (1 << intid) != 0
         }
 
-        pub fn ack_group1(&mut self) -> u32 {
+        pub(crate) fn ack(&mut self, _group1: bool) -> Option<u32> {
             let pending = self.shared.pending.load(Ordering::Relaxed);
             if pending == 0 {
-                1023
+                None
             } else {
-                let intid = 31 - (pending & !self.active).leading_zeros();
+                let mut state = self.shared.mutable.lock();
+                let intid = 31 - (pending & !state.active).leading_zeros();
                 tracing::trace!(intid, "ack");
                 self.shared
                     .pending
                     .fetch_and(!(1 << intid), Ordering::Relaxed);
-                self.active |= 1 << intid;
-                intid
+                state.active |= 1 << intid;
+                Some(intid)
             }
         }
 
-        pub fn eoi_group1(&mut self, intid: u32) {
-            if intid < 32 {
-                tracing::trace!(intid, "eoi");
-                self.active &= !(1 << intid);
-            }
+        pub(crate) fn eoi(&mut self, _group1: bool, intid: u32) {
+            assert!(intid < 32);
+            tracing::trace!(intid, "eoi");
+            self.shared.mutable.lock().active &= !(1 << intid);
         }
     }
 }

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -27,6 +27,7 @@ pub mod artifacts {
     openvmm_native!(OPENVMM_LINUX_X64, "linux", "x86_64");
     openvmm_native!(OPENVMM_WIN_AARCH64, "windows", "aarch64");
     openvmm_native!(OPENVMM_LINUX_AARCH64, "linux", "aarch64");
+    openvmm_native!(OPENVMM_MACOS_AARCH64, "macos", "aarch64");
 
     declare_artifacts! {
         /// openvmm windows x86_64 executable
@@ -37,6 +38,8 @@ pub mod artifacts {
         OPENVMM_WIN_AARCH64,
         /// openvmm linux aarch64 executable
         OPENVMM_LINUX_AARCH64,
+        /// openvmm macos aarch64 executable
+        OPENVMM_MACOS_AARCH64,
         /// Directory to put OpenHCL dumps in
         OPENHCL_DUMP_DIRECTORY,
     }


### PR DESCRIPTION
This fixes guest-initiated power off, and it gets us closer to multi-proc support.

The GIC code is still very much prototype quality.

The `aarch64::uefi_aarch64_frontpage` test now passes with virt_hvf.