### PR TITLE
devices: move vtl permissions guard to its own crate (#488)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,6 +3426,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lower_vtl_permissions_guard"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "hvdef",
+ "inspect",
+ "user_driver",
+ "virt",
+]
+
+[[package]]
 name = "lx"
 version = "0.0.0"
 dependencies = [
@@ -6688,6 +6699,7 @@ dependencies = [
  "loader",
  "loader_defs",
  "local_clock",
+ "lower_vtl_permissions_guard",
  "mana_driver",
  "mcr_resources",
  "memory_range",
@@ -7689,7 +7701,6 @@ dependencies = [
  "tracelimit",
  "tracing",
  "user_driver",
- "virt",
  "vmbus_channel",
  "vmbus_client",
  "vmbus_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7692,7 +7692,6 @@ dependencies = [
  "futures",
  "guid",
  "hcl",
- "hvdef",
  "inspect",
  "mesh",
  "pal_async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ diag_server = { path = "openhcl/diag_server" }
 hcl = { path = "openhcl/hcl" }
 host_fdt_parser = { path = "openhcl/host_fdt_parser" }
 kmsg_defs = { path = "openhcl/kmsg_defs" }
+lower_vtl_permissions_guard = { path = "openhcl/lower_vtl_permissions_guard" }
 minimal_rt = { path = "openhcl/minimal_rt" }
 minimal_rt_build = { path = "openhcl/minimal_rt_build" }
 page_pool_alloc = { path = "openhcl/page_pool_alloc" }

--- a/openhcl/lower_vtl_permissions_guard/Cargo.toml
+++ b/openhcl/lower_vtl_permissions_guard/Cargo.toml
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "lower_vtl_permissions_guard"
+edition = "2021"
+rust-version.workspace = true
+
+[features]
+vfio = ["dep:user_driver"]
+
+[target.'cfg(target_os = "linux")'.dependencies]
+hvdef.workspace = true
+inspect.workspace = true
+user_driver = { workspace = true, optional = true }
+virt.workspace = true
+
+anyhow.workspace = true
+
+[lints]
+workspace = true

--- a/openhcl/lower_vtl_permissions_guard/src/device_dma.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/device_dma.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Implements the [`MappedDmaTarget`] trait for a wrapped [`MemoryBlock`]
+//! returned by [`LowerVtlMemorySpawner`].
+
+// UNSAFETY: No unsafe code here, but required for implementing MappedDmaTarget.
+// The implementation is just forwarding the calls to the underlying wrapped
+// MemoryBlock.
+#![allow(unsafe_code)]
+
+use crate::PagesAccessibleToLowerVtl;
+use inspect::Inspect;
+use user_driver::memory::MappedDmaTarget;
+use user_driver::memory::MemoryBlock;
+
+/// A DMA buffer where permissions of the pages have been lowered to allow
+/// access to all VTLs.
+#[derive(Inspect)]
+pub struct LowerVtlDmaBuffer {
+    #[inspect(skip)]
+    pub(crate) block: MemoryBlock,
+    pub(crate) _vtl_guard: PagesAccessibleToLowerVtl,
+}
+
+// SAFETY: The underlying MemoryBlock is providing the implementation for this
+// trait.
+unsafe impl MappedDmaTarget for LowerVtlDmaBuffer {
+    fn base(&self) -> *const u8 {
+        self.block.base()
+    }
+
+    fn len(&self) -> usize {
+        self.block.len()
+    }
+
+    fn pfns(&self) -> &[u64] {
+        self.block.pfns()
+    }
+}

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(target_os = "linux")]
+
+//! Implements a VtlMemoryProtection guard that can be used to temporarily allow
+//! access to pages that were previously protected.
+
+#![warn(missing_docs)]
+#[cfg(feature = "vfio")]
+mod device_dma;
+
+#[cfg(feature = "vfio")]
+pub use device_dma::LowerVtlDmaBuffer;
+
+use anyhow::Context;
+use anyhow::Result;
+use inspect::Inspect;
+use std::sync::Arc;
+#[cfg(all(feature = "vfio", target_os = "linux"))]
+use user_driver::memory::MemoryBlock;
+#[cfg(all(feature = "vfio", target_os = "linux"))]
+use user_driver::vfio::VfioDmaBuffer;
+use virt::VtlMemoryProtection;
+
+/// A guard that will restore [`hvdef::HV_MAP_GPA_PERMISSIONS_NONE`] permissions
+/// on the pages when dropped.
+#[derive(Inspect)]
+struct PagesAccessibleToLowerVtl {
+    #[inspect(skip)]
+    vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
+    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    pages: Vec<u64>,
+}
+
+impl PagesAccessibleToLowerVtl {
+    /// Creates a new guard that will lower the VTL permissions of the pages
+    /// while the returned guard is held.
+    fn new_from_pages(
+        vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
+        pages: &[u64],
+    ) -> Result<Self> {
+        for pfn in pages {
+            vtl_protect
+                .modify_vtl_page_setting(*pfn, hvdef::HV_MAP_GPA_PERMISSIONS_ALL)
+                .context("failed to update VTL protections on page")?;
+        }
+        Ok(Self {
+            vtl_protect,
+            pages: pages.to_vec(),
+        })
+    }
+}
+
+impl Drop for PagesAccessibleToLowerVtl {
+    fn drop(&mut self) {
+        if let Err(err) = self
+            .pages
+            .iter()
+            .map(|pfn| {
+                self.vtl_protect
+                    .modify_vtl_page_setting(*pfn, hvdef::HV_MAP_GPA_PERMISSIONS_NONE)
+                    .context("failed to update VTL protections on page")
+            })
+            .collect::<Result<Vec<_>>>()
+        {
+            // The inability to rollback any pages is fatal. We cannot leave the
+            // pages in the state where the correct VTL protections are not
+            // applied, because that would compromise the security of the
+            // platform.
+            panic!(
+                "failed to reset page protections {}",
+                err.as_ref() as &dyn std::error::Error
+            );
+        }
+    }
+}
+
+/// A [`VfioDmaBuffer`] wrapper that will lower the VTL permissions of the page
+/// on the allocated memory block.
+#[cfg(all(feature = "vfio", target_os = "linux"))]
+pub struct LowerVtlMemorySpawner<T: VfioDmaBuffer> {
+    spawner: T,
+    vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
+}
+
+#[cfg(all(feature = "vfio", target_os = "linux"))]
+impl<T: VfioDmaBuffer> LowerVtlMemorySpawner<T> {
+    /// Create a new wrapped [`VfioDmaBuffer`] spawner that will lower the VTL
+    /// permissions of the returned [`MemoryBlock`].
+    pub fn new(spawner: T, vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>) -> Self {
+        Self {
+            spawner,
+            vtl_protect,
+        }
+    }
+}
+
+#[cfg(all(feature = "vfio", target_os = "linux"))]
+impl<T: VfioDmaBuffer> VfioDmaBuffer for LowerVtlMemorySpawner<T> {
+    fn create_dma_buffer(&self, len: usize) -> Result<MemoryBlock> {
+        let mem = self.spawner.create_dma_buffer(len)?;
+        let vtl_guard =
+            PagesAccessibleToLowerVtl::new_from_pages(self.vtl_protect.clone(), mem.pfns())
+                .context("failed to lower VTL permissions on memory block")?;
+
+        Ok(MemoryBlock::new(LowerVtlDmaBuffer {
+            block: mem,
+            _vtl_guard: vtl_guard,
+        }))
+    }
+}

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -64,6 +64,7 @@ ide.workspace = true
 ide_resources.workspace = true
 input_core.workspace = true
 kmsg_defs.workspace = true
+lower_vtl_permissions_guard = { workspace = true, features = ["vfio"] }
 mana_driver.workspace = true
 mcr_resources.workspace = true
 net_backend.workspace = true

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -81,6 +81,7 @@ use input_core::InputData;
 use input_core::MultiplexedInputHandle;
 use inspect::Inspect;
 use loader_defs::shim::MemoryVtlType;
+use lower_vtl_permissions_guard::LowerVtlMemorySpawner;
 use memory_range::MemoryRange;
 use mesh::rpc::RpcSend;
 use mesh::CancelContext;
@@ -2756,7 +2757,10 @@ async fn new_underhill_vm(
 
         let shutdown_guest = SimpleVmbusClientDeviceWrapper::new(
             driver_source.simple(),
-            partition.clone(),
+            Arc::new(LowerVtlMemorySpawner::new(
+                LockedMemorySpawner,
+                partition.clone(),
+            )),
             shutdown_guest,
         )?;
         vmbus_intercept_devices

--- a/vm/devices/user_driver/src/memory.rs
+++ b/vm/devices/user_driver/src/memory.rs
@@ -115,6 +115,11 @@ impl MemoryBlock {
         }
     }
 
+    /// Get the base address of the buffer.
+    pub fn base(&self) -> *const u8 {
+        self.base
+    }
+
     /// Gets the length of the buffer in bytes.
     pub fn len(&self) -> usize {
         self.len

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/Cargo.toml
@@ -24,7 +24,6 @@ pal_async.workspace = true
 safeatomic.workspace = true
 task_control.workspace = true
 user_driver.workspace = true
-virt.workspace = true
 
 anyhow.workspace = true
 futures.workspace = true

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/Cargo.toml
@@ -17,7 +17,6 @@ vmcore.workspace = true
 
 guid.workspace = true
 hcl.workspace = true
-hvdef.workspace = true
 inspect.workspace = true
 mesh.workspace = true
 pal_async.workspace = true

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -19,7 +19,6 @@ use anyhow::Result;
 use futures::StreamExt;
 use guid::Guid;
 use hcl::vmbus::HclVmbus;
-use inspect::Inspect;
 use inspect::InspectMut;
 use mesh::rpc::RpcSend;
 use pal_async::driver::SpawnDriver;
@@ -31,10 +30,8 @@ use task_control::InspectTaskMut;
 use task_control::StopTask;
 use task_control::TaskControl;
 use tracing::Instrument;
-use user_driver::lockmem::LockedMemorySpawner;
 use user_driver::memory::MemoryBlock;
 use user_driver::vfio::VfioDmaBuffer;
-use virt::VtlMemoryProtection;
 use vmbus_channel::bus::GpadlRequest;
 use vmbus_channel::bus::OpenData;
 use vmbus_channel::ChannelClosed;
@@ -151,7 +148,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceWrapper<T> {
     /// Create a new instance.
     pub fn new(
         driver: impl SpawnDriver + Clone,
-        vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
+        dma_alloc: Arc<dyn VfioDmaBuffer>,
         device: T,
     ) -> Result<Self> {
         let hcl_vmbus = Arc::new(HclVmbus::new().context("failed to open hcl_vmbus")?);
@@ -162,7 +159,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceWrapper<T> {
                 device,
                 hcl_vmbus,
                 spawner.clone(),
-                vtl_protect,
+                dma_alloc,
             )),
             spawner,
         })
@@ -226,7 +223,10 @@ struct SimpleVmbusClientDeviceTaskState {
     offer: Option<OfferInfo>,
     #[inspect(skip)]
     recv_relay: mesh::Receiver<InterceptChannelRequest>,
-    vtl_pages: Option<PagesAccessibleToLowerVtl>,
+    #[inspect(
+        with = "|x| x.as_ref().map(|x| inspect::iter_by_index(x.pfns()).map_value(inspect::AsHex))"
+    )]
+    vtl_pages: Option<MemoryBlock>,
 }
 
 struct SimpleVmbusClientDeviceTask<T: SimpleVmbusClientDeviceAsync> {
@@ -234,7 +234,7 @@ struct SimpleVmbusClientDeviceTask<T: SimpleVmbusClientDeviceAsync> {
     hcl_vmbus: Arc<HclVmbus>,
     saved_state: Option<T::SavedState>,
     spawner: Arc<dyn SpawnDriver>,
-    vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
+    dma_alloc: Arc<dyn VfioDmaBuffer>,
 }
 
 impl<T: SimpleVmbusClientDeviceAsync> AsyncRun<SimpleVmbusClientDeviceTaskState>
@@ -268,14 +268,14 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
         device: T,
         hcl_vmbus: Arc<HclVmbus>,
         spawner: Arc<dyn SpawnDriver>,
-        vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
+        dma_alloc: Arc<dyn VfioDmaBuffer>,
     ) -> Self {
         Self {
             device: TaskControl::new(RelayDeviceTask(device)),
             hcl_vmbus,
             saved_state: None,
             spawner,
-            vtl_protect,
+            dma_alloc,
         }
     }
 
@@ -404,11 +404,15 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
             return;
         }
 
-        // Close the channel on every stop.
-        // Overlay devices cannot be saved / restored because the physical
-        // pages used for the ring buffer, et al. would need to be reserved at
-        // boot, otherwise the host may end up scribbling on random memory as
-        // it continues updating a ring buffer it assumes it has ownership of.
+        // Close the channel on every stop. Overlay devices cannot be saved /
+        // restored because the physical pages used for the ring buffer, et al.
+        // would need to be reserved at boot, otherwise the host may end up
+        // scribbling on random memory as it continues updating a ring buffer it
+        // assumes it has ownership of.
+        //
+        // TODO: We could support save restore, if we had a pool of memory that
+        // supports that. This should be possible once the page_pool_alloc is
+        // available everywhere.
         {
             let offer = state.offer.as_ref().expect("device opened");
             offer.request_send.send(ChannelRequest::Close);
@@ -439,17 +443,14 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
         // one for the control bytes and at least one for the ring.
         assert!(page_count >= 4);
 
-        let shared_mem_spawner = LockedMemorySpawner;
-        let vmbus_mem = shared_mem_spawner
+        let mem = self
+            .dma_alloc
             .create_dma_buffer(page_count * PAGE_SIZE)
-            .context("Allocating memory for vmbus rings")?;
-        state.vtl_pages = Some(PagesAccessibleToLowerVtl::new_from_memory_block(
-            self.vtl_protect.clone(),
-            &vmbus_mem,
-        )?);
-        let buf: Vec<_> = [vmbus_mem.len() as u64]
+            .context("allocating memory for vmbus rings")?;
+        state.vtl_pages = Some(mem.clone());
+        let buf: Vec<_> = [mem.len() as u64]
             .iter()
-            .chain(vmbus_mem.pfns())
+            .chain(mem.pfns())
             .copied()
             .collect();
 
@@ -468,7 +469,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
         if !success {
             return Err(anyhow!("Failed reserving GPADL ID"));
         }
-        Ok((vmbus_mem, gpadl_id))
+        Ok((mem, gpadl_id))
     }
 
     /// Open the channel offered by the host.
@@ -635,54 +636,5 @@ impl SignalVmbusChannel for MemoryBlockChannelSignal {
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), ChannelClosed>> {
         self.event.poll_wait(cx).map(Ok)
-    }
-}
-
-#[derive(Inspect)]
-struct PagesAccessibleToLowerVtl {
-    #[inspect(skip)]
-    vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
-    pages: Vec<u64>,
-}
-
-impl PagesAccessibleToLowerVtl {
-    pub fn new_from_memory_block(
-        vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
-        memory: &MemoryBlock,
-    ) -> Result<Self> {
-        let pages = Vec::with_capacity(memory.pfns().len());
-        let mut this = Self { vtl_protect, pages };
-        for pfn in memory.pfns() {
-            this.vtl_protect
-                .modify_vtl_page_setting(*pfn, hvdef::HV_MAP_GPA_PERMISSIONS_ALL)
-                .context("failed to update VTL protections on page")?;
-            this.pages.push(*pfn);
-        }
-        Ok(this)
-    }
-
-    pub fn pfns(&self) -> &[u64] {
-        &self.pages
-    }
-}
-
-impl Drop for PagesAccessibleToLowerVtl {
-    fn drop(&mut self) {
-        if let Err(err) = self
-            .pages
-            .iter()
-            .map(|pfn| {
-                self.vtl_protect
-                    .modify_vtl_page_setting(*pfn, hvdef::HV_MAP_GPA_PERMISSIONS_NONE)
-                    .context("failed to update VTL protections on page")
-            })
-            .collect::<Result<Vec<_>>>()
-        {
-            tracing::error!(
-                err = err.as_ref() as &dyn std::error::Error,
-                "Failed resetting page protections"
-            );
-        }
     }
 }


### PR DESCRIPTION
Move the vmbus_relay_intercept_device VTL permissions guard to its own crate. It will be used for the GET in the AK cert PR, because the protocol requires the pages to have no VTL protections. Provide a wrapped interface so the caller just needs a memory block and otherwise the lowering of VTL permissions is invisible to the device.

Note that we change the error trace to a panic, as any failure to rollback should be fatal to the system.

Backport of #488.