### PR TITLE
hypestv: support relaying serial ports to new windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_relay"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "getrandom",
+ "pal_async",
+ "term",
+ "unix_socket",
+]
+
+[[package]]
 name = "consomme"
 version = "0.0.0"
 dependencies = [
@@ -2955,9 +2967,11 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_dyn_complete",
+ "console_relay",
  "diag_client",
  "dirs",
  "futures",
+ "futures-concurrency",
  "guid",
  "inspect",
  "mesh",
@@ -4417,6 +4431,7 @@ dependencies = [
  "chipset_resources",
  "clap",
  "clap_dyn_complete",
+ "console_relay",
  "debug_worker_defs",
  "diag_client",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ cache_topology = { path = "support/cache_topology" }
 closeable_mutex = { path = "support/closeable_mutex" }
 ci_logger = { path = "support/ci_logger" }
 clap_dyn_complete = { path = "support/clap_dyn_complete" }
+console_relay = { path = "support/console_relay" }
 safe_intrinsics = { path = "support/safe_intrinsics" }
 debug_ptr = { path = "support/debug_ptr" }
 fast_select = { path = "support/fast_select" }

--- a/Guide/src/dev_guide/dev_tools/hypestv.md
+++ b/Guide/src/dev_guide/dev_tools/hypestv.md
@@ -44,11 +44,12 @@ After this, all commands will implicitly operate on `tdxvm`. Use `select` again
 to work on another VM.
 
 To enable serial port output, use the `serial` command. This can be used at any
-time, even while the VM is not running. E.g., to enable serial port output for
-COM2:
+time, even while the VM is not running. E.g., to open a separate window for
+interactive use of COM1 and enable logging serial port output for COM2:
 
 ```
-tdxvm [off]> serial 2 output
+tdxvm [off]> serial 1 term
+tdxvm [off]> serial 2 log
 ```
 
 Start a VM with `start`. This is an asynchronous command: you can continue to
@@ -61,6 +62,7 @@ on the prompt may not be accurate until you type another command or press Enter.
 
 ```
 tdxvm [off]> start
+serial port 1 connected
 serial port 2 connected
 VM started
 tdxvm [off]>
@@ -92,6 +94,7 @@ VM.
 
 ```
 tdxvm [running]> kill
+serial port 1 disconnected
 serial port 2 disconnected
 VM killed
 tdxvm [stopping]>

--- a/hyperv/tools/hypestv/Cargo.toml
+++ b/hyperv/tools/hypestv/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 clap_dyn_complete.workspace = true
+console_relay.workspace = true
 diag_client.workspace = true
 guid.workspace = true
 inspect.workspace = true
@@ -18,6 +19,7 @@ anyhow.workspace = true
 clap.workspace = true
 dirs.workspace = true
 futures.workspace = true
+futures-concurrency.workspace = true
 parking_lot.workspace = true
 rustyline = { workspace = true, features = ["derive"] }
 shell-words.workspace = true

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -331,7 +331,7 @@ impl VmInner {
                     }
                 },
                 Event::Request(None) => {
-                    break Ok(());
+                    break;
                 }
             }
         }
@@ -340,5 +340,7 @@ impl VmInner {
             drop(serial);
             writeln!(self.printer.out(), "COM{port} disconnected").ok();
         }
+
+        Ok(())
     }
 }

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -13,6 +13,9 @@ use anyhow::Context as _;
 use diag_client::DiagClient;
 use futures::io::BufReader;
 use futures::AsyncBufReadExt;
+use futures::FutureExt;
+use futures::StreamExt;
+use futures_concurrency::future::Race;
 use guid::Guid;
 use pal_async::pipe::PolledPipe;
 use pal_async::task::Spawn;
@@ -24,7 +27,13 @@ use std::time::Duration;
 pub struct Vm {
     paravisor_diag: Option<DiagClient>,
     inner: Arc<VmInner>,
-    serial: Vec<Option<Task<()>>>,
+    serial: Vec<Option<SerialTask>>,
+}
+
+struct SerialTask {
+    mode: SerialMode,
+    task: Task<()>,
+    req: mesh::Sender<SerialRequest>,
 }
 
 struct VmInner {
@@ -136,33 +145,60 @@ impl Vm {
                     Ok(())
                 });
             }
-            VmCommand::Serial { port, mode } => {
-                let port_index = port.checked_sub(1).context("invalid port")? as usize;
-                if let Some(task) = self
-                    .serial
-                    .get_mut(port_index)
-                    .context("invalid port")?
-                    .take()
-                {
-                    // TODO: preserve the existing serial port connection if
-                    // changing between non-off modes.
-                    task.cancel().await;
+            VmCommand::Serial {
+                port: None,
+                mode: _,
+            } => {
+                for (i, port) in self.serial.iter().enumerate() {
+                    println!(
+                        "COM{}: {}",
+                        i + 1,
+                        port.as_ref().map_or(SerialMode::Off, |t| t.mode)
+                    );
                 }
-                match mode {
-                    SerialMode::Off => {}
-                    SerialMode::Output => {
+            }
+            VmCommand::Serial {
+                port: Some(port),
+                mode: None,
+            } => {
+                let port_index = port.checked_sub(1).context("invalid port")? as usize;
+                let task = self.serial.get_mut(port_index).context("invalid port")?;
+                println!("{}", task.as_ref().map_or(SerialMode::Off, |t| t.mode));
+            }
+            VmCommand::Serial {
+                port: Some(port),
+                mode: Some(mode),
+            } => {
+                let port_index = port.checked_sub(1).context("invalid port")? as usize;
+                let task = self.serial.get_mut(port_index).context("invalid port")?;
+
+                let target = match mode {
+                    SerialMode::Off => {
+                        if let Some(task) = task.take() {
+                            drop(task.req);
+                            task.task.await;
+                        }
+                        None
+                    }
+                    SerialMode::Log => Some(SerialTarget::Printer),
+                    SerialMode::Term => Some(SerialTarget::Console(
+                        console_relay::Console::new(self.inner.driver.clone(), None)
+                            .context("failed to launch console")?,
+                    )),
+                };
+                if let Some(target) = target {
+                    if let Some(task) = task {
+                        task.mode = mode;
+                        task.req.send(SerialRequest::NewTarget(target));
+                    } else {
+                        let (req, recv) = mesh::channel();
                         let inner = self.inner.clone();
-                        let task = self.inner.driver.spawn("serial", async move {
-                            if let Err(err) = inner.handle_serial(port).await {
-                                writeln!(
-                                    inner.printer.out(),
-                                    "serial port {port} failed: {:#}",
-                                    err
-                                )
-                                .ok();
+                        let t = self.inner.driver.spawn("serial", async move {
+                            if let Err(err) = inner.handle_serial(recv, target, port).await {
+                                writeln!(inner.printer.out(), "COM{port} failed: {:#}", err).ok();
                             }
                         });
-                        self.serial[port_index] = Some(task);
+                        *task = Some(SerialTask { task: t, mode, req });
                     }
                 }
             }
@@ -219,32 +255,90 @@ impl Vm {
     }
 }
 
+enum SerialRequest {
+    NewTarget(SerialTarget),
+}
+
+enum SerialTarget {
+    Printer,
+    Console(console_relay::Console),
+}
+
 impl VmInner {
-    async fn handle_serial(&self, port: u32) -> anyhow::Result<()> {
+    async fn handle_serial(
+        &self,
+        mut req: mesh::Receiver<SerialRequest>,
+        mut target: SerialTarget,
+        port: u32,
+    ) -> anyhow::Result<()> {
+        let mut current_serial = None;
+
+        enum Event {
+            TaskDone(anyhow::Result<()>),
+            Request(Option<SerialRequest>),
+        }
+
         loop {
-            let serial = diag_client::hyperv::open_serial_port(
-                &self.driver,
-                &self.name,
-                diag_client::hyperv::ComPortAccessInfo::PortNumber(port),
-            )
-            .await
-            .context("failed to open serial port")?;
+            let task = async {
+                let serial = if let Some(serial) = &mut current_serial {
+                    serial
+                } else {
+                    let new_serial = diag_client::hyperv::open_serial_port(
+                        &self.driver,
+                        &self.name,
+                        diag_client::hyperv::ComPortAccessInfo::PortNumber(port),
+                    )
+                    .await
+                    .context("failed to open serial port")?;
 
-            writeln!(self.printer.out(), "serial port {port} connected").ok();
+                    current_serial.insert(BufReader::new(
+                        PolledPipe::new(&self.driver, new_serial)
+                            .context("failed to create polled pipe")?,
+                    ))
+                };
 
-            let mut serial = BufReader::new(
-                PolledPipe::new(&self.driver, serial).context("failed to create polled pipe")?,
-            );
+                writeln!(self.printer.out(), "COM{port} connected").ok();
 
-            let mut line = String::new();
-            while let Ok(n) = serial.read_line(&mut line).await {
-                if n == 0 {
-                    break;
+                match &mut target {
+                    SerialTarget::Printer => {
+                        let mut line = String::new();
+                        while let Ok(n) = serial.read_line(&mut line).await {
+                            if n == 0 {
+                                break;
+                            }
+                            write!(self.printer.out(), "[COM{port}]: {}", line).ok();
+                            line.clear();
+                        }
+                    }
+                    SerialTarget::Console(console) => {
+                        console.relay(serial).await?;
+                    }
                 }
-                write!(self.printer.out(), "{}", line).ok();
-                line.clear();
+
+                writeln!(self.printer.out(), "COM{port} disconnected").ok();
+                current_serial = None;
+                Ok(())
+            };
+
+            let event = (task.map(Event::TaskDone), req.next().map(Event::Request))
+                .race()
+                .await;
+            match event {
+                Event::TaskDone(r) => r?,
+                Event::Request(Some(y)) => match y {
+                    SerialRequest::NewTarget(new_target) => {
+                        target = new_target;
+                    }
+                },
+                Event::Request(None) => {
+                    break Ok(());
+                }
             }
-            writeln!(self.printer.out(), "serial port {port} disconnected").ok();
+        }
+
+        if let Some(serial) = current_serial {
+            drop(serial);
+            writeln!(self.printer.out(), "COM{port} disconnected").ok();
         }
     }
 }

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -68,6 +68,7 @@ vtl2_settings_proto.workspace = true
 mcr_resources.workspace = true
 
 clap_dyn_complete.workspace = true
+console_relay.workspace = true
 guid.workspace = true
 inspect.workspace = true
 inspect_proto.workspace = true

--- a/support/console_relay/Cargo.toml
+++ b/support/console_relay/Cargo.toml
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "console_relay"
+edition = "2021"
+rust-version.workspace = true
+
+[dependencies]
+pal_async.workspace = true
+term.workspace = true
+unix_socket.workspace = true
+
+anyhow.workspace = true
+futures.workspace = true
+getrandom.workspace = true
+
+[lints]
+workspace = true

--- a/support/console_relay/src/unix.rs
+++ b/support/console_relay/src/unix.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(unix)]
+
+//! Console relay support using Unix domain sockets.
+
+use futures::AsyncRead;
+use futures::AsyncWrite;
+use pal_async::driver::Driver;
+use pal_async::socket::PolledSocket;
+use std::path::Path;
+use std::pin::Pin;
+use std::task::ready;
+use std::task::Context;
+use unix_socket::UnixListener;
+use unix_socket::UnixStream;
+
+pub struct UnixSocketConsole {
+    driver: Box<dyn Driver>,
+    state: UnixSocketConsoleState,
+}
+
+enum UnixSocketConsoleState {
+    Listening(PolledSocket<UnixListener>),
+    Connected(PolledSocket<UnixStream>),
+}
+
+impl UnixSocketConsole {
+    pub fn new(driver: Box<dyn Driver>, path: &Path) -> std::io::Result<Self> {
+        let listener = UnixListener::bind(path)?;
+        Ok(Self {
+            state: UnixSocketConsoleState::Listening(PolledSocket::new(&driver, listener)?),
+            driver,
+        })
+    }
+
+    fn poll_connect(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> std::task::Poll<std::io::Result<&mut PolledSocket<UnixStream>>> {
+        match &mut self.state {
+            UnixSocketConsoleState::Listening(l) => {
+                let (c, _) = ready!(l.poll_accept(cx))?;
+                let c = PolledSocket::new(&self.driver, c)?;
+                self.state = UnixSocketConsoleState::Connected(c);
+            }
+            UnixSocketConsoleState::Connected(_) => {}
+        }
+        let UnixSocketConsoleState::Connected(c) = &mut self.state else {
+            unreachable!()
+        };
+        Ok(c).into()
+    }
+}
+
+impl AsyncRead for UnixSocketConsole {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        let c = ready!(self.poll_connect(cx))?;
+        Pin::new(c).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for UnixSocketConsole {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        let c = ready!(self.poll_connect(cx))?;
+        Pin::new(c).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match &mut self.state {
+            UnixSocketConsoleState::Listening(_) => Ok(()).into(),
+            UnixSocketConsoleState::Connected(c) => Pin::new(c).poll_flush(cx),
+        }
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match &mut self.state {
+            UnixSocketConsoleState::Listening(_) => Ok(()).into(),
+            UnixSocketConsoleState::Connected(c) => Pin::new(c).poll_close(cx),
+        }
+    }
+}

--- a/support/console_relay/src/windows.rs
+++ b/support/console_relay/src/windows.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(windows)]
+
+//! Console relay support using Windows named pipes.
+
+use futures::AsyncRead;
+use futures::AsyncWrite;
+use futures::FutureExt;
+use pal_async::driver::Driver;
+use pal_async::pipe::PolledPipe;
+use std::path::Path;
+use std::pin::Pin;
+use std::task::ready;
+
+pub struct WindowsNamedPipeConsole {
+    driver: Box<dyn Driver>,
+    state: WindowsNamedPipeConsoleState,
+}
+
+enum WindowsNamedPipeConsoleState {
+    Listening(pal_async::windows::pipe::ListeningPipe),
+    Connected(PolledPipe),
+}
+
+impl WindowsNamedPipeConsole {
+    pub fn new(driver: Box<dyn Driver>, path: &Path) -> std::io::Result<Self> {
+        let server = pal_async::windows::pipe::NamedPipeServer::create(path)?;
+        let listener = server.accept(&driver)?;
+        Ok(Self {
+            driver,
+            state: WindowsNamedPipeConsoleState::Listening(listener),
+        })
+    }
+
+    fn poll_connect(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<&mut PolledPipe>> {
+        match &mut self.state {
+            WindowsNamedPipeConsoleState::Listening(l) => {
+                let pipe = ready!(l.poll_unpin(cx))?;
+                let pipe = PolledPipe::new(&self.driver, pipe)?;
+                self.state = WindowsNamedPipeConsoleState::Connected(pipe);
+            }
+            WindowsNamedPipeConsoleState::Connected(_) => {}
+        }
+        let WindowsNamedPipeConsoleState::Connected(pipe) = &mut self.state else {
+            unreachable!()
+        };
+        Ok(pipe).into()
+    }
+}
+
+impl AsyncRead for WindowsNamedPipeConsole {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        let c = ready!(self.poll_connect(cx))?;
+        Pin::new(c).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for WindowsNamedPipeConsole {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        let c = ready!(self.poll_connect(cx))?;
+        Pin::new(c).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match &mut self.state {
+            WindowsNamedPipeConsoleState::Listening(_) => Ok(()).into(),
+            WindowsNamedPipeConsoleState::Connected(c) => Pin::new(c).poll_flush(cx),
+        }
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match &mut self.state {
+            WindowsNamedPipeConsoleState::Listening(_) => Ok(()).into(),
+            WindowsNamedPipeConsoleState::Connected(c) => Pin::new(c).poll_close(cx),
+        }
+    }
+}


### PR DESCRIPTION
Lift the console relay support from OpenVMM and use it to launch serial ports in separate windows. This replaces the need to separately use `hvc` for interactive serial ports.

To use:

```
serial 1 term
```

Also, add support for `quit`, and rename the `output` serial mode to `log`.