### PR TITLE
openhcl/loader: move snp specific pages to new vtl2 reserved region

### DIFF
--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -509,6 +509,7 @@ pub fn write_dt(
                     ReservedMemoryType::Vtl2Config => MemoryVtlType::VTL2_CONFIG,
                     ReservedMemoryType::SidecarImage => MemoryVtlType::VTL2_SIDECAR_IMAGE,
                     ReservedMemoryType::SidecarNode => MemoryVtlType::VTL2_SIDECAR_NODE,
+                    ReservedMemoryType::Vtl2Reserved => MemoryVtlType::VTL2_RESERVED,
                 },
             )
         }),

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -444,6 +444,7 @@ impl PartitionInfo {
             vtl2_ram: _,
             vtl2_full_config_region: vtl2_config_region,
             vtl2_config_region_reclaim: vtl2_config_region_reclaim_struct,
+            vtl2_reserved_region,
             partition_ram: _,
             isolation,
             bsp_reg,
@@ -466,6 +467,10 @@ impl PartitionInfo {
         );
         *vtl2_config_region_reclaim_struct = vtl2_config_region_reclaim;
         assert!(vtl2_config_region.contains(&vtl2_config_region_reclaim));
+        *vtl2_reserved_region = MemoryRange::new(
+            params.vtl2_reserved_region_start
+                ..(params.vtl2_reserved_region_start + params.vtl2_reserved_region_size),
+        );
         *bsp_reg = parsed.boot_cpuid_phys;
         cpus.extend(parsed.cpus.iter().copied());
         *com3_serial = parsed.com3_serial;

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -53,7 +53,10 @@ pub struct PartitionInfo {
     /// Additional ram that can be reclaimed from the parameter region. Today,
     /// this is the whole device tree provided by the host.
     pub vtl2_config_region_reclaim: MemoryRange,
-    /// The full memory map provided by the host.
+    /// The vtl2 reserved region, that is reserved to both the kernel and
+    /// usermode.
+    pub vtl2_reserved_region: MemoryRange,
+    ///  The full memory map provided by the host.
     pub partition_ram: ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>,
     /// The partiton's isolation type.
     pub isolation: IsolationType,
@@ -87,6 +90,7 @@ impl PartitionInfo {
             vtl2_ram: ArrayVec::new_const(),
             vtl2_full_config_region: MemoryRange::EMPTY,
             vtl2_config_region_reclaim: MemoryRange::EMPTY,
+            vtl2_reserved_region: MemoryRange::EMPTY,
             partition_ram: ArrayVec::new_const(),
             isolation: IsolationType::None,
             bsp_reg: 0,

--- a/openhcl/openhcl_boot/src/host_params/shim_params.rs
+++ b/openhcl/openhcl_boot/src/host_params/shim_params.rs
@@ -95,6 +95,10 @@ pub struct ShimParams {
     pub parameter_region_start: u64,
     /// The size of the parameter region.
     pub parameter_region_size: u64,
+    /// The base address of the VTL2 reserved region.
+    pub vtl2_reserved_region_start: u64,
+    /// The size of the VTL2 reserved region.
+    pub vtl2_reserved_region_size: u64,
     /// Isolation type supported by the boot shim.
     pub isolation_type: IsolationType,
     pub sidecar_entry_address: u64,
@@ -120,6 +124,8 @@ impl ShimParams {
             memory_size,
             parameter_region_offset,
             parameter_region_size,
+            vtl2_reserved_region_offset,
+            vtl2_reserved_region_size,
             sidecar_offset,
             sidecar_size,
             sidecar_entry_offset,
@@ -148,6 +154,9 @@ impl ShimParams {
             memory_size,
             parameter_region_start: shim_base_address.wrapping_add_signed(parameter_region_offset),
             parameter_region_size,
+            vtl2_reserved_region_start: shim_base_address
+                .wrapping_add_signed(vtl2_reserved_region_offset),
+            vtl2_reserved_region_size,
             isolation_type,
             sidecar_entry_address: shim_base_address.wrapping_add_signed(sidecar_entry_offset),
             sidecar_base: shim_base_address.wrapping_add_signed(sidecar_offset),
@@ -163,15 +172,17 @@ impl ShimParams {
     /// Get the base address of the secrets page.
     #[cfg(target_arch = "x86_64")]
     pub fn secrets_start(&self) -> u64 {
-        self.parameter_region_start
-            + loader_defs::paravisor::PARAVISOR_CONFIG_SECRETS_PAGE_INDEX * hvdef::HV_PAGE_SIZE
+        self.vtl2_reserved_region_start
+            + loader_defs::paravisor::PARAVISOR_RESERVED_VTL2_SNP_SECRETS_PAGE_INDEX
+                * hvdef::HV_PAGE_SIZE
     }
 
     /// Get the size of the CPUID page.
     #[cfg(target_arch = "x86_64")]
     pub fn cpuid_start(&self) -> u64 {
-        self.parameter_region_start
-            + loader_defs::paravisor::PARAVISOR_CONFIG_CPUID_PAGE_INDEX * hvdef::HV_PAGE_SIZE
+        self.vtl2_reserved_region_start
+            + loader_defs::paravisor::PARAVISOR_RESERVED_VTL2_SNP_CPUID_PAGE_INDEX
+                * hvdef::HV_PAGE_SIZE
     }
 
     /// Get the base address of the host provided device tree.

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -296,6 +296,7 @@ pub const MAX_RESERVED_MEM_RANGES: usize = 3 + sidecar_defs::MAX_NODES;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ReservedMemoryType {
     Vtl2Config,
+    Vtl2Reserved,
     SidecarImage,
     SidecarNode,
 }
@@ -322,6 +323,15 @@ fn reserved_memory_regions(
             )
         }));
     }
+
+    // Add the VTL2 reserved region, if it exists.
+    if !partition_info.vtl2_reserved_region.is_empty() {
+        reserved.push((
+            partition_info.vtl2_reserved_region,
+            ReservedMemoryType::Vtl2Reserved,
+        ));
+    }
+
     reserved
         .as_mut()
         .sort_unstable_by_key(|(r, _typ)| r.start());
@@ -855,6 +865,7 @@ mod test {
             vtl2_ram: ArrayVec::new(),
             vtl2_full_config_region: MemoryRange::EMPTY,
             vtl2_config_region_reclaim: MemoryRange::EMPTY,
+            vtl2_reserved_region: MemoryRange::EMPTY,
             partition_ram: ArrayVec::new(),
             isolation: IsolationType::None,
             bsp_reg: cpus[0].reg as u32,

--- a/vm/loader/loader_defs/src/paravisor.rs
+++ b/vm/loader/loader_defs/src/paravisor.rs
@@ -9,7 +9,6 @@ use hvdef::HV_PAGE_SIZE;
 #[cfg(feature = "inspect")]
 use inspect::Inspect;
 use open_enum::open_enum;
-use static_assertions::const_assert;
 use static_assertions::const_assert_eq;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
@@ -23,35 +22,12 @@ pub const PARAVISOR_CONFIG_SLIT_SIZE_PAGES: u64 = 20;
 pub const PARAVISOR_CONFIG_PPTT_SIZE_PAGES: u64 = 20;
 /// Size in pages for the device tree.
 pub const PARAVISOR_CONFIG_DEVICE_TREE_SIZE_PAGES: u64 = 64;
-/// Size in pages for the secrets page.
-pub const PARAVISOR_CONFIG_SECRETS_SIZE_PAGES: u64 = 1;
-/// Size in pages for the CPUID pages.
-pub const PARAVISOR_CONFIG_CPUID_SIZE_PAGES: u64 = 2;
-/// Size in pages for the VMSA page.
-pub const PARAVISOR_CONFIG_VMSA_SIZE_PAGES: u64 = 1;
 
-/// Count for unmeasured config region size on different isolation types.
-pub const PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_PAGE_COUNT_COMMON: u64 =
+/// The maximum size in pages of the unmeasured vtl 2 config region.
+pub const PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_PAGE_COUNT_MAX: u64 =
     PARAVISOR_CONFIG_SLIT_SIZE_PAGES
         + PARAVISOR_CONFIG_PPTT_SIZE_PAGES
         + PARAVISOR_CONFIG_DEVICE_TREE_SIZE_PAGES;
-
-/// Size in pages for VSM isolation.
-pub const PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_PAGE_COUNT_VSM: u64 =
-    PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_PAGE_COUNT_COMMON;
-/// Size in pages for AMD SEV-SNP isolation.
-pub const PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_PAGE_COUNT_SNP: u64 =
-    PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_PAGE_COUNT_COMMON
-        + PARAVISOR_CONFIG_SECRETS_SIZE_PAGES
-        + PARAVISOR_CONFIG_CPUID_SIZE_PAGES
-        + PARAVISOR_CONFIG_VMSA_SIZE_PAGES;
-const_assert!(
-    PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_PAGE_COUNT_SNP
-        >= PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_PAGE_COUNT_VSM
-);
-/// The maximum size in pages of the unmeasured vtl 2 config region out of all isolation architectures.
-pub const PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_PAGE_COUNT_MAX: u64 =
-    PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_PAGE_COUNT_SNP; // TODO: const fn max or macro possible?
 
 // Page indices for different parameters within the unmeasured vtl 2 config region.
 /// The page index to the SLIT.
@@ -62,18 +38,37 @@ pub const PARAVISOR_CONFIG_PPTT_PAGE_INDEX: u64 =
 /// The page index to the device tree.
 pub const PARAVISOR_CONFIG_DEVICE_TREE_PAGE_INDEX: u64 =
     PARAVISOR_CONFIG_PPTT_PAGE_INDEX + PARAVISOR_CONFIG_PPTT_SIZE_PAGES;
-/// The page index to the secrets page.
-pub const PARAVISOR_CONFIG_SECRETS_PAGE_INDEX: u64 =
-    PARAVISOR_CONFIG_DEVICE_TREE_PAGE_INDEX + PARAVISOR_CONFIG_DEVICE_TREE_SIZE_PAGES;
-/// The page index to the first CPUID page.
-pub const PARAVISOR_CONFIG_CPUID_PAGE_INDEX: u64 =
-    PARAVISOR_CONFIG_SECRETS_PAGE_INDEX + PARAVISOR_CONFIG_SECRETS_SIZE_PAGES;
-/// The page index to the VMSA page.
-pub const PARAVISOR_CONFIG_VMSA_PAGE_INDEX: u64 =
-    PARAVISOR_CONFIG_CPUID_PAGE_INDEX + PARAVISOR_CONFIG_CPUID_SIZE_PAGES;
 /// Base index for the unmeasured vtl 2 config region
 pub const PARAVISOR_UNMEASURED_VTL2_CONFIG_REGION_BASE_INDEX: u64 =
     PARAVISOR_CONFIG_SLIT_PAGE_INDEX;
+
+/// Size in pages for the SNP CPUID pages.
+pub const PARAVISOR_RESERVED_VTL2_SNP_CPUID_SIZE_PAGES: u64 = 2;
+/// Size in pages for the VMSA page.
+pub const PARAVISOR_RESERVED_VTL2_SNP_VMSA_SIZE_PAGES: u64 = 1;
+/// Size in pages for the secrets page.
+pub const PARAVISOR_RESERVED_VTL2_SNP_SECRETS_SIZE_PAGES: u64 = 1;
+
+/// Total size of the reserved vtl2 range.
+pub const PARAVISOR_RESERVED_VTL2_PAGE_COUNT_MAX: u64 = PARAVISOR_RESERVED_VTL2_SNP_CPUID_SIZE_PAGES
+    + PARAVISOR_RESERVED_VTL2_SNP_VMSA_SIZE_PAGES
+    + PARAVISOR_RESERVED_VTL2_SNP_SECRETS_SIZE_PAGES;
+
+// Page indices for reserved vtl2 ranges, ranges that are marked as reserved to
+// both the kernel and usermode. Today, these are SNP specific pages.
+//
+// TODO SNP: Does the kernel require that the CPUID and secrets pages are
+// persisted, or after the kernel boots, and usermode reads them, can we discard
+// them?
+//
+/// The page index to the SNP VMSA page.
+pub const PARAVISOR_RESERVED_VTL2_SNP_VMSA_PAGE_INDEX: u64 = 0;
+/// The page index to the first SNP CPUID page.
+pub const PARAVISOR_RESERVED_VTL2_SNP_CPUID_PAGE_INDEX: u64 =
+    PARAVISOR_RESERVED_VTL2_SNP_VMSA_PAGE_INDEX + PARAVISOR_RESERVED_VTL2_SNP_VMSA_SIZE_PAGES;
+/// The page index to the first SNP secrets page.
+pub const PARAVISOR_RESERVED_VTL2_SNP_SECRETS_PAGE_INDEX: u64 =
+    PARAVISOR_RESERVED_VTL2_SNP_CPUID_PAGE_INDEX + PARAVISOR_RESERVED_VTL2_SNP_CPUID_SIZE_PAGES;
 
 // Number of pages for each type of parameter in the vtl 2 measured config
 // region.

--- a/vm/loader/loader_defs/src/shim.rs
+++ b/vm/loader/loader_defs/src/shim.rs
@@ -34,6 +34,10 @@ pub struct ShimParamsRaw {
     pub parameter_region_offset: i64,
     /// The size of the parameter region.
     pub parameter_region_size: u64,
+    /// The offset to the VTL2 reserved region.
+    pub vtl2_reserved_region_offset: i64,
+    /// The size of the VTL2 reserved region.
+    pub vtl2_reserved_region_size: u64,
     /// The offset to the sidecar memory region.
     pub sidecar_offset: i64,
     /// The size of the sidecar memory region.
@@ -88,6 +92,10 @@ open_enum! {
         VTL0_MMIO = 5,
         /// This range is mmio for VTL2.
         VTL2_MMIO = 6,
+        /// This memory holds VTL2 data which should be preserved by the kernel
+        /// and usermode. Today, this is only used for SNP: VMSA, CPUID pages,
+        /// and secrets pages.
+        VTL2_RESERVED = 7,
     }
 }
 
@@ -101,6 +109,7 @@ impl MemoryVtlType {
                 | MemoryVtlType::VTL2_CONFIG
                 | MemoryVtlType::VTL2_SIDECAR_IMAGE
                 | MemoryVtlType::VTL2_SIDECAR_NODE
+                | MemoryVtlType::VTL2_RESERVED
         )
     }
 }


### PR DESCRIPTION
Cherry pick of #304 to release/2411

Previously, we put some SNP specific pages into the same VTL2 config region. #265 broke SNP, because this region contains pages that _cannot be_ zeroed, like the VMSA, CPUID pages and secrets pages.

Move those to a new region, that is marked as persisted to both kernelmode and usermode. It is unclear to me if the kernel requires that the CPUID page and secrets page are persisted, but treat them like the VMSA for now.

Fixes #295