### PR TITLE
openhcl: make nvme keep alive enabled only via environment arg

### DIFF
--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -179,6 +179,7 @@ pub(crate) struct LoadedVm {
 
     pub shared_vis_pool: Option<PagePool>,
     pub private_pool: Option<PagePool>,
+    pub nvme_keep_alive: bool,
 }
 
 pub struct LoadedVmState<T> {
@@ -469,14 +470,15 @@ impl LoadedVm {
         &mut self,
         correlation_id: Guid,
         deadline: std::time::Instant,
-        capabilities_flags: SaveGuestVtl2StateFlags,
+        _capabilities_flags: SaveGuestVtl2StateFlags,
     ) -> anyhow::Result<ServicingState> {
         if self.isolation.is_isolated() {
             anyhow::bail!("Servicing is not yet supported for isolated VMs");
         }
 
-        // capabilities_flags says if we should do nvme keep alive or not.
-        let nvme_keepalive = capabilities_flags.enable_nvme_keepalive();
+        // NOTE: This is set via the corresponding env arg, as this feature is
+        // experimental.
+        let nvme_keepalive = self.nvme_keep_alive;
 
         // Do everything before the log flush under a span.
         let mut state = async {
@@ -626,8 +628,8 @@ impl LoadedVm {
 
         let emuplat = (self.emuplat_servicing.save()).context("emuplat save failed")?;
 
-        // Only save NVMe state when there are NVMe controllers and nvme_keepalive
-        // wasn't explicitly disabled through capabilities_flags, otherwise save None.
+        // Only save NVMe state when there are NVMe controllers and keep alive
+        // was enabled.
         let nvme_state = if let Some(n) = &self.nvme_manager {
             n.save(vf_keepalive_flag)
                 .instrument(tracing::info_span!("nvme_manager_save"))

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -475,9 +475,8 @@ impl LoadedVm {
             anyhow::bail!("Servicing is not yet supported for isolated VMs");
         }
 
-        // capabilities_flags used to explicitly disable the feature
-        // which is enabled by default.
-        let nvme_keepalive = !capabilities_flags.disable_nvme_keepalive();
+        // capabilities_flags says if we should do nvme keep alive or not.
+        let nvme_keepalive = capabilities_flags.enable_nvme_keepalive();
 
         // Do everything before the log flush under a span.
         let mut state = async {

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -322,6 +322,7 @@ async fn launch_workers(
         no_sidecar_hotplug: opt.no_sidecar_hotplug,
         gdbstub: opt.gdbstub,
         hide_isolation: opt.hide_isolation,
+        nvme_keep_alive: opt.nvme_keep_alive,
     };
 
     let (mut remote_console_cfg, framebuffer_access) =

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -113,6 +113,9 @@ pub struct Options {
     /// (OPENHCL_NO_SIDECAR_HOTPLUG=1) Leave sidecar VPs remote even if they
     /// hit exits.
     pub no_sidecar_hotplug: bool,
+
+    /// (OPENHCL_NVME_KEEP_ALIVE=1) Enable nvme keep alive when servicing.
+    pub nvme_keep_alive: bool,
 }
 
 impl Options {
@@ -181,6 +184,7 @@ impl Options {
         let no_sidecar_hotplug = parse_legacy_env_bool("OPENHCL_NO_SIDECAR_HOTPLUG");
         let gdbstub = parse_legacy_env_bool("OPENHCL_GDBSTUB");
         let gdbstub_port = parse_legacy_env_number("OPENHCL_GDBSTUB_PORT")?.map(|x| x as u32);
+        let nvme_keep_alive = parse_env_bool("OPENHCL_NVME_KEEP_ALIVE");
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.
@@ -234,6 +238,7 @@ impl Options {
             hide_isolation,
             halt_on_guest_halt,
             no_sidecar_hotplug,
+            nvme_keep_alive,
         })
     }
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -295,6 +295,8 @@ pub struct UnderhillEnvCfg {
     pub gdbstub: bool,
     /// Hide the isolation mode from the guest.
     pub hide_isolation: bool,
+    /// Enable nvme keep alive.
+    pub nvme_keep_alive: bool,
 }
 
 /// Bundle of config + runtime objects for hooking into the underhill remote
@@ -1841,7 +1843,7 @@ async fn new_underhill_vm(
 
         let private_pool_spanwer = private_pool.as_ref().map(|p| p.allocator_spawner());
 
-        let save_restore_supported = shared_vis_pool_spawner.is_some() || private_pool.is_some();
+        let save_restore_supported = env_cfg.nvme_keep_alive;
         let vfio_dma_buffer_spawner = Box::new(
             move |device_id: String| -> anyhow::Result<Arc<dyn VfioDmaBuffer>> {
                 shared_vis_pool_spawner
@@ -3024,6 +3026,7 @@ async fn new_underhill_vm(
         _periodic_telemetry_task: periodic_telemetry_task,
         shared_vis_pool: shared_vis_pages_pool,
         private_pool,
+        nvme_keep_alive: env_cfg.nvme_keep_alive,
     };
 
     Ok(loaded_vm)

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -1181,9 +1181,9 @@ impl UpdateGenerationId {
 #[bitfield(u64)]
 #[derive(AsBytes, FromBytes, FromZeroes)]
 pub struct SaveGuestVtl2StateFlags {
-    /// Disable nvme_keepalive feature when servicing.
+    /// Enable nvme_keepalive feature when servicing.
     #[bits(1)]
-    pub disable_nvme_keepalive: bool,
+    pub enable_nvme_keepalive: bool,
 
     /// Reserved
     #[bits(63)]

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -1181,12 +1181,8 @@ impl UpdateGenerationId {
 #[bitfield(u64)]
 #[derive(AsBytes, FromBytes, FromZeroes)]
 pub struct SaveGuestVtl2StateFlags {
-    /// Enable nvme_keepalive feature when servicing.
-    #[bits(1)]
-    pub enable_nvme_keepalive: bool,
-
-    /// Reserved
-    #[bits(63)]
+    /// Reserved, must be zero.
+    #[bits(64)]
     _rsvd1: u64,
 }
 

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -529,8 +529,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                         correlation_id: Guid::ZERO,
                         // TODO: disable nvme keep alive as it doesn't work with
                         // openvmm yet.
-                        capabilities_flags: SaveGuestVtl2StateFlags::new()
-                            .with_disable_nvme_keepalive(true),
+                        capabilities_flags: SaveGuestVtl2StateFlags::new(),
                         timeout_hint_secs: 60,
                     };
 

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -527,8 +527,6 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                             get_protocol::GuestNotifications::SAVE_GUEST_VTL2_STATE,
                         ),
                         correlation_id: Guid::ZERO,
-                        // TODO: disable nvme keep alive as it doesn't work with
-                        // openvmm yet.
                         capabilities_flags: SaveGuestVtl2StateFlags::new(),
                         timeout_hint_secs: 60,
                     };


### PR DESCRIPTION
NVMe keep alive requires host changes. Make this experimental feature opt in only via environment arg. 

Additionally revert the get protocol changes. The protocol was specified incorrectly and we cannot have a flag that must be set to 1 to get the old behavior. This fixes servicing on older hosts that do not know how to report this flag. 