### PR TITLE
Move PCI from bitflags to bitfield-struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,7 +4912,7 @@ dependencies = [
 name = "pci_core"
 version = "0.0.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitfield-struct",
  "chipset_device",
  "guestmem",
  "inspect",

--- a/vm/devices/pci/pci_core/Cargo.toml
+++ b/vm/devices/pci/pci_core/Cargo.toml
@@ -11,10 +11,10 @@ chipset_device.workspace = true
 guestmem.workspace = true
 vmcore.workspace = true
 
+bitfield-struct.workspace = true
 inspect.workspace = true
 mesh.workspace = true
 open_enum.workspace = true
-bitflags.workspace = true
 parking_lot.workspace = true
 thiserror.workspace = true
 tracelimit.workspace = true

--- a/vm/devices/pci/pci_core/src/bar_mapping.rs
+++ b/vm/devices/pci/pci_core/src/bar_mapping.rs
@@ -42,7 +42,7 @@ impl BarMappings {
             let bar_address;
             let mut bar_mask;
             let len;
-            if bar_masks[i] & cfg_space::BarEncodingBits::TYPE_64_BIT.into_bits() != 0 {
+            if cfg_space::BarEncodingBits::from_bits(bar_masks[i]).type_64_bit() {
                 bar_mask = (bar_masks[i + 1] as u64) << 32 | bar_masks[i] as u64;
                 bar_address = (base_addresses[i + 1] as u64) << 32 | base_addresses[i] as u64;
                 len = 2;

--- a/vm/devices/pci/pci_core/src/bar_mapping.rs
+++ b/vm/devices/pci/pci_core/src/bar_mapping.rs
@@ -42,7 +42,7 @@ impl BarMappings {
             let bar_address;
             let mut bar_mask;
             let len;
-            if bar_masks[i] & cfg_space::BarEncodingBits::TYPE_64_BIT.bits() != 0 {
+            if bar_masks[i] & cfg_space::BarEncodingBits::TYPE_64_BIT.into_bits() != 0 {
                 bar_mask = (bar_masks[i + 1] as u64) << 32 | bar_masks[i] as u64;
                 bar_address = (base_addresses[i + 1] as u64) << 32 | base_addresses[i] as u64;
                 len = 2;

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -495,8 +495,8 @@ impl ConfigSpaceType0Emulator {
                 if command.into_bits() & !SUPPORTED_COMMAND_BITS != 0 {
                     tracelimit::warn_ratelimited!(offset, val, "setting invalid command bits");
                     // still do our best
-                    command.set_reserved(0);
-                    command.set_reserved2(0);
+                    command =
+                        cfg_space::Command::from_bits(command.into_bits() & SUPPORTED_COMMAND_BITS);
                 };
 
                 if self.state.command.intx_disable() != command.intx_disable() {

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -479,7 +479,7 @@ impl ConfigSpaceType0Emulator {
         match HeaderType00(offset) {
             HeaderType00::STATUS_COMMAND => {
                 let mut command = cfg_space::Command::from_bits(val as u16);
-                if command.reserved() != 0 || command.reserved2() != 0 {
+                if command.into_bits() & !cfg_space::Command::VALID_BITS != 0 {
                     tracelimit::warn_ratelimited!(offset, val, "setting invalid command bits");
                     // still do our best
                     command.set_reserved(0);
@@ -643,7 +643,7 @@ mod save_restore {
                 latency_timer,
             };
 
-            if self.state.command.reserved() != 0 || self.state.command.reserved2() != 0 {
+            if command & !cfg_space::Command::VALID_BITS != 0 {
                 return Err(RestoreError::InvalidSavedState(
                     ConfigSpaceRestoreError::InvalidConfigBits.into(),
                 ));

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -247,8 +247,9 @@ impl ConfigSpaceType0Emulator {
             const MIN_BAR_SIZE: u64 = 4096;
             let len = std::cmp::max(len.next_power_of_two(), MIN_BAR_SIZE);
             let mask64 = !(len - 1);
-            bar_masks[bar_index] =
-                mask64 as u32 | cfg_space::BarEncodingBits::TYPE_64_BIT.into_bits();
+            bar_masks[bar_index] = cfg_space::BarEncodingBits::from_bits(mask64 as u32)
+                .with_type_64_bit(true)
+                .into_bits();
             bar_masks[bar_index + 1] = (mask64 >> 32) as u32;
             mapped_memory[bar_index] = Some(mapped);
         }
@@ -510,7 +511,9 @@ impl ConfigSpaceType0Emulator {
                     let bar_index = (offset - HeaderType00::BAR0.0) as usize / 4;
                     let mut bar_value = val & self.bar_masks[bar_index];
                     if bar_index & 1 == 0 && self.bar_masks[bar_index] != 0 {
-                        bar_value |= cfg_space::BarEncodingBits::TYPE_64_BIT.into_bits();
+                        bar_value = cfg_space::BarEncodingBits::from_bits(bar_value)
+                            .with_type_64_bit(true)
+                            .into_bits();
                     }
                     self.state.base_addresses[bar_index] = bar_value;
                 }

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -98,7 +98,7 @@ impl ConfigSpaceType0EmulatorState {
     fn new() -> Self {
         Self {
             latency_timer: 0,
-            command: cfg_space::Command::empty(),
+            command: cfg_space::Command::new(),
             base_addresses: [0; 6],
             interrupt_line: 0,
         }
@@ -247,7 +247,8 @@ impl ConfigSpaceType0Emulator {
             const MIN_BAR_SIZE: u64 = 4096;
             let len = std::cmp::max(len.next_power_of_two(), MIN_BAR_SIZE);
             let mask64 = !(len - 1);
-            bar_masks[bar_index] = mask64 as u32 | cfg_space::BarEncodingBits::TYPE_64_BIT.bits();
+            bar_masks[bar_index] =
+                mask64 as u32 | cfg_space::BarEncodingBits::TYPE_64_BIT.into_bits();
             bar_masks[bar_index + 1] = (mask64 >> 32) as u32;
             mapped_memory[bar_index] = Some(mapped);
         }
@@ -264,7 +265,7 @@ impl ConfigSpaceType0Emulator {
             intx_interrupt: None,
 
             state: ConfigSpaceType0EmulatorState {
-                command: cfg_space::Command::empty(),
+                command: cfg_space::Command::new(),
                 base_addresses: [0; 6],
                 interrupt_line: 0,
                 latency_timer: 0,
@@ -332,18 +333,16 @@ impl ConfigSpaceType0Emulator {
                 (self.hardware_ids.device_id as u32) << 16 | self.hardware_ids.vendor_id as u32
             }
             HeaderType00::STATUS_COMMAND => {
-                let mut status = cfg_space::Status::empty();
-                if !self.capabilities.is_empty() {
-                    status |= cfg_space::Status::CAPABILITIES_LIST;
-                }
+                let mut status =
+                    cfg_space::Status::new().with_capabilities_list(!self.capabilities.is_empty());
 
                 if let Some(intx_interrupt) = &self.intx_interrupt {
                     if intx_interrupt.interrupt_status.load(Ordering::SeqCst) {
-                        status |= cfg_space::Status::INTERRUPT_STATUS;
+                        status.set_interrupt_status(true);
                     }
                 }
 
-                (status.bits() as u32) << 16 | self.state.command.bits() as u32
+                (status.into_bits() as u32) << 16 | self.state.command.into_bits() as u32
             }
             HeaderType00::CLASS_REVISION => {
                 (u8::from(self.hardware_ids.base_class) as u32) << 24
@@ -436,12 +435,12 @@ impl ConfigSpaceType0Emulator {
 
     fn update_intx_disable(&mut self, command: cfg_space::Command) {
         if let Some(intx_interrupt) = &self.intx_interrupt {
-            intx_interrupt.set_disabled(command.contains(cfg_space::Command::INTX_DISABLE))
+            intx_interrupt.set_disabled(command.intx_disable())
         }
     }
 
     fn update_mmio_enabled(&mut self, command: cfg_space::Command) {
-        if command.contains(cfg_space::Command::MMIO_ENABLED) {
+        if command.mmio_enabled() {
             self.active_bars = BarMappings::parse(&self.state.base_addresses, &self.bar_masks);
             for (bar, mapping) in self.mapped_memory.iter_mut().enumerate() {
                 if let Some(mapping) = mapping {
@@ -478,30 +477,19 @@ impl ConfigSpaceType0Emulator {
 
         match HeaderType00(offset) {
             HeaderType00::STATUS_COMMAND => {
-                let command = match cfg_space::Command::from_bits(val as u16) {
-                    Some(command) => command,
-                    None => {
-                        tracelimit::warn_ratelimited!(offset, val, "setting invalid command bits");
-                        // still do our best
-                        cfg_space::Command::from_bits_truncate(val as u16)
-                    }
+                let mut command = cfg_space::Command::from_bits(val as u16);
+                if command.reserved() != 0 || command.reserved2() != 0 {
+                    tracelimit::warn_ratelimited!(offset, val, "setting invalid command bits");
+                    // still do our best
+                    command.set_reserved(0);
+                    command.set_reserved2(0);
                 };
 
-                if self
-                    .state
-                    .command
-                    .contains(cfg_space::Command::INTX_DISABLE)
-                    != command.contains(cfg_space::Command::INTX_DISABLE)
-                {
+                if self.state.command.intx_disable() != command.intx_disable() {
                     self.update_intx_disable(command)
                 }
 
-                if self
-                    .state
-                    .command
-                    .contains(cfg_space::Command::MMIO_ENABLED)
-                    != command.contains(cfg_space::Command::MMIO_ENABLED)
-                {
+                if self.state.command.mmio_enabled() != command.mmio_enabled() {
                     self.update_mmio_enabled(command)
                 }
 
@@ -518,15 +506,11 @@ impl ConfigSpaceType0Emulator {
             | HeaderType00::BAR3
             | HeaderType00::BAR4
             | HeaderType00::BAR5 => {
-                if !self
-                    .state
-                    .command
-                    .contains(cfg_space::Command::MMIO_ENABLED)
-                {
+                if !self.state.command.mmio_enabled() {
                     let bar_index = (offset - HeaderType00::BAR0.0) as usize / 4;
                     let mut bar_value = val & self.bar_masks[bar_index];
                     if bar_index & 1 == 0 && self.bar_masks[bar_index] != 0 {
-                        bar_value |= cfg_space::BarEncodingBits::TYPE_64_BIT.bits();
+                        bar_value |= cfg_space::BarEncodingBits::TYPE_64_BIT.into_bits();
                     }
                     self.state.base_addresses[bar_index] = bar_value;
                 }
@@ -623,7 +607,7 @@ mod save_restore {
             } = self.state;
 
             let saved_state = state::SavedState {
-                command: command.bits(),
+                command: command.into_bits(),
                 base_addresses,
                 interrupt_line,
                 latency_timer,
@@ -650,15 +634,17 @@ mod save_restore {
             } = state;
 
             self.state = ConfigSpaceType0EmulatorState {
-                command: cfg_space::Command::from_bits(command).ok_or(
-                    RestoreError::InvalidSavedState(
-                        ConfigSpaceRestoreError::InvalidConfigBits.into(),
-                    ),
-                )?,
+                command: cfg_space::Command::from_bits(command),
                 base_addresses,
                 interrupt_line,
                 latency_timer,
             };
+
+            if self.state.command.reserved() != 0 || self.state.command.reserved2() != 0 {
+                return Err(RestoreError::InvalidSavedState(
+                    ConfigSpaceRestoreError::InvalidConfigBits.into(),
+                ));
+            }
 
             self.sync_command_register(self.state.command);
             for (id, entry) in capabilities {

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -186,6 +186,7 @@ pub mod hwid {
 /// Sources: PCI 2.3 Spec - Chapter 6
 #[allow(missing_docs)] // primarily enums/structs with self-explanatory variants
 pub mod cfg_space {
+    use bitfield_struct::bitfield;
     use inspect::Inspect;
     use zerocopy::AsBytes;
     use zerocopy::FromBytes;
@@ -236,63 +237,104 @@ pub mod cfg_space {
 
     pub const HEADER_TYPE_00_SIZE: u16 = 0x40;
 
-    bitflags::bitflags! {
-        /// BAR in-band encoding bits.
-        ///
-        /// The low bits of the BAR are not actually part of the address.
-        /// Instead, they are used to in-band encode various bits of
-        /// metadata about the BAR, and are masked off when determining the
-        /// actual address.
-        pub struct BarEncodingBits: u32 {
-            const USE_PIO = 1 << 0;
-            // only used in MMIO
-            const TYPE_32_BIT = 0b00 << 1;
-            const TYPE_64_BIT = 0b10 << 1;
-            const PREFETCHABLE = 1 << 3;
-        }
+    /// BAR in-band encoding bits.
+    ///
+    /// The low bits of the BAR are not actually part of the address.
+    /// Instead, they are used to in-band encode various bits of
+    /// metadata about the BAR, and are masked off when determining the
+    /// actual address.
+    #[bitfield(u32)]
+    pub struct BarEncodingBits {
+        pub use_pio: bool,
+
+        _reserved: bool,
+
+        /// False indicates 32 bit.
+        /// Only used in MMIO
+        pub type_64_bit: bool,
+        pub prefetchable: bool,
+
+        #[bits(28)]
+        _reserved2: u32,
     }
 
-    bitflags::bitflags! {
-        /// Command Register
-        #[derive(AsBytes, FromBytes, FromZeroes, Inspect)]
-        #[repr(transparent)]
-        #[inspect(debug)]
-        pub struct Command: u16 {
-            const PIO_ENABLED                    = 1 << 0;
-            const MMIO_ENABLED                   = 1 << 1;
-            const BUS_MASTER                     = 1 << 2;
-            const SPECIAL_CYCLES                 = 1 << 3;
-            const ENABLE_MEMORY_WRITE_INVALIDATE = 1 << 4;
-            const VGA_PALETTE_SNOOP              = 1 << 5;
-            const PARITY_ERROR_RESPONSE          = 1 << 6;
-            // const RESERVED                    = 1 << 7; // must be 0
-            const ENABLE_SERR                    = 1 << 8;
-            const ENABLE_FAST_B2B                = 1 << 9;
-            const INTX_DISABLE                   = 1 << 10;
-            // rest of bits are reserved
-        }
+    impl BarEncodingBits {
+        pub const TYPE_64_BIT: BarEncodingBits = BarEncodingBits::new().with_type_64_bit(true);
     }
 
-    bitflags::bitflags! {
-        /// Status Register
-        #[derive(AsBytes, FromBytes, FromZeroes)]
-        #[repr(transparent)]
-        pub struct Status: u16 {
-            // const RESERVED           = 0b000 << 0;
-            const INTERRUPT_STATUS      = 1 << 3;
-            const CAPABILITIES_LIST     = 1 << 4;
-            const CAPABLE_MHZ_66        = 1 << 5;
-            // const RESERVED           = 1 << 6;
-            const CAPABLE_FAST_B2B      = 1 << 7;
-            const ERR_MASTER_PARITY     = 1 << 8;
-            const DEVSEL_FAST           = 0b00 << 10;
-            const DEVSEL_MED            = 0b01 << 10;
-            const DEVSEL_SLOW           = 0b10 << 10;
-            const ABORT_TARGET_SIGNALED = 1 << 11;
-            const ABORT_TARGET_RECEIVED = 1 << 12;
-            const ABORT_MASTER_RECEIVED = 1 << 13;
-            const ERR_SIGNALED          = 1 << 14;
-            const ERR_DETECTED_PARITY   = 1 << 15;
+    /// Command Register
+    #[derive(Inspect)]
+    #[bitfield(u16)]
+    #[derive(AsBytes, FromBytes, FromZeroes)]
+    pub struct Command {
+        pub pio_enabled: bool,
+        pub mmio_enabled: bool,
+        pub bus_master: bool,
+        pub special_cycles: bool,
+        pub enable_memory_write_invalidate: bool,
+        pub vga_palette_snoop: bool,
+        pub parity_error_response: bool,
+        /// must be 0
+        #[bits(1)]
+        pub reserved: u16,
+        pub enable_serr: bool,
+        pub enable_fast_b2b: bool,
+        pub intx_disable: bool,
+        #[bits(5)]
+        pub reserved2: u16,
+    }
+
+    impl Command {
+        pub const MMIO_ENABLED: Command = Command::new().with_mmio_enabled(true);
+    }
+
+    /// Status Register
+    #[bitfield(u16)]
+    #[derive(AsBytes, FromBytes, FromZeroes)]
+    pub struct Status {
+        #[bits(3)]
+        _reserved: u16,
+        pub interrupt_status: bool,
+        pub capabilities_list: bool,
+        pub capable_mhz_66: bool,
+        _reserved2: bool,
+        pub capable_fast_b2b: bool,
+        pub err_master_parity: bool,
+
+        #[bits(2)]
+        pub devsel: DevSel,
+
+        pub abort_target_signaled: bool,
+        pub abort_target_received: bool,
+        pub abort_master_received: bool,
+        pub err_signaled: bool,
+        pub err_detected_parity: bool,
+    }
+
+    impl Status {
+        pub const CAPABILITIES_LIST: Status = Status::new().with_capabilities_list(true);
+    }
+
+    #[derive(Debug)]
+    #[repr(u16)]
+    pub enum DevSel {
+        Fast = 0b00,
+        Medium = 0b01,
+        Slow = 0b10,
+    }
+
+    impl DevSel {
+        pub const fn from_bits(bits: u16) -> Self {
+            match bits {
+                0b00 => DevSel::Fast,
+                0b01 => DevSel::Medium,
+                0b10 => DevSel::Slow,
+                _ => unreachable!(),
+            }
+        }
+
+        pub const fn into_bits(self) -> u16 {
+            self as u16
         }
     }
 }

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -272,12 +272,12 @@ pub mod cfg_space {
         pub parity_error_response: bool,
         /// must be 0
         #[bits(1)]
-        pub reserved: u16,
+        _reserved: u16,
         pub enable_serr: bool,
         pub enable_fast_b2b: bool,
         pub intx_disable: bool,
         #[bits(5)]
-        pub reserved2: u16,
+        _reserved2: u16,
     }
 
     /// Status Register

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -258,10 +258,6 @@ pub mod cfg_space {
         _reserved2: u32,
     }
 
-    impl BarEncodingBits {
-        pub const TYPE_64_BIT: BarEncodingBits = BarEncodingBits::new().with_type_64_bit(true);
-    }
-
     /// Command Register
     #[derive(Inspect)]
     #[bitfield(u16)]
@@ -282,10 +278,6 @@ pub mod cfg_space {
         pub intx_disable: bool,
         #[bits(5)]
         pub reserved2: u16,
-    }
-
-    impl Command {
-        pub const MMIO_ENABLED: Command = Command::new().with_mmio_enabled(true);
     }
 
     /// Status Register
@@ -311,10 +303,6 @@ pub mod cfg_space {
         pub err_detected_parity: bool,
     }
 
-    impl Status {
-        pub const CAPABILITIES_LIST: Status = Status::new().with_capabilities_list(true);
-    }
-
     #[derive(Debug)]
     #[repr(u16)]
     pub enum DevSel {
@@ -324,7 +312,7 @@ pub mod cfg_space {
     }
 
     impl DevSel {
-        pub const fn from_bits(bits: u16) -> Self {
+        const fn from_bits(bits: u16) -> Self {
             match bits {
                 0b00 => DevSel::Fast,
                 0b01 => DevSel::Medium,
@@ -333,7 +321,7 @@ pub mod cfg_space {
             }
         }
 
-        pub const fn into_bits(self) -> u16 {
+        const fn into_bits(self) -> u16 {
             self as u16
         }
     }

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -280,6 +280,21 @@ pub mod cfg_space {
         pub reserved2: u16,
     }
 
+    impl Command {
+        pub const VALID_BITS: u16 = Command::new()
+            .with_pio_enabled(true)
+            .with_mmio_enabled(true)
+            .with_bus_master(true)
+            .with_special_cycles(true)
+            .with_enable_memory_write_invalidate(true)
+            .with_vga_palette_snoop(true)
+            .with_parity_error_response(true)
+            .with_enable_serr(true)
+            .with_enable_fast_b2b(true)
+            .with_intx_disable(true)
+            .into_bits();
+    }
+
     /// Status Register
     #[bitfield(u16)]
     #[derive(AsBytes, FromBytes, FromZeroes)]

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -280,21 +280,6 @@ pub mod cfg_space {
         pub reserved2: u16,
     }
 
-    impl Command {
-        pub const VALID_BITS: u16 = Command::new()
-            .with_pio_enabled(true)
-            .with_mmio_enabled(true)
-            .with_bus_master(true)
-            .with_special_cycles(true)
-            .with_enable_memory_write_invalidate(true)
-            .with_vga_palette_snoop(true)
-            .with_parity_error_response(true)
-            .with_enable_serr(true)
-            .with_enable_fast_b2b(true)
-            .with_intx_disable(true)
-            .into_bits();
-    }
-
     /// Status Register
     #[bitfield(u16)]
     #[derive(AsBytes, FromBytes, FromZeroes)]

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -830,7 +830,7 @@ impl VpciChannel {
                 return Err(InvalidBars::ResourceHigh64 { index: i });
             }
             let mut mask = self.bar_masks[i] as u64;
-            if mask as u32 & cfg_space::BarEncodingBits::TYPE_64_BIT.into_bits() != 0 {
+            if cfg_space::BarEncodingBits::from_bits(mask as u32).type_64_bit() {
                 high64 = true;
                 mask |= (self.bar_masks[i + 1] as u64) << 32;
             }
@@ -883,10 +883,13 @@ impl VpciChannel {
                 .map(|_| value)
                 .unwrap_or(0)
         };
+        let mmio = cfg_space::Command::new()
+            .with_mmio_enabled(true)
+            .into_bits() as u32;
         if on {
-            command |= cfg_space::Command::MMIO_ENABLED.into_bits() as u32;
+            command |= mmio;
         } else {
-            command &= !(cfg_space::Command::MMIO_ENABLED.into_bits() as u32);
+            command &= !mmio;
         }
         {
             device
@@ -1624,7 +1627,9 @@ mod tests {
 
         pci.pci_cfg_write(
             0x4,
-            pci_core::spec::cfg_space::Command::MMIO_ENABLED.into_bits() as u32,
+            pci_core::spec::cfg_space::Command::new()
+                .with_mmio_enabled(true)
+                .into_bits() as u32,
         )
         .unwrap();
 
@@ -1790,7 +1795,9 @@ mod tests {
         pci.lock()
             .pci_cfg_write(
                 0x4,
-                pci_core::spec::cfg_space::Command::MMIO_ENABLED.into_bits() as u32,
+                pci_core::spec::cfg_space::Command::new()
+                    .with_mmio_enabled(true)
+                    .into_bits() as u32,
             )
             .unwrap();
 

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -830,7 +830,7 @@ impl VpciChannel {
                 return Err(InvalidBars::ResourceHigh64 { index: i });
             }
             let mut mask = self.bar_masks[i] as u64;
-            if mask as u32 & cfg_space::BarEncodingBits::TYPE_64_BIT.bits() != 0 {
+            if mask as u32 & cfg_space::BarEncodingBits::TYPE_64_BIT.into_bits() != 0 {
                 high64 = true;
                 mask |= (self.bar_masks[i + 1] as u64) << 32;
             }
@@ -884,9 +884,9 @@ impl VpciChannel {
                 .unwrap_or(0)
         };
         if on {
-            command |= cfg_space::Command::MMIO_ENABLED.bits() as u32;
+            command |= cfg_space::Command::MMIO_ENABLED.into_bits() as u32;
         } else {
-            command &= !(cfg_space::Command::MMIO_ENABLED.bits() as u32);
+            command &= !(cfg_space::Command::MMIO_ENABLED.into_bits() as u32);
         }
         {
             device
@@ -1624,7 +1624,7 @@ mod tests {
 
         pci.pci_cfg_write(
             0x4,
-            pci_core::spec::cfg_space::Command::MMIO_ENABLED.bits() as u32,
+            pci_core::spec::cfg_space::Command::MMIO_ENABLED.into_bits() as u32,
         )
         .unwrap();
 
@@ -1790,7 +1790,7 @@ mod tests {
         pci.lock()
             .pci_cfg_write(
                 0x4,
-                pci_core::spec::cfg_space::Command::MMIO_ENABLED.bits() as u32,
+                pci_core::spec::cfg_space::Command::MMIO_ENABLED.into_bits() as u32,
             )
             .unwrap();
 

--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -944,8 +944,10 @@ impl PciConfigSpace for IdeDevice {
             let offset = HeaderType00(offset);
             tracing::trace!(?offset, value, "ide pci config space write");
 
-            const BUS_MASTER_IO_ENABLE_MASK: u32 =
-                (Command::PIO_ENABLED.bits() | Command::BUS_MASTER.bits()) as u32;
+            const BUS_MASTER_IO_ENABLE_MASK: u32 = Command::new()
+                .with_pio_enabled(true)
+                .with_bus_master(true)
+                .into_bits() as u32;
 
             match offset {
                 HeaderType00::STATUS_COMMAND => {

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -82,7 +82,7 @@ impl<T: PciConfigSpace + MmioIntercept> EmulatedDevice<T> {
         device
             .pci_cfg_write(
                 0x4,
-                pci_core::spec::cfg_space::Command::MMIO_ENABLED.bits() as u32,
+                pci_core::spec::cfg_space::Command::MMIO_ENABLED.into_bits() as u32,
             )
             .unwrap();
 

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -82,7 +82,9 @@ impl<T: PciConfigSpace + MmioIntercept> EmulatedDevice<T> {
         device
             .pci_cfg_write(
                 0x4,
-                pci_core::spec::cfg_space::Command::MMIO_ENABLED.into_bits() as u32,
+                pci_core::spec::cfg_space::Command::new()
+                    .with_mmio_enabled(true)
+                    .into_bits() as u32,
             )
             .unwrap();
 

--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -987,7 +987,7 @@ mod tests {
                 .unwrap();
 
             dev.pci_device
-                .pci_cfg_write(0x4, cfg_space::Command::MMIO_ENABLED.bits() as u32)
+                .pci_cfg_write(0x4, cfg_space::Command::MMIO_ENABLED.into_bits() as u32)
                 .unwrap();
 
             let mut device_status = VIRTIO_ACKNOWLEDGE as u8;
@@ -1616,7 +1616,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             capabilities,
-            (cfg_space::Status::CAPABILITIES_LIST.bits() as u32) << 16
+            (cfg_space::Status::CAPABILITIES_LIST.into_bits() as u32) << 16
         );
         let mut next_cap_offset = 0;
         pci_test_device
@@ -1772,7 +1772,7 @@ mod tests {
 
         pci_test_device
             .pci_device
-            .pci_cfg_write(0x4, cfg_space::Command::MMIO_ENABLED.bits() as u32)
+            .pci_cfg_write(0x4, cfg_space::Command::MMIO_ENABLED.into_bits() as u32)
             .unwrap();
 
         // device feature bank index

--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -987,7 +987,12 @@ mod tests {
                 .unwrap();
 
             dev.pci_device
-                .pci_cfg_write(0x4, cfg_space::Command::MMIO_ENABLED.into_bits() as u32)
+                .pci_cfg_write(
+                    0x4,
+                    cfg_space::Command::new()
+                        .with_mmio_enabled(true)
+                        .into_bits() as u32,
+                )
                 .unwrap();
 
             let mut device_status = VIRTIO_ACKNOWLEDGE as u8;
@@ -1616,7 +1621,10 @@ mod tests {
             .unwrap();
         assert_eq!(
             capabilities,
-            (cfg_space::Status::CAPABILITIES_LIST.into_bits() as u32) << 16
+            (cfg_space::Status::new()
+                .with_capabilities_list(true)
+                .into_bits() as u32)
+                << 16
         );
         let mut next_cap_offset = 0;
         pci_test_device
@@ -1772,7 +1780,12 @@ mod tests {
 
         pci_test_device
             .pci_device
-            .pci_cfg_write(0x4, cfg_space::Command::MMIO_ENABLED.into_bits() as u32)
+            .pci_cfg_write(
+                0x4,
+                cfg_space::Command::new()
+                    .with_mmio_enabled(true)
+                    .into_bits() as u32,
+            )
             .unwrap();
 
         // device feature bank index

--- a/vmm_core/virt_whp/src/device.rs
+++ b/vmm_core/virt_whp/src/device.rs
@@ -181,7 +181,7 @@ fn parse_probed_bars(probed_bars: [u32; 6]) -> [u32; 6] {
     let mut i = 0;
     while i < probed_bars.len() {
         bar_flags[i] = probed_bars[i] & 0xf;
-        if probed_bars[i] & cfg_space::BarEncodingBits::TYPE_64_BIT.bits() != 0 {
+        if probed_bars[i] & cfg_space::BarEncodingBits::TYPE_64_BIT.into_bits() != 0 {
             i += 2;
         } else {
             i += 1;
@@ -432,7 +432,7 @@ impl PciConfigSpace for AssignedPciDevice {
             4 => {
                 // Power on/off the device if there is no power cap.
                 let command = value as u16;
-                if command & cfg_space::Command::MMIO_ENABLED.bits() != 0 {
+                if command & cfg_space::Command::MMIO_ENABLED.into_bits() != 0 {
                     if self.power_reg.is_none() && self.power_state != 0 {
                         tracing::info!("implicitly transitioning to D0");
                         self.set_power_state(0);
@@ -459,7 +459,7 @@ impl PciConfigSpace for AssignedPciDevice {
                 if Some(offset as u32) == self.power_reg {
                     let power_state = value & 3;
                     if power_state == 0
-                        && self.command & cfg_space::Command::MMIO_ENABLED.bits() != 0
+                        && self.command & cfg_space::Command::MMIO_ENABLED.into_bits() != 0
                     {
                         self.set_power_state(power_state);
                         self.enable_mmio();

--- a/vmm_core/virt_whp/src/device.rs
+++ b/vmm_core/virt_whp/src/device.rs
@@ -181,7 +181,7 @@ fn parse_probed_bars(probed_bars: [u32; 6]) -> [u32; 6] {
     let mut i = 0;
     while i < probed_bars.len() {
         bar_flags[i] = probed_bars[i] & 0xf;
-        if probed_bars[i] & cfg_space::BarEncodingBits::TYPE_64_BIT.into_bits() != 0 {
+        if cfg_space::BarEncodingBits::from_bits(probed_bars[i]).type_64_bit() {
             i += 2;
         } else {
             i += 1;
@@ -431,8 +431,8 @@ impl PciConfigSpace for AssignedPciDevice {
         match offset {
             4 => {
                 // Power on/off the device if there is no power cap.
-                let command = value as u16;
-                if command & cfg_space::Command::MMIO_ENABLED.into_bits() != 0 {
+                let command = cfg_space::Command::from_bits(value as u16);
+                if command.mmio_enabled() {
                     if self.power_reg.is_none() && self.power_state != 0 {
                         tracing::info!("implicitly transitioning to D0");
                         self.set_power_state(0);
@@ -448,7 +448,7 @@ impl PciConfigSpace for AssignedPciDevice {
                     }
                 }
                 self.write_phys_config(offset, value);
-                self.command = command;
+                self.command = command.into_bits();
             }
 
             0x10 | 0x14 | 0x18 | 0x1c | 0x20 | 0x24 => {
@@ -458,9 +458,7 @@ impl PciConfigSpace for AssignedPciDevice {
             _ => {
                 if Some(offset as u32) == self.power_reg {
                     let power_state = value & 3;
-                    if power_state == 0
-                        && self.command & cfg_space::Command::MMIO_ENABLED.into_bits() != 0
-                    {
+                    if power_state == 0 && cfg_space::Command::from(self.command).mmio_enabled() {
                         self.set_power_state(power_state);
                         self.enable_mmio();
                     } else {


### PR DESCRIPTION
Part of moving all of our bitfield types to bitfield-struct. Only IDE is left I think. There could definitely be more cleanup here to make things more idiomatic, but I'm just trying to do a minimum viable change here for now.