### PR TITLE
virt_mshv_vtl: flush deferred actions during servicing

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -742,6 +742,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                 }
             }
         }
+        self.runner.flush_deferred_actions();
         Ok(())
     }
 


### PR DESCRIPTION
There may be pending deferred actions (i.e., synic events to signal) on the VP at time of servicing. Ordinarily, these are flushed the next time we run the VP, but there is no next time when saving for servicing. These actions must be flushed to the actual partition state to ensure we don't drop a signal, which would cause a guest hang.

This fixes a regression from a previous change. Previously, the `ProcessorRunner` was dropped before a servicing operation, and the `Drop` implementation would flush deferred actions. Now, the runner never gets dropped until the partition is torn down. Add a path to explicitly flush deferred actions before saving.