### PR TITLE
Support get/set_vp_register for synic registers

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -507,8 +507,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             | HvX64RegisterName::Stimer3Count
             | HvX64RegisterName::VsmVina) => self.vp.backing.cvm_state_mut().hv[vtl]
                 .synic
-                .read_reg(synic_reg.into())
-                .map_err(|_| HvError::OperationFailed),
+                .read_reg(synic_reg.into()),
             _ => {
                 tracing::error!(
                     ?name,
@@ -681,8 +680,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             | HvX64RegisterName::Stimer3Count
             | HvX64RegisterName::VsmVina) => self.vp.backing.cvm_state_mut().hv[vtl]
                 .synic
-                .write_reg(&self.vp.partition.gm[vtl], synic_reg.into(), reg.value)
-                .map_err(|_| HvError::OperationFailed),
+                .write_reg(&self.vp.partition.gm[vtl], synic_reg.into(), reg.value),
             _ => {
                 tracing::error!(
                     ?reg,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -313,8 +313,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             HvX64RegisterName::VpAssistPage => Ok(self.vp.backing.cvm_state_mut().hv[vtl]
                 .vp_assist_page()
                 .into()),
-            // TODO GUEST VSM: add the synic registers (definitely missing VINA
-            // and ApicBase)
+            // TODO GUEST VSM: add VINA and ApicBase registers
             virt_msr @ (HvX64RegisterName::Star
             | HvX64RegisterName::Lstar
             | HvX64RegisterName::Cstar
@@ -531,6 +530,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         // - validate the values being set, e.g. that addresses are canonical,
         //   that efer and pat make sense, etc. Similar validation is needed in
         //   the write_msr path.
+        // TODO GUEST VSM: add VINA and ApicBase registers
 
         match HvX64RegisterName::from(reg.name) {
             HvX64RegisterName::VsmPartitionConfig => self.vp.set_vsm_partition_config(

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -477,6 +477,38 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
                 .map_err(Self::reg_access_error_to_hv_err)?
                 .msr_cr_pat
                 .into()),
+            synic_reg @ (HvX64RegisterName::Sint0
+            | HvX64RegisterName::Sint1
+            | HvX64RegisterName::Sint2
+            | HvX64RegisterName::Sint3
+            | HvX64RegisterName::Sint4
+            | HvX64RegisterName::Sint5
+            | HvX64RegisterName::Sint6
+            | HvX64RegisterName::Sint7
+            | HvX64RegisterName::Sint8
+            | HvX64RegisterName::Sint9
+            | HvX64RegisterName::Sint10
+            | HvX64RegisterName::Sint11
+            | HvX64RegisterName::Sint12
+            | HvX64RegisterName::Sint13
+            | HvX64RegisterName::Sint14
+            | HvX64RegisterName::Sint15
+            | HvX64RegisterName::Scontrol
+            | HvX64RegisterName::Sversion
+            | HvX64RegisterName::Sifp
+            | HvX64RegisterName::Sipp
+            | HvX64RegisterName::Eom
+            | HvX64RegisterName::Stimer0Config
+            | HvX64RegisterName::Stimer0Count
+            | HvX64RegisterName::Stimer1Config
+            | HvX64RegisterName::Stimer1Count
+            | HvX64RegisterName::Stimer2Config
+            | HvX64RegisterName::Stimer2Count
+            | HvX64RegisterName::Stimer3Config
+            | HvX64RegisterName::Stimer3Count) => self.vp.backing.cvm_state_mut().hv[vtl]
+                .synic
+                .read_reg(synic_reg.into())
+                .map_err(|_| HvError::OperationFailed),
             _ => {
                 tracing::error!(
                     ?name,
@@ -617,6 +649,38 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
                     .map_err(Self::reg_access_error_to_hv_err)?;
                 Ok(())
             }
+            synic_reg @ (HvX64RegisterName::Sint0
+            | HvX64RegisterName::Sint1
+            | HvX64RegisterName::Sint2
+            | HvX64RegisterName::Sint3
+            | HvX64RegisterName::Sint4
+            | HvX64RegisterName::Sint5
+            | HvX64RegisterName::Sint6
+            | HvX64RegisterName::Sint7
+            | HvX64RegisterName::Sint8
+            | HvX64RegisterName::Sint9
+            | HvX64RegisterName::Sint10
+            | HvX64RegisterName::Sint11
+            | HvX64RegisterName::Sint12
+            | HvX64RegisterName::Sint13
+            | HvX64RegisterName::Sint14
+            | HvX64RegisterName::Sint15
+            | HvX64RegisterName::Scontrol
+            | HvX64RegisterName::Sversion
+            | HvX64RegisterName::Sifp
+            | HvX64RegisterName::Sipp
+            | HvX64RegisterName::Eom
+            | HvX64RegisterName::Stimer0Config
+            | HvX64RegisterName::Stimer0Count
+            | HvX64RegisterName::Stimer1Config
+            | HvX64RegisterName::Stimer1Count
+            | HvX64RegisterName::Stimer2Config
+            | HvX64RegisterName::Stimer2Count
+            | HvX64RegisterName::Stimer3Config
+            | HvX64RegisterName::Stimer3Count) => self.vp.backing.cvm_state_mut().hv[vtl]
+                .synic
+                .write_reg(&self.vp.partition.gm[vtl], synic_reg.into(), reg.value)
+                .map_err(|_| HvError::OperationFailed),
             _ => {
                 tracing::error!(
                     ?reg,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -313,7 +313,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             HvX64RegisterName::VpAssistPage => Ok(self.vp.backing.cvm_state_mut().hv[vtl]
                 .vp_assist_page()
                 .into()),
-            // TODO GUEST VSM: add VINA and ApicBase registers
+            // TODO GUEST VSM: add ApicBase register
             virt_msr @ (HvX64RegisterName::Star
             | HvX64RegisterName::Lstar
             | HvX64RegisterName::Cstar
@@ -504,7 +504,8 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             | HvX64RegisterName::Stimer2Config
             | HvX64RegisterName::Stimer2Count
             | HvX64RegisterName::Stimer3Config
-            | HvX64RegisterName::Stimer3Count) => self.vp.backing.cvm_state_mut().hv[vtl]
+            | HvX64RegisterName::Stimer3Count
+            | HvX64RegisterName::VsmVina) => self.vp.backing.cvm_state_mut().hv[vtl]
                 .synic
                 .read_reg(synic_reg.into())
                 .map_err(|_| HvError::OperationFailed),
@@ -530,7 +531,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         // - validate the values being set, e.g. that addresses are canonical,
         //   that efer and pat make sense, etc. Similar validation is needed in
         //   the write_msr path.
-        // TODO GUEST VSM: add VINA and ApicBase registers
+        // TODO GUEST VSM: add ApicBase register
 
         match HvX64RegisterName::from(reg.name) {
             HvX64RegisterName::VsmPartitionConfig => self.vp.set_vsm_partition_config(
@@ -677,7 +678,8 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             | HvX64RegisterName::Stimer2Config
             | HvX64RegisterName::Stimer2Count
             | HvX64RegisterName::Stimer3Config
-            | HvX64RegisterName::Stimer3Count) => self.vp.backing.cvm_state_mut().hv[vtl]
+            | HvX64RegisterName::Stimer3Count
+            | HvX64RegisterName::VsmVina) => self.vp.backing.cvm_state_mut().hv[vtl]
                 .synic
                 .write_reg(&self.vp.partition.gm[vtl], synic_reg.into(), reg.value)
                 .map_err(|_| HvError::OperationFailed),

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1786,12 +1786,7 @@ impl UhProcessor<'_, TdxBacked> {
             msr @ (hvdef::HV_X64_MSR_GUEST_OS_ID | hvdef::HV_X64_MSR_VP_INDEX) => {
                 self.backing.cvm.hv[intercepted_vtl].msr_read(msr)
             }
-            _ => self
-                .backing
-                .untrusted_synic
-                .as_mut()
-                .unwrap()
-                .read_nontimer_msr(msr),
+            _ => self.backing.untrusted_synic.as_mut().unwrap().read_msr(msr),
         }
     }
 
@@ -1809,11 +1804,11 @@ impl UhProcessor<'_, TdxBacked> {
                 // If we get here we must have an untrusted synic, as otherwise
                 // we wouldn't be handling the TDVMCALL that ends up here. Therefore
                 // this is fine to unwrap.
-                self.backing
-                    .untrusted_synic
-                    .as_mut()
-                    .unwrap()
-                    .write_nontimer_msr(&self.partition.gm[GuestVtl::Vtl0], msr, value)?;
+                self.backing.untrusted_synic.as_mut().unwrap().write_msr(
+                    &self.partition.gm[GuestVtl::Vtl0],
+                    msr,
+                    value,
+                )?;
                 // Propagate sint MSR writes to the hypervisor as well
                 // so that the hypervisor can directly inject events.
                 if matches!(msr, hvdef::HV_X64_MSR_SINT0..=hvdef::HV_X64_MSR_SINT15) {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1786,7 +1786,12 @@ impl UhProcessor<'_, TdxBacked> {
             msr @ (hvdef::HV_X64_MSR_GUEST_OS_ID | hvdef::HV_X64_MSR_VP_INDEX) => {
                 self.backing.cvm.hv[intercepted_vtl].msr_read(msr)
             }
-            _ => self.backing.untrusted_synic.as_mut().unwrap().read_msr(msr),
+            _ => self
+                .backing
+                .untrusted_synic
+                .as_mut()
+                .unwrap()
+                .read_nontimer_msr(msr),
         }
     }
 
@@ -1804,11 +1809,11 @@ impl UhProcessor<'_, TdxBacked> {
                 // If we get here we must have an untrusted synic, as otherwise
                 // we wouldn't be handling the TDVMCALL that ends up here. Therefore
                 // this is fine to unwrap.
-                self.backing.untrusted_synic.as_mut().unwrap().write_msr(
-                    &self.partition.gm[GuestVtl::Vtl0],
-                    msr,
-                    value,
-                )?;
+                self.backing
+                    .untrusted_synic
+                    .as_mut()
+                    .unwrap()
+                    .write_nontimer_msr(&self.partition.gm[GuestVtl::Vtl0], msr, value)?;
                 // Propagate sint MSR writes to the hypervisor as well
                 // so that the hypervisor can directly inject events.
                 if matches!(msr, hvdef::HV_X64_MSR_SINT0..=hvdef::HV_X64_MSR_SINT15) {

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -1883,6 +1883,7 @@ macro_rules! registers {
                 Sifp = 0x000A0012,
                 Sipp = 0x000A0013,
                 Eom = 0x000A0014,
+                Sirbp = 0x000A0015,
 
                 Stimer0Config = 0x000B0000,
                 Stimer0Count = 0x000B0001,

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -1883,7 +1883,17 @@ macro_rules! registers {
                 Sifp = 0x000A0012,
                 Sipp = 0x000A0013,
                 Eom = 0x000A0014,
-                Sirbp = 0x000A0015,
+
+                Stimer0Config = 0x000B0000,
+                Stimer0Count = 0x000B0001,
+                Stimer1Config = 0x000B0002,
+                Stimer1Count = 0x000B0003,
+                Stimer2Config = 0x000B0004,
+                Stimer2Count = 0x000B0005,
+                Stimer3Config = 0x000B0006,
+                Stimer3Count = 0x000B0007,
+                StimeUnhaltedTimerConfig = 0x000B0100,
+                StimeUnhaltedTimerCount = 0x000B0101,
 
                 VsmCodePageOffsets = 0x000D0002,
                 VsmVpStatus = 0x000D0003,

--- a/vmm_core/virt/src/x86/mod.rs
+++ b/vmm_core/virt/src/x86/mod.rs
@@ -474,7 +474,7 @@ pub enum MsrError {
     /// The MSR is not implemented. Depending on the configuration, this should
     /// either be ignored (returning 0 for reads) or should result in a #GP.
     Unknown,
-    /// The msr is implemented but this is an invalid read or write and should
+    /// The MSR is implemented but this is an invalid read or write and should
     /// always result in a #GP.
     InvalidAccess,
 }


### PR DESCRIPTION
We do this by just converting the register index to an msr index and calling the existing read/write msr functions. This comes along with a refactor to the timer MSRs to move their control inside the synic, making read/write_msr more complete.

A follow up PR will tackle the apic base register.