### PR TITLE
VmBus: disable client ID support in OpenHCL when not isolated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2743,6 +2743,7 @@ dependencies = [
  "vm_resource",
  "vm_topology",
  "vmbus_channel",
+ "vmbus_core",
  "vmbus_server",
  "vmcore",
  "vmgs",

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2592,11 +2592,14 @@ async fn new_underhill_vm(
             .vmbus_max_version
             .map(vmbus_core::MaxVersionInfo::new)
             .or_else(|| {
-                // For compatibility with rollback, the client ID feature is currently disabled,
+                // For compatibility with rollback, any additional features are currently disabled,
                 // except for isolated guests which do not support servicing.
                 (!hardware_isolated).then_some(vmbus_core::MaxVersionInfo {
-                    version: u32::MAX,
-                    feature_flags: vmbus_core::protocol::FeatureFlags::all().with_client_id(false),
+                    version: vmbus_core::protocol::Version::Copper as u32,
+                    feature_flags: vmbus_core::protocol::FeatureFlags::new()
+                        .with_guest_specified_signal_parameters(true)
+                        .with_channel_interrupt_redirection(true)
+                        .with_modify_connection(true),
                 })
             });
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2588,14 +2588,35 @@ async fn new_underhill_vm(
             .unwrap_or(!controllers.mana.is_empty());
         tracing::info!(enable_mnf, "Underhill MNF enabled?");
 
+        let max_version = env_cfg
+            .vmbus_max_version
+            .map(vmbus_core::MaxVersionInfo::new)
+            .or_else(|| {
+                // For compatibility with rollback, the client ID feature is currently disabled,
+                // except for isolated guests which do not support servicing.
+                (!hardware_isolated).then_some(vmbus_core::MaxVersionInfo {
+                    version: u32::MAX,
+                    feature_flags: vmbus_core::protocol::FeatureFlags::all().with_client_id(false),
+                })
+            });
+
+        // Delay the max version if the requested version is older than what the UEFI firmware
+        // supports.
+        let delay_max_version = if let Some(max_version) = max_version {
+            firmware_type == FirmwareType::Uefi
+                && max_version.version < vmbus_core::protocol::Version::Win10 as u32
+        } else {
+            false
+        };
+
         // N.B. VmBus uses untrusted memory by default for relay channels, and uses additional
         //      trusted memory only for confidential channels offered by Underhill itself.
         let vmbus = VmbusServer::builder(&tp, synic.clone(), device_memory.clone())
             .private_gm(gm.private_vtl0_memory().cloned())
             .hvsock_notify(hvsock_notify)
             .server_relay(server_relay)
-            .max_version(env_cfg.vmbus_max_version)
-            .delay_max_version(firmware_type == FirmwareType::Uefi)
+            .max_version(max_version)
+            .delay_max_version(delay_max_version)
             .enable_mnf(enable_mnf)
             .force_confidential_external_memory(env_cfg.vmbus_force_confidential_external_memory)
             .build()

--- a/openvmm/hvlite_core/Cargo.toml
+++ b/openvmm/hvlite_core/Cargo.toml
@@ -68,6 +68,7 @@ storvsp.workspace = true
 virtio.workspace = true
 virtio_serial.workspace = true
 vmbus_channel.workspace = true
+vmbus_core.workspace = true
 vmbus_server.workspace = true
 vpci.workspace = true
 watchdog_core.workspace = true

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1633,7 +1633,11 @@ impl InitializedVm {
                 let vmbus_driver = driver_source.simple();
                 let vtl2_vmbus = VmbusServer::builder(&vmbus_driver, synic.clone(), gm.clone())
                     .vtl(Vtl::Vtl2)
-                    .max_version(vtl2_vmbus_cfg.vmbus_max_version)
+                    .max_version(
+                        vtl2_vmbus_cfg
+                            .vmbus_max_version
+                            .map(vmbus_core::MaxVersionInfo::new),
+                    )
                     .hvsock_notify(Some(vtl2_hvsock_channel.server_half))
                     .external_requests(Some(server_request_recv))
                     .enable_mnf(true)
@@ -1668,7 +1672,11 @@ impl InitializedVm {
                 .hvsock_notify(Some(hvsock_channel.server_half))
                 .external_server(vtl2_request_send)
                 .use_message_redirect(vmbus_cfg.vtl2_redirect)
-                .max_version(vmbus_cfg.vmbus_max_version)
+                .max_version(
+                    vmbus_cfg
+                        .vmbus_max_version
+                        .map(vmbus_core::MaxVersionInfo::new),
+                )
                 .delay_max_version(matches!(cfg.load_mode, LoadMode::Uefi { .. }))
                 .enable_mnf(true)
                 .build()

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -110,7 +110,7 @@ pub struct VmbusServerBuilder<'a, T: Spawn> {
     external_requests: Option<mesh::Receiver<InitiateContactRequest>>,
     use_message_redirect: bool,
     channel_id_offset: u16,
-    max_version: Option<u32>,
+    max_version: Option<MaxVersionInfo>,
     delay_max_version: bool,
     enable_mnf: bool,
     force_confidential_external_memory: bool,
@@ -327,7 +327,7 @@ impl<'a, T: Spawn> VmbusServerBuilder<'a, T> {
     /// Tells the server to limit the protocol version offered to the guest.
     ///
     /// N.B. This is used for testing older protocols without requiring a specific guest OS.
-    pub fn max_version(mut self, max_version: Option<u32>) -> Self {
+    pub fn max_version(mut self, max_version: Option<MaxVersionInfo>) -> Self {
         self.max_version = max_version;
         self
     }
@@ -422,9 +422,9 @@ impl<'a, T: Spawn> VmbusServerBuilder<'a, T> {
 
         let mut server = channels::Server::new(self.vtl, connection_id, self.channel_id_offset);
 
-        // If requested for testing purposes, limit the maximum protocol version.
+        // If requested, limit the maximum protocol version and feature flags.
         if let Some(version) = self.max_version {
-            server.set_compatibility_version(MaxVersionInfo::new(version), self.delay_max_version);
+            server.set_compatibility_version(version, self.delay_max_version);
         }
         let (relay_request_send, relay_response_recv) =
             if let Some(server_relay) = self.server_relay {


### PR DESCRIPTION
Enabling new VmBus feature flags can lead to issues when rolling back to an older version of OpenHCL. For this reason, this change disables the client ID feature flag until a better solution is available.

Isolated guests are excluded from this as they do not currently support servicing.