### PR TITLE
Convert allow to expect

### DIFF
--- a/Guide/src/dev_guide/contrib/code.md
+++ b/Guide/src/dev_guide/contrib/code.md
@@ -142,17 +142,16 @@ project, and will fast-fail if it catches any warnings / errors.
 ### Suppressing Lints
 
 In general, lints should be fixed by modifying the code to satisfy the lint.
-However, there are cases where a lint may need to be `allow`'d inline.
+However, there are cases where a lint may need to be `expect`'d inline.
 
-In these cases, you _must_ provide a inline comment providing reasonable
+In these cases, you _must_ provide a reason providing
 justification for the suppressed lint.
 
 e.g:
 
 ```rust
-// x86_64-unknown-linux-musl targets have a different type defn for
-// `libc::cmsghdr`, hence why these lints are being suppressed.
-#[allow(clippy::needless_update, clippy::useless_conversion)]
+#[expect(clippy::needless_update, clippy::useless_conversion,
+reason = "x86_64-unknown-linux-musl targets have a different type defn for `libc::cmsghdr`")]
 libc::cmsghdr {
     cmsg_level: libc::SOL_SOCKET,
     cmsg_type: libc::SCM_RIGHTS,

--- a/Guide/src/dev_guide/contrib/code.md
+++ b/Guide/src/dev_guide/contrib/code.md
@@ -150,8 +150,11 @@ justification for the suppressed lint.
 e.g:
 
 ```rust
-#[expect(clippy::needless_update, clippy::useless_conversion,
-reason = "x86_64-unknown-linux-musl targets have a different type defn for `libc::cmsghdr`")]
+#[expect(
+    clippy::needless_update,
+    clippy::useless_conversion,
+    reason = "x86_64-unknown-linux-musl targets have a different type defn for `libc::cmsghdr`"
+)]
 libc::cmsghdr {
     cmsg_level: libc::SOL_SOCKET,
     cmsg_type: libc::SCM_RIGHTS,

--- a/flowey/flowey_cli/src/cli/exec_snippet.rs
+++ b/flowey/flowey_cli/src/cli/exec_snippet.rs
@@ -370,7 +370,7 @@ pub(crate) mod serialized_request {
     use serde::Deserializer;
     use serde::Serializer;
 
-    #[allow(clippy::borrowed_box)] // required by serde
+    #[expect(clippy::borrowed_box, reason = "Required by serde")]
     pub fn serialize<S: Serializer>(v: &Box<[u8]>, ser: S) -> Result<S::Ok, S::Error> {
         ser.serialize_str(
             &serde_json::to_string(&serde_json::from_slice::<serde_json::Value>(v).unwrap())

--- a/flowey/flowey_cli/src/cli/exec_snippet.rs
+++ b/flowey/flowey_cli/src/cli/exec_snippet.rs
@@ -370,7 +370,7 @@ pub(crate) mod serialized_request {
     use serde::Deserializer;
     use serde::Serializer;
 
-    #[expect(clippy::borrowed_box, reason = "Required by serde")]
+    #[expect(clippy::borrowed_box, reason = "required by serde")]
     pub fn serialize<S: Serializer>(v: &Box<[u8]>, ser: S) -> Result<S::Ok, S::Error> {
         ser.serialize_str(
             &serde_json::to_string(&serde_json::from_slice::<serde_json::Value>(v).unwrap())

--- a/flowey/flowey_cli/src/cli/pipeline.rs
+++ b/flowey/flowey_cli/src/cli/pipeline.rs
@@ -143,7 +143,7 @@ pub struct Pipeline<P: clap::Subcommand> {
     /// today may not work after making changes to the pipeline definition /
     /// updating flowey.
     #[clap(help_heading = "Global Options (flowey)", global = true, long)]
-    #[allow(clippy::option_option)] // for clap derive
+    #[expect(clippy::option_option, reason = "For clap derive")]
     include_jobs: Option<Option<IncludeJobs>>,
 
     #[clap(subcommand)]
@@ -370,7 +370,7 @@ enum EarlyExit {
     No,
 }
 
-#[allow(clippy::option_option)] // for clap derive
+#[expect(clippy::option_option, reason = "For clap derive")]
 fn resolve_include_jobs(
     resolved_pipeline: &mut crate::pipeline_resolver::generic::ResolvedPipeline,
     include_jobs: Option<Option<IncludeJobs>>,

--- a/flowey/flowey_cli/src/flow_resolver/stage1_dag.rs
+++ b/flowey/flowey_cli/src/flow_resolver/stage1_dag.rs
@@ -719,7 +719,7 @@ impl flowey_core::node::NodeCtxBackend for EmitFlowCtx<'_> {
             step: Step::Rust {
                 idx: self.step_idx_tracker,
                 label: label.into(),
-                #[allow(clippy::arc_with_non_send_sync)]
+                #[expect(clippy::arc_with_non_send_sync)]
                 code: Arc::new(Mutex::new(Some(code))),
             },
         });
@@ -763,7 +763,7 @@ impl flowey_core::node::NodeCtxBackend for EmitFlowCtx<'_> {
                 label: label.into(),
                 raw_yaml,
                 code_idx: self.step_idx_tracker,
-                #[allow(clippy::arc_with_non_send_sync)]
+                #[expect(clippy::arc_with_non_send_sync)]
                 code: Arc::new(Mutex::new(code)),
                 ado_to_rust,
                 rust_to_ado,

--- a/flowey/flowey_hvlite/src/pipelines/mod.rs
+++ b/flowey/flowey_hvlite/src/pipelines/mod.rs
@@ -10,7 +10,7 @@ pub mod custom_vmfirmwareigvm_dll;
 pub mod restore_packages;
 
 #[derive(clap::Subcommand)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum OpenvmmPipelines {
     /// Alias for root-level `regen` command.
     // DEVNOTE: this enables the useful `cargo xflowey regen` alias

--- a/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs
@@ -340,7 +340,7 @@ Otherwise, press `ctrl-c` to cancel the run.
     }
 }
 
-#[allow(unused)]
+#[expect(unused)]
 enum AzCopyAuthMethod {
     /// Pull credentials from the Azure CLI instance running the command.
     AzureCli,

--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -61,7 +61,7 @@ impl BuildInfo {
 // to use.
 
 // UNSAFETY: link_section and export_name are considered unsafe.
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 #[unsafe(link_section = ".build_info")]
 #[unsafe(export_name = "BUILD_INFO")]
 static BUILD_INFO: BuildInfo = BuildInfo::new();

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -109,7 +109,7 @@ impl MshvVtl {
             return Ok(());
         }
 
-        #[allow(clippy::undocumented_unsafe_blocks)] // TODO SNP
+        #[expect(clippy::undocumented_unsafe_blocks, reason = "TODO")] // TODO SNP
         let ret = unsafe {
             hcl_rmpadjust_pages(
                 self.file.as_raw_fd(),

--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -480,7 +480,7 @@ impl<
                             error,
                         })?;
 
-                        #[allow(clippy::single_match)]
+                        #[expect(clippy::single_match)]
                         match openhcl_child.name {
                             "entropy" => {
                                 let host_entropy = openhcl_child

--- a/openhcl/minimal_rt/src/reloc.rs
+++ b/openhcl/minimal_rt/src/reloc.rs
@@ -18,7 +18,7 @@ macro_rules! panic_no_relocs {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(u64)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum ElfDynTag {
     Null = 0,
     RelA = 7,

--- a/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
@@ -19,7 +19,7 @@ pub enum AcceptGpaStatus {
     Retry,
 }
 
-#[allow(dead_code)] // Printed via Debug in the error case.
+#[expect(dead_code, reason = "Debug is used for logging")]
 #[derive(Debug)]
 pub enum AcceptGpaError {
     MemorySecurityViolation {

--- a/openhcl/openhcl_boot/src/boot_logger.rs
+++ b/openhcl/openhcl_boot/src/boot_logger.rs
@@ -101,7 +101,7 @@ pub(crate) use log;
 //
 // Allow unused macros for the same reason as unused_imports below, as there
 // should be no usage of this macro normally.
-#[allow(unused_macros)]
+#[expect(unused_macros)]
 macro_rules! debug_log {
     ($($arg:tt)*) => {
         $crate::boot_logger::log!($($arg)*)

--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -52,8 +52,7 @@ mod aarch64 {
 
 #[derive(Debug)]
 pub enum DtError {
-    // Field is stored solely for logging via debug, not actually dead.
-    Fdt(#[allow(dead_code)] fdt::builder::Error),
+    Fdt(#[expect(dead_code, reason = "Debug is used for logging")] fdt::builder::Error),
 }
 
 impl From<fdt::builder::Error> for DtError {

--- a/openhcl/underhill_core/src/servicing.rs
+++ b/openhcl/underhill_core/src/servicing.rs
@@ -109,7 +109,7 @@ impl From<Firmware> for FirmwareType {
     }
 }
 
-#[allow(clippy::option_option)]
+#[expect(clippy::option_option)]
 pub mod transposed {
     use super::*;
     use vmcore::save_restore::SaveRestore;

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1573,7 +1573,7 @@ async fn new_underhill_vm(
     // `agent_data` and `guest_secret_key` may also be used by vTPM
     // initialization.
     let platform_attestation_data = {
-        #[allow(clippy::if_same_then_else)] // clearer
+        #[expect(clippy::if_same_then_else, reason = "clearer")]
         if is_restoring {
             // TODO CVM: Save and restore last returned data when live servicing is supported.
             // We also need to revisit what states should be saved and restored.

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1573,7 +1573,6 @@ async fn new_underhill_vm(
     // `agent_data` and `guest_secret_key` may also be used by vTPM
     // initialization.
     let platform_attestation_data = {
-        #[expect(clippy::if_same_then_else, reason = "clearer")]
         if is_restoring {
             // TODO CVM: Save and restore last returned data when live servicing is supported.
             // We also need to revisit what states should be saved and restored.

--- a/openhcl/underhill_crash/src/options.rs
+++ b/openhcl/underhill_crash/src/options.rs
@@ -29,7 +29,7 @@ pub struct Options {
 }
 
 impl Options {
-    #[allow(clippy::expect_fun_call)]
+    #[expect(clippy::expect_fun_call)]
     pub(crate) fn parse() -> Self {
         let mut args = std::env::args_os();
 

--- a/openhcl/underhill_init/src/options.rs
+++ b/openhcl/underhill_init/src/options.rs
@@ -18,7 +18,7 @@ pub struct Options {
 }
 
 impl Options {
-    #[allow(clippy::expect_fun_call)]
+    #[expect(clippy::expect_fun_call)]
     pub(crate) fn parse() -> Self {
         let mut opts = Self::default();
 
@@ -69,7 +69,7 @@ impl Options {
         opts
     }
 
-    #[allow(clippy::expect_fun_call)]
+    #[expect(clippy::expect_fun_call)]
     #[must_use]
     fn parse_value_arg(opts: &mut Self, name: &str, value: &str) -> bool {
         match name {

--- a/openhcl/underhill_init/src/options.rs
+++ b/openhcl/underhill_init/src/options.rs
@@ -18,7 +18,6 @@ pub struct Options {
 }
 
 impl Options {
-    #[expect(clippy::expect_fun_call)]
     pub(crate) fn parse() -> Self {
         let mut opts = Self::default();
 
@@ -69,7 +68,6 @@ impl Options {
         opts
     }
 
-    #[expect(clippy::expect_fun_call)]
     #[must_use]
     fn parse_value_arg(opts: &mut Self, name: &str, value: &str) -> bool {
         match name {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -80,7 +80,10 @@ pub struct SnpBacked {
     #[inspect(iter_by_index)]
     direct_overlays_pfns: [u64; UhDirectOverlay::Count as usize],
     #[inspect(skip)]
-    #[allow(dead_code)] // Allocation handle for direct overlays held until drop
+    #[expect(
+        dead_code,
+        reason = "Allocation handle for direct overlays held until drop"
+    )]
     direct_overlay_pfns_handle: shared_pool_alloc::SharedPoolHandle,
     #[inspect(hex)]
     hv_sint_notifications: u16,
@@ -1682,7 +1685,7 @@ impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, SnpBac
     }
 }
 
-#[allow(unused)]
+#[expect(unused)]
 impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
     type Error = vp_state::Error;
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -390,7 +390,10 @@ pub struct TdxBacked {
     #[inspect(iter_by_index)]
     direct_overlays_pfns: [u64; UhDirectOverlay::Count as usize],
     #[inspect(skip)]
-    #[allow(dead_code)] // Allocation handle for direct overlays held until drop
+    #[expect(
+        dead_code,
+        reason = "Allocation handle for direct overlays held until drop"
+    )]
     direct_overlay_pfns_handle: shared_pool_alloc::SharedPoolHandle,
 
     untrusted_synic: Option<ProcessorSynic>,

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -704,7 +704,6 @@ impl InitializedVm {
         }
     }
 
-    #[allow(dead_code)]
     async fn new_with_hypervisor<P, H>(
         driver_source: VmTaskDriverSource,
         hypervisor: &mut H,
@@ -2417,7 +2416,7 @@ impl LoadedVmInner {
                 };
                 super::vm_loaders::igvm::load_igvm(params)?
             }
-            #[allow(unreachable_patterns)]
+            #[expect(unreachable_patterns)]
             _ => anyhow::bail!("load mode not supported on this platform"),
         };
 

--- a/openvmm/membacking/src/memory_manager/device_memory.rs
+++ b/openvmm/membacking/src/memory_manager/device_memory.rs
@@ -145,7 +145,6 @@ struct DeviceMemoryControl(Arc<DeviceMemoryRegion>);
 impl MappableGuestMemory for DeviceMemoryControl {
     fn map_to_guest(&mut self, gpa: u64, writable: bool) -> io::Result<()> {
         let mut state = self.0.state.lock();
-        #[allow(clippy::await_holding_lock)] // Treat all this as sync for now.
         block_on(async {
             if let Some(handle) = state.handle.take() {
                 handle.teardown().await;

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -382,7 +382,7 @@ flags:
     ///
     /// Used internally for debugging and diagnostics.
     #[clap(long, default_value = "control", hide(true))]
-    #[allow(clippy::option_option)]
+    #[expect(clippy::option_option)]
     pub internal_worker: Option<Option<String>>,
 
     /// redirect the VTL 0 vmbus control plane to a proxy in VTL 2.

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -111,7 +111,7 @@ impl Worker for TtrpcWorker {
                 RpcTransport::Ttrpc => ResolvedTransport::Ttrpc,
                 #[cfg(feature = "grpc")]
                 RpcTransport::Grpc => ResolvedTransport::Grpc,
-                #[allow(unreachable_patterns)]
+                #[expect(unreachable_patterns)]
                 transport => bail!("unsupported transport {transport}"),
             },
         })

--- a/petri/pipette/src/agent.rs
+++ b/petri/pipette/src/agent.rs
@@ -29,7 +29,7 @@ pub struct Agent {
     watch_send: mesh::OneshotSender<()>,
 }
 
-#[allow(dead_code)] // Not used on all platforms yet
+#[allow(dead_code, reason = "Not used on all platforms yet")]
 #[derive(Clone)]
 pub struct DiagnosticSender(Arc<mesh::Sender<DiagnosticFile>>);
 
@@ -167,7 +167,7 @@ async fn write_file(mut request: pipette_protocol::WriteFileRequest) -> anyhow::
 }
 
 impl DiagnosticSender {
-    #[allow(dead_code)] // Not used on all platforms yet
+    #[expect(dead_code)] // Not used on all platforms yet
     pub async fn send(&self, filename: &str) -> anyhow::Result<()> {
         tracing::debug!(filename, "Beginning diagnostic file request");
         let file = fs_err::File::open(filename)?;

--- a/petri/pipette/src/shutdown.rs
+++ b/petri/pipette/src/shutdown.rs
@@ -123,7 +123,7 @@ pub fn handle_shutdown(request: pipette_protocol::ShutdownRequest) -> anyhow::Re
 }
 
 #[cfg(windows)]
-#[allow(dead_code)] // Currently unused, but left as an example
+#[expect(dead_code, reason = "Currently unused, but left as an example")]
 pub fn start_shutdown_trace() -> anyhow::Result<()> {
     use anyhow::Context;
 
@@ -150,7 +150,7 @@ pub fn start_shutdown_trace() -> anyhow::Result<()> {
 }
 
 #[cfg(windows)]
-#[allow(dead_code)] // Currently unused, but left as an example
+#[expect(dead_code, reason = "Currently unused, but left as an example")]
 pub async fn send_shutdown_trace(
     diag_file_send: crate::agent::DiagnosticSender,
 ) -> anyhow::Result<()> {

--- a/petri/pipette_client/src/lib.rs
+++ b/petri/pipette_client/src/lib.rs
@@ -227,8 +227,10 @@ async fn recv_diag_files(output_dir: PathBuf, mut diag_file_recv: mesh::Receiver
             .expect("failed to write diagnostic file");
         tracing::debug!(name, "diagnostic file transfer complete");
 
-        // ATTACHMENT is most reliable when using true canonicalized paths
-        #[allow(clippy::disallowed_methods)]
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "ATTACHMENT is most reliable when using true canonicalized paths"
+        )]
         let canonical_path = path
             .canonicalize()
             .expect("failed to canonicalize attachment path");

--- a/petri/src/openhcl_diag.rs
+++ b/petri/src/openhcl_diag.rs
@@ -20,7 +20,7 @@ pub(crate) struct OpenHclDiagHandler {
 
 /// The result of running a VTL2 command.
 #[derive(Debug)]
-#[allow(dead_code)] // Fields output via Debug for debugging purposes.
+#[expect(dead_code, reason = "Fields output via Debug for debugging purposes.")]
 pub(crate) struct Vtl2CommandResult {
     /// The stdout of the command.
     pub stdout: String,

--- a/petri/src/tracing.rs
+++ b/petri/src/tracing.rs
@@ -77,8 +77,10 @@ impl<'a> MakeWriter<'a> for PetriWriter {
 /// that the file makes it into the test results.
 pub fn trace_attachment(path: impl AsRef<Path>) {
     fn trace(path: &Path) {
-        // ATTACHMENT is most reliable when using true canonicalized paths
-        #[allow(clippy::disallowed_methods)]
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "ATTACHMENT is most reliable when using true canonicalized paths"
+        )]
         match path.canonicalize() {
             Ok(path) => {
                 // Use the inline junit syntax to attach the file to the test

--- a/support/arc_cyclic_builder/src/lib.rs
+++ b/support/arc_cyclic_builder/src/lib.rs
@@ -174,7 +174,7 @@ impl<T> ArcCyclicBuilderExt<T> for Arc<T> {
 }
 
 #[expect(
-    clippy::disallowed_methods,
+    clippy::disallowed_types,
     reason = "Requiring parking_lot just for a test? nah"
 )]
 #[cfg(test)]

--- a/support/arc_cyclic_builder/src/lib.rs
+++ b/support/arc_cyclic_builder/src/lib.rs
@@ -173,7 +173,10 @@ impl<T> ArcCyclicBuilderExt<T> for Arc<T> {
     }
 }
 
-#[allow(clippy::disallowed_types)] // requiring parking_lot just for a test? nah
+#[expect(
+    clippy::disallowed_methods,
+    reason = "Requiring parking_lot just for a test? nah"
+)]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -1886,7 +1886,10 @@ impl InternalNode {
     any(feature = "defer", feature = "initiate"),
     derive(mesh::MeshPayload)
 )]
-#[allow(unused)] // some invariants are unused in some configurations, but order matters in their mesh derive, so keep them
+#[allow(
+    unused,
+    reason = "some invariants are unused in some configurations, but order matters in their mesh derive, so keep them"
+)]
 enum InternalError {
     Immutable,
     Update(String),
@@ -2682,7 +2685,7 @@ mod tests {
         struct Tr2(#[inspect(debug)] ());
 
         #[derive(Inspect)]
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         enum Enum {
             Foo,
             BarBaz,
@@ -2727,16 +2730,16 @@ mod tests {
 
     #[test]
     fn test_derive_enum() {
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         enum EmptyUnitEmum {}
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         #[inspect(untagged)]
         enum EmptyUntaggedEmum {}
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         enum UnitEnum {
             A,
@@ -2746,7 +2749,7 @@ mod tests {
 
         assert_eq!(inspect_sync("", None, &UnitEnum::B).to_string(), r#""b""#);
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         #[inspect(tag = "tag")]
         enum TaggedEnum {
@@ -2759,7 +2762,7 @@ mod tests {
             r#"{tag: "b", y: true}"#
         );
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         #[inspect(external_tag)]
         enum ExternallyTaggedEnum {
@@ -2781,7 +2784,7 @@ mod tests {
             r#"{c: 5}"#
         );
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         #[inspect(untagged)]
         enum UntaggedEnum {

--- a/support/mesh/mesh_channel/src/cancel.rs
+++ b/support/mesh/mesh_channel/src/cancel.rs
@@ -482,7 +482,7 @@ mod tests {
         assert!(futures::poll!(ctx.cancelled()).is_ready());
     }
 
-    #[allow(clippy::redundant_clone)] // explicitly testing chained clones
+    #[expect(clippy::redundant_clone, reason = "explicitly testing chained clones")]
     async fn chain(use_cancel: bool) {
         let ctx = CancelContext::new();
         let (mut ctx, mut cancel) = ctx.with_cancel();

--- a/support/mesh/mesh_node/src/local_node.rs
+++ b/support/mesh/mesh_node/src/local_node.rs
@@ -1648,6 +1648,7 @@ impl LocalNode {
     /// process of being sent to another node.
     pub async fn wait_for_ports(&self, all_ports: bool) {
         loop {
+            // #[allow(clippy::disallowed_methods, reason = "TODO")] // TODO
             let (send, recv) = oneshot::channel::<()>();
             let ports: Vec<_> = {
                 let mut state = self.inner.state.lock();

--- a/support/mesh/mesh_node/src/local_node.rs
+++ b/support/mesh/mesh_node/src/local_node.rs
@@ -929,8 +929,13 @@ impl PortInnerState {
 enum EventError {
     UnknownPort,
     Truncated,
-    // Field is stored solely for logging via debug, not actually dead.
-    UnknownEventType(#[allow(dead_code)] protocol::EventType),
+    UnknownEventType(
+        #[expect(
+            dead_code,
+            reason = "Field is stored solely for logging via debug, not actually dead."
+        )]
+        protocol::EventType,
+    ),
     MissingOsResource,
 }
 
@@ -1643,7 +1648,6 @@ impl LocalNode {
     /// process of being sent to another node.
     pub async fn wait_for_ports(&self, all_ports: bool) {
         loop {
-            #[allow(clippy::disallowed_methods)] // TODO
             let (send, recv) = oneshot::channel::<()>();
             let ports: Vec<_> = {
                 let mut state = self.inner.state.lock();

--- a/support/mesh/mesh_node/src/local_node.rs
+++ b/support/mesh/mesh_node/src/local_node.rs
@@ -1648,7 +1648,7 @@ impl LocalNode {
     /// process of being sent to another node.
     pub async fn wait_for_ports(&self, all_ports: bool) {
         loop {
-            // #[allow(clippy::disallowed_methods, reason = "TODO")] // TODO
+            #[allow(clippy::disallowed_methods, reason = "TODO")] // TODO
             let (send, recv) = oneshot::channel::<()>();
             let ports: Vec<_> = {
                 let mut state = self.inner.state.lock();

--- a/support/mesh/mesh_protobuf/src/encoding.rs
+++ b/support/mesh/mesh_protobuf/src/encoding.rs
@@ -1707,7 +1707,7 @@ impl<T, U> Downcast<Arc<U>> for Arc<T> where T: Downcast<U> {}
 // Derive an encoding for `Result`.
 #[derive(mesh_derive::Protobuf)]
 #[mesh(impl_for = "::core::result::Result")]
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum ResultAsPayload<T, U> {
     #[mesh(transparent)]
     Ok(T),
@@ -1718,7 +1718,7 @@ enum ResultAsPayload<T, U> {
 // Derive an encoding for `Range`.
 #[derive(mesh_derive::Protobuf)]
 #[mesh(impl_for = "::core::ops::Range")]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct RangeAsPayload<T> {
     start: T,
     end: T,

--- a/support/mesh/mesh_protobuf/src/protofile/mod.rs
+++ b/support/mesh/mesh_protobuf/src/protofile/mod.rs
@@ -220,7 +220,6 @@ impl<'a> FieldType<'a> {
     }
 
     /// Returns a field type for an anonymous tuple.
-    #[allow(clippy::redundant_guards)] // https://github.com/rust-lang/rust-clippy/issues/12243
     pub const fn tuple(field_types: &'a [Self]) -> Self {
         // Use well-known types instead of new anonymous ones when possible.
         match field_types {

--- a/support/mesh/mesh_protobuf/src/table/mod.rs
+++ b/support/mesh/mesh_protobuf/src/table/mod.rs
@@ -49,7 +49,7 @@ pub unsafe trait StructMetadata {
 }
 
 #[cfg(test)]
-#[allow(clippy::undocumented_unsafe_blocks)]
+#[expect(clippy::undocumented_unsafe_blocks)]
 mod tests {
     use super::decode::ErasedDecoderEntry;
     use super::decode::StructDecodeMetadata;

--- a/support/mesh/mesh_remote/src/alpc_node.rs
+++ b/support/mesh/mesh_remote/src/alpc_node.rs
@@ -171,7 +171,7 @@ impl AlpcNode {
         let port = PolledWait::new(&driver, port)?;
 
         let invitations = Default::default();
-        #[allow(clippy::disallowed_methods)] // TODO
+        #[expect(clippy::disallowed_methods, reason = "TODO")] // TODO
         let (connect_send, connect_recv) = mpsc::unbounded();
         let local_node = Arc::new(LocalNode::with_id(
             local_id,

--- a/support/mesh/mesh_remote/src/unix_node.rs
+++ b/support/mesh/mesh_remote/src/unix_node.rs
@@ -502,7 +502,7 @@ fn start_connection(
     handle: RemoteNodeHandle,
     socket: UnixSocket,
 ) {
-    #[allow(clippy::disallowed_methods)] // TODO
+    #[expect(clippy::disallowed_methods)] // TODO
     let (send, recv) = mpsc::unbounded();
     let socket = Arc::new(socket);
     let sender = PacketSender {
@@ -1163,7 +1163,7 @@ impl UnixSocket {
 /// ErrorKind::WouldBlock.
 // x86_64-unknown-linux-musl targets have a different type defn for
 // `libc::cmsghdr`, hence why these lints are being suppressed.
-#[allow(clippy::needless_update, clippy::useless_conversion)]
+#[expect(clippy::needless_update, clippy::useless_conversion)]
 fn try_send(socket: &Socket, msg: &[IoSlice<'_>], fds: &[OsResource]) -> io::Result<usize> {
     let mut cmsg = CmsgScmRights {
         hdr: libc::cmsghdr {

--- a/support/mesh/src/lib.rs
+++ b/support/mesh/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! This crate provides cross-process message-based communication over channels.
 
-#[allow(unused_extern_crates)]
+#[expect(unused_extern_crates)]
 extern crate self as mesh;
 
 pub mod payload {

--- a/support/mesh_tracing/src/bounded.rs
+++ b/support/mesh_tracing/src/bounded.rs
@@ -187,7 +187,6 @@ impl<T: MeshField> BoundedSender<T> {
         })
     }
 
-    #[allow(dead_code)]
     pub async fn send(&mut self, message: T) {
         let mut message = Some(message);
         poll_fn(|cx| self.poll_send(cx, &mut message)).await

--- a/support/open_enum/src/lib.rs
+++ b/support/open_enum/src/lib.rs
@@ -24,7 +24,7 @@
 /// # #[macro_use] extern crate open_enum; fn main() {
 /// use open_enum::open_enum;
 /// open_enum! {
-///     #[allow(dead_code)] // This will apply to the generated struct defn
+///     #[expect(dead_code)] // This will apply to the generated struct defn
 ///     pub enum ExampleEnumName: u32 {
 ///         #![allow(missing_docs)] // This will apply to all subfields of the enum
 ///         THIS_IS_AN_ENUM = 32,
@@ -34,10 +34,10 @@
 /// //
 /// // #[repr(transparent)]
 //  // #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-/// // #[allow(dead_code)]
+/// // #[expect(dead_code)]
 /// // struct ExampleEnumName(u32);
 /// //
-/// // #[allow(missing_docs)]
+/// // #[expect(missing_docs)]
 /// // impl ExampleEnumName {
 /// //     pub const THIS_IS_AN_ENUM: ExampleEnumName = ExampleEnumName(0)
 /// // }

--- a/support/openssl_kdf/src/sys/evp.rs
+++ b/support/openssl_kdf/src/sys/evp.rs
@@ -14,7 +14,7 @@ use libc::c_uchar;
 use libc::size_t;
 use openssl_sys::EVP_MD;
 
-#[allow(clippy::upper_case_acronyms)]
+#[expect(clippy::upper_case_acronyms)]
 pub enum KDF {}
 
 pub enum KDF_CTX {}

--- a/support/pal/pal_async/src/waker.rs
+++ b/support/pal/pal_async/src/waker.rs
@@ -18,7 +18,7 @@ impl WakerList {
         }
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn push(&mut self, waker: Waker) {
         self.0.push(waker);
     }

--- a/support/pal/pal_async/src/windows/tp.rs
+++ b/support/pal/pal_async/src/windows/tp.rs
@@ -451,7 +451,7 @@ impl Timer {
         if !self.tp_timer.set(duration) {
             // Donate the reference to be released in tp_timer_callback() or
             // in drop().
-            #[allow(clippy::let_underscore_lock)] // false positive
+            #[expect(clippy::let_underscore_lock, reason = "false positive")]
             let _ = Arc::into_raw(inner_ref);
         }
     }

--- a/support/pal/src/windows.rs
+++ b/support/pal/src/windows.rs
@@ -315,7 +315,7 @@ impl IoCompletionPort {
 
     // Per MSDN, overlapped values are not dereferenced by PostQueuedCompletionStatus,
     // they are passed as-is to the caller of GetQueuedCompletionStatus.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    #[expect(clippy::not_unsafe_ptr_arg_deref)]
     pub fn post(&self, bytes: u32, key: usize, overlapped: *mut OVERLAPPED) {
         unsafe {
             if PostQueuedCompletionStatus(self.0.as_raw_handle(), bytes, key, overlapped) == 0 {
@@ -996,14 +996,14 @@ macro_rules! delayload {
     };
 
     (@func pub fn $name:ident($($params:ident : $types:ty),* $(,)?) -> $result:ty) => {
-        #[allow(non_snake_case, clippy::too_many_arguments, clippy::diverging_sub_expression)]
+        #[expect(non_snake_case, clippy::too_many_arguments, clippy::diverging_sub_expression)]
         pub unsafe fn $name($($params: $types,)*) -> $result {
             $crate::delayload!(@body $name($($params : $types),*) -> $result)
         }
     };
 
     (@func fn $name:ident($($params:ident : $types:ty),* $(,)?) -> $result:ty) => {
-        #[allow(non_snake_case, clippy::diverging_sub_expression)]
+        #[expect(non_snake_case, clippy::diverging_sub_expression)]
         unsafe fn $name($($params: $types,)*) -> $result {
             $crate::delayload!(@body $name($($params : $types),*) -> $result)
         }
@@ -1021,7 +1021,7 @@ macro_rules! delayload {
             static FNCELL: AtomicUsize = AtomicUsize::new(0);
             let mut fnval = FNCELL.load(Ordering::Relaxed);
             if fnval == 0 {
-                #[allow(unreachable_code)]
+                #[expect(unreachable_code)]
                 match get_module() {
                     Ok(module) => {
                         fnval = GetProcAddress(
@@ -1037,7 +1037,7 @@ macro_rules! delayload {
                 FNCELL.store(fnval, Ordering::Relaxed);
             }
             if fnval == 1 {
-                #[allow(unreachable_code)]
+                #[expect(unreachable_code)]
                 return $crate::delayload!(@result_from_win32(($result), ERROR_PROC_NOT_FOUND));
             }
             type FnType = unsafe extern "stdcall" fn($($params: $types,)*) -> $result;

--- a/support/pal/src/windows/pipe.rs
+++ b/support/pal/src/windows/pipe.rs
@@ -407,7 +407,6 @@ const FSCTL_PIPE_EVENT_ENUM: u32 = ctl_code(
 );
 
 #[repr(C)]
-#[expect(clippy::upper_case_acronyms, reason = "C type")]
 struct FILE_PIPE_EVENT_SELECT_BUFFER {
     event_types: u32,
     event_handle: u64,

--- a/support/pal/src/windows/pipe.rs
+++ b/support/pal/src/windows/pipe.rs
@@ -407,7 +407,7 @@ const FSCTL_PIPE_EVENT_ENUM: u32 = ctl_code(
 );
 
 #[repr(C)]
-#[allow(clippy::upper_case_acronyms)] // C type
+#[expect(clippy::upper_case_acronyms, reason = "C type")]
 struct FILE_PIPE_EVENT_SELECT_BUFFER {
     event_types: u32,
     event_handle: u64,

--- a/support/serde_helpers/src/lib.rs
+++ b/support/serde_helpers/src/lib.rs
@@ -16,7 +16,6 @@ pub mod base64_vec {
     use crate::prelude::*;
     use base64::Engine;
 
-    #[allow(clippy::ptr_arg)] // required by serde
     pub fn serialize<S: Serializer>(v: &Vec<u8>, ser: S) -> Result<S::Ok, S::Error> {
         ser.serialize_str(&base64::engine::general_purpose::STANDARD.encode(v))
     }
@@ -120,7 +119,6 @@ pub mod opt_base64_vec {
     use base64::Engine;
     use serde::*;
 
-    #[allow(clippy::ptr_arg)] // required by serde
     pub fn serialize<S: Serializer>(v: &Option<Vec<u8>>, ser: S) -> Result<S::Ok, S::Error> {
         match v {
             Some(v) => ser.serialize_str(&base64::engine::general_purpose::STANDARD.encode(v)),

--- a/support/win_prng_support/src/lib.rs
+++ b/support/win_prng_support/src/lib.rs
@@ -198,7 +198,7 @@ pub mod private {
         len: u32,
         flags: u32,
     ) -> u32 {
-        #[allow(clippy::if_same_then_else)]
+        #[expect(clippy::if_same_then_else)]
         if algorithm == BCRYPT_MAGIC_ALGORITHM_HANDLE && flags == 0 {
             // Rust 1.65 calls BCryptGenRandom this way with the magic handle we return from our implementation of
             // BCryptOpenAlgorithmProvider.

--- a/support/win_prng_support/src/lib.rs
+++ b/support/win_prng_support/src/lib.rs
@@ -198,7 +198,7 @@ pub mod private {
         len: u32,
         flags: u32,
     ) -> u32 {
-        #[expect(clippy::if_same_then_else)]
+        #[allow(clippy::if_same_then_else)]
         if algorithm == BCRYPT_MAGIC_ALGORITHM_HANDLE && flags == 0 {
             // Rust 1.65 calls BCryptGenRandom this way with the magic handle we return from our implementation of
             // BCryptOpenAlgorithmProvider.

--- a/vm/acpi/src/dsdt/helpers.rs
+++ b/vm/acpi/src/dsdt/helpers.rs
@@ -133,7 +133,6 @@ pub fn encode_dword(value: u32) -> Vec<u8> {
     byte_stream
 }
 
-#[allow(clippy::vec_init_then_push)] // vec![0xd] followed by extend_from_slice looks weird
 pub fn encode_string(value: &[u8]) -> Vec<u8> {
     let mut byte_stream: Vec<u8> = Vec::new();
     byte_stream.push(0xd);

--- a/vm/acpi_spec/src/lib.rs
+++ b/vm/acpi_spec/src/lib.rs
@@ -14,7 +14,7 @@ pub mod madt;
 pub mod pptt;
 pub mod srat;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 mod packed_nums {
     pub type u16_ne = zerocopy::U16<zerocopy::NativeEndian>;
     pub type u32_ne = zerocopy::U32<zerocopy::NativeEndian>;

--- a/vm/chipset_arc_mutex_device/src/device.rs
+++ b/vm/chipset_arc_mutex_device/src/device.rs
@@ -239,7 +239,6 @@ where
     /// Includes some basic validation that returns an error if a device
     /// attempts to use a service without also implementing the service's
     /// corresponding `ChipsetDevice::supports_` method.
-    #[allow(clippy::should_implement_trait)] // obviously not std::ops::Add
     #[instrument(name = "add_device", skip_all, fields(device = self.dev_name.as_ref()))]
     pub fn add<F>(mut self, f: F) -> Result<Arc<CloseableMutex<T>>, AddDeviceError>
     where

--- a/vm/chipset_arc_mutex_device/src/test_chipset.rs
+++ b/vm/chipset_arc_mutex_device/src/test_chipset.rs
@@ -85,7 +85,6 @@ impl ControlMmioIntercept for TestDeviceRange {
     fn offset_of(&self, addr: u64) -> Option<u64> {
         let base = self.addr?;
 
-        #[allow(clippy::unnecessary_lazy_evaluations)] // prevents underflow error
         (base..(base + self.len))
             .contains(&addr)
             .then(|| addr - base)

--- a/vm/devices/chipset/src/battery/mod.rs
+++ b/vm/devices/chipset/src/battery/mod.rs
@@ -64,7 +64,7 @@ pub const BATTERY_STATUS_IRQ_NO: u32 = 4;
 // No functionality is lost by not using this constant, but we prefer
 // ACPI_DEVICE_NOTIFY_BIX_CHANGED because it tells the guest to check for both
 // the BST and BIX registers.
-#[allow(unused)]
+#[allow(unused, reason = "Deprecated")]
 pub const ACPI_DEVICE_NOTIFY_BST_CHANGED: u32 = 0x1;
 pub const ACPI_DEVICE_NOTIFY_BIX_CHANGED: u32 = 0x2;
 

--- a/vm/devices/chipset/src/battery/resolver.rs
+++ b/vm/devices/chipset/src/battery/resolver.rs
@@ -36,7 +36,6 @@ declare_static_async_resolver! {
 /// Currently marked unused to dodge compiler warning despite needing
 /// this for the type Error below.
 #[derive(Debug, Error)]
-#[allow(unused)]
 pub enum ResolveBatteryError {
     #[error("failed to resolve battery")]
     ResolveBattery(#[source] ResolveError),

--- a/vm/devices/firmware/hyperv_uefi_custom_vars_json/src/lib.rs
+++ b/vm/devices/firmware/hyperv_uefi_custom_vars_json/src/lib.rs
@@ -240,7 +240,7 @@ mod json {
             })
         }
 
-        #[allow(clippy::many_single_char_names)]
+        #[expect(clippy::many_single_char_names)]
         pub fn base64_u32<'de, D: Deserializer<'de>>(d: D) -> Result<u32, D::Error> {
             let s: &str = Deserialize::deserialize(d)?;
 

--- a/vm/devices/firmware/uefi_specs/src/hyperv/crypto.rs
+++ b/vm/devices/firmware/uefi_specs/src/hyperv/crypto.rs
@@ -10,7 +10,7 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 mod packed_nums {
     pub type u64_ne = zerocopy::U64<zerocopy::NativeEndian>;
 }

--- a/vm/devices/firmware/uefi_specs/src/hyperv/nvram.rs
+++ b/vm/devices/firmware/uefi_specs/src/hyperv/nvram.rs
@@ -12,7 +12,7 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 mod packed_nums {
     pub type u64_ne = zerocopy::U64<zerocopy::NativeEndian>;
 }

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -162,7 +162,7 @@ open_enum! {
 
 pub use header::*;
 // UNSAFETY: The unsafe manual impl of AsBytes for HeaderGeneric
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 pub mod header {
     use super::MessageTypes;
     use super::MessageVersions;

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -326,7 +326,7 @@ pub struct TestGedClient {
     sender: mesh::Sender<GuestEmulationRequest>,
 }
 
-#[allow(dead_code)] // Tasks are spawned and just need to be held.
+#[expect(dead_code, reason = "Tasks are spawned and just need to be held.")]
 enum TestTask {
     Test(Task<Result<(), Error>>),
     Prod(TaskControl<GuestEmulationDevice, GedChannel<FlatRingMem>>),

--- a/vm/devices/get/underhill_config/src/schema/v1.rs
+++ b/vm/devices/get/underhill_config/src/schema/v1.rs
@@ -235,7 +235,7 @@ impl ParseSchema<crate::PhysicalDevices> for Lun {
         &self,
         errors: &mut ParseErrors<'_>,
     ) -> Result<crate::PhysicalDevices, ParsingStopped> {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         if (self.is_dvd || self.physical_devices.is_some())
             && (self.device_type.is_some()
                 || self.device_path.is_some()
@@ -286,7 +286,7 @@ impl ParseSchema<crate::PhysicalDevices> for Lun {
             crate::PhysicalDevices::EmptyDrive
         } else {
             // Legacy compat path.
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let (device_path, sub_device_path) =
                 self.device_path.as_ref().zip(self.sub_device_path).ok_or(
                     Error::StorageSchemaVersionMismatch("could not find any physical devices"),

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -216,7 +216,7 @@ impl<T: RingMem + 'static + Sync> InspectTaskMut<Worker<T>> for NetQueue {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 enum WorkerState {
     Init(Option<InitState>),
     Ready(ReadyState),
@@ -345,7 +345,7 @@ struct RxBufferRanges {
 impl RxBufferRanges {
     fn new(buffer_count: u32, queue_count: u32) -> (Self, Vec<mpsc::UnboundedReceiver<u32>>) {
         let buffers_per_queue = (buffer_count - RX_RESERVED_CONTROL_BUFFERS) / queue_count;
-        #[allow(clippy::disallowed_methods)] // TODO
+        #[expect(clippy::disallowed_methods)] // TODO
         let (send, recv): (Vec<_>, Vec<_>) = (0..queue_count).map(|_| mpsc::unbounded()).unzip();
         (
             Self {
@@ -1362,7 +1362,7 @@ impl Nic {
         // processor.
         driver_builder.run_on_target(!self.adapter.tx_fast_completions);
 
-        #[allow(clippy::disallowed_methods)] // TODO
+        #[expect(clippy::disallowed_methods)] // TODO
         let (send, recv) = mpsc::channel(1);
         self.coordinator_send = Some(send);
         self.coordinator.insert(

--- a/vm/devices/net/vmswitch/src/kernel.rs
+++ b/vm/devices/net/vmswitch/src/kernel.rs
@@ -116,7 +116,7 @@ impl KernelVmNic {
 
 #[derive(Debug)]
 // Just a newtype to give a better name and ergonomics, field needs to be held to keep handle alive.
-pub struct SwitchPort(#[allow(dead_code)] OwnedHandle);
+pub struct SwitchPort(#[expect(dead_code)] OwnedHandle);
 
 impl SwitchPort {
     pub fn new(id: &SwitchPortId) -> io::Result<Self> {

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -156,7 +156,6 @@ impl QueuePair {
         });
 
         const PER_QUEUE_PAGES: usize = 128;
-        #[expect(clippy::assertions_on_constants)]
         const _: () = assert!(
             PER_QUEUE_PAGES * PAGE_SIZE >= 128 * 1024 + PAGE_SIZE,
             "not enough room for an ATAPI IO plus a PRP list"

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -156,7 +156,7 @@ impl QueuePair {
         });
 
         const PER_QUEUE_PAGES: usize = 128;
-        #[allow(clippy::assertions_on_constants)]
+        #[expect(clippy::assertions_on_constants)]
         const _: () = assert!(
             PER_QUEUE_PAGES * PAGE_SIZE >= 128 * 1024 + PAGE_SIZE,
             "not enough room for an ATAPI IO plus a PRP list"

--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -1836,7 +1836,7 @@ mod tests {
         device_head: u8,
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     enum Addressing {
         Chs,
         Lba28Bit,

--- a/vm/devices/storage/ide/src/protocol.rs
+++ b/vm/devices/storage/ide/src/protocol.rs
@@ -9,7 +9,7 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 mod packed_nums {
     pub type u32_le = zerocopy::U32<zerocopy::LittleEndian>;
     pub type u64_le = zerocopy::U64<zerocopy::LittleEndian>;

--- a/vm/devices/storage/nvme/src/lib.rs
+++ b/vm/devices/storage/nvme/src/lib.rs
@@ -39,5 +39,4 @@ const PAGE_SIZE: usize = 4096;
 const PAGE_SIZE64: u64 = 4096;
 const PAGE_MASK: u64 = !(PAGE_SIZE64 - 1);
 const PAGE_SHIFT: u32 = PAGE_SIZE.trailing_zeros();
-#[allow(clippy::assertions_on_constants)]
 const _: () = assert!(PAGE_SIZE == PagedRange::PAGE_SIZE);

--- a/vm/devices/storage/nvme/src/tests/test_helpers.rs
+++ b/vm/devices/storage/nvme/src/tests/test_helpers.rs
@@ -30,7 +30,7 @@ struct TestPciInterruptControllerInner {
 
 impl TestPciInterruptController {
     /// Return a new test PCI interrupt controller
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn new() -> Self {
         Self {
             inner: Arc::new(TestPciInterruptControllerInner {
@@ -40,7 +40,7 @@ impl TestPciInterruptController {
     }
 
     /// Fetch the first (addr, data) MSI-X interrupt in the FIFO interrupt queue
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn get_next_interrupt(&self) -> Option<(u64, u32)> {
         self.inner.msi_requests.lock().pop_front()
     }

--- a/vm/devices/storage/nvme/src/workers/admin.rs
+++ b/vm/devices/storage/nvme/src/workers/admin.rs
@@ -141,7 +141,7 @@ impl AdminState {
     pub fn new(handler: &AdminHandler, asq: u64, asqs: u16, acq: u64, acqs: u16) -> Self {
         // Start polling for namespace changes. Use a bounded channel to avoid
         // unbounded memory allocation when the queue is stuck.
-        #[allow(clippy::disallowed_methods)] // TODO
+        #[expect(clippy::disallowed_methods, reason = "TODO")] // TODO
         let (send_changed_namespace, recv_changed_namespace) = futures::channel::mpsc::channel(256);
         let poll_namespace_change = handler
             .namespaces

--- a/vm/devices/storage/scsi_core/src/lib.rs
+++ b/vm/devices/storage/scsi_core/src/lib.rs
@@ -147,7 +147,7 @@ pub mod save_restore {
     }
 
     #[derive(Debug, Default, PartialEq, Eq, Copy, Clone, inspect::Inspect, Protobuf)]
-    #[allow(clippy::enum_variant_names)]
+    #[expect(clippy::enum_variant_names)]
     #[mesh(package = "storage.scsi.dvd")]
     pub enum DriveState {
         #[mesh(1)]

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -706,7 +706,7 @@ impl<T: RingMem + 'static> Worker<T> {
         force_path_id: Option<u8>,
     ) -> anyhow::Result<Self> {
         let queue = Queue::new(channel)?;
-        #[allow(clippy::disallowed_methods)] // TODO
+        #[expect(clippy::disallowed_methods, reason = "TODO")] // TODO
         let (source, target) = futures::channel::mpsc::channel(1);
         controller.add_rescan_notification_source(source);
 

--- a/vm/devices/support/fs/lx/src/lib.rs
+++ b/vm/devices/support/fs/lx/src/lib.rs
@@ -13,17 +13,17 @@ use thiserror::Error;
 pub use string::LxStr;
 pub use string::LxString;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub type uid_t = u32;
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub type gid_t = u32;
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub type mode_t = u32;
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub type ino_t = u64;
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub type off_t = i64;
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub type dev_t = usize;
 
 pub const MODE_INVALID: mode_t = mode_t::MAX;

--- a/vm/devices/support/fs/lxutil/src/lib.rs
+++ b/vm/devices/support/fs/lxutil/src/lib.rs
@@ -1037,9 +1037,9 @@ impl Default for LxVolumeOptions {
 #[derive(Default)]
 pub struct LxCreateOptions {
     mode: lx::mode_t,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     uid: lx::uid_t,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     gid: lx::gid_t,
 }
 

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -238,7 +238,7 @@ impl LxVolume {
             let block_size = api::LxUtilFsGetFileSystemBlockSize(root.as_raw_handle());
             Ok(Self {
                 root,
-                #[allow(clippy::disallowed_methods)] // need actual canonical path here
+                #[expect(clippy::disallowed_methods, reason = "need actual canonical path here")]
                 root_path: root_path.canonicalize()?,
                 state: VolumeState::new(fs_context, options, block_size),
             })
@@ -1036,7 +1036,7 @@ impl LxVolume {
 
             /// Only the required header for FSCTL_SET_REPARSE_POINT, with data length of zero.
             /// See ntifs.h REPARSE_DATA_BUFFER.
-            #[allow(non_snake_case)]
+            #[expect(non_snake_case)]
             #[repr(C)]
             #[derive(Clone, Copy, AsBytes, FromBytes, FromZeroes)]
             struct REPARSE_DATA_BUFFER {
@@ -1227,7 +1227,7 @@ impl LxVolume {
         path.push(symlink_parent);
         path.push(target);
         path = {
-            #[allow(clippy::disallowed_methods)] // need actual canonical path here
+            #[expect(clippy::disallowed_methods)] // need actual canonical path here
             match path.canonicalize() {
                 Ok(p) => p,
                 Err(_) => return SymlinkType::Lx,

--- a/vm/devices/support/fs/lxutil/src/windows/util.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/util.rs
@@ -365,7 +365,10 @@ pub fn check_lx_error_size(result: isize) -> lx::Result<usize> {
 }
 
 // Convert a DOS path to an NT path depending on whether the root is set.
-#[allow(clippy::join_absolute_paths)] // https://github.com/rust-lang/rust-clippy/issues/12244
+#[expect(
+    clippy::join_absolute_paths,
+    reason = "https://github.com/rust-lang/rust-clippy/issues/12244"
+)]
 pub fn dos_to_nt_path(
     root: Option<&OwnedHandle>,
     path: &Path,
@@ -791,7 +794,7 @@ pub fn create_link(
 
     // This matches the public definition of FILE_LINK_INFORMATION in ntifs.h, with the variable length payload field
     // at the end removed. u8 arrays are used for fields to remove the need for padding and repr(packed).
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     #[repr(C)]
     #[derive(Debug, Clone, Copy, AsBytes, FromBytes, FromZeroes)]
     struct FILE_LINK_INFORMATION {

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -142,7 +142,7 @@ struct ControlArea {
 }
 
 // TODO: switch this over to open_enum!
-#[allow(dead_code)]
+#[expect(dead_code)]
 impl ControlArea {
     const OFFSET_OF_LOC_STATE: usize = 0x00;
     const OFFSET_OF_LOC_CTRL: usize = 0x08;
@@ -1256,7 +1256,7 @@ mod io_port_interface {
         }
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     #[repr(u32)]
     #[derive(Debug, Copy, Clone)]
     pub enum TcgProtocol {

--- a/vm/devices/uidevices/src/keyboard/mod.rs
+++ b/vm/devices/uidevices/src/keyboard/mod.rs
@@ -290,7 +290,7 @@ impl<T: RingMem + Unpin> KeyboardChannel<T> {
                                 _ => return Err(Error::UnexpectedPacketOrder),
                             }
                         }
-                        #[allow(unreachable_code)]
+                        #[expect(unreachable_code)]
                         Ok(())
                     });
 

--- a/vm/devices/uidevices/src/mouse/mod.rs
+++ b/vm/devices/uidevices/src/mouse/mod.rs
@@ -352,7 +352,7 @@ impl<T: RingMem + Unpin> MouseChannel<T> {
 }
 
 //transforms MouseData from the vnc server to an HID input report (mouse packet) by scaling coordinates and marking button flags
-#[allow(clippy::field_reassign_with_default)] // performing protocol translation
+
 async fn post_mouse_packet(
     mouse_data: MouseData,
     channel: &mut (impl AsyncSend + Unpin),
@@ -368,7 +368,7 @@ async fn post_mouse_packet(
         protocol::HID_MOUSE_BUTTON_RIGHT,
     ];
 
-    #[allow(clippy::needless_range_loop)] // rare case of a clippy misfire
+    #[expect(clippy::needless_range_loop, reason = "rare case of a clippy misfire")]
     for i in 0..protocol::MOUSE_NUMBER_BUTTONS {
         if ((1u8 << i) & mouse_data.button_mask) == (1u8 << i) {
             if i < 3 {

--- a/vm/devices/uidevices/src/video/protocol.rs
+++ b/vm/devices/uidevices/src/video/protocol.rs
@@ -41,7 +41,7 @@ pub const MAX_DIRTY_REGIONS: u8 = 255;
 
 macro_rules! packed {
     ($wrap:ident, $prim:ident, $count:literal) => {
-        #[allow(non_camel_case_types)]
+        #[expect(non_camel_case_types)]
         #[repr(transparent)]
         #[derive(Copy, Clone, AsBytes, FromBytes, FromZeroes)]
         pub struct $wrap([u8; $count]);

--- a/vm/devices/vga/src/emu.rs
+++ b/vm/devices/vga/src/emu.rs
@@ -1452,7 +1452,7 @@ impl Emulator {
         }
 
         if self.state.persistent_state.crt_regs_locked {
-            #[allow(clippy::comparison_chain)]
+            #[expect(clippy::comparison_chain)]
             if reg == CrtControlReg::OVERFLOW_REGISTER {
                 // Only update bit 4.
                 value &= 0x10;
@@ -2403,7 +2403,6 @@ impl Emulator {
         // Linux special case #1
         // When the depth is 16 on a Trio 64, the Linux driver doubles all of the
         // horizontal register values.
-        #[allow(clippy::if_same_then_else)]
         if self.state.persistent_state.bits_per_pixel == 16 {
             new_width /= 2;
         } else if self.state.persistent_state.bits_per_pixel == 2 {

--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -614,7 +614,7 @@ impl<T: LegacyVirtioDevice> Drop for LegacyWrapper<T> {
 
 // UNSAFETY: test code implements a custom `GuestMemory` backing, which requires
 // unsafe.
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vm/devices/virtio/virtio/src/spec.rs
+++ b/vm/devices/virtio/virtio/src/spec.rs
@@ -5,7 +5,7 @@
 
 pub use packed_nums::*;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 mod packed_nums {
     pub type u16_le = zerocopy::U16<zerocopy::LittleEndian>;
     pub type u32_le = zerocopy::U32<zerocopy::LittleEndian>;

--- a/vm/devices/virtio/virtio/src/transport/pci.rs
+++ b/vm/devices/virtio/virtio/src/transport/pci.rs
@@ -300,7 +300,7 @@ impl VirtioPciDevice {
                 } else {
                     0
                 };
-                #[allow(clippy::if_same_then_else)] // fix when TODO is resolved
+                #[expect(clippy::if_same_then_else, reason = "TODO")] // fix when TODO is resolved
                 let notify_offset = if queue_select < self.queues.len() {
                     0 // TODO: when should this be non-zero? ever?
                 } else {

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -101,7 +101,7 @@ struct NetStatus {
 
 const DEFAULT_MTU: u16 = 1514;
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 const VIRTIO_NET_MAX_QUEUES: u16 = 0x8000;
 
 #[repr(C)]

--- a/vm/devices/virtio/virtiofs/src/lib.rs
+++ b/vm/devices/virtio/virtiofs/src/lib.rs
@@ -451,7 +451,7 @@ impl<T> HandleMap<T> {
     }
 
     /// Retrieves a value from the map.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn get_mut(&mut self, handle: u64) -> Option<&mut T> {
         self.values.get_mut(&handle)
     }

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -267,7 +267,6 @@ pub enum RestoreError {
 /// Encapsulates a response from the server when requesting offers.
 /// Signifies either an offer from the server or the cessation of offers.
 #[derive(Debug)]
-#[expect(clippy::large_enum_variant)]
 enum Offer {
     Offer(OfferInfo),
     AllOffersDelivered,

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -267,7 +267,7 @@ pub enum RestoreError {
 /// Encapsulates a response from the server when requesting offers.
 /// Signifies either an offer from the server or the cessation of offers.
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 enum Offer {
     Offer(OfferInfo),
     AllOffersDelivered,

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -361,7 +361,7 @@ impl<'a, T: Spawn> VmbusServerBuilder<'a, T> {
     /// When the object is dropped, all channels will be closed and revoked
     /// automatically.
     pub fn build(self) -> anyhow::Result<VmbusServer> {
-        #[allow(clippy::disallowed_methods)] // TODO
+        #[expect(clippy::disallowed_methods, reason = "TODO")] // TODO
         let (message_send, message_recv) = mpsc::channel(64);
         let message_sender = Arc::new(MessageSender {
             send: message_send.clone(),

--- a/vm/kvm/src/lib.rs
+++ b/vm/kvm/src/lib.rs
@@ -465,7 +465,7 @@ impl Partition {
         Ok(())
     }
 
-    #[allow(clippy::missing_safety_doc, clippy::undocumented_unsafe_blocks)]
+    #[expect(clippy::missing_safety_doc, clippy::undocumented_unsafe_blocks)]
     pub unsafe fn set_user_memory_region(
         &self,
         slot: u32,

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -71,7 +71,7 @@ fn to_igvm_vtl(vtl: Vtl) -> igvm::hv_defs::Vtl {
 
 /// Page table relocation information kept for debugging purposes.
 // Allow dead code because clippy doesn't count #[derive(Debug)] as non-dead code usage.
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Debug, Clone)]
 struct PageTableRegion {
     gpa: u64,

--- a/vm/loader/loader_defs/src/linux.rs
+++ b/vm/loader/loader_defs/src/linux.rs
@@ -13,7 +13,7 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 mod packed_nums {
     pub type u16_ne = zerocopy::U16<zerocopy::NativeEndian>;
     pub type u32_ne = zerocopy::U32<zerocopy::NativeEndian>;

--- a/vm/loader/page_table/src/aarch64.rs
+++ b/vm/loader/page_table/src/aarch64.rs
@@ -9,7 +9,7 @@ use bitfield_struct::bitfield;
 /// manual for further details and other types.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 #[repr(u8)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 pub enum MemoryAttributeEl1 {
     /// Most restricted device memory: non-gathering,
     /// non-reordering, non-early-ack.

--- a/vm/vhd1_defs/src/lib.rs
+++ b/vm/vhd1_defs/src/lib.rs
@@ -13,7 +13,7 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 mod packed_nums {
     pub type u32_be = zerocopy::U32<zerocopy::BigEndian>;
     pub type u64_be = zerocopy::U64<zerocopy::BigEndian>;

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -203,9 +203,12 @@ struct AlignedPage([AtomicU8; PAGE_SIZE]);
 impl AlignedHeapMemory {
     /// Allocates a new memory of `size` bytes, rounded up to a page size.
     pub fn new(size: usize) -> Self {
-        #[allow(clippy::declare_interior_mutable_const)] // <https://github.com/rust-lang/rust-clippy/issues/7665>
+        #[expect(
+            clippy::declare_interior_mutable_const,
+            reason = "<https://github.com/rust-lang/rust-clippy/issues/7665>"
+        )]
         const ZERO: AtomicU8 = AtomicU8::new(0);
-        #[allow(clippy::declare_interior_mutable_const)]
+        #[expect(clippy::declare_interior_mutable_const)]
         const ZERO_PAGE: AlignedPage = AlignedPage([ZERO; PAGE_SIZE]);
         let mut pages = Vec::new();
         pages.resize_with((size + PAGE_SIZE - 1) / PAGE_SIZE, || ZERO_PAGE);
@@ -1791,7 +1794,7 @@ impl Debug for LockedPages {
 
 #[derive(Copy, Clone, Debug)]
 // Field is read via slice transmute and pointer casts, not actually dead.
-struct PagePtr(#[allow(dead_code)] *const AtomicU8);
+struct PagePtr(#[expect(dead_code)] *const AtomicU8);
 
 // SAFETY: PagePtr is just a pointer with no methods and has no inherent safety
 // constraints.
@@ -2089,7 +2092,7 @@ pub trait UnmapRom: Send + Sync {
 }
 
 #[cfg(test)]
-#[allow(clippy::undocumented_unsafe_blocks)]
+#[expect(clippy::undocumented_unsafe_blocks)]
 mod tests {
     use crate::BitmapInfo;
     use crate::GuestMemory;

--- a/vm/vmcore/memory_range/src/lib.rs
+++ b/vm/vmcore/memory_range/src/lib.rs
@@ -435,7 +435,10 @@ struct RangeWalkIter<I: Iterator, J: Iterator> {
 
 struct PeekableSorted<I: Iterator> {
     iter: I,
-    #[allow(clippy::option_option)] // `Some(None)` is used to remember that `iter` is empty.
+    #[expect(
+        clippy::option_option,
+        reason = "`Some(None)` is used to remember that `iter` is empty."
+    )]
     item: Option<Option<I::Item>>,
 }
 

--- a/vm/vmgs/vmgs/src/encrypt/mod.rs
+++ b/vm/vmgs/vmgs/src/encrypt/mod.rs
@@ -3,7 +3,6 @@
 
 #![cfg(with_encryption)]
 
-#[allow(unused_macros)]
 macro_rules! activate {
     ($plat:ident) => {
         mod $plat;

--- a/vm/vmgs/vmgs_lib/src/lib.rs
+++ b/vm/vmgs/vmgs_lib/src/lib.rs
@@ -205,7 +205,7 @@ async fn do_write(
 
     // manually allow, since we want to differentiate between the file not being
     // accessible, and a read operation failing
-    #[allow(clippy::verbose_file_reads)]
+    #[expect(clippy::verbose_file_reads)]
     file.read_to_end(&mut buf)
         .map_err(|_| VmgsError::CantReadFile)?;
 

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -584,9 +584,6 @@ async fn vmgs_file_write(
     let mut file = File::open(data_path.as_ref()).map_err(Error::DataFile)?;
     let mut buf = Vec::new();
 
-    // manually allow, since we want to differentiate between the file not being
-    // accessible, and a read operation failing
-    #[expect(clippy::verbose_file_reads)]
     file.read_to_end(&mut buf).map_err(Error::DataFile)?;
 
     println!("Size: {} bytes", buf.len());

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -586,7 +586,7 @@ async fn vmgs_file_write(
 
     // manually allow, since we want to differentiate between the file not being
     // accessible, and a read operation failing
-    #[allow(clippy::verbose_file_reads)]
+    #[expect(clippy::verbose_file_reads)]
     file.read_to_end(&mut buf).map_err(Error::DataFile)?;
 
     println!("Size: {} bytes", buf.len());

--- a/vm/whp/benches/primitives.rs
+++ b/vm/whp/benches/primitives.rs
@@ -6,8 +6,8 @@
 #[cfg(all(windows, target_arch = "x86_64"))]
 // UNSAFETY: Manual memory management to prepare the testing environment and
 // calling WHP APIs.
-#[allow(unsafe_code)]
-#[allow(clippy::undocumented_unsafe_blocks)]
+#[expect(unsafe_code)]
+#[expect(clippy::undocumented_unsafe_blocks)]
 mod windows {
     use criterion::criterion_group;
     use criterion::BenchmarkId;

--- a/vm/whp/src/api.rs
+++ b/vm/whp/src/api.rs
@@ -53,7 +53,7 @@ macro_rules! delayload {
         }
         $(
             $(#[$a])*
-            #[allow(non_snake_case)]
+            #[expect(non_snake_case)]
             pub unsafe fn $name($($params: $types,)*) -> HRESULT {
                 let fnval = funcs::$name();
                 if fnval == 0 {

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -1914,9 +1914,7 @@ macro_rules! set_registers {
     ($vp:expr, [$(($name:expr, $value:expr)),+ $(,)? ] $(,)? ) => {
         {
             let names = [$($crate::RegisterName::as_abi(&($name))),+];
-            #[expect(unused_parens)]
             let values = [$($crate::inject_helper(($name), &($value))),+];
-            #[expect(unused_parens)]
             ($vp).set_registers(&names, &values)
         }
     }
@@ -1930,7 +1928,6 @@ macro_rules! get_registers {
             let mut values = [$($crate::get_registers!(@def $name)),+];
             ($vp).get_registers(&names, &mut values).map(|_| {
                 let mut vs = &values[..];
-                #[expect(unused_assignments, clippy::mixed_read_write_in_expression)]
                 ($({
                     let n = $name;
                     let v = &vs[0];

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -559,7 +559,7 @@ impl Partition {
         }
     }
 
-    #[allow(clippy::missing_safety_doc)]
+    #[expect(clippy::missing_safety_doc)]
     pub unsafe fn map_range(
         &self,
         process: Option<BorrowedHandle<'_>>,
@@ -743,7 +743,7 @@ impl Partition {
         self.get_property(abi::WhvPartitionPropertyCodePhysicalAddressWidth)
     }
 
-    #[allow(clippy::missing_safety_doc)]
+    #[expect(clippy::missing_safety_doc)]
     pub unsafe fn register_doorbell(&self, m: &DoorbellMatch, event: RawHandle) -> Result<()> {
         unsafe {
             check_hresult(api::WHvRegisterPartitionDoorbellEvent(
@@ -1914,9 +1914,9 @@ macro_rules! set_registers {
     ($vp:expr, [$(($name:expr, $value:expr)),+ $(,)? ] $(,)? ) => {
         {
             let names = [$($crate::RegisterName::as_abi(&($name))),+];
-            #[allow(unused_parens)]
+            #[expect(unused_parens)]
             let values = [$($crate::inject_helper(($name), &($value))),+];
-            #[allow(unused_parens)]
+            #[expect(unused_parens)]
             ($vp).set_registers(&names, &values)
         }
     }
@@ -1930,7 +1930,7 @@ macro_rules! get_registers {
             let mut values = [$($crate::get_registers!(@def $name)),+];
             ($vp).get_registers(&names, &mut values).map(|_| {
                 let mut vs = &values[..];
-                #[allow(unused_assignments, clippy::mixed_read_write_in_expression)]
+                #[expect(unused_assignments, clippy::mixed_read_write_in_expression)]
                 ($({
                     let n = $name;
                     let v = &vs[0];

--- a/vm/x86/x86emu/src/emulator.rs
+++ b/vm/x86/x86emu/src/emulator.rs
@@ -703,7 +703,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
             Err(self.unsupported_instruction(instr))?;
         }
 
-        #[allow(clippy::wildcard_in_or_patterns)]
+        #[expect(clippy::wildcard_in_or_patterns)]
         match instr.code() {
             // mov r/m, r
             // mov r, r/m

--- a/vmm_core/state_unit/src/lib.rs
+++ b/vmm_core/state_unit/src/lib.rs
@@ -96,7 +96,7 @@ pub enum StateRequest {
 /// Implementing this is optional, to be used with [`UnitBuilder::spawn`] or
 /// [`StateRequest::apply`]; state units can also directly process incoming
 /// [`StateRequest`]s.
-#[allow(async_fn_in_trait)] // Don't need Send bounds
+#[expect(async_fn_in_trait, reason = "Don't need Send bounds")]
 pub trait StateUnit: InspectMut {
     /// Start asynchronous processing.
     async fn start(&mut self);

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -410,7 +410,7 @@ pub trait Processor: InspectMut {
     ///
     /// Returns when an error occurs, the VP halts, or the VP is requested to
     /// stop via `stop`.
-    #[allow(async_fn_in_trait)] // don't or want Send bound
+    #[expect(async_fn_in_trait, reason = "don't need or want Send bound")]
     async fn run_vp(
         &mut self,
         stop: StopVp<'_>,

--- a/vmm_core/virt_hvf/src/abi.rs
+++ b/vmm_core/virt_hvf/src/abi.rs
@@ -82,7 +82,7 @@ unsafe extern "C" {
     pub fn hv_vcpu_set_reg(vcpu: u64, reg: HvReg, value: u64) -> HvfResult;
     pub fn hv_vcpu_get_sys_reg(vcpu: u64, reg: HvSysReg, value: *mut u64) -> HvfResult;
     pub fn hv_vcpu_set_sys_reg(vcpu: u64, reg: HvSysReg, value: u64) -> HvfResult;
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn hv_vcpu_get_pending_interrupt(
         vcpu: u64,
         ty: HvInterruptType,
@@ -93,7 +93,7 @@ unsafe extern "C" {
         ty: HvInterruptType,
         pending: bool,
     ) -> HvfResult;
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn hv_vcpu_get_vtimer_mask(vcpu: u64, vtimer_is_masked: *mut bool) -> HvfResult;
     pub fn hv_vcpu_set_vtimer_mask(vcpu: u64, vtimer_is_masked: bool) -> HvfResult;
 }

--- a/vmm_core/virt_kvm/src/arch/x86_64/regs.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/regs.rs
@@ -5,7 +5,7 @@ use hvdef::HvX64RegisterName;
 
 #[derive(Debug)]
 // Field is stored solely for logging via debug, not actually dead.
-pub struct NoRegisterMapping(#[allow(dead_code)] HvX64RegisterName);
+pub struct NoRegisterMapping(#[expect(dead_code)] HvX64RegisterName);
 
 /// Converts a register name to an msr.
 pub const fn register_to_msr(name: HvX64RegisterName) -> Result<u32, NoRegisterMapping> {

--- a/vmm_core/virt_mshv/src/vp_state.rs
+++ b/vmm_core/virt_mshv/src/vp_state.rs
@@ -83,7 +83,7 @@ fn hvdef_to_mshv_mut(regs: &mut [HvRegisterAssoc]) -> &mut [hv_register_assoc] {
     unsafe { std::mem::transmute(regs) }
 }
 
-#[allow(unused_variables)]
+#[expect(unused_variables)]
 impl AccessVpState for &'_ mut MshvProcessor<'_> {
     type Error = Error;
 

--- a/vmm_core/virt_whp/src/memory.rs
+++ b/vmm_core/virt_whp/src/memory.rs
@@ -343,7 +343,7 @@ impl MemoryMapper for WhpMemoryMapper {
 
 /// What VTL access to apply to a page.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Inspect)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub enum VtlAccess {
     /// No access
     NoAccess,

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -1084,7 +1084,7 @@ pub mod options {
         use crate::BusIdPci;
         use chipset_resources::battery::HostBatteryUpdate;
         use local_clock::InspectableLocalClock;
-        #[allow(unused)]
+        #[expect(unused)]
         use vmcore::non_volatile_store::NonVolatileStore;
 
         macro_rules! feature_gated {

--- a/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/device.rs
+++ b/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/device.rs
@@ -206,7 +206,6 @@ where
     /// Includes some basic validation that returns an error if a device
     /// attempts to use a service without also implementing the service's
     /// corresponding `ChipsetDevice::supports_` method.
-    #[allow(clippy::should_implement_trait)] // obviously not std::ops::Add
     #[instrument(name = "add_device", skip_all, fields(device = self.dev_name.as_ref()))]
     pub fn add<F>(mut self, f: F) -> Result<Arc<CloseableMutex<T>>, AddDeviceError>
     where

--- a/vmm_core/vmotherboard/src/chipset/builder/errors.rs
+++ b/vmm_core/vmotherboard/src/chipset/builder/errors.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 // DEVNOTE: many of these _could_ potentially be lifted to compile time through
 // the use of a `typed_builder`...
 #[derive(Debug, Error)]
-#[allow(clippy::enum_variant_names)] // these are descriptive
+#[expect(clippy::enum_variant_names, reason = "these are descriptive")]
 pub enum ChipsetBuilderError {
     /// detected static mmio intercept region conflict
     #[error("static mmio intercept region conflict: {0}")]

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -331,7 +331,7 @@ impl Parse for Args {
             .collect();
 
         for config in &configs {
-            #[allow(clippy::single_match)] // more patterns coming later
+            #[expect(clippy::single_match, reason = "more patterns coming later")]
             match config.firmware {
                 Firmware::Uefi(UefiGuest::Vhd(ImageInfo { arch, .. })) => {
                     if config.arch != arch {

--- a/workers/debug_worker/src/gdb/arch/x86/mod.rs
+++ b/workers/debug_worker/src/gdb/arch/x86/mod.rs
@@ -9,7 +9,8 @@ use gdbstub::arch::SingleStepGdbBehavior;
 pub mod reg;
 
 /// Implements `Arch` for 64-bit x86 the same way QEMU does
-#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+#[expect(non_camel_case_types)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum X86_64_QEMU {}
 
 impl Arch for X86_64_QEMU {

--- a/workers/debug_worker/src/gdb/arch/x86/reg/mod.rs
+++ b/workers/debug_worker/src/gdb/arch/x86/reg/mod.rs
@@ -6,7 +6,7 @@
 use gdbstub::arch::Registers;
 
 /// `RegId` definitions for x86 architectures.
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub mod id;
 
 mod core32;

--- a/workers/debug_worker/src/gdb/mod.rs
+++ b/workers/debug_worker/src/gdb/mod.rs
@@ -64,7 +64,7 @@ impl VmProxy {
         NonZeroUsize::new(vp as usize + 1).unwrap()
     }
 
-    #[allow(dead_code)] // TODO: add monitor command to inspect physical memory?
+    #[expect(dead_code, reason = "TODO")] // TODO: add monitor command to inspect physical memory?
     fn read_guest_physical_memory(&mut self, gpa: u64, data: &mut [u8]) -> anyhow::Result<()> {
         let buf = block_on(self.req_chan.call(
             DebugRequest::ReadMemory,

--- a/workers/vnc_worker/vnc/src/lib.rs
+++ b/workers/vnc_worker/vnc/src/lib.rs
@@ -75,7 +75,7 @@ impl<F: Framebuffer, I: Input> Server<F, I> {
         fb: F,
         input: I,
     ) -> Server<F, I> {
-        #[allow(clippy::disallowed_methods)] // TODO
+        #[expect(clippy::disallowed_methods, reason = "TODO")] // TODO
         let (update_send, update_recv) = mpsc::channel(1);
         Self {
             socket,

--- a/workers/vnc_worker/vnc/src/rfb.rs
+++ b/workers/vnc_worker/vnc/src/rfb.rs
@@ -8,7 +8,7 @@ use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types)]
 mod packed_nums {
     pub type u16_be = zerocopy::U16<zerocopy::BigEndian>;
     pub type u32_be = zerocopy::U32<zerocopy::BigEndian>;

--- a/xsync/xsync/src/main.rs
+++ b/xsync/xsync/src/main.rs
@@ -53,7 +53,7 @@ struct Cli {
     command: Option<Commands>,
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 enum Commands {
     CargoToml(tasks::CargoToml),

--- a/xsync/xsync/src/tasks/cargo_lock.rs
+++ b/xsync/xsync/src/tasks/cargo_lock.rs
@@ -257,7 +257,7 @@ impl Cmd for CargoLock {
     }
 }
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 mod cargo_external_lock {
     use serde::Deserialize;
     use serde::Serialize;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -61,7 +61,7 @@ struct Cli {
     custom_root: Option<PathBuf>,
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 enum Commands {
     #[clap(hide = true)]

--- a/xtask/src/tasks/fuzz/parse_fuzz_crate_toml.rs
+++ b/xtask/src/tasks/fuzz/parse_fuzz_crate_toml.rs
@@ -27,7 +27,7 @@ pub(super) struct FuzzCrateMetadata {
 #[derive(Debug)]
 pub(super) struct RepoFuzzTarget {
     pub fuzz_dir: PathBuf,
-    #[allow(dead_code)] // useful in `dump` debug output
+    #[expect(dead_code)] // useful in `dump` debug output
     pub crate_name: String,
     pub allowlist: Vec<PathBuf>,
     pub target_options: Vec<String>,

--- a/xtask/src/tasks/guest_test/uefi/mod.rs
+++ b/xtask/src/tasks/guest_test/uefi/mod.rs
@@ -23,12 +23,12 @@ pub struct Uefi {
 
     /// File to set as `bootx64.efi`. Builds `guest_test_uefi` for x64 if no file is provided (default).
     #[clap(long)]
-    #[allow(clippy::option_option)]
+    #[expect(clippy::option_option)]
     bootx64: Option<Option<PathBuf>>,
 
     /// File to set as `bootaa64.efi`. Builds `guest_test_uefi` for ARM64 if no file is provided.
     #[clap(long)]
-    #[allow(clippy::option_option)]
+    #[expect(clippy::option_option)]
     bootaa64: Option<Option<PathBuf>>,
 }
 


### PR DESCRIPTION
Start on converting allow to expect - avoided codegen / macros as in some cases makes sense (eg lint fires off in some code generated and not others), and avoided some lints such as Missing_Docs, where expect would say the lint is not needed but no allow resulted in the lint triggering