### PR TITLE
vmbus_relay: split HCL driver interactions to new crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6872,6 +6872,7 @@ dependencies = [
  "vm_topology",
  "vmbus_async",
  "vmbus_channel",
+ "vmbus_client_hcl",
  "vmbus_core",
  "vmbus_relay",
  "vmbus_relay_intercept_device",
@@ -7730,12 +7731,29 @@ dependencies = [
  "inspect",
  "mesh",
  "pal_async",
+ "pal_event",
  "parking_lot",
  "thiserror 2.0.0",
  "tracing",
  "vmbus_async",
  "vmbus_channel",
  "vmbus_core",
+ "zerocopy",
+]
+
+[[package]]
+name = "vmbus_client_hcl"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "hcl",
+ "hvdef",
+ "pal_async",
+ "pal_event",
+ "tracing",
+ "vmbus_async",
+ "vmbus_client",
  "zerocopy",
 ]
 
@@ -7778,8 +7796,6 @@ dependencies = [
  "anyhow",
  "futures",
  "guid",
- "hcl",
- "hvdef",
  "inspect",
  "mesh",
  "mesh_protobuf",
@@ -7789,7 +7805,6 @@ dependencies = [
  "parking_lot",
  "tracelimit",
  "tracing",
- "vmbus_async",
  "vmbus_channel",
  "vmbus_client",
  "vmbus_core",
@@ -7805,7 +7820,6 @@ dependencies = [
  "anyhow",
  "futures",
  "guid",
- "hcl",
  "hvdef",
  "inspect",
  "mesh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -298,6 +298,7 @@ vmbfs_resources = { path = "vm/devices/vmbus/vmbfs_resources" }
 vmbus_async = { path = "vm/devices/vmbus/vmbus_async" }
 vmbus_channel = { path = "vm/devices/vmbus/vmbus_channel" }
 vmbus_client = { path = "vm/devices/vmbus/vmbus_client" }
+vmbus_client_hcl = { path = "vm/devices/vmbus/vmbus_client_hcl" }
 vmbus_core = { path = "vm/devices/vmbus/vmbus_core" }
 vmbus_proxy = { path = "vm/devices/vmbus/vmbus_proxy" }
 vmbus_relay = { path = "vm/devices/vmbus/vmbus_relay" }

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -99,6 +99,7 @@ vmbus_async.workspace = true
 vmbus_user_channel.workspace = true
 vmbus_channel.workspace = true
 vmbus_core.workspace = true
+vmbus_client_hcl.workspace = true
 vmbus_relay.workspace = true
 vmbus_relay_intercept_device.workspace = true
 vmbus_serial_guest.workspace = true

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2565,6 +2565,7 @@ async fn new_underhill_vm(
 
     let mut vmbus_server = None;
     let mut host_vmbus_relay = None;
+    let mut vmbus_synic_client = None;
 
     // VMBus
     if with_vmbus {
@@ -2603,15 +2604,24 @@ async fn new_underhill_vm(
 
         let vmbus = VmbusServerHandle::new(&tp, state_units.add("vmbus"), vmbus)?;
         if let Some((relay_channel, hvsock_relay)) = relay_channels {
+            let relay_driver = tp.driver(0);
+            let (synic, msg_source) =
+                vmbus_client_hcl::new_synic_client_and_messsage_source(relay_driver)
+                    .context("failed to create synic client and message source")?;
+
+            let synic = Arc::new(synic);
+
             let vmbus_relay = vmbus_relay::HostVmbusTransport::new(
-                tp.driver(0).clone(),
+                relay_driver.clone(),
                 Arc::clone(vmbus.control()),
                 relay_channel,
                 hvsock_relay,
+                synic.clone(),
+                msg_source,
             )
-            .await
-            .expect("failed to create host vmbus transport");
+            .context("failed to create host vmbus transport")?;
 
+            vmbus_synic_client = Some(synic);
             host_vmbus_relay = Some(VmbusRelayHandle::new(
                 &tp,
                 state_units
@@ -2787,6 +2797,7 @@ async fn new_underhill_vm(
         let shutdown_guest = SimpleVmbusClientDeviceWrapper::new(
             driver_source.simple(),
             partition.clone(),
+            vmbus_synic_client.clone().unwrap(),
             shutdown_guest,
         )?;
         vmbus_intercept_devices

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -19,6 +19,7 @@ use pal_async::task::Spawn;
 use pal_async::task::Task;
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::sync::Arc;
 use thiserror::Error;
 use vmbus_async::async_dgram::AsyncRecv;
 use vmbus_async::async_dgram::AsyncRecvExt;
@@ -49,6 +50,12 @@ const SUPPORTED_FEATURE_FLAGS: FeatureFlags = FeatureFlags::all();
 /// The client interface to the synic.
 pub trait SynicClient: Send + Sync {
     fn post_message(&self, connection_id: u32, typ: u32, msg: &[u8]);
+    /// Maps an incoming event signal on SINT7 to `event`.
+    fn map_event(&self, event_flag: u16, event: &pal_event::Event) -> std::io::Result<()>;
+    /// Unmaps an event previously mapped with `map_event`.
+    fn unmap_event(&self, event_flag: u16);
+    /// Signals an event on the synic.
+    fn signal_event(&self, connection_id: u32, event_flag: u16) -> std::io::Result<()>;
 }
 
 /// A stream of vmbus messages that can be paused and resumed.
@@ -73,7 +80,7 @@ pub struct VmbusClient {
 impl VmbusClient {
     /// Creates a new instance with a receiver for incoming synic messages.
     pub fn new(
-        synic: impl 'static + SynicClient,
+        synic: Arc<dyn SynicClient>,
         notify_send: mesh::Sender<ClientNotification>,
         msg_source: impl VmbusMessageSource + 'static,
         spawner: &impl Spawn,
@@ -85,7 +92,7 @@ impl VmbusClient {
         let (unload_send, unload_recv) = mesh::channel();
 
         let inner = ClientTaskInner {
-            synic: Box::new(synic),
+            synic,
             channels: HashMap::new(),
             gpadls: HashMap::new(),
             teardown_gpadls: HashMap::new(),
@@ -1324,7 +1331,7 @@ enum GpadlState {
 }
 
 struct ClientTaskInner {
-    synic: Box<dyn SynicClient>,
+    synic: Arc<dyn SynicClient>,
     channels: HashMap<ChannelId, Channel>,
     gpadls: HashMap<(ChannelId, GpadlId), GpadlState>,
     teardown_gpadls: HashMap<GpadlId, Option<ChannelId>>,
@@ -1489,6 +1496,18 @@ mod tests {
                 .lock()
                 .push(OutgoingMessage::from_message(msg));
         }
+
+        fn map_event(&self, _event_flag: u16, _event: &pal_event::Event) -> std::io::Result<()> {
+            Err(std::io::ErrorKind::Unsupported.into())
+        }
+
+        fn unmap_event(&self, _event_flag: u16) {
+            unreachable!()
+        }
+
+        fn signal_event(&self, _connection_id: u32, _event_flag: u16) -> std::io::Result<()> {
+            Err(std::io::ErrorKind::Unsupported.into())
+        }
     }
 
     struct TestMessageSource {
@@ -1533,7 +1552,7 @@ mod tests {
         let (notify_send, notify_recv) = mesh::channel();
 
         let mut client = VmbusClient::new(
-            server.clone(),
+            Arc::new(server.clone()),
             notify_send,
             TestMessageSource { msg_recv },
             &driver,

--- a/vm/devices/vmbus/vmbus_client_hcl/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_client_hcl/Cargo.toml
@@ -2,30 +2,22 @@
 # Licensed under the MIT License.
 
 [package]
-name = "vmbus_client"
+name = "vmbus_client_hcl"
 edition = "2021"
 rust-version.workspace = true
 
-[dependencies]
-vmbus_async.workspace = true
-vmbus_channel.workspace = true
-vmbus_core.workspace = true
-
-guid.workspace = true
-mesh.workspace = true
+[target.'cfg(target_os = "linux")'.dependencies]
+hcl.workspace = true
+hvdef.workspace = true
 pal_async.workspace = true
 pal_event.workspace = true
-inspect.workspace = true
+vmbus_async.workspace = true
+vmbus_client.workspace = true
 
 anyhow.workspace = true
 futures.workspace = true
-thiserror.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
-
-[dev-dependencies]
-parking_lot.workspace = true
-pal_async.workspace = true
 
 [lints]
 workspace = true

--- a/vm/devices/vmbus/vmbus_client_hcl/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client_hcl/src/lib.rs
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(target_os = "linux")]
+
+//! Implementation of [`vmbus_client`] traits to communicate with the synic via
+//! the Linux HCL driver.
+
+#![warn(missing_docs)]
+#![forbid(unsafe_code)]
+
+use anyhow::Context as _;
+use futures::AsyncRead;
+use hcl::ioctl::HypercallError;
+use hcl::vmbus::HclVmbus;
+use hvdef::HvError;
+use hvdef::HvMessage;
+use hvdef::HvMessageHeader;
+use pal_async::driver::Driver;
+use pal_async::pipe::PolledPipe;
+use std::io;
+use std::io::IoSliceMut;
+use std::os::fd::AsFd;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::ready;
+use std::task::Poll;
+use vmbus_async::async_dgram::AsyncRecv;
+use vmbus_client::SynicClient;
+use vmbus_client::VmbusMessageSource;
+use zerocopy::AsBytes;
+
+/// Returns the synic client and message source for use with
+/// [`vmbus_client::VmbusClient`].
+pub fn new_synic_client_and_messsage_source(
+    driver: &(impl Driver + ?Sized),
+) -> anyhow::Result<(impl SynicClient, impl VmbusMessageSource)> {
+    // Open an HCL vmbus fd for issuing synic requests.
+    let hcl_vmbus = Arc::new(HclVmbus::new().context("failed to open hcl_vmbus")?);
+    let synic = HclSynic {
+        hcl_vmbus: Arc::clone(&hcl_vmbus),
+    };
+
+    // Open another one for polling for messages.
+    let vmbus_fd = HclVmbus::new()
+        .context("failed to open hcl_vmbus")?
+        .into_inner();
+
+    let pipe = PolledPipe::new(driver, vmbus_fd).context("failed to created PolledPipe")?;
+    let msg_source = MessageSource {
+        pipe,
+        hcl_vmbus: Arc::clone(&hcl_vmbus),
+    };
+
+    Ok((synic, msg_source))
+}
+
+struct HclSynic {
+    hcl_vmbus: Arc<HclVmbus>,
+}
+
+impl SynicClient for HclSynic {
+    fn post_message(&self, connection_id: u32, typ: u32, msg: &[u8]) {
+        let mut tries = 0;
+        let mut wait = 1;
+        // If we receive HV_STATUS_INSUFFICIENT_BUFFERS block till the call is
+        // successful with a delay.
+        loop {
+            let ret = self.hcl_vmbus.post_message(connection_id, typ.into(), msg);
+            match ret {
+                Ok(()) => break,
+                Err(HypercallError::Hypervisor(HvError::InsufficientBuffers)) => {
+                    tracing::debug!("received HV_STATUS_INSUFFICIENT_BUFFERS, retrying");
+                    if tries < 22 {
+                        wait *= 2;
+                        tries += 1;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(wait / 1000));
+                }
+                Err(err) => {
+                    panic!("received error code from post message call {}", err);
+                }
+            }
+        }
+    }
+
+    fn map_event(&self, event_flag: u16, event: &pal_event::Event) -> io::Result<()> {
+        self.hcl_vmbus
+            .set_eventfd(event_flag.into(), Some(event.as_fd()))
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+    }
+
+    fn unmap_event(&self, event_flag: u16) {
+        self.hcl_vmbus.set_eventfd(event_flag.into(), None).unwrap();
+    }
+
+    fn signal_event(&self, connection_id: u32, event_flag: u16) -> io::Result<()> {
+        self.hcl_vmbus
+            .signal_event(connection_id, event_flag.into())
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+    }
+}
+
+struct MessageSource {
+    pipe: PolledPipe,
+    hcl_vmbus: Arc<HclVmbus>,
+}
+
+impl AsyncRecv for MessageSource {
+    fn poll_recv(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        mut bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let mut msg = HvMessage::default();
+        let size = ready!(Pin::new(&mut self.pipe).poll_read(cx, msg.as_bytes_mut()))?;
+        if size == 0 {
+            return Ok(0).into();
+        }
+
+        assert!(size >= size_of::<HvMessageHeader>());
+        let mut remaining = msg.payload();
+        let mut total_size = 0;
+        while !remaining.is_empty() && !bufs.is_empty() {
+            let size = bufs[0].len().min(remaining.len());
+            bufs[0][..size].copy_from_slice(&remaining[..size]);
+            remaining = &remaining[size..];
+            bufs = &mut bufs[1..];
+            total_size += size;
+        }
+
+        Ok(total_size).into()
+    }
+}
+
+impl VmbusMessageSource for MessageSource {
+    fn pause_message_stream(&mut self) {
+        self.hcl_vmbus
+            .pause_message_stream(true)
+            .expect("Unable to disable HCL vmbus message stream.");
+    }
+
+    fn resume_message_stream(&mut self) {
+        self.hcl_vmbus
+            .pause_message_stream(false)
+            .expect("Unable to enable HCL vmbus message stream.");
+    }
+}

--- a/vm/devices/vmbus/vmbus_relay/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_relay/Cargo.toml
@@ -7,16 +7,13 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-vmbus_async.workspace = true
 vmbus_channel.workspace = true
 vmbus_client.workspace = true
 vmbus_core.workspace = true
 vmbus_server.workspace = true
 
 guid.workspace = true
-hvdef.workspace = true
 vmcore.workspace = true
-hcl.workspace = true
 inspect.workspace = true
 mesh.workspace = true
 mesh_protobuf.workspace = true

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/Cargo.toml
@@ -16,7 +16,6 @@ vmbus_server.workspace = true
 vmcore.workspace = true
 
 guid.workspace = true
-hcl.workspace = true
 hvdef.workspace = true
 inspect.workspace = true
 mesh.workspace = true


### PR DESCRIPTION
Instead of hard-coding the interactions with the Linux HCL driver, go through a trait object. Extend the same `SynicClient` trait that we already use.

After additional changes, this trait will be consumed only by `vmbus_client` and won't be used in `vmbus_relay` or `vmbus_relay_intercept_device` at all.