### PR TITLE
CI: Update trigger of refresh-mirror workflow to release/2411

### DIFF
--- a/.github/workflows/refresh-mirror.yml
+++ b/.github/workflows/refresh-mirror.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
+    - release/2411
 
 permissions:
   id-token: write


### PR DESCRIPTION
This change updates the branch trigger of the refresh-mirror pipeline to the correct branch.