### PR TITLE
Use kernel ioctl for getting/setting all VTL-shared registers

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1710,8 +1710,8 @@ impl<'a, T: Backing> ProcessorRunner<'a, T> {
     }
 
     #[cfg(guest_arch = "aarch64")]
-    fn is_kernel_managed(&self, _name: HvArm64RegisterName) -> bool {
-        false
+    fn is_kernel_managed(&self, name: HvArm64RegisterName) -> bool {
+        is_vtl_shared_reg(name)
     }
 
     fn set_reg(&mut self, vtl: GuestVtl, regs: &[HvRegisterAssoc]) -> Result<(), Error> {

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1702,19 +1702,10 @@ impl<'a, T: Backing> ProcessorRunner<'a, T> {
     // an HvArmRegisterName that overlaps one of these x86-specific values.
     #[cfg(guest_arch = "x86_64")]
     fn is_kernel_managed(&self, name: HvX64RegisterName) -> bool {
-        if name == HvX64RegisterName::Xfem {
-            self.hcl.isolation == IsolationType::Tdx
-        } else if name == HvX64RegisterName::Dr6 {
+        if name == HvX64RegisterName::Dr6 {
             self.hcl.dr6_shared()
         } else {
-            is_vtl_shared_mtrr(name)
-                || matches!(
-                    name,
-                    HvX64RegisterName::Dr0
-                        | HvX64RegisterName::Dr1
-                        | HvX64RegisterName::Dr2
-                        | HvX64RegisterName::Dr3
-                )
+            is_vtl_shared_reg(name)
         }
     }
 

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1697,9 +1697,10 @@ impl<T> Drop for ProcessorRunner<'_, T> {
 }
 
 impl<'a, T: Backing> ProcessorRunner<'a, T> {
-    // These registers are handled specially by the kernel through a dedicated
-    // ioctl. is_kernel_managed is arch-specific to guard against an into() on
-    // an HvArmRegisterName that overlaps one of these x86-specific values.
+    // Registers that are shared between VTLs need to be handled by the kernel
+    // as they may require special handling there. set_reg and get_reg will
+    // handle these registers using a dedicated ioctl, instead of the general-
+    // purpose Set/GetVpRegisters hypercalls.
     #[cfg(guest_arch = "x86_64")]
     fn is_kernel_managed(&self, name: HvX64RegisterName) -> bool {
         if name == HvX64RegisterName::Dr6 {


### PR DESCRIPTION
#125 introduced using a generic, VTL-aware hypercall to get and set VTL-private registers. Unfortunately, it introduced multiple sources of truth about how certain registers (in particular, Xfem) should be handled. This change modifies ProcessorRunner::set_reg and get_reg to route any VTL-shared register through the special kernel ioctl, and use the generic hypercall only for registers that are definitely VTL-private. This ensures that the decision made by get_reg and set_reg matches the assert in, e.g., get_vp_register_for_vtl.