### PR TITLE
disk_layered: rework layer attach lifecycle infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
 name = "disk_layered"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "disk_backend",
  "disk_backend_resources",

--- a/vm/devices/storage/disk_layered/Cargo.toml
+++ b/vm/devices/storage/disk_layered/Cargo.toml
@@ -15,6 +15,7 @@ guestmem.workspace = true
 vm_resource.workspace = true
 inspect = { workspace = true, features = ["std"] }
 
+anyhow.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 thiserror.workspace = true

--- a/vm/devices/storage/disk_layered/src/resolve.rs
+++ b/vm/devices/storage/disk_layered/src/resolve.rs
@@ -4,7 +4,7 @@
 //! Resolver-related definitions for disk layer resources.
 
 use super::DiskLayer;
-use super::LayerIo;
+use crate::AttachLayer;
 use vm_resource::kind::DiskLayerHandleKind;
 use vm_resource::CanResolveTo;
 
@@ -29,7 +29,7 @@ pub struct ResolvedDiskLayer(pub DiskLayer);
 
 impl ResolvedDiskLayer {
     /// Returns a resolved disk wrapping a backing object.
-    pub fn new<T: LayerIo>(layer: T) -> Self {
+    pub fn new<T: AttachLayer>(layer: T) -> Self {
         Self(DiskLayer::new(layer))
     }
 }

--- a/vm/devices/storage/disk_layered/src/resolver.rs
+++ b/vm/devices/storage/disk_layered/src/resolver.rs
@@ -5,10 +5,10 @@
 
 use super::resolve::ResolveDiskLayerParameters;
 use super::resolve::ResolvedDiskLayer;
-use super::DiskLayer;
 use super::InvalidLayeredDisk;
 use super::LayerConfiguration;
 use super::LayeredDisk;
+use crate::DiskLayer;
 use async_trait::async_trait;
 use disk_backend::resolve::ResolveDiskParameters;
 use disk_backend::resolve::ResolvedDisk;
@@ -91,6 +91,7 @@ impl AsyncResolveResource<DiskHandleKind, LayeredDiskHandle> for LayeredDiskReso
             .await?;
 
         let disk = LayeredDisk::new(input.read_only, layers)
+            .await
             .map_err(ResolveLayeredDiskError::CreateDisk)?;
 
         ResolvedDisk::new(disk).map_err(ResolveLayeredDiskError::InvalidDisk)


### PR DESCRIPTION
The `on_attach` model needs to be reworked in order to support disklayer_sqlite,

Namely: in order to initialize a sqlite disk layer `dbhd` file, one must know the properties of the lower layer at initialization time, in order to encode that information in the dbhd's metadata table. Unfortunately, that information isn't available in `new` - its only available in `on_attach`. Sticking with the existing `on_attach` model would require disklayer_sqlite to exist in a "half-initialized" state between initialization and attachment, thus incurring the need to include runtime checks in each DiskLayerIo method in order to determine whether or not the backing store has been initialized or not. Not ideal.

Instead, this new model hoists the state transition from initialized to attached into the type-system itself, with LayeredDisk invoking an `fn attach()` method in order to obtain an actual instance of `LayerIo` that can be used at runtime.

While this does make the LayeredDisk initialization logic a bit more complicated, it should significantly simplify the disk-layer implementation of sqlitedisk, and other future disk-layer implementations.