### PR TITLE
Don't run CI for draft PRs

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -11,9 +11,6 @@ on:
         default: false
         required: false
         type: boolean
-  pull_request_target:
-    types:
-    - ready_for_review
   push:
     branches:
     - main

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -11,6 +11,9 @@ on:
         default: false
         required: false
         type: boolean
+  pull_request_target:
+    types:
+    - ready_for_review
   push:
     branches:
     - main

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -212,7 +212,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -415,7 +415,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -776,7 +776,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -1200,7 +1200,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -1615,7 +1615,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2202,7 +2202,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2527,7 +2527,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2900,7 +2900,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -3271,7 +3271,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -3558,7 +3558,7 @@ jobs:
     - job9
     - job9
     - job9
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -3917,7 +3917,7 @@ jobs:
     - job9
     - job9
     - job9
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -4269,7 +4269,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -4492,7 +4492,7 @@ jobs:
     - job11
     - job9
     - job11
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -4852,7 +4852,7 @@ jobs:
     - job7
     - job7
     - job7
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -5204,7 +5204,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5337,7 +5337,7 @@ jobs:
     - job1
     - job2
     - job0
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -5415,7 +5415,7 @@ jobs:
       id-token: write
     needs:
     - job5
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5605,7 +5605,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5806,7 +5806,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6106,7 +6106,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6401,7 +6401,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6704,7 +6704,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -211,6 +212,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -413,6 +415,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -773,6 +776,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -1196,6 +1200,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -1610,6 +1615,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2196,6 +2202,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2520,6 +2527,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2892,6 +2900,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -3262,6 +3271,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -3548,6 +3558,7 @@ jobs:
     - job9
     - job9
     - job9
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -3906,6 +3917,7 @@ jobs:
     - job9
     - job9
     - job9
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -4257,6 +4269,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -4479,6 +4492,7 @@ jobs:
     - job11
     - job9
     - job11
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -4838,6 +4852,7 @@ jobs:
     - job7
     - job7
     - job7
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -5189,6 +5204,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5321,6 +5337,7 @@ jobs:
     - job1
     - job2
     - job0
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -5398,6 +5415,7 @@ jobs:
       id-token: write
     needs:
     - job5
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5587,6 +5605,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5787,6 +5806,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6086,6 +6106,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6380,6 +6401,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6682,6 +6704,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -15,8 +15,10 @@ on:
     branches:
     - main
     - release/*
-  pull_request_target:
     types:
+    - opened
+    - synchronize
+    - reopened
     - ready_for_review
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -214,6 +215,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -416,6 +418,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -839,6 +842,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -1253,6 +1257,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -1839,6 +1844,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2163,6 +2169,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2535,6 +2542,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2905,6 +2913,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -3191,6 +3200,7 @@ jobs:
     - job8
     - job8
     - job8
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -3549,6 +3559,7 @@ jobs:
     - job8
     - job8
     - job8
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -3906,6 +3917,7 @@ jobs:
     - job10
     - job8
     - job10
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -4257,6 +4269,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -4473,6 +4486,7 @@ jobs:
     - job6
     - job6
     - job6
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -4824,6 +4838,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -4974,7 +4989,7 @@ jobs:
     - job2
     - job1
     - job0
-    if: ${{ always() }}
+    if: ${{ !github.event.pull_request.draft }}
     env:
       ANY_JOBS_FAILED: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:
@@ -5012,6 +5027,7 @@ jobs:
       id-token: write
     needs:
     - job4
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5201,6 +5217,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5401,6 +5418,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5700,6 +5718,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5994,6 +6013,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6296,6 +6316,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6591,6 +6612,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -4989,7 +4989,7 @@ jobs:
     - job2
     - job1
     - job0
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ always() }}
     env:
       ANY_JOBS_FAILED: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -15,6 +15,9 @@ on:
     branches:
     - main
     - release/*
+  pull_request_target:
+    types:
+    - ready_for_review
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -215,7 +215,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -418,7 +418,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -842,7 +842,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -1257,7 +1257,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -1844,7 +1844,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2169,7 +2169,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2542,7 +2542,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -2913,7 +2913,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -3200,7 +3200,7 @@ jobs:
     - job8
     - job8
     - job8
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -3559,7 +3559,7 @@ jobs:
     - job8
     - job8
     - job8
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -3917,7 +3917,7 @@ jobs:
     - job10
     - job8
     - job10
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -4269,7 +4269,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -4486,7 +4486,7 @@ jobs:
     - job6
     - job6
     - job6
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - name: 🌼🥾 Download bootstrapped flowey
       uses: actions/download-artifact@v4
@@ -4838,7 +4838,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -4989,7 +4989,7 @@ jobs:
     - job2
     - job1
     - job0
-    if: ${{ always() }}
+    if: always() && github.event.pull_request.draft == false
     env:
       ANY_JOBS_FAILED: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:
@@ -5027,7 +5027,7 @@ jobs:
       id-token: write
     needs:
     - job4
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5217,7 +5217,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5418,7 +5418,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -5718,7 +5718,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6013,7 +6013,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6316,7 +6316,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey
@@ -6612,7 +6612,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.event.pull_request.draft == false
     steps:
     - run: echo "injected!"
       name: 🌼🥾 Bootstrap flowey

--- a/.github/workflows/unsafe-reviewers.yml
+++ b/.github/workflows/unsafe-reviewers.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   UnsafeReview:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged != true && github.event.action != 'closed' && github.event.pull_request.draft == false
+    if: github.event.pull_request.merged != true && github.event.action != 'closed'
     steps:
       - name: Checkout actions
         uses: actions/checkout@v4

--- a/.github/workflows/unsafe-reviewers.yml
+++ b/.github/workflows/unsafe-reviewers.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   UnsafeReview:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged != true && github.event.action != 'closed'
+    if: github.event.pull_request.merged != true && github.event.action != 'closed' && github.event.pull_request.draft == false
     steps:
       - name: Checkout actions
         uses: actions/checkout@v4

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/github_yaml_defs.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/github_yaml_defs.rs
@@ -70,11 +70,6 @@ pub struct PrTrigger {
     pub branches: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub branches_ignore: Vec<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct PrTarget {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub types: Vec<String>,
 }
@@ -113,8 +108,6 @@ pub struct Triggers {
     pub workflow_dispatch: Option<WorkflowDispatch>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pull_request: Option<PrTrigger>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pull_request_target: Option<PrTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub push: Option<CiTrigger>,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/github_yaml_defs.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/github_yaml_defs.rs
@@ -74,6 +74,13 @@ pub struct PrTrigger {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+pub struct PrTarget {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub types: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct CiTrigger {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub branches: Vec<String>,
@@ -106,6 +113,8 @@ pub struct Triggers {
     pub workflow_dispatch: Option<WorkflowDispatch>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pull_request: Option<PrTrigger>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pull_request_target: Option<PrTarget>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub push: Option<CiTrigger>,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -641,13 +641,11 @@ EOF
                 Some(github_yaml_defs::PrTrigger {
                     branches: gh_pr_triggers.branches.clone(),
                     branches_ignore: gh_pr_triggers.exclude_branches.clone(),
+                    types: gh_pr_triggers.types.clone(),
                 })
             }
             None => None,
         },
-        pull_request_target: Some(github_yaml_defs::PrTarget {
-            types: vec!["ready_for_review".to_string()],
-        }),
         push: match gh_ci_triggers {
             Some(gh_ci_triggers) => Some(github_yaml_defs::CiTrigger {
                 branches: gh_ci_triggers.branches,

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -570,7 +570,9 @@ EOF
                         })
                         .collect()
                 },
-                r#if: Some("${{ !github.event.pull_request.draft }}".to_string()),
+                r#if: gh_override_if
+                    .clone()
+                    .or_else(|| Some("${{ !github.event.pull_request.draft }}".to_string())),
                 env: gh_global_env.clone(),
                 steps: gh_steps,
             },

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -570,9 +570,10 @@ EOF
                         })
                         .collect()
                 },
-                r#if: gh_override_if
-                    .clone()
-                    .or_else(|| Some("${{ !github.event.pull_request.draft }}".to_string())),
+                r#if: Some(gh_override_if.clone().map_or_else(
+                    || "github.event.pull_request.draft == false".to_string(),
+                    |original| format!("{} && github.event.pull_request.draft == false", original),
+                )),
                 env: gh_global_env.clone(),
                 steps: gh_steps,
             },

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -570,10 +570,9 @@ EOF
                         })
                         .collect()
                 },
-                r#if: Some(gh_override_if.clone().map_or_else(
-                    || "github.event.pull_request.draft == false".to_string(),
-                    |original| format!("{} && github.event.pull_request.draft == false", original),
-                )),
+                r#if: gh_override_if
+                    .clone()
+                    .or_else(|| Some("github.event.pull_request.draft == false".to_string())),
                 env: gh_global_env.clone(),
                 steps: gh_steps,
             },

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -645,6 +645,9 @@ EOF
             }
             None => None,
         },
+        pull_request_target: Some(github_yaml_defs::PrTarget {
+            types: vec!["ready_for_review".to_string()],
+        }),
         push: match gh_ci_triggers {
             Some(gh_ci_triggers) => Some(github_yaml_defs::CiTrigger {
                 branches: gh_ci_triggers.branches,

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -570,7 +570,7 @@ EOF
                         })
                         .collect()
                 },
-                r#if: gh_override_if.clone(),
+                r#if: Some("${{ !github.event.pull_request.draft }}".to_string()),
                 env: gh_global_env.clone(),
                 steps: gh_steps,
             },

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -226,6 +226,8 @@ pub struct GhPrTriggers {
     /// Automatically cancel the pipeline run if a new commit lands in the
     /// branch. Defaults to `true`.
     pub auto_cancel: bool,
+    /// Run the pipeline whenever the PR trigger matches the specified types
+    pub types: Vec<String>,
 }
 
 /// Trigger Github Actions pipelines per PR
@@ -250,6 +252,12 @@ impl Default for GhPrTriggers {
         Self {
             branches: Vec::new(),
             exclude_branches: Vec::new(),
+            types: vec![
+                "opened".into(),
+                "synchronize".into(),
+                "reopened".into(),
+                "ready_for_review".into(),
+            ],
             run_on_draft: false,
             auto_cancel: true,
         }

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -221,8 +221,6 @@ pub struct GhPrTriggers {
     /// Specify any branches which should be filtered out from the list of
     /// `branches` (supports glob syntax)
     pub exclude_branches: Vec<String>,
-    /// Run the pipeline even if the PR is a draft PR. Defaults to `false`.
-    pub run_on_draft: bool,
     /// Automatically cancel the pipeline run if a new commit lands in the
     /// branch. Defaults to `true`.
     pub auto_cancel: bool,
@@ -247,8 +245,9 @@ pub struct GhCiTriggers {
     pub exclude_tags: Vec<String>,
 }
 
-impl Default for GhPrTriggers {
-    fn default() -> Self {
+impl GhPrTriggers {
+    /// Triggers the pipeline on the default PR events plus when a draft is marked as ready for review.
+    pub fn new_draftable() -> Self {
         Self {
             branches: Vec::new(),
             exclude_branches: Vec::new(),
@@ -258,7 +257,6 @@ impl Default for GhPrTriggers {
                 "reopened".into(),
                 "ready_for_review".into(),
             ],
-            run_on_draft: false,
             auto_cancel: true,
         }
     }

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1028,7 +1028,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 ))
                 // always run this job, regardless whether or not any previous jobs failed
-                .gh_dangerous_override_if("always()")
+                .gh_dangerous_override_if("always() && github.event.pull_request.draft == false")
                 .gh_dangerous_global_env_var("ANY_JOBS_FAILED", "${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}")
                 .dep_on(|ctx| flowey_lib_hvlite::_jobs::all_good_job::Params {
                     did_fail_env_var: "ANY_JOBS_FAILED".into(),

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -77,7 +77,7 @@ impl IntoPipeline for CheckinGatesCli {
                     pipeline
                         .gh_set_pr_triggers(GhPrTriggers {
                             branches,
-                            ..Default::default()
+                            ..GhPrTriggers::new_draftable()
                         })
                         .gh_set_name("[flowey] OpenVMM PR");
                 }

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1028,7 +1028,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
                 ))
                 // always run this job, regardless whether or not any previous jobs failed
-                .gh_dangerous_override_if("${{ always() }}")
+                .gh_dangerous_override_if("always()")
                 .gh_dangerous_global_env_var("ANY_JOBS_FAILED", "${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}")
                 .dep_on(|ctx| flowey_lib_hvlite::_jobs::all_good_job::Params {
                     did_fail_env_var: "ANY_JOBS_FAILED".into(),


### PR DESCRIPTION
This changes our CI to not run on draft pull requests and marks CI as "skipped." When the PR is marked as ready for review CI should run. 

To do so, we add an `if` conditional to every job that checks for draft status. In addition, if an override exists (currently only one job uses the override), we'll concatenate the conditionals. The brackets in the conditional have been removed as they're unnecessary ([github actions automatically treat if blocks as being enclosed in brackets](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idif)) which makes the concatenation much easier.