### PR TITLE
CI: Update refresh-vso.yml to pass the branch to mirror

### DIFF
--- a/.github/workflows/refresh-vso.yml
+++ b/.github/workflows/refresh-vso.yml
@@ -37,3 +37,4 @@ jobs:
           azure-devops-project-url: '${{ secrets.VSO_MIRROR_URL }}'
           azure-pipeline-name: '${{ secrets.VSO_REFRESH_PIPELINE_NAME }}'
           azure-devops-token: '${{ steps.AzureKeyVault.outputs.HvliteMirrorPAT }}' # This PAT should have the Build (read & execute) permission.
+          azure-pipeline-variables: '{"branch": "main"}'


### PR DESCRIPTION
This change adds a new parameter to the GitHub action responsible for keeping the mirror repo in-sync to allow specifying a branch to sync. This will be useful in the future when we care about mirroring branches other than main.