### PR TITLE
Properly serialize ACPI tables

### DIFF
--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -157,6 +157,7 @@ pub struct HclDevicePlatformSettingsV2Dynamic {
     pub is_servicing_scenario: bool,
 
     #[serde(default)]
+    #[serde(with = "serde_helpers::vec_base64_vec")]
     pub acpi_tables: Vec<Vec<u8>>,
 }
 


### PR DESCRIPTION
Adds a new vec_base64_vec module for deserializing a Vec of Vec's. Used for the ACPI tables.