### PR TITLE
virt_mshv_vtl: Save the vmbus message queues during SaveRestore

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -804,7 +804,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                 .map(|lapic| lapic.set_apic_base(apic_base).unwrap());
             // Only the VTL 0 non-BSP LAPICs should be in the startup suspend state.
             let mut first = true;
-            let lapic_states = lapics.map(|lapic| {
+            lapics.map(|lapic| {
                 let state = LapicState {
                     lapic,
                     halted: false,
@@ -814,8 +814,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                 };
                 first = false;
                 state
-            });
-            lapic_states.into()
+            })
         });
 
         let hv = partition.hv.as_ref().map(|hv| {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -2150,7 +2150,7 @@ mod save_restore {
             #[mesh(28)]
             pub(super) variable_mtrrs: [u64; 16],
             #[mesh(29)]
-            pub(super) message_queues: [virt::vp::SynicMessageQueues; 2],
+            pub(super) message_queues: Vec<virt::vp::SynicMessageQueues>, // Per-vtl
         }
     }
 
@@ -2291,7 +2291,11 @@ mod save_restore {
                 msr_mtrr_def_type,
                 fixed_mtrrs,
                 variable_mtrrs,
-                message_queues: message_queues.each_ref().map(|q| q.save()).into_inner(),
+                message_queues: message_queues
+                    .each_ref()
+                    .map(|q| q.save())
+                    .into_inner()
+                    .into(),
             };
 
             Ok(state)

--- a/vm/hv1/vtl_array/src/lib.rs
+++ b/vm/hv1/vtl_array/src/lib.rs
@@ -49,9 +49,24 @@ impl<T, const N: usize> VtlArray<T, N> {
     where
         F: FnMut(T) -> U,
     {
-        assert!(N > 0 && N <= 3);
         VtlArray {
             data: self.data.map(f),
+        }
+    }
+
+    /// Borrows each element and returns an array of references with the same
+    /// size as self.
+    pub fn each_ref(&self) -> VtlArray<&T, N> {
+        VtlArray {
+            data: self.data.each_ref(),
+        }
+    }
+
+    /// Borrows each element mutably and returns an array of mutable references
+    /// with the same size as self.
+    pub fn each_mut(&mut self) -> VtlArray<&mut T, N> {
+        VtlArray {
+            data: self.data.each_mut(),
         }
     }
 


### PR DESCRIPTION
It seems that we will be unable to make these go away completely, though we may be able to shrink them, so save them going forward.