### PR TITLE
CI: Disable component governance and codeql3000 on the mirror-branch pipeline

### DIFF
--- a/azure-pipelines/mirror-branch.yaml
+++ b/azure-pipelines/mirror-branch.yaml
@@ -1,6 +1,9 @@
 trigger:
 - main
 pr: none
+variables:
+- name: skipComponentGovernanceDetection
+  value: 'true'
 jobs:
   - job: mirror
     steps:

--- a/codeql3000.yml
+++ b/codeql3000.yml
@@ -1,0 +1,6 @@
+# CodeQL is autoinjected into all pipelines by organization policy.
+# However CodeQL does not support analyzing Rust code today.
+# It also has known memory leaks when analyzing Rust binaries.
+# Disable it repo-wide for now.
+variables:
+  Codeql.Enabled: false


### PR DESCRIPTION
This change disables these unneeded checks that that are auto-injected by our ADO organization policy. This saves about 7 minutes of runtime on the mirror-branch pipeline.