### PR TITLE
Fixup some vmm test comments

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -121,7 +121,6 @@ async fn vbs_boot_single_proc(config: PetriVmConfig) -> anyhow::Result<()> {
 }
 
 /// Basic VBS boot test with TPM enabled.
-// TODO: Reenable the linux test after the reboot failure is resolved.
 #[vmm_test(
     openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64))
@@ -143,7 +142,7 @@ async fn vbs_boot_with_tpm(config: PetriVmConfig) -> anyhow::Result<()> {
 }
 
 /// Validate we can reboot a VM and reconnect to pipette.
-// TODO: Reenable interesting guests once #523 is fixed.
+// TODO: Reenable interesting guests once #74 is fixed.
 #[vmm_test(
     linux_direct_x64,
     openhcl_linux_direct_x64,


### PR DESCRIPTION
The first one is fixed, the comment is no longer needed. The second was referencing an issue in our old staging repo, not the ported version in this repo.