### PR TITLE
openhcl/page_pool_alloc: support save restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4650,12 +4650,14 @@ dependencies = [
  "hvdef",
  "inspect",
  "memory_range",
+ "mesh",
  "parking_lot",
  "sparse_mmap",
  "thiserror 2.0.0",
  "tracing",
  "user_driver",
  "vm_topology",
+ "vmcore",
 ]
 
 [[package]]

--- a/openhcl/page_pool_alloc/Cargo.toml
+++ b/openhcl/page_pool_alloc/Cargo.toml
@@ -13,19 +13,19 @@ vfio = ["user_driver/vfio"]
 hcl.workspace = true
 
 user_driver.workspace = true
-vm_topology.workspace = true
 hvdef.workspace = true
 sparse_mmap.workspace = true
+vmcore.workspace = true
+memory_range = { workspace = true, features = [ "inspect", "mesh" ] }
+vm_topology = { workspace = true, features = [ "inspect", "mesh" ] }
 
 inspect.workspace = true
+mesh.workspace = true
 
 parking_lot.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
-
-[dev-dependencies]
-memory_range.workspace = true
 
 [lints]
 workspace = true

--- a/openhcl/page_pool_alloc/src/lib.rs
+++ b/openhcl/page_pool_alloc/src/lib.rs
@@ -1030,9 +1030,9 @@ mod test {
             0,
         )
         .unwrap();
+        pool.restore(state).unwrap();
         let alloc = pool.allocator("test".into()).unwrap();
 
-        pool.restore(state).unwrap();
         let allocs = alloc.restore_allocations();
         assert_eq!(allocs.len(), 2);
 

--- a/openhcl/page_pool_alloc/src/lib.rs
+++ b/openhcl/page_pool_alloc/src/lib.rs
@@ -74,8 +74,6 @@ pub mod save_restore {
         state: Vec<SlotSavedState>,
         #[mesh(2)]
         ranges: Vec<MemoryRange>,
-        #[mesh(3)]
-        pfn_bias: u64,
     }
 
     impl SaveRestore for PagePool {
@@ -111,7 +109,6 @@ pub mod save_restore {
                     })
                     .collect(),
                 ranges: self.ranges.clone(),
-                pfn_bias: state.pfn_bias,
             })
         }
 

--- a/openhcl/page_pool_alloc/src/lib.rs
+++ b/openhcl/page_pool_alloc/src/lib.rs
@@ -17,6 +17,7 @@ use anyhow::Context;
 use hcl::ioctl::MshvVtlLow;
 use hvdef::HV_PAGE_SIZE;
 use inspect::Inspect;
+use memory_range::MemoryRange;
 use parking_lot::Mutex;
 use std::num::NonZeroU64;
 use std::sync::Arc;
@@ -27,7 +28,8 @@ use vm_topology::memory::MemoryRangeWithNode;
 pub mod save_restore {
     use super::DeviceId;
     use super::PagePool;
-    use super::State;
+    use super::Slot;
+    use super::SlotState;
     use memory_range::MemoryRange;
     use mesh::payload::Protobuf;
     use vmcore::save_restore::SaveRestore;
@@ -35,140 +37,34 @@ pub mod save_restore {
 
     #[derive(Protobuf)]
     #[mesh(package = "openhcl.pagepool")]
-    enum InnerState {
+    enum InnerSlotState {
         #[mesh(1)]
-        Free {
-            #[mesh(1)]
-            base_pfn: u64,
-            #[mesh(2)]
-            pfn_bias: u64,
-            #[mesh(3)]
-            size_pages: u64,
-        },
+        Free,
         #[mesh(2)]
         Allocated {
             #[mesh(1)]
-            base_pfn: u64,
+            device_id: String,
             #[mesh(2)]
-            pfn_bias: u64,
-            #[mesh(3)]
-            size_pages: u64,
-            #[mesh(4)]
-            device_id: usize,
-            #[mesh(5)]
             tag: String,
         },
         #[mesh(3)]
         Leaked {
             #[mesh(1)]
-            base_pfn: u64,
+            device_id: String,
             #[mesh(2)]
-            pfn_bias: u64,
-            #[mesh(3)]
-            size_pages: u64,
-            #[mesh(4)]
-            device_id: usize,
-            #[mesh(5)]
             tag: String,
         },
     }
 
-    impl From<State> for InnerState {
-        fn from(state: State) -> Self {
-            match state {
-                State::Free {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                } => InnerState::Free {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                },
-                State::Allocated {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                    device_id,
-                    tag,
-                } => InnerState::Allocated {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                    device_id,
-                    tag,
-                },
-                State::AllocatedPendingRestore { .. } => {
-                    panic!("should not save AllocatedPendingRestore")
-                }
-                State::Leaked {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                    device_id,
-                    tag,
-                } => InnerState::Leaked {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                    device_id,
-                    tag,
-                },
-            }
-        }
-    }
-
-    impl From<InnerState> for State {
-        fn from(state: InnerState) -> Self {
-            match state {
-                InnerState::Free {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                } => State::Free {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                },
-                InnerState::Allocated {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                    device_id,
-                    tag,
-                } => State::AllocatedPendingRestore {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                    device_id,
-                    tag,
-                },
-                InnerState::Leaked {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                    device_id,
-                    tag,
-                } => State::Leaked {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                    device_id,
-                    tag,
-                },
-            }
-        }
-    }
-
-    // TODO: It seems unfortunate to define this type which is the same as
-    // MemoryRangeWithNode in vm_topology.
     #[derive(Protobuf)]
     #[mesh(package = "openhcl.pagepool")]
-    struct MemoryRangeWithNode {
+    struct SlotSavedState {
         #[mesh(1)]
-        range: MemoryRange,
+        base_pfn: u64,
         #[mesh(2)]
-        vnode: u32,
+        size_pages: u64,
+        #[mesh(3)]
+        state: InnerSlotState,
     }
 
     #[derive(Protobuf)]
@@ -210,11 +106,13 @@ pub mod save_restore {
     #[mesh(package = "openhcl.pagepool")]
     pub struct PagePoolState {
         #[mesh(1)]
-        state: Vec<InnerState>,
+        state: Vec<SlotSavedState>,
         #[mesh(2)]
         device_ids: Vec<DeviceIdState>,
         #[mesh(3)]
-        ranges: Vec<MemoryRangeWithNode>,
+        ranges: Vec<MemoryRange>,
+        #[mesh(4)]
+        pfn_bias: u64,
     }
 
     impl SaveRestore for PagePool {
@@ -223,20 +121,39 @@ pub mod save_restore {
         fn save(&mut self) -> Result<Self::SavedState, vmcore::save_restore::SaveError> {
             let state = self.inner.lock();
             Ok(PagePoolState {
-                state: state.state.iter().map(|s| s.clone().into()).collect(),
+                state: state
+                    .slots
+                    .iter()
+                    .map(|slot| {
+                        let inner_state = match &slot.state {
+                            SlotState::Free => InnerSlotState::Free,
+                            SlotState::Allocated { device_id, tag } => InnerSlotState::Allocated {
+                                device_id: state.device_ids[*device_id].name().to_string(),
+                                tag: tag.clone(),
+                            },
+                            SlotState::Leaked { device_id, tag } => InnerSlotState::Leaked {
+                                device_id: state.device_ids[*device_id].name().to_string(),
+                                tag: tag.clone(),
+                            },
+                            SlotState::AllocatedPendingRestore { .. } => {
+                                panic!("should not save allocated pending restore")
+                            }
+                        };
+
+                        SlotSavedState {
+                            base_pfn: slot.base_pfn,
+                            size_pages: slot.size_pages,
+                            state: inner_state,
+                        }
+                    })
+                    .collect(),
                 device_ids: state
                     .device_ids
                     .iter()
                     .map(|id| id.clone().into())
                     .collect(),
-                ranges: self
-                    .ranges
-                    .iter()
-                    .map(|range| MemoryRangeWithNode {
-                        range: range.range,
-                        vnode: range.vnode,
-                    })
-                    .collect(),
+                ranges: self.ranges.clone(),
+                pfn_bias: state.pfn_bias,
             })
         }
 
@@ -247,7 +164,7 @@ pub mod save_restore {
             // Verify that the pool describes the same regions of memory as the
             // saved state.
             for (current, saved) in self.ranges.iter().zip(state.ranges.iter()) {
-                if current.range != saved.range || current.vnode != saved.vnode {
+                if current != saved {
                     // TODO: return unmatched range or vecs?
                     return Err(vmcore::save_restore::RestoreError::InvalidSavedState(
                         anyhow::anyhow!("pool ranges do not match"),
@@ -258,8 +175,8 @@ pub mod save_restore {
             let mut inner = self.inner.lock();
 
             // Verify there are no existing allocators present, as we rely on
-            // the pool being completely free because device_ids are durable
-            // indices into a vec.
+            // the pool being completely free since we will overwrite the state
+            // of the pool with the stored slot info.
             //
             // Note that this also means that the pool does not have any pending
             // allocations, as it's impossible to allocate without creating an
@@ -270,8 +187,40 @@ pub mod save_restore {
                 ));
             }
 
-            inner.state = state.state.into_iter().map(|s| s.into()).collect();
             inner.device_ids = state.device_ids.into_iter().map(|id| id.into()).collect();
+            inner.slots = state
+                .state
+                .into_iter()
+                .map(|slot| {
+                    let inner = match slot.state {
+                        InnerSlotState::Free => SlotState::Free,
+                        InnerSlotState::Allocated { device_id, tag } => {
+                            SlotState::AllocatedPendingRestore {
+                                device_id: inner
+                                    .device_ids
+                                    .iter()
+                                    .position(|id| id.name() == device_id)
+                                    .expect("device id not found"),
+                                tag,
+                            }
+                        }
+                        InnerSlotState::Leaked { device_id, tag } => SlotState::Leaked {
+                            device_id: inner
+                                .device_ids
+                                .iter()
+                                .position(|id| id.name() == device_id)
+                                .expect("device id not found"),
+                            tag,
+                        },
+                    };
+
+                    Slot {
+                        base_pfn: slot.base_pfn,
+                        size_pages: slot.size_pages,
+                        state: inner,
+                    }
+                })
+                .collect();
 
             Ok(())
         }
@@ -286,26 +235,23 @@ pub struct PagePoolOutOfMemory {
     tag: String,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct Slot {
+    base_pfn: u64,
+    size_pages: u64,
+    state: SlotState,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
-enum State {
-    Free {
-        base_pfn: u64,
-        pfn_bias: u64,
-        size_pages: u64,
-    },
+enum SlotState {
+    Free,
     Allocated {
-        base_pfn: u64,
-        pfn_bias: u64,
-        size_pages: u64,
         /// This is an index into the outer [`PagePoolInner`]'s device_ids
         /// vector.
         device_id: usize,
         tag: String,
     },
     AllocatedPendingRestore {
-        base_pfn: u64,
-        pfn_bias: u64,
-        size_pages: u64,
         /// This is an index into the outer [`PagePoolInner`]'s device_ids
         /// vector.
         device_id: usize,
@@ -313,14 +259,38 @@ enum State {
     },
     /// This allocation was leaked, and is no longer able to be allocated from.
     Leaked {
-        base_pfn: u64,
-        pfn_bias: u64,
-        size_pages: u64,
         /// This is an index into the outer [`PagePoolInner`]'s device_ids
         /// vector.
         device_id: usize,
         tag: String,
     },
+}
+
+impl SlotState {
+    fn restore_allocated(&mut self) {
+        if !matches!(self, SlotState::AllocatedPendingRestore { .. }) {
+            panic!("invalid state");
+        }
+
+        // Temporarily swap with free so we can move the string tag to the
+        // restored state without allocating.
+        let prev = std::mem::replace(self, SlotState::Free);
+        *self = match prev {
+            SlotState::AllocatedPendingRestore { device_id, tag } => {
+                SlotState::Allocated { device_id, tag }
+            }
+            _ => unreachable!(),
+        };
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            SlotState::Free => "free",
+            SlotState::Allocated { .. } => "allocated",
+            SlotState::AllocatedPendingRestore { .. } => "allocated_pending_restore",
+            SlotState::Leaked { .. } => "leaked",
+        }
+    }
 }
 
 /// What kind of memory this pool is.
@@ -362,8 +332,10 @@ impl DeviceId {
 
 #[derive(Debug)]
 struct PagePoolInner {
-    /// The internal state of the pool.
-    state: Vec<State>,
+    /// The internal slots for the pool, representing page state.
+    slots: Vec<Slot>,
+    /// The pfn_bias for the pool.
+    pfn_bias: u64,
     /// The list of device ids for outstanding allocators. Each name must be
     /// unique.
     device_ids: Vec<DeviceId>,
@@ -375,65 +347,23 @@ impl Inspect for PagePoolInner {
     fn inspect(&self, req: inspect::Request<'_>) {
         req.respond()
             .field("device_ids", inspect::iter_by_index(&self.device_ids))
-            .child("state", |req| {
+            .child("slots", |req| {
                 let mut resp = req.respond();
-                for (i, state) in self.state.iter().enumerate() {
-                    resp.child(&i.to_string(), |req| match state {
-                        State::Free {
-                            base_pfn,
-                            pfn_bias,
-                            size_pages,
-                        } => {
-                            req.respond()
-                                .field("state", "free")
-                                .field("base_pfn", inspect::AsHex(base_pfn))
-                                .field("pfn_bias", inspect::AsHex(pfn_bias))
-                                .field("size_pages", inspect::AsHex(size_pages));
-                        }
-                        State::Allocated {
-                            base_pfn,
-                            pfn_bias,
-                            size_pages,
-                            device_id,
-                            tag,
-                        } => {
-                            req.respond()
-                                .field("state", "allocated")
-                                .field("base_pfn", inspect::AsHex(base_pfn))
-                                .field("pfn_bias", inspect::AsHex(pfn_bias))
-                                .field("size_pages", inspect::AsHex(size_pages))
-                                .field("device_id", self.device_ids[*device_id].clone())
-                                .field("tag", tag);
-                        }
-                        State::AllocatedPendingRestore {
-                            base_pfn,
-                            pfn_bias,
-                            size_pages,
-                            device_id,
-                            tag,
-                        } => {
-                            req.respond()
-                                .field("state", "allocated_pending_restore")
-                                .field("base_pfn", inspect::AsHex(base_pfn))
-                                .field("pfn_bias", inspect::AsHex(pfn_bias))
-                                .field("size_pages", inspect::AsHex(size_pages))
-                                .field("device_id", self.device_ids[*device_id].clone())
-                                .field("tag", tag);
-                        }
-                        State::Leaked {
-                            base_pfn,
-                            pfn_bias,
-                            size_pages,
-                            device_id,
-                            tag,
-                        } => {
-                            req.respond()
-                                .field("state", "leaked")
-                                .field("base_pfn", inspect::AsHex(base_pfn))
-                                .field("pfn_bias", inspect::AsHex(pfn_bias))
-                                .field("size_pages", inspect::AsHex(size_pages))
-                                .field("device_id", self.device_ids[*device_id].clone())
-                                .field("tag", tag);
+                for (i, slot) in self.slots.iter().enumerate() {
+                    resp.child(&i.to_string(), |req| {
+                        let mut resp = req.respond();
+                        resp.field("base_pfn", inspect::AsHex(slot.base_pfn))
+                            .field("size_pages", inspect::AsHex(slot.size_pages))
+                            .field("state", slot.state.name());
+
+                        match &slot.state {
+                            SlotState::Free => {}
+                            SlotState::Allocated { device_id, tag }
+                            | SlotState::AllocatedPendingRestore { device_id, tag }
+                            | SlotState::Leaked { device_id, tag } => {
+                                resp.field("device_id", self.device_ids[*device_id].clone())
+                                    .field("tag", tag);
+                            }
                         }
                     });
                 }
@@ -472,32 +402,19 @@ impl Drop for PagePoolHandle {
     fn drop(&mut self) {
         let mut inner = self.inner.lock();
 
-        let entry = inner
-            .state
+        let slot = inner
+            .slots
             .iter_mut()
-            .find(|state| {
-                if let State::Allocated {
-                    base_pfn,
-                    pfn_bias,
-                    size_pages,
-                    device_id: _,
-                    tag: _,
-                } = state
-                {
-                    *base_pfn == self.base_pfn
-                        && *pfn_bias == self.pfn_bias
-                        && *size_pages == self.size_pages
+            .find(|slot| {
+                if matches!(slot.state, SlotState::Allocated { .. }) {
+                    slot.base_pfn == self.base_pfn && slot.size_pages == self.size_pages
                 } else {
                     false
                 }
             })
             .expect("must find allocation");
 
-        *entry = State::Free {
-            base_pfn: self.base_pfn,
-            pfn_bias: self.pfn_bias,
-            size_pages: self.size_pages,
-        };
+        slot.state = SlotState::Free;
     }
 }
 
@@ -516,7 +433,7 @@ pub struct PagePool {
     #[inspect(flatten)]
     inner: Arc<Mutex<PagePoolInner>>,
     #[inspect(iter_by_index)]
-    ranges: Vec<MemoryRangeWithNode>,
+    ranges: Vec<MemoryRange>,
     typ: PoolType,
 }
 
@@ -546,21 +463,26 @@ impl PagePool {
         typ: PoolType,
         addr_bias: u64,
     ) -> anyhow::Result<Self> {
+        // TODO: Allow callers to specify the vnode, but today we discard this
+        // information. In the future we may keep ranges with vnode in order to
+        // allow per-node allocations.
+
         let pages = memory
             .iter()
-            .map(|range| State::Free {
+            .map(|range| Slot {
                 base_pfn: range.range.start() / HV_PAGE_SIZE,
-                pfn_bias: addr_bias / HV_PAGE_SIZE,
                 size_pages: range.range.len() / HV_PAGE_SIZE,
+                state: SlotState::Free,
             })
             .collect();
 
         Ok(Self {
             inner: Arc::new(Mutex::new(PagePoolInner {
-                state: pages,
+                slots: pages,
+                pfn_bias: addr_bias / HV_PAGE_SIZE,
                 device_ids: Vec::new(),
             })),
-            ranges: memory.to_vec(),
+            ranges: memory.iter().map(|r| r.range).collect(),
             typ,
         })
     }
@@ -596,35 +518,28 @@ impl PagePool {
         let mut unrestored_allocation = false;
 
         // Mark unrestored allocations as leaked.
-        for state in inner.state.iter_mut() {
-            if let State::AllocatedPendingRestore {
-                base_pfn,
-                pfn_bias,
-                size_pages,
-                device_id,
-                tag,
-            } = state
-            {
-                tracing::warn!(
-                    base_pfn = *base_pfn,
-                    pfn_bias = *pfn_bias,
-                    size_pages = *size_pages,
-                    device_id = *device_id,
-                    tag = tag.as_str(),
-                    "unrestored allocation"
-                );
+        for slot in inner.slots.iter_mut() {
+            match &slot.state {
+                SlotState::Free | SlotState::Allocated { .. } | SlotState::Leaked { .. } => {}
+                SlotState::AllocatedPendingRestore { device_id, tag } => {
+                    tracing::warn!(
+                        base_pfn = slot.base_pfn,
+                        pfn_bias = slot.size_pages,
+                        size_pages = slot.size_pages,
+                        device_id = device_id,
+                        tag = tag.as_str(),
+                        "unrestored allocation"
+                    );
 
-                if leak_unrestored {
-                    *state = State::Leaked {
-                        base_pfn: *base_pfn,
-                        pfn_bias: *pfn_bias,
-                        size_pages: *size_pages,
-                        device_id: *device_id,
-                        tag: tag.clone(),
-                    };
+                    if leak_unrestored {
+                        slot.state = SlotState::Leaked {
+                            device_id: *device_id,
+                            tag: tag.clone(),
+                        };
+                    }
+
+                    unrestored_allocation = true;
                 }
-
-                unrestored_allocation = true;
             }
         }
 
@@ -741,50 +656,43 @@ impl PagePoolAllocator {
         let size_pages = size_pages.get();
 
         let index = inner
-            .state
+            .slots
             .iter()
-            .position(|state| match state {
-                State::Free {
-                    base_pfn: _,
-                    pfn_bias: _,
-                    size_pages: len,
-                } => *len >= size_pages,
-                State::Allocated { .. } => false,
-                State::AllocatedPendingRestore { .. } => false,
-                State::Leaked { .. } => false,
+            .position(|slot| match slot.state {
+                SlotState::Free => slot.size_pages >= size_pages,
+                SlotState::Allocated { .. }
+                | SlotState::AllocatedPendingRestore { .. }
+                | SlotState::Leaked { .. } => false,
             })
             .ok_or(PagePoolOutOfMemory {
                 size: size_pages,
                 tag: tag.clone(),
             })?;
 
-        let (base_pfn, pfn_bias) = match inner.state.swap_remove(index) {
-            State::Free {
-                base_pfn: base,
-                pfn_bias: offset,
-                size_pages: len,
-            } => {
-                inner.state.push(State::Allocated {
-                    base_pfn: base,
-                    pfn_bias: offset,
-                    size_pages,
+        let pfn_bias = inner.pfn_bias;
+
+        let base_pfn = {
+            let slot = inner.slots.swap_remove(index);
+            assert!(matches!(slot.state, SlotState::Free));
+
+            inner.slots.push(Slot {
+                base_pfn: slot.base_pfn,
+                size_pages,
+                state: SlotState::Allocated {
                     device_id: self.device_id,
-                    tag,
+                    tag: tag.clone(),
+                },
+            });
+
+            if slot.size_pages > size_pages {
+                inner.slots.push(Slot {
+                    base_pfn: slot.base_pfn + size_pages,
+                    size_pages: slot.size_pages - size_pages,
+                    state: SlotState::Free,
                 });
-
-                if len > size_pages {
-                    inner.state.push(State::Free {
-                        base_pfn: base + size_pages,
-                        pfn_bias: offset,
-                        size_pages: len - size_pages,
-                    });
-                }
-
-                (base, offset)
             }
-            State::Allocated { .. } => unreachable!(),
-            State::AllocatedPendingRestore { .. } => unreachable!(),
-            State::Leaked { .. } => unreachable!(),
+
+            slot.base_pfn
         };
 
         Ok(PagePoolHandle {
@@ -795,46 +703,36 @@ impl PagePoolAllocator {
         })
     }
 
-    /// Restore allocations after a restore operation on the pool. This will
-    /// return any allocations that were previously allocated for this
-    /// allocator.
-    pub fn restore_allocations(&self) -> Vec<PagePoolHandle> {
+    /// Restore an allocation that was previously allocated in the pool. The
+    /// base_pfn, size_pages, and device must match.
+    pub fn restore_alloc(
+        &self,
+        base_pfn: u64,
+        size_pages: NonZeroU64,
+    ) -> anyhow::Result<PagePoolHandle> {
         let mut inner = self.inner.lock();
-        let mut handles = Vec::new();
-
-        for state in inner.state.iter_mut() {
-            if let State::AllocatedPendingRestore {
-                base_pfn,
-                pfn_bias,
-                size_pages,
-                device_id,
-                tag,
-            } = state
-            {
-                if *device_id != self.device_id {
-                    continue;
+        let index = inner
+            .slots
+            .iter()
+            .position(|slot| {
+                if let SlotState::AllocatedPendingRestore { device_id, tag: _ } = &slot.state {
+                    *device_id == self.device_id
+                        && slot.base_pfn == base_pfn
+                        && slot.size_pages == size_pages.get()
+                } else {
+                    false
                 }
+            })
+            .ok_or(anyhow::anyhow!("matching allocation not found"))?;
 
-                let handle = PagePoolHandle {
-                    inner: self.inner.clone(),
-                    base_pfn: *base_pfn,
-                    pfn_bias: *pfn_bias,
-                    size_pages: *size_pages,
-                };
+        inner.slots[index].state.restore_allocated();
 
-                *state = State::Allocated {
-                    base_pfn: *base_pfn,
-                    pfn_bias: *pfn_bias,
-                    size_pages: *size_pages,
-                    device_id: *device_id,
-                    tag: tag.clone(),
-                };
-
-                handles.push(handle);
-            }
-        }
-
-        handles
+        Ok(PagePoolHandle {
+            inner: self.inner.clone(),
+            base_pfn,
+            pfn_bias: inner.pfn_bias,
+            size_pages: size_pages.get(),
+        })
     }
 }
 
@@ -954,7 +852,7 @@ mod test {
         drop(a2);
 
         let inner = alloc.inner.lock();
-        assert_eq!(inner.state.len(), 2);
+        assert_eq!(inner.slots.len(), 2);
     }
 
     #[test]
@@ -1033,16 +931,20 @@ mod test {
         pool.restore(state).unwrap();
         let alloc = pool.allocator("test".into()).unwrap();
 
-        let allocs = alloc.restore_allocations();
-        assert_eq!(allocs.len(), 2);
+        let restored_a1 = alloc
+            .restore_alloc(a1_pfn, a1_size.try_into().unwrap())
+            .unwrap();
+        let restored_a2 = alloc
+            .restore_alloc(a2_pfn, a2_size.try_into().unwrap())
+            .unwrap();
 
-        assert_eq!(allocs[0].base_pfn(), a1_pfn);
-        assert_eq!(allocs[0].pfn_bias, a1_pfn_bias);
-        assert_eq!(allocs[0].size_pages, a1_size);
+        assert_eq!(restored_a1.base_pfn(), a1_pfn);
+        assert_eq!(restored_a1.pfn_bias, a1_pfn_bias);
+        assert_eq!(restored_a1.size_pages, a1_size);
 
-        assert_eq!(allocs[1].base_pfn(), a2_pfn);
-        assert_eq!(allocs[1].pfn_bias, a2_pfn_bias);
-        assert_eq!(allocs[1].size_pages, a2_size);
+        assert_eq!(restored_a2.base_pfn(), a2_pfn);
+        assert_eq!(restored_a2.pfn_bias, a2_pfn_bias);
+        assert_eq!(restored_a2.size_pages, a2_size);
 
         pool.validate_restore(false).unwrap();
     }

--- a/openhcl/underhill_core/src/servicing.rs
+++ b/openhcl/underhill_core/src/servicing.rs
@@ -77,9 +77,6 @@ mod state {
         #[mesh(10000)]
         pub nvme_state: Option<NvmeSavedState>,
         /// Shared pool information.
-        ///
-        /// BUGBUG: Think about if this should be an enum or substruct for all
-        /// pools (there will be more in the future).
         #[mesh(8)]
         pub shared_pool_state: Option<page_pool_alloc::save_restore::PagePoolState>,
     }

--- a/openhcl/underhill_core/src/servicing.rs
+++ b/openhcl/underhill_core/src/servicing.rs
@@ -141,11 +141,8 @@ pub mod transposed {
             disk_get_vmgs::save_restore::SavedBlockStorageMetadata,
         )>,
         pub overlay_shutdown_device: Option<bool>,
-<<<<<<< HEAD
         pub nvme_state: Option<Option<NvmeSavedState>>,
-=======
         pub shared_pool_state: Option<Option<page_pool_alloc::save_restore::PagePoolState>>,
->>>>>>> 9424b92 (save restore for pool)
     }
 
     /// A transposed `Option<EmuplatSavedState>`, where each field of
@@ -173,11 +170,8 @@ pub mod transposed {
                     flush_logs_result,
                     vmgs,
                     overlay_shutdown_device,
-<<<<<<< HEAD
                     nvme_state,
-=======
                     shared_pool_state,
->>>>>>> 9424b92 (save restore for pool)
                 } = state;
 
                 OptionServicingInitState {
@@ -191,11 +185,8 @@ pub mod transposed {
                     flush_logs_result: Some(flush_logs_result),
                     vmgs: Some(vmgs),
                     overlay_shutdown_device: Some(overlay_shutdown_device),
-<<<<<<< HEAD
                     nvme_state: Some(nvme_state),
-=======
                     shared_pool_state: Some(shared_pool_state),
->>>>>>> 9424b92 (save restore for pool)
                 }
             } else {
                 OptionServicingInitState::default()

--- a/openhcl/underhill_core/src/servicing.rs
+++ b/openhcl/underhill_core/src/servicing.rs
@@ -76,6 +76,12 @@ mod state {
         /// NVMe saved state.
         #[mesh(10000)]
         pub nvme_state: Option<NvmeSavedState>,
+        /// Shared pool information.
+        ///
+        /// BUGBUG: Think about if this should be an enum or substruct for all
+        /// pools (there will be more in the future).
+        #[mesh(8)]
+        pub shared_pool_state: Option<page_pool_alloc::save_restore::PagePoolState>,
     }
 
     #[derive(Protobuf)]
@@ -138,7 +144,11 @@ pub mod transposed {
             disk_get_vmgs::save_restore::SavedBlockStorageMetadata,
         )>,
         pub overlay_shutdown_device: Option<bool>,
+<<<<<<< HEAD
         pub nvme_state: Option<Option<NvmeSavedState>>,
+=======
+        pub shared_pool_state: Option<Option<page_pool_alloc::save_restore::PagePoolState>>,
+>>>>>>> 9424b92 (save restore for pool)
     }
 
     /// A transposed `Option<EmuplatSavedState>`, where each field of
@@ -166,7 +176,11 @@ pub mod transposed {
                     flush_logs_result,
                     vmgs,
                     overlay_shutdown_device,
+<<<<<<< HEAD
                     nvme_state,
+=======
+                    shared_pool_state,
+>>>>>>> 9424b92 (save restore for pool)
                 } = state;
 
                 OptionServicingInitState {
@@ -180,7 +194,11 @@ pub mod transposed {
                     flush_logs_result: Some(flush_logs_result),
                     vmgs: Some(vmgs),
                     overlay_shutdown_device: Some(overlay_shutdown_device),
+<<<<<<< HEAD
                     nvme_state: Some(nvme_state),
+=======
+                    shared_pool_state: Some(shared_pool_state),
+>>>>>>> 9424b92 (save restore for pool)
                 }
             } else {
                 OptionServicingInitState::default()

--- a/openhcl/underhill_core/src/servicing.rs
+++ b/openhcl/underhill_core/src/servicing.rs
@@ -77,7 +77,7 @@ mod state {
         #[mesh(10000)]
         pub nvme_state: Option<NvmeSavedState>,
         /// Shared pool information.
-        #[mesh(8)]
+        #[mesh(10001)]
         pub shared_pool_state: Option<page_pool_alloc::save_restore::PagePoolState>,
     }
 


### PR DESCRIPTION
Support save restore for the page_pool_alloc crate. This allows save restore of the shared visibility pool.

A future PR will add support for a private page pool to be used by AK cert renewal and other usages. 