### PR TITLE
Fix warnings for Rust 1.83

### DIFF
--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -838,7 +838,7 @@ pub struct NodeCtx<'a> {
     backend: Rc<RefCell<&'a mut dyn NodeCtxBackend>>,
 }
 
-impl<'backend> NodeCtx<'backend> {
+impl NodeCtx<'_> {
     /// Emit a Rust-based step.
     ///
     /// As a convenience feature, this function returns a special _optional_

--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -60,13 +60,13 @@ pub struct GicInfo {
 #[derive(Debug)]
 pub struct Error<'a>(ErrorKind<'a>);
 
-impl<'a> Display for Error<'a> {
+impl Display for Error<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!("Parsing failed due to: {}", self.0))
     }
 }
 
-impl<'a> core::error::Error for Error<'a> {}
+impl core::error::Error for Error<'_> {}
 
 #[derive(Debug)]
 enum ErrorKind<'a> {
@@ -138,7 +138,7 @@ enum ErrorKind<'a> {
     },
 }
 
-impl<'a> Display for ErrorKind<'a> {
+impl Display for ErrorKind<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             ErrorKind::Dt(e) => f.write_fmt(format_args!("invalid device tree: {}", e)),

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -22,9 +22,7 @@ const MAX_SIDECAR_NODE_SIZE: usize = 32;
 // Assert that there are enough sidecar nodes for the maximum number of CPUs, if
 // all NUMA nodes but one have one processor.
 const _: () = assert!(
-    sidecar_defs::MAX_NODES
-        >= (MAX_NUMA_NODES - 1)
-            + (MAX_CPU_COUNT + MAX_SIDECAR_NODE_SIZE - 1) / MAX_SIDECAR_NODE_SIZE
+    sidecar_defs::MAX_NODES >= (MAX_NUMA_NODES - 1) + MAX_CPU_COUNT.div_ceil(MAX_SIDECAR_NODE_SIZE)
 );
 
 pub struct SidecarConfig<'a> {
@@ -114,8 +112,8 @@ pub fn start_sidecar<'a>(
             .cpus
             .chunk_by(|a, b| a.vnode == b.vnode)
             .flat_map(|cpus| {
-                let chunks = (cpus.len() + MAX_SIDECAR_NODE_SIZE - 1) / MAX_SIDECAR_NODE_SIZE;
-                cpus.chunks((cpus.len() + chunks - 1) / chunks)
+                let chunks = cpus.len().div_ceil(MAX_SIDECAR_NODE_SIZE);
+                cpus.chunks(cpus.len().div_ceil(chunks))
             })
     };
     if cpus_by_node().all(|cpus_by_node| cpus_by_node.len() == 1) {

--- a/openhcl/underhill_mem/src/registrar.rs
+++ b/openhcl/underhill_mem/src/registrar.rs
@@ -64,7 +64,7 @@ struct Bitmap(Vec<AtomicU64>);
 
 impl Bitmap {
     fn new(address_space_size: u64) -> Self {
-        let chunks = (address_space_size + (GRANULARITY - 1)) / GRANULARITY;
+        let chunks = address_space_size.div_ceil(GRANULARITY);
         let words = (chunks + 63) / 64;
         let mut v = Vec::new();
         v.resize_with(words as usize, AtomicU64::default);
@@ -114,7 +114,7 @@ impl<T: RegisterMemory> MemoryRegistrar<T> {
         let address_space_size = layout.ram().last().unwrap().range.end();
 
         Self {
-            chunk_count: (address_space_size + (GRANULARITY - 1)) / GRANULARITY,
+            chunk_count: address_space_size.div_ceil(GRANULARITY),
             registered: Bitmap::new(address_space_size),
             state: Mutex::new(RegistrarState {
                 failed: Bitmap::new(address_space_size),
@@ -127,7 +127,7 @@ impl<T: RegisterMemory> MemoryRegistrar<T> {
 
     fn chunks(range: MemoryRange) -> Range<u64> {
         let start = range.start() / GRANULARITY;
-        let end = (range.end() + (GRANULARITY - 1)) / GRANULARITY;
+        let end = range.end().div_ceil(GRANULARITY);
         start..end
     }
 

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -402,7 +402,7 @@ pub struct SnpCpuidIterator<'a> {
     index: CpuidPageIndex,
 }
 
-impl<'a> Iterator for SnpCpuidIterator<'a> {
+impl Iterator for SnpCpuidIterator<'_> {
     type Item = ParsedCpuidEntry;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -540,7 +540,7 @@ impl UhProcessorBox {
         &'a mut self,
         driver: &impl Driver,
         control: Option<&'a mut IdleControl>,
-    ) -> Result<UhProcessor<'_, T>, Error> {
+    ) -> Result<UhProcessor<'a, T>, Error> {
         if let Some(control) = &control {
             let vp_index = self.vp_info.base.vp_index;
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -454,7 +454,7 @@ fn duration_from_100ns(n: u64) -> Duration {
     Duration::new(n / NUM_100NS_IN_SEC, (n % NUM_100NS_IN_SEC) as u32 * 100)
 }
 
-impl<'a, T: Backing> UhProcessor<'a, T> {
+impl<T: Backing> UhProcessor<'_, T> {
     fn inspect_extra(&mut self, resp: &mut inspect::Response<'_>) {
         resp.child("stats", |req| {
             // Get all the VP stats and just grab this VP's.
@@ -560,7 +560,10 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
 impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
     type Error = ProcessorError;
     type RunVpError = UhRunVpError;
-    type StateAccess<'a> = T::StateAccess<'p, 'a> where Self: 'a;
+    type StateAccess<'a>
+        = T::StateAccess<'p, 'a>
+    where
+        Self: 'a;
 
     #[cfg(guest_arch = "aarch64")]
     fn set_debug_state(

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -128,7 +128,11 @@ impl BackingPrivate for HypervisorBackedArm64 {
 
     fn init(_this: &mut UhProcessor<'_, Self>) {}
 
-    type StateAccess<'p, 'a> = UhVpStateAccess<'a, 'p, Self> where Self: 'a + 'p, 'p: 'a;
+    type StateAccess<'p, 'a>
+        = UhVpStateAccess<'a, 'p, Self>
+    where
+        Self: 'a + 'p,
+        'p: 'a;
 
     fn access_vp_state<'a, 'p>(
         this: &'a mut UhProcessor<'p, Self>,
@@ -707,7 +711,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBacked>
     }
 }
 
-impl<'a, 'b, T: CpuIo> AccessCpuState for UhEmulationState<'a, 'b, T, HypervisorBacked> {
+impl<T: CpuIo> AccessCpuState for UhEmulationState<'_, '_, T, HypervisorBacked> {
     fn commit(&mut self) {
         self.vp.commit()
     }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/tlb_lock.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/tlb_lock.rs
@@ -10,7 +10,7 @@ use hvdef::hypercall::HvInputVtl;
 use hvdef::HvAllArchRegisterName;
 use hvdef::Vtl;
 
-impl<'a> UhProcessor<'a, HypervisorBacked> {
+impl UhProcessor<'_, HypervisorBacked> {
     /// Causes the specified VTL on the current VP to wait on all TLB locks.
     /// This is typically used to synchronize VTL permission changes with
     /// concurrent instruction emulation.

--- a/support/fdt/src/parser.rs
+++ b/support/fdt/src/parser.rs
@@ -16,14 +16,14 @@ use zerocopy_helpers::FromBytesExt;
 #[derive(Debug)]
 pub struct Error<'a>(ErrorKind<'a>);
 
-impl<'a> Display for Error<'a> {
+impl Display for Error<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.0.fmt(f)
     }
 }
 
 // TODO: Once core::error::Error is stablized, we can remove this feature gate.
-impl<'a> core::error::Error for Error<'a> {}
+impl core::error::Error for Error<'_> {}
 
 /// Types of errors when parsing a FDT.
 #[derive(Debug)]
@@ -91,7 +91,7 @@ enum ErrorKind<'a> {
     FdtEnd,
 }
 
-impl<'a> Display for ErrorKind<'a> {
+impl Display for ErrorKind<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             ErrorKind::BufferAlignment => f.write_str("Buffer is not aligned to u32"),

--- a/support/inspect/fuzz/fuzz_inspect.rs
+++ b/support/inspect/fuzz/fuzz_inspect.rs
@@ -23,7 +23,7 @@ struct InspectNode<'a, 'b> {
     depth_limit: usize,
 }
 
-impl<'a, 'b> InspectMut for InspectNode<'a, 'b> {
+impl InspectMut for InspectNode<'_, '_> {
     fn inspect_mut(&mut self, req: Request<'_>) {
         fuzz_eprintln!("depth {}", self.depth);
         // Depth limit so that we don't recurse infinitely
@@ -35,7 +35,7 @@ impl<'a, 'b> InspectMut for InspectNode<'a, 'b> {
     }
 }
 
-impl<'a, 'b> InspectNode<'a, 'b> {
+impl InspectNode<'_, '_> {
     fn inspect_inner(&mut self, req: Request<'_>) -> Result<(), arbitrary::Error> {
         match self.u.int_in_range(0..=5)? {
             0 => {

--- a/support/mesh/mesh_protobuf/src/buffer.rs
+++ b/support/mesh/mesh_protobuf/src/buffer.rs
@@ -86,7 +86,7 @@ pub struct Buf<'a> {
     filled: &'a mut usize,
 }
 
-impl<'a> Buf<'a> {
+impl Buf<'_> {
     /// Returns the remaining bytes that fit.
     #[inline(always)]
     pub fn remaining(&self) -> usize {

--- a/support/mesh/mesh_protobuf/src/encoding.rs
+++ b/support/mesh/mesh_protobuf/src/encoding.rs
@@ -843,7 +843,7 @@ impl<'a, T: From<&'a str> + Default, R> FieldDecode<'a, T, R> for StringField {
 /// [`Cow::Borrowed`] on read.
 pub struct BorrowedCowField;
 
-impl<'a> DescribeField<Cow<'a, str>> for BorrowedCowField {
+impl DescribeField<Cow<'_, str>> for BorrowedCowField {
     const FIELD_TYPE: FieldType<'static> = FieldType::builtin("string");
 }
 
@@ -1649,15 +1649,15 @@ default_encodings! {
     Infallible: ImpossibleField,
 }
 
-impl<'a> DefaultEncoding for &'a str {
+impl DefaultEncoding for &str {
     type Encoding = StringField;
 }
 
-impl<'a> DefaultEncoding for &'a [u8] {
+impl DefaultEncoding for &[u8] {
     type Encoding = BytesField;
 }
 
-impl<'a> DefaultEncoding for Cow<'a, str> {
+impl DefaultEncoding for Cow<'_, str> {
     type Encoding = StringField;
 }
 

--- a/support/mesh/mesh_protobuf/src/inplace.rs
+++ b/support/mesh/mesh_protobuf/src/inplace.rs
@@ -141,7 +141,7 @@ impl<'a, T> InplaceOption<'a, T> {
     }
 }
 
-impl<'a, T> InplaceOption<'a, Box<T>> {
+impl<T> InplaceOption<'_, Box<T>> {
     /// Updates a boxed value in place.
     ///
     /// N.B. This will allocate space for a value if one is not already present,
@@ -175,7 +175,7 @@ impl<'a, T> InplaceOption<'a, Box<T>> {
     }
 }
 
-impl<'a, T: Clone> InplaceOption<'a, Arc<T>> {
+impl<T: Clone> InplaceOption<'_, Arc<T>> {
     /// Updates a reference counted value in place.
     ///
     /// N.B. This will allocate space for a value if one is not already present,

--- a/support/mesh/mesh_protobuf/src/table/mod.rs
+++ b/support/mesh/mesh_protobuf/src/table/mod.rs
@@ -96,7 +96,7 @@ mod tests {
             <StringField as FieldDecode<'de, &'de str, R>>::ENTRY.erase(),
         ];
     }
-    impl<'a> crate::DefaultEncoding for Foo<'a> {
+    impl crate::DefaultEncoding for Foo<'_> {
         type Encoding = TableEncoder;
     }
 

--- a/support/pal/src/windows.rs
+++ b/support/pal/src/windows.rs
@@ -678,7 +678,7 @@ impl<'a> AnsiStringRef<'a> {
     }
 }
 
-impl<'a> AsRef<ANSI_STRING> for AnsiStringRef<'a> {
+impl AsRef<ANSI_STRING> for AnsiStringRef<'_> {
     fn as_ref(&self) -> &ANSI_STRING {
         &self.0
     }

--- a/support/tracing_helpers/src/formatter.rs
+++ b/support/tracing_helpers/src/formatter.rs
@@ -17,7 +17,7 @@ struct FieldFormatterVisitor<'a> {
     result: fmt::Result,
 }
 
-impl<'a> FieldFormatterVisitor<'a> {
+impl FieldFormatterVisitor<'_> {
     fn maybe_pad(&mut self) {
         if self.is_empty {
             self.is_empty = false;
@@ -42,7 +42,7 @@ impl<'a> FieldFormatterVisitor<'a> {
     }
 }
 
-impl<'a> Visit for FieldFormatterVisitor<'a> {
+impl Visit for FieldFormatterVisitor<'_> {
     fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
         self.record_display(field, &value)
     }
@@ -92,7 +92,7 @@ impl<'a> Visit for FieldFormatterVisitor<'a> {
 ///    for values that we tend to log in HvLite.
 pub struct FieldFormatter;
 
-impl<'a> FormatFields<'a> for FieldFormatter {
+impl FormatFields<'_> for FieldFormatter {
     fn format_fields<R: RecordFields>(&self, writer: Writer<'_>, fields: R) -> fmt::Result {
         let mut visitor = FieldFormatterVisitor {
             writer,

--- a/support/ucs2/src/lib.rs
+++ b/support/ucs2/src/lib.rs
@@ -99,7 +99,7 @@ impl<'a> From<&'a Ucs2LeSlice> for std::borrow::Cow<'a, Ucs2LeSlice> {
     }
 }
 
-impl<'a> From<Ucs2LeVec> for std::borrow::Cow<'a, Ucs2LeSlice> {
+impl From<Ucs2LeVec> for std::borrow::Cow<'_, Ucs2LeSlice> {
     fn from(val: Ucs2LeVec) -> Self {
         std::borrow::Cow::Owned(val)
     }

--- a/vm/devices/firmware/uefi_nvram_specvars/src/signature_list.rs
+++ b/vm/devices/firmware/uefi_nvram_specvars/src/signature_list.rs
@@ -86,7 +86,7 @@ pub enum SignatureList<'a> {
     X509(SignatureData<X509Data<'a>>),
 }
 
-impl<'a> SignatureList<'a> {
+impl SignatureList<'_> {
     /// Serialize the signature list as a `EFI_SIGNATURE_LIST` into a vec
     pub fn extend_as_spec_signature_list(&self, res: &mut Vec<u8>) {
         let (signature_type, sig_data_size, multiplier) = match &self {

--- a/vm/devices/get/underhill_config/src/errors.rs
+++ b/vm/devices/get/underhill_config/src/errors.rs
@@ -50,7 +50,7 @@ impl ParseErrorsBase {
     }
 }
 
-impl<'a> ParseErrors<'a> {
+impl ParseErrors<'_> {
     /// Calls `f` with a new error list accessor with the given context.
     ///
     /// The context is used to provide more detailed error messages. It is

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -805,9 +805,8 @@ impl<'a> TestNicChannel<'a> {
     pub async fn send_receive_buffer_message(&mut self) {
         // Need reserved control channel buffers and one queue buffer (more if subchannels are requested).
         let min_buffer_pages = ((RX_RESERVED_CONTROL_BUFFERS as usize + 1)
-            * sub_allocation_size_for_mtu(DEFAULT_MTU) as usize
-            + (PAGE_SIZE - 1))
-            / PAGE_SIZE;
+            * sub_allocation_size_for_mtu(DEFAULT_MTU) as usize)
+            .div_ceil(PAGE_SIZE);
         let (gpadl_handle, page_array) = self.nic.add_guest_pages(min_buffer_pages).await;
         let recv_range = MultiPagedRangeBuf::new(1, page_array).unwrap();
         self.gpadl_map.add(gpadl_handle, recv_range);

--- a/vm/devices/storage/disk_blockdevice/src/nvme.rs
+++ b/vm/devices/storage/disk_blockdevice/src/nvme.rs
@@ -177,7 +177,7 @@ fn nvme_reservation_report(
 )> {
     // One page should be good enough for most cases. Just in case let caller set bigger buffer size.
     let size = std::cmp::max(size, PAGE_SIZE);
-    let mut buffer = vec![ZERO_PAGE; (size + PAGE_SIZE - 1) / PAGE_SIZE];
+    let mut buffer = vec![ZERO_PAGE; size.div_ceil(PAGE_SIZE)];
     let buffer = &mut buffer.as_bytes_mut()[..size];
     let cmd = NvmeCommand {
         ns_id,
@@ -246,7 +246,7 @@ pub fn nvme_identify_namespace_data(
     ns_id: u32,
 ) -> io::Result<nvm::IdentifyNamespace> {
     let size = size_of::<nvm::IdentifyNamespace>();
-    let mut buffer = vec![ZERO_PAGE; (size + PAGE_SIZE - 1) / PAGE_SIZE];
+    let mut buffer = vec![ZERO_PAGE; size.div_ceil(PAGE_SIZE)];
     let buffer = &mut buffer.as_bytes_mut()[..size];
     let cmd = NvmeCommand {
         ns_id,
@@ -270,7 +270,7 @@ pub fn nvme_identify_namespace_data(
 
 pub fn nvme_identify_controller_data(file: &fs::File) -> io::Result<nvme_spec::IdentifyController> {
     let size = size_of::<nvme_spec::IdentifyController>();
-    let mut buffer = vec![ZERO_PAGE; (size + PAGE_SIZE - 1) / PAGE_SIZE];
+    let mut buffer = vec![ZERO_PAGE; size.div_ceil(PAGE_SIZE)];
     let buffer = &mut buffer.as_bytes_mut()[..size];
     let cmd = NvmeCommand {
         cdw10: nvme_spec::Cdw10Identify::new()

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/page_allocator.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/page_allocator.rs
@@ -80,7 +80,7 @@ impl PageAllocator {
     }
 
     pub async fn alloc_bytes(&self, n: usize) -> Option<ScopedPages<'_>> {
-        self.alloc_pages((n + PAGE_SIZE - 1) / PAGE_SIZE).await
+        self.alloc_pages(n.div_ceil(PAGE_SIZE)).await
     }
 }
 
@@ -119,7 +119,7 @@ struct ScopedPage {
     physical_address: u64,
 }
 
-impl<'a> ScopedPages<'a> {
+impl ScopedPages<'_> {
     pub fn page_count(&self) -> usize {
         self.pages.len()
     }

--- a/vm/devices/storage/disk_striped/src/lib.rs
+++ b/vm/devices/storage/disk_striped/src/lib.rs
@@ -210,8 +210,7 @@ impl StripedDisk {
         }
 
         let start_chunk_index = start_sector / self.sector_count_per_chunk as u64;
-        let end_chunk_index = (end_sector + self.sector_count_per_chunk as u64 - 1)
-            / self.sector_count_per_chunk as u64;
+        let end_chunk_index = end_sector.div_ceil(self.sector_count_per_chunk as u64);
 
         let chunk_iter = ChunkIter {
             disk_count: self.block_devices.len(),
@@ -645,7 +644,7 @@ mod tests {
         write_gpns: &[u64],
         read_gpns: &[u64],
     ) {
-        let page_count = (offset + length + HV_PAGE_SIZE as usize - 1) / HV_PAGE_SIZE as usize;
+        let page_count = (offset + length).div_ceil(HV_PAGE_SIZE as usize);
         // Create continuous guest memory pages and initialize them with random data.
         let guest_mem = create_guest_mem(page_count * 2 * HV_PAGE_SIZE as usize);
         assert_eq!(write_gpns.len(), page_count);
@@ -981,8 +980,7 @@ mod tests {
         // write 1 sector off shall be caught.
         let guest_mem = create_guest_mem(2 * HV_PAGE_SIZE as usize);
         let write_buffers = OwnedRequestBuffers::new(&[0]);
-        let buf_sector_count =
-            (write_buffers.len() + disk.sector_size as usize - 1) / disk.sector_size as usize;
+        let buf_sector_count = write_buffers.len().div_ceil(disk.sector_size as usize);
         match disk
             .write_vectored(
                 &write_buffers.buffer(&guest_mem),
@@ -1002,8 +1000,7 @@ mod tests {
         // read 1 sector off shall be caught.
         let guest_mem = create_guest_mem(2 * HV_PAGE_SIZE as usize);
         let read_buffers = OwnedRequestBuffers::new(&[1]);
-        let buf_sector_count =
-            (read_buffers.len() + disk.sector_size as usize - 1) / disk.sector_size as usize;
+        let buf_sector_count = read_buffers.len().div_ceil(disk.sector_size as usize);
         match disk
             .read_vectored(
                 &write_buffers.buffer(&guest_mem),
@@ -1038,8 +1035,7 @@ mod tests {
         // write 1 byte off shall be caught.
         let write_buffers =
             OwnedRequestBuffers::new_unaligned(&[0], 0, disk.sector_size as usize + 1);
-        let buf_sector_count =
-            (write_buffers.len() + disk.sector_size as usize - 1) / disk.sector_size as usize;
+        let buf_sector_count = write_buffers.len().div_ceil(disk.sector_size as usize);
         match disk
             .write_vectored(
                 &write_buffers.buffer(&guest_mem),
@@ -1059,8 +1055,7 @@ mod tests {
         // read 1 byte off shall be caught.
         let read_buffers =
             OwnedRequestBuffers::new_unaligned(&[1], 0, disk.sector_size as usize + 1);
-        let buf_sector_count =
-            (read_buffers.len() + disk.sector_size as usize - 1) / disk.sector_size as usize;
+        let buf_sector_count = read_buffers.len().div_ceil(disk.sector_size as usize);
         match disk
             .read_vectored(
                 &read_buffers.buffer(&guest_mem),

--- a/vm/devices/storage/floppy/src/lib.rs
+++ b/vm/devices/storage/floppy/src/lib.rs
@@ -1102,8 +1102,8 @@ impl FloppyDiskController {
             }
         };
 
-        let size = (((buffer.size + STANDARD_FLOPPY_SECTOR_SIZE - 1) / STANDARD_FLOPPY_SECTOR_SIZE)
-            * STANDARD_FLOPPY_SECTOR_SIZE) as u32;
+        let size = (buffer.size.div_ceil(STANDARD_FLOPPY_SECTOR_SIZE) * STANDARD_FLOPPY_SECTOR_SIZE)
+            as u32;
 
         let buffer_ptr = &self.command_buffer.buffer[0..size as usize][..size as usize];
 
@@ -1601,8 +1601,7 @@ impl FloppyDiskController {
         let lba = (self.state.position).chs_to_lba(self.state.internals.sectors_per_track) as u64;
 
         let size = {
-            let num = (((size_hint + STANDARD_FLOPPY_SECTOR_SIZE - 1)
-                / STANDARD_FLOPPY_SECTOR_SIZE)
+            let num = (size_hint.div_ceil(STANDARD_FLOPPY_SECTOR_SIZE)
                 * STANDARD_FLOPPY_SECTOR_SIZE) as u32;
             if num < STANDARD_FLOPPY_SECTOR_SIZE as u32 {
                 STANDARD_FLOPPY_SECTOR_SIZE as u32
@@ -1688,8 +1687,7 @@ impl FloppyDiskController {
             }
         };
 
-        let size = ((buffer.size + STANDARD_FLOPPY_SECTOR_SIZE - 1) / STANDARD_FLOPPY_SECTOR_SIZE)
-            * STANDARD_FLOPPY_SECTOR_SIZE;
+        let size = buffer.size.div_ceil(STANDARD_FLOPPY_SECTOR_SIZE) * STANDARD_FLOPPY_SECTOR_SIZE;
 
         let command_buffer = self.command_buffer.access();
 
@@ -1761,8 +1759,8 @@ impl FloppyDiskController {
             }
         };
 
-        let size = (((buffer.size + STANDARD_FLOPPY_SECTOR_SIZE - 1) / STANDARD_FLOPPY_SECTOR_SIZE)
-            * STANDARD_FLOPPY_SECTOR_SIZE) as u32;
+        let size = (buffer.size.div_ceil(STANDARD_FLOPPY_SECTOR_SIZE) * STANDARD_FLOPPY_SECTOR_SIZE)
+            as u32;
 
         let command_buffer = self.command_buffer.access();
 

--- a/vm/devices/storage/nvme/src/prp.rs
+++ b/vm/devices/storage/nvme/src/prp.rs
@@ -35,7 +35,7 @@ impl PrpRange {
         let pfns = if len + offset <= PAGE_SIZE * 2 {
             PrpPfns::Short(prp.map(|x| x >> PAGE_SHIFT))
         } else {
-            let count = (offset + len + PAGE_SIZE - 1) / PAGE_SIZE;
+            let count = (offset + len).div_ceil(PAGE_SIZE);
             let mut v = vec![0; count];
             v[0] = prp[0];
             let mut pfns = &mut v[1..];

--- a/vm/devices/storage/scsi_defs/src/lib.rs
+++ b/vm/devices/storage/scsi_defs/src/lib.rs
@@ -500,7 +500,7 @@ pub struct VpdMsftPagingExtentPropertiesPage {
     pub reserved: [u8; 2],
 }
 
-/// VPD Page 0xB2, Logical Block Provisioning
+// VPD Page 0xB2, Logical Block Provisioning
 
 pub const PROVISIONING_TYPE_UNKNOWN: u8 = 0x0;
 pub const PROVISIONING_TYPE_RESOURCE: u8 = 0x1;

--- a/vm/devices/storage/scsidisk/src/getlbastatus.rs
+++ b/vm/devices/storage/scsidisk/src/getlbastatus.rs
@@ -66,7 +66,7 @@ fn file_offset_to_device_block_index_and_length(
     // LogicalBlockCount and can have an issue for larger than 2TB disks.
     let lba_per_block = std::cmp::min(sector_count, u32::MAX.into());
     let block_size_large = lba_per_block * sector_size;
-    let block_count = ((disk_size + block_size_large - 1) / block_size_large) as u32;
+    let block_count = disk_size.div_ceil(block_size_large) as u32;
     DeviceBlockIndexInfo {
         first_partial_block_size: 0,
         first_full_block_index: 0,

--- a/vm/devices/support/fs/fuse/tests/fuse_hello.rs
+++ b/vm/devices/support/fs/fuse/tests/fuse_hello.rs
@@ -183,7 +183,7 @@ struct Unmounter<'a> {
     mount_point: &'a Path,
 }
 
-impl<'a> Drop for Unmounter<'a> {
+impl Drop for Unmounter<'_> {
     fn drop(&mut self) {
         if let Err(e) = Connection::unmount(self.mount_point, libc::MNT_DETACH) {
             tracing::error!("Unmount failed: {}", e);

--- a/vm/devices/support/fs/plan9/src/protocol.rs
+++ b/vm/devices/support/fs/plan9/src/protocol.rs
@@ -204,7 +204,7 @@ pub struct NameIterator<'a> {
     index: u16,
 }
 
-impl<'a> NameIterator<'a> {
+impl NameIterator<'_> {
     pub fn name_count(&self) -> u16 {
         self.count
     }
@@ -223,7 +223,7 @@ impl<'a> Iterator for NameIterator<'a> {
     }
 }
 
-impl<'a> fmt::Debug for NameIterator<'a> {
+impl fmt::Debug for NameIterator<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -236,7 +236,7 @@ pub struct QidIterator<'a> {
     index: u16,
 }
 
-impl<'a> Iterator for QidIterator<'a> {
+impl Iterator for QidIterator<'_> {
     type Item = lx::Result<Qid>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -249,7 +249,7 @@ impl<'a> Iterator for QidIterator<'a> {
     }
 }
 
-impl<'a> fmt::Debug for QidIterator<'a> {
+impl fmt::Debug for QidIterator<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }

--- a/vm/devices/vga/src/emu.rs
+++ b/vm/devices/vga/src/emu.rs
@@ -2765,7 +2765,6 @@ impl Emulator {
     /// This routine recalculates the VGA access range. It should be
     /// called when the graphics controller misc register value is
     /// changed.
-
     fn calculate_vga_address_range(&mut self) {
         let range_start;
         let range_end;

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -228,7 +228,7 @@ struct VirtioReplySender<'a> {
     mem: &'a GuestMemory,
 }
 
-impl<'a> fuse::ReplySender for VirtioReplySender<'a> {
+impl fuse::ReplySender for VirtioReplySender<'_> {
     fn send(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<()> {
         let mut writer = VirtioPayloadWriter::new(self.mem, &self.work);
         let mut size = 0;

--- a/vm/devices/vmbus/vmbus_ring/src/gparange.rs
+++ b/vm/devices/vmbus/vmbus_ring/src/gparange.rs
@@ -202,7 +202,7 @@ impl<'a> Iterator for MultiPagedRangeIter<'a> {
             return None;
         }
         let hdr = GpaRange::read_from_prefix(self.buf[0].as_bytes()).unwrap();
-        let page_count = ((hdr.offset + hdr.len) as usize + (PAGE_SIZE - 1)) / PAGE_SIZE; // N.B. already validated
+        let page_count = ((hdr.offset + hdr.len) as usize).div_ceil(PAGE_SIZE); // N.B. already validated
         let (this, rest) = self.buf.split_at(page_count + 1);
         let range = PagedRange::new(hdr.offset as usize, hdr.len as usize, &this[1..]).unwrap();
         self.count -= 1;

--- a/vm/devices/vmbus/vmbus_ring/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_ring/src/lib.rs
@@ -96,7 +96,7 @@ mod protocol {
     /// A control page accessor.
     pub struct Control<'a>(pub &'a [AtomicU32; CONTROL_WORD_COUNT]);
 
-    impl<'a> Control<'a> {
+    impl Control<'_> {
         pub fn inp(&self) -> &AtomicU32 {
             &self.0[0]
         }
@@ -275,7 +275,7 @@ pub struct RingRangeReader<'a, T> {
     mem: &'a T,
 }
 
-impl<'a, T: RingMem> MemoryRead for RingRangeReader<'a, T> {
+impl<T: RingMem> MemoryRead for RingRangeReader<'_, T> {
     fn read(&mut self, data: &mut [u8]) -> Result<&mut Self, AccessError> {
         if self.len() < data.len() {
             return Err(AccessError::OutOfRange(self.len(), data.len()));
@@ -305,7 +305,7 @@ pub struct RingRangeWriter<'a, T> {
     mem: &'a T,
 }
 
-impl<'a, T: RingMem> MemoryWrite for RingRangeWriter<'a, T> {
+impl<T: RingMem> MemoryWrite for RingRangeWriter<'_, T> {
     fn write(&mut self, data: &[u8]) -> Result<(), AccessError> {
         if self.len() < data.len() {
             return Err(AccessError::OutOfRange(self.len(), data.len()));
@@ -692,7 +692,7 @@ impl PacketSize {
         Self::in_band(payload_len)
     }
 
-    /// Computes the size of a gpa direct packet.
+    // Computes the size of a gpa direct packet.
     // pub fn gpa_direct()
 
     /// Computes the size of a transfer page packet.

--- a/vm/loader/igvmfilegen/src/signed_measurement/vbs.rs
+++ b/vm/loader/igvmfilegen/src/signed_measurement/vbs.rs
@@ -141,7 +141,7 @@ pub fn generate_vbs_measurement(
                     .with_data_unmeasured(true);
                 digest.record_gpa_page(
                     *gpa / PAGE_SIZE_4K,
-                    (*size_bytes as u64 + PAGE_SIZE_4K - 1) / PAGE_SIZE_4K,
+                    (*size_bytes as u64).div_ceil(PAGE_SIZE_4K),
                     page_metadata,
                     &[],
                 )?;

--- a/vm/loader/src/uefi/mod.rs
+++ b/vm/loader/src/uefi/mod.rs
@@ -498,7 +498,7 @@ pub mod x86_64 {
             ConfigType::ConfigBlob(config) => {
                 let data = config.complete();
                 assert!(!data.is_empty());
-                let config_blob_page_count = (data.len() as u64 + HV_PAGE_SIZE - 1) / HV_PAGE_SIZE;
+                let config_blob_page_count = (data.len() as u64).div_ceil(HV_PAGE_SIZE);
                 importer
                     .import_pages(
                         CONFIG_BLOB_GPA_BASE / HV_PAGE_SIZE,

--- a/vm/vbs_defs/src/lib.rs
+++ b/vm/vbs_defs/src/lib.rs
@@ -54,7 +54,7 @@ pub struct VBS_VM_BOOT_MEASUREMENT_SIGNED_DATA {
 ///     } u;
 /// } VBS_VM_BOOT_MEASUREMENT_CHUNK, *PVBS_VM_BOOT_MEASUREMENT_CHUNK;
 /// ```
-
+///
 /// Structure describing the chunk to be measured
 #[repr(C)]
 #[derive(AsBytes)]

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -208,7 +208,7 @@ impl AlignedHeapMemory {
         #[allow(clippy::declare_interior_mutable_const)]
         const ZERO_PAGE: AlignedPage = AlignedPage([ZERO; PAGE_SIZE]);
         let mut pages = Vec::new();
-        pages.resize_with((size + PAGE_SIZE - 1) / PAGE_SIZE, || ZERO_PAGE);
+        pages.resize_with(size.div_ceil(PAGE_SIZE), || ZERO_PAGE);
         Self {
             pages: pages.into(),
         }

--- a/vm/vmcore/guestmem/src/ranges.rs
+++ b/vm/vmcore/guestmem/src/ranges.rs
@@ -128,7 +128,7 @@ impl<'a> PagedRange<'a> {
     /// Returns the range's list of page numbers.
     pub fn gpns(&self) -> &'a [u64] {
         let start_page = self.start / PAGE_SIZE;
-        let end_page = (self.end + PAGE_SIZE - 1) / PAGE_SIZE;
+        let end_page = self.end.div_ceil(PAGE_SIZE);
         &self.gpns[start_page..end_page]
     }
 
@@ -194,7 +194,7 @@ impl<'a> PagedRange<'a> {
             None
         } else {
             let start_page = self.start / PAGE_SIZE;
-            let end_page = (self.end + PAGE_SIZE - 1) / PAGE_SIZE;
+            let end_page = self.end.div_ceil(PAGE_SIZE);
             let mut page = start_page + 1;
             while page < end_page && self.gpns[page - 1] + 1 == self.gpns[page] {
                 page += 1;
@@ -237,7 +237,7 @@ impl<'a> PagedRange<'a> {
 #[derive(Debug, Clone)]
 pub struct PagedRangeRangeIter<'a>(PagedRange<'a>);
 
-impl<'a> Iterator for PagedRangeRangeIter<'a> {
+impl Iterator for PagedRangeRangeIter<'_> {
     type Item = Result<AddressRange, InvalidGpn>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -251,7 +251,7 @@ pub struct PagedRangeReader<'a> {
     mem: &'a GuestMemory,
 }
 
-impl<'a> MemoryRead for PagedRangeReader<'a> {
+impl MemoryRead for PagedRangeReader<'_> {
     fn read(&mut self, data: &mut [u8]) -> Result<&mut Self, AccessError> {
         let range = self
             .range
@@ -283,7 +283,7 @@ pub struct PagedRangeWriter<'a> {
     mem: &'a GuestMemory,
 }
 
-impl<'a> MemoryWrite for PagedRangeWriter<'a> {
+impl MemoryWrite for PagedRangeWriter<'_> {
     fn write(&mut self, data: &[u8]) -> Result<(), AccessError> {
         let range = self
             .range

--- a/vm/whp/src/api.rs
+++ b/vm/whp/src/api.rs
@@ -15,7 +15,7 @@ use winapi::um::winnt::HANDLE;
 unsafe fn get_proc(name: &[u8]) -> usize {
     unsafe {
         GetProcAddress(
-            GetModuleHandleA(b"winhvplatform.dll\0".as_ptr().cast()),
+            GetModuleHandleA(c"winhvplatform.dll".as_ptr().cast()),
             name.as_ptr().cast(),
         ) as usize
     }

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -1721,7 +1721,7 @@ pub struct ProcessorRunner<'a> {
     ctx: abi::WHV_RUN_VP_EXIT_CONTEXT,
 }
 
-impl<'a> ProcessorRunner<'a> {
+impl ProcessorRunner<'_> {
     pub fn run(&mut self) -> Result<Exit<'_>> {
         unsafe {
             check_hresult(api::WHvRunVirtualProcessor(

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -363,7 +363,7 @@ impl virt::vp::AccessVpState for &'_ mut KvmProcessor<'_> {
     }
 }
 
-impl<'a> virt::vm::AccessVmState for &'a KvmPartition {
+impl virt::vm::AccessVmState for &KvmPartition {
     type Error = KvmError;
 
     fn caps(&self) -> &PartitionCapabilities {
@@ -378,7 +378,10 @@ impl<'a> virt::vm::AccessVmState for &'a KvmPartition {
 impl virt::Processor for KvmProcessor<'_> {
     type Error = KvmError;
     type RunVpError = KvmRunVpError;
-    type StateAccess<'a> = &'a mut Self where Self: 'a;
+    type StateAccess<'a>
+        = &'a mut Self
+    where
+        Self: 'a;
 
     fn set_debug_state(
         &mut self,
@@ -597,7 +600,7 @@ impl KvmProtoPartition<'_> {
     }
 }
 
-impl<'a> virt::ProtoPartition for KvmProtoPartition<'a> {
+impl virt::ProtoPartition for KvmProtoPartition<'_> {
     type Error = KvmError;
     type Partition = KvmPartition;
     type ProcessorBinder = KvmProcessorBinder;

--- a/vmm_core/virt_support_apic/src/lib.rs
+++ b/vmm_core/virt_support_apic/src/lib.rs
@@ -1343,7 +1343,7 @@ pub struct OffloadNotSupported;
 
 impl LocalApic {
     /// Returns an object to access APIC registers.
-    pub fn access<'a, T: ApicClient>(&'a mut self, client: &'a mut T) -> LocalApicAccess<'_, T> {
+    pub fn access<'a, T: ApicClient>(&'a mut self, client: &'a mut T) -> LocalApicAccess<'a, T> {
         LocalApicAccess { apic: self, client }
     }
 

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -30,7 +30,7 @@ pub(crate) struct WhpHypercallExit<'a, 'b, T> {
     registers: arch::WhpHypercallRegisters<'a>,
 }
 
-impl<'a, 'b, T: CpuIo> WhpHypercallExit<'a, 'b, T> {
+impl<T: CpuIo> WhpHypercallExit<'_, '_, T> {
     const DISPATCHER: hv1_hypercall::Dispatcher<Self> = hv1_hypercall::dispatcher!(
         Self,
         [


### PR DESCRIPTION
This fixes most of the new warnings from Rust 1.83. 99% of it is eliding lifetimes and fixing manual div_ceil reimplementations.

A few warnings are left in sidecar regarding mutable statics, those will get fixed sooner or later.

We likely won't actually update CI to 1.83, since the internal toolchain isn't going to update until 1.84 is out next year, but all these should be backwards compatible.