### PR TITLE
virt_mshv_vtl: Add cvm support for get/set ApicBase register

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -320,7 +320,10 @@ pub struct UhCvmVpState {
 #[cfg(guest_arch = "x86_64")]
 impl UhCvmVpState {
     /// Creates a new CVM VP state.
-    pub fn new(hv: VtlArray<ProcessorVtlHv, 2>, lapics: VtlArray<processor::LapicState, 2>) -> Self {
+    pub fn new(
+        hv: VtlArray<ProcessorVtlHv, 2>,
+        lapics: VtlArray<processor::LapicState, 2>,
+    ) -> Self {
         Self {
             vtls_tlb_waiting: VtlArray::new(false),
             exit_vtl: GuestVtl::Vtl0,

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -76,7 +76,6 @@ use pal_uring::IdleControl;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
 use processor::BackingSharedParams;
-use processor::LapicState;
 use processor::SidecarExitReason;
 use sidecar_client::NewSidecarClientError;
 use std::ops::RangeInclusive;
@@ -315,13 +314,13 @@ pub struct UhCvmVpState {
     /// Hypervisor enlightenment emulator state.
     hv: VtlArray<ProcessorVtlHv, 2>,
     /// LAPIC state.
-    lapics: VtlArray<LapicState, 2>,
+    lapics: VtlArray<processor::LapicState, 2>,
 }
 
 #[cfg(guest_arch = "x86_64")]
 impl UhCvmVpState {
     /// Creates a new CVM VP state.
-    pub fn new(hv: VtlArray<ProcessorVtlHv, 2>, lapics: VtlArray<LapicState, 2>) -> Self {
+    pub fn new(hv: VtlArray<ProcessorVtlHv, 2>, lapics: VtlArray<processor::LapicState, 2>) -> Self {
         Self {
             vtls_tlb_waiting: VtlArray::new(false),
             exit_vtl: GuestVtl::Vtl0,

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -76,6 +76,7 @@ use pal_uring::IdleControl;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
 use processor::BackingSharedParams;
+use processor::LapicState;
 use processor::SidecarExitReason;
 use sidecar_client::NewSidecarClientError;
 use std::ops::RangeInclusive;
@@ -313,16 +314,19 @@ pub struct UhCvmVpState {
     exit_vtl: GuestVtl,
     /// Hypervisor enlightenment emulator state.
     hv: VtlArray<ProcessorVtlHv, 2>,
+    /// LAPIC state.
+    lapics: VtlArray<LapicState, 2>,
 }
 
 #[cfg(guest_arch = "x86_64")]
 impl UhCvmVpState {
     /// Creates a new CVM VP state.
-    pub fn new(hv: VtlArray<ProcessorVtlHv, 2>) -> Self {
+    pub fn new(hv: VtlArray<ProcessorVtlHv, 2>, lapics: VtlArray<LapicState, 2>) -> Self {
         Self {
             vtls_tlb_waiting: VtlArray::new(false),
             exit_vtl: GuestVtl::Vtl0,
             hv,
+            lapics,
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -320,7 +320,6 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             HvX64RegisterName::VpAssistPage => Ok(self.vp.backing.cvm_state_mut().hv[vtl]
                 .vp_assist_page()
                 .into()),
-            // TODO GUEST VSM: add ApicBase register
             virt_msr @ (HvX64RegisterName::Star
             | HvX64RegisterName::Lstar
             | HvX64RegisterName::Cstar
@@ -515,6 +514,10 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             | HvX64RegisterName::VsmVina) => self.vp.backing.cvm_state_mut().hv[vtl]
                 .synic
                 .read_reg(synic_reg.into()),
+            HvX64RegisterName::ApicBase => Ok(self.vp.backing.cvm_state_mut().lapics[vtl]
+                .lapic
+                .apic_base()
+                .into()),
             _ => {
                 tracing::error!(
                     ?name,
@@ -688,6 +691,16 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             | HvX64RegisterName::VsmVina) => self.vp.backing.cvm_state_mut().hv[vtl]
                 .synic
                 .write_reg(&self.vp.partition.gm[vtl], synic_reg.into(), reg.value),
+            HvX64RegisterName::ApicBase => {
+                // No changes are allowed on this path.
+                let current = self.vp.backing.cvm_state_mut().lapics[vtl]
+                    .lapic
+                    .apic_base();
+                if reg.value.as_u64() != current {
+                    return Err(HvError::InvalidParameter);
+                }
+                Ok(())
+            }
             _ => {
                 tracing::error!(
                     ?reg,


### PR DESCRIPTION
Add support for calling get/set_vp_register on the ApicBase register for CVMs. This required moving the lapics into cvm state, which necessitated a lot of churn, but ultimately this is a pretty small change.