### PR TITLE
mesh_protobuf: fix no_std build

### DIFF
--- a/support/mesh/mesh_protobuf/Cargo.toml
+++ b/support/mesh/mesh_protobuf/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 default = []
 prost = ["dep:prost", "dep:prost-types", "dep:prost-build"]
 socket2 = ["dep:socket2"]
-std = []
+std = ["dep:heck", "dep:fs-err"]
 
 [dependencies]
 mesh_derive.workspace = true
@@ -19,8 +19,8 @@ prost = { workspace = true, optional = true }
 prost-types = { workspace = true, optional = true }
 thiserror.workspace = true
 
-fs-err.workspace = true
-heck.workspace = true
+fs-err = { workspace = true, optional = true }
+heck = { workspace = true, optional = true }
 socket2 = { workspace = true, optional = true }
 zerocopy.workspace = true
 


### PR DESCRIPTION
Only pull in `heck` or `fs-err` when building with `feature = "std"`. They are otherwise not used, and they block building for targets that lack `std`.