### PR TITLE
virt_mshv_vtl: Remove comments relating to unwinding interrupts

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -626,7 +626,6 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             }
         }
 
-        // TODO GUEST VSM: interrupt rewinding
         // TODO TDX GUEST VSM: update execution mode
     }
 }
@@ -818,9 +817,6 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlReturn for UhHypercallHand
 
         B::switch_vtl_state(self.vp, self.intercepted_vtl, GuestVtl::Vtl0);
         self.vp.backing.cvm_state_mut().exit_vtl = GuestVtl::Vtl0;
-
-        // TODO CVM GUEST_VSM:
-        // - rewind interrupts
 
         if !fast {
             let [rax, rcx] = self.vp.backing.cvm_state_mut().hv[GuestVtl::Vtl1]

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -385,7 +385,7 @@ impl BackingPrivate for SnpBacked {
             }
         }
 
-        // Clear any pending interrupt.
+        // Clear any pending interrupts.
         this.runner.vmsa_mut(vtl).v_intr_cntrl_mut().set_irq(false);
 
         let ApicWork {
@@ -1342,8 +1342,6 @@ impl UhProcessor<'_, SnpBacked> {
                 // Receipt of a virtual interrupt intercept indicates that a virtual interrupt is ready
                 // for injection but injection cannot complete due to the intercept. Rewind the pending
                 // virtual interrupt so it is reinjected as a fixed interrupt.
-
-                // TODO SNP: Rewind the interrupt.
                 unimplemented!("SevExitCode::VINTR");
             }
 


### PR DESCRIPTION
The legacy HCL has a concept of 'rewinding' interrupts, which allows it to reevaluate interrupt state in certain scenarios that update it. I believe this is not needed in OpenHCL due to our architecture of always reevaluating all of our interrupt state every time we re-enter run_vp. Remove the comments mentioning this as a todo.