### PR TITLE
CI: Add release/* to default CI and PR triggers

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -14,6 +14,7 @@ on:
   push:
     branches:
     - main
+    - release/*
 jobs:
   job0:
     name: build mdbook guide

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -14,6 +14,7 @@ on:
   pull_request:
     branches:
     - main
+    - release/*
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -63,11 +63,12 @@ impl IntoPipeline for CheckinGatesCli {
 
         // configure pr/ci branch triggers and add gh pipeline name
         {
+            let branches = vec!["main".into(), "release/*".into()];
             match config {
                 PipelineConfig::Ci => {
                     pipeline
                         .gh_set_ci_triggers(GhCiTriggers {
-                            branches: vec!["main".into()],
+                            branches,
                             ..Default::default()
                         })
                         .gh_set_name("[flowey] OpenVMM CI");
@@ -75,7 +76,7 @@ impl IntoPipeline for CheckinGatesCli {
                 PipelineConfig::Pr => {
                     pipeline
                         .gh_set_pr_triggers(GhPrTriggers {
-                            branches: vec!["main".into()],
+                            branches,
                             ..Default::default()
                         })
                         .gh_set_name("[flowey] OpenVMM PR");


### PR DESCRIPTION
This change updates the default branches we run CI and PR on to include `release/*`. This will ensure that future forks of main will inherit the correct PR and CI policy.