### PR TITLE
Cherry-pick: virt_mshv_vtl: flush deferred actions during servicing

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1513,15 +1513,21 @@ mod private {
 
 impl<T> Drop for ProcessorRunner<'_, T> {
     fn drop(&mut self) {
+        self.flush_deferred_actions();
+        let old_state = std::mem::replace(&mut *self.vp.state.lock(), VpState::NotRunning);
+        assert!(matches!(old_state, VpState::Running(thread) if thread == Pthread::current()));
+    }
+}
+
+impl<T> ProcessorRunner<'_, T> {
+    /// Flushes any pending deferred actions. Must be called if preparing the
+    /// partition for save/restore (servicing), since otherwise the deferred
+    /// actions will be lost.
+    pub fn flush_deferred_actions(&mut self) {
         if self.sidecar.is_none() {
-            // Apply any deferred actions now since we may not be returning to lower
-            // VTL for a while (or ever, in the case of servicing).
             let mut deferred_actions = DEFERRED_ACTIONS.with(|state| state.take().unwrap());
             deferred_actions.run_actions(self.hcl);
         }
-
-        let old_state = std::mem::replace(&mut *self.vp.state.lock(), VpState::NotRunning);
-        assert!(matches!(old_state, VpState::Running(thread) if thread == Pthread::current()));
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -723,6 +723,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                 }
             }
         }
+        self.runner.flush_deferred_actions();
         Ok(())
     }
 


### PR DESCRIPTION
Cherry-pick save path fix of lost synic issue.

There may be pending deferred actions (i.e., synic events to signal) on
the VP at time of servicing. Ordinarily, these are flushed the next time
we run the VP, but there is no next time when saving for servicing.
These actions must be flushed to the actual partition state to ensure we
don't drop a signal, which would cause a guest hang.

This fixes a regression from a previous change. Previously, the
`ProcessorRunner` was dropped before a servicing operation, and the
`Drop` implementation would flush deferred actions. Now, the runner
never gets dropped until the partition is torn down. Add a path to
explicitly flush deferred actions before saving.