### PR TITLE
vmbus_server: call unstick_channels to mitigate the lost synic issue

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -878,8 +878,7 @@ impl ServerTask {
                 });
             }
             VmbusRequest::Save(rpc) => {
-                // TODO: update to true once the save part fix in.
-                let lost_synic_bug_fixed = false;
+                let lost_synic_bug_fixed = true;
                 rpc.handle_sync(|()| SavedState {
                     server: self.server.save(),
                     lost_synic_bug_fixed,

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -877,13 +877,10 @@ impl ServerTask {
                         .merge(&self.server.with_notifier(&mut self.inner));
                 });
             }
-            VmbusRequest::Save(rpc) => {
-                let lost_synic_bug_fixed = true;
-                rpc.handle_sync(|()| SavedState {
-                    server: self.server.save(),
-                    lost_synic_bug_fixed,
-                })
-            }
+            VmbusRequest::Save(rpc) => rpc.handle_sync(|()| SavedState {
+                server: self.server.save(),
+                lost_synic_bug_fixed: true,
+            }),
             VmbusRequest::Restore(rpc) => rpc.handle_sync(|state| {
                 self.unstick_on_start = !state.lost_synic_bug_fixed;
                 self.server.restore(state.server)

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -231,6 +231,9 @@ impl EventPort for ChannelEvent {
 pub struct SavedState {
     #[mesh(1)]
     server: channels::SavedState,
+    // Indicates if the lost synic bug is fixed or not. By default it's false.
+    // During the restore process, we check if the field is not true then
+    // unstick_channels() function will be called to mitigate the issue.
     #[mesh(2)]
     lost_synic_bug_fixed: bool,
 }
@@ -900,6 +903,7 @@ impl ServerTask {
                     if self.unstick_on_start {
                         tracing::info!("lost synic bug fix is not in yet, call unstick_channels to mitigate the issue.");
                         self.unstick_channels(false);
+                        self.unstick_on_start = false;
                     }
                 }
             }


### PR DESCRIPTION
This PR addresses an issue where the synic event was lost during the save process. To mitigate this issue during the restore process, we have introduced a new field lost_synic_bug_fixed in the SavedState structure. The lost_synic_bug_fixed field will indicate whether the issue was fixed in save code path. During the restore process, we check if the field is not set then unstick_channels() function is called to mitigate the issue.

In below kmsg traces, yellow line shows we check the field to see if need call unstick_channels and green line shows we did hit the issue where the rings were not empty and need signal the guest:

![image](https://github.com/user-attachments/assets/222a6131-2085-4ec8-a067-c68ee91e67be)

