### PR TITLE
Convert IDE from bitflags to bitfield-struct, and remove bitflags entirely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,6 @@ name = "ide"
 version = "0.0.0"
 dependencies = [
  "bitfield-struct",
- "bitflags 1.3.2",
  "chipset_device",
  "disk_backend",
  "disk_file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,7 +381,6 @@ awaitgroup = "0.7"
 base64 = "0.21.7"
 base64-serde = "0.7"
 bitfield-struct = "0.7"
-bitflags = "1.3"
 bitvec = { version = "1.1", default-features = false }
 blocking = "1.2"
 caps = "0.5"
@@ -654,8 +653,6 @@ bool_assert_comparison = "allow"
 # This lint suggests collapsing Box::new(Foo::default()) into Box::default(). We often
 # prefer to specify types completely for local code clarity's sake.
 box_default = "allow"
-# Needed for bitflags 1.x compatibility. Remove when we update to bitflags 2.x
-bad_bit_mask = "allow"
 # Besides the misleading name (this lint also triggers on arrays), we believe that it
 # doesn't provide value. If a developer gets their type wrong they'll notice and fix it.
 # Sometimes you do want a list of a single range.

--- a/vm/devices/storage/ide/Cargo.toml
+++ b/vm/devices/storage/ide/Cargo.toml
@@ -26,7 +26,6 @@ guestmem.workspace = true
 vmcore.workspace = true
 
 bitfield-struct.workspace = true
-bitflags.workspace = true
 static_assertions.workspace = true
 thiserror.workspace = true
 tracelimit.workspace = true

--- a/vm/devices/storage/ide/src/drive/atapi_drive.rs
+++ b/vm/devices/storage/ide/src/drive/atapi_drive.rs
@@ -97,11 +97,11 @@ impl Registers {
             byte_count_high: protocol::ATAPI_RESET_LBA_HIGH,
             lba_low: 1, // CHS mode
             device_head: DeviceHeadReg::new(),
-            error: ErrorReg::ERR_AMNF_ILI_DEFAULT,
+            error: ErrorReg::new().with_ERR_AMNF_ILI_DEFAULT(true),
             features: 0,
             sector_count: protocol::ATAPI_READY_FOR_PACKET_DEFAULT,
-            device_control_reg: DeviceControlReg::empty(),
-            status: Status::empty(),
+            device_control_reg: DeviceControlReg::new(),
+            status: Status::new(),
         }
     }
 
@@ -287,7 +287,7 @@ impl AtapiDrive {
 
         let regs = &self.state.regs;
         match register {
-            DriveRegister::ErrorFeatures => regs.error.bits(),
+            DriveRegister::ErrorFeatures => regs.error.into_bits(),
             DriveRegister::SectorCount => regs.sector_count,
             DriveRegister::LbaLow => regs.lba_low,
             DriveRegister::LbaMid => regs.byte_count_low,
@@ -297,12 +297,12 @@ impl AtapiDrive {
                 let status = self.state.regs.status;
                 tracing::trace!(status = ?status, path = ?self.disk_path, "status query, deasserting");
                 self.request_interrupt(false);
-                status.bits()
+                status.into_bits()
             }
             DriveRegister::AlternateStatusDeviceControl => {
                 let status = self.state.regs.status;
                 tracing::trace!(status = ?status, path = ?self.disk_path, "alter status query");
-                status.bits()
+                status.into_bits()
             }
         }
     }
@@ -329,13 +329,13 @@ impl AtapiDrive {
             }
             DriveRegister::AlternateStatusDeviceControl => {
                 let v = DeviceControlReg::from_bits_truncate(data);
-                self.state.regs.device_control_reg = v & !DeviceControlReg::RESET;
-                if v.contains(DeviceControlReg::RESET) && !self.state.pending_software_reset {
-                    if !self.state.regs.status.contains(Status::BSY) {
+                self.state.regs.device_control_reg = v.with_RESET(false);
+                if v.RESET() && !self.state.pending_software_reset {
+                    if !self.state.regs.status.BSY() {
                         self.reset();
                     } else {
                         self.state.pending_software_reset = true;
-                        self.insert_status(Status::BSY);
+                        self.state.regs.status.set_BSY(true);
                     }
                 }
             }
@@ -344,11 +344,7 @@ impl AtapiDrive {
 
     pub fn interrupt_pending(&self) -> bool {
         self.state.pending_interrupt
-            && !self
-                .state
-                .regs
-                .device_control_reg
-                .contains(DeviceControlReg::INTERRUPT_MASK)
+            && !self.state.regs.device_control_reg.INTERRUPT_MASK()
             && self.is_selected()
             && !self.state.pending_software_reset
     }
@@ -393,8 +389,8 @@ impl AtapiDrive {
                 DmaType::Read => self.write_data_port_buffer_complete(),
             };
             if self.state.buffer.is_none() {
-                assert!(!self.state.regs.status.contains(Status::BSY));
-                assert!(!self.state.regs.status.contains(Status::DRQ));
+                assert!(!self.state.regs.status.BSY());
+                assert!(!self.state.regs.status.DRQ());
                 self.request_interrupt(true);
             }
         }
@@ -416,8 +412,8 @@ impl AtapiDrive {
                 DmaType::Read => self.write_data_port_buffer_complete(),
             };
             if self.state.buffer.is_none() {
-                assert!(!self.state.regs.status.contains(Status::BSY));
-                assert!(!self.state.regs.status.contains(Status::DRQ));
+                assert!(!self.state.regs.status.BSY());
+                assert!(!self.state.regs.status.DRQ());
                 self.request_interrupt(true);
             }
         }
@@ -440,9 +436,9 @@ impl AtapiDrive {
             "write_device_head"
         );
         // After the device select, update status for the selected device.
-        if self.is_selected() && self.state.regs.status.is_empty() {
+        if self.is_selected() && self.state.regs.status.into_bits() == 0 {
             // Update the status of the device if it is 0
-            self.set_status(Status::DRDY | Status::DSC);
+            self.state.regs.status = Status::new().with_DRDY(true).with_DSC(true);
         }
     }
 
@@ -455,8 +451,11 @@ impl AtapiDrive {
     }
 
     fn complete_data_port_read(&mut self) {
-        self.remove_status(Status::BSY | Status::ERR | Status::DRQ);
-        self.insert_status(Status::DRDY | Status::DSC);
+        self.state.regs.status.set_BSY(false);
+        self.state.regs.status.set_ERR(false);
+        self.state.regs.status.set_DRQ(false);
+        self.state.regs.status.set_DRDY(true);
+        self.state.regs.status.set_DSC(true);
 
         self.state.regs.sector_count = protocol::ATAPI_COMMAND_COMPLETE;
         self.state.buffer = None;
@@ -556,29 +555,14 @@ impl AtapiDrive {
         &mut self.state
     }
 
-    fn set_status(&mut self, status: Status) {
-        self.state.regs.status = status;
-    }
-
-    fn remove_status(&mut self, status: Status) {
-        self.state.regs.status.remove(status);
-    }
-
-    fn insert_status(&mut self, status: Status) {
-        self.state.regs.status.insert(status);
-    }
-
-    fn clear_status(&mut self) {
-        self.state.regs.status = Status::empty();
-    }
-
     pub fn handle_read_dma_descriptor_error(&mut self) -> bool {
         // Check if there's any pending IO
         if self.io.is_none() {
             if self.state.pending_software_reset {
                 self.reset();
             }
-            self.remove_status(Status::BSY | Status::DRQ);
+            self.state.regs.status.set_BSY(false);
+            self.state.regs.status.set_DRQ(false);
             return true;
         }
 
@@ -590,20 +574,20 @@ impl AtapiDrive {
         let command = IdeCommand(command);
         tracing::debug!(path = ?self.disk_path, ?command, ?self.state.regs, "atapi command");
 
-        if self.state.regs.status.contains(Status::BSY) {
+        if self.state.regs.status.BSY() {
             tracelimit::warn_ratelimited!(new_command = ?command, "A command is already pending");
             return;
         }
 
-        if self.state.regs.status.contains(Status::DRQ) {
+        if self.state.regs.status.DRQ() {
             tracelimit::warn_ratelimited!(new_command = ?command, "data transfer is in progress");
             return;
         }
 
-        self.remove_status(Status::DRDY);
-        self.insert_status(Status::BSY);
-        self.state.regs.error = ErrorReg::ERR_NONE;
-        self.remove_status(Status::ERR);
+        self.state.regs.status.set_DRDY(false);
+        self.state.regs.status.set_BSY(true);
+        self.state.regs.error = ErrorReg::new();
+        self.state.regs.status.set_ERR(false);
 
         match command {
             IdeCommand::DEVICE_RESET => {
@@ -613,7 +597,7 @@ impl AtapiDrive {
             IdeCommand::EXECUTE_DEVICE_DIAGNOSTIC => {
                 // As specified by ATA-6 9.12.
                 self.state.regs.reset_signature(true);
-                self.state.regs.error = ErrorReg::ERR_AMNF_ILI_DEFAULT;
+                self.state.regs.error = ErrorReg::new().with_ERR_AMNF_ILI_DEFAULT(true);
             }
             IdeCommand::PACKET_COMMAND => {
                 // Needn't issue interrupt
@@ -634,18 +618,19 @@ impl AtapiDrive {
             IdeCommand::IDENTIFY_DEVICE | IdeCommand::READ_SECTORS => {
                 // As specified by ATA-6 9.12.
                 self.state.regs.reset_signature(false);
-                self.insert_status(Status::ERR);
-                self.state.regs.error = ErrorReg::ERR_UNKNOWN_COMMAND;
+                self.state.regs.status.set_ERR(true);
+                self.state.regs.error = ErrorReg::new().with_ERR_UNKNOWN_COMMAND(true);
             }
             command => {
                 tracing::debug!(?command, "unknown command");
-                self.insert_status(Status::ERR);
-                self.state.regs.error = ErrorReg::ERR_UNKNOWN_COMMAND;
+                self.state.regs.status.set_ERR(true);
+                self.state.regs.error = ErrorReg::new().with_ERR_UNKNOWN_COMMAND(true);
             }
         };
 
-        self.remove_status(Status::BSY);
-        self.insert_status(Status::DRDY | Status::DSC);
+        self.state.regs.status.set_BSY(false);
+        self.state.regs.status.set_DRDY(true);
+        self.state.regs.status.set_DSC(true);
         self.request_interrupt(true);
     }
 
@@ -666,8 +651,10 @@ impl AtapiDrive {
         // Specify that the buffer is ready to receive bytes
         self.state.buffer = Some(BufferState::new(COMMAND_PACKET_SIZE as u32, dma));
         self.state.regs.sector_count = protocol::ATAPI_READY_FOR_PACKET_DEFAULT;
-        self.remove_status(Status::BSY);
-        self.insert_status(Status::DRDY | Status::DSC | Status::DRQ);
+        self.state.regs.status.set_BSY(false);
+        self.state.regs.status.set_DRDY(true);
+        self.state.regs.status.set_DSC(true);
+        self.state.regs.status.set_DRQ(true);
     }
 
     fn handle_soft_reset(&mut self, reset_dev: bool) {
@@ -675,8 +662,8 @@ impl AtapiDrive {
         self.state.buffer = None;
 
         self.state.regs.reset_signature(reset_dev);
-        self.state.regs.error = ErrorReg::ERR_AMNF_ILI_DEFAULT;
-        self.clear_status();
+        self.state.regs.error = ErrorReg::new().with_ERR_AMNF_ILI_DEFAULT(true);
+        self.state.regs.status = Status::new();
     }
 
     /// IDENTIFY DEVICE command enables the host to receive parameter information
@@ -712,7 +699,7 @@ impl AtapiDrive {
             None,
         ));
         self.state.regs.sector_count = protocol::ATAPI_DATA_FOR_HOST;
-        self.insert_status(Status::DRQ);
+        self.state.regs.status.set_DRQ(true);
     }
 
     // This function handles ATAPI commands. These are only used
@@ -724,8 +711,9 @@ impl AtapiDrive {
             tracelimit::error_ratelimited!(path = ?self.disk_path, "Unexpected: pending_packet_command at beginning of atapi packet command");
         }
 
-        self.remove_status(Status::DRDY | Status::DRQ);
-        self.insert_status(Status::BSY);
+        self.state.regs.status.set_DRDY(false);
+        self.state.regs.status.set_DRQ(false);
+        self.state.regs.status.set_BSY(true);
 
         self.state.regs.byte_count_high = 0;
         self.state.regs.byte_count_low = 0;
@@ -780,18 +768,21 @@ impl AtapiDrive {
         // signal the status can be read. We do this by updating
         // the status and requesting an interrupt.
         self.state.regs.error = (sense.sense_key.0 << 4).into();
-        self.remove_status(Status::BSY | Status::ERR | Status::DRQ);
-        self.insert_status(Status::DRDY | Status::DSC);
+        self.state.regs.status.set_BSY(false);
+        self.state.regs.status.set_ERR(false);
+        self.state.regs.status.set_DRQ(false);
+        self.state.regs.status.set_DRDY(true);
+        self.state.regs.status.set_DSC(true);
 
-        if self.state.regs.error != ErrorReg::ERR_NONE {
+        if self.state.regs.error != ErrorReg::new() {
             // Set error flag
             if sense.sense_key == SenseKey::ILLEGAL_REQUEST
                 || sense.sense_key == SenseKey::ABORTED_COMMAND
             {
-                self.state.regs.error |= ErrorReg::ERR_UNKNOWN_COMMAND;
+                self.state.regs.error.set_ERR_UNKNOWN_COMMAND(true);
             }
 
-            self.insert_status(Status::ERR);
+            self.state.regs.status.set_ERR(true);
         }
 
         self.state.regs.sector_count = protocol::ATAPI_COMMAND_COMPLETE;
@@ -822,8 +813,9 @@ impl AtapiDrive {
         self.state.regs.byte_count_high = ((tx & 0xFF00) >> 8) as u8;
         self.state.regs.sector_count = protocol::ATAPI_DATA_FOR_HOST;
 
-        self.remove_status(Status::BSY);
-        self.insert_status(Status::DRQ | Status::DRDY);
+        self.state.regs.status.set_BSY(false);
+        self.state.regs.status.set_DRQ(true);
+        self.state.regs.status.set_DRDY(true);
         self.request_interrupt(true);
     }
 
@@ -850,9 +842,7 @@ impl AtapiDrive {
                 self.process_atapi_command_result(result);
 
                 // Wait until the command that initiated this IO is completed
-                if !self.state.regs.status.contains(Status::BSY)
-                    && self.state.pending_software_reset
-                {
+                if !self.state.regs.status.BSY() && self.state.pending_software_reset {
                     self.reset();
                 }
             }
@@ -976,15 +966,15 @@ pub(crate) mod save_restore {
 
             Ok(SavedAtapiDriveState {
                 registers: SavedRegisterState {
-                    error: error.bits(),
+                    error: error.into_bits(),
                     features: *features,
                     device_head: (*device_head).into(),
                     lba_low: *lba_low,
                     byte_count_low: *byte_count_low,
                     byte_count_high: *byte_count_high,
                     sector_count: *sector_count,
-                    device_control_reg: device_control_reg.bits(),
-                    status: status.bits(),
+                    device_control_reg: device_control_reg.into_bits(),
+                    status: status.into_bits(),
                 },
                 pending_interrupt: *pending_interrupt,
                 error_pending: *error_pending,
@@ -1036,8 +1026,8 @@ pub(crate) mod save_restore {
                     byte_count_high: lba_high,
                     lba_low,
                     sector_count,
-                    device_control_reg: DeviceControlReg::from_bits(device_control_reg).unwrap(),
-                    status: Status::from_bits(status).unwrap(),
+                    device_control_reg: DeviceControlReg::from_bits(device_control_reg),
+                    status: Status::from_bits(status),
                 },
                 pending_software_reset,
                 pending_interrupt,

--- a/vm/devices/storage/ide/src/drive/atapi_drive.rs
+++ b/vm/devices/storage/ide/src/drive/atapi_drive.rs
@@ -97,7 +97,7 @@ impl Registers {
             byte_count_high: protocol::ATAPI_RESET_LBA_HIGH,
             lba_low: 1, // CHS mode
             device_head: DeviceHeadReg::new(),
-            error: ErrorReg::new().with_err_amnf_ili_default(true),
+            error: ErrorReg::new().with_amnf_ili_default(true),
             features: 0,
             sector_count: protocol::ATAPI_READY_FOR_PACKET_DEFAULT,
             device_control_reg: DeviceControlReg::new(),
@@ -597,7 +597,7 @@ impl AtapiDrive {
             IdeCommand::EXECUTE_DEVICE_DIAGNOSTIC => {
                 // As specified by ATA-6 9.12.
                 self.state.regs.reset_signature(true);
-                self.state.regs.error = ErrorReg::new().with_err_amnf_ili_default(true);
+                self.state.regs.error = ErrorReg::new().with_amnf_ili_default(true);
             }
             IdeCommand::PACKET_COMMAND => {
                 // Needn't issue interrupt
@@ -619,12 +619,12 @@ impl AtapiDrive {
                 // As specified by ATA-6 9.12.
                 self.state.regs.reset_signature(false);
                 self.state.regs.status.set_err(true);
-                self.state.regs.error = ErrorReg::new().with_err_unknown_command(true);
+                self.state.regs.error = ErrorReg::new().with_unknown_command(true);
             }
             command => {
                 tracing::debug!(?command, "unknown command");
                 self.state.regs.status.set_err(true);
-                self.state.regs.error = ErrorReg::new().with_err_unknown_command(true);
+                self.state.regs.error = ErrorReg::new().with_unknown_command(true);
             }
         };
 
@@ -662,7 +662,7 @@ impl AtapiDrive {
         self.state.buffer = None;
 
         self.state.regs.reset_signature(reset_dev);
-        self.state.regs.error = ErrorReg::new().with_err_amnf_ili_default(true);
+        self.state.regs.error = ErrorReg::new().with_amnf_ili_default(true);
         self.state.regs.status = Status::new();
     }
 
@@ -779,7 +779,7 @@ impl AtapiDrive {
             if sense.sense_key == SenseKey::ILLEGAL_REQUEST
                 || sense.sense_key == SenseKey::ABORTED_COMMAND
             {
-                self.state.regs.error.set_err_unknown_command(true);
+                self.state.regs.error.set_unknown_command(true);
             }
 
             self.state.regs.status.set_err(true);

--- a/vm/devices/storage/ide/src/drive/hard_drive.rs
+++ b/vm/devices/storage/ide/src/drive/hard_drive.rs
@@ -81,7 +81,7 @@ impl Registers {
             lba_mid: 0,
             lba_high: 0,
             device_head: DeviceHeadReg::new(),
-            error: ErrorReg::new().with_err_amnf_ili_default(true),
+            error: ErrorReg::new().with_amnf_ili_default(true),
             features: 0,
             device_control_reg: DeviceControlReg::new(),
         }
@@ -809,7 +809,7 @@ impl HardDrive {
         let command = match command {
             IdeCommand::EXECUTE_DEVICE_DIAGNOSTIC => {
                 self.state.regs.reset_signature();
-                self.state.regs.error = ErrorReg::new().with_err_amnf_ili_default(true);
+                self.state.regs.error = ErrorReg::new().with_amnf_ili_default(true);
                 return Ok(());
             }
             x if (IdeCommand::RECALIBRATE_START..=IdeCommand::RECALIBRATE_END).contains(&x) => {
@@ -953,7 +953,7 @@ impl HardDrive {
             command => {
                 tracing::debug!(?command, "unknown command");
                 self.state.error_pending = true;
-                self.state.regs.error = ErrorReg::new().with_err_unknown_command(true);
+                self.state.regs.error = ErrorReg::new().with_unknown_command(true);
                 None
             }
         };
@@ -1343,10 +1343,10 @@ impl HardDrive {
     fn log_and_update_error(&mut self, error: IdeError, register: Option<DriveRegister>) {
         let ide_error = match error {
             IdeError::IdeBadLocation { .. } | IdeError::ZeroSector | IdeError::LbaBitNotSet => {
-                ErrorReg::new().with_err_bad_location(true)
+                ErrorReg::new().with_bad_location(true)
             }
-            IdeError::IdeBadSector { .. } => ErrorReg::new().with_err_bad_sector(true),
-            IdeError::Flush { .. } => ErrorReg::new().with_err_unknown_command(true), // strange, but matches Hyper-V behavior
+            IdeError::IdeBadSector { .. } => ErrorReg::new().with_bad_sector(true),
+            IdeError::Flush { .. } => ErrorReg::new().with_unknown_command(true), // strange, but matches Hyper-V behavior
         };
 
         tracelimit::warn_ratelimited!(

--- a/vm/devices/storage/ide/src/drive/hard_drive.rs
+++ b/vm/devices/storage/ide/src/drive/hard_drive.rs
@@ -81,9 +81,9 @@ impl Registers {
             lba_mid: 0,
             lba_high: 0,
             device_head: DeviceHeadReg::new(),
-            error: ErrorReg::ERR_AMNF_ILI_DEFAULT,
+            error: ErrorReg::new().with_ERR_AMNF_ILI_DEFAULT(true),
             features: 0,
-            device_control_reg: DeviceControlReg::empty(),
+            device_control_reg: DeviceControlReg::new(),
         }
     }
 
@@ -519,19 +519,14 @@ impl HardDrive {
         // Select a byte from a two-byte FIFO register based on the state of
         // the HOB bit.
         let select_byte = |x: u16| {
-            if self
-                .state
-                .regs
-                .device_control_reg
-                .contains(DeviceControlReg::HIGH_ORDER_BYTE)
-            {
+            if self.state.regs.device_control_reg.HIGH_ORDER_BYTE() {
                 (x >> 8) as u8
             } else {
                 x as u8
             }
         };
         match register {
-            DriveRegister::ErrorFeatures => self.state.regs.error.bits(),
+            DriveRegister::ErrorFeatures => self.state.regs.error.into_bits(),
             DriveRegister::SectorCount => select_byte(self.state.regs.sector_count),
             DriveRegister::LbaLow => select_byte(self.state.regs.lba_low),
             DriveRegister::LbaMid => select_byte(self.state.regs.lba_mid),
@@ -541,9 +536,9 @@ impl HardDrive {
                 let status = self.status();
                 tracing::trace!(status = ?status, "status query, deasserting");
                 self.state.pending_interrupt = false;
-                status.bits()
+                status.into_bits()
             }
-            DriveRegister::AlternateStatusDeviceControl => self.status().bits(),
+            DriveRegister::AlternateStatusDeviceControl => self.status().into_bits(),
         }
     }
 
@@ -589,8 +584,8 @@ impl HardDrive {
             DriveRegister::AlternateStatusDeviceControl => {
                 clear_hob = false;
                 let v = DeviceControlReg::from_bits_truncate(data);
-                self.state.regs.device_control_reg = v & !DeviceControlReg::RESET;
-                if v.contains(DeviceControlReg::RESET) && !self.state.pending_software_reset {
+                self.state.regs.device_control_reg = v.with_RESET(false);
+                if v.RESET() && !self.state.pending_software_reset {
                     if self.state.command.is_none() {
                         self.reset();
                     } else {
@@ -602,7 +597,10 @@ impl HardDrive {
         // Clear the HOB bit on command register writes, as specified in the
         // ATA spec.
         if clear_hob {
-            self.state.regs.device_control_reg &= !DeviceControlReg::HIGH_ORDER_BYTE;
+            self.state
+                .regs
+                .device_control_reg
+                .set_HIGH_ORDER_BYTE(false);
         }
     }
 
@@ -623,11 +621,7 @@ impl HardDrive {
 
     pub fn interrupt_pending(&self) -> bool {
         self.state.pending_interrupt
-            && !self
-                .state
-                .regs
-                .device_control_reg
-                .contains(DeviceControlReg::INTERRUPT_MASK)
+            && !self.state.regs.device_control_reg.INTERRUPT_MASK()
             && self.is_selected()
             && !self.state.pending_software_reset
     }
@@ -772,25 +766,27 @@ impl HardDrive {
             // The drive was not selected, so don't return status for the wrong
             // drive. This is used to support configurations with only device 0
             // enabled.
-            Status::empty()
+            Status::new()
         } else {
-            let mut status = Status::empty();
+            let mut status = Status::new();
             if self.state.pending_software_reset {
-                status |= Status::BSY;
+                status.set_BSY(true);
             } else if self.state.buffer.is_some() {
                 // Set DRQ if there is an accessible buffer.
-                status |= Status::DRQ | Status::DRDY;
+                status.set_DRQ(true);
+                status.set_DRDY(true);
             } else if self.state.command.is_some() {
                 // Set BSY if there is no buffer and a command is pending.
-                status |= Status::BSY;
+                status.set_BSY(true);
             } else {
-                status |= Status::DRDY;
+                status.set_DRDY(true);
             }
             if self.state.error_pending {
-                status |= Status::ERR;
+                status.set_ERR(true);
             }
             // Always set DSC.
-            status | Status::DSC
+            status.set_DSC(true);
+            status
         }
     }
 
@@ -808,12 +804,12 @@ impl HardDrive {
         }
 
         self.state.error_pending = false;
-        self.state.regs.error = ErrorReg::ERR_NONE;
+        self.state.regs.error = ErrorReg::new();
 
         let command = match command {
             IdeCommand::EXECUTE_DEVICE_DIAGNOSTIC => {
                 self.state.regs.reset_signature();
-                self.state.regs.error = ErrorReg::ERR_AMNF_ILI_DEFAULT;
+                self.state.regs.error = ErrorReg::new().with_ERR_AMNF_ILI_DEFAULT(true);
                 return Ok(());
             }
             x if (IdeCommand::RECALIBRATE_START..=IdeCommand::RECALIBRATE_END).contains(&x) => {
@@ -957,7 +953,7 @@ impl HardDrive {
             command => {
                 tracing::debug!(?command, "unknown command");
                 self.state.error_pending = true;
-                self.state.regs.error = ErrorReg::ERR_UNKNOWN_COMMAND;
+                self.state.regs.error = ErrorReg::new().with_ERR_UNKNOWN_COMMAND(true);
                 None
             }
         };
@@ -1347,10 +1343,10 @@ impl HardDrive {
     fn log_and_update_error(&mut self, error: IdeError, register: Option<DriveRegister>) {
         let ide_error = match error {
             IdeError::IdeBadLocation { .. } | IdeError::ZeroSector | IdeError::LbaBitNotSet => {
-                ErrorReg::ERR_BAD_LOCATION
+                ErrorReg::new().with_ERR_BAD_LOCATION(true)
             }
-            IdeError::IdeBadSector { .. } => ErrorReg::ERR_BAD_SECTOR,
-            IdeError::Flush { .. } => ErrorReg::ERR_UNKNOWN_COMMAND, // strange, but matches Hyper-V behavior
+            IdeError::IdeBadSector { .. } => ErrorReg::new().with_ERR_BAD_SECTOR(true),
+            IdeError::Flush { .. } => ErrorReg::new().with_ERR_UNKNOWN_COMMAND(true), // strange, but matches Hyper-V behavior
         };
 
         tracelimit::warn_ratelimited!(
@@ -1531,14 +1527,14 @@ pub(crate) mod save_restore {
 
             Ok(state::SavedHardDriveState {
                 registers: SavedRegisterState {
-                    error: error.bits(),
+                    error: error.into_bits(),
                     features: *features,
                     device_head: (*device_head).into(),
                     lba_low: *lba_low,
                     lba_mid: *lba_mid,
                     lba_high: *lba_high,
                     sector_count: *sector_count,
-                    device_control_reg: device_control_reg.bits(),
+                    device_control_reg: device_control_reg.into_bits(),
                 },
                 pending_interrupt: *pending_interrupt,
                 max_sector: *max_sector,
@@ -1621,7 +1617,7 @@ pub(crate) mod save_restore {
                     lba_mid,
                     lba_high,
                     sector_count,
-                    device_control_reg: DeviceControlReg::from_bits(device_control_reg).unwrap(),
+                    device_control_reg: DeviceControlReg::from_bits(device_control_reg),
                 },
                 pending_software_reset,
                 pending_interrupt,

--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -136,7 +136,7 @@ struct ChannelBusMasterState {
 
 impl ChannelBusMasterState {
     fn dma_io_type(&self) -> DmaType {
-        if self.command_reg.contains(BusMasterCommandReg::WRITE) {
+        if self.command_reg.WRITE() {
             DmaType::Write
         } else {
             DmaType::Read
@@ -298,12 +298,12 @@ impl Channel {
         }
 
         if let Some(status) = self.current_drive_status() {
-            if status.intersects(Status::ERR) {
+            if status.ERR() {
                 tracelimit::warn_ratelimited!(
                     "drive is in error state, ignoring enlightened command",
                 );
                 return IoResult::Ok;
-            } else if status.intersects(Status::BSY | Status::DRQ) {
+            } else if status.BSY() || status.DRQ() {
                 tracelimit::warn_ratelimited!(
                     "command is already pending on this drive, ignoring enlightened command"
                 );
@@ -450,23 +450,25 @@ impl Channel {
         let old_adapter_control_reg = self.state.shadow_adapter_control_reg;
         self.write_drive_register(
             DriveRegister::AlternateStatusDeviceControl,
-            DeviceControlReg::INTERRUPT_MASK.bits(),
+            DeviceControlReg::new()
+                .with_INTERRUPT_MASK(true)
+                .into_bits(),
             bus_master_state,
         );
 
         // Start the dma engine.
-        let mut bus_master_flags = BusMasterCommandReg::START;
+        let mut bus_master_flags = BusMasterCommandReg::new().with_START(true);
         if cmd == IdeCommand::READ_DMA_EXT
             || cmd == IdeCommand::READ_DMA
             || cmd == IdeCommand::READ_DMA_ALT
         {
             // set rw flag to 1 to inticate that bus master is performing a read
-            bus_master_flags |= BusMasterCommandReg::WRITE;
+            bus_master_flags.set_WRITE(true);
         }
 
         self.write_bus_master_reg(
             BusMasterReg::COMMAND,
-            &[bus_master_flags.bits() as u8],
+            &[bus_master_flags.into_bits() as u8],
             bus_master_state,
         )
         .unwrap();
@@ -485,7 +487,7 @@ impl Channel {
 
         tracing::trace!(enlightened_write = ?self.enlightened_write, "enlightened_hdd_command");
         if let Some(status) = self.current_drive_status() {
-            if status.intersects(Status::DRQ) {
+            if status.DRQ() {
                 tracelimit::warn_ratelimited!(
                     "command is waiting for data read from guest or data write to guest"
                 );
@@ -519,7 +521,9 @@ impl Channel {
         let old_adapter_control_reg = self.state.shadow_adapter_control_reg;
         self.write_drive_register(
             DriveRegister::AlternateStatusDeviceControl,
-            DeviceControlReg::INTERRUPT_MASK.bits(),
+            DeviceControlReg::new()
+                .with_INTERRUPT_MASK(true)
+                .into_bits(),
             bus_master_state,
         );
 
@@ -565,7 +569,7 @@ impl Channel {
 
         tracing::trace!(enlightened_write = ?self.enlightened_write, "enlightened_cd_command");
         if let Some(status) = self.current_drive_status() {
-            if status.intersects(Status::DRQ) {
+            if status.DRQ() {
                 tracelimit::warn_ratelimited!(
                     "command is waiting for data read from guest or data write to guest"
                 );
@@ -587,15 +591,15 @@ impl Channel {
 
         // Clear the pending interrupt and read status.
         let status = self.read_drive_register(DriveRegister::StatusCmd, bus_master_state);
-        let status = Status::from_bits_truncate(status);
+        let status = Status::from_bits(status);
 
-        if status.contains(Status::ERR) {
+        if status.ERR() {
             // If there was an error, copy back the status into the enlightened INT13 command in
             // the guest so that the guest can check it.
             if let Err(err) = self.guest_memory.write_at(
                 write.guest_address
                     + offset_of!(protocol::EnlightenedInt13Command, result_status) as u64,
-                &[status.bits()],
+                &[status.into_bits()],
             ) {
                 tracelimit::error_ratelimited!(
                     ?status,
@@ -622,15 +626,15 @@ impl Channel {
     ) {
         // Clear the pending interrupt and read status.
         let status = self.read_drive_register(DriveRegister::StatusCmd, bus_master_state);
-        let status = Status::from_bits_truncate(status);
+        let status = Status::from_bits(status);
 
-        if status.contains(Status::ERR) {
+        if status.ERR() {
             // If there was an error, copy back the status into the enlightened INT13 command in
             // the guest so that the guest can check it.
             if let Err(err) = self.guest_memory.write_at(
                 write.guest_address
                     + offset_of!(protocol::EnlightenedInt13Command, result_status) as u64,
-                &[status.bits()],
+                &[status.into_bits()],
             ) {
                 tracelimit::error_ratelimited!(
                     ?status,
@@ -1125,7 +1129,7 @@ impl Channel {
     fn current_drive_status(&mut self) -> Option<Status> {
         if let Some(drive) = &mut self.drives[self.state.current_drive_idx] {
             let status = drive.read_register(DriveRegister::AlternateStatusDeviceControl);
-            Some(Status::from_bits_truncate(status))
+            Some(Status::from_bits(status))
         } else {
             None
         }
@@ -1138,7 +1142,7 @@ impl Channel {
             .as_mut()
             .unwrap()
             .read_register(DriveRegister::AlternateStatusDeviceControl);
-        Status::from_bits_truncate(status)
+        Status::from_bits(status)
     }
 
     fn current_drive_type(&self) -> Option<DriveType> {
@@ -1168,8 +1172,8 @@ impl Channel {
 
             let status = self.drive_status(drive_index);
             let completed = match self.drive_type(drive_index) {
-                DriveType::Hard => !status.intersects(Status::BSY | Status::DRQ),
-                DriveType::Optical => status.intersects(Status::DRDY),
+                DriveType::Hard => !(status.BSY() || status.DRQ()),
+                DriveType::Optical => status.DRDY(),
             };
             if completed {
                 // The command is done.
@@ -1193,7 +1197,7 @@ impl Channel {
             .any(|drive| drive.interrupt_pending());
         if interrupt {
             tracing::trace!(channel = self.channel, interrupt, "post_drive_access");
-            self.bus_master_state.status_reg |= BusMasterStatusReg::INTERRUPT;
+            self.bus_master_state.status_reg.set_INTERRUPT(true);
         }
         self.interrupt.set_level(interrupt);
     }
@@ -1246,9 +1250,7 @@ impl Channel {
                 // Save this for restoring in the enlightened path.
                 self.state.shadow_adapter_control_reg = data;
                 let v = DeviceControlReg::from_bits_truncate(data);
-                if v.contains(DeviceControlReg::RESET)
-                    && (self.drives[0].is_some() || self.drives[1].is_some())
-                {
+                if v.RESET() && (self.drives[0].is_some() || self.drives[1].is_some()) {
                     self.state = ChannelState::default();
                 }
             }
@@ -1313,7 +1315,7 @@ impl Channel {
         match bus_master_reg {
             BusMasterReg::COMMAND => match data_len {
                 1 | 2 => data.copy_from_slice(
-                    &self.bus_master_state.command_reg.bits().to_ne_bytes()[..data_len],
+                    &self.bus_master_state.command_reg.into_bits().to_ne_bytes()[..data_len],
                 ),
                 _ => return IoResult::Err(IoError::InvalidAccessSize),
             },
@@ -1321,11 +1323,11 @@ impl Channel {
                 let mut status = self.bus_master_state.status_reg;
 
                 if self.bus_master_state.dma_state.is_some() {
-                    status |= BusMasterStatusReg::ACTIVE;
+                    status.set_ACTIVE(true);
                 }
 
                 match data_len {
-                    1 | 2 => data.copy_from_slice(&status.bits().to_ne_bytes()[..data_len]),
+                    1 | 2 => data.copy_from_slice(&status.into_bits().to_ne_bytes()[..data_len]),
                     _ => return IoResult::Err(IoError::InvalidAccessSize),
                 }
             }
@@ -1377,15 +1379,14 @@ impl Channel {
                 let mut new_value = BusMasterCommandReg::from_bits_truncate(value as u32);
 
                 // The read/write bit is marked as read-only when dma is active.
-                if old_value.contains(BusMasterCommandReg::START) {
+                if old_value.START() {
                     // Set the new value of the read/write flag to match the
                     // existing value, regardless of the new value of the flag.
-                    new_value.remove(BusMasterCommandReg::WRITE);
-                    new_value |= old_value & BusMasterCommandReg::WRITE;
-                    if !new_value.contains(BusMasterCommandReg::START) {
+                    new_value.set_WRITE(old_value.WRITE());
+                    if !new_value.START() {
                         self.bus_master_state.dma_state = None
                     }
-                } else if new_value.contains(BusMasterCommandReg::START) {
+                } else if new_value.START() {
                     self.bus_master_state.dma_state = Some(Default::default());
                 };
 
@@ -1398,12 +1399,15 @@ impl Channel {
 
                 let value = BusMasterStatusReg::from_bits_truncate(value as u32);
                 let old_value = self.bus_master_state.status_reg;
-                let mut new_value = (old_value & !BusMasterStatusReg::SETTABLE)
-                    | (value & BusMasterStatusReg::SETTABLE);
+                let mut new_value = old_value.with_settable(value.settable());
 
                 // These bits are reset if a one is written
-                new_value &=
-                    !(value & (BusMasterStatusReg::INTERRUPT | BusMasterStatusReg::DMA_ERROR));
+                if value.INTERRUPT() {
+                    new_value.set_INTERRUPT(false);
+                }
+                if value.DMA_ERROR() {
+                    new_value.set_DMA_ERROR(false);
+                }
 
                 tracing::trace!(?old_value, ?new_value, "set bus master status");
                 self.bus_master_state.status_reg = new_value;
@@ -1626,8 +1630,8 @@ mod save_restore {
                 shadow_adapter_control_reg,
                 shadow_features_reg,
                 bus_master: state::SavedChannelBusMasterState {
-                    command_reg: command_reg.bits(),
-                    status_reg: status_reg.bits(),
+                    command_reg: command_reg.into_bits(),
+                    status_reg: status_reg.into_bits(),
                     desc_table_ptr: *desc_table_ptr,
                     dma_state: dma_state.as_ref().map(|dma| {
                         let DmaState {
@@ -1683,8 +1687,8 @@ mod save_restore {
             };
 
             self.bus_master_state = ChannelBusMasterState {
-                command_reg: BusMasterCommandReg::from_bits(command_reg).unwrap(),
-                status_reg: BusMasterStatusReg::from_bits(status_reg).unwrap(),
+                command_reg: BusMasterCommandReg::from_bits(command_reg),
+                status_reg: BusMasterStatusReg::from_bits(status_reg),
                 desc_table_ptr,
                 dma_state: dma_state.map(|dma| {
                     let state::SavedDmaState {
@@ -1866,14 +1870,14 @@ mod tests {
             )
             .unwrap();
 
-        Status::from_bits(data[0]).unwrap()
+        Status::from_bits(data[0])
     }
 
     async fn check_status_loop(ide_device: &mut IdeDevice, dev_path: &IdePath) -> Status {
         // loop until device is not busy and is ready to transfer data.
         wait_for(ide_device, |ide_device| {
             let status: Status = get_status(ide_device, dev_path);
-            (!status.contains(Status::BSY) && !status.contains(Status::DRQ)).then_some(status)
+            (!status.BSY() && !status.DRQ()).then_some(status)
         })
         .await
     }
@@ -1882,7 +1886,7 @@ mod tests {
         // loop until device is not busy and is ready to transfer data.
         wait_for(ide_device, |ide_device| {
             let status: Status = get_status(ide_device, dev_path);
-            (!status.contains(Status::BSY) && status.contains(Status::DRDY)).then_some(status)
+            (!status.BSY() && status.DRDY()).then_some(status)
         })
         .await
     }
@@ -2075,20 +2079,22 @@ mod tests {
 
         // drive status should contain DRQ as data is ready to be exchanged with host
         let status = get_status(&mut ide_device, &dev_path);
-        assert!(status.contains(Status::DRQ) && !status.contains(Status::BSY));
+        assert!(status.DRQ() && !status.BSY());
 
         // PIO - writes to data port
         let data = &[0xFF_u8; 2][..];
         for _ in 0..SECTOR_COUNT {
             let status = check_command_ready(&mut ide_device, &dev_path).await;
-            assert_eq!(status & (Status::ERR | Status::DRQ), Status::DRQ);
+            assert!(status.DRQ());
+            assert!(!status.ERR());
             for _ in 0..protocol::HARD_DRIVE_SECTOR_BYTES / 2 {
                 ide_device.io_write(IdeIoPort::PRI_DATA.0, data).unwrap();
             }
         }
 
         let status = check_command_ready(&mut ide_device, &dev_path).await;
-        assert_eq!(status & (Status::ERR | Status::DRQ), Status::empty());
+        assert!(!status.ERR());
+        assert!(!status.DRQ());
 
         let buffer =
             &mut [0_u8; (protocol::HARD_DRIVE_SECTOR_BYTES * SECTOR_COUNT as u32) as usize][..];
@@ -2124,11 +2130,11 @@ mod tests {
         execute_command(&mut ide_device, &dev_path, IdeCommand::WRITE_SECTORS.0);
         // drive status should contain DRQ as data is ready to be exchanged with host
         let status = get_status(&mut ide_device, &dev_path);
-        assert!(status.contains(Status::DRQ) && !status.contains(Status::BSY));
+        assert!(status.DRQ() && !status.BSY());
 
         execute_soft_reset_command(&mut ide_device, &dev_path, IdeCommand::SOFT_RESET.0);
         let status = get_status(&mut ide_device, &dev_path);
-        assert!(status.contains(Status::BSY));
+        assert!(status.BSY());
     }
 
     // Command: READ SECTOR(S)
@@ -2159,13 +2165,15 @@ mod tests {
         execute_command(&mut ide_device, &dev_path, IdeCommand::READ_SECTORS.0);
 
         let status = check_command_ready(&mut ide_device, &dev_path).await;
-        assert_eq!(status & (Status::ERR | Status::DRQ), Status::DRQ);
+        assert!(status.DRQ());
+        assert!(!status.ERR());
 
         // PIO - reads data from track cache buffer
         let content_bytes = file_contents.as_bytes();
         for sector in 0..SECTOR_COUNT {
             let status = check_command_ready(&mut ide_device, &dev_path).await;
-            assert_eq!(status & (Status::ERR | Status::DRQ), Status::DRQ);
+            assert!(status.DRQ());
+            assert!(!status.ERR());
             for word in 0..protocol::HARD_DRIVE_SECTOR_BYTES / 2 {
                 let data = &mut [0, 0][..];
                 ide_device.io_read(IdeIoPort::PRI_DATA.0, data).unwrap();
@@ -2278,7 +2286,8 @@ mod tests {
         );
 
         let status = check_command_ready(&mut ide_device, &dev_path).await;
-        assert_eq!(status & (Status::ERR | Status::DRQ), Status::DRQ);
+        assert!(status.DRQ());
+        assert!(!status.ERR());
 
         // PIO - reads data from track cache buffer
         let data = &mut [0_u8; protocol::IDENTIFY_DEVICE_BYTES];
@@ -2321,7 +2330,8 @@ mod tests {
         execute_command(&mut ide_device, &dev_path, IdeCommand::IDENTIFY_DEVICE.0);
 
         let status = check_command_ready(&mut ide_device, &dev_path).await;
-        assert_eq!(status & (Status::ERR | Status::DRQ), Status::DRQ);
+        assert!(status.DRQ());
+        assert!(!status.ERR());
 
         // PIO - reads data from track cache buffer
         let data = &mut [0_u8; protocol::IDENTIFY_DEVICE_BYTES];

--- a/vm/devices/storage/ide/src/protocol.rs
+++ b/vm/devices/storage/ide/src/protocol.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 use bitfield_struct::bitfield;
-use bitflags::bitflags;
 use inspect::Inspect;
 use open_enum::open_enum;
 use zerocopy::AsBytes;
@@ -16,19 +15,25 @@ mod packed_nums {
 }
 
 // status register flags
-bitflags! {
-    #[derive(Inspect)]
-    #[inspect(debug)]
-    pub struct Status: u8 {
-        const ERR =  0b0000_0001; // Error occurred on last transaction (see error reg for details)
-        const HIT =  0b0000_0010; // Set once per rotation (we don't support it)
-        const CORR =  0b0000_0100; // Correctable read error was hit (we don't support it)
-        const DRQ =  0b0000_1000; // Drive wants to exchange data with host
-        const DSC =  0b0001_0000; // Heads are positioned over desired cylinder
-        const DF =  0b0010_0000; // Drive fault - major hardware error (we don't support it)
-        const DRDY = 0b0100_0000; // Drive is ready for next command
-        const BSY =  0b1000_0000; // Host cannot access any IDE registers at this time
-    }
+#[derive(Inspect)]
+#[bitfield(u8)]
+pub struct Status {
+    /// Error occurred on last transaction (see error reg for details)
+    pub ERR: bool,
+    /// Set once per rotation (we don't support it)
+    pub HIT: bool,
+    /// Correctable read error was hit (we don't support it)
+    pub CORR: bool,
+    /// Drive wants to exchange data with host
+    pub DRQ: bool,
+    /// Heads are positioned over desired cylinder
+    pub DSC: bool,
+    /// Drive fault - major hardware error (we don't support it)
+    pub DF: bool,
+    /// Drive is ready for next command
+    pub DRDY: bool,
+    /// Host cannot access any IDE registers at this time
+    pub BSY: bool,
 }
 
 // ide commands
@@ -85,26 +90,26 @@ open_enum! {
 }
 
 // errors
-bitflags! {
-    #[repr(C)]
-    #[derive(Inspect, AsBytes, FromBytes, FromZeroes)]
-    pub struct ErrorReg: u8 {
-        const ERR_NONE = 0x00;
-        const ERR_AMNF_ILI_DEFAULT = 0x01; // no address mark or illegal length indication, register default values
-        const ERR_TK0NF_EOM = 0x02; // track 0 not found or end of media detected
-        const ERR_UNKNOWN_COMMAND = 0x04; // Command aborted
-        const ERR_MCR = 0x08; // media change request
-        const ERR_BAD_LOCATION = 0x10; // IDNF, ID mark not found
-        const ERR_MEDIA_CHANGED = 0x20; // mc, media changed
-        const ERR_UNC = 0x40; // uncorrectable data
-        const ERR_BAD_SECTOR = 0x80; // bbk, bad block
-    }
-}
-
-impl From<u8> for ErrorReg {
-    fn from(v: u8) -> Self {
-        Self::from_bits(v).unwrap()
-    }
+#[derive(Inspect)]
+#[bitfield(u8)]
+#[derive(AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
+pub struct ErrorReg {
+    /// no address mark or illegal length indication, register default values
+    pub ERR_AMNF_ILI_DEFAULT: bool,
+    /// track 0 not found or end of media detected
+    pub ERR_TK0NF_EOM: bool,
+    /// Command aborted
+    pub ERR_UNKNOWN_COMMAND: bool,
+    /// media change request
+    pub ERR_MCR: bool,
+    /// IDNF, ID mark not found
+    pub ERR_BAD_LOCATION: bool,
+    /// mc, media changed
+    pub ERR_MEDIA_CHANGED: bool,
+    /// uncorrectable data
+    pub ERR_UNC: bool,
+    /// bbk, bad block
+    pub ERR_BAD_SECTOR: bool,
 }
 
 pub const MAX_SECTORS_MULT_TRANSFER_DEFAULT: u16 = 128;
@@ -226,31 +231,61 @@ open_enum! {
     }
 }
 
-bitflags! {
-    #[derive(Default, Inspect)]
-    #[inspect(debug)]
-    pub struct BusMasterCommandReg: u32 {
-        const START = 0x01;
-        const WRITE = 0x08;
-    }
+#[derive(Inspect)]
+#[bitfield(u32)]
+pub struct BusMasterCommandReg {
+    pub START: bool,
+    #[bits(2)]
+    reserved: u32,
+    pub WRITE: bool,
+    #[bits(28)]
+    reserved2: u32,
+}
 
-    #[derive(Default, Inspect)]
-    #[inspect(debug)]
-    pub struct BusMasterStatusReg: u32 {
-        const ACTIVE = 0x01;
-        const DMA_ERROR = 0x02;
-        const INTERRUPT = 0x04;
-        const SETTABLE = 0x60; // Don't know what these bits mean, but they can be set by the guest.
+impl BusMasterCommandReg {
+    pub fn from_bits_truncate(bits: u32) -> Self {
+        Self::from_bits(bits).with_reserved(0).with_reserved2(0)
     }
 }
 
-bitflags! {
-    #[derive(Inspect)]
-    #[inspect(debug)]
-    pub struct DeviceControlReg: u8 {
-        const HIGH_ORDER_BYTE = 0x80;   // HOB
-        const RESET = 0x4;              // SRST
-        const INTERRUPT_MASK = 0x2;     // nIEN
+#[derive(Inspect)]
+#[bitfield(u32)]
+pub struct BusMasterStatusReg {
+    pub ACTIVE: bool,
+    pub DMA_ERROR: bool,
+    pub INTERRUPT: bool,
+    #[bits(2)]
+    reserved: u32,
+    /// Don't know what these bits mean, but they can be set by the guest.
+    #[bits(2)]
+    pub settable: u32,
+    #[bits(25)]
+    reserved2: u32,
+}
+
+impl BusMasterStatusReg {
+    pub fn from_bits_truncate(bits: u32) -> Self {
+        Self::from_bits(bits).with_reserved(0).with_reserved2(0)
+    }
+}
+
+#[derive(Inspect)]
+#[bitfield(u8)]
+pub struct DeviceControlReg {
+    reserved: bool,
+    /// nIEN
+    pub INTERRUPT_MASK: bool,
+    /// SRST
+    pub RESET: bool,
+    #[bits(4)]
+    reserved2: u8,
+    /// HOB
+    pub HIGH_ORDER_BYTE: bool,
+}
+
+impl DeviceControlReg {
+    pub fn from_bits_truncate(bits: u8) -> Self {
+        Self::from_bits(bits).with_reserved(false).with_reserved2(0)
     }
 }
 

--- a/vm/devices/storage/ide/src/protocol.rs
+++ b/vm/devices/storage/ide/src/protocol.rs
@@ -95,21 +95,21 @@ open_enum! {
 #[derive(AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct ErrorReg {
     /// no address mark or illegal length indication, register default values
-    pub err_amnf_ili_default: bool,
+    pub amnf_ili_default: bool,
     /// track 0 not found or end of media detected
-    pub err_tk0nf_eom: bool,
+    pub tk0nf_eom: bool,
     /// Command aborted
-    pub err_unknown_command: bool,
+    pub unknown_command: bool,
     /// media change request
-    pub err_mcr: bool,
+    pub mcr: bool,
     /// IDNF, ID mark not found
-    pub err_bad_location: bool,
+    pub bad_location: bool,
     /// mc, media changed
-    pub err_media_changed: bool,
+    pub media_changed: bool,
     /// uncorrectable data
-    pub err_unc: bool,
+    pub unc: bool,
     /// bbk, bad block
-    pub err_bad_sector: bool,
+    pub bad_sector: bool,
 }
 
 pub const MAX_SECTORS_MULT_TRANSFER_DEFAULT: u16 = 128;

--- a/vm/devices/storage/ide/src/protocol.rs
+++ b/vm/devices/storage/ide/src/protocol.rs
@@ -19,21 +19,21 @@ mod packed_nums {
 #[bitfield(u8)]
 pub struct Status {
     /// Error occurred on last transaction (see error reg for details)
-    pub ERR: bool,
+    pub err: bool,
     /// Set once per rotation (we don't support it)
-    pub HIT: bool,
+    pub hit: bool,
     /// Correctable read error was hit (we don't support it)
-    pub CORR: bool,
+    pub corr: bool,
     /// Drive wants to exchange data with host
-    pub DRQ: bool,
+    pub drq: bool,
     /// Heads are positioned over desired cylinder
-    pub DSC: bool,
+    pub dsc: bool,
     /// Drive fault - major hardware error (we don't support it)
-    pub DF: bool,
+    pub df: bool,
     /// Drive is ready for next command
-    pub DRDY: bool,
+    pub drdy: bool,
     /// Host cannot access any IDE registers at this time
-    pub BSY: bool,
+    pub bsy: bool,
 }
 
 // ide commands
@@ -95,21 +95,21 @@ open_enum! {
 #[derive(AsBytes, FromBytes, FromZeroes, PartialEq, Eq)]
 pub struct ErrorReg {
     /// no address mark or illegal length indication, register default values
-    pub ERR_AMNF_ILI_DEFAULT: bool,
+    pub err_amnf_ili_default: bool,
     /// track 0 not found or end of media detected
-    pub ERR_TK0NF_EOM: bool,
+    pub err_tk0nf_eom: bool,
     /// Command aborted
-    pub ERR_UNKNOWN_COMMAND: bool,
+    pub err_unknown_command: bool,
     /// media change request
-    pub ERR_MCR: bool,
+    pub err_mcr: bool,
     /// IDNF, ID mark not found
-    pub ERR_BAD_LOCATION: bool,
+    pub err_bad_location: bool,
     /// mc, media changed
-    pub ERR_MEDIA_CHANGED: bool,
+    pub err_media_changed: bool,
     /// uncorrectable data
-    pub ERR_UNC: bool,
+    pub err_unc: bool,
     /// bbk, bad block
-    pub ERR_BAD_SECTOR: bool,
+    pub err_bad_sector: bool,
 }
 
 pub const MAX_SECTORS_MULT_TRANSFER_DEFAULT: u16 = 128;
@@ -234,10 +234,10 @@ open_enum! {
 #[derive(Inspect)]
 #[bitfield(u32)]
 pub struct BusMasterCommandReg {
-    pub START: bool,
+    pub start: bool,
     #[bits(2)]
     reserved: u32,
-    pub WRITE: bool,
+    pub write: bool,
     #[bits(28)]
     reserved2: u32,
 }
@@ -251,9 +251,9 @@ impl BusMasterCommandReg {
 #[derive(Inspect)]
 #[bitfield(u32)]
 pub struct BusMasterStatusReg {
-    pub ACTIVE: bool,
-    pub DMA_ERROR: bool,
-    pub INTERRUPT: bool,
+    pub active: bool,
+    pub dma_error: bool,
+    pub interrupt: bool,
     #[bits(2)]
     reserved: u32,
     /// Don't know what these bits mean, but they can be set by the guest.
@@ -274,13 +274,13 @@ impl BusMasterStatusReg {
 pub struct DeviceControlReg {
     reserved: bool,
     /// nIEN
-    pub INTERRUPT_MASK: bool,
+    pub interrupt_mask: bool,
     /// SRST
-    pub RESET: bool,
+    pub reset: bool,
     #[bits(4)]
     reserved2: u8,
     /// HOB
-    pub HIGH_ORDER_BYTE: bool,
+    pub high_order_byte: bool,
 }
 
 impl DeviceControlReg {


### PR DESCRIPTION
The last bit of making our code fully bitflags-free and unified.