### PR TITLE
hypestv: add force flag to `kill` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -6155,6 +6156,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/hyperv/tools/hypestv/Cargo.toml
+++ b/hyperv/tools/hypestv/Cargo.toml
@@ -16,7 +16,7 @@ mesh.workspace = true
 pal_async.workspace = true
 
 anyhow.workspace = true
-clap.workspace = true
+clap = { workspace = true, features = ["wrap_help"] }
 dirs.workspace = true
 futures.workspace = true
 futures-concurrency.workspace = true

--- a/hyperv/tools/hypestv/src/windows/hyperv.rs
+++ b/hyperv/tools/hypestv/src/windows/hyperv.rs
@@ -5,6 +5,19 @@
 
 use anyhow::Context as _;
 
+/// Runs hcsdiag with the given arguments.
+pub fn run_hcsdiag(
+    f: impl FnOnce(&mut std::process::Command) -> &mut std::process::Command,
+) -> anyhow::Result<()> {
+    let mut cmd = std::process::Command::new("hcsdiag.exe");
+    f(&mut cmd);
+    let status = cmd.status().context("failed to launch hcsdiag")?;
+    if !status.success() {
+        anyhow::bail!("hcsdiag failed with exit code: {}", status);
+    }
+    Ok(())
+}
+
 /// Runs hvc with the given arguments.
 pub fn run_hvc(
     f: impl FnOnce(&mut std::process::Command) -> &mut std::process::Command,

--- a/hyperv/tools/hypestv/src/windows/mod.rs
+++ b/hyperv/tools/hypestv/src/windows/mod.rs
@@ -29,6 +29,7 @@ use vm::Vm;
     disable_help_flag = true,
     disable_version_flag = true,
     no_binary_name = true,
+    max_term_width = 100,
     help_template("{subcommands}")
 )]
 pub(crate) enum InteractiveCommand {
@@ -62,7 +63,15 @@ pub(crate) enum VmCommand {
     },
 
     /// Power off the VM.
-    Kill,
+    Kill {
+        /// Force powering off the VM via the HCS API.
+        ///
+        /// Without this flag, this command uses the Hyper-V WMI interface.
+        /// This may fail if the VM is in a transition state that prevents
+        /// powering off for whatever reason (usually due to Hyper-V bugs).
+        #[clap(short, long)]
+        force: bool,
+    },
 
     /// Reset the VM.
     Reset,

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -4,6 +4,7 @@
 //! VM command handling.
 
 use super::hyperv::hvc_output;
+use super::hyperv::run_hcsdiag;
 use super::hyperv::run_hvc;
 use super::rustyline_printer::Printer;
 use super::InspectTarget;
@@ -111,8 +112,12 @@ impl Vm {
                     })
                 }
             }
-            VmCommand::Kill => self.delay(move |inner| {
-                run_hvc(|cmd| cmd.arg("kill").arg(&inner.name))?;
+            VmCommand::Kill { force } => self.delay(move |inner| {
+                if force {
+                    run_hcsdiag(|cmd| cmd.arg("kill").arg(inner.id.to_string()))?;
+                } else {
+                    run_hvc(|cmd| cmd.arg("kill").arg(&inner.name))?;
+                }
                 writeln!(inner.printer.out(), "VM killed")?;
                 Ok(())
             }),


### PR DESCRIPTION
Normally, `kill` will power off the VM using `hvc.exe`, which uses the VMMS WMI API internally. In some cases, the VMMS thinks the VM is not in a state where it can be powered off even though it can be, e.g. if there is a pending shutdown request.

Add a `force` flag that uses the HCS API instead (via `hcsdiag.exe`), which skips the VMMS state machine evaluation and just stops the worker process.