### PR TITLE
virt_mshv_vtl: support XAPIC mode for TDX VMs

### DIFF
--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -919,6 +919,18 @@ impl EmulatorSupport for MshvEmulationState<'_> {
                     && (!write || range.flags & HV_MAP_GPA_WRITABLE == HV_MAP_GPA_WRITABLE)
             })
     }
+
+    fn lapic_base_address(&self) -> Option<u64> {
+        None
+    }
+
+    fn lapic_read(&mut self, _address: u64, _data: &mut [u8]) {
+        unreachable!()
+    }
+
+    fn lapic_write(&mut self, _address: u64, _data: &[u8]) {
+        unreachable!()
+    }
 }
 
 impl TranslateGvaSupport for MshvEmulationState<'_> {

--- a/vmm_core/virt_support_apic/src/lib.rs
+++ b/vmm_core/virt_support_apic/src/lib.rs
@@ -69,6 +69,8 @@ pub struct LocalApic {
     #[inspect(hex)]
     apic_base: u64,
     #[inspect(hex)]
+    base_address: Option<u64>,
+    #[inspect(hex)]
     id: u32,
     #[inspect(hex)]
     version: u32,
@@ -372,6 +374,7 @@ impl LocalApicSet {
             shared,
             global: self.global.clone(),
             apic_base: 0,
+            base_address: None,
             id: vp.apic_id,
             version: APIC_VERSION,
             ldr: 0,
@@ -1360,11 +1363,7 @@ impl LocalApic {
 
     /// Gets the APIC base address, if the APIC is enabled and in xapic mode.
     pub fn base_address(&self) -> Option<u64> {
-        if self.xapic_enabled() {
-            Some((ApicBase::from(self.apic_base).base_page() as u64) << 12)
-        } else {
-            None
-        }
+        self.base_address
     }
 
     /// Sets the APIC base MSR.
@@ -1710,6 +1709,7 @@ impl LocalApic {
             shared: _,
             global: _,
             apic_base: _,
+            base_address: _,
             id: _,
             version: _,
             ldr,
@@ -1766,7 +1766,13 @@ impl LocalApic {
         self.update_slot();
     }
 
-    fn update_slot(&self) {
+    fn update_slot(&mut self) {
+        // Cache the base address, since `base_address()` is called in the
+        // instruction emulator hot path.
+        self.base_address = self
+            .xapic_enabled()
+            .then(|| (ApicBase::from(self.apic_base).base_page() as u64) << 12);
+
         let mut mutable = self.global.mutable.write();
         let mutable = &mut *mutable;
         let slot = &mut mutable.by_apic_id[self.id as usize];

--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -92,25 +92,19 @@ pub trait EmulatorSupport {
 
     /// Returns the page-aligned base address of the enabled local APIC in xapic
     /// mode.
-    fn lapic_base_address(&self) -> Option<u64> {
-        None
-    }
+    fn lapic_base_address(&self) -> Option<u64>;
 
     /// Read from the current processor's local APIC memory mapped interface.
     ///
     /// This will only be called on an address in the page returned by
     /// `lapic_base_address`.
-    fn lapic_read(&mut self, _address: u64, _data: &mut [u8]) {
-        unimplemented!()
-    }
+    fn lapic_read(&mut self, address: u64, data: &mut [u8]);
 
     /// Write to the current processor's local APIC memory mapped interface.
     ///
     /// This will only be called on an address in the page returned by
     /// `lapic_base_address`.
-    fn lapic_write(&mut self, _address: u64, _data: &[u8]) {
-        unimplemented!()
-    }
+    fn lapic_write(&mut self, address: u64, data: &[u8]);
 }
 
 pub trait TranslateGvaSupport {

--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -16,7 +16,6 @@ use thiserror::Error;
 use virt::io::CpuIo;
 use virt::VpHaltReason;
 use vm_topology::processor::VpIndex;
-use x86defs::apic::APIC_BASE_ADDRESS;
 use x86defs::Exception;
 use x86emu::CpuState;
 use zerocopy::AsBytes;
@@ -703,7 +702,7 @@ impl<T: EmulatorSupport, U: CpuIo> x86emu::Cpu for EmulatorCpu<'_, T, U> {
     ) -> Result<(), Self::Error> {
         let gpa = self.translate_gva(gva, TranslateMode::Read, is_user_mode)?;
 
-        if gpa & !0xfff == APIC_BASE_ADDRESS as u64 {
+        if Some(gpa & !0xfff) == self.support.lapic_base_address() {
             self.support.lapic_read(gpa, bytes);
             return Ok(());
         }
@@ -728,7 +727,7 @@ impl<T: EmulatorSupport, U: CpuIo> x86emu::Cpu for EmulatorCpu<'_, T, U> {
     ) -> Result<(), Self::Error> {
         let gpa = self.translate_gva(gva, TranslateMode::Write, is_user_mode)?;
 
-        if gpa & !0xfff == APIC_BASE_ADDRESS as u64 {
+        if Some(gpa & !0xfff) == self.support.lapic_base_address() {
             self.support.lapic_write(gpa, bytes);
             return Ok(());
         }

--- a/vmm_core/virt_support_x86emu/tests/tests/checkvtlaccess.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/checkvtlaccess.rs
@@ -110,6 +110,18 @@ impl EmulatorSupport for MockSupport {
     fn is_gpa_mapped(&self, _gpa: u64, _write: bool) -> bool {
         true
     }
+
+    fn lapic_base_address(&self) -> Option<u64> {
+        None
+    }
+
+    fn lapic_read(&mut self, _address: u64, _data: &mut [u8]) {
+        unreachable!()
+    }
+
+    fn lapic_write(&mut self, _address: u64, _data: &[u8]) {
+        unreachable!()
+    }
 }
 
 const TEST_ADDRESS: u64 = 0x100;

--- a/vmm_core/virt_support_x86emu/tests/tests/emulate.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/emulate.rs
@@ -91,6 +91,18 @@ impl EmulatorSupport for MockSupport {
     fn is_gpa_mapped(&self, _gpa: u64, _write: bool) -> bool {
         true
     }
+
+    fn lapic_base_address(&self) -> Option<u64> {
+        None
+    }
+
+    fn lapic_read(&mut self, _address: u64, _data: &mut [u8]) {
+        unreachable!()
+    }
+
+    fn lapic_write(&mut self, _address: u64, _data: &[u8]) {
+        unreachable!()
+    }
 }
 
 #[async_test]

--- a/vmm_core/virt_support_x86emu/tests/tests/translate.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/translate.rs
@@ -285,6 +285,18 @@ impl EmulatorSupport for MockSupport {
     fn is_gpa_mapped(&self, _gpa: u64, _write: bool) -> bool {
         true
     }
+
+    fn lapic_base_address(&self) -> Option<u64> {
+        None
+    }
+
+    fn lapic_read(&mut self, _address: u64, _data: &mut [u8]) {
+        unreachable!()
+    }
+
+    fn lapic_write(&mut self, _address: u64, _data: &[u8]) {
+        unreachable!()
+    }
 }
 
 #[async_test]


### PR DESCRIPTION
When running unenlightened, VMs may try to use XAPIC mode. Wire it up, and fix the instruction emulator code to look at the correct APIC base.