### PR TITLE
openhcl: log how large the saved state buffer is for servicing (#400)

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -498,7 +498,11 @@ impl UnderhillVmWorker {
                 mesh::payload::decode(&saved_state_buf)
                     .context("failed to decode servicing state")?,
             );
-            tracing::info!("received servicing state from host");
+
+            tracing::info!(
+                saved_state_len = saved_state_buf.len(),
+                "received servicing state from host"
+            );
         }
 
         let is_post_servicing = servicing_state.is_some();

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -183,6 +183,7 @@ pub struct GuestEmulationDevice {
     vmgs: Vec<u8>,
     #[inspect(with = "Option::is_some")]
     save_restore_buf: Option<Vec<u8>>,
+    last_save_restore_buf_len: usize,
 }
 
 impl GuestEmulationDevice {
@@ -203,6 +204,7 @@ impl GuestEmulationDevice {
             vmgs: vec![0; VMGS_CAPACITY],
             save_restore_buf: None,
             waiting_for_vtl0_start: Vec::new(),
+            last_save_restore_buf_len: 0,
         }
     }
 
@@ -386,6 +388,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     let saved_state_size = buffer.len();
                     if *written >= saved_state_size {
                         self.state = GedState::Ready;
+                        state.last_save_restore_buf_len = saved_state_size;
                         state.save_restore_buf = None;
                         continue;
                     }


### PR DESCRIPTION
We know how large it is, but log it so it's discoverable. 

In the future, we are probably moving to a model where we do not send the saved state to the host. This will help us decide how large to size a reserved memory range inside OpenHCL.

Cherry pick of #400 