### PR TITLE
Fixup return position impl trait overcapturing for the 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -588,9 +588,8 @@ nonstandard_style = { level = "deny", priority = -2 }
 rust_2018_idioms = { level = "deny", priority = -2 }
 
 rust-2024-compatibility = { level = "warn", priority = -1 }
-# TODO: Fix all of the below, https://github.com/microsoft/openvmm/issues/288
 edition_2024_expr_fragment_specifier = "allow"
-impl_trait_overcaptures = "allow"
+# TODO: Fix all of the below, https://github.com/microsoft/openvmm/issues/288
 deprecated-safe-2024 = "allow"
 tail-expr-drop-order = "allow"
 if-let-rescope = "allow"

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -69,7 +69,7 @@ fn allocate_vtl2_ram(
     params: &ShimParams,
     partition_memory_map: &[MemoryEntry],
     ram_size: Option<u64>,
-) -> OffStackRef<'static, impl AsRef<[MemoryEntry]>> {
+) -> OffStackRef<'static, impl AsRef<[MemoryEntry]> + use<>> {
     // First, calculate how many numa nodes there are by looking at unique numa
     // nodes in the memory map.
     let mut numa_nodes = off_stack!(ArrayVec<u32, MAX_NUMA_NODES>, ArrayVec::new_const());
@@ -262,7 +262,7 @@ fn allocate_vtl2_ram(
 fn parse_host_vtl2_ram(
     params: &ShimParams,
     memory: &[MemoryEntry],
-) -> OffStackRef<'static, impl AsRef<[MemoryEntry]>> {
+) -> OffStackRef<'static, impl AsRef<[MemoryEntry]> + use<>> {
     // If no VTL2 protectable ram was provided by the host, use the build time
     // value encoded in ShimParams.
     let mut vtl2_ram = off_stack!(ArrayVec<MemoryEntry, MAX_NUMA_NODES>, ArrayVec::new_const());

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -126,7 +126,7 @@ impl PartitionInfo {
     }
 
     /// Returns the parameter regions that are not being reclaimed.
-    pub fn vtl2_config_regions(&self) -> impl Iterator<Item = MemoryRange> {
+    pub fn vtl2_config_regions(&self) -> impl Iterator<Item = MemoryRange> + use<> {
         subtract_ranges(
             [self.vtl2_full_config_region],
             [self.vtl2_config_region_reclaim],

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -314,7 +314,7 @@ enum ReservedMemoryType {
 fn reserved_memory_regions(
     partition_info: &PartitionInfo,
     sidecar: Option<&SidecarConfig<'_>>,
-) -> OffStackRef<'static, impl AsRef<[(MemoryRange, ReservedMemoryType)]>> {
+) -> OffStackRef<'static, impl AsRef<[(MemoryRange, ReservedMemoryType)]> + use<>> {
     let mut reserved = off_stack!(ArrayVec<(MemoryRange, ReservedMemoryType), MAX_RESERVED_MEM_RANGES>, ArrayVec::new_const());
     reserved.clear();
     reserved.extend(

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -364,7 +364,7 @@ impl VmService {
         &self,
         ctx: mesh::CancelContext,
         request: inspect_proto::InspectRequest,
-    ) -> impl Future<Output = anyhow::Result<InspectResponse2>> {
+    ) -> impl Future<Output = anyhow::Result<InspectResponse2>> + use<> {
         let mut inspection = InspectionBuilder::new(&request.path)
             .depth(Some(request.depth as usize))
             .inspect(inspect::adhoc(|req| {
@@ -387,7 +387,7 @@ impl VmService {
         &self,
         ctx: mesh::CancelContext,
         request: inspect_proto::UpdateRequest,
-    ) -> impl Future<Output = anyhow::Result<UpdateResponse2>> {
+    ) -> impl Future<Output = anyhow::Result<UpdateResponse2>> + use<> {
         let update = inspect::update(
             &request.path,
             &request.value,
@@ -603,12 +603,12 @@ impl VmService {
         Ok(())
     }
 
-    fn pause_vm(&mut self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> {
+    fn pause_vm(&mut self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> + use<> {
         let recv = vm.worker_rpc.call(VmRpc::Pause, ());
         async move { recv.await.map(drop).context("pause failed") }
     }
 
-    fn resume_vm(&mut self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> {
+    fn resume_vm(&mut self, vm: &Vm) -> impl Future<Output = anyhow::Result<()>> + use<> {
         let recv = vm.worker_rpc.call(VmRpc::Resume, ());
         async move { recv.await.map(drop).context("resume failed") }
     }
@@ -617,7 +617,7 @@ impl VmService {
         &mut self,
         mut ctx: mesh::CancelContext,
         vm: Arc<Vm>,
-    ) -> anyhow::Result<impl Future<Output = anyhow::Result<()>>> {
+    ) -> anyhow::Result<impl Future<Output = anyhow::Result<()>> + use<>> {
         let mut notify_recv = vm
             .notify_recv
             .lock()
@@ -642,7 +642,7 @@ impl VmService {
         &mut self,
         vm: &Vm,
         request: vmservice::ModifyResourceRequest,
-    ) -> anyhow::Result<impl Future<Output = anyhow::Result<()>>> {
+    ) -> anyhow::Result<impl Future<Output = anyhow::Result<()>> + use<>> {
         use vmservice::modify_resource_request::Resource;
         match request.resource.context("missing resource")? {
             Resource::ScsiDisk(disk) => {

--- a/support/fdt/src/parser.rs
+++ b/support/fdt/src/parser.rs
@@ -671,7 +671,7 @@ impl<'a> Property<'a> {
     }
 
     /// Read data as an iterator of u64 values.
-    pub fn as_64_list(&self) -> Result<impl Iterator<Item = u64> + 'a, Error<'a>> {
+    pub fn as_64_list(&self) -> Result<impl Iterator<Item = u64> + use<'a>, Error<'a>> {
         Ok(U64b::slice_from(self.data)
             .ok_or(Error(ErrorKind::PropertyDataTypeBuffer {
                 node_name: self.node_name,

--- a/support/mesh/mesh_protobuf/src/protobuf.rs
+++ b/support/mesh/mesh_protobuf/src/protobuf.rs
@@ -666,7 +666,7 @@ impl<'a, 'b, R> MessageReader<'a, 'b, R> {
     }
 
     /// Returns an iterator to consume the resources for this message.
-    pub fn take_resources(&mut self) -> impl 'b + ExactSizeIterator<Item = Result<R>> {
+    pub fn take_resources(&mut self) -> impl ExactSizeIterator<Item = Result<R>> + use<'b, R> {
         let state = self.state;
         self.resources.clone().map(move |i| {
             state

--- a/vm/devices/pci/pci_core/src/capabilities/msix.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/msix.rs
@@ -233,7 +233,7 @@ impl MsixEmulator {
         bar: u8,
         count: u16,
         register_msi: &mut dyn RegisterMsi,
-    ) -> (Self, impl PciCapability) {
+    ) -> (Self, impl PciCapability + use<>) {
         let state = MsixState {
             enabled: false,
             vectors: (0..count)

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -452,7 +452,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
         drop(self);
     }
 
-    fn reset(&mut self) -> impl 'static + Send + std::future::Future<Output = ()> {
+    fn reset(&mut self) -> impl Send + std::future::Future<Output = ()> + use<T> {
         let driver = self.driver.clone();
         let mut task = std::mem::take(&mut self.task).unwrap();
         async move {

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -221,7 +221,7 @@ impl VmbusClientAccess {
     pub fn connect_hvsock(
         &self,
         request: HvsockConnectRequest,
-    ) -> impl Future<Output = Option<OfferInfo>> {
+    ) -> impl Future<Output = Option<OfferInfo>> + use<> {
         self.client_request_send
             .call(ClientRequest::HvsockConnect, request)
             .map(|r| r.ok().flatten())

--- a/vm/devices/vmbus/vmbus_client_hcl/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client_hcl/src/lib.rs
@@ -32,9 +32,9 @@ use zerocopy::AsBytes;
 
 /// Returns the synic client and message source for use with
 /// [`vmbus_client::VmbusClient`].
-pub fn new_synic_client_and_messsage_source(
-    driver: &(impl Driver + ?Sized),
-) -> anyhow::Result<(impl SynicClient, impl VmbusMessageSource)> {
+pub fn new_synic_client_and_messsage_source<T: Driver + ?Sized>(
+    driver: &T,
+) -> anyhow::Result<(impl SynicClient + use<T>, impl VmbusMessageSource + use<T>)> {
     // Open an HCL vmbus fd for issuing synic requests.
     let hcl_vmbus = Arc::new(HclVmbus::new().context("failed to open hcl_vmbus")?);
     let synic = HclSynic {

--- a/vm/devices/vmbus/vmbus_server/src/hvsock.rs
+++ b/vm/devices/vmbus/vmbus_server/src/hvsock.rs
@@ -114,7 +114,7 @@ impl HvsockRelay {
         &self,
         ctx: &mut CancelContext,
         service_id: Guid,
-    ) -> impl std::future::Future<Output = anyhow::Result<UnixStream>> + Send {
+    ) -> impl std::future::Future<Output = anyhow::Result<UnixStream>> + Send + use<> {
         let inner = self.inner.clone();
         let host_send = self.host_send.clone();
         let (send, recv) = mesh::oneshot();

--- a/vmm_core/state_unit/src/lib.rs
+++ b/vmm_core/state_unit/src/lib.rs
@@ -888,12 +888,12 @@ impl ReadySet {
 /// future with a span, and wrapping its error with something more informative.
 ///
 /// `operation` and `name` are used in tracing and error construction.
-fn state_change<I: 'static, R: 'static + Send>(
+fn state_change<I: 'static, R: 'static + Send, Req: FnOnce(Rpc<I, R>) -> StateRequest>(
     name: Arc<str>,
     unit: &Unit,
-    request: impl FnOnce(Rpc<I, R>) -> StateRequest,
+    request: Req,
     input: Option<I>,
-) -> impl Future<Output = Result<Option<R>, UnitRecvError>> {
+) -> impl Future<Output = Result<Option<R>, UnitRecvError>> + use<I, R, Req> {
     let send = unit.send.clone();
 
     async move {

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1642,7 +1642,7 @@ mod aarch64 {
             &self,
             vp: VpIndex,
             vtl: Vtl,
-        ) -> impl hv1_emulator::RequestInterrupt {
+        ) -> impl hv1_emulator::RequestInterrupt + use<> {
             let _ = (vp, vtl);
             move |_vec, _auto_eoi| todo!("TODO-aarch64")
         }

--- a/vmm_core/virt_whp/src/vtl2.rs
+++ b/vmm_core/virt_whp/src/vtl2.rs
@@ -190,7 +190,7 @@ pub(crate) struct Vtl2Emulation {
 mod inspect_helpers {
     use super::*;
 
-    pub(super) fn vsm_config_raw(raw: &AtomicU64) -> impl Inspect {
+    pub(super) fn vsm_config_raw(raw: &AtomicU64) -> impl Inspect + use<> {
         let config = HvRegisterVsmPartitionConfig::from(raw.load(Ordering::Relaxed));
         inspect::AsDebug(config)
     }


### PR DESCRIPTION
The Rust 2024 edition will be changing how `impl Trait` in return position functions. Namely it will be changing the rules from capturing no lifetimes, to capturing all lifetimes. The reasons for this are documented in [RFC 3498](https://github.com/rust-lang/rfcs/blob/master/text/3498-lifetime-capture-rules-2024.md) and [the migration guide](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html). A new 'precise capturing' syntax has been added to allow cases that don't need everything captured to scope down what they take. This PR updates all such cases to use the new syntax.

Note that currently this new syntax requires all type parameters in scope to be listed. This currently results in overcapturing of type parameters. This will be relaxed in the future, and is tracked by [RFC 3617](https://github.com/rust-lang/rust/issues/130043).

This PR also marks the edition_2024_expr_fragment_specifier lint as no longer needing fixing, as I have completed an audit of all our macros that it flagged and none of them need changing.

Part of #288