### PR TITLE
guide: document the use of CVM kernel config fragments

### DIFF
--- a/Guide/src/dev_guide/getting_started/build_ohcl_kernel.md
+++ b/Guide/src/dev_guide/getting_started/build_ohcl_kernel.md
@@ -43,6 +43,14 @@ Do once for every machine that hasn't run this step successfully:
 ./Microsoft/install-deps.sh
 ```
 
+If you plan to use your custom kernel to work with confidential VMs, you need to enable a few more options
+in the kernel. Do once after cloning the kernel repository or every time you remove local changes from your
+kernel configuration file:
+
+```sh
+./Microsoft/merge-cvm-config.sh
+```
+
 Every time the kernel needs to be rebuilt:
 
 ```sh


### PR DESCRIPTION
L1 kernels fail to boot when the host hypervisor enforces isolation features for confidential VMs. The reason of the failed boot is not obvious and debugging tools may provide no hits (e.g., WinDBG does not show any kernel boot logs).

The kernel fails to boot because the necessary isolation features are not enabled in the default hcl-*.config files. The script merge-cvm-config.sh selects this features.

Document this extra step.