### PR TITLE
openhcl: remove fixed_pool_alloc, replace with page_pool_alloc (#450)

### DIFF
--- a/openhcl/page_pool_alloc/src/lib.rs
+++ b/openhcl/page_pool_alloc/src/lib.rs
@@ -296,7 +296,7 @@ impl Inspect for PagePoolInner {
                         match &slot.state {
                             SlotState::Free => {}
                             SlotState::Allocated { device_id, tag } => {
-                                resp.field("device_id", self.device_ids[*device_id].clone())
+                                resp.field("device_id", self.device_ids[*device_id].name())
                                     .field("tag", tag);
                             }
                             SlotState::AllocatedPendingRestore { device_id, tag }
@@ -334,6 +334,51 @@ impl PagePoolHandle {
     /// The number of 4K pages for this allocation.
     pub fn size_pages(&self) -> u64 {
         self.size_pages
+    }
+
+    /// Create a memory block from this allocation.
+    #[cfg(all(feature = "vfio", target_os = "linux"))]
+    fn into_memory_block(
+        self,
+        pool_type: PoolType,
+        zero_block: bool,
+    ) -> anyhow::Result<user_driver::memory::MemoryBlock> {
+        let gpa_fd = MshvVtlLow::new().context("failed to open gpa fd")?;
+        let len = (self.size_pages * HV_PAGE_SIZE) as usize;
+        let mapping = sparse_mmap::SparseMapping::new(len).context("failed to create mapping")?;
+        let gpa = self.base_pfn() * HV_PAGE_SIZE;
+
+        // When the pool references shared memory, on hardware isolated
+        // platforms the file_offset must have the shared bit set as these are
+        // decrypted pages. Setting this bit is okay on non-hardware isolated
+        // platforms, as it does nothing.
+        let file_offset = match pool_type {
+            PoolType::Private => gpa,
+            PoolType::Shared => {
+                tracing::trace!("setting MshvVtlLow::SHARED_MEMORY_FLAG");
+                gpa | MshvVtlLow::SHARED_MEMORY_FLAG
+            }
+        };
+
+        tracing::trace!(gpa, file_offset, len, "mapping dma buffer");
+        mapping
+            .map_file(0, len, gpa_fd.get(), file_offset, true)
+            .context("unable to map allocation")?;
+
+        // Zero memory block if requested.
+        if zero_block {
+            mapping
+                .fill_at(0, 0, len)
+                .context("failed to zero allocated memory")?;
+        }
+
+        let pfns: Vec<_> = (self.base_pfn()..self.base_pfn() + self.size_pages).collect();
+
+        Ok(user_driver::memory::MemoryBlock::new(PagePoolDmaBuffer {
+            mapping,
+            _alloc: self,
+            pfns,
+        }))
     }
 }
 
@@ -690,40 +735,9 @@ impl user_driver::vfio::VfioDmaBuffer for PagePoolAllocator {
             .alloc(size_pages, "vfio dma".into())
             .context("failed to allocate shared mem")?;
 
-        let gpa_fd = MshvVtlLow::new().context("failed to open gpa fd")?;
-        let mapping = sparse_mmap::SparseMapping::new(len).context("failed to create mapping")?;
-
-        let gpa = alloc.base_pfn() * HV_PAGE_SIZE;
-
-        // When the pool references shared memory, on hardware isolated
-        // platforms the file_offset must have the shared bit set as these are
-        // decrypted pages. Setting this bit is okay on non-hardware isolated
-        // platforms, as it does nothing.
-        let file_offset = match self.typ {
-            PoolType::Private => gpa,
-            PoolType::Shared => {
-                tracing::trace!("setting MshvVtlLow::SHARED_MEMORY_FLAG");
-                gpa | MshvVtlLow::SHARED_MEMORY_FLAG
-            }
-        };
-
-        tracing::trace!(gpa, file_offset, len, "mapping dma buffer");
-        mapping
-            .map_file(0, len, gpa_fd.get(), file_offset, true)
-            .context("unable to map allocation")?;
-
-        // The VfioDmaBuffer trait requires that allocated buffers are zeroed.
-        mapping
-            .fill_at(0, 0, len)
-            .context("failed to zero allocated memory")?;
-
-        let pfns: Vec<_> = (alloc.base_pfn()..alloc.base_pfn() + alloc.size_pages).collect();
-
-        Ok(user_driver::memory::MemoryBlock::new(PagePoolDmaBuffer {
-            mapping,
-            _alloc: alloc,
-            pfns,
-        }))
+        // The VfioDmaBuffer trait requires that newly allocated buffers are
+        // zeroed.
+        alloc.into_memory_block(self.typ, true)
     }
 }
 

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -176,6 +176,8 @@ pub(crate) struct LoadedVm {
     pub _periodic_telemetry_task: Task<()>,
 
     pub shared_vis_pool: Option<PagePool>,
+    #[expect(dead_code, reason = "backport to be used in a follow up change")]
+    pub private_pool: Option<PagePool>,
 }
 
 pub struct LoadedVmState<T> {

--- a/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
+++ b/openhcl/underhill_core/src/loader/vtl2_config/mod.rs
@@ -71,6 +71,11 @@ impl RuntimeParameters {
     pub fn snp_secrets(&self) -> Option<&[u8]> {
         self.snp_secrets.as_deref()
     }
+
+    /// The memory ranges to use for the private pool
+    pub fn private_pool_ranges(&self) -> &[MemoryRangeWithNode] {
+        &self.parsed_openhcl_boot.private_pool_ranges
+    }
 }
 
 /// Structure that holds the read IGVM parameters from the guest address space.

--- a/vm/loader/loader_defs/src/shim.rs
+++ b/vm/loader/loader_defs/src/shim.rs
@@ -96,6 +96,10 @@ open_enum! {
         /// and usermode. Today, this is only used for SNP: VMSA, CPUID pages,
         /// and secrets pages.
         VTL2_RESERVED = 7,
+        /// This memory is used by VTL2 usermode as a persisted GPA page pool.
+        /// This memory is part of VTL2's address space, not VTL0's. It is
+        /// marked as reserved to the kernel.
+        VTL2_GPA_POOL = 8,
     }
 }
 
@@ -110,6 +114,7 @@ impl MemoryVtlType {
                 | MemoryVtlType::VTL2_SIDECAR_IMAGE
                 | MemoryVtlType::VTL2_SIDECAR_NODE
                 | MemoryVtlType::VTL2_RESERVED
+                | MemoryVtlType::VTL2_GPA_POOL
         )
     }
 }


### PR DESCRIPTION
Remove the fixed pool alloc that was temporarily added for the POC NVMe keep alive PR.

Cleanup a few other things as well.

Fixes #443

Backport of #450