### PR TITLE
mesh_protobuf: support building with no_std

### DIFF
--- a/support/mesh/mesh_channel/Cargo.toml
+++ b/support/mesh/mesh_channel/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 mesh_node.workspace = true
-mesh_protobuf.workspace = true
+mesh_protobuf = { workspace = true, features = ["std"] }
 
 futures-core.workspace = true
 futures-io.workspace = true

--- a/support/mesh/mesh_protobuf/Cargo.toml
+++ b/support/mesh/mesh_protobuf/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 default = []
 prost = ["dep:prost", "dep:prost-types", "dep:prost-build"]
 socket2 = ["dep:socket2"]
+std = []
 
 [dependencies]
 mesh_derive.workspace = true

--- a/support/mesh/mesh_protobuf/src/buffer.rs
+++ b/support/mesh/mesh_protobuf/src/buffer.rs
@@ -6,7 +6,8 @@
 //! This is different from `bytes::BufMut` in that the buffer is required to be
 //! contiguous, which allows for more efficient use with type erasure.
 
-use std::mem::MaybeUninit;
+use alloc::vec::Vec;
+use core::mem::MaybeUninit;
 
 /// Models a partially written, contiguous byte buffer.
 pub trait Buffer {
@@ -66,11 +67,12 @@ impl Buffer for Buf<'_> {
     }
 }
 
+#[cfg(feature = "std")]
 impl Buffer for std::io::Cursor<&mut [u8]> {
     unsafe fn unwritten(&mut self) -> &mut [MaybeUninit<u8>] {
         let slice = self.get_mut();
         // SAFETY: the caller promises not to uninitialize any initialized data.
-        unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), slice.len()) }
+        unsafe { core::slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), slice.len()) }
     }
 
     unsafe fn extend_written(&mut self, len: usize) {
@@ -187,6 +189,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::write_with;
+    use alloc::vec;
 
     #[test]
     #[should_panic]

--- a/support/mesh/mesh_protobuf/src/encode_with.rs
+++ b/support/mesh/mesh_protobuf/src/encode_with.rs
@@ -16,8 +16,8 @@ use super::MessageEncode;
 use super::Result;
 use crate::inplace;
 use crate::Downcast;
-use std::ops::Deref;
-use std::ops::DerefMut;
+use core::ops::Deref;
+use core::ops::DerefMut;
 
 /// Wrapper type to easily support custom mesh encoding.
 ///
@@ -72,7 +72,7 @@ impl<T, U: From<T>> EncodeAs<T, U> {
     }
 
     fn encode(&mut self) -> &mut U {
-        match std::mem::replace(&mut self.0, Inner::Invalid) {
+        match core::mem::replace(&mut self.0, Inner::Invalid) {
             Inner::Unencoded(t) => {
                 self.0 = Inner::Encoded(t.into());
             }

--- a/support/mesh/mesh_protobuf/src/message.rs
+++ b/support/mesh/mesh_protobuf/src/message.rs
@@ -20,6 +20,9 @@ use crate::Error;
 use crate::MessageDecode;
 use crate::MessageEncode;
 use crate::Protobuf;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 use thiserror::Error;
 
 /// An opaque protobuf message.
@@ -130,10 +133,13 @@ impl ProtobufAny {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use crate::encode;
     use crate::message::ProtobufAny;
     use crate::message::ProtobufMessage;
     use crate::Protobuf;
+    use std::println;
 
     #[test]
     fn test_message() {

--- a/support/mesh/mesh_protobuf/src/prost.rs
+++ b/support/mesh/mesh_protobuf/src/prost.rs
@@ -9,6 +9,7 @@ use super::MessageDecode;
 use super::MessageEncode;
 use super::Result;
 use crate::Error;
+use alloc::vec::Vec;
 
 /// Encoding for using Prost messages as Mesh messages.
 pub struct ProstMessage;
@@ -44,6 +45,7 @@ impl<T: prost::Message + Default, R> MessageDecode<'_, T, R> for ProstMessage {
 #[cfg(test)]
 mod tests {
     use crate::SerializedMessage;
+    use alloc::string::ToString;
 
     mod items {
         // Crates used by generated code. Reference them explicitly to ensure that

--- a/support/mesh/mesh_protobuf/src/protobuf.rs
+++ b/support/mesh/mesh_protobuf/src/protobuf.rs
@@ -13,8 +13,10 @@ use super::MessageEncode;
 use super::RefCell;
 use super::Result;
 use crate::DefaultEncoding;
-use std::marker::PhantomData;
-use std::ops::Range;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use core::ops::Range;
 
 /// Writes a variable-length integer, as defined in the protobuf specification.
 fn write_varint(v: &mut Buf<'_>, mut n: u64) {
@@ -116,7 +118,7 @@ impl<'a, R> DecodeState<'a, R> {
 
 struct EncodeState<'a, R> {
     data: Buf<'a>,
-    message_sizes: std::slice::Iter<'a, MessageSize>,
+    message_sizes: core::slice::Iter<'a, MessageSize>,
     resources: &'a mut Vec<R>,
     field_number: u32,
     in_sequence: bool,
@@ -366,7 +368,7 @@ impl<'a> FieldSizer<'a> {
         let index = self.state.message_sizes.len();
         self.state.message_sizes.push(MessageSize::default());
         PreviousSizeParams {
-            index: std::mem::replace(&mut self.state.index, index) as u32,
+            index: core::mem::replace(&mut self.state.index, index) as u32,
             tag_size: self.state.tag_size,
             in_sequence: self.state.in_sequence,
         }
@@ -374,7 +376,7 @@ impl<'a> FieldSizer<'a> {
 
     fn set_cached_message_size(&mut self, prev: PreviousSizeParams) {
         let size = self.state.message_sizes[self.state.index];
-        let index = std::mem::replace(&mut self.state.index, prev.index as usize);
+        let index = core::mem::replace(&mut self.state.index, prev.index as usize);
         let parent_size = &mut self.state.message_sizes[self.state.index];
         let mut len = varint_size(size.len as u64) + size.len;
         if size.num_resources > 0 {
@@ -831,7 +833,7 @@ pub struct PackedReader<'a> {
 impl<'a> PackedReader<'a> {
     /// Reads the remaining bytes.
     pub fn bytes(&mut self) -> &'a [u8] {
-        std::mem::take(&mut self.data)
+        core::mem::take(&mut self.data)
     }
 
     /// Reads a varint.
@@ -970,8 +972,11 @@ pub fn decode_with<'a, E: MessageDecode<'a, T, R>, T, R>(
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use super::*;
     use crate::buffer;
+    use std::eprintln;
 
     #[test]
     fn test_zigzag() {

--- a/support/mesh/mesh_protobuf/src/protofile/mod.rs
+++ b/support/mesh/mesh_protobuf/src/protofile/mod.rs
@@ -7,10 +7,11 @@
 
 mod writer;
 
+#[cfg(feature = "std")]
 pub use writer::DescriptorWriter;
 
 use crate::DefaultEncoding;
-use std::fmt::Display;
+use core::fmt::Display;
 
 /// A trait for a self-describing protobuf message field.
 pub trait DescribeField<T> {
@@ -66,7 +67,7 @@ impl TypeUrl<'_> {
 }
 
 impl Display for TypeUrl<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "type.googleapis.com/{}.{}", self.package, self.name)
     }
 }

--- a/support/mesh/mesh_protobuf/src/protofile/writer.rs
+++ b/support/mesh/mesh_protobuf/src/protofile/writer.rs
@@ -3,6 +3,8 @@
 
 //! Code to write .proto files from descriptors.
 
+#![cfg(feature = "std")]
+
 use super::FieldDescriptor;
 use super::FieldType;
 use super::MessageDescriptor;
@@ -11,8 +13,12 @@ use super::TopLevelDescriptor;
 use crate::protofile::FieldKind;
 use crate::protofile::MessageDescription;
 use crate::protofile::SequenceType;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
 use heck::ToUpperCamelCase;
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::io;
 use std::io::Write;
@@ -470,9 +476,12 @@ mod tests {
     use super::DescriptorWriter;
     use crate::protofile::message_description;
     use crate::Protobuf;
-    use std::cell::RefCell;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+    use core::cell::RefCell;
     use std::collections::HashMap;
     use std::io::Write;
+    use std::println;
 
     /// Comment on this guy.
     #[derive(Protobuf)]

--- a/support/mesh/mesh_protobuf/src/table/decode.rs
+++ b/support/mesh/mesh_protobuf/src/table/decode.rs
@@ -11,9 +11,10 @@ use crate::protobuf::MessageReader;
 use crate::Error;
 use crate::FieldDecode;
 use crate::MessageDecode;
+use alloc::slice;
+use alloc::vec;
 use core::marker::PhantomData;
-use std::mem::MaybeUninit;
-use std::slice;
+use core::mem::MaybeUninit;
 
 /// Calls `f` on `item`, splitting the pointer and initialized flag out.
 ///
@@ -404,12 +405,12 @@ impl<'a, T, R> DecoderEntry<'a, T, R> {
     pub(crate) const fn custom<E: FieldDecode<'a, T, R>>() -> Self {
         Self(
             ErasedDecoderEntry(
-                std::ptr::from_ref(
+                core::ptr::from_ref(
                     const {
                         &StaticDecoderVtable {
                             read_fn: read_field_dyn::<T, R, E>,
                             default_fn: default_field_dyn::<T, R, E>,
-                            drop_fn: if std::mem::needs_drop::<T>() {
+                            drop_fn: if core::mem::needs_drop::<T>() {
                                 Some(drop_field_dyn::<T>)
                             } else {
                                 None
@@ -429,7 +430,7 @@ impl<'a, T, R> DecoderEntry<'a, T, R> {
     {
         Self(
             ErasedDecoderEntry(
-                std::ptr::from_ref(
+                core::ptr::from_ref(
                     const {
                         &DecoderTable {
                             count: T::NUMBERS.len(),

--- a/support/mesh/mesh_protobuf/src/table/encode.rs
+++ b/support/mesh/mesh_protobuf/src/table/encode.rs
@@ -11,9 +11,9 @@ use crate::protobuf::MessageSizer;
 use crate::protobuf::MessageWriter;
 use crate::FieldEncode;
 use crate::MessageEncode;
+use alloc::slice;
 use core::marker::PhantomData;
-use std::mem::MaybeUninit;
-use std::slice;
+use core::mem::MaybeUninit;
 
 impl<T, R> MessageEncode<T, R> for TableEncoder
 where
@@ -42,7 +42,7 @@ where
                 T::NUMBERS,
                 T::ENCODERS,
                 T::OFFSETS,
-                std::ptr::from_mut(item).cast::<u8>(),
+                core::ptr::from_mut(item).cast::<u8>(),
                 sizer,
             );
         }
@@ -80,7 +80,7 @@ where
                 T::NUMBERS,
                 T::ENCODERS,
                 T::OFFSETS,
-                std::ptr::from_mut(item).cast::<u8>(),
+                core::ptr::from_mut(item).cast::<u8>(),
                 sizer,
             );
         }
@@ -367,7 +367,7 @@ impl<T, R> EncoderEntry<T, R> {
     pub(crate) const fn custom<E: FieldEncode<T, R>>() -> Self {
         Self(
             ErasedEncoderEntry(
-                std::ptr::from_ref(
+                core::ptr::from_ref(
                     const {
                         &StaticEncoderVtable {
                             write_fn: write_field_dyn::<T, R, E>,
@@ -388,7 +388,7 @@ impl<T, R> EncoderEntry<T, R> {
     {
         Self(
             ErasedEncoderEntry(
-                std::ptr::from_ref(
+                core::ptr::from_ref(
                     const {
                         &EncoderTable {
                             count: T::NUMBERS.len(),


### PR DESCRIPTION
Support encoding/decoding protobuf messages from `no_std` environments.

We don't have an immediate use case for this, but there is some talk of using this within the boot loader (which would need a global allocator).