### PR TITLE
Re-enable unsafe reviewers check

### DIFF
--- a/.github/workflows/unsafe-reviewers-clone.yml
+++ b/.github/workflows/unsafe-reviewers-clone.yml
@@ -1,4 +1,4 @@
-name: Unsafe Reviewers Check
+name: Unsafe Reviewers Check Clone
 on:
   workflow_dispatch:
   pull_request_target:

--- a/.github/workflows/unsafe-reviewers.yml
+++ b/.github/workflows/unsafe-reviewers.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   id-token: write
   contents: read
-  pull-requests: write 
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/unsafe-reviewers.yml
+++ b/.github/workflows/unsafe-reviewers.yml
@@ -25,9 +25,10 @@ jobs:
       # running code from a potentially malicious PR
       # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
       # https://nathandavison.com/blog/github-actions-and-the-threat-of-malicious-pull-requests
-      - name: Checkout base repo 
+      - name: Checkout base repo
         uses: actions/checkout@v4
         with:
+          path: base
           fetch-depth: 0
       - name: Checkout head repo
         uses: actions/checkout@v4
@@ -39,5 +40,5 @@ jobs:
           path: head-repo
 
       - name: Run unsafe code review script
-        run: pip3 install -r .github/scripts/add_unsafe_reviewers/requirements.txt && python3 .github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py ./head-repo "origin/${{ github.base_ref }}" --token "${{ secrets.GITHUB_TOKEN }}" --pull-request "${{ github.event.number }}"
+        run: pip3 install -r ./base/.github/scripts/add_unsafe_reviewers/requirements.txt && python3 ./base/.github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py ./head-repo "origin/${{ github.base_ref }}" --token "${{ secrets.GITHUB_TOKEN }}" --pull-request "${{ github.event.number }}"
         shell: bash

--- a/.github/workflows/unsafe-reviewers.yml
+++ b/.github/workflows/unsafe-reviewers.yml
@@ -1,4 +1,4 @@
-name: Unsafe Reviewers Check Clone
+name: Unsafe Reviewers Check
 on:
   workflow_dispatch:
   pull_request_target:

--- a/.github/workflows/unsafe-reviewers.yml
+++ b/.github/workflows/unsafe-reviewers.yml
@@ -26,5 +26,5 @@ jobs:
           fetch-depth: 0
 
       - name: Run unsafe code review script
-        run: pip3 install -r .github/scripts/add_unsafe_reviewers/requirements.txt && python3 .github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py . "origin/${{ github.base_ref }}" --token "${{ secrets.ONEBLUE_GH_PAT }}" --pull-request "${{ github.event.number }}"
+        run: pip3 install -r .github/scripts/add_unsafe_reviewers/requirements.txt && python3 .github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py . "origin/${{ github.base_ref }}" --token "${{ secrets.GITHUB_TOKEN }}" --pull-request "${{ github.event.number }}"
         shell: bash

--- a/.github/workflows/unsafe-reviewers.yml
+++ b/.github/workflows/unsafe-reviewers.yml
@@ -1,4 +1,4 @@
-name: Unsafe Reviewers Check
+name: Unsafe Reviewers Check Clone
 on:
   workflow_dispatch:
   pull_request_target:
@@ -8,7 +8,7 @@ on:
 permissions:
   id-token: write
   contents: read
-  pull-requests: read
+  pull-requests: write 
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -20,11 +20,24 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged != true && github.event.action != 'closed'
     steps:
-      - name: Checkout actions
+      # NOTE: We're checking out both repos to avoid a security vulnerability
+      # Any code that runs in this workflow should be using the checked out base repo to avoid
+      # running code from a potentially malicious PR
+      # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+      # https://nathandavison.com/blog/github-actions-and-the-threat-of-malicious-pull-requests
+      - name: Checkout base repo 
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Checkout head repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          path: head-repo
 
       - name: Run unsafe code review script
-        run: pip3 install -r .github/scripts/add_unsafe_reviewers/requirements.txt && python3 .github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py . "origin/${{ github.base_ref }}" --token "${{ secrets.GITHUB_TOKEN }}" --pull-request "${{ github.event.number }}"
+        run: pip3 install -r .github/scripts/add_unsafe_reviewers/requirements.txt && python3 .github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py ./head-repo "origin/${{ github.base_ref }}" --token "${{ secrets.GITHUB_TOKEN }}" --pull-request "${{ github.event.number }}"
         shell: bash


### PR DESCRIPTION
This change enables a workflow that automatically requests a review from `openvmm-unsafe-approvers` if any unsafe code is introduced as part of a change. 