### PR TITLE
ucs2: remove optional mesh derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6529,7 +6529,6 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 name = "ucs2"
 version = "0.0.0"
 dependencies = [
- "mesh_protobuf",
  "thiserror 2.0.0",
 ]
 

--- a/support/ucs2/Cargo.toml
+++ b/support/ucs2/Cargo.toml
@@ -6,12 +6,7 @@ name = "ucs2"
 edition = "2021"
 rust-version.workspace = true
 
-[features]
-mesh = ["mesh_protobuf"]
-
 [dependencies]
-mesh_protobuf = { workspace = true, optional = true }
-
 thiserror.workspace = true
 
 [lints]

--- a/support/ucs2/src/lib.rs
+++ b/support/ucs2/src/lib.rs
@@ -34,7 +34,6 @@ pub enum Ucs2ParseError {
 /// `unsafe` code to impl `Deref<Target = Ucs2LeSlice>` by reinterpretting the
 /// `Vec<u16>` as a `&[u8]`, so there wouldn't be any major ergonomic hit.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "mesh", derive(mesh_protobuf::Protobuf))]
 pub struct Ucs2LeVec(Vec<u8>);
 
 impl Ucs2LeVec {

--- a/vm/devices/firmware/firmware_uefi/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/Cargo.toml
@@ -38,7 +38,7 @@ local_clock.workspace = true
 mesh.workspace = true
 open_enum.workspace = true
 pal_async.workspace = true
-ucs2 = { workspace = true, features = ["mesh"] }
+ucs2.workspace = true
 
 async-trait.workspace = true
 bitfield-struct.workspace = true


### PR DESCRIPTION
No one actually relies on this, and the mesh encoding for it is kind of sus.