### PR TITLE
disk_backend: unify unmap handling between DiskIo and LayerIo

### DIFF
--- a/vm/devices/storage/disk_blob/src/lib.rs
+++ b/vm/devices/storage/disk_blob/src/lib.rs
@@ -13,6 +13,7 @@ pub mod resolver;
 use blob::Blob;
 use disk_backend::DiskError;
 use disk_backend::DiskIo;
+use disk_backend::UnmapBehavior;
 use guestmem::MemoryWrite;
 use inspect::Inspect;
 use scsi_buffers::RequestBuffers;
@@ -167,10 +168,23 @@ impl DiskIo for BlobDisk {
         _sector: u64,
         _fua: bool,
     ) -> Result<(), DiskError> {
-        unreachable!()
+        Err(DiskError::ReadOnly)
     }
 
     async fn sync_cache(&self) -> Result<(), DiskError> {
-        unreachable!()
+        Err(DiskError::ReadOnly)
+    }
+
+    async fn unmap(
+        &self,
+        _sector: u64,
+        _count: u64,
+        _block_level_only: bool,
+    ) -> Result<(), DiskError> {
+        Err(DiskError::ReadOnly)
+    }
+
+    fn unmap_behavior(&self) -> UnmapBehavior {
+        UnmapBehavior::Ignored
     }
 }

--- a/vm/devices/storage/disk_crypt/src/lib.rs
+++ b/vm/devices/storage/disk_crypt/src/lib.rs
@@ -88,12 +88,6 @@ impl DiskIo for CryptDisk {
         self.inner.is_read_only()
     }
 
-    /// Optionally returns a trait object to issue unmap (trim/discard)
-    /// requests.
-    fn unmap(&self) -> Option<impl disk_backend::Unmap> {
-        self.inner.unmap()
-    }
-
     /// Optionally returns a trait object to issue persistent reservation
     /// requests.
     fn pr(&self) -> Option<&dyn disk_backend::pr::PersistentReservation> {
@@ -163,6 +157,23 @@ impl DiskIo for CryptDisk {
     /// Waits for the disk sector size to be different than the specified value.
     async fn wait_resize(&self, sector_count: u64) -> u64 {
         self.inner.wait_resize(sector_count).await
+    }
+
+    fn unmap(
+        &self,
+        sector: u64,
+        count: u64,
+        block_level_only: bool,
+    ) -> impl std::future::Future<Output = Result<(), DiskError>> + Send {
+        self.inner.unmap(sector, count, block_level_only)
+    }
+
+    fn unmap_behavior(&self) -> disk_backend::UnmapBehavior {
+        self.inner.unmap_behavior()
+    }
+
+    fn optimal_unmap_sectors(&self) -> u32 {
+        self.inner.optimal_unmap_sectors()
     }
 }
 

--- a/vm/devices/storage/disk_file/src/lib.rs
+++ b/vm/devices/storage/disk_file/src/lib.rs
@@ -192,4 +192,17 @@ impl DiskIo for FileDisk {
     async fn sync_cache(&self) -> Result<(), DiskError> {
         self.flush().await
     }
+
+    async fn unmap(
+        &self,
+        _sector: u64,
+        _count: u64,
+        _block_level_only: bool,
+    ) -> Result<(), DiskError> {
+        Ok(())
+    }
+
+    fn unmap_behavior(&self) -> disk_backend::UnmapBehavior {
+        disk_backend::UnmapBehavior::Ignored
+    }
 }

--- a/vm/devices/storage/disk_get_vmgs/src/lib.rs
+++ b/vm/devices/storage/disk_get_vmgs/src/lib.rs
@@ -230,6 +230,19 @@ impl DiskIo for GetVmgsDisk {
             .await
             .map_err(|err| DiskError::Io(io::Error::new(io::ErrorKind::Other, err)))
     }
+
+    async fn unmap(
+        &self,
+        _sector: u64,
+        _count: u64,
+        _block_level_only: bool,
+    ) -> Result<(), DiskError> {
+        Ok(())
+    }
+
+    fn unmap_behavior(&self) -> disk_backend::UnmapBehavior {
+        disk_backend::UnmapBehavior::Ignored
+    }
 }
 
 /// Save/restore structure definitions.

--- a/vm/devices/storage/disk_nvme/src/lib.rs
+++ b/vm/devices/storage/disk_nvme/src/lib.rs
@@ -150,6 +150,9 @@ impl DiskIo for NvmeDisk {
         sector_count: u64,
         _block_level_only: bool,
     ) -> Result<(), DiskError> {
+        if !self.namespace.supports_dataset_management() {
+            return Ok(());
+        }
         let mut processed = 0;
         let max = self.namespace.dataset_management_range_size_limit();
         while processed < sector_count {

--- a/vm/devices/storage/disk_nvme/src/lib.rs
+++ b/vm/devices/storage/disk_nvme/src/lib.rs
@@ -187,8 +187,6 @@ impl DiskIo for NvmeDisk {
     }
 }
 
-impl GetLbaStatus for NvmeDisk {}
-
 #[async_trait]
 impl pr::PersistentReservation for NvmeDisk {
     fn capabilities(&self) -> pr::ReservationCapabilities {

--- a/vm/devices/storage/disk_prwrap/src/lib.rs
+++ b/vm/devices/storage/disk_prwrap/src/lib.rs
@@ -124,7 +124,22 @@ impl DiskIo for DiskWithReservations {
         self.inner.is_read_only()
     }
 
-    // TODO: Implement unmap
+    fn unmap(
+        &self,
+        sector: u64,
+        count: u64,
+        block_level_only: bool,
+    ) -> impl Future<Output = Result<(), DiskError>> + Send {
+        self.inner.unmap(sector, count, block_level_only)
+    }
+
+    fn unmap_behavior(&self) -> disk_backend::UnmapBehavior {
+        self.inner.unmap_behavior()
+    }
+
+    fn optimal_unmap_sectors(&self) -> u32 {
+        self.inner.optimal_unmap_sectors()
+    }
 
     fn pr(&self) -> Option<&dyn pr::PersistentReservation> {
         Some(self)

--- a/vm/devices/storage/disk_ramdisk/src/lib.rs
+++ b/vm/devices/storage/disk_ramdisk/src/lib.rs
@@ -11,12 +11,12 @@ pub mod resolver;
 use anyhow::Context;
 use disk_backend::Disk;
 use disk_backend::DiskError;
+use disk_backend::UnmapBehavior;
 use disk_layered::DiskLayer;
 use disk_layered::LayerConfiguration;
 use disk_layered::LayerIo;
 use disk_layered::LayeredDisk;
 use disk_layered::SectorMarker;
-use disk_layered::UnmapBehavior;
 use disk_layered::WriteNoOverwrite;
 use guestmem::MemoryRead;
 use guestmem::MemoryWrite;
@@ -370,7 +370,6 @@ mod tests {
     use super::RamLayer;
     use super::SECTOR_SIZE;
     use disk_backend::DiskIo;
-    use disk_backend::Unmap;
     use disk_layered::DiskLayer;
     use disk_layered::LayerConfiguration;
     use disk_layered::LayerIo;
@@ -518,12 +517,11 @@ mod tests {
         const SECTORS: usize = SIZE / SECTOR_USIZE;
 
         let (guest_mem, mut upper) = prep_disk(SIZE).await;
-        Unmap::unmap(&upper, 0, SECTORS as u64 - 1, false)
-            .await
-            .unwrap();
+        upper.unmap(0, SECTORS as u64 - 1, false).await.unwrap();
         read(&guest_mem, &mut upper, 0, SECTORS).await;
         check(&guest_mem, 0, 0, SECTORS, 0);
-        Unmap::unmap(&upper, SECTORS as u64 / 2, SECTORS as u64 / 2, false)
+        upper
+            .unmap(SECTORS as u64 / 2, SECTORS as u64 / 2, false)
             .await
             .unwrap();
         read(&guest_mem, &mut upper, 0, SECTORS).await;

--- a/vm/devices/storage/disk_vhd1/src/lib.rs
+++ b/vm/devices/storage/disk_vhd1/src/lib.rs
@@ -221,6 +221,19 @@ impl DiskIo for Vhd1Disk {
     async fn sync_cache(&self) -> Result<(), DiskError> {
         self.file.sync_cache().await
     }
+
+    async fn unmap(
+        &self,
+        _sector: u64,
+        _count: u64,
+        _block_level_only: bool,
+    ) -> Result<(), DiskError> {
+        Ok(())
+    }
+
+    fn unmap_behavior(&self) -> disk_backend::UnmapBehavior {
+        disk_backend::UnmapBehavior::Ignored
+    }
 }
 
 #[cfg(test)]

--- a/vm/devices/storage/disk_vhdmp/src/lib.rs
+++ b/vm/devices/storage/disk_vhdmp/src/lib.rs
@@ -480,6 +480,19 @@ impl DiskIo for VhdmpDisk {
         let _locked = self.io_lock.lock().await;
         self.vhd.flush().await
     }
+
+    async fn unmap(
+        &self,
+        _sector: u64,
+        _count: u64,
+        _block_level_only: bool,
+    ) -> Result<(), DiskError> {
+        Ok(())
+    }
+
+    fn unmap_behavior(&self) -> disk_backend::UnmapBehavior {
+        disk_backend::UnmapBehavior::Ignored
+    }
 }
 
 #[cfg(test)]

--- a/vm/devices/storage/scsidisk/src/lib.rs
+++ b/vm/devices/storage/scsidisk/src/lib.rs
@@ -18,6 +18,7 @@ pub use inquiry::INQUIRY_DATA_TEMPLATE;
 
 use disk_backend::Disk;
 use disk_backend::DiskError;
+use disk_backend::UnmapBehavior;
 use guestmem::AccessError;
 use guestmem::MemoryRead;
 use guestmem::MemoryWrite;
@@ -183,8 +184,8 @@ impl SimpleScsiDisk {
                 support_fua: fua.unwrap_or_else(|| disk.is_fua_respected()),
                 write_cache_enabled: write_cache.unwrap_or(true),
                 support_odx: odx.unwrap_or(false),
-                support_unmap: unmap.unwrap_or(disk.unmap().is_some()),
                 support_get_lba_status: get_lba_status,
+                support_unmap: unmap.unwrap_or(disk.unmap_behavior() != UnmapBehavior::Ignored),
                 maximum_transfer_length: max_transfer_length.unwrap_or(8 * 1024 * 1024),
                 identity: identity.unwrap_or_else(DiskIdentity::msft),
                 serial_number,

--- a/vm/devices/storage/scsidisk/src/scsidvd/mod.rs
+++ b/vm/devices/storage/scsidisk/src/scsidvd/mod.rs
@@ -2449,13 +2449,13 @@ mod tests {
             todo!()
         }
 
-        fn unmap(
+        async fn unmap(
             &self,
             _sector: u64,
             _count: u64,
             _block_level_only: bool,
-        ) -> impl std::future::Future<Output = Result<(), DiskError>> + Send {
-            async move { Ok(()) }
+        ) -> Result<(), DiskError> {
+            Ok(())
         }
 
         fn unmap_behavior(&self) -> disk_backend::UnmapBehavior {

--- a/vm/devices/storage/scsidisk/src/scsidvd/mod.rs
+++ b/vm/devices/storage/scsidisk/src/scsidvd/mod.rs
@@ -2448,6 +2448,19 @@ mod tests {
         async fn sync_cache(&self) -> Result<(), DiskError> {
             todo!()
         }
+
+        fn unmap(
+            &self,
+            _sector: u64,
+            _count: u64,
+            _block_level_only: bool,
+        ) -> impl std::future::Future<Output = Result<(), DiskError>> + Send {
+            async move { Ok(()) }
+        }
+
+        fn unmap_behavior(&self) -> disk_backend::UnmapBehavior {
+            disk_backend::UnmapBehavior::Ignored
+        }
     }
 
     fn new_scsi_dvd(sector_size: u32, sector_count: u64, read_only: bool) -> SimpleScsiDvd {

--- a/vm/devices/storage/scsidisk/src/tests/test_helpers.rs
+++ b/vm/devices/storage/scsidisk/src/tests/test_helpers.rs
@@ -144,13 +144,13 @@ impl DiskIo for TestDisk {
         Ok(())
     }
 
-    fn unmap(
+    async fn unmap(
         &self,
         _sector: u64,
         _count: u64,
         _block_level_only: bool,
-    ) -> impl std::future::Future<Output = Result<(), DiskError>> + Send {
-        async move { Ok(()) }
+    ) -> Result<(), DiskError> {
+        Ok(())
     }
 
     fn unmap_behavior(&self) -> disk_backend::UnmapBehavior {

--- a/vm/devices/storage/scsidisk/src/tests/test_helpers.rs
+++ b/vm/devices/storage/scsidisk/src/tests/test_helpers.rs
@@ -143,6 +143,19 @@ impl DiskIo for TestDisk {
     async fn sync_cache(&self) -> Result<(), DiskError> {
         Ok(())
     }
+
+    fn unmap(
+        &self,
+        _sector: u64,
+        _count: u64,
+        _block_level_only: bool,
+    ) -> impl std::future::Future<Output = Result<(), DiskError>> + Send {
+        async move { Ok(()) }
+    }
+
+    fn unmap_behavior(&self) -> disk_backend::UnmapBehavior {
+        disk_backend::UnmapBehavior::Ignored
+    }
 }
 
 pub fn new_scsi_disk(


### PR DESCRIPTION
Instead of using an IDET to model the unmap behavior of the disk, just use plain methods. Unmap is pretty fundamental to disks these days, so it's not really optional to think about it. And the no-op implementation is a legal implementation, so the IDET doesn't buy us much.