### PR TITLE
github: add labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+Guide:
+ - changed-files:
+   - any-glob-to-any-file: 'Guide/**'
+
+release_2411:
+ - base-branch: 'release/2411'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
Apply the `release_2411` label to PRs targeting the `release/2411` branch.

Apply the `Guide` label to PRs modifying the developer guide.

See <https://github.com/actions/labeler>.