### PR TITLE
openhcl: cleanup private page pool changes 

### DIFF
--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -510,7 +510,7 @@ pub fn write_dt(
                     ReservedMemoryType::SidecarImage => MemoryVtlType::VTL2_SIDECAR_IMAGE,
                     ReservedMemoryType::SidecarNode => MemoryVtlType::VTL2_SIDECAR_NODE,
                     ReservedMemoryType::Vtl2Reserved => MemoryVtlType::VTL2_RESERVED,
-                    ReservedMemoryType::PersistentGpaPool => MemoryVtlType::VTL2_GPA_POOL,
+                    ReservedMemoryType::Vtl2GpaPool => MemoryVtlType::VTL2_GPA_POOL,
                 },
             )
         }),

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -40,6 +40,9 @@ const MAX_PARTITION_RAM_RANGES: usize = 1024;
 /// Maximum size of the host-provided entropy
 pub const MAX_ENTROPY_SIZE: usize = 256;
 
+/// Maximum number of supported VTL2 used ranges.
+pub const MAX_VTL2_USED_RANGES: usize = 16;
+
 /// Information about the guest partition.
 #[derive(Debug)]
 pub struct PartitionInfo {
@@ -56,6 +59,14 @@ pub struct PartitionInfo {
     /// The vtl2 reserved region, that is reserved to both the kernel and
     /// usermode.
     pub vtl2_reserved_region: MemoryRange,
+    /// Memory used for the VTL2 private pool.
+    pub vtl2_pool_memory: MemoryRange,
+    /// Memory ranges that are in use by the bootshim, and any other persisted
+    /// ranges, such as the VTL2 private pool.
+    ///
+    /// TODO: Refactor these different ranges and consolidate address space
+    /// management.
+    pub vtl2_used_ranges: ArrayVec<MemoryRange, MAX_VTL2_USED_RANGES>,
     ///  The full memory map provided by the host.
     pub partition_ram: ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>,
     /// The partiton's isolation type.
@@ -93,6 +104,8 @@ impl PartitionInfo {
             vtl2_full_config_region: MemoryRange::EMPTY,
             vtl2_config_region_reclaim: MemoryRange::EMPTY,
             vtl2_reserved_region: MemoryRange::EMPTY,
+            vtl2_pool_memory: MemoryRange::EMPTY,
+            vtl2_used_ranges: ArrayVec::new_const(),
             partition_ram: ArrayVec::new_const(),
             isolation: IsolationType::None,
             bsp_reg: 0,

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -92,8 +92,6 @@ pub struct PartitionInfo {
     pub entropy: Option<ArrayVec<u8, MAX_ENTROPY_SIZE>>,
     /// The VTL0 alias map physical address.
     pub vtl0_alias_map: Option<u64>,
-    /// Hint from Host on how many pages to preserve during servicing.
-    pub preserve_dma_4k_pages: Option<u64>,
 }
 
 impl PartitionInfo {
@@ -124,7 +122,6 @@ impl PartitionInfo {
             memory_allocation_mode: MemoryAllocationMode::Host,
             entropy: None,
             vtl0_alias_map: None,
-            preserve_dma_4k_pages: None,
         }
     }
 

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -910,7 +910,6 @@ mod test {
             memory_allocation_mode: host_fdt_parser::MemoryAllocationMode::Host,
             entropy: None,
             vtl0_alias_map: None,
-            preserve_dma_4k_pages: None,
         }
     }
 

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -32,7 +32,6 @@ use arrayvec::ArrayString;
 use arrayvec::ArrayVec;
 use boot_logger::LoggerType;
 use core::fmt::Write;
-use core::ops::Range;
 use dt::write_dt;
 use dt::BootTimes;
 use host_params::shim_params::IsolationType;
@@ -297,13 +296,17 @@ pub const MAX_RESERVED_MEM_RANGES: usize = 5 + sidecar_defs::MAX_NODES;
 enum ReservedMemoryType {
     /// VTL2 parameter regions (could be up to 2).
     Vtl2Config,
+    /// Reserved memory that should not be used by the kernel or usermode. There
+    /// should only be one.
     Vtl2Reserved,
-    /// Sidecar image.
+    /// Sidecar image. There should only be one.
     SidecarImage,
     /// A reserved range per sidecar node.
     SidecarNode,
-    /// Persistent GPA pool preserved during servicing.
-    PersistentGpaPool,
+    /// Persistent VTL2 memory used for page allocations in usermode. This
+    /// memory is persisted, both location and contents, across servicing.
+    /// Today, we only support a single range.
+    Vtl2GpaPool,
 }
 
 /// Construct a slice representing the reserved memory ranges to be reported to
@@ -336,18 +339,13 @@ fn reserved_memory_regions(
             ReservedMemoryType::Vtl2Reserved,
         ));
     }
-    let dma_4k_pages = partition_info.preserve_dma_4k_pages.unwrap_or(0);
-    // If DMA reserved hint was provided by Host, allocate top of VTL2 memory range
-    // for that purpose.
-    if !partition_info.vtl2_ram.is_empty() && (dma_4k_pages > 0) {
-        let last_mem_entry = &partition_info.vtl2_ram[partition_info.vtl2_ram.len() - 1];
-        if last_mem_entry.range.page_count_4k() > dma_4k_pages {
-            let reserved_dma = MemoryRange::from_4k_gpn_range(Range {
-                start: last_mem_entry.range.end_4k_gpn() - dma_4k_pages,
-                end: last_mem_entry.range.end_4k_gpn(),
-            });
-            reserved.push((reserved_dma, ReservedMemoryType::PersistentGpaPool));
-        }
+
+    // Add any VTL2 private pool.
+    if partition_info.vtl2_pool_memory != MemoryRange::EMPTY {
+        reserved.push((
+            partition_info.vtl2_pool_memory,
+            ReservedMemoryType::Vtl2GpaPool,
+        ));
     }
 
     reserved
@@ -892,6 +890,8 @@ mod test {
             vtl2_full_config_region: MemoryRange::EMPTY,
             vtl2_config_region_reclaim: MemoryRange::EMPTY,
             vtl2_reserved_region: MemoryRange::EMPTY,
+            vtl2_pool_memory: MemoryRange::EMPTY,
+            vtl2_used_ranges: ArrayVec::new(),
             partition_ram: ArrayVec::new(),
             isolation: IsolationType::None,
             bsp_reg: cpus[0].reg as u32,

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -93,7 +93,11 @@ pub fn start_sidecar<'a>(
     free_memory.extend((0..max_vnode + 1).map(|_| MemoryRange::EMPTY));
     for (range, r) in memory_range::walk_ranges(
         partition_info.vtl2_ram.iter().map(|e| (e.range, e.vnode)),
-        [(p.used, ())],
+        partition_info
+            .vtl2_used_ranges
+            .iter()
+            .cloned()
+            .map(|range| (range, ())),
     ) {
         if let memory_range::RangeWalkResult::Left(vnode) = r {
             let free = &mut free_memory[vnode as usize];

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -650,12 +650,19 @@ impl LoadedVm {
             .map(vmcore::save_restore::SaveRestore::save)
             .transpose()
             .context("shared_vis_pool save failed")?;
-        let private_pool = self
-            .private_pool
-            .as_mut()
-            .map(vmcore::save_restore::SaveRestore::save)
-            .transpose()
-            .context("private_pool save failed")?;
+
+        // Only save private pool state if we are expected to keep VF devices
+        // alive across save. Otherwise, don't persist the state at all, as
+        // there should be no live DMA across save.
+        let private_pool = if vf_keepalive_flag {
+            self.private_pool
+                .as_mut()
+                .map(vmcore::save_restore::SaveRestore::save)
+                .transpose()
+                .context("private_pool save failed")?
+        } else {
+            None
+        };
 
         Ok(ServicingState {
             init_state: servicing::ServicingInitState {

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -304,6 +304,7 @@ impl LoadedVm {
                             inspect_helpers::vtl0_memory_map(&self.vtl0_memory_map),
                         );
                         resp.field("shared_vis_pool", &self.shared_vis_pool);
+                        resp.field("private_pool", &self.private_pool);
                         resp.field("memory", &self.memory);
                     }),
                 },

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -1179,6 +1179,7 @@ impl UpdateGenerationId {
 
 /// Bitfield describing SaveGuestVtl2StateNotification::capabilities_flags
 #[bitfield(u64)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
 pub struct SaveGuestVtl2StateFlags {
     /// Disable nvme_keepalive feature when servicing.
     #[bits(1)]
@@ -1194,7 +1195,7 @@ pub struct SaveGuestVtl2StateFlags {
 pub struct SaveGuestVtl2StateNotification {
     pub message_header: HeaderGuestNotification,
     pub correlation_id: Guid,
-    pub capabilities_flags: u64,
+    pub capabilities_flags: SaveGuestVtl2StateFlags,
     pub timeout_hint_secs: u16,
 }
 

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -28,6 +28,7 @@ use get_protocol::HeaderGeneric;
 use get_protocol::HostNotifications;
 use get_protocol::HostRequests;
 use get_protocol::RegisterState;
+use get_protocol::SaveGuestVtl2StateFlags;
 use get_protocol::SecureBootTemplateType;
 use get_protocol::StartVtl0Status;
 use get_protocol::UefiConsoleMode;
@@ -526,7 +527,10 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                             get_protocol::GuestNotifications::SAVE_GUEST_VTL2_STATE,
                         ),
                         correlation_id: Guid::ZERO,
-                        capabilities_flags: 0,
+                        // TODO: disable nvme keep alive as it doesn't work with
+                        // openvmm yet.
+                        capabilities_flags: SaveGuestVtl2StateFlags::new()
+                            .with_disable_nvme_keepalive(true),
                         timeout_hint_secs: 60,
                     };
 

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -1303,7 +1303,7 @@ impl<T: RingMem> ProcessLoop<T> {
                 correlation_id: notification_header.correlation_id,
                 deadline: std::time::Instant::now()
                     + std::time::Duration::from_secs(notification_header.timeout_hint_secs as u64),
-                capabilities_flags: notification_header.capabilities_flags.into(),
+                capabilities_flags: notification_header.capabilities_flags,
             })
             .map_err(|_| {
                 FatalError::TooManyGuestNotifications(


### PR DESCRIPTION
Some additional cleanup of the private pool and fixes with keep alive on openvmm, and enable using the private pool via cmdline.

Do not save the pool state if we are not doing keep alive, as no device should have allocations that need persisting. Fix advertising keep alive support on openvmm because it doesn't work yet. 