### PR TITLE
openhcl: cleanup private page pool changes  (#461)

### DIFF
--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -1339,7 +1339,7 @@ mod tests {
             .end_node()
             .unwrap();
 
-        // openhcl node - contains memory allocation mode.
+        // openhcl node - contains openhcl specific information.
         let p_memory_allocation_mode = root.add_string("memory-allocation-mode").unwrap();
         let p_memory_allocation_size = root.add_string("memory-size").unwrap();
         let p_mmio_allocation_size = root.add_string("mmio-size").unwrap();
@@ -1364,11 +1364,11 @@ mod tests {
             }
         };
 
-        root = openhcl
+        openhcl = openhcl
             .add_str(p_memory_allocation_mode, memory_alloc_str)
-            .unwrap()
-            .end_node()
             .unwrap();
+
+        root = openhcl.end_node().unwrap();
 
         let bytes_used = root
             .end_node()

--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -510,6 +510,7 @@ pub fn write_dt(
                     ReservedMemoryType::SidecarImage => MemoryVtlType::VTL2_SIDECAR_IMAGE,
                     ReservedMemoryType::SidecarNode => MemoryVtlType::VTL2_SIDECAR_NODE,
                     ReservedMemoryType::Vtl2Reserved => MemoryVtlType::VTL2_RESERVED,
+                    ReservedMemoryType::Vtl2GpaPool => MemoryVtlType::VTL2_GPA_POOL,
                 },
             )
         }),

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -12,16 +12,20 @@ use crate::host_params::MAX_CPU_COUNT;
 use crate::host_params::MAX_ENTROPY_SIZE;
 use crate::host_params::MAX_NUMA_NODES;
 use crate::host_params::MAX_PARTITION_RAM_RANGES;
+use crate::host_params::MAX_VTL2_USED_RANGES;
 use crate::single_threaded::off_stack;
 use crate::single_threaded::OffStackRef;
 use arrayvec::ArrayVec;
+use core::cmp::max;
 use core::fmt::Display;
 use core::fmt::Write;
 use host_fdt_parser::MemoryAllocationMode;
 use host_fdt_parser::MemoryEntry;
 use host_fdt_parser::ParsedDeviceTree;
+use hvdef::HV_PAGE_SIZE;
 use igvm_defs::MemoryMapEntryType;
 use loader_defs::paravisor::CommandLinePolicy;
+use memory_range::flatten_ranges;
 use memory_range::subtract_ranges;
 use memory_range::walk_ranges;
 use memory_range::MemoryRange;
@@ -88,7 +92,7 @@ fn allocate_vtl2_ram(
                 ram_size, params.memory_size
             );
         }
-        core::cmp::max(ram_size, params.memory_size)
+        max(ram_size, params.memory_size)
     } else {
         params.memory_size
     };
@@ -279,7 +283,7 @@ fn parse_host_vtl2_ram(
             params.memory_size
         );
 
-        let vtl2_size = core::cmp::max(vtl2_size, params.memory_size);
+        let vtl2_size = max(vtl2_size, params.memory_size);
         vtl2_ram.push(MemoryEntry {
             range: MemoryRange::new(
                 params.memory_start_address..(params.memory_start_address + vtl2_size),
@@ -394,7 +398,7 @@ impl PartitionInfo {
             // Decide the amount of mmio VTL2 should allocate. Enforce a minimum
             // of 128 MB mmio for VTL2.
             const MINIMUM_MMIO_SIZE: u64 = 128 * (1 << 20);
-            let mmio_size = core::cmp::max(
+            let mmio_size = max(
                 match parsed.memory_allocation_mode {
                     MemoryAllocationMode::Vtl2 { mmio_size, .. } => mmio_size.unwrap_or(0),
                     _ => 0,
@@ -439,12 +443,70 @@ impl PartitionInfo {
             storage.partition_ram.push(*entry);
         }
 
+        // Add all the ranges are not free for further allocation.
+        let mut used_ranges =
+            off_stack!(ArrayVec<MemoryRange, MAX_VTL2_USED_RANGES>, ArrayVec::new_const());
+        used_ranges.push(params.used);
+        used_ranges.sort_unstable_by_key(|r| r.start());
+        storage.vtl2_used_ranges.clear();
+        storage
+            .vtl2_used_ranges
+            .extend(flatten_ranges(used_ranges.iter().copied()));
+
+        // Decide if we will reserve memory for a VTL2 private pool. Parse this
+        // from the final command line.
+        let vtl2_gpa_pool_size = {
+            let cmdline_page_count =
+                crate::cmdline::parse_boot_command_line(storage.cmdline.as_str())
+                    .enable_vtl2_gpa_pool;
+
+            cmdline_page_count.unwrap_or(0)
+        };
+        if vtl2_gpa_pool_size != 0 {
+            // Reserve the specified number of pages for the pool. Use the used
+            // ranges to figure out which VTL2 memory is free to allocate from.
+            let pool_size_bytes = vtl2_gpa_pool_size * HV_PAGE_SIZE;
+            let free_memory = subtract_ranges(
+                storage.vtl2_ram.iter().map(|e| e.range),
+                storage.vtl2_used_ranges.iter().copied(),
+            );
+
+            let mut pool = MemoryRange::EMPTY;
+
+            for range in free_memory {
+                if range.len() >= pool_size_bytes {
+                    pool = MemoryRange::new(range.start()..(range.start() + pool_size_bytes));
+                    break;
+                }
+            }
+
+            if pool.is_empty() {
+                panic!(
+                    "failed to find {pool_size_bytes} bytes of free VTL2 memory for VTL2 GPA pool"
+                );
+            }
+
+            // Update the used ranges to mark the pool range as used.
+            used_ranges.clear();
+            used_ranges.extend(storage.vtl2_used_ranges.iter().copied());
+            used_ranges.push(pool);
+            used_ranges.sort_unstable_by_key(|r| r.start());
+            storage.vtl2_used_ranges.clear();
+            storage
+                .vtl2_used_ranges
+                .extend(flatten_ranges(used_ranges.iter().copied()));
+
+            storage.vtl2_pool_memory = pool;
+        }
+
         // Set remaining struct fields before returning.
         let Self {
             vtl2_ram: _,
             vtl2_full_config_region: vtl2_config_region,
             vtl2_config_region_reclaim: vtl2_config_region_reclaim_struct,
             vtl2_reserved_region,
+            vtl2_pool_memory: _,
+            vtl2_used_ranges,
             partition_ram: _,
             isolation,
             bsp_reg,
@@ -458,6 +520,8 @@ impl PartitionInfo {
             entropy,
             vtl0_alias_map: _,
         } = storage;
+
+        assert!(!vtl2_used_ranges.is_empty());
 
         *isolation = params.isolation_type;
 

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -40,6 +40,9 @@ const MAX_PARTITION_RAM_RANGES: usize = 1024;
 /// Maximum size of the host-provided entropy
 pub const MAX_ENTROPY_SIZE: usize = 256;
 
+/// Maximum number of supported VTL2 used ranges.
+pub const MAX_VTL2_USED_RANGES: usize = 16;
+
 /// Information about the guest partition.
 #[derive(Debug)]
 pub struct PartitionInfo {
@@ -56,6 +59,14 @@ pub struct PartitionInfo {
     /// The vtl2 reserved region, that is reserved to both the kernel and
     /// usermode.
     pub vtl2_reserved_region: MemoryRange,
+    /// Memory used for the VTL2 private pool.
+    pub vtl2_pool_memory: MemoryRange,
+    /// Memory ranges that are in use by the bootshim, and any other persisted
+    /// ranges, such as the VTL2 private pool.
+    ///
+    /// TODO: Refactor these different ranges and consolidate address space
+    /// management.
+    pub vtl2_used_ranges: ArrayVec<MemoryRange, MAX_VTL2_USED_RANGES>,
     ///  The full memory map provided by the host.
     pub partition_ram: ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>,
     /// The partiton's isolation type.
@@ -91,6 +102,8 @@ impl PartitionInfo {
             vtl2_full_config_region: MemoryRange::EMPTY,
             vtl2_config_region_reclaim: MemoryRange::EMPTY,
             vtl2_reserved_region: MemoryRange::EMPTY,
+            vtl2_pool_memory: MemoryRange::EMPTY,
+            vtl2_used_ranges: ArrayVec::new_const(),
             partition_ram: ArrayVec::new_const(),
             isolation: IsolationType::None,
             bsp_reg: 0,

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -93,7 +93,11 @@ pub fn start_sidecar<'a>(
     free_memory.extend((0..max_vnode + 1).map(|_| MemoryRange::EMPTY));
     for (range, r) in memory_range::walk_ranges(
         partition_info.vtl2_ram.iter().map(|e| (e.range, e.vnode)),
-        [(p.used, ())],
+        partition_info
+            .vtl2_used_ranges
+            .iter()
+            .cloned()
+            .map(|range| (range, ())),
     ) {
         if let memory_range::RangeWalkResult::Left(vnode) = r {
             let free = &mut free_memory[vnode as usize];

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -176,7 +176,6 @@ pub(crate) struct LoadedVm {
     pub _periodic_telemetry_task: Task<()>,
 
     pub shared_vis_pool: Option<PagePool>,
-    #[expect(dead_code, reason = "backport to be used in a follow up change")]
     pub private_pool: Option<PagePool>,
 }
 
@@ -303,6 +302,7 @@ impl LoadedVm {
                             inspect_helpers::vtl0_memory_map(&self.vtl0_memory_map),
                         );
                         resp.field("shared_vis_pool", &self.shared_vis_pool);
+                        resp.field("private_pool", &self.private_pool);
                         resp.field("memory", &self.memory);
                     }),
                 },

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -1179,6 +1179,7 @@ impl UpdateGenerationId {
 
 /// Bitfield describing SaveGuestVtl2StateNotification::capabilities_flags
 #[bitfield(u64)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
 pub struct SaveGuestVtl2StateFlags {
     /// Disable nvme_keepalive feature when servicing.
     #[bits(1)]
@@ -1194,7 +1195,7 @@ pub struct SaveGuestVtl2StateFlags {
 pub struct SaveGuestVtl2StateNotification {
     pub message_header: HeaderGuestNotification,
     pub correlation_id: Guid,
-    pub capabilities_flags: u64,
+    pub capabilities_flags: SaveGuestVtl2StateFlags,
     pub timeout_hint_secs: u16,
 }
 

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -26,6 +26,7 @@ use get_protocol::HeaderGeneric;
 use get_protocol::HostNotifications;
 use get_protocol::HostRequests;
 use get_protocol::RegisterState;
+use get_protocol::SaveGuestVtl2StateFlags;
 use get_protocol::SecureBootTemplateType;
 use get_protocol::StartVtl0Status;
 use get_protocol::UefiConsoleMode;
@@ -525,7 +526,10 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                             get_protocol::GuestNotifications::SAVE_GUEST_VTL2_STATE,
                         ),
                         correlation_id: Guid::ZERO,
-                        capabilities_flags: 0,
+                        // TODO: disable nvme keep alive as it doesn't work with
+                        // openvmm yet.
+                        capabilities_flags: SaveGuestVtl2StateFlags::new()
+                            .with_disable_nvme_keepalive(true),
                         timeout_hint_secs: 60,
                     };
 

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -1303,7 +1303,7 @@ impl<T: RingMem> ProcessLoop<T> {
                 correlation_id: notification_header.correlation_id,
                 deadline: std::time::Instant::now()
                     + std::time::Duration::from_secs(notification_header.timeout_hint_secs as u64),
-                capabilities_flags: notification_header.capabilities_flags.into(),
+                capabilities_flags: notification_header.capabilities_flags,
             })
             .map_err(|_| {
                 FatalError::TooManyGuestNotifications(


### PR DESCRIPTION
Some additional cleanup of the private pool and fixes with keep alive on openvmm, and enable using the private pool via cmdline.

Do not save the pool state if we are not doing keep alive, as no device should have allocations that need persisting. Fix advertising keep alive support on openvmm because it doesn't work yet.

NOTE: Backport commit from main that has dropped changes that do not matter for release/2411.

Backport of #461