### PR TITLE
disk_backend: remove GetLbaStatus

### DIFF
--- a/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
+++ b/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
@@ -1145,6 +1145,7 @@ fn make_disk_config_inner(
         scsi_disk_size_in_bytes: disk_params.scsi_disk_size_in_bytes,
         odx: disk_params.odx,
         unmap: disk_params.unmap,
+        get_lba_status: true,
         max_transfer_length: disk_params.max_transfer_length,
         optimal_unmap_sectors: None, // TODO
     })

--- a/vm/devices/storage/disk_blockdevice/src/lib.rs
+++ b/vm/devices/storage/disk_blockdevice/src/lib.rs
@@ -23,7 +23,6 @@ use disk_backend::resolve::ResolveDiskParameters;
 use disk_backend::resolve::ResolvedDisk;
 use disk_backend::DiskError;
 use disk_backend::DiskIo;
-use disk_backend::GetLbaStatus;
 use disk_backend::Unmap;
 use fs_err::PathExt;
 use guestmem::MemoryRead;
@@ -527,10 +526,6 @@ impl DiskIo for BlockDevice {
         (self.optimal_unmap_sectors != 0).then_some(self)
     }
 
-    fn lba_status(&self) -> Option<&dyn GetLbaStatus> {
-        Some(self)
-    }
-
     fn pr(&self) -> Option<&dyn PersistentReservation> {
         if self.supports_pr {
             Some(self)
@@ -709,8 +704,6 @@ impl Unmap for BlockDevice {
         self.optimal_unmap_sectors
     }
 }
-
-impl GetLbaStatus for BlockDevice {}
 
 #[async_trait::async_trait]
 impl PersistentReservation for BlockDevice {

--- a/vm/devices/storage/disk_crypt/src/lib.rs
+++ b/vm/devices/storage/disk_crypt/src/lib.rs
@@ -94,11 +94,6 @@ impl DiskIo for CryptDisk {
         self.inner.unmap()
     }
 
-    /// Optionally returns a trait object to issue get LBA status requests.
-    fn lba_status(&self) -> Option<&dyn disk_backend::GetLbaStatus> {
-        self.inner.lba_status()
-    }
-
     /// Optionally returns a trait object to issue persistent reservation
     /// requests.
     fn pr(&self) -> Option<&dyn disk_backend::pr::PersistentReservation> {

--- a/vm/devices/storage/disk_nvme/src/lib.rs
+++ b/vm/devices/storage/disk_nvme/src/lib.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use disk_backend::pr;
 use disk_backend::DiskError;
 use disk_backend::DiskIo;
-use disk_backend::GetLbaStatus;
 use disk_backend::MediumErrorDetails;
 use disk_backend::Unmap;
 use inspect::Inspect;
@@ -68,10 +67,6 @@ impl DiskIo for NvmeDisk {
 
     fn unmap(&self) -> Option<impl Unmap> {
         self.namespace.supports_dataset_management().then_some(self)
-    }
-
-    fn lba_status(&self) -> Option<&dyn GetLbaStatus> {
-        Some(self)
     }
 
     fn pr(&self) -> Option<&dyn pr::PersistentReservation> {
@@ -154,8 +149,6 @@ impl DiskIo for NvmeDisk {
         self.namespace.wait_resize(sector_count).await
     }
 }
-
-impl GetLbaStatus for NvmeDisk {}
 
 impl Unmap for NvmeDisk {
     async fn unmap(

--- a/vm/devices/storage/disk_prwrap/src/lib.rs
+++ b/vm/devices/storage/disk_prwrap/src/lib.rs
@@ -126,10 +126,6 @@ impl DiskIo for DiskWithReservations {
 
     // TODO: Implement unmap
 
-    fn lba_status(&self) -> Option<&dyn disk_backend::GetLbaStatus> {
-        self.inner.lba_status()
-    }
-
     fn pr(&self) -> Option<&dyn pr::PersistentReservation> {
         Some(self)
     }

--- a/vm/devices/storage/disk_striped/src/lib.rs
+++ b/vm/devices/storage/disk_striped/src/lib.rs
@@ -12,7 +12,6 @@ use disk_backend::resolve::ResolvedDisk;
 use disk_backend::Disk;
 use disk_backend::DiskError;
 use disk_backend::DiskIo;
-use disk_backend::GetLbaStatus;
 use disk_backend::Unmap;
 use disk_backend_resources::StripedDiskHandle;
 use futures::future::join_all;
@@ -368,10 +367,6 @@ impl DiskIo for StripedDisk {
         self.supports_unmap.then_some(self)
     }
 
-    fn lba_status(&self) -> Option<&dyn GetLbaStatus> {
-        Some(self)
-    }
-
     fn disk_id(&self) -> Option<[u8; 16]> {
         None
     }
@@ -571,8 +566,6 @@ impl Unmap for StripedDisk {
             .unwrap_or(1)
     }
 }
-
-impl GetLbaStatus for StripedDisk {}
 
 async fn await_all_and_check<T, E>(futures: T) -> Result<(), E>
 where

--- a/vm/devices/storage/scsidisk_resources/src/lib.rs
+++ b/vm/devices/storage/scsidisk_resources/src/lib.rs
@@ -63,6 +63,11 @@ pub struct DiskParameters {
     pub max_transfer_length: Option<usize>,
     /// The minimum optimal number of sectors to unmap in a request.
     pub optimal_unmap_sectors: Option<u32>,
+    /// Report LBA status to the guest.
+    ///
+    /// Note that this will always report fully mapped LBAs, since the
+    /// underlying disk implementation has no mechanism to report unmapped LBAs.
+    pub get_lba_status: bool,
 }
 
 /// The disk identity.


### PR DESCRIPTION
There is no support in any backend for querying LBA status, and the trait for querying it is not really suitable for use with async disks. All devices that opt into supporting LBA status queries just end up using the default implementation, which reports that all blocks are fully mapped.

Perhaps a future change will actually support these queries properly. For now, move this functionality entirely into the SCSI emulator.