### PR TITLE
TDX: Support VTL0 IOMMU posted interrupts + interrupt relay

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -361,6 +361,7 @@ mod ioctls {
     const MSHV_VTL_RMPQUERY: u16 = 0x35;
     const MSHV_INVLPGB: u16 = 0x36;
     const MSHV_TLBSYNC: u16 = 0x37;
+    const MSHV_REMAP_GUEST_INTERRUPT: u16 = 0x38;
 
     #[repr(C)]
     #[derive(Copy, Clone)]
@@ -575,7 +576,16 @@ mod ioctls {
         MSHV_IOCTL,
         MSHV_TLBSYNC
     );
+
+    ioctl_readwrite!(
+        /// Remap VTL0 device interrupt in VTL2.
+        hcl_remap_guest_interrupt,
+        MSHV_IOCTL,
+        MSHV_REMAP_GUEST_INTERRUPT,
+        u32
+    );
 }
+
 
 /// The `/dev/mshv_vtl_low` device for accessing VTL0 memory.
 pub struct MshvVtlLow {
@@ -3204,5 +3214,17 @@ impl Hcl {
         unsafe {
             hcl_tlbsync(self.mshv_vtl.file.as_raw_fd()).expect("should always succeed");
         }
+    }
+
+    /// Register a proxy vector for guest device interrupt
+    pub fn proxy_device_irr(&self, vector: u32) -> u32 {
+        let mut vector = vector; // Input VTL0 guest vector, output VTL2 vector
+
+        unsafe {
+            hcl_remap_guest_interrupt(self.mshv_vtl.file.as_raw_fd(), &mut vector)
+                .expect("should always succeed");
+        }
+
+        vector
     }
 }

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -582,7 +582,7 @@ mod ioctls {
         hcl_remap_guest_interrupt,
         MSHV_IOCTL,
         MSHV_REMAP_GUEST_INTERRUPT,
-        u32
+        u8
     );
 }
 
@@ -1481,6 +1481,8 @@ pub struct Hcl {
     isolation: IsolationType,
     snp_register_bitmap: [u8; 64],
     sidecar: Option<SidecarClient>,
+    device_irr_remapped_to_target_vector: [u8; 256],
+    device_irr_target_to_remapped_vector: [u8; 256],
 }
 
 /// The isolation type for a partition.
@@ -1858,6 +1860,36 @@ impl<'a, T: Backing> ProcessorRunner<'a, T> {
                     *r = irr.swap(0, Ordering::Relaxed);
                 }
             }
+
+            // Scan for remapped device interrupts
+            let scan_device_irr =
+                &*(addr_of!((*self.run.as_ptr()).scan_device_irr).cast::<AtomicU8>());                
+            if scan_device_irr.load(Ordering::Relaxed) == 0 {
+                return Some(r);
+            }
+
+            let device_irr = &*(addr_of!((*self.run.as_ptr()).device_irr).cast::<[AtomicU32; 8]>());
+            scan_device_irr.store(0, Ordering::Relaxed);
+            let mut d = [0; 8];
+            for (irr, d) in device_irr.iter().zip(d.iter_mut()) {
+                // In theory we don't need atomic operations, we just need the
+                // swap to happen in a single instruction. This would require
+                // inline assembly.
+                if irr.load(Ordering::Relaxed) != 0 {
+                    *d = irr.swap(0, Ordering::Relaxed);
+                }
+            }
+
+            // Translate to vtl0 selected target vector and write into to r
+            for (i, &value) in d.iter().enumerate() {
+                for bit in 0..32 {
+                    if (value & (1 << bit)) != 0 {
+                        let remapped_vector = i * 32 + bit;
+                        let target_vector = self.hcl.device_irr_remapped_to_target_vector[remapped_vector];
+                        r[(target_vector / 32) as usize] |= 1 << target_vector % 32;
+                    }
+                }
+            }            
             Some(r)
         }
     }
@@ -2182,6 +2214,8 @@ impl Hcl {
         let supports_register_page = supports_register_page && !isolation.is_hardware_isolated();
         let dr6_shared = dr6_shared && !isolation.is_hardware_isolated();
         let snp_register_bitmap = [0u8; 64];
+        let device_irr_remapped_to_target_vector = [0u8; 256];
+        let device_irr_target_to_remapped_vector = [0u8; 256];
 
         Ok(Hcl {
             mshv_hvcall,
@@ -2193,6 +2227,8 @@ impl Hcl {
             isolation,
             snp_register_bitmap,
             sidecar,
+            device_irr_remapped_to_target_vector,
+            device_irr_target_to_remapped_vector,
         })
     }
 
@@ -3216,8 +3252,28 @@ impl Hcl {
         }
     }
 
+    /// Get vtl0 target vector for remapped device interrupt
+    pub fn get_device_irr_map(&self, target_vector: u8) -> Option<u8> {
+        let remaped_vector = self.device_irr_target_to_remapped_vector[target_vector as usize];
+        if remaped_vector == 0 {
+            return None;
+        }
+        Some(remaped_vector)
+    }
+
+    /// Update vtl0 device interrupt map
+    pub fn set_device_irr_map(&self, remapped_vector: u8, target_vector: u8) {
+        // update target(vtl0) to remaped(vtl2) vector mapping
+        let device_irr_remapped_vector = unsafe { &*(addr_of!(self.device_irr_target_to_remapped_vector[target_vector as usize]).cast::<AtomicU8>()) };
+        device_irr_remapped_vector.store(remapped_vector, Ordering::SeqCst);
+
+        // update remapped(vtl2) to target(vtl0) vector mapping
+        let device_irr_target_vector = unsafe { &*(addr_of!(self.device_irr_remapped_to_target_vector[remapped_vector as usize]).cast::<AtomicU8>()) };
+        device_irr_target_vector.store(target_vector, Ordering::SeqCst);
+    }
+
     /// Register a proxy vector for guest device interrupt
-    pub fn proxy_device_irr(&self, vector: u32) -> u32 {
+    pub fn register_new_device_irr(&self, vector: u8) -> u8 {
         let mut vector = vector; // Input VTL0 guest vector, output VTL2 vector
 
         unsafe {

--- a/openhcl/hcl/src/protocol.rs
+++ b/openhcl/hcl/src/protocol.rs
@@ -119,12 +119,14 @@ pub struct hcl_run {
     pub vtl_ret_action_size: u32,
     pub flags: u32,
     pub scan_proxy_irr: u8,
+    pub scan_device_irr: u8,
     pub pad: [u8; 2],
     pub mode: EnterModes,
     pub exit_message: [u8; HV_MESSAGE_SIZE],
     pub context: [u8; 1024],
     pub vtl_ret_actions: [u8; VTL_RETURN_ACTION_SIZE],
     pub proxy_irr: [u32; 8],
+    pub device_irr: [u32; 8],
     pub target_vtl: HvInputVtl,
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -3226,6 +3226,10 @@ impl<T: CpuIo> hv1_hypercall::RetargetDeviceInterrupt for UhHypercallHandler<'_,
         data: u32,
         params: &hv1_hypercall::HvInterruptParameters<'_>,
     ) -> hvdef::HvResult<()> {
+
+        // Register proxy vector for guest device interrupt
+        self.vp.partition.hcl.proxy_device_irr(params.vector);
+
         self.hcvm_retarget_interrupt(
             device_id,
             address,

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -3227,6 +3227,9 @@ impl<T: CpuIo> hv1_hypercall::RetargetDeviceInterrupt for UhHypercallHandler<'_,
         params: &hv1_hypercall::HvInterruptParameters<'_>,
     ) -> hvdef::HvResult<()> {
 
+        // TODO: Concurrent retarget hypercalls for same vector from multiple VPs can introduce a 
+        // race condition for callsto register_new_device_irr(). Do we need to handle this scenario?
+
         // Register proxy vector remapped in vtl2 for the guest device interrupt
         let remapped_vector = self.vp.partition.hcl.get_device_irr_map((params.vector & 0xff) as u8)
             .unwrap_or_else(|| {


### PR DESCRIPTION
Implements [tdx: Implement posted-interrupt support for DDA devices + relaying device interrupts from VTL2 to VTL0 #362](https://github.com/microsoft/openvmm/issues/362) 

(Needs kernel change to support interrupt remap IOCTL. Without that, this will break device interrupt delivery to vtl0)

