### PR TITLE
inspect: Remove the no longer needed Option from Node's sensitivity level

### DIFF
--- a/support/inspect/src/defer.rs
+++ b/support/inspect/src/defer.rs
@@ -163,7 +163,7 @@ impl Deferred {
                         InternalNode::DirResolved(alloc::vec![crate::InternalEntry {
                             name: name.to_owned(),
                             node,
-                            sensitivity: Some(sensitivity),
+                            sensitivity,
                         }])
                     });
 
@@ -204,7 +204,7 @@ impl InternalNode {
                     .into_iter()
                     .filter_map(|e| {
                         // If the returned sensitivity level is not allowed for this request, drop it.
-                        if e.sensitivity.unwrap_or_default() > request_sensitivity {
+                        if e.sensitivity > request_sensitivity {
                             return None;
                         }
                         InternalNode::from_node(e.node, request_sensitivity).map(|v| {

--- a/support/inspect/src/initiate.rs
+++ b/support/inspect/src/initiate.rs
@@ -62,7 +62,7 @@ pub struct Entry {
     pub node: Node,
     /// The sensitivity level of this entry.
     #[mesh(3)]
-    pub sensitivity: Option<SensitivityLevel>,
+    pub sensitivity: SensitivityLevel,
 }
 
 /// A node resolution error.

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -818,7 +818,7 @@ impl Response<'_> {
                 children.push(InternalEntry {
                     name: name.to_owned(),
                     node: InternalNode::Unevaluated,
-                    sensitivity: Some(sensitivity),
+                    sensitivity,
                 });
                 let entry = children.last_mut().unwrap();
                 Some(Request::new(
@@ -834,7 +834,7 @@ impl Response<'_> {
                 self.cell.as_dir().push(InternalEntry {
                     name: name.to_owned(),
                     node: InternalNode::DepthExhausted,
-                    sensitivity: Some(sensitivity),
+                    sensitivity,
                 });
                 None
             }
@@ -999,7 +999,7 @@ assert_eq!(
         children.push(InternalEntry {
             name: String::new(),
             node: InternalNode::Unevaluated,
-            sensitivity: Some(SensitivityLevel::Unspecified),
+            sensitivity: SensitivityLevel::Unspecified,
         });
         let entry = children.last_mut().unwrap();
         Request::new(
@@ -1863,7 +1863,7 @@ enum InternalNode {
 struct InternalEntry {
     name: String,
     node: InternalNode,
-    sensitivity: Option<SensitivityLevel>,
+    sensitivity: SensitivityLevel,
 }
 
 impl InternalNode {


### PR DESCRIPTION
We first added SensitivityLevel in 1.4. To maintain compatibility with 1.2 we had to add this Option. We are now working on 1.6, and hence outside the support window for 1.2. So we can remove the Option and require sensitivity_level to always be present.

I think this is the first time we're testing breaking compatibility in this way. Should be a good smoke test, and easy to revert if needed.