### PR TITLE
Interrupt rewinding

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1211,14 +1211,14 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             return;
         }
 
-        if let Some(vector) = self.backing.clear_pending_interrupt() {
+        if let Some(vector) = B::clear_pending_interrupt(self, vtl) {
             lapic
                 .lapic
                 .access(&mut ())
                 .rewind_offloaded_interrupt(vector);
         }
 
-        if rewind_nmi && self.backing.clear_pending_nmi() {
+        if rewind_nmi && B::clear_pending_nmi(self, vtl) {
             lapic.nmi_pending = true;
         }
     }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -661,7 +661,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
                 if let HvX64RegisterName::Cr8 | HvX64RegisterName::Rflags =
                     HvX64RegisterName::from(reg.name)
                 {
-                    self.vp.rewind_offloaded_interrupt(self.bus, vtl, false);
+                    self.vp.rewind_interrupt(self.bus, vtl, false);
                 }
                 Ok(())
             }
@@ -915,8 +915,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> hv1_hypercall::VtlReturn
         // pending, which would cause preemption back into the same VTL.  Rewind
         // any pending virtual interrupt so that preemption can be reevaluated
         // correctly.
-        self.vp
-            .rewind_offloaded_interrupt(self.bus, GuestVtl::Vtl1, true);
+        self.vp.rewind_interrupt(self.bus, GuestVtl::Vtl1, true);
 
         if !fast {
             let [rax, rcx] = self.vp.backing.cvm_state_mut().hv[GuestVtl::Vtl1]
@@ -1210,12 +1209,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
     /// Rewind an interrupt from the offloaded vAPIC into the synthetic APIC so
     /// it can be queued for redelivery.
-    pub(crate) fn rewind_offloaded_interrupt(
-        &mut self,
-        dev: &impl CpuIo,
-        vtl: GuestVtl,
-        rewind_nmi: bool,
-    ) {
+    pub(crate) fn rewind_interrupt(&mut self, dev: &impl CpuIo, vtl: GuestVtl, rewind_nmi: bool) {
         if !self.backing.cvm_state_mut().lapics[vtl]
             .lapic
             .is_offloaded()

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -289,6 +289,10 @@ pub trait HardwareIsolatedBacking: Backing {
     ) -> TranslationRegisters;
     /// Gets the pat register
     fn pat(&self, this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64;
+    /// If an interrupt is pending in the backing, clear it and return the vector.
+    fn clear_pending_interrupt(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> Option<u8>;
+    /// If an NMI is pending in the backing, clear it.
+    fn clear_pending_nmi(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> bool;
 }
 
 #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -293,6 +293,13 @@ pub trait HardwareIsolatedBacking: Backing {
     fn clear_pending_interrupt(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> Option<u8>;
     /// If an NMI is pending in the backing, clear it.
     fn clear_pending_nmi(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> bool;
+    /// Rewind the interrupt with the given vector on the synthetic LAPIC.
+    fn rewind_interrupt(
+        this: &mut UhProcessor<'_, Self>,
+        dev: &impl CpuIo,
+        vtl: GuestVtl,
+        vector: u8,
+    );
 }
 
 #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1394,7 +1394,7 @@ impl UhProcessor<'_, SnpBacked> {
                 // Receipt of a virtual interrupt intercept indicates that a virtual interrupt is ready
                 // for injection but injection cannot complete due to the intercept. Rewind the pending
                 // virtual interrupt so it is reinjected as a fixed interrupt.
-                self.rewind_offloaded_interrupt(dev, entered_from_vtl, false);
+                self.rewind_interrupt(dev, entered_from_vtl, false);
                 unimplemented!("SevExitCode::VINTR");
             }
 

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1394,7 +1394,7 @@ impl UhProcessor<'_, SnpBacked> {
                 // Receipt of a virtual interrupt intercept indicates that a virtual interrupt is ready
                 // for injection but injection cannot complete due to the intercept. Rewind the pending
                 // virtual interrupt so it is reinjected as a fixed interrupt.
-                self.rewind_interrupt(dev, entered_from_vtl, false);
+                self.rewind_offloaded_interrupt(dev, entered_from_vtl, false);
                 unimplemented!("SevExitCode::VINTR");
             }
 

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -250,6 +250,24 @@ impl HardwareIsolatedBacking for SnpBacked {
             false
         }
     }
+
+    fn rewind_interrupt(
+        this: &mut UhProcessor<'_, Self>,
+        dev: &impl CpuIo,
+        vtl: GuestVtl,
+        vector: u8,
+    ) {
+        this.backing.cvm.lapics[vtl]
+            .lapic
+            .access(&mut SnpApicClient {
+                partition: this.partition,
+                vmsa: this.runner.vmsa_mut(vtl),
+                dev,
+                vmtime: &this.vmtime,
+                vtl,
+            })
+            .rewind_offloaded_interrupt(vector);
+    }
 }
 
 /// Partition-wide shared data for SNP VPs.
@@ -1376,7 +1394,7 @@ impl UhProcessor<'_, SnpBacked> {
                 // Receipt of a virtual interrupt intercept indicates that a virtual interrupt is ready
                 // for injection but injection cannot complete due to the intercept. Rewind the pending
                 // virtual interrupt so it is reinjected as a fixed interrupt.
-                self.rewind_offloaded_interrupt(entered_from_vtl, false);
+                self.rewind_offloaded_interrupt(dev, entered_from_vtl, false);
                 unimplemented!("SevExitCode::VINTR");
             }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -530,6 +530,23 @@ impl HardwareIsolatedBacking for TdxBacked {
             false
         }
     }
+
+    fn rewind_interrupt(
+        this: &mut UhProcessor<'_, Self>,
+        dev: &impl CpuIo,
+        vtl: GuestVtl,
+        vector: u8,
+    ) {
+        this.backing.cvm.lapics[vtl]
+            .lapic
+            .access(&mut TdxApicClient {
+                partition: this.partition,
+                dev,
+                vmtime: &this.vmtime,
+                apic_page: zerocopy::transmute_mut!(this.runner.tdx_apic_page_mut()),
+            })
+            .rewind_offloaded_interrupt(vector);
+    }
 }
 
 /// Partition-wide shared data for TDX VPs.
@@ -1371,10 +1388,10 @@ impl UhProcessor<'_, TdxBacked> {
                 self.backing.interruption_information = next_interruption;
                 match next_interruption.interruption_type() {
                     INTERRUPT_TYPE_EXTERNAL => {
-                        self.rewind_offloaded_interrupt(GuestVtl::Vtl0, false);
+                        self.rewind_offloaded_interrupt(dev, GuestVtl::Vtl0, false);
                     }
                     INTERRUPT_TYPE_NMI => {
-                        self.rewind_offloaded_interrupt(GuestVtl::Vtl0, true);
+                        self.rewind_offloaded_interrupt(dev, GuestVtl::Vtl0, true);
                     }
                     INTERRUPT_TYPE_HARDWARE_EXCEPTION => {
                         self.backing.exception_error_code = exit_info.idt_vectoring_error_code();
@@ -1728,11 +1745,11 @@ impl UhProcessor<'_, TdxBacked> {
             // that a virtual interrupt is ready for injection. Rewind the
             // pending virtual interrupt so it is reinjected as a fixed interrupt.
             VmxExit::TPR_BELOW_THRESHOLD => {
-                self.rewind_offloaded_interrupt(intercepted_vtl, false);
+                self.rewind_offloaded_interrupt(dev, intercepted_vtl, false);
                 &mut self.backing.exit_stats.tpr_below_threshold
             }
             VmxExit::INTERRUPT_WINDOW => {
-                self.rewind_offloaded_interrupt(intercepted_vtl, false);
+                self.rewind_offloaded_interrupt(dev, intercepted_vtl, false);
                 &mut self.backing.exit_stats.interrupt_window
             }
             VmxExit::NMI_WINDOW => {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1388,10 +1388,10 @@ impl UhProcessor<'_, TdxBacked> {
                 self.backing.interruption_information = next_interruption;
                 match next_interruption.interruption_type() {
                     INTERRUPT_TYPE_EXTERNAL => {
-                        self.rewind_interrupt(dev, GuestVtl::Vtl0, false);
+                        self.rewind_offloaded_interrupt(dev, GuestVtl::Vtl0, false);
                     }
                     INTERRUPT_TYPE_NMI => {
-                        self.rewind_interrupt(dev, GuestVtl::Vtl0, true);
+                        self.rewind_offloaded_interrupt(dev, GuestVtl::Vtl0, true);
                     }
                     INTERRUPT_TYPE_HARDWARE_EXCEPTION => {
                         self.backing.exception_error_code = exit_info.idt_vectoring_error_code();
@@ -1745,11 +1745,11 @@ impl UhProcessor<'_, TdxBacked> {
             // that a virtual interrupt is ready for injection. Rewind the
             // pending virtual interrupt so it is reinjected as a fixed interrupt.
             VmxExit::TPR_BELOW_THRESHOLD => {
-                self.rewind_interrupt(dev, intercepted_vtl, false);
+                self.rewind_offloaded_interrupt(dev, intercepted_vtl, false);
                 &mut self.backing.exit_stats.tpr_below_threshold
             }
             VmxExit::INTERRUPT_WINDOW => {
-                self.rewind_interrupt(dev, intercepted_vtl, false);
+                self.rewind_offloaded_interrupt(dev, intercepted_vtl, false);
                 &mut self.backing.exit_stats.interrupt_window
             }
             VmxExit::NMI_WINDOW => {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -507,6 +507,29 @@ impl HardwareIsolatedBacking for TdxBacked {
     fn pat(&self, this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64 {
         this.runner.read_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_PAT)
     }
+
+    fn clear_pending_interrupt(this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl) -> Option<u8> {
+        if this.backing.interruption_information.interruption_type() == INTERRUPT_TYPE_EXTERNAL
+            && this.backing.interruption_information.valid()
+        {
+            let vector = this.backing.interruption_information.vector();
+            this.backing.interruption_information = Default::default();
+            Some(vector)
+        } else {
+            None
+        }
+    }
+
+    fn clear_pending_nmi(this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl) -> bool {
+        if this.backing.interruption_information.interruption_type() == INTERRUPT_TYPE_NMI
+            && this.backing.interruption_information.valid()
+        {
+            this.backing.interruption_information = Default::default();
+            true
+        } else {
+            false
+        }
+    }
 }
 
 /// Partition-wide shared data for TDX VPs.

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1388,10 +1388,10 @@ impl UhProcessor<'_, TdxBacked> {
                 self.backing.interruption_information = next_interruption;
                 match next_interruption.interruption_type() {
                     INTERRUPT_TYPE_EXTERNAL => {
-                        self.rewind_offloaded_interrupt(dev, GuestVtl::Vtl0, false);
+                        self.rewind_interrupt(dev, GuestVtl::Vtl0, false);
                     }
                     INTERRUPT_TYPE_NMI => {
-                        self.rewind_offloaded_interrupt(dev, GuestVtl::Vtl0, true);
+                        self.rewind_interrupt(dev, GuestVtl::Vtl0, true);
                     }
                     INTERRUPT_TYPE_HARDWARE_EXCEPTION => {
                         self.backing.exception_error_code = exit_info.idt_vectoring_error_code();
@@ -1745,11 +1745,11 @@ impl UhProcessor<'_, TdxBacked> {
             // that a virtual interrupt is ready for injection. Rewind the
             // pending virtual interrupt so it is reinjected as a fixed interrupt.
             VmxExit::TPR_BELOW_THRESHOLD => {
-                self.rewind_offloaded_interrupt(dev, intercepted_vtl, false);
+                self.rewind_interrupt(dev, intercepted_vtl, false);
                 &mut self.backing.exit_stats.tpr_below_threshold
             }
             VmxExit::INTERRUPT_WINDOW => {
-                self.rewind_offloaded_interrupt(dev, intercepted_vtl, false);
+                self.rewind_interrupt(dev, intercepted_vtl, false);
                 &mut self.backing.exit_stats.interrupt_window
             }
             VmxExit::NMI_WINDOW => {

--- a/vmm_core/virt_support_apic/src/lib.rs
+++ b/vmm_core/virt_support_apic/src/lib.rs
@@ -1070,12 +1070,12 @@ impl<T: ApicClient> LocalApicAccess<'_, T> {
 
     /// Pull offloaded APIC state and rewind the given vector.
     pub fn rewind_offloaded_interrupt(&mut self, vector: u8) {
+        assert!(self.apic.is_offloaded());
         self.ensure_state_local();
         let local_isr_top = self.apic.isr.pop();
         assert_eq!(local_isr_top, Some(vector));
         let (bank, mask) = bank_mask(vector);
         self.apic.irr[bank] |= mask;
-        self.apic.auto_eoi[bank] &= !mask;
         self.apic.recompute_next_irr();
     }
 


### PR DESCRIPTION
Implement full interrupt rewinding, and call it in every location the HCL does. This still needs testing on both SNP and TDX, as I'm not very confident I've got the right bits here.