### PR TITLE
Lock the release branch to the current Rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[toolchain]
+channel = "1.82.0"


### PR DESCRIPTION
This helps ensure that we don't accidentally take rust version updates to the release branch, or write code that depends on a newer version to begin with.