### PR TITLE
vmbus_client: track hvsock requests and simplify RPC contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7831,7 +7831,6 @@ dependencies = [
  "vmbus_core",
  "vmbus_server",
  "vmcore",
- "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7825,6 +7825,7 @@ dependencies = [
  "parking_lot",
  "tracelimit",
  "tracing",
+ "unicycle",
  "vmbus_channel",
  "vmbus_client",
  "vmbus_core",

--- a/vm/devices/vmbus/vmbus_client/src/hvsock.rs
+++ b/vm/devices/vmbus/vmbus_client/src/hvsock.rs
@@ -6,7 +6,7 @@ use mesh::rpc::Rpc;
 use vmbus_core::protocol;
 use vmbus_core::HvsockConnectRequest;
 
-/// Tracks guest-to-host hvsocket requests that the host has not responded toyet.
+/// Tracks guest-to-host hvsocket requests that the host has not responded to yet.
 pub(crate) struct HvsockRequestTracker {
     pending_requests: Vec<Request>,
 }

--- a/vm/devices/vmbus/vmbus_client/src/hvsock.rs
+++ b/vm/devices/vmbus/vmbus_client/src/hvsock.rs
@@ -1,14 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::OfferInfo;
+use mesh::rpc::Rpc;
 use vmbus_core::protocol;
 use vmbus_core::HvsockConnectRequest;
-use vmbus_core::HvsockConnectResult;
 
 /// Tracks guest-to-host hvsocket requests that the host has not responded toyet.
-pub struct HvsockRequestTracker {
-    pending_requests: Vec<HvsockConnectRequest>,
+pub(crate) struct HvsockRequestTracker {
+    pending_requests: Vec<Request>,
 }
+
+pub(crate) type Request = Rpc<HvsockConnectRequest, Option<OfferInfo>>;
 
 impl HvsockRequestTracker {
     /// Create a new request tracker.
@@ -19,24 +22,33 @@ impl HvsockRequestTracker {
     }
 
     /// Adds a new request to be tracked.
-    pub fn add_request(&mut self, request: HvsockConnectRequest) {
+    pub fn add_request(&mut self, request: Request) {
         self.pending_requests.push(request);
     }
 
     /// Checks if a result from the host matches a request, and if so removes it.
-    pub fn check_result(&mut self, result: &HvsockConnectResult) {
+    pub fn check_result(&mut self, result: &protocol::TlConnectResult) -> Option<Request> {
+        if result.status >= 0 {
+            tracing::warn!(
+                status = result.status,
+                "protocol violation: unexpected tl connect result success status"
+            );
+            return None;
+        }
         if let Some(index) = self.pending_requests.iter().position(|request| {
-            request.service_id == result.service_id && request.endpoint_id == result.endpoint_id
+            request.0.service_id == result.service_id && request.0.endpoint_id == result.endpoint_id
         }) {
-            self.pending_requests.swap_remove(index);
+            let rpc = self.pending_requests.swap_remove(index);
+            Some(rpc)
         } else {
             tracing::warn!(?result, "Result for unknown hvsock request");
+            None
         }
     }
 
     /// Checks if an offer from the host matches a request, and if so removes it and returns a
     /// result message to send to the vmbus server.
-    pub fn check_offer(&mut self, offer: &protocol::OfferChannel) -> Option<HvsockConnectResult> {
+    pub fn check_offer(&mut self, offer: &protocol::OfferChannel) -> Option<Request> {
         if !offer.flags.tlnpi_provider() {
             return None;
         }
@@ -49,25 +61,25 @@ impl HvsockRequestTracker {
         // Since silo_id isn't part of the result message, it doesn't need to be checked here
         // either.
         let Some(index) = self.pending_requests.iter().position(|request| {
-            request.service_id == offer.interface_id && request.endpoint_id == offer.instance_id
+            request.0.service_id == offer.interface_id && request.0.endpoint_id == offer.instance_id
         }) else {
             tracing::warn!(?offer, "Channel offer for unknown hvsock request");
             return None;
         };
 
-        let request = self.pending_requests.swap_remove(index);
-        tracing::debug!(?request, "channel offer matches hvsocket request");
-        Some(HvsockConnectResult::from_request(&request, true))
+        let rpc = self.pending_requests.swap_remove(index);
+        tracing::debug!(request = ?rpc.0, "channel offer matches hvsocket request");
+        Some(rpc)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use guid::Guid;
     use vmbus_core::protocol::HvsockUserDefinedParameters;
     use vmbus_core::protocol::OfferFlags;
     use vmbus_core::protocol::UserDefinedData;
-    use vmbus_server::Guid;
     use zerocopy::FromZeroes;
 
     #[test]
@@ -79,31 +91,35 @@ mod tests {
             silo_id: Guid::new_random(),
         };
 
-        tracker.add_request(request);
+        tracker.add_request(Rpc(request, mesh::oneshot().0));
         assert_eq!(1, tracker.pending_requests.len());
 
         // Endpoint ID mismatch.
-        let result = HvsockConnectResult {
+        let result = protocol::TlConnectResult {
             service_id: request.service_id,
             endpoint_id: Guid::new_random(),
-            success: false,
+            status: -1,
         };
 
         tracker.check_result(&result);
         assert_eq!(1, tracker.pending_requests.len());
 
         // Service ID mismatch.
-        let result = HvsockConnectResult {
+        let result = protocol::TlConnectResult {
             service_id: Guid::new_random(),
             endpoint_id: request.endpoint_id,
-            success: false,
+            status: -1,
         };
 
         tracker.check_result(&result);
         assert_eq!(1, tracker.pending_requests.len());
 
         // Match.
-        let result = HvsockConnectResult::from_request(&request, false);
+        let result = protocol::TlConnectResult {
+            service_id: request.service_id,
+            endpoint_id: request.endpoint_id,
+            status: -1,
+        };
         tracker.check_result(&result);
         assert_eq!(0, tracker.pending_requests.len());
     }
@@ -117,7 +133,7 @@ mod tests {
             silo_id: Guid::new_random(),
         };
 
-        tracker.add_request(request);
+        tracker.add_request(Rpc(request, mesh::oneshot().0));
         assert_eq!(1, tracker.pending_requests.len());
 
         // Endpoint ID mismatch.
@@ -139,7 +155,7 @@ mod tests {
         // Match.
         let offer = create_offer(request.service_id, request.endpoint_id, true, false);
         let found = tracker.check_offer(&offer).unwrap();
-        assert_eq!(found, HvsockConnectResult::from_request(&request, true));
+        assert_eq!(found.0, request);
         assert_eq!(0, tracker.pending_requests.len());
 
         // It no longer exists.

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -218,7 +218,6 @@ impl VmbusClientAccess {
             .expect("Failed to send modify request")
     }
 
-    #[must_use]
     pub fn connect_hvsock(
         &self,
         request: HvsockConnectRequest,
@@ -584,7 +583,7 @@ impl<T: VmbusMessageSource> ClientTask<T> {
         // The client only supports protocol versions which use the newer message format.
         // The host will not send a TlConnectRequestResult message on success, so a response to this
         // message is not guaranteed.
-        let request = rpc.0.clone();
+        let request = rpc.0;
         self.hvsock_tracker.add_request(rpc);
         let message = protocol::TlConnectRequest2::from(request);
         self.inner.send(&message);

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod hvsock;
 mod saved_state;
 
 pub use self::saved_state::SavedState;
@@ -19,6 +20,7 @@ use pal_async::task::Spawn;
 use pal_async::task::Task;
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::future::Future;
 use std::sync::Arc;
 use thiserror::Error;
 use vmbus_async::async_dgram::AsyncRecv;
@@ -35,7 +37,6 @@ use vmbus_core::protocol::Message;
 use vmbus_core::protocol::OpenChannelFlags;
 use vmbus_core::protocol::Version;
 use vmbus_core::HvsockConnectRequest;
-use vmbus_core::HvsockConnectResult;
 use vmbus_core::MonitorPageGpas;
 use vmbus_core::OutgoingMessage;
 use vmbus_core::TaggedStream;
@@ -70,7 +71,7 @@ pub trait VmbusMessageSource: AsyncRecv + Send {
 
 pub struct VmbusClient {
     task_send: mesh::Sender<TaskRequest>,
-    client_request_send: mesh::Sender<ClientRequest>,
+    access: VmbusClientAccess,
     _thread: Task<()>,
 }
 
@@ -82,6 +83,11 @@ pub enum ConnectError {
     NoSupportedVersions,
     #[error("failed to connect to the server: {0:?}")]
     FailedToConnect(ConnectionState),
+}
+
+#[derive(Clone)]
+pub struct VmbusClientAccess {
+    client_request_send: Arc<mesh::Sender<ClientRequest>>,
 }
 
 impl VmbusClient {
@@ -112,12 +118,15 @@ impl VmbusClient {
             client_request_recv,
             state: ClientState::Disconnected,
             modify_request: None,
+            hvsock_tracker: hvsock::HvsockRequestTracker::new(),
         };
 
         let thread = spawner.spawn("vmbus client", async move { task.run().await });
 
         Self {
-            client_request_send,
+            access: VmbusClientAccess {
+                client_request_send: Arc::new(client_request_send),
+            },
             task_send,
             _thread: thread,
         }
@@ -136,7 +145,8 @@ impl VmbusClient {
             client_id,
         };
 
-        self.client_request_send
+        self.access
+            .client_request_send
             .call(ClientRequest::InitiateContact, request)
             .await
             .unwrap()
@@ -146,29 +156,23 @@ impl VmbusClient {
     /// which the client can forward received offers to.
     pub async fn request_offers(&mut self) -> Vec<OfferInfo> {
         let (send, recv) = mesh::channel();
-        self.client_request_send
+        self.access
+            .client_request_send
             .send(ClientRequest::RequestOffers(send));
         recv.collect().await
     }
 
     /// Send the Unload message to the server.
     pub async fn unload(&mut self) {
-        self.client_request_send
+        self.access
+            .client_request_send
             .call(ClientRequest::Unload, ())
             .await
             .unwrap();
     }
 
-    pub async fn modify(&mut self, request: ModifyConnectionRequest) -> ConnectionState {
-        self.client_request_send
-            .call(ClientRequest::Modify, request)
-            .await
-            .expect("Failed to send modify request")
-    }
-
-    pub fn connect_hvsock(&mut self, request: HvsockConnectRequest) {
-        self.client_request_send
-            .send(ClientRequest::HvsockConnect(request));
+    pub fn access(&self) -> &VmbusClientAccess {
+        &self.access
     }
 
     pub fn start(&mut self) {
@@ -203,6 +207,25 @@ impl VmbusClient {
 impl Inspect for VmbusClient {
     fn inspect(&self, req: inspect::Request<'_>) {
         self.task_send.send(TaskRequest::Inspect(req.defer()));
+    }
+}
+
+impl VmbusClientAccess {
+    pub async fn modify(&self, request: ModifyConnectionRequest) -> ConnectionState {
+        self.client_request_send
+            .call(ClientRequest::Modify, request)
+            .await
+            .expect("Failed to send modify request")
+    }
+
+    #[must_use]
+    pub fn connect_hvsock(
+        &self,
+        request: HvsockConnectRequest,
+    ) -> impl Future<Output = Option<OfferInfo>> {
+        self.client_request_send
+            .call(ClientRequest::HvsockConnect, request)
+            .map(|r| r.ok().flatten())
     }
 }
 
@@ -269,7 +292,6 @@ pub struct OfferInfo {
 pub enum ClientNotification {
     Offer(OfferInfo),
     Revoke(ChannelId),
-    HvsockConnectResult(HvsockConnectResult),
 }
 
 #[derive(Debug)]
@@ -278,7 +300,7 @@ enum ClientRequest {
     RequestOffers(mesh::Sender<OfferInfo>),
     Unload(Rpc<(), ()>),
     Modify(Rpc<ModifyConnectionRequest, ConnectionState>),
-    HvsockConnect(HvsockConnectRequest),
+    HvsockConnect(Rpc<HvsockConnectRequest, Option<OfferInfo>>),
 }
 
 impl std::fmt::Display for ClientRequest {
@@ -470,6 +492,7 @@ impl Channel {
 struct ClientTask<T: VmbusMessageSource> {
     inner: ClientTaskInner,
     state: ClientState,
+    hvsock_tracker: hvsock::HvsockRequestTracker,
     running: bool,
     modify_request: Option<Rpc<ModifyConnectionRequest, ConnectionState>>,
     msg_source: T,
@@ -557,10 +580,12 @@ impl<T: VmbusMessageSource> ClientTask<T> {
         self.inner.send(&message);
     }
 
-    fn handle_tl_connect(&mut self, request: HvsockConnectRequest) {
+    fn handle_tl_connect(&mut self, rpc: Rpc<HvsockConnectRequest, Option<OfferInfo>>) {
         // The client only supports protocol versions which use the newer message format.
         // The host will not send a TlConnectRequestResult message on success, so a response to this
         // message is not guaranteed.
+        let request = rpc.0.clone();
+        self.hvsock_tracker.add_request(rpc);
         let message = protocol::TlConnectRequest2::from(request);
         self.inner.send(&message);
     }
@@ -678,10 +703,14 @@ impl<T: VmbusMessageSource> ClientTask<T> {
                 subchannel_index = offer.subchannel_index,
                 "received offer");
 
-            if let ClientState::RequestingOffers(_, send) = &self.state {
-                send.send(offer_info);
+            if let Some(offer) = self.hvsock_tracker.check_offer(&offer_info.offer) {
+                offer.complete(Some(offer_info));
             } else {
-                self.notify_send.send(ClientNotification::Offer(offer_info));
+                if let ClientState::RequestingOffers(_, send) = &self.state {
+                    send.send(offer_info);
+                } else {
+                    self.notify_send.send(ClientNotification::Offer(offer_info));
+                }
             }
         }
     }
@@ -897,8 +926,9 @@ impl<T: VmbusMessageSource> ClientTask<T> {
     }
 
     fn handle_tl_connect_result(&mut self, response: protocol::TlConnectResult) {
-        self.notify_send
-            .send(ClientNotification::HvsockConnectResult(response.into()))
+        if let Some(rpc) = self.hvsock_tracker.check_result(&response) {
+            rpc.complete(None);
+        }
     }
 
     fn handle_synic_message(&mut self, data: &[u8]) {
@@ -1409,7 +1439,7 @@ mod tests {
         }
 
         async fn connect(&self, client: &mut VmbusClient) {
-            let recv = client.client_request_send.call(
+            let recv = client.access.client_request_send.call(
                 ClientRequest::InitiateContact,
                 InitiateContactRequest::default(),
             );
@@ -1439,6 +1469,7 @@ mod tests {
 
             let (send, mut recv) = mesh::channel();
             client
+                .access
                 .client_request_send
                 .send(ClientRequest::RequestOffers(send));
 
@@ -1550,7 +1581,7 @@ mod tests {
     #[async_test]
     async fn test_initiate_contact_success() {
         let (server, client, _) = test_init();
-        let _recv = client.client_request_send.call(
+        let _recv = client.access.client_request_send.call(
             ClientRequest::InitiateContact,
             InitiateContactRequest::default(),
         );
@@ -1574,7 +1605,7 @@ mod tests {
     #[async_test]
     async fn test_connect_success() {
         let (server, client, _) = test_init();
-        let recv = client.client_request_send.call(
+        let recv = client.access.client_request_send.call(
             ClientRequest::InitiateContact,
             InitiateContactRequest::default(),
         );
@@ -1616,7 +1647,7 @@ mod tests {
     #[async_test]
     async fn test_feature_flags() {
         let (server, client, _) = test_init();
-        let recv = client.client_request_send.call(
+        let recv = client.access.client_request_send.call(
             ClientRequest::InitiateContact,
             InitiateContactRequest::default(),
         );
@@ -1668,6 +1699,7 @@ mod tests {
             ..Default::default()
         };
         let _recv = client
+            .access
             .client_request_send
             .call(ClientRequest::InitiateContact, initiate_contact);
 
@@ -1690,7 +1722,7 @@ mod tests {
     #[async_test]
     async fn test_version_negotiation() {
         let (server, client, _) = test_init();
-        let recv = client.client_request_send.call(
+        let recv = client.access.client_request_send.call(
             ClientRequest::InitiateContact,
             InitiateContactRequest::default(),
         );
@@ -1755,6 +1787,7 @@ mod tests {
 
         let (send, mut recv) = mesh::channel();
         client
+            .access
             .client_request_send
             .send(ClientRequest::RequestOffers(send));
 
@@ -2193,7 +2226,7 @@ mod tests {
     async fn test_modify_connection() {
         let (server, mut client, _) = test_init();
         server.connect(&mut client).await;
-        let call = client.client_request_send.call(
+        let call = client.access.client_request_send.call(
             ClientRequest::Modify,
             ModifyConnectionRequest {
                 monitor_page: Some(MonitorPageGpas {
@@ -2224,7 +2257,7 @@ mod tests {
 
     #[async_test]
     async fn test_hvsock() {
-        let (server, mut client, mut notify_recv) = test_init();
+        let (server, mut client, _notify_recv) = test_init();
         server.connect(&mut client).await;
         let request = HvsockConnectRequest {
             service_id: Guid::new_random(),
@@ -2232,7 +2265,7 @@ mod tests {
             silo_id: Guid::new_random(),
         };
 
-        client.connect_hvsock(request);
+        let resp = client.access().connect_hvsock(request);
         assert_eq!(
             server.next().unwrap(),
             OutgoingMessage::new(&protocol::TlConnectRequest2 {
@@ -2242,31 +2275,6 @@ mod tests {
                 },
                 silo_id: request.silo_id,
             })
-        );
-
-        // Send a success result (even though the host shouldn't send one, try it anyway to make
-        // sure the success field gets set correctly).
-        server.send(in_msg(
-            MessageType::TL_CONNECT_REQUEST_RESULT,
-            protocol::TlConnectResult {
-                service_id: request.service_id,
-                endpoint_id: request.endpoint_id,
-                status: 0,
-            },
-        ));
-
-        let ClientNotification::HvsockConnectResult(result) = notify_recv.next().await.unwrap()
-        else {
-            panic!("invalid notification")
-        };
-
-        assert_eq!(
-            result,
-            HvsockConnectResult {
-                service_id: request.service_id,
-                endpoint_id: request.endpoint_id,
-                success: true
-            }
         );
 
         // Now send a failure result.
@@ -2279,18 +2287,7 @@ mod tests {
             },
         ));
 
-        let ClientNotification::HvsockConnectResult(result) = notify_recv.next().await.unwrap()
-        else {
-            panic!("invalid notification")
-        };
-
-        assert_eq!(
-            result,
-            HvsockConnectResult {
-                service_id: request.service_id,
-                endpoint_id: request.endpoint_id,
-                success: false
-            }
-        );
+        let result = resp.await;
+        assert!(result.is_none());
     }
 }

--- a/vm/devices/vmbus/vmbus_relay/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_relay/Cargo.toml
@@ -26,6 +26,7 @@ futures.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 tracing.workspace = true
+unicycle.workspace = true
 zerocopy.workspace = true
 
 [lints]

--- a/vm/devices/vmbus/vmbus_relay/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_relay/Cargo.toml
@@ -27,7 +27,6 @@ once_cell.workspace = true
 parking_lot.workspace = true
 tracing.workspace = true
 unicycle.workspace = true
-zerocopy.workspace = true
 
 [lints]
 workspace = true

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![forbid(unsafe_code)]
 
-mod hvsock;
 mod saved_state;
 
 use anyhow::Context;
@@ -17,7 +16,6 @@ use futures::FutureExt;
 use futures::Stream;
 use futures::StreamExt;
 use guid::Guid;
-use hvsock::HvsockRequestTracker;
 use inspect::Inspect;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
@@ -32,12 +30,14 @@ use parking_lot::Mutex;
 use saved_state::SavedState;
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::task::Poll;
+use unicycle::FuturesUnordered;
 use vmbus_channel::bus::ChannelRequest;
 use vmbus_channel::bus::ChannelServerRequest;
 use vmbus_channel::bus::GpadlRequest;
@@ -50,6 +50,7 @@ use vmbus_core::protocol::ChannelId;
 use vmbus_core::protocol::FeatureFlags;
 use vmbus_core::protocol::GpadlId;
 use vmbus_core::HvsockConnectRequest;
+use vmbus_core::HvsockConnectResult;
 use vmbus_core::VersionInfo;
 use vmbus_server::HvsockRelayChannelHalf;
 use vmbus_server::ModifyConnectionResponse;
@@ -657,7 +658,15 @@ struct RelayTask {
     use_interrupt_relay: Arc<AtomicBool>,
     server_response_send: mesh::Sender<ModifyConnectionResponse>,
     hvsock_relay: HvsockRelayChannelHalf,
-    hvsock_tracker: HvsockRequestTracker,
+    hvsock_requests: FuturesUnordered<
+        Pin<
+            Box<
+                dyn Future<Output = (HvsockConnectRequest, Option<client::OfferInfo>)>
+                    + Sync
+                    + Send,
+            >,
+        >,
+    >,
     running: bool,
 }
 
@@ -681,8 +690,8 @@ impl RelayTask {
             use_interrupt_relay: Arc::new(AtomicBool::new(false)),
             server_response_send,
             hvsock_relay,
-            hvsock_tracker: HvsockRequestTracker::new(),
             running: false,
+            hvsock_requests: FuturesUnordered::new(),
         }
     }
 
@@ -777,12 +786,6 @@ impl RelayTask {
             }
 
             return Ok(());
-        }
-
-        // Check if this channel is for an hvsock request, and if so send a success message to the
-        // server. This is needed because the host will not send a result on success.
-        if let Some(result) = self.hvsock_tracker.check_offer(&offer.offer) {
-            self.hvsock_relay.response_send.send(result);
         }
 
         // Check if this channel is being intercepted. A previously relayed
@@ -1047,11 +1050,13 @@ impl RelayTask {
             Update::Unchanged => protocol::ConnectionState::SUCCESSFUL,
             Update::Reset => {
                 self.vmbus_client
+                    .access()
                     .modify(ModifyConnectionRequest { monitor_page: None })
                     .await
             }
             Update::Set(value) => {
                 self.vmbus_client
+                    .access()
                     .modify(ModifyConnectionRequest {
                         monitor_page: Some(value),
                     })
@@ -1070,8 +1075,33 @@ impl RelayTask {
 
     fn handle_hvsock_request(&mut self, request: HvsockConnectRequest) {
         tracing::debug!(request = ?request, "received hvsock connect request");
-        self.hvsock_tracker.add_request(request);
-        self.vmbus_client.connect_hvsock(request);
+        let fut = self.vmbus_client.access().connect_hvsock(request);
+        self.hvsock_requests
+            .push(Box::pin(fut.map(move |offer| (request, offer))));
+    }
+
+    async fn handle_hvsock_response(
+        &mut self,
+        request: HvsockConnectRequest,
+        offer: Option<client::OfferInfo>,
+    ) {
+        let success = if let Some(offer) = offer {
+            match self.handle_offer(offer, None).await {
+                Ok(()) => true,
+                Err(err) => {
+                    tracing::error!(
+                        error = err.as_ref() as &dyn std::error::Error,
+                        "failed add hvsock offer"
+                    );
+                    false
+                }
+            }
+        } else {
+            false
+        };
+        self.hvsock_relay
+            .response_send
+            .send(HvsockConnectResult::from_request(&request, success));
     }
 
     async fn handle_offer_request(&mut self, request: ClientNotification) -> Result<()> {
@@ -1086,11 +1116,6 @@ impl RelayTask {
             }
             ClientNotification::Revoke(channel_id) => {
                 self.handle_revoke(channel_id).await;
-            }
-            ClientNotification::HvsockConnectResult(result) => {
-                tracing::debug!(result = ?result, "received hvsock connect result");
-                self.hvsock_tracker.check_result(&result);
-                self.hvsock_relay.response_send.send(result);
             }
         }
 
@@ -1112,6 +1137,9 @@ impl RelayTask {
                 }
                 r = self.hvsock_relay.request_receive.select_next_some() => {
                     self.handle_hvsock_request(r);
+                }
+                r = self.hvsock_requests.select_next_some() => {
+                    self.handle_hvsock_response(r.0, r.1).await;
                 }
                 r = notify_recv.select_next_some() => {
                     self.handle_offer_request(r).await?;

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -658,17 +658,12 @@ struct RelayTask {
     use_interrupt_relay: Arc<AtomicBool>,
     server_response_send: mesh::Sender<ModifyConnectionResponse>,
     hvsock_relay: HvsockRelayChannelHalf,
-    hvsock_requests: FuturesUnordered<
-        Pin<
-            Box<
-                dyn Future<Output = (HvsockConnectRequest, Option<client::OfferInfo>)>
-                    + Sync
-                    + Send,
-            >,
-        >,
-    >,
+    hvsock_requests: FuturesUnordered<HvsockRequestFuture>,
     running: bool,
 }
+
+type HvsockRequestFuture =
+    Pin<Box<dyn Future<Output = (HvsockConnectRequest, Option<client::OfferInfo>)> + Sync + Send>>;
 
 impl RelayTask {
     fn new(

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -599,9 +599,6 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
                 InterceptChannelRequest::Client(ClientNotification::Revoke(_)) => {
                     self.handle_revoke(state).await;
                 }
-                InterceptChannelRequest::Client(ClientNotification::HvsockConnectResult(_)) => {
-                    tracing::error!("Unexpected hvsock notification");
-                }
                 InterceptChannelRequest::Start => {
                     self.handle_start(state).await;
                 }


### PR DESCRIPTION
Track hvsock connect requests inside `vmbus_client` so that we can return the response (either an offer or a failure message) to the specific user that made the hvsock request. This is necessary to support multiple concurrent users of vmbus_client.

Also, separate connection-related APIs into `VmbusClientAccess`, leaving state machine (start/stop/save/restore) in `VmbusClient`. Ultimately, users of the vmbus client driver will just get `VmbusClientAccess` (plus `OfferInfo`(s) for the channels they are using).