### PR TITLE
repo: add ubuntu devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,16 +3,24 @@
 {
 	"name": "Ubuntu",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:jammy"
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	"features": {
+		"ghcr.io/devcontainers/features/rust:1": {
+			"version": "latest",
+			"targets": "aarch64-apple-darwin,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,x86_64-unknown-none"
+		}
+	},
+
+	// Allow kvm by setting priviledged to true.
+	"privileged": true,
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
+	"postCreateCommand": "cargo xflowey restore-packages"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/rust:1": {
 			"version": "latest",
+			"profile": "default",
 			"targets": "aarch64-apple-darwin,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,x86_64-unknown-none"
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 		}
 	},
 
-	// Allow kvm by setting priviledged to true.
+	// Allow kvm by setting privileged to true.
 	"privileged": true,
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+// This devcontainer is intended for developer use only, via the dev containers
+// extension or Github codespaces. It is not used for CI or anything else.
 {
 	"name": "Ubuntu",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/base:jammy",
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
+	// Add the Rust feature and install all supported targets, since this is
+	// meant for local developer use.
 	"features": {
 		"ghcr.io/devcontainers/features/rust:1": {
 			"version": "latest",
@@ -17,11 +17,9 @@
 	// Allow kvm by setting privileged to true.
 	"privileged": true,
 
-	// Use 'postCreateCommand' to run commands after the container is created.
+	// Restore packages so that users can build as soon as the container is
+	// ready.
 	"postCreateCommand": "cargo xflowey restore-packages"
-
-	// Configure tool-specific properties.
-	// "customizations": {},
 
 	// TODO: mounts for local flowey-out/artifacts?
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,15 +17,11 @@
 	// Allow kvm by setting privileged to true.
 	"privileged": true,
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "cargo xflowey restore-packages"
 
 	// Configure tool-specific properties.
 	// "customizations": {},
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	// TODO: mounts for local flowey-out/artifacts?
 }

--- a/Guide/src/SUMMARY.md
+++ b/Guide/src/SUMMARY.md
@@ -21,6 +21,7 @@
 - [Getting Started](./dev_guide/getting_started.md)
   - [On Linux / WSL2](./dev_guide/getting_started/linux.md)
   - [On Windows](./dev_guide/getting_started/windows.md)
+  - [Via Codespaces / Dev Container](./dev_guide/getting_started/devcontainer.md)
   - [Building OpenVMM](./dev_guide/getting_started/build_openvmm.md)
   - [Building OpenHCL](./dev_guide/getting_started/build_openhcl.md)
     - [Building a Custom Kernel](./dev_guide/getting_started/build_ohcl_kernel.md)

--- a/Guide/src/dev_guide/getting_started/devcontainer.md
+++ b/Guide/src/dev_guide/getting_started/devcontainer.md
@@ -1,0 +1,52 @@
+# Getting started via Dev Container
+
+This page provides instructions for setting up a development environment using
+the repo provided Dev Container configuration for local development or
+development using GitHub Codespaces.
+
+The repo provides an Ubuntu `devcontainer.json` that installs Rust and the
+supported targets for the project.
+
+## Developing using a GitHub Codespace
+
+Either create a GitHub Codespace via your fork by clicking on the `Code` box, or
+visit the link [here](https://github.com/codespaces/new) and select your fork
+and branch.
+
+If you plan on using rust-analyzer or doing any sort of dev work, it's
+recommended to use an 8 core SKU or beefier.
+
+More documentation can be found at the official GitHub
+[docs](https://docs.github.com/en/codespaces).
+
+## Developing using a local dev container
+
+This will use Docker + the dev container vscode extension to launch the repo
+provided `devcontainer.json` on your local machine.
+
+Follow the install instructions outlined
+[here](https://code.visualstudio.com/docs/devcontainers/containers#_installation).
+
+From there, use the dev container extension in vscode to create a new dev
+container for the repository.
+
+It's recommended to clone the repo _inside_ the dev container using the `Dev
+Containers: Clone Repository Inside Container Volume...` command, as the
+filesystem otherwise will be very slow over the bind mount, which will make your
+builds & rust-analyzer very slow.
+
+More documentation can be found at the official vscode
+[docs](https://code.visualstudio.com/docs/devcontainers/containers).
+
+## Customizing your dev container
+
+Both GitHub codespaces and local dev containers support dotfile repos which can
+be used to run personalized install scripts like installing your favorite tools
+and shells, and copying over your dotfiles and configuration.
+
+For codespaces, see the documentation
+[here](https://docs.github.com/en/codespaces/setting-your-user-preferences/personalizing-github-codespaces-for-your-account#dotfiles).
+For dev containers, see the documentation [here](https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories).
+
+You can use the same dotfiles repo for both, but note that codespaces has a few
+more limitations outlined in their documentation.

--- a/Guide/src/dev_guide/getting_started/suggested_dev_env.md
+++ b/Guide/src/dev_guide/getting_started/suggested_dev_env.md
@@ -5,6 +5,7 @@
 - One of:
   - [Getting started on Windows](./windows.md)
   - [Getting started on Linux / WSL2](./linux.md).
+  - [Getting started via Dev Container](./devcontainer.md)
 - One of:
   - [Building OpenVMM](./build_openvmm.md)
   - [Building OpenHCL](./build_openhcl.md)


### PR DESCRIPTION
This lets you get a codespace up and running, or use the devcontainer vscode extension locally. You probably want to make any codespace have at least 8 VPs, if you plan on actually building anything.  

For local devcontainers, you'll want to clone the repo inside the container volume for filesystem performance reasons. It might also be useful to figure out how to mount the flowey-out directory for running igvm files locally. 

Individual customization (like installing other shells, dotfiles, etc) can be done via the dotfiles repo and install script under your personal codespaces settings, or in the devcontainer extensions settings.