### PR TITLE
Add generic ACPI tables from DPS to UEFI config

### DIFF
--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -624,7 +624,8 @@ pub fn write_uefi_config(
     }
 
     // ACPI tables that come from the DevicePlatformSettings
-    {
+    // We can only trust these tables from the host if this is not an isolated VM
+    if !isolated {
         if let Some(hmat) = &platform_config.acpi_tables.hmat {
             cfg.add_raw(config::BlobStructureType::Hmat, hmat);
         }

--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -623,6 +623,22 @@ pub fn write_uefi_config(
         });
     }
 
+    // ACPI tables that come from the DevicePlatformSettings
+    {
+        if let Some(hmat) = &platform_config.acpi_tables.hmat {
+            cfg.add_raw(config::BlobStructureType::Hmat, hmat);
+        }
+        if let Some(iort) = &platform_config.acpi_tables.iort {
+            cfg.add_raw(config::BlobStructureType::Iort, iort);
+        }
+        if let Some(mcfg) = &platform_config.acpi_tables.mcfg {
+            cfg.add_raw(config::BlobStructureType::Mcfg, mcfg);
+        }
+        if let Some(ssdt) = &platform_config.acpi_tables.ssdt {
+            cfg.add_raw(config::BlobStructureType::Ssdt, ssdt);
+        }
+    }
+
     // Finally, with the bios config constructed, we can inject it into guest memory
     gm.write_at(loader::uefi::CONFIG_BLOB_GPA_BASE, &cfg.complete())
         .map_err(Error::GuestMemoryAccess)

--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -72,6 +72,8 @@ pub enum Error {
     LinuxSupport,
     #[error("finalizing boot")]
     Finalize(#[source] vtl0_config::Error),
+    #[error("invalid acpi table: {0}")]
+    InvalidAcpiTable(String),
 }
 
 pub const PV_CONFIG_BASE_PAGE: u64 = if cfg!(guest_arch = "x86_64") {
@@ -628,17 +630,19 @@ pub fn write_uefi_config(
     // We can only trust these tables from the host if this is not an isolated VM
     if !isolated {
         for table in &platform_config.acpi_tables {
-            let header =
-                acpi_spec::Header::ref_from_prefix(table).expect("Invalid ACPI table: too short");
+            let header = acpi_spec::Header::ref_from_prefix(table)
+                .ok_or(Error::InvalidAcpiTable("too short".to_string()))?;
             match &header.signature {
                 b"HMAT" => cfg.add_raw(config::BlobStructureType::Hmat, table),
                 b"IORT" => cfg.add_raw(config::BlobStructureType::Iort, table),
                 b"MCFG" => cfg.add_raw(config::BlobStructureType::Mcfg, table),
                 b"SSDT" => cfg.add_raw(config::BlobStructureType::Ssdt, table),
-                _ => panic!(
-                    "Invalid ACPI table: unknown header signature {:?}",
-                    header.signature
-                ),
+                _ => {
+                    return Err(Error::InvalidAcpiTable(format!(
+                        "unknown header signature {:?}",
+                        header.signature
+                    )))
+                }
             };
         }
     }

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -157,7 +157,7 @@ pub struct HclDevicePlatformSettingsV2Dynamic {
     pub is_servicing_scenario: bool,
 
     #[serde(default)]
-    pub acpi_tables: Option<HclDevicePlatformSettingsAcpiTables>,
+    pub acpi_tables: Vec<Vec<u8>>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -179,23 +179,6 @@ pub struct HclDevicePlatformSettingsV2DynamicSmbios {
     pub voltage: u8,
     pub status: u8,
     pub processor_upgrade: u8,
-}
-
-#[derive(Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct HclDevicePlatformSettingsAcpiTables {
-    #[serde(default)]
-    #[serde(with = "serde_helpers::opt_base64_vec")]
-    pub hmat: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(with = "serde_helpers::opt_base64_vec")]
-    pub iort: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(with = "serde_helpers::opt_base64_vec")]
-    pub mcfg: Option<Vec<u8>>,
-    #[serde(default)]
-    #[serde(with = "serde_helpers::opt_base64_vec")]
-    pub ssdt: Option<Vec<u8>>,
 }
 
 #[cfg(test)]

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -155,6 +155,9 @@ pub struct HclDevicePlatformSettingsV2Dynamic {
     pub generation_id_high: u64,
     pub smbios: HclDevicePlatformSettingsV2DynamicSmbios,
     pub is_servicing_scenario: bool,
+
+    #[serde(default)]
+    pub acpi_tables: Option<HclDevicePlatformSettingsAcpiTables>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -176,6 +179,23 @@ pub struct HclDevicePlatformSettingsV2DynamicSmbios {
     pub voltage: u8,
     pub status: u8,
     pub processor_upgrade: u8,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct HclDevicePlatformSettingsAcpiTables {
+    #[serde(default)]
+    #[serde(with = "serde_helpers::opt_base64_vec")]
+    pub hmat: Option<Vec<u8>>,
+    #[serde(default)]
+    #[serde(with = "serde_helpers::opt_base64_vec")]
+    pub iort: Option<Vec<u8>>,
+    #[serde(default)]
+    #[serde(with = "serde_helpers::opt_base64_vec")]
+    pub mcfg: Option<Vec<u8>>,
+    #[serde(default)]
+    #[serde(with = "serde_helpers::opt_base64_vec")]
+    pub ssdt: Option<Vec<u8>>,
 }
 
 #[cfg(test)]

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -33,6 +33,7 @@ pub mod platform_settings {
     pub struct DevicePlatformSettings {
         pub smbios: Smbios,
         pub general: General,
+        pub acpi_tables: AcpiTables,
     }
 
     /// All available SMBIOS related config.
@@ -114,6 +115,14 @@ pub mod platform_settings {
         pub watchdog_enabled: bool,
         pub firmware_mode_is_pcat: bool,
         pub imc_enabled: bool,
+    }
+
+    #[derive(Debug, Inspect)]
+    pub struct AcpiTables {
+        pub hmat: Option<Vec<u8>>,
+        pub iort: Option<Vec<u8>>,
+        pub mcfg: Option<Vec<u8>>,
+        pub ssdt: Option<Vec<u8>>,
     }
 
     #[derive(Copy, Clone, Debug, Inspect)]

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -33,7 +33,8 @@ pub mod platform_settings {
     pub struct DevicePlatformSettings {
         pub smbios: Smbios,
         pub general: General,
-        pub acpi_tables: AcpiTables,
+        #[inspect(with = "inspect::iter_by_index")]
+        pub acpi_tables: Vec<Vec<u8>>,
     }
 
     /// All available SMBIOS related config.
@@ -115,14 +116,6 @@ pub mod platform_settings {
         pub watchdog_enabled: bool,
         pub firmware_mode_is_pcat: bool,
         pub imc_enabled: bool,
-    }
-
-    #[derive(Debug, Inspect)]
-    pub struct AcpiTables {
-        pub hmat: Option<Vec<u8>>,
-        pub iort: Option<Vec<u8>>,
-        pub mcfg: Option<Vec<u8>>,
-        pub ssdt: Option<Vec<u8>>,
     }
 
     #[derive(Copy, Clone, Debug, Inspect)]

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -206,6 +206,8 @@ impl GuestEmulationTransportClient {
             None
         };
 
+        let acpi_tables = json.v2.dynamic.acpi_tables.unwrap_or_default();
+
         Ok(platform_settings::DevicePlatformSettings {
             smbios: platform_settings::Smbios {
                 serial_number: json.v1.serial_number.into(),
@@ -333,6 +335,12 @@ impl GuestEmulationTransportClient {
                 is_servicing_scenario: json.v2.dynamic.is_servicing_scenario,
                 firmware_mode_is_pcat: json.v2.r#static.firmware_mode_is_pcat,
                 imc_enabled: json.v2.r#static.imc_enabled,
+            },
+            acpi_tables: platform_settings::AcpiTables {
+                hmat: acpi_tables.hmat,
+                iort: acpi_tables.iort,
+                mcfg: acpi_tables.mcfg,
+                ssdt: acpi_tables.ssdt,
             },
         })
     }

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -206,8 +206,6 @@ impl GuestEmulationTransportClient {
             None
         };
 
-        let acpi_tables = json.v2.dynamic.acpi_tables.unwrap_or_default();
-
         Ok(platform_settings::DevicePlatformSettings {
             smbios: platform_settings::Smbios {
                 serial_number: json.v1.serial_number.into(),
@@ -336,12 +334,7 @@ impl GuestEmulationTransportClient {
                 firmware_mode_is_pcat: json.v2.r#static.firmware_mode_is_pcat,
                 imc_enabled: json.v2.r#static.imc_enabled,
             },
-            acpi_tables: platform_settings::AcpiTables {
-                hmat: acpi_tables.hmat,
-                iort: acpi_tables.iort,
-                mcfg: acpi_tables.mcfg,
-                ssdt: acpi_tables.ssdt,
-            },
+            acpi_tables: json.v2.dynamic.acpi_tables,
         })
     }
 

--- a/vm/loader/src/uefi/config.rs
+++ b/vm/loader/src/uefi/config.rs
@@ -179,6 +179,10 @@ pub enum BlobStructureType {
     Aspt = 0x21,
     Pptt = 0x22,
     Gic = 0x23,
+    Mcfg = 0x24,
+    Ssdt = 0x25,
+    Hmat = 0x26,
+    Iort = 0x27,
 }
 
 //


### PR DESCRIPTION
Add generic ACPI tables from DevicePlatformSettings to the UEFI config blob. UEFI currently only supports specific tables, so this is limited to HMAT, IORT, MCFG, and SSDT for now.