### PR TITLE
Use VTL-aware direct hypercall to get/set registers when possible

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -122,6 +122,8 @@ pub enum Error {
     TranslateGvaToGpa(#[source] TranslateGvaToGpaError),
     #[error("gpa failed vtl access check")]
     CheckVtlAccess(#[source] HvError),
+    #[error("failed to set registers using set_vp_registers hypercall")]
+    SetRegisters(#[source] HvError),
     #[error("Unknown register name: {0:x}")]
     UnknownRegisterName(u32),
     #[error("Invalid register value")]
@@ -455,10 +457,6 @@ mod ioctls {
         mshv_vp_registers
     );
 
-    // The kernel has a bug where it only supports one register at a time.
-    // Increase this when this is fixed.
-    pub const MSHV_VP_MAX_REGISTERS: usize = 1;
-
     ioctl_write_ptr!(
         /// Adds the VTL0 memory as a ZONE_DEVICE memory (I/O) to support
         /// DMA from the guest.
@@ -670,6 +668,163 @@ impl MshvVtl {
 
         Ok(())
     }
+}
+
+#[cfg(guest_arch = "x86_64")]
+fn is_vtl_shared_mtrr(reg: HvX64RegisterName) -> bool {
+    matches!(
+        reg,
+        HvX64RegisterName::MsrMtrrCap
+            | HvX64RegisterName::MsrMtrrDefType
+            | HvX64RegisterName::MsrMtrrPhysBase0
+            | HvX64RegisterName::MsrMtrrPhysBase1
+            | HvX64RegisterName::MsrMtrrPhysBase2
+            | HvX64RegisterName::MsrMtrrPhysBase3
+            | HvX64RegisterName::MsrMtrrPhysBase4
+            | HvX64RegisterName::MsrMtrrPhysBase5
+            | HvX64RegisterName::MsrMtrrPhysBase6
+            | HvX64RegisterName::MsrMtrrPhysBase7
+            | HvX64RegisterName::MsrMtrrPhysBase8
+            | HvX64RegisterName::MsrMtrrPhysBase9
+            | HvX64RegisterName::MsrMtrrPhysBaseA
+            | HvX64RegisterName::MsrMtrrPhysBaseB
+            | HvX64RegisterName::MsrMtrrPhysBaseC
+            | HvX64RegisterName::MsrMtrrPhysBaseD
+            | HvX64RegisterName::MsrMtrrPhysBaseE
+            | HvX64RegisterName::MsrMtrrPhysBaseF
+            | HvX64RegisterName::MsrMtrrPhysMask0
+            | HvX64RegisterName::MsrMtrrPhysMask1
+            | HvX64RegisterName::MsrMtrrPhysMask2
+            | HvX64RegisterName::MsrMtrrPhysMask3
+            | HvX64RegisterName::MsrMtrrPhysMask4
+            | HvX64RegisterName::MsrMtrrPhysMask5
+            | HvX64RegisterName::MsrMtrrPhysMask6
+            | HvX64RegisterName::MsrMtrrPhysMask7
+            | HvX64RegisterName::MsrMtrrPhysMask8
+            | HvX64RegisterName::MsrMtrrPhysMask9
+            | HvX64RegisterName::MsrMtrrPhysMaskA
+            | HvX64RegisterName::MsrMtrrPhysMaskB
+            | HvX64RegisterName::MsrMtrrPhysMaskC
+            | HvX64RegisterName::MsrMtrrPhysMaskD
+            | HvX64RegisterName::MsrMtrrPhysMaskE
+            | HvX64RegisterName::MsrMtrrPhysMaskF
+            | HvX64RegisterName::MsrMtrrFix64k00000
+            | HvX64RegisterName::MsrMtrrFix16k80000
+            | HvX64RegisterName::MsrMtrrFix16kA0000
+            | HvX64RegisterName::MsrMtrrFix4kC0000
+            | HvX64RegisterName::MsrMtrrFix4kC8000
+            | HvX64RegisterName::MsrMtrrFix4kD0000
+            | HvX64RegisterName::MsrMtrrFix4kD8000
+            | HvX64RegisterName::MsrMtrrFix4kE0000
+            | HvX64RegisterName::MsrMtrrFix4kE8000
+            | HvX64RegisterName::MsrMtrrFix4kF0000
+            | HvX64RegisterName::MsrMtrrFix4kF8000
+    )
+}
+
+/// Indicate whether reg is shared across VTLs.
+///
+/// This function is not complete: DR6 may or may not be shared, depending on
+/// the processor type; the caller needs to check HvRegisterVsmCapabilities.
+/// Some MSRs are not included here as they are not represented in
+/// HvX64RegisterName, including MSR_TSC_FREQUENCY, MSR_MCG_CAP,
+/// MSR_MCG_STATUS, MSR_RESET, MSR_GUEST_IDLE, and MSR_DEBUG_DEVICE_OPTIONS.
+#[cfg(guest_arch = "x86_64")]
+fn is_vtl_shared_reg(reg: HvX64RegisterName) -> bool {
+    is_vtl_shared_mtrr(reg)
+        || matches!(
+            reg,
+            HvX64RegisterName::VpIndex
+                | HvX64RegisterName::VpRuntime
+                | HvX64RegisterName::TimeRefCount
+                | HvX64RegisterName::Rax
+                | HvX64RegisterName::Rbx
+                | HvX64RegisterName::Rcx
+                | HvX64RegisterName::Rdx
+                | HvX64RegisterName::Rsi
+                | HvX64RegisterName::Rdi
+                | HvX64RegisterName::Rbp
+                | HvX64RegisterName::Cr2
+                | HvX64RegisterName::R8
+                | HvX64RegisterName::R9
+                | HvX64RegisterName::R10
+                | HvX64RegisterName::R11
+                | HvX64RegisterName::R12
+                | HvX64RegisterName::R13
+                | HvX64RegisterName::R14
+                | HvX64RegisterName::R15
+                | HvX64RegisterName::Dr0
+                | HvX64RegisterName::Dr1
+                | HvX64RegisterName::Dr2
+                | HvX64RegisterName::Dr3
+                | HvX64RegisterName::Xmm0
+                | HvX64RegisterName::Xmm1
+                | HvX64RegisterName::Xmm2
+                | HvX64RegisterName::Xmm3
+                | HvX64RegisterName::Xmm4
+                | HvX64RegisterName::Xmm5
+                | HvX64RegisterName::Xmm6
+                | HvX64RegisterName::Xmm7
+                | HvX64RegisterName::Xmm8
+                | HvX64RegisterName::Xmm9
+                | HvX64RegisterName::Xmm10
+                | HvX64RegisterName::Xmm11
+                | HvX64RegisterName::Xmm12
+                | HvX64RegisterName::Xmm13
+                | HvX64RegisterName::Xmm14
+                | HvX64RegisterName::Xmm15
+                | HvX64RegisterName::FpMmx0
+                | HvX64RegisterName::FpMmx1
+                | HvX64RegisterName::FpMmx2
+                | HvX64RegisterName::FpMmx3
+                | HvX64RegisterName::FpMmx4
+                | HvX64RegisterName::FpMmx5
+                | HvX64RegisterName::FpMmx6
+                | HvX64RegisterName::FpMmx7
+                | HvX64RegisterName::FpControlStatus
+                | HvX64RegisterName::XmmControlStatus
+                | HvX64RegisterName::Xfem
+        )
+}
+
+/// Indicate whether reg is shared across VTLs.
+#[cfg(guest_arch = "aarch64")]
+fn is_vtl_shared_reg(reg: HvArm64RegisterName) -> bool {
+    use hvdef::HvArm64RegisterName;
+
+    matches!(
+        reg,
+        HvArm64RegisterName::X0
+            | HvArm64RegisterName::X1
+            | HvArm64RegisterName::X2
+            | HvArm64RegisterName::X3
+            | HvArm64RegisterName::X4
+            | HvArm64RegisterName::X5
+            | HvArm64RegisterName::X6
+            | HvArm64RegisterName::X7
+            | HvArm64RegisterName::X8
+            | HvArm64RegisterName::X9
+            | HvArm64RegisterName::X10
+            | HvArm64RegisterName::X11
+            | HvArm64RegisterName::X12
+            | HvArm64RegisterName::X13
+            | HvArm64RegisterName::X14
+            | HvArm64RegisterName::X15
+            | HvArm64RegisterName::X16
+            | HvArm64RegisterName::X17
+            | HvArm64RegisterName::X19
+            | HvArm64RegisterName::X20
+            | HvArm64RegisterName::X21
+            | HvArm64RegisterName::X22
+            | HvArm64RegisterName::X23
+            | HvArm64RegisterName::X24
+            | HvArm64RegisterName::X25
+            | HvArm64RegisterName::X26
+            | HvArm64RegisterName::X27
+            | HvArm64RegisterName::X28
+            | HvArm64RegisterName::XFp
+            | HvArm64RegisterName::XLr
+    )
 }
 
 /// The `/dev/mshv_hvcall` device for issuing hypercalls directly to the
@@ -1193,8 +1348,8 @@ impl MshvHvcall {
     /// panic if the hypercall fails.
     fn get_vp_register_for_vtl_inner(
         &self,
-        name: HvRegisterName,
         target_vtl: HvInputVtl,
+        name: HvRegisterName,
     ) -> HvRegisterValue {
         let header = hvdef::hypercall::GetSetVpRegisters {
             partition_id: HV_PARTITION_ID_SELF,
@@ -1228,8 +1383,8 @@ impl MshvHvcall {
     #[cfg(guest_arch = "x86_64")]
     pub fn get_vp_register_for_vtl(
         &self,
-        name: HvX64RegisterName,
         vtl: HvInputVtl,
+        name: HvX64RegisterName,
     ) -> HvRegisterValue {
         match vtl.target_vtl().unwrap() {
             None | Some(Vtl::Vtl2) => {
@@ -1245,15 +1400,24 @@ impl MshvHvcall {
                 ));
             }
             Some(Vtl::Vtl1) => {
-                // TODO: allowed registers for VTL1
-                todo!();
+                todo!("TODO: allowed registers for VTL1");
             }
             Some(Vtl::Vtl0) => {
-                assert!(matches!(name, HvX64RegisterName::GuestOsId));
+                // Only VTL-private registers can go through this path.
+                // VTL-shared registers have to go through the kernel (either
+                // via the CPU context page or via the dedicated ioctl), as
+                // they may require special handling there.
+                //
+                // Register access should go through the register page if
+                // possible (as a performance optimization). In practice,
+                // registers that are normally available on the register page
+                // are handled here only when it is unavailable (e.g., running
+                // in WHP).
+                assert!(!is_vtl_shared_reg(name));
             }
         }
 
-        self.get_vp_register_for_vtl_inner(name.into(), vtl)
+        self.get_vp_register_for_vtl_inner(vtl, name.into())
     }
 
     /// Get a single VP register for the given VTL via hypercall. Only a select
@@ -1261,8 +1425,8 @@ impl MshvHvcall {
     #[cfg(guest_arch = "aarch64")]
     pub fn get_vp_register_for_vtl(
         &self,
-        name: HvArm64RegisterName,
         vtl: HvInputVtl,
+        name: HvArm64RegisterName,
     ) -> HvRegisterValue {
         match vtl.target_vtl().unwrap() {
             None | Some(Vtl::Vtl2) => {
@@ -1283,11 +1447,15 @@ impl MshvHvcall {
                 todo!();
             }
             Some(Vtl::Vtl0) => {
-                assert!(matches!(name, HvArm64RegisterName::GuestOsId));
+                // Only VTL-private registers can go through this path.
+                // VTL-shared registers have to go through the kernel (either
+                // via the CPU context page or via the dedicated ioctl), as
+                // they may require special handling there.
+                assert!(!is_vtl_shared_reg(name));
             }
         }
 
-        self.get_vp_register_for_vtl_inner(name.into(), vtl)
+        self.get_vp_register_for_vtl_inner(vtl, name.into())
     }
 }
 
@@ -1489,6 +1657,7 @@ mod private {
     use super::HclVp;
     use super::NoRunner;
     use super::ProcessorRunner;
+    use crate::GuestVtl;
     use hvdef::HvRegisterName;
     use hvdef::HvRegisterValue;
     use sidecar_client::SidecarVp;
@@ -1498,6 +1667,7 @@ mod private {
 
         fn try_set_reg(
             runner: &mut ProcessorRunner<'_, Self>,
+            vtl: GuestVtl,
             name: HvRegisterName,
             value: HvRegisterValue,
         ) -> Result<bool, Error>;
@@ -1506,6 +1676,7 @@ mod private {
 
         fn try_get_reg(
             runner: &ProcessorRunner<'_, Self>,
+            vtl: GuestVtl,
             name: HvRegisterName,
         ) -> Result<Option<HvRegisterValue>, Error>;
     }
@@ -1526,57 +1697,115 @@ impl<T> Drop for ProcessorRunner<'_, T> {
 }
 
 impl<'a, T: Backing> ProcessorRunner<'a, T> {
-    fn set_reg(&mut self, regs: &[HvRegisterAssoc]) -> Result<(), Error> {
+    // These registers are handled specially by the kernel through a dedicated
+    // ioctl. is_kernel_managed is arch-specific to guard against an into() on
+    // an HvArmRegisterName that overlaps one of these x86-specific values.
+    #[cfg(guest_arch = "x86_64")]
+    fn is_kernel_managed(&self, name: HvX64RegisterName) -> bool {
+        if name == HvX64RegisterName::Xfem {
+            self.hcl.isolation == IsolationType::Tdx
+        } else if name == HvX64RegisterName::Dr6 {
+            self.hcl.dr6_shared()
+        } else {
+            is_vtl_shared_mtrr(name)
+                || matches!(
+                    name,
+                    HvX64RegisterName::Dr0
+                        | HvX64RegisterName::Dr1
+                        | HvX64RegisterName::Dr2
+                        | HvX64RegisterName::Dr3
+                )
+        }
+    }
+
+    #[cfg(guest_arch = "aarch64")]
+    fn is_kernel_managed(&self, _name: HvArm64RegisterName) -> bool {
+        false
+    }
+
+    fn set_reg(&mut self, vtl: GuestVtl, regs: &[HvRegisterAssoc]) -> Result<(), Error> {
         if regs.is_empty() {
             return Ok(());
         }
-        // TODO GUEST_VSM
-        let vtl = Vtl::Vtl0;
+
         if let Some(sidecar) = &mut self.sidecar {
             sidecar
                 .set_vp_registers(vtl.into(), regs)
                 .map_err(Error::Sidecar)?;
         } else {
-            for regs in regs.chunks(MSHV_VP_MAX_REGISTERS) {
-                let hv_vp_register_args = mshv_vp_registers {
-                    count: regs.len() as i32,
-                    regs: regs.as_ptr().cast_mut(),
-                };
-                // SAFETY: IOCTL call with correct types.
-                unsafe {
-                    hcl_set_vp_register(self.hcl.mshv_vtl.file.as_raw_fd(), &hv_vp_register_args)
+            // TODO: group up to MSHV_VP_MAX_REGISTERS regs. The kernel
+            // currently has a bug where it only supports one register at a
+            // time. Once that's fixed, this code could set a group of
+            // registers in one ioctl.
+            for reg in regs {
+                let hc_regs = &mut [HvRegisterAssoc {
+                    name: reg.name,
+                    pad: [0; 3],
+                    value: reg.value,
+                }];
+
+                if self.is_kernel_managed(reg.name.into()) {
+                    let hv_vp_register_args = mshv_vp_registers {
+                        count: 1,
+                        regs: hc_regs.as_mut_ptr(),
+                    };
+                    // SAFETY: ioctl call with correct types.
+                    unsafe {
+                        hcl_set_vp_register(
+                            self.hcl.mshv_vtl.file.as_raw_fd(),
+                            &hv_vp_register_args,
+                        )
                         .map_err(Error::SetVpRegister)?;
+                    }
+                } else {
+                    let hc_regs = [HvRegisterAssoc {
+                        name: reg.name,
+                        pad: [0; 3],
+                        value: reg.value,
+                    }];
+                    self.set_vp_registers_hvcall_inner(vtl.into(), &hc_regs)
+                        .map_err(Error::SetRegisters)?;
                 }
             }
         }
         Ok(())
     }
 
-    fn get_reg(&mut self, regs: &mut [HvRegisterAssoc]) -> Result<(), Error> {
+    fn get_reg(&mut self, vtl: GuestVtl, regs: &mut [HvRegisterAssoc]) -> Result<(), Error> {
         if regs.is_empty() {
             return Ok(());
         }
-        // TODO GUEST_VSM
-        let vtl = Vtl::Vtl0;
+
         if let Some(sidecar) = &mut self.sidecar {
             sidecar
                 .get_vp_registers(vtl.into(), regs)
                 .map_err(Error::Sidecar)?;
         } else {
-            for reg_names in regs.chunks_mut(MSHV_VP_MAX_REGISTERS) {
-                let mut mshv_vp_register_args = mshv_vp_registers {
-                    count: reg_names.len() as i32,
-                    regs: reg_names.as_mut_ptr(),
-                };
-                // SAFETY: we know that our file is a vCPU fd, we know the kernel will only read the
-                // correct amount of memory from our pointer, and we verify the return result.
-                unsafe {
-                    hcl_get_vp_register(
-                        self.hcl.mshv_vtl.file.as_raw_fd(),
-                        &mut mshv_vp_register_args,
-                    )
-                    .map_err(Error::GetVpRegister)?;
-                };
+            // TODO: group up to MSHV_VP_MAX_REGISTERS regs. The kernel
+            // currently has a bug where it only supports one register at a
+            // time. Once that's fixed, this code could set a group of
+            // registers in one ioctl.
+            for reg in regs {
+                if self.is_kernel_managed(reg.name.into()) {
+                    let mut mshv_vp_register_args = mshv_vp_registers {
+                        count: 1,
+                        regs: reg,
+                    };
+                    // SAFETY: we know that our file is a vCPU fd, we know the kernel will only read the
+                    // correct amount of memory from our pointer, and we verify the return result.
+                    unsafe {
+                        hcl_get_vp_register(
+                            self.hcl.mshv_vtl.file.as_raw_fd(),
+                            &mut mshv_vp_register_args,
+                        )
+                        .map_err(Error::GetVpRegister)?;
+                    }
+                } else {
+                    reg.value = self
+                        .hcl
+                        .mshv_hvcall
+                        .get_vp_register_for_vtl(vtl.into(), reg.name.into());
+                }
             }
         }
         Ok(())
@@ -1696,121 +1925,9 @@ impl<'a, T: Backing> ProcessorRunner<'a, T> {
 }
 
 impl<T: Backing> ProcessorRunner<'_, T> {
-    fn set_vp_register_inner(
-        &mut self,
-        name: HvRegisterName,
-        value: HvRegisterValue,
-    ) -> Result<(), Error> {
-        let set = T::try_set_reg(self, name, value)?;
-        if set {
-            return Ok(());
-        }
-
-        // Set the register via a hypercall.
-        let info = [HvRegisterAssoc {
-            name,
-            pad: Default::default(),
-            value,
-        }];
-
-        self.set_reg(&info)?;
-
-        Ok(())
-    }
-
-    /// Set the following register on the given VP, x86_64
-    ///
-    /// This will fail for registers that are in the mmapped CPU context, i.e.
-    /// registers that are shared between VTL0 and VTL2.
-    ///
-    /// Can only set registers for VTL 0.
-    #[cfg(guest_arch = "x86_64")]
-    pub fn set_vp_register(
-        &mut self,
-        name: HvX64RegisterName,
-        value: HvRegisterValue,
-    ) -> Result<(), Error> {
-        tracing::trace!(?name, ?value, "set_vp_register");
-        self.set_vp_register_inner(name.into(), value)
-    }
-
-    /// Set the following register on the given VP, aarch64
-    ///
-    /// This will fail for registers that are in the mmapped CPU context, i.e.
-    /// registers that are shared between VTL0 and VTL2.
-    ///
-    /// Can only set registers for VTL 0.
-    #[cfg(guest_arch = "aarch64")]
-    pub fn set_vp_register(
-        &mut self,
-        name: HvArm64RegisterName,
-        value: HvRegisterValue,
-    ) -> Result<(), Error> {
-        tracing::trace!(?name, ?value, "set_vp_register");
-        self.set_vp_register_inner(name.into(), value)
-    }
-
-    fn get_vp_register_inner(&mut self, name: HvRegisterName) -> Result<HvRegisterValue, Error> {
-        if let Some(value) = T::try_get_reg(self, name)? {
-            return Ok(value);
-        }
-        let mut info = [HvRegisterAssoc {
-            name,
-            pad: Default::default(),
-            value: FromZeroes::new_zeroed(),
-        }];
-        self.get_reg(&mut info)?;
-        Ok(info[0].value)
-    }
-
-    /// Get the following register on the current VP, x86_64.
-    ///
-    /// This will fail for registers that are in the mmapped CPU context, i.e.
-    /// registers that are shared between VTL0 and VTL2.
-    ///
-    /// Can only get registers for VTL 0.
-    #[cfg(guest_arch = "x86_64")]
-    pub fn get_vp_register(&mut self, name: HvX64RegisterName) -> Result<HvRegisterValue, Error> {
-        self.get_vp_register_inner(name.into())
-    }
-
-    /// Get the following register on the current VP, aarch64.
-    ///
-    /// This will fail for registers that are in the mmapped CPU context, i.e.
-    /// registers that are shared between VTL0 and VTL2.
-    ///
-    /// Can only get registers for VTL 0.
-    #[cfg(guest_arch = "aarch64")]
-    pub fn get_vp_register(&mut self, name: HvArm64RegisterName) -> Result<HvRegisterValue, Error> {
-        tracing::trace!(?name, "get_vp_register");
-        self.get_vp_register_inner(name.into())
-    }
-
-    /// Sets a set of VP registers on the last intercepting VTL.
-    pub fn set_vp_registers<I>(&mut self, values: I) -> Result<(), Error>
-    where
-        I: IntoIterator,
-        I::Item: Into<HvRegisterAssoc> + Clone,
-    {
-        let mut assoc = Vec::new();
-        for HvRegisterAssoc { name, value, .. } in values.into_iter().map(Into::into) {
-            if !assoc.is_empty() && T::must_flush_regs_on(self, name) {
-                self.set_reg(&assoc)?;
-                assoc.clear();
-            }
-            if !T::try_set_reg(self, name, value)? {
-                assoc.push(HvRegisterAssoc {
-                    name,
-                    pad: Default::default(),
-                    value,
-                });
-            }
-        }
-        self.set_reg(&assoc)
-    }
-
     fn get_vp_registers_inner<R: Copy + Into<HvRegisterName>>(
         &mut self,
+        vtl: GuestVtl,
         names: &[R],
         values: &mut [HvRegisterValue],
     ) -> Result<(), Error> {
@@ -1818,7 +1935,7 @@ impl<T: Backing> ProcessorRunner<'_, T> {
         let mut assoc = Vec::new();
         let mut offset = Vec::new();
         for (i, (&name, value)) in names.iter().zip(values.iter_mut()).enumerate() {
-            if let Some(v) = T::try_get_reg(self, name.into())? {
+            if let Some(v) = T::try_get_reg(self, vtl, name.into())? {
                 *value = v;
             } else {
                 assoc.push(HvRegisterAssoc {
@@ -1830,37 +1947,113 @@ impl<T: Backing> ProcessorRunner<'_, T> {
             }
         }
 
-        self.get_reg(&mut assoc)?;
+        self.get_reg(vtl, &mut assoc)?;
         for (&i, assoc) in offset.iter().zip(&assoc) {
             values[i] = assoc.value;
         }
         Ok(())
     }
 
-    /// Get the following VP registers on the current VP.
+    /// Get the following register on the current VP.
     ///
-    /// # Panics
-    /// Panics if `names.len() != values.len()`.
-    #[cfg(guest_arch = "x86_64")]
-    pub fn get_vp_registers(
+    /// This will fail for registers that are in the mmapped CPU context, i.e.
+    /// registers that are shared between VTL0 and VTL2.
+    pub fn get_vp_register(
         &mut self,
-        names: &[HvX64RegisterName],
-        values: &mut [HvRegisterValue],
-    ) -> Result<(), Error> {
-        self.get_vp_registers_inner(names, values)
+        vtl: GuestVtl,
+        #[cfg(guest_arch = "x86_64")] name: HvX64RegisterName,
+        #[cfg(guest_arch = "aarch64")] name: HvArm64RegisterName,
+    ) -> Result<HvRegisterValue, Error> {
+        let mut value = [0u64.into(); 1];
+        self.get_vp_registers_inner(vtl, &[name], &mut value)?;
+        Ok(value[0])
     }
 
     /// Get the following VP registers on the current VP.
     ///
     /// # Panics
     /// Panics if `names.len() != values.len()`.
-    #[cfg(guest_arch = "aarch64")]
     pub fn get_vp_registers(
         &mut self,
-        names: &[HvArm64RegisterName],
+        vtl: GuestVtl,
+        #[cfg(guest_arch = "x86_64")] names: &[HvX64RegisterName],
+        #[cfg(guest_arch = "aarch64")] names: &[HvArm64RegisterName],
         values: &mut [HvRegisterValue],
     ) -> Result<(), Error> {
-        self.get_vp_registers_inner(names, values)
+        self.get_vp_registers_inner(vtl, names, values)
+    }
+
+    /// Set the following register on the current VP.
+    ///
+    /// This will fail for registers that are in the mmapped CPU context, i.e.
+    /// registers that are shared between VTL0 and VTL2.
+    pub fn set_vp_register(
+        &mut self,
+        vtl: GuestVtl,
+        #[cfg(guest_arch = "x86_64")] name: HvX64RegisterName,
+        #[cfg(guest_arch = "aarch64")] name: HvArm64RegisterName,
+        value: HvRegisterValue,
+    ) -> Result<(), Error> {
+        self.set_vp_registers(vtl, [(name, value)])
+    }
+
+    /// Sets a set of VP registers.
+    pub fn set_vp_registers<I>(&mut self, vtl: GuestVtl, values: I) -> Result<(), Error>
+    where
+        I: IntoIterator,
+        I::Item: Into<HvRegisterAssoc> + Clone,
+    {
+        let mut assoc = Vec::new();
+        for HvRegisterAssoc { name, value, .. } in values.into_iter().map(Into::into) {
+            if !assoc.is_empty() && T::must_flush_regs_on(self, name) {
+                self.set_reg(vtl, &assoc)?;
+                assoc.clear();
+            }
+            if !T::try_set_reg(self, vtl, name, value)? {
+                assoc.push(HvRegisterAssoc {
+                    name,
+                    pad: Default::default(),
+                    value,
+                });
+            }
+        }
+        if !assoc.is_empty() {
+            self.set_reg(vtl, &assoc)?;
+        }
+        Ok(())
+    }
+
+    fn set_vp_registers_hvcall_inner(
+        &mut self,
+        vtl: Vtl,
+        registers: &[HvRegisterAssoc],
+    ) -> Result<(), HvError> {
+        let header = hvdef::hypercall::GetSetVpRegisters {
+            partition_id: HV_PARTITION_ID_SELF,
+            vp_index: HV_VP_INDEX_SELF,
+            target_vtl: vtl.into(),
+            rsvd: [0; 3],
+        };
+
+        tracing::trace!(?registers, "HvCallSetVpRegisters rep");
+
+        // SAFETY: The input header and rep slice are the correct types for this hypercall.
+        //         The hypercall output is validated right after the hypercall is issued.
+        let status = unsafe {
+            self.hcl
+                .mshv_hvcall
+                .hvcall_rep::<hvdef::hypercall::GetSetVpRegisters, HvRegisterAssoc, u8>(
+                    HypercallCode::HvCallSetVpRegisters,
+                    &header,
+                    HvcallRepInput::Elements(registers),
+                    None,
+                )
+                .expect("set_vp_registers hypercall should not fail")
+        };
+
+        // Status must be success
+        status.result()?;
+        Ok(())
     }
 
     /// Sets the following registers on the current VP and given VTL using a
@@ -1868,6 +2061,8 @@ impl<T: Backing> ProcessorRunner<'_, T> {
     ///
     /// This should not be used on the fast path. Therefore only a select set of
     /// registers are supported, and others will cause a panic.
+    ///
+    /// This function can be used with VTL2 as a target.
     pub fn set_vp_registers_hvcall<I>(&mut self, vtl: Vtl, values: I) -> Result<(), HvError>
     where
         I: IntoIterator,
@@ -1893,34 +2088,7 @@ impl<T: Backing> ProcessorRunner<'_, T> {
                     | HvX64RegisterName::VsmVpSecureConfigVtl1
             )
         ));
-
-        let header = hvdef::hypercall::GetSetVpRegisters {
-            partition_id: HV_PARTITION_ID_SELF,
-            vp_index: HV_VP_INDEX_SELF,
-            target_vtl: vtl.into(),
-            rsvd: [0; 3],
-        };
-
-        tracing::trace!(?registers, "HvCallSetVpRegisters rep");
-
-        // SAFETY: The input header and rep slice are the correct types for this hypercall.
-        //         The hypercall output is validated right after the hypercall is issued.
-        let status = unsafe {
-            self.hcl
-                .mshv_hvcall
-                .hvcall_rep::<hvdef::hypercall::GetSetVpRegisters, HvRegisterAssoc, u8>(
-                    HypercallCode::HvCallSetVpRegisters,
-                    &header,
-                    HvcallRepInput::Elements(registers.as_slice()),
-                    None,
-                )
-                .expect("set_vp_registers hypercall should not fail")
-        };
-
-        // Status must be success
-        status.result()?;
-
-        Ok(())
+        self.set_vp_registers_hvcall_inner(vtl, &registers)
     }
 
     /// Sets the VTL that should be returned to when underhill exits
@@ -2294,7 +2462,7 @@ impl Hcl {
         name: impl Into<HvX64RegisterName>,
         vtl: HvInputVtl,
     ) -> HvRegisterValue {
-        self.mshv_hvcall.get_vp_register_for_vtl(name.into(), vtl)
+        self.mshv_hvcall.get_vp_register_for_vtl(vtl, name.into())
     }
 
     /// Get a single VP register for the given VTL via hypercall. Only a select
@@ -2305,7 +2473,7 @@ impl Hcl {
         name: impl Into<HvArm64RegisterName>,
         vtl: HvInputVtl,
     ) -> HvRegisterValue {
-        self.mshv_hvcall.get_vp_register_for_vtl(name.into(), vtl)
+        self.mshv_hvcall.get_vp_register_for_vtl(vtl, name.into())
     }
 
     /// Set a single VP register via hypercall as VTL2. Only a select set of registers are

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -186,6 +186,7 @@ impl super::private::BackingPrivate for Snp {
 
     fn try_set_reg(
         _runner: &mut ProcessorRunner<'_, Self>,
+        _vtl: GuestVtl,
         _name: HvRegisterName,
         _value: HvRegisterValue,
     ) -> Result<bool, super::Error> {
@@ -198,6 +199,7 @@ impl super::private::BackingPrivate for Snp {
 
     fn try_get_reg(
         _runner: &ProcessorRunner<'_, Self>,
+        _vtl: GuestVtl,
         _name: HvRegisterName,
     ) -> Result<Option<HvRegisterValue>, super::Error> {
         Ok(None)

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -323,6 +323,7 @@ impl super::private::BackingPrivate for Tdx {
 
     fn try_set_reg(
         _runner: &mut ProcessorRunner<'_, Self>,
+        _vtl: GuestVtl,
         _name: HvRegisterName,
         _value: HvRegisterValue,
     ) -> Result<bool, super::Error> {
@@ -335,6 +336,7 @@ impl super::private::BackingPrivate for Tdx {
 
     fn try_get_reg(
         _runner: &ProcessorRunner<'_, Self>,
+        _vtl: GuestVtl,
         _name: HvRegisterName,
     ) -> Result<Option<HvRegisterValue>, super::Error> {
         Ok(None)

--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -200,10 +200,14 @@ impl BackingPrivate for MshvX64 {
 
     fn try_set_reg(
         runner: &mut ProcessorRunner<'_, Self>,
+        vtl: GuestVtl,
         name: HvRegisterName,
         value: HvRegisterValue,
     ) -> Result<bool, Error> {
-        // Try to set the register in the CPU context.
+        // Try to set the register in the CPU context, the fastest path. Only
+        // VTL-shared registers can be set this way: the CPU context only
+        // exposes the last VTL, and if we entered VTL2 on an interrupt,
+        // OpenHCL doesn't know what the last VTL is.
         let name = name.into();
         let set = match name {
             HvX64RegisterName::Rax
@@ -251,45 +255,48 @@ impl BackingPrivate for MshvX64 {
         }
 
         if let Some(reg_page) = runner.reg_page_mut() {
-            let set = match name {
-                HvX64RegisterName::Rsp => {
-                    reg_page.gp_registers[(name.0 - HvX64RegisterName::Rax.0) as usize] =
-                        value.as_u64();
-                    reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_GENERAL;
-                    true
-                }
-                HvX64RegisterName::Rip => {
-                    reg_page.rip = value.as_u64();
-                    reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_IP;
-                    true
-                }
-                HvX64RegisterName::Rflags => {
-                    reg_page.rflags = value.as_u64();
-                    reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_FLAGS;
-                    true
-                }
-                HvX64RegisterName::Es
-                | HvX64RegisterName::Cs
-                | HvX64RegisterName::Ss
-                | HvX64RegisterName::Ds
-                | HvX64RegisterName::Fs
-                | HvX64RegisterName::Gs => {
-                    reg_page.segment[(name.0 - HvX64RegisterName::Es.0) as usize] = value.as_u128();
-                    reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_SEGMENT;
-                    true
-                }
+            if reg_page.vtl == vtl as u8 {
+                let set = match name {
+                    HvX64RegisterName::Rsp => {
+                        reg_page.gp_registers[(name.0 - HvX64RegisterName::Rax.0) as usize] =
+                            value.as_u64();
+                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_GENERAL;
+                        true
+                    }
+                    HvX64RegisterName::Rip => {
+                        reg_page.rip = value.as_u64();
+                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_IP;
+                        true
+                    }
+                    HvX64RegisterName::Rflags => {
+                        reg_page.rflags = value.as_u64();
+                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_FLAGS;
+                        true
+                    }
+                    HvX64RegisterName::Es
+                    | HvX64RegisterName::Cs
+                    | HvX64RegisterName::Ss
+                    | HvX64RegisterName::Ds
+                    | HvX64RegisterName::Fs
+                    | HvX64RegisterName::Gs => {
+                        reg_page.segment[(name.0 - HvX64RegisterName::Es.0) as usize] =
+                            value.as_u128();
+                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_SEGMENT;
+                        true
+                    }
 
-                // Skip unnecessary register updates.
-                HvX64RegisterName::Cr0 => reg_page.cr0 == value.as_u64(),
-                HvX64RegisterName::Cr3 => reg_page.cr3 == value.as_u64(),
-                HvX64RegisterName::Cr4 => reg_page.cr4 == value.as_u64(),
-                HvX64RegisterName::Cr8 => reg_page.cr8 == value.as_u64(),
-                HvX64RegisterName::Efer => reg_page.efer == value.as_u64(),
-                HvX64RegisterName::Dr7 => reg_page.dr7 == value.as_u64(),
-                _ => false,
-            };
-            if set {
-                return Ok(true);
+                    // Skip unnecessary register updates.
+                    HvX64RegisterName::Cr0 => reg_page.cr0 == value.as_u64(),
+                    HvX64RegisterName::Cr3 => reg_page.cr3 == value.as_u64(),
+                    HvX64RegisterName::Cr4 => reg_page.cr4 == value.as_u64(),
+                    HvX64RegisterName::Cr8 => reg_page.cr8 == value.as_u64(),
+                    HvX64RegisterName::Efer => reg_page.efer == value.as_u64(),
+                    HvX64RegisterName::Dr7 => reg_page.dr7 == value.as_u64(),
+                    _ => false,
+                };
+                if set {
+                    return Ok(true);
+                }
             }
         }
 
@@ -305,6 +312,7 @@ impl BackingPrivate for MshvX64 {
 
     fn try_get_reg(
         runner: &ProcessorRunner<'_, Self>,
+        vtl: GuestVtl,
         name: HvRegisterName,
     ) -> Result<Option<HvRegisterValue>, Error> {
         let name = name.into();
@@ -356,39 +364,41 @@ impl BackingPrivate for MshvX64 {
         }
 
         if let Some(reg_page) = runner.reg_page() {
-            let value = match name {
-                HvX64RegisterName::Rsp => Some(HvRegisterValue(
-                    reg_page.gp_registers[(name.0 - HvX64RegisterName::Rax.0) as usize].into(),
-                )),
-                HvX64RegisterName::Rip => Some(HvRegisterValue((reg_page.rip).into())),
-                HvX64RegisterName::Rflags => Some(HvRegisterValue((reg_page.rflags).into())),
-                HvX64RegisterName::Es
-                | HvX64RegisterName::Cs
-                | HvX64RegisterName::Ss
-                | HvX64RegisterName::Ds
-                | HvX64RegisterName::Fs
-                | HvX64RegisterName::Gs => Some(HvRegisterValue(
-                    reg_page.segment[(name.0 - HvX64RegisterName::Es.0) as usize].into(),
-                )),
-                HvX64RegisterName::Cr0 => Some(HvRegisterValue((reg_page.cr0).into())),
-                HvX64RegisterName::Cr3 => Some(HvRegisterValue((reg_page.cr3).into())),
-                HvX64RegisterName::Cr4 => Some(HvRegisterValue((reg_page.cr4).into())),
-                HvX64RegisterName::Cr8 => Some(HvRegisterValue((reg_page.cr8).into())),
-                HvX64RegisterName::Efer => Some(HvRegisterValue((reg_page.efer).into())),
-                HvX64RegisterName::Dr7 => Some(HvRegisterValue((reg_page.dr7).into())),
-                HvX64RegisterName::InstructionEmulationHints => Some(HvRegisterValue(
-                    (u64::from(reg_page.instruction_emulation_hints)).into(),
-                )),
-                HvX64RegisterName::PendingInterruption => {
-                    Some(u64::from(reg_page.pending_interruption).into())
+            if reg_page.vtl == vtl as u8 {
+                let value = match name {
+                    HvX64RegisterName::Rsp => Some(HvRegisterValue(
+                        reg_page.gp_registers[(name.0 - HvX64RegisterName::Rax.0) as usize].into(),
+                    )),
+                    HvX64RegisterName::Rip => Some(HvRegisterValue((reg_page.rip).into())),
+                    HvX64RegisterName::Rflags => Some(HvRegisterValue((reg_page.rflags).into())),
+                    HvX64RegisterName::Es
+                    | HvX64RegisterName::Cs
+                    | HvX64RegisterName::Ss
+                    | HvX64RegisterName::Ds
+                    | HvX64RegisterName::Fs
+                    | HvX64RegisterName::Gs => Some(HvRegisterValue(
+                        reg_page.segment[(name.0 - HvX64RegisterName::Es.0) as usize].into(),
+                    )),
+                    HvX64RegisterName::Cr0 => Some(HvRegisterValue((reg_page.cr0).into())),
+                    HvX64RegisterName::Cr3 => Some(HvRegisterValue((reg_page.cr3).into())),
+                    HvX64RegisterName::Cr4 => Some(HvRegisterValue((reg_page.cr4).into())),
+                    HvX64RegisterName::Cr8 => Some(HvRegisterValue((reg_page.cr8).into())),
+                    HvX64RegisterName::Efer => Some(HvRegisterValue((reg_page.efer).into())),
+                    HvX64RegisterName::Dr7 => Some(HvRegisterValue((reg_page.dr7).into())),
+                    HvX64RegisterName::InstructionEmulationHints => Some(HvRegisterValue(
+                        (u64::from(reg_page.instruction_emulation_hints)).into(),
+                    )),
+                    HvX64RegisterName::PendingInterruption => {
+                        Some(u64::from(reg_page.pending_interruption).into())
+                    }
+                    HvX64RegisterName::InterruptState => {
+                        Some(u64::from(reg_page.interrupt_state).into())
+                    }
+                    _ => None,
+                };
+                if let Some(value) = value {
+                    return Ok(Some(value));
                 }
-                HvX64RegisterName::InterruptState => {
-                    Some(u64::from(reg_page.interrupt_state).into())
-                }
-                _ => None,
-            };
-            if let Some(value) = value {
-                return Ok(Some(value));
             }
         }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -223,7 +223,11 @@ mod private {
         /// message slot.
         ///
         /// This is used for hypervisor-managed and untrusted SINTs.
-        fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16);
+        fn request_untrusted_sint_readiness(
+            this: &mut UhProcessor<'_, Self>,
+            vtl: GuestVtl,
+            sints: u16,
+        );
 
         /// Copies shared registers (per VSM TLFS spec) from the source VTL to
         /// the target VTL that will become active.
@@ -858,7 +862,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                             #[cfg(guest_arch = "aarch64")]
                             let sint_reg =
                                 HvArm64RegisterName(HvArm64RegisterName::Sint0.0 + sint as u32);
-                            self.runner.get_vp_register(sint_reg).unwrap().as_u64()
+                            self.runner.get_vp_register(vtl, sint_reg).unwrap().as_u64()
                         };
                         masked_sints |= (HvSynicSint::from(sint_msr).masked() as u16) << sint;
                     }
@@ -919,7 +923,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         };
 
         if sints & untrusted_sints != 0 {
-            T::request_untrusted_sint_readiness(self, sints & untrusted_sints);
+            T::request_untrusted_sint_readiness(self, vtl, sints & untrusted_sints);
         }
     }
 
@@ -1206,7 +1210,7 @@ impl<T: CpuIo, B: Backing> Arm64RegisterState for UhHypercallHandler<'_, '_, T, 
     fn pc(&mut self) -> u64 {
         self.vp
             .runner
-            .get_vp_register(HvArm64RegisterName::XPc)
+            .get_vp_register(self.intercepted_vtl, HvArm64RegisterName::XPc)
             .expect("get vp register cannot fail")
             .as_u64()
     }
@@ -1214,14 +1218,17 @@ impl<T: CpuIo, B: Backing> Arm64RegisterState for UhHypercallHandler<'_, '_, T, 
     fn set_pc(&mut self, pc: u64) {
         self.vp
             .runner
-            .set_vp_register(HvArm64RegisterName::XPc, pc.into())
+            .set_vp_register(self.intercepted_vtl, HvArm64RegisterName::XPc, pc.into())
             .expect("set vp register cannot fail");
     }
 
     fn x(&mut self, n: u8) -> u64 {
         self.vp
             .runner
-            .get_vp_register(HvArm64RegisterName(HvArm64RegisterName::X0.0 + n as u32))
+            .get_vp_register(
+                self.intercepted_vtl,
+                HvArm64RegisterName(HvArm64RegisterName::X0.0 + n as u32),
+            )
             .expect("get vp register cannot fail")
             .as_u64()
     }
@@ -1230,6 +1237,7 @@ impl<T: CpuIo, B: Backing> Arm64RegisterState for UhHypercallHandler<'_, '_, T, 
         self.vp
             .runner
             .set_vp_register(
+                self.intercepted_vtl,
                 HvArm64RegisterName(HvArm64RegisterName::X0.0 + n as u32),
                 v.into(),
             )

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -142,6 +142,8 @@ impl BackingPrivate for HypervisorBackedArm64 {
             tracing::trace!(?notifications, "setting notifications");
             this.runner
                 .set_vp_register(
+                    // TODO GUEST VSM
+                    GuestVtl::Vtl0,
                     VpRegisterName::DeliverabilityNotifications,
                     u64::from(notifications).into(),
                 )
@@ -206,7 +208,11 @@ impl BackingPrivate for HypervisorBackedArm64 {
             .set_interrupt_notification(true);
     }
 
-    fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16) {
+    fn request_untrusted_sint_readiness(
+        this: &mut UhProcessor<'_, Self>,
+        _vtl: GuestVtl,
+        sints: u16,
+    ) {
         this.backing
             .next_deliverability_notifications
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
@@ -371,7 +377,10 @@ impl AccessCpuState for UhProcessor<'_, HypervisorBackedArm64> {
         if self.backing.cpu_state.sp.is_some() {
             expensive_regs.push((HvArm64RegisterName::XSp, self.sp()));
         }
-        self.runner.set_vp_registers(expensive_regs).unwrap();
+        self.runner
+            // TODO GUEST VSM
+            .set_vp_registers(GuestVtl::Vtl0, expensive_regs)
+            .unwrap();
         self.runner.cpu_context_mut().x = self.backing.cpu_state.x;
         self.runner.cpu_context_mut().q = self.backing.cpu_state.q;
     }
@@ -381,7 +390,8 @@ impl AccessCpuState for UhProcessor<'_, HypervisorBackedArm64> {
         if index == 18 && !self.backing.cpu_state.x18_valid {
             let reg_val = self
                 .runner
-                .get_vp_register(HvArm64RegisterName::X18)
+                // TODO GUEST VSM
+                .get_vp_register(GuestVtl::Vtl0, HvArm64RegisterName::X18)
                 .expect("register query should not fail");
             self.backing.cpu_state.x[18] = reg_val.as_u64();
             self.backing.cpu_state.x18_valid = true;
@@ -443,7 +453,8 @@ impl AccessCpuState for UhProcessor<'_, HypervisorBackedArm64> {
         if self.backing.cpu_state.sp.is_none() {
             let reg_val = self
                 .runner
-                .get_vp_register(HvArm64RegisterName::XSp)
+                // TODO GUEST VSM
+                .get_vp_register(GuestVtl::Vtl0, HvArm64RegisterName::XSp)
                 .expect("register query should not fail");
             self.backing.cpu_state.sp = Some(reg_val.as_u64());
         }
@@ -474,7 +485,8 @@ impl AccessCpuState for UhProcessor<'_, HypervisorBackedArm64> {
         if self.backing.cpu_state.pc.is_none() {
             let reg_val = self
                 .runner
-                .get_vp_register(HvArm64RegisterName::XPc)
+                // TODO GUEST VSM
+                .get_vp_register(GuestVtl::Vtl0, HvArm64RegisterName::XPc)
                 .expect("register query should not fail");
             self.backing.cpu_state.pc = Some(reg_val.as_u64());
         }
@@ -489,7 +501,8 @@ impl AccessCpuState for UhProcessor<'_, HypervisorBackedArm64> {
         if self.backing.cpu_state.cpsr.is_none() {
             let reg_val = self
                 .runner
-                .get_vp_register(HvArm64RegisterName::Cpsr)
+                // TODO GUEST VSM
+                .get_vp_register(GuestVtl::Vtl0, HvArm64RegisterName::Cpsr)
                 .expect("register query should not fail");
             self.backing.cpu_state.cpsr = Some(reg_val.as_u64());
         }
@@ -579,7 +592,8 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBacked>
             let cpsr: Cpsr64 = self
                 .vp
                 .runner
-                .get_vp_register(HvArm64RegisterName::SpsrEl2)
+                // TODO GUEST VSM
+                .get_vp_register(GuestVtl::Vtl0, HvArm64RegisterName::SpsrEl2)
                 .map_err(UhRunVpError::EmulationState)?
                 .as_u64()
                 .into();
@@ -812,7 +826,7 @@ impl UhVpStateAccess<'_, '_, HypervisorBackedArm64> {
         regs.get_values(values.iter_mut());
         self.vp
             .runner
-            .set_vp_registers(names.iter().copied().zip(values))
+            .set_vp_registers(self.vtl, names.iter().copied().zip(values))
             .map_err(vp_state::Error::SetRegisters)?;
         Ok(())
     }
@@ -828,7 +842,7 @@ impl UhVpStateAccess<'_, '_, HypervisorBackedArm64> {
         let mut values = [HvRegisterValue::new_zeroed(); N];
         self.vp
             .runner
-            .get_vp_registers(&names, &mut values)
+            .get_vp_registers(self.vtl, &names, &mut values)
             .map_err(vp_state::Error::GetRegisters)?;
 
         regs.set_values(values.into_iter());
@@ -877,10 +891,12 @@ impl AccessVpState for UhVpStateAccess<'_, '_, HypervisorBackedArm64> {
     }
 }
 
+// TODO GUEST VSM Audit save state
 mod save_restore {
     use super::HypervisorBackedArm64;
     use super::UhProcessor;
     use anyhow::anyhow;
+    use hcl::GuestVtl;
     use hvdef::HvArm64RegisterName;
     use hvdef::HvInternalActivityRegister;
     use virt::Processor;
@@ -914,7 +930,8 @@ mod save_restore {
 
             let internal_activity = self
                 .runner
-                .get_vp_register(HvArm64RegisterName::InternalActivityState)
+                // TODO GUEST VSM
+                .get_vp_register(GuestVtl::Vtl0, HvArm64RegisterName::InternalActivityState)
                 .map_err(|err| {
                     SaveError::Other(anyhow!("unable to query startup suspend: {}", err))
                 })?;
@@ -935,7 +952,11 @@ mod save_restore {
             if state.startup_suspend {
                 let reg = u64::from(HvInternalActivityRegister::new().with_startup_suspend(true));
                 self.runner
-                    .set_vp_registers([(HvArm64RegisterName::InternalActivityState, reg)])
+                    .set_vp_registers(
+                        // TODO GUEST VSM
+                        GuestVtl::Vtl0,
+                        [(HvArm64RegisterName::InternalActivityState, reg)],
+                    )
                     .map_err(|err| {
                         RestoreError::Other(anyhow!(
                             "unable to set internal activity register: {}",

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -145,7 +145,8 @@ impl BackingPrivate for HypervisorBackedX86 {
         let lapics = if let Some(mut lapics) = params.lapics {
             let apic_base = params
                 .runner
-                .get_vp_register(HvX64RegisterName::ApicBase)
+                // TODO GUEST VSM
+                .get_vp_register(GuestVtl::Vtl0, HvX64RegisterName::ApicBase)
                 .unwrap()
                 .as_u64();
 
@@ -190,6 +191,8 @@ impl BackingPrivate for HypervisorBackedX86 {
             tracing::trace!(?notifications, "setting notifications");
             this.runner
                 .set_vp_register(
+                    // TODO GUEST VSM
+                    GuestVtl::Vtl0,
                     VpRegisterName::DeliverabilityNotifications,
                     u64::from(notifications).into(),
                 )
@@ -327,7 +330,7 @@ impl BackingPrivate for HypervisorBackedX86 {
         }
 
         if let Some(vector) = interrupt {
-            this.handle_interrupt(vector, vtl)?;
+            this.handle_interrupt(vtl, vector)?;
         }
 
         if extint {
@@ -361,7 +364,11 @@ impl BackingPrivate for HypervisorBackedX86 {
             .set_interrupt_notification(true);
     }
 
-    fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16) {
+    fn request_untrusted_sint_readiness(
+        this: &mut UhProcessor<'_, Self>,
+        _vtl: GuestVtl,
+        sints: u16,
+    ) {
         this.backing
             .next_deliverability_notifications
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
@@ -596,7 +603,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
 
             self.vp
                 .runner
-                .set_vp_register(HvX64RegisterName::PendingEvent0, u128::from(event).into())
+                .set_vp_register(
+                    self.intercepted_vtl,
+                    HvX64RegisterName::PendingEvent0,
+                    u128::from(event).into(),
+                )
                 .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::Event(e)))?;
         }
 
@@ -680,14 +691,14 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
             let instruction_bytes = &instruction_bytes[..message.instruction_byte_count as usize];
             let tlb_lock_held = message.memory_access_info.gva_gpa_valid()
                 || message.memory_access_info.tlb_locked();
-            let mut state = self.vp.emulator_state();
+            let mut state = self.vp.emulator_state(self.intercepted_vtl);
             if let Some(bit) = virt_support_x86emu::emulate::emulate_mnf_write_fast_path(
                 instruction_bytes,
                 &mut state,
                 interruption_pending,
                 tlb_lock_held,
             ) {
-                self.vp.set_emulator_state(&state);
+                self.vp.set_emulator_state(self.intercepted_vtl, &state);
                 if let Some(connection_id) = self.vp.partition.monitor_page.write_bit(bit) {
                     signal_mnf(dev, connection_id);
                 }
@@ -914,7 +925,7 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
 }
 
 impl UhProcessor<'_, HypervisorBackedX86> {
-    fn handle_interrupt(&mut self, vector: u8, vtl: GuestVtl) -> Result<(), UhRunVpError> {
+    fn handle_interrupt(&mut self, vtl: GuestVtl, vector: u8) -> Result<(), UhRunVpError> {
         const NAMES: &[HvX64RegisterName] = &[
             HvX64RegisterName::Rflags,
             HvX64RegisterName::Cr8,
@@ -924,7 +935,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         ];
         let mut values = [0u32.into(); NAMES.len()];
         self.runner
-            .get_vp_registers(NAMES, &mut values)
+            .get_vp_registers(vtl, NAMES, &mut values)
             .map_err(UhRunVpError::EmulationState)?;
 
         let &[rflags, cr8, interrupt_state, pending_interruption, pending_event] = &values;
@@ -976,6 +987,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         self.runner
             .set_vp_register(
+                vtl,
                 HvX64RegisterName::PendingInterruption,
                 u64::from(interruption).into(),
             )
@@ -997,7 +1009,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         ];
         let mut values = [0u32.into(); NAMES.len()];
         self.runner
-            .get_vp_registers(NAMES, &mut values)
+            .get_vp_registers(vtl, NAMES, &mut values)
             .map_err(UhRunVpError::EmulationState)?;
 
         let &[interrupt_state, pending_interruption, pending_event] = &values;
@@ -1031,6 +1043,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         self.runner
             .set_vp_register(
+                vtl,
                 HvX64RegisterName::PendingInterruption,
                 u64::from(interruption).into(),
             )
@@ -1062,10 +1075,13 @@ impl UhProcessor<'_, HypervisorBackedX86> {
                 attributes: 0x9b,
             };
             self.runner
-                .set_vp_registers([
-                    (HvX64RegisterName::Cs, HvRegisterValue::from(cs)),
-                    (HvX64RegisterName::Rip, 0u64.into()),
-                ])
+                .set_vp_registers(
+                    vtl,
+                    [
+                        (HvX64RegisterName::Cs, HvRegisterValue::from(cs)),
+                        (HvX64RegisterName::Rip, 0u64.into()),
+                    ],
+                )
                 .map_err(UhRunVpError::EmulationState)?;
             lapic.startup_suspend = false;
             lapic.halted = false;
@@ -1073,15 +1089,15 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         Ok(())
     }
 
-    fn set_rip(&mut self, _vtl: GuestVtl, rip: u64) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn set_rip(&mut self, vtl: GuestVtl, rip: u64) -> Result<(), VpHaltReason<UhRunVpError>> {
         self.runner
-            .set_vp_register(HvX64RegisterName::Rip, rip.into())
+            .set_vp_register(vtl, HvX64RegisterName::Rip, rip.into())
             .map_err(|e| VpHaltReason::Hypervisor(UhRunVpError::AdvanceRip(e)))?;
 
         Ok(())
     }
 
-    fn inject_gpf(&mut self, _vtl: GuestVtl) {
+    fn inject_gpf(&mut self, vtl: GuestVtl) {
         let exception_event = hvdef::HvX64PendingExceptionEvent::new()
             .with_event_pending(true)
             .with_event_type(hvdef::HV_X64_PENDING_EVENT_EXCEPTION)
@@ -1091,13 +1107,14 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         self.runner
             .set_vp_register(
+                vtl,
                 HvX64RegisterName::PendingEvent0,
                 u128::from(exception_event).into(),
             )
             .expect("set_vp_register should succeed for pending event");
     }
 
-    fn emulator_state(&mut self) -> x86emu::CpuState {
+    fn emulator_state(&mut self, vtl: GuestVtl) -> x86emu::CpuState {
         const NAMES: &[HvX64RegisterName] = &[
             HvX64RegisterName::Rsp,
             HvX64RegisterName::Es,
@@ -1110,7 +1127,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         ];
         let mut values = [FromZeroes::new_zeroed(); NAMES.len()];
         self.runner
-            .get_vp_registers(NAMES, &mut values)
+            .get_vp_registers(vtl, NAMES, &mut values)
             .expect("register query should not fail");
 
         let [rsp, es, ds, fs, gs, ss, cr0, efer] = values;
@@ -1138,13 +1155,16 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         }
     }
 
-    fn set_emulator_state(&mut self, state: &x86emu::CpuState) {
+    fn set_emulator_state(&mut self, vtl: GuestVtl, state: &x86emu::CpuState) {
         self.runner
-            .set_vp_registers([
-                (HvX64RegisterName::Rip, state.rip),
-                (HvX64RegisterName::Rflags, state.rflags.into()),
-                (HvX64RegisterName::Rsp, state.gps[x86emu::CpuState::RSP]),
-            ])
+            .set_vp_registers(
+                vtl,
+                [
+                    (HvX64RegisterName::Rip, state.rip),
+                    (HvX64RegisterName::Rflags, state.rflags.into()),
+                    (HvX64RegisterName::Rsp, state.gps[x86emu::CpuState::RSP]),
+                ],
+            )
             .unwrap();
 
         self.runner.cpu_context_mut().gps = state.gps;
@@ -1152,8 +1172,8 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
     fn set_vsm_partition_config(
         &mut self,
-        value: HvRegisterVsmPartitionConfig,
         vtl: GuestVtl,
+        value: HvRegisterVsmPartitionConfig,
     ) -> Result<(), HvError> {
         if vtl != GuestVtl::Vtl1 {
             return Err(HvError::InvalidParameter);
@@ -1268,11 +1288,11 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
     }
 
     fn state(&mut self) -> Result<x86emu::CpuState, Self::Error> {
-        Ok(self.vp.emulator_state())
+        Ok(self.vp.emulator_state(self.vtl))
     }
 
     fn set_state(&mut self, state: x86emu::CpuState) -> Result<(), Self::Error> {
-        self.vp.set_emulator_state(&state);
+        self.vp.set_emulator_state(self.vtl, &state);
         Ok(())
     }
 
@@ -1372,7 +1392,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
             let mbec_user_execute = self
                 .vp
                 .runner
-                .get_vp_register(HvX64RegisterName::InstructionEmulationHints)
+                .get_vp_register(self.vtl, HvX64RegisterName::InstructionEmulationHints)
                 .map_err(UhRunVpError::EmulationState)?;
 
             let flags =
@@ -1647,7 +1667,7 @@ impl UhVpStateAccess<'_, '_, HypervisorBackedX86> {
         regs.get_values(values.iter_mut());
         self.vp
             .runner
-            .set_vp_registers(names.iter().copied().zip(values))
+            .set_vp_registers(self.vtl, names.iter().copied().zip(values))
             .map_err(vp_state::Error::SetRegisters)?;
         Ok(())
     }
@@ -1663,7 +1683,7 @@ impl UhVpStateAccess<'_, '_, HypervisorBackedX86> {
         let mut values = [HvRegisterValue::new_zeroed(); N];
         self.vp
             .runner
-            .get_vp_registers(&names, &mut values)
+            .get_vp_registers(self.vtl, &names, &mut values)
             .map_err(vp_state::Error::GetRegisters)?;
 
         regs.set_values(values.into_iter());
@@ -1906,7 +1926,7 @@ impl<T> hv1_hypercall::SetVpRegisters for UhHypercallHandler<'_, '_, T, Hypervis
             if reg.name == HvX64RegisterName::VsmPartitionConfig.into() {
                 let value = HvRegisterVsmPartitionConfig::from(reg.value.as_u64());
                 self.vp
-                    .set_vsm_partition_config(value, target_vtl)
+                    .set_vsm_partition_config(target_vtl, value)
                     .map_err(|e| (e, i))?;
             } else {
                 return Err((HvError::InvalidParameter, i));
@@ -1987,20 +2007,20 @@ struct UhApicClient<'a, 'b, T> {
 impl<T: CpuIo> ApicClient for UhApicClient<'_, '_, T> {
     fn cr8(&mut self) -> u32 {
         self.runner
-            .get_vp_register(HvX64RegisterName::Cr8)
+            .get_vp_register(self.vtl, HvX64RegisterName::Cr8)
             .unwrap()
             .as_u32()
     }
 
     fn set_cr8(&mut self, value: u32) {
         self.runner
-            .set_vp_register(HvX64RegisterName::Cr8, value.into())
+            .set_vp_register(self.vtl, HvX64RegisterName::Cr8, value.into())
             .unwrap();
     }
 
     fn set_apic_base(&mut self, value: u64) {
         self.runner
-            .set_vp_register(HvX64RegisterName::ApicBase, value.into())
+            .set_vp_register(self.vtl, HvX64RegisterName::ApicBase, value.into())
             .unwrap();
     }
 
@@ -2025,6 +2045,7 @@ impl<T: CpuIo> ApicClient for UhApicClient<'_, '_, T> {
     }
 }
 
+// TODO GUEST VSM Audit save state
 mod save_restore {
     use super::HypervisorBackedX86;
     use super::UhProcessor;
@@ -2125,13 +2146,15 @@ mod save_restore {
             };
 
             self.runner
-                .get_vp_registers(&SHARED_REGISTERS[..len], &mut values[..len])
+                // TODO GUEST VSM: Does dr6 need special handling?
+                .get_vp_registers(GuestVtl::Vtl0, &SHARED_REGISTERS[..len], &mut values[..len])
                 .context("failed to get shared registers")
                 .map_err(SaveError::Other)?;
 
             let startup_suspend = match self
                 .runner
-                .get_vp_register(HvX64RegisterName::InternalActivityState)
+                // TODO GUEST VSM
+                .get_vp_register(GuestVtl::Vtl0, HvX64RegisterName::InternalActivityState)
             {
                 Ok(val) => Some(HvInternalActivityRegister::from(val.as_u64()).startup_suspend()),
                 Err(e) => {
@@ -2229,7 +2252,10 @@ mod save_restore {
 
             let values = [dr0, dr1, dr2, dr3, dr6.unwrap_or(0)];
             self.runner
-                .set_vp_registers(SHARED_REGISTERS[..len].iter().copied().zip(values))
+                .set_vp_registers(
+                    GuestVtl::Vtl0,
+                    SHARED_REGISTERS[..len].iter().copied().zip(values),
+                )
                 .context("failed to set shared registers")
                 .map_err(RestoreError::Other)?;
 
@@ -2261,7 +2287,8 @@ mod save_restore {
                     ];
                     let mut values = [FromZeroes::new_zeroed(); NAMES.len()];
                     self.runner
-                        .get_vp_registers(&NAMES, &mut values)
+                        // TODO GUEST VSM
+                        .get_vp_registers(GuestVtl::Vtl0, &NAMES, &mut values)
                         .context("failed to get VP registers for startup suspend log")
                         .map_err(RestoreError::Other)?;
                     let [rip, rflags, cr0, efer] = values.map(|reg| reg.as_u64());
@@ -2282,9 +2309,11 @@ mod save_restore {
 
             if inject_startup_suspend {
                 let reg = u64::from(HvInternalActivityRegister::new().with_startup_suspend(true));
-                let result = self
-                    .runner
-                    .set_vp_registers([(HvX64RegisterName::InternalActivityState, reg)]);
+                let result = self.runner.set_vp_registers(
+                    // TODO GUEST VSM
+                    GuestVtl::Vtl0,
+                    [(HvX64RegisterName::InternalActivityState, reg)],
+                );
 
                 if let Err(e) = result {
                     // The ioctl set_vp_register path does not tell us hv_status

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -378,7 +378,14 @@ impl BackingPrivate for SnpBacked {
         unreachable!("extint managed through software apic")
     }
 
-    fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16) {
+    fn request_untrusted_sint_readiness(
+        this: &mut UhProcessor<'_, Self>,
+        vtl: GuestVtl,
+        sints: u16,
+    ) {
+        if vtl == GuestVtl::Vtl1 {
+            todo!("TODO: handle untrusted sints for VTL1");
+        }
         if this.backing.hv_sint_notifications & !sints == 0 {
             return;
         }
@@ -388,6 +395,7 @@ impl BackingPrivate for SnpBacked {
         tracing::trace!(?notifications, "setting notifications");
         this.runner
             .set_vp_register(
+                vtl,
                 HvX64RegisterName::DeliverabilityNotifications,
                 u64::from(notifications).into(),
             )

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -767,7 +767,11 @@ impl BackingPrivate for TdxBacked {
         unreachable!("extint managed through software apic")
     }
 
-    fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16) {
+    fn request_untrusted_sint_readiness(
+        this: &mut UhProcessor<'_, Self>,
+        _vtl: GuestVtl,
+        sints: u16,
+    ) {
         if let Some(synic) = &mut this.backing.untrusted_synic {
             synic.request_sint_readiness(sints);
         } else {
@@ -1422,7 +1426,8 @@ impl UhProcessor<'_, TdxBacked> {
                 let subleaf = enter_state.rcx() as u32;
                 let xfem = self
                     .runner
-                    .get_vp_register(HvX64RegisterName::Xfem)
+                    // TODO TDX GUEST VSM
+                    .get_vp_register(GuestVtl::Vtl0, HvX64RegisterName::Xfem)
                     .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err)))?
                     .as_u64();
                 let guest_state = crate::cvm_cpuid::CpuidGuestState {
@@ -1542,7 +1547,8 @@ impl UhProcessor<'_, TdxBacked> {
                     })
                 {
                     self.runner
-                        .set_vp_register(HvX64RegisterName::Xfem, value.into())
+                        // TODO TDX GUEST VSM
+                        .set_vp_register(GuestVtl::Vtl0, HvX64RegisterName::Xfem, value.into())
                         .map_err(|err| {
                             VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err))
                         })?;
@@ -1794,6 +1800,8 @@ impl UhProcessor<'_, TdxBacked> {
                 // so that the hypervisor can directly inject events.
                 if matches!(msr, hvdef::HV_X64_MSR_SINT0..=hvdef::HV_X64_MSR_SINT15) {
                     if let Err(err) = self.runner.set_vp_register(
+                        // TODO TDX GUEST VSM
+                        GuestVtl::Vtl0,
                         HvX64RegisterName(
                             HvX64RegisterName::Sint0.0 + (msr - hvdef::HV_X64_MSR_SINT0),
                         ),
@@ -2801,7 +2809,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
             value: self
                 .vp
                 .runner
-                .get_vp_register(HvX64RegisterName::Xfem)
+                .get_vp_register(self.vtl, HvX64RegisterName::Xfem)
                 .unwrap()
                 .as_u64(),
         })
@@ -2925,6 +2933,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
         self.vp
             .runner
             .get_vp_registers(
+                self.vtl,
                 &[
                     HvX64RegisterName::Dr0,
                     HvX64RegisterName::Dr1,
@@ -2962,13 +2971,16 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
         } = value;
         self.vp
             .runner
-            .set_vp_registers([
-                (HvX64RegisterName::Dr0, dr0),
-                (HvX64RegisterName::Dr1, dr1),
-                (HvX64RegisterName::Dr2, dr2),
-                (HvX64RegisterName::Dr3, dr3),
-                (HvX64RegisterName::Dr6, dr6),
-            ])
+            .set_vp_registers(
+                self.vtl,
+                [
+                    (HvX64RegisterName::Dr0, dr0),
+                    (HvX64RegisterName::Dr1, dr1),
+                    (HvX64RegisterName::Dr2, dr2),
+                    (HvX64RegisterName::Dr3, dr3),
+                    (HvX64RegisterName::Dr6, dr6),
+                ],
+            )
             .map_err(vp_state::Error::SetRegisters)?;
 
         self.vp


### PR DESCRIPTION
Cherry-pick PRs 125 and 360 to release/2411.

Modify ProcessorRunner::get_reg and ProcessorRunner::set_reg to use a
direct hypercall when possible, instead of our dedicated
get/set-register ioctl. Certain registers have special handling in the
kernel ioctl handler. Those are left as-is. Get/set for other registers
is now made with a direct hypercall.

This has the benefit of being VTL-aware, so this change also adds a VTL
parameter.

This change also removes some proliferation of
(g|s)et_vp_registers?(_inner)?, hopefully making it simpler and cleaner.
The singular (g|s)et_vp_register is left as an ergonomic convenience.

One unaddressed capability is making ioctls/hypercalls on a batch of
registers. This is not strictly a regression, because
MSHV_VP_MAX_REGISTERS was previously 1.

This change modifies ProcessorRunner::set_reg and get_reg to
route any VTL-shared register through the special kernel ioctl, and use
the generic hypercall only for registers that are definitely
VTL-private. This ensures that the decision made by get_reg and set_reg
matches the assert in, e.g., get_vp_register_for_vtl.