### PR TITLE
hypestv: add paravisor kmsg output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,6 +2966,7 @@ dependencies = [
  "futures-concurrency",
  "guid",
  "inspect",
+ "kmsg",
  "mesh",
  "pal_async",
  "parking_lot",

--- a/Guide/src/dev_guide/dev_tools/hypestv.md
+++ b/Guide/src/dev_guide/dev_tools/hypestv.md
@@ -17,14 +17,15 @@ will always be a Hyper-V specific tool.
 Currently, it can:
 
 * Change VM state (starting/stopping/resetting)
-* Enable serial port output
+* Enable serial port output to standard output, or input/output to another
+  terminal window
+* Enable paravisor log output to standard output or another terminal window
 * Inspect paravisor state
 
 In the future, it might be able to:
 
-* Enable paravisor and Hyper-V log output
-* Enable serial port input
-* Capture serial port output to another terminal window or file
+* Enable Hyper-V log output
+* Capture serial port output to a file
 * Inspect host state
 * Persistence workspaces (save/restore configured serial ports and logs)
 
@@ -52,6 +53,12 @@ tdxvm [off]> serial 1 term
 tdxvm [off]> serial 2 log
 ```
 
+You can also enable paravisor log output at any time:
+
+```
+tdxvm [off]> paravisor kmsg log
+```
+
 Start a VM with `start`. This is an asynchronous command: you can continue to
 type other commands at the prompt while the VM starts. You should see an output
 message when the VM finishes starting, as well as output about any configured
@@ -62,8 +69,8 @@ on the prompt may not be accurate until you type another command or press Enter.
 
 ```
 tdxvm [off]> start
-serial port 1 connected
-serial port 2 connected
+com1 connected
+com2 connected
 VM started
 tdxvm [off]>
 tdxvm [running]>
@@ -71,11 +78,10 @@ tdxvm [running]>
 
 At this point, the VM is running, including the paravisor (if one is
 configured). As in the OpenVMM interactive console, you can inspect paravisor
-state with the `inspect` or `x` command, passing `-p` to specify that you want
-to inspect paravisor state:
+state with the `inspect` or `x` command, but under the `paravisor`/`pv` command:
 
 ```
-tdxvm [running]> x -p
+tdxvm [running]> pv x
 {
     build_info: _,
     control_state: "started",
@@ -94,8 +100,8 @@ VM.
 
 ```
 tdxvm [running]> kill
-serial port 1 disconnected
-serial port 2 disconnected
+com1 disconnected
+com2 disconnected
 VM killed
 tdxvm [stopping]>
 tdxvm [off]>

--- a/hyperv/tools/hypestv/Cargo.toml
+++ b/hyperv/tools/hypestv/Cargo.toml
@@ -12,6 +12,7 @@ console_relay.workspace = true
 diag_client.workspace = true
 guid.workspace = true
 inspect.workspace = true
+kmsg.workspace = true
 mesh.workspace = true
 pal_async.workspace = true
 

--- a/hyperv/tools/hypestv/src/windows/completions.rs
+++ b/hyperv/tools/hypestv/src/windows/completions.rs
@@ -80,7 +80,7 @@ impl clap_dyn_complete::CustomCompleter for OpenvmmComplete {
         arg_id: &str,
     ) -> Vec<String> {
         match (subcommand_path, arg_id) {
-            (["hypestv", "inspect"], "element") => {
+            (["hypestv", "paravisor", "inspect"], "element") => {
                 let on_error = vec!["failed/to/connect".into()];
 
                 let (parent_path, to_complete) = (ctx.to_complete)
@@ -88,30 +88,11 @@ impl clap_dyn_complete::CustomCompleter for OpenvmmComplete {
                     .unwrap_or(("", ctx.to_complete));
 
                 let node = {
-                    let paravisor = {
-                        let raw_arg = ctx
-                            .matches
-                            .subcommand()
-                            .unwrap()
-                            .1
-                            .get_one::<String>("paravisor")
-                            .map(|x| x.as_str())
-                            .unwrap_or_default();
-                        raw_arg == "true"
-                    };
-
                     let r = self
                         .req
                         .call_failable(
                             super::Request::Inspect,
-                            (
-                                if paravisor {
-                                    super::InspectTarget::Paravisor
-                                } else {
-                                    super::InspectTarget::Host
-                                },
-                                parent_path.to_owned(),
-                            ),
+                            (super::InspectTarget::Paravisor, parent_path.to_owned()),
                         )
                         .await;
                     let Ok(node) = r else {


### PR DESCRIPTION
Add kmsg output options for seeing paravisor logs in real time.

Also move existing paravisor commands (including paravisor modes for `inspect` and `start`) under a new `paravisor` subcommand (alias `pv`). This is just as short as using `-p`, and it's easier to understand and extend.