### PR TITLE
Add a missing feature dependency

### DIFF
--- a/vm/devices/chipset_resources/Cargo.toml
+++ b/vm/devices/chipset_resources/Cargo.toml
@@ -12,7 +12,7 @@ vm_resource.workspace = true
 inspect.workspace = true
 mesh.workspace = true
 
-arbitrary = { workspace = true, optional = true }
+arbitrary = { workspace = true, optional = true, features = ["derive"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
This one missing feature dep allows the following command to complete successfully on WSL:

`cargo hack --workspace --at-least-one-of grpc,ttrpc --feature-powerset --skip encryption_win check`

We may want to consider fixing the grpc,ttrpc issue (hvlite_entry breaks if --no-default-features is specified), and maybe checking something like this in CI.