### PR TITLE
Fix incidental references to static muts in sidecar

### DIFF
--- a/openhcl/minimal_rt/src/arch/x86_64/hypercall.rs
+++ b/openhcl/minimal_rt/src/arch/x86_64/hypercall.rs
@@ -8,7 +8,7 @@
 unsafe extern "C" {
     /// The hypercall page. The actual hypercall page must be mapped on top of
     /// this page before it is used.
-    pub unsafe static mut HYPERCALL_PAGE: [u8; 4096];
+    pub static mut HYPERCALL_PAGE: [u8; 4096];
 }
 
 core::arch::global_asm! {

--- a/openhcl/minimal_rt/src/arch/x86_64/hypercall.rs
+++ b/openhcl/minimal_rt/src/arch/x86_64/hypercall.rs
@@ -8,7 +8,7 @@
 unsafe extern "C" {
     /// The hypercall page. The actual hypercall page must be mapped on top of
     /// this page before it is used.
-    pub static mut HYPERCALL_PAGE: [u8; 4096];
+    pub unsafe static mut HYPERCALL_PAGE: [u8; 4096];
 }
 
 core::arch::global_asm! {

--- a/openhcl/sidecar/src/arch/x86_64/init.rs
+++ b/openhcl/sidecar/src/arch/x86_64/init.rs
@@ -197,7 +197,7 @@ fn init(
         // no invariant requirements.
         let hypercall_page = unsafe { mapper.map::<[u8; 4096]>(hypercall_page) };
         // SAFETY: no concurrent accessors to the page.
-        unsafe { HYPERCALL_PAGE.copy_from_slice(&*hypercall_page) };
+        unsafe { (&raw mut HYPERCALL_PAGE).copy_from_nonoverlapping(&*hypercall_page, 1) };
     }
 
     // Initialize the IDT.

--- a/openhcl/sidecar/src/arch/x86_64/vp.rs
+++ b/openhcl/sidecar/src/arch/x86_64/vp.rs
@@ -363,7 +363,7 @@ fn set_debug_register(name: HvX64RegisterName, value: u64) -> bool {
             HvX64RegisterName::Dr1 => core::arch::asm!("mov dr1, {}", in(reg) value),
             HvX64RegisterName::Dr2 => core::arch::asm!("mov dr2, {}", in(reg) value),
             HvX64RegisterName::Dr3 => core::arch::asm!("mov dr3, {}", in(reg) value),
-            HvX64RegisterName::Dr6 if VSM_CAPABILITIES.dr6_shared() => {
+            HvX64RegisterName::Dr6 if (&raw const VSM_CAPABILITIES).read().dr6_shared() => {
                 core::arch::asm!("mov dr6, {}", in(reg) value)
             }
             _ => return false,
@@ -382,7 +382,7 @@ fn get_debug_register(name: HvX64RegisterName) -> Option<u64> {
             HvX64RegisterName::Dr1 => core::arch::asm!("mov {}, dr1", lateout(reg) v),
             HvX64RegisterName::Dr2 => core::arch::asm!("mov {}, dr2", lateout(reg) v),
             HvX64RegisterName::Dr3 => core::arch::asm!("mov {}, dr3", lateout(reg) v),
-            HvX64RegisterName::Dr6 if VSM_CAPABILITIES.dr6_shared() => {
+            HvX64RegisterName::Dr6 if (&raw const VSM_CAPABILITIES).read().dr6_shared() => {
                 core::arch::asm!("mov {}, dr6", lateout(reg) v)
             }
             _ => return None,


### PR DESCRIPTION
Fix new warnings in sidecar from Rust 1.83 getting stricter around the handling of mutable statics. The methods previously being called would automatically create references. We shouldn't do that.