### PR TITLE
Assign hardcoded values to GuestVtl

### DIFF
--- a/openhcl/hcl/src/lib.rs
+++ b/openhcl/hcl/src/lib.rs
@@ -27,9 +27,9 @@ pub mod vmsa;
 #[derive(Copy, Clone, Debug, Inspect, PartialEq, Eq, PartialOrd, Ord)]
 pub enum GuestVtl {
     /// VTL0
-    Vtl0,
+    Vtl0 = 0,
     /// VTL1
-    Vtl1,
+    Vtl1 = 1,
 }
 
 impl From<GuestVtl> for HvInputVtl {


### PR DESCRIPTION
This ensures that GuestVtl always matches Vtl.