### PR TITLE
openvmm_hcl: add option to hide isolation from the guest

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -322,6 +322,7 @@ async fn launch_workers(
         halt_on_guest_halt: opt.halt_on_guest_halt,
         no_sidecar_hotplug: opt.no_sidecar_hotplug,
         gdbstub: opt.gdbstub,
+        hide_isolation: opt.hide_isolation,
     };
 
     let (mut remote_console_cfg, framebuffer_access) =

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -100,6 +100,10 @@ pub struct Options {
     /// Enable support for guest vsm in CVMs. This is disabled by default.
     pub cvm_guest_vsm: bool,
 
+    /// (OPENHCL_HIDE_ISOLATION=1)
+    /// Hide the isolation mode from the guest.
+    pub hide_isolation: bool,
+
     /// (OPENHCL_HALT_ON_GUEST_HALT=1) When receiving a halt request from a
     /// lower VTL, halt underhill instead of forwarding the halt request to the
     /// host. This allows for debugging state without the partition state
@@ -172,6 +176,7 @@ impl Options {
         let enable_shared_visibility_pool =
             parse_legacy_env_bool("OPENHCL_ENABLE_SHARED_VISIBILITY_POOL");
         let cvm_guest_vsm = parse_legacy_env_bool("OPENHCL_CVM_GUEST_VSM");
+        let hide_isolation = parse_env_bool("OPENHCL_HIDE_ISOLATION");
         let halt_on_guest_halt = parse_legacy_env_bool("OPENHCL_HALT_ON_GUEST_HALT");
         let no_sidecar_hotplug = parse_legacy_env_bool("OPENHCL_NO_SIDECAR_HOTPLUG");
         let gdbstub = parse_legacy_env_bool("OPENHCL_GDBSTUB");
@@ -226,6 +231,7 @@ impl Options {
             emulate_apic,
             enable_shared_visibility_pool,
             cvm_guest_vsm,
+            hide_isolation,
             halt_on_guest_halt,
             no_sidecar_hotplug,
         })

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -292,6 +292,8 @@ pub struct UnderhillEnvCfg {
     pub no_sidecar_hotplug: bool,
     /// Enables the GDB stub for debugging the guest.
     pub gdbstub: bool,
+    /// Hide the isolation mode from the guest.
+    pub hide_isolation: bool,
 }
 
 /// Bundle of config + runtime objects for hooking into the underhill remote
@@ -1310,11 +1312,16 @@ async fn new_underhill_vm(
     )
     .context("failed to construct the processor topology")?;
 
+    let hide_isolation = isolation.is_isolated() && env_cfg.hide_isolation;
+
     let mut with_vmbus: bool = false;
     let mut with_vmbus_relay = false;
     if dps.general.vmbus_redirection_enabled {
         with_vmbus = true;
-        with_vmbus_relay = true;
+        // If the guest is isolated but we are hiding this fact, then don't
+        // start the relay--the guest will not be able to use relayed channels
+        // since it will not be able to put their ring buffers in shared memory.
+        with_vmbus_relay = !hide_isolation;
     }
 
     // also construct the VMGS nice and early, as much like the GET, it also
@@ -1414,6 +1421,7 @@ async fn new_underhill_vm(
         no_sidecar_hotplug: env_cfg.no_sidecar_hotplug,
         use_mmio_hypercalls,
         intercept_debug_exceptions: env_cfg.gdbstub,
+        hide_isolation,
     };
 
     let proto_partition = UhProtoPartition::new(params, |cpu| tp.driver(cpu).clone())
@@ -1439,6 +1447,19 @@ async fn new_underhill_vm(
     })
     .await
     .context("failed to initialize memory")?;
+
+    // Devices in isolated VMs default to accessing only shared memory, since
+    // that is what the guest expects--it will double buffer memory to be DMAed
+    // through a shared memory pool.
+    //
+    // For non-isolated VMs, there is no shared/private distinction, so devices
+    // access the same memory as the guest.
+    let device_memory = if hide_isolation || !isolation.is_isolated() {
+        gm.vtl0()
+    } else {
+        gm.shared_memory()
+            .expect("isolated VMs should have shared memory")
+    };
 
     let shared_vis_pages_pool = if shared_pool_size != 0 {
         Some(
@@ -1491,7 +1512,12 @@ async fn new_underhill_vm(
 
     // Set the shared memory allocator to GET that is required by attestation call-out.
     if let Some(allocator) = shared_vis_pages_pool.as_ref().map(|p| p.allocator()) {
-        get_client.set_shared_memory_allocator(allocator, gm.untrusted_dma_memory().clone());
+        get_client.set_shared_memory_allocator(
+            allocator,
+            gm.shared_memory()
+                .context("missing shared memory for shared pool allocator")?
+                .clone(),
+        );
     }
 
     // Create the `AttestationVmConfig` from `dps`, which will be used in
@@ -1641,7 +1667,7 @@ async fn new_underhill_vm(
             gm.vtl1().cloned().unwrap_or(GuestMemory::empty()),
         ]
         .into(),
-        untrusted_dma_memory: gm.untrusted_dma_memory().clone(),
+        shared_memory: gm.shared_memory().cloned(),
         #[cfg(guest_arch = "x86_64")]
         cpuid,
         crash_notification_send,
@@ -1715,9 +1741,13 @@ async fn new_underhill_vm(
         ))
     };
 
-    // ARM64 always bounces, as the OpenHCL kernel does not
-    // have access to VTL0 pages. Necessary until #273 is resolved.
-    let always_bounce = cfg!(guest_arch = "aarch64");
+    // ARM64 always bounces, as the OpenHCL kernel does not have access to VTL0
+    // pages. Necessary until #273 is resolved.
+    //
+    // Similarly, when hiding isolation from the guest, we must bounce because
+    // the guest buffers are in private memory, which the kernel does not have
+    // access to.
+    let always_bounce = cfg!(guest_arch = "aarch64") || hide_isolation;
     resolver.add_async_resolver::<DiskHandleKind, _, OpenBlockDeviceConfig, _>(
         BlockDeviceResolver::new(
             Arc::new(tp.clone()),
@@ -2434,7 +2464,7 @@ async fn new_underhill_vm(
     } = BaseChipsetBuilder::new(
         BaseChipsetFoundation {
             is_restoring,
-            untrusted_dma_memory: gm.untrusted_dma_memory().clone(),
+            untrusted_dma_memory: device_memory.clone(),
             trusted_vtl0_dma_memory: gm.vtl0().clone(),
             vmtime: &vmtime_source,
             vmtime_unit: vmtime.handle(),
@@ -2507,19 +2537,24 @@ async fn new_underhill_vm(
         // prevents them from conflicting with channels offered by the host, for which Hyper-V vmbus
         // allocates ports even if not connected.
         //
+        // This is not necessary when hardware isolation is enabled but the isolation is hidden from
+        // the guest, because the hypervisor's synic will not be used and so the port conflicts will
+        // not matter.
+        //
         // If the relay is present, guest-specified channel IDs are used instead (which the host
         // must support).
         //
-        // N.B. VmBus uses untrusted memory by default for relay channels, and uses additional
-        //      trusted memory only for confidential channels offered by Underhill itself.
-        //
         // N.B. The channel ID offset can break older Linux versions (that only support vmbus
         //      protocol V1 and Win7) because they don't support channel IDs above 255.
-        let vmbus = VmbusServer::builder(&tp, synic.clone(), gm.untrusted_dma_memory().clone())
+        let enable_channel_id_offset = !with_vmbus_relay && !(hardware_isolated && hide_isolation);
+
+        // N.B. VmBus uses untrusted memory by default for relay channels, and uses additional
+        //      trusted memory only for confidential channels offered by Underhill itself.
+        let vmbus = VmbusServer::builder(&tp, synic.clone(), device_memory.clone())
             .private_gm(gm.private_vtl0_memory().cloned())
             .hvsock_notify(hvsock_notify)
             .server_relay(server_relay)
-            .enable_channel_id_offset(!with_vmbus_relay)
+            .enable_channel_id_offset(enable_channel_id_offset)
             .max_version(env_cfg.vmbus_max_version)
             .delay_max_version(firmware_type == FirmwareType::Uefi)
             .enable_mnf(enable_mnf)
@@ -2599,7 +2634,7 @@ async fn new_underhill_vm(
             vmm_core::device_builder::build_vpci_device(
                 &driver_source,
                 &resolver,
-                gm.untrusted_dma_memory(),
+                device_memory,
                 vmbus.control(),
                 instance_id,
                 resource,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1452,6 +1452,9 @@ async fn new_underhill_vm(
     // since that is what the guest expects--it will double buffer memory to be
     // DMAed through a shared memory pool.
     //
+    // When hiding isolation, allow devices to access all memory, since that's
+    // the only option: the guest won't and can't transition anything to shared.
+    //
     // For non-isolated VMs, there is no shared/private distinction, so devices
     // access the same memory as the guest. For software-isolated VMs, the
     // hypervisor does not allow the paravisor to observe changes to

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1290,11 +1290,17 @@ impl<'a> UhProtoPartition<'a> {
             IsolationType::Vbs | IsolationType::None => None,
         };
 
-        let guest_vsm_available = Self::check_guest_vsm_support(&hcl, &params, cvm_cpuid.as_ref());
+        let guest_vsm_available = Self::check_guest_vsm_support(
+            &hcl,
+            &params,
+            #[cfg(guest_arch = "x86_64")]
+            cvm_cpuid.as_ref(),
+        );
 
         Ok(UhProtoPartition {
             hcl,
             params,
+            #[cfg(guest_arch = "x86_64")]
             cvm_cpuid,
             guest_vsm_available,
         })
@@ -1313,6 +1319,7 @@ impl<'a> UhProtoPartition<'a> {
         let Self {
             mut hcl,
             params,
+            #[cfg(guest_arch = "x86_64")]
             cvm_cpuid,
             guest_vsm_available,
         } = self;
@@ -1670,11 +1677,8 @@ impl UhProtoPartition<'_> {
     fn check_guest_vsm_support(
         hcl: &Hcl,
         params: &UhPartitionNewParams<'_>,
-        cvm_cpuid: Option<&cvm_cpuid::CpuidResults>,
+        #[cfg(guest_arch = "x86_64")] cvm_cpuid: Option<&cvm_cpuid::CpuidResults>,
     ) -> bool {
-        #[cfg(guest_arch = "aarch64")]
-        let _ = cvm_state;
-
         match params.isolation {
             IsolationType::None | IsolationType::Vbs => {}
             #[cfg(guest_arch = "x86_64")]

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -152,6 +152,8 @@ pub enum Error {
     FailedToSetL2Ctls(TdCallResult),
     #[error("debugging is configured but the binary does not have the gdb feature")]
     InvalidDebugConfiguration,
+    #[error("missing shared memory for an isolated partition")]
+    MissingSharedMemory,
 }
 
 /// Error revoking guest VSM.
@@ -190,7 +192,7 @@ struct UhPartitionInner {
     cpuid: Mutex<CpuidLeafSet>,
     lower_vtl_memory_layout: MemoryLayout,
     gm: VtlArray<GuestMemory, 2>,
-    untrusted_dma_memory: GuestMemory,
+    shared_memory: Option<GuestMemory>,
     #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
     #[inspect(skip)]
     crash_notification_send: mesh::Sender<VtlCrash>,
@@ -200,6 +202,7 @@ struct UhPartitionInner {
     #[inspect(skip)]
     vmtime: VmTimeSource,
     isolation: IsolationType,
+    hide_isolation: bool,
     /// The emulated hypervisor state. This is only present for
     /// hardware-isolated VMs (and for software VMs in test environments).
     hv: Option<GlobalHv>,
@@ -219,17 +222,19 @@ struct UhPartitionInner {
     #[inspect(with = "inspect::AtomicMut")]
     no_sidecar_hotplug: AtomicBool,
     use_mmio_hypercalls: bool,
+    backing_shared: BackingShared,
 }
 
-#[derive(Clone, Inspect)]
+#[derive(Inspect)]
 #[inspect(external_tag)]
-enum BackingShared {
+#[doc(hidden)]
+pub enum BackingShared {
     // No shared state for hypervisor-backed VMs today.
     Hypervisor,
     #[cfg(guest_arch = "x86_64")]
-    Snp(#[inspect(flatten)] Arc<SnpBackedShared>),
+    Snp(#[inspect(flatten)] SnpBackedShared),
     #[cfg(guest_arch = "x86_64")]
-    Tdx(#[inspect(flatten)] Arc<TdxBackedShared>),
+    Tdx(#[inspect(flatten)] TdxBackedShared),
 }
 
 impl BackingShared {
@@ -247,13 +252,9 @@ impl BackingShared {
                 BackingShared::Hypervisor
             }
             #[cfg(guest_arch = "x86_64")]
-            IsolationType::Snp => {
-                BackingShared::Snp(Arc::new(SnpBackedShared::new(backing_shared_params)?))
-            }
+            IsolationType::Snp => BackingShared::Snp(SnpBackedShared::new(backing_shared_params)?),
             #[cfg(guest_arch = "x86_64")]
-            IsolationType::Tdx => {
-                BackingShared::Tdx(Arc::new(TdxBackedShared::new(backing_shared_params)?))
-            }
+            IsolationType::Tdx => BackingShared::Tdx(TdxBackedShared::new(backing_shared_params)?),
             #[cfg(not(guest_arch = "x86_64"))]
             _ => unreachable!(),
         })
@@ -342,6 +343,7 @@ pub struct UhCvmPartitionState {
         with = "|vec| inspect::iter_by_index(vec.iter().map(|arr| inspect::iter_by_index(arr.iter())))"
     )]
     tlb_lock_info: Vec<VtlArray<TlbLockInfo, 2>>,
+    shared_memory: GuestMemory,
 }
 
 /// Partition-wide state for CVMs.
@@ -496,7 +498,6 @@ impl virt::Aarch64Partition for UhPartition {
 pub struct UhProcessorBox {
     partition: Arc<UhPartitionInner>,
     vp_info: TargetVpInfo,
-    backing_shared: BackingShared,
 }
 
 impl UhProcessorBox {
@@ -540,13 +541,7 @@ impl UhProcessorBox {
                 .map_err(Error::Hcl)?;
         }
 
-        UhProcessor::new(
-            driver,
-            &self.partition,
-            self.vp_info,
-            &self.backing_shared,
-            control,
-        )
+        UhProcessor::new(driver, &self.partition, self.vp_info, control)
     }
 
     /// Sets the sidecar remove reason for the processor to be due to a task
@@ -1108,6 +1103,9 @@ fn set_vtl2_vsm_partition_config(hcl: &mut Hcl) -> Result<(), Error> {
 pub struct UhPartitionNewParams<'a> {
     /// The isolation type for the partition.
     pub isolation: IsolationType,
+    /// Hide isolation from the guest. The guest will run as if it is not
+    /// isolated.
+    pub hide_isolation: bool,
     /// The memory layout for lower VTLs.
     pub lower_vtl_memory_layout: &'a MemoryLayout,
     /// The guest processor topology.
@@ -1139,7 +1137,7 @@ pub struct UhPartitionNewParams<'a> {
 /// Parameters to [`UhProtoPartition::build`].
 pub struct UhLateParams<'a> {
     /// Guest memory for untrusted devices, like overlay pages.
-    pub untrusted_dma_memory: GuestMemory,
+    pub shared_memory: Option<GuestMemory>,
     /// Guest memory for lower VTLs.
     pub gm: VtlArray<GuestMemory, 2>,
     /// The CPUID leaves to expose to the guest.
@@ -1217,7 +1215,8 @@ pub trait ProtectIsolatedMemory: Send + Sync {
 pub struct UhProtoPartition<'a> {
     params: UhPartitionNewParams<'a>,
     hcl: Hcl,
-    cvm_state: Option<UhCvmPartitionState>,
+    #[cfg(guest_arch = "x86_64")]
+    cvm_cpuid: Option<cvm_cpuid::CpuidResults>,
     guest_vsm_available: bool,
 }
 
@@ -1276,13 +1275,27 @@ impl<'a> UhProtoPartition<'a> {
 
         hcl.set_allowed_hypercalls(allowed_hypercalls.as_slice());
 
-        let cvm_state = Self::construct_cvm_state(&params)?;
-        let guest_vsm_available = Self::check_guest_vsm_support(&hcl, &params, cvm_state.as_ref());
+        #[cfg(guest_arch = "x86_64")]
+        let cvm_cpuid = match params.isolation {
+            IsolationType::Snp => Some(
+                cvm_cpuid::CpuidResults::new(cvm_cpuid::CpuidResultsIsolationType::Snp {
+                    cpuid_pages: params.cvm_cpuid_info.unwrap(),
+                })
+                .map_err(Error::CvmCpuid)?,
+            ),
+            IsolationType::Tdx => Some(
+                cvm_cpuid::CpuidResults::new(cvm_cpuid::CpuidResultsIsolationType::Tdx)
+                    .map_err(Error::CvmCpuid)?,
+            ),
+            IsolationType::Vbs | IsolationType::None => None,
+        };
+
+        let guest_vsm_available = Self::check_guest_vsm_support(&hcl, &params, cvm_cpuid.as_ref());
 
         Ok(UhProtoPartition {
             hcl,
             params,
-            cvm_state,
+            cvm_cpuid,
             guest_vsm_available,
         })
     }
@@ -1300,7 +1313,7 @@ impl<'a> UhProtoPartition<'a> {
         let Self {
             mut hcl,
             params,
-            cvm_state,
+            cvm_cpuid,
             guest_vsm_available,
         } = self;
         let isolation = params.isolation;
@@ -1453,15 +1466,16 @@ impl<'a> UhProtoPartition<'a> {
             guest_vsm_available,
             params.vtom,
             isolation,
-            is_hardware_isolated,
+            params.hide_isolation,
         );
 
         #[cfg(guest_arch = "x86_64")]
         let caps = UhPartition::construct_capabilities(
             params.topology,
             &cpuid,
-            cvm_state.as_ref().map(|state| &state.cpuid),
+            cvm_cpuid.as_ref(),
             isolation,
+            params.hide_isolation,
         );
 
         #[cfg(guest_arch = "x86_64")]
@@ -1514,7 +1528,11 @@ impl<'a> UhProtoPartition<'a> {
                 // sharing the untrusted SINTs with the TDX L1. Even if it did,
                 // performance would be poor for cases where the L1 implements
                 // high-performance devices.
-                Some(GlobalSynic::new(params.topology.vp_count()))
+                if !params.hide_isolation {
+                    Some(GlobalSynic::new(params.topology.vp_count()))
+                } else {
+                    None
+                }
             } else {
                 // The hypervisor will manage the untrusted SINTs (or the whole
                 // synic for non-hardware-isolated VMs), but some event ports
@@ -1533,6 +1551,13 @@ impl<'a> UhProtoPartition<'a> {
             None
         };
 
+        #[cfg(guest_arch = "x86_64")]
+        let cvm_state = cvm_cpuid
+            .map(|cpuid| Self::construct_cvm_state(&params, &late_params, cpuid))
+            .transpose()?;
+        #[cfg(guest_arch = "aarch64")]
+        let cvm_state = None;
+
         let enter_modes = EnterModes::default();
 
         let partition = Arc::new(UhPartitionInner {
@@ -1543,7 +1568,7 @@ impl<'a> UhProtoPartition<'a> {
             enter_modes: Mutex::new(enter_modes),
             enter_modes_atomic: u8::from(hcl::protocol::EnterModes::from(enter_modes)).into(),
             gm: late_params.gm,
-            untrusted_dma_memory: late_params.untrusted_dma_memory,
+            shared_memory: late_params.shared_memory,
             cpuid,
             crash_notification_send: late_params.crash_notification_send,
             monitor_page: MonitorPage::new(),
@@ -1552,6 +1577,7 @@ impl<'a> UhProtoPartition<'a> {
             lapic,
             vmtime: late_params.vmtime.clone(),
             isolation,
+            hide_isolation: params.hide_isolation,
             hv,
             untrusted_synic,
             guest_vsm: RwLock::new(vsm_state),
@@ -1559,6 +1585,7 @@ impl<'a> UhProtoPartition<'a> {
             shared_vis_pages_pool: late_params.shared_vis_pages_pool,
             no_sidecar_hotplug: params.no_sidecar_hotplug.into(),
             use_mmio_hypercalls: params.use_mmio_hypercalls,
+            backing_shared: BackingShared::new(isolation, BackingSharedParams { cvm_state })?,
         });
 
         if cfg!(guest_arch = "x86_64") {
@@ -1566,15 +1593,12 @@ impl<'a> UhProtoPartition<'a> {
             partition.manage_io_port_intercept_region(0, !0, true);
         }
 
-        let backing_shared = BackingShared::new(isolation, BackingSharedParams { cvm_state })?;
-
         let vps = params
             .topology
             .vps_arch()
             .map(|vp_info| UhProcessorBox {
                 partition: partition.clone(),
                 vp_info,
-                backing_shared: backing_shared.clone(),
             })
             .collect();
 
@@ -1646,7 +1670,7 @@ impl UhProtoPartition<'_> {
     fn check_guest_vsm_support(
         hcl: &Hcl,
         params: &UhPartitionNewParams<'_>,
-        cvm_state: Option<&UhCvmPartitionState>,
+        cvm_cpuid: Option<&cvm_cpuid::CpuidResults>,
     ) -> bool {
         #[cfg(guest_arch = "aarch64")]
         let _ = cvm_state;
@@ -1662,9 +1686,8 @@ impl UhProtoPartition<'_> {
                 }
                 // Require RMP Query
                 let rmp_query = x86defs::cpuid::ExtendedSevFeaturesEax::from(
-                    cvm_state
+                    cvm_cpuid
                         .unwrap()
-                        .cpuid
                         .registered_result(x86defs::cpuid::CpuidFunction::ExtendedSevFeatures, 0)
                         .eax,
                 )
@@ -1702,47 +1725,26 @@ impl UhProtoPartition<'_> {
 
     #[cfg(guest_arch = "x86_64")]
     /// Constructs partition-wide CVM state.
-    ///
-    /// Returns whether guest vsm should be exposed to the guest as available.
     fn construct_cvm_state(
         params: &UhPartitionNewParams<'_>,
-    ) -> Result<Option<UhCvmPartitionState>, Error> {
-        let cpuid = match params.isolation {
-            IsolationType::Snp => Some(
-                cvm_cpuid::CpuidResults::new(cvm_cpuid::CpuidResultsIsolationType::Snp {
-                    cpuid_pages: params.cvm_cpuid_info.unwrap(),
-                })
-                .map_err(Error::CvmCpuid)?,
-            ),
-            IsolationType::Tdx => Some(
-                cvm_cpuid::CpuidResults::new(cvm_cpuid::CpuidResultsIsolationType::Tdx)
-                    .map_err(Error::CvmCpuid)?,
-            ),
-            IsolationType::Vbs | IsolationType::None => None,
-        };
-
+        late_params: &UhLateParams<'_>,
+        cpuid: cvm_cpuid::CpuidResults,
+    ) -> Result<UhCvmPartitionState, Error> {
         let vp_count = params.topology.vp_count() as usize;
-        let cvm_state = cpuid.map(|cpuid| {
-            let tlb_lock_info = (0..vp_count)
-                .map(|_| VtlArray::from_fn(|_| TlbLockInfo::new(vp_count)))
-                .collect();
-            let tlb_locked_vps =
-                VtlArray::from_fn(|_| BitVec::repeat(false, vp_count).into_boxed_bitslice());
-            UhCvmPartitionState {
-                cpuid,
-                tlb_locked_vps,
-                tlb_lock_info,
-            }
-        });
-
-        Ok(cvm_state)
-    }
-
-    #[cfg(not(guest_arch = "x86_64"))]
-    fn construct_cvm_state(
-        _params: &UhPartitionNewParams<'_>,
-    ) -> Result<Option<UhCvmPartitionState>, Error> {
-        Ok(None)
+        let tlb_lock_info = (0..vp_count)
+            .map(|_| VtlArray::from_fn(|_| TlbLockInfo::new(vp_count)))
+            .collect();
+        let tlb_locked_vps =
+            VtlArray::from_fn(|_| BitVec::repeat(false, vp_count).into_boxed_bitslice());
+        Ok(UhCvmPartitionState {
+            cpuid,
+            tlb_locked_vps,
+            tlb_lock_info,
+            shared_memory: late_params
+                .shared_memory
+                .clone()
+                .ok_or(Error::MissingSharedMemory)?,
+        })
     }
 }
 
@@ -1756,20 +1758,30 @@ impl UhPartition {
         access_vsm: bool,
         vtom: Option<u64>,
         isolation: IsolationType,
-        is_hardware_isolated: bool,
+        hide_isolation: bool,
     ) -> CpuidLeafSet {
         let mut cpuid = CpuidLeafSet::new(Vec::new());
 
-        if emulate_apic || is_hardware_isolated {
+        if emulate_apic || isolation.is_hardware_isolated() {
+            // Get the hypervisor version from the host. This is just for
+            // reporting purposes, so it is safe even if the hypervisor is not
+            // trusted.
+            let hv_version = safe_intrinsics::cpuid(hvdef::HV_CPUID_FUNCTION_MS_HV_VERSION, 0);
             cpuid.extend(&hv1_emulator::cpuid::hv_cpuid_leaves(
                 topology,
                 emulate_apic,
-                isolation,
+                if hide_isolation {
+                    IsolationType::None
+                } else {
+                    isolation
+                },
                 access_vsm,
-                is_hardware_isolated.then_some(&mut |leaf, sub_leaf| {
-                    let result = safe_intrinsics::cpuid(leaf, sub_leaf);
-                    [result.eax, result.ebx, result.ecx, result.edx]
-                }),
+                [
+                    hv_version.eax,
+                    hv_version.ebx,
+                    hv_version.ecx,
+                    hv_version.edx,
+                ],
                 vtom,
             ));
         }
@@ -1785,6 +1797,7 @@ impl UhPartition {
         cpuid: &CpuidLeafSet,
         cvm_cpuid: Option<&cvm_cpuid::CpuidResults>,
         isolation: IsolationType,
+        hide_isolation: bool,
     ) -> virt::x86::X86PartitionCapabilities {
         let mut native_cpuid_fn;
         let mut cvm_cpuid_fn;
@@ -1821,12 +1834,12 @@ impl UhPartition {
         let mut caps = virt::x86::X86PartitionCapabilities::from_cpuid(topology, cpuid_fn);
         match isolation {
             IsolationType::Tdx => {
-                assert!(caps.vtom.is_some());
+                assert_eq!(caps.vtom.is_some(), !hide_isolation);
                 // TDX 1.5 requires EFER.NXE to be set to 1, so set it at RESET/INIT.
                 caps.nxe_forced_on = true;
             }
             IsolationType::Snp => {
-                assert!(caps.vtom.is_some());
+                assert_eq!(caps.vtom.is_some(), !hide_isolation);
             }
             _ => {
                 assert!(caps.vtom.is_none());

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/tlb_lock.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/tlb_lock.rs
@@ -4,12 +4,17 @@
 //! TLB lock infrastructure support for hardware-isolated partitions.
 
 use crate::processor::HardwareIsolatedBacking;
+use crate::UhCvmPartitionState;
 use crate::UhProcessor;
 use hcl::GuestVtl;
 use hvdef::Vtl;
 use std::sync::atomic::Ordering;
 
 impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
+    fn cvm_partition(&self) -> &'a UhCvmPartitionState {
+        B::cvm_partition_state(self.shared)
+    }
+
     /// Causes the specified VTL on the current VP to wait on all TLB locks.
     /// This is typically used to synchronize VTL permission changes with
     /// concurrent instruction emulation.
@@ -19,8 +24,8 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
         // any VP that acquires the lock after this point is guaranteed to see
         // state that this VP has already flushed.
         let self_index = self.vp_index().index() as usize;
-        let self_lock = &self.backing.cvm_partition_state().tlb_lock_info[self_index][target_vtl];
-        for vp in self.backing.cvm_partition_state().tlb_locked_vps[target_vtl]
+        let self_lock = &self.cvm_partition().tlb_lock_info[self_index][target_vtl];
+        for vp in self.cvm_partition().tlb_locked_vps[target_vtl]
             .clone()
             .iter_ones()
         {
@@ -43,7 +48,7 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
             // Because the wait by the current VP on the target VP is known to
             // be new, this bit should not already be set.
             let other_lock_blocked =
-                &self.backing.cvm_partition_state().tlb_lock_info[vp][target_vtl].blocked_vps;
+                &self.cvm_partition().tlb_lock_info[vp][target_vtl].blocked_vps;
             let _was_other_lock_blocked = other_lock_blocked.set_aliased(self_index, true);
             debug_assert!(!_was_other_lock_blocked);
 
@@ -51,7 +56,7 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
             // the current VP was added to its blocked set. Check again to
             // see whether the TLB lock is still held, and if not, remove the
             // block.
-            if !self.backing.cvm_partition_state().tlb_locked_vps[target_vtl][vp] {
+            if !self.cvm_partition().tlb_locked_vps[target_vtl][vp] {
                 other_lock_blocked.set_aliased(self_index, false);
                 if self_lock.blocking_vps.set_aliased(vp, false) {
                     self_lock.blocking_vp_count.fetch_sub(1, Ordering::Relaxed);
@@ -67,7 +72,7 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
     pub fn set_tlb_lock(&mut self, requesting_vtl: Vtl, target_vtl: GuestVtl) {
         debug_assert!(requesting_vtl > Vtl::from(target_vtl));
 
-        self.backing.cvm_partition_state().tlb_locked_vps[target_vtl]
+        self.cvm_partition().tlb_locked_vps[target_vtl]
             .set_aliased(self.vp_index().index() as usize, true);
         self.vtls_tlb_locked.set(requesting_vtl, target_vtl, true);
     }
@@ -97,8 +102,7 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
                 }
 
                 // Now we can remove ourselves from the global TLB lock.
-                self.backing.cvm_partition_state().tlb_locked_vps[target_vtl]
-                    .set_aliased(self_index, false);
+                self.cvm_partition().tlb_locked_vps[target_vtl].set_aliased(self_index, false);
 
                 // Check to see whether any other VPs are waiting for this VP to release
                 // the TLB lock. Note that other processors may be in the process of
@@ -109,13 +113,12 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
                 // of blocked VPs may be changing, it must be captured locally, since the
                 // VP set scan below cannot safely be performed on a VP set that may be
                 // changing.
-                for blocked_vp in self.backing.cvm_partition_state().tlb_lock_info[self_index]
-                    [target_vtl]
+                for blocked_vp in self.cvm_partition().tlb_lock_info[self_index][target_vtl]
                     .blocked_vps
                     .clone()
                     .iter_ones()
                 {
-                    self.backing.cvm_partition_state().tlb_lock_info[self_index][target_vtl]
+                    self.cvm_partition().tlb_lock_info[self_index][target_vtl]
                         .blocked_vps
                         .set_aliased(blocked_vp, false);
 
@@ -123,8 +126,7 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
                     // Note that the target VP may have already marked itself as not
                     // blocked if is has already noticed that the lock has already
                     // been released on the current VP.
-                    let other_lock =
-                        &self.backing.cvm_partition_state().tlb_lock_info[blocked_vp][target_vtl];
+                    let other_lock = &self.cvm_partition().tlb_lock_info[blocked_vp][target_vtl];
                     if other_lock.blocking_vps.set_aliased(self_index, false) {
                         let other_old_count =
                             other_lock.blocking_vp_count.fetch_sub(1, Ordering::Relaxed);
@@ -153,8 +155,7 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
         if self.backing.cvm_state_mut().vtls_tlb_waiting[target_vtl] {
             // No wait is required unless this VP is blocked on another VP that
             // holds the TLB flush lock.
-            let self_lock =
-                &self.backing.cvm_partition_state().tlb_lock_info[self_index][target_vtl];
+            let self_lock = &self.cvm_partition().tlb_lock_info[self_index][target_vtl];
             if self_lock.blocking_vp_count.load(Ordering::Relaxed) != 0 {
                 self_lock.sleeping.store(true, Ordering::Relaxed);
                 // Now that this VP has been marked as sleeping, check to see
@@ -169,7 +170,7 @@ impl<'a, B: HardwareIsolatedBacking> UhProcessor<'a, B> {
             self.backing.cvm_state_mut().vtls_tlb_waiting[target_vtl] = false;
         } else {
             debug_assert_eq!(
-                self.backing.cvm_partition_state().tlb_lock_info[self_index][target_vtl]
+                self.cvm_partition().tlb_lock_info[self_index][target_vtl]
                     .blocking_vp_count
                     .load(Ordering::Relaxed),
                 0

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -21,6 +21,7 @@ use crate::processor::SidecarRemoveExit;
 use crate::processor::UhHypercallHandler;
 use crate::processor::UhProcessor;
 use crate::validate_vtl_gpa_flags;
+use crate::BackingShared;
 use crate::Error;
 use crate::GuestVsmState;
 use crate::GuestVsmVtl1State;
@@ -122,8 +123,13 @@ struct ProcessorStatsX86 {
 
 impl BackingPrivate for HypervisorBackedX86 {
     type HclBacking = MshvX64;
+    type Shared = ();
 
-    fn new(params: BackingParams<'_, '_, Self>) -> Result<Self, Error> {
+    fn shared(_: &BackingShared) -> &Self::Shared {
+        &()
+    }
+
+    fn new(params: BackingParams<'_, '_, Self>, _shared: &()) -> Result<Self, Error> {
         // Initialize shared register state to architectural state. The kernel
         // zero initializes this.
         //

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -69,7 +69,7 @@ impl TdxFlushState {
 impl UhProcessor<'_, TdxBacked> {
     /// Completes any pending TLB flush activity on the current VP.
     pub(super) fn do_tlb_flush(&mut self, target_vtl: GuestVtl) {
-        let partition_flush_state = self.backing.shared.flush_state[target_vtl].read();
+        let partition_flush_state = self.shared.flush_state[target_vtl].read();
 
         // NOTE: It is theoretically possible that we haven't run in so long that the
         // partition counters have wrapped all the way around and are back to

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -925,7 +925,7 @@ impl WhpPartitionInner {
                         proto_config.user_mode_apic,
                         IsolationType::None,
                         false,
-                        None,
+                        [0; 4],
                         None,
                     ));
                 }


### PR DESCRIPTION
Add `OPENHCL_HIDE_ISOLATION=1` command line option to hide the isolation type from the guest and to disable support for isolation-related enlightenments such as changing host memory protections on pages.

This allows a VM to run without any shared memory, using normal architectural and Hyper-V interfaces to interact with devices.

This does not work with the vmbus relay, since the relay relies on the guest knowing to put the ring buffer in shared memory. Similarly, this doesn't work with VTL0 assigned PCI devices. Nor does it work with the net_mana backend, since the MANA driver relies on directly DMAing to shared memory.

With this, we can boot modern and old guests alike, without enlightenments, on TDX. SNP is not tested and is unlikely to work without similar fixups.