### PR TITLE
repo: tweak some dev container settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
 
 	// Set the minimum host cpus to 8, since otherwise builds or rust-analyzer
 	// will not work well.
-	"hostRequirements": {"cpus": 8}
+	"hostRequirements": { "cpus": 8 }
 
 	// TODO: mounts for local flowey-out/artifacts?
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,11 @@
 
 	// Restore packages so that users can build as soon as the container is
 	// ready.
-	"updateContentCommand": "cargo xflowey restore-packages"
+	"updateContentCommand": "cargo xflowey restore-packages",
+
+	// Set the minimum host cpus to 8, since otherwise builds or rust-analyzer
+	// will not work well.
+	"hostRequirements": {"cpus": 8}
 
 	// TODO: mounts for local flowey-out/artifacts?
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,10 @@
 			"version": "latest",
 			"profile": "default",
 			"targets": "aarch64-apple-darwin,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,x86_64-unknown-none"
-		}
+		},
+
+		// Add the SSHD feature so that users can SSH into the container.
+		"ghcr.io/devcontainers/features/sshd:1": {}
 	},
 
 	// Allow kvm by setting privileged to true.
@@ -19,7 +22,7 @@
 
 	// Restore packages so that users can build as soon as the container is
 	// ready.
-	"postCreateCommand": "cargo xflowey restore-packages"
+	"updateContentCommand": "cargo xflowey restore-packages"
 
 	// TODO: mounts for local flowey-out/artifacts?
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,24 +1,24 @@
 // This devcontainer is intended for developer use only, via the dev containers
 // extension or Github codespaces. It is not used for CI or anything else.
 {
-	"name": "Ubuntu",
-	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "name": "Ubuntu",
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
 
-	// Add the Rust feature and install all supported targets, since this is
-	// meant for local developer use.
-	"features": {
-		"ghcr.io/devcontainers/features/rust:1": {
-			"version": "latest",
-			"profile": "default",
-			"targets": "aarch64-apple-darwin,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,x86_64-unknown-none"
-		},
+    // Add the Rust feature and install all supported targets, since this is
+    // meant for local developer use.
+    "features": {
+        "ghcr.io/devcontainers/features/rust:1": {
+            "version": "latest",
+            "profile": "default",
+            "targets": "aarch64-apple-darwin,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,x86_64-unknown-none"
+        },
 
-		// Add the SSHD feature so that users can SSH into the container.
-		"ghcr.io/devcontainers/features/sshd:1": {}
-	},
+        // Add the SSHD feature so that users can SSH into the container.
+        "ghcr.io/devcontainers/features/sshd:1": {}
+    },
 
-	// Add rust-analyzer by default.
-	"customizations": {
+    // Add rust-analyzer by default.
+    "customizations": {
         "vscode": {
             "extensions": [
                 "rust-lang.rust-analyzer"
@@ -26,16 +26,16 @@
         }
     },
 
-	// Allow kvm by setting privileged to true.
-	"privileged": true,
+    // Allow kvm by setting privileged to true.
+    "privileged": true,
 
-	// Restore packages so that users can build as soon as the container is
-	// ready.
-	"updateContentCommand": "cargo xflowey restore-packages",
+    // Restore packages so that users can build as soon as the container is
+    // ready.
+    "updateContentCommand": "cargo xflowey restore-packages",
 
-	// Set the minimum host cpus to 8, since otherwise builds or rust-analyzer
-	// will not work well.
-	"hostRequirements": { "cpus": 8 }
+    // Set the minimum host cpus to 8, since otherwise builds or rust-analyzer
+    // will not work well.
+    "hostRequirements": { "cpus": 8 }
 
-	// TODO: mounts for local flowey-out/artifacts?
+    // TODO: mounts for local flowey-out/artifacts?
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,15 @@
 		"ghcr.io/devcontainers/features/sshd:1": {}
 	},
 
+	// Add rust-analyzer by default.
+	"customizations": {
+        "vscode": {
+            "extensions": [
+                "rust-lang.rust-analyzer"
+            ]
+        }
+    },
+
 	// Allow kvm by setting privileged to true.
 	"privileged": true,
 


### PR DESCRIPTION
Turns out that having ssh is useful for gh cli, and use `updateContentCommand` instead for restore-packages, so that rust-analyzer actually works when you connect, instead of you having to restart it because the command hasn't finished.

Also actually restrict codespaces to 8 CPUs or greater, because anything less than that and you might as well just use the vscode web editor, not a codespace.