### PR TITLE
ci: fixes for issues with unsafe reviewers script

### DIFF
--- a/.github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py
+++ b/.github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py
@@ -8,7 +8,7 @@ from github import Auth
 @click.argument('target_branch', required=True)
 @click.option('--token', default=None)
 @click.option('--pull-request', default=None)
-@click.option('--team', default='openvmm-unsafe-approvers')
+@click.option('--team', default='@microsoft/openvmm-unsafe-approvers')
 def main(repo_path: str, target_branch: str, token: str, pull_request: str, team: str):
     def contains_unsafe(change) -> bool:
         if change.change_type not in ['A', 'M'] or not change.a_path.endswith('.rs'):

--- a/.github/workflows/unsafe-reviewers.yml
+++ b/.github/workflows/unsafe-reviewers.yml
@@ -39,6 +39,14 @@ jobs:
           fetch-depth: 0
           path: head-repo
 
+      - name: Get merge base commit
+        id: merge-base
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git merge-base HEAD origin/${{ github.base_ref }} > merge-base.txt
+          echo "MERGE_BASE=$(cat merge-base.txt)" >> $GITHUB_ENV
+        working-directory: head-repo
+
       - name: Run unsafe code review script
-        run: pip3 install -r ./base/.github/scripts/add_unsafe_reviewers/requirements.txt && python3 ./base/.github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py ./head-repo "origin/${{ github.base_ref }}" --token "${{ secrets.GITHUB_TOKEN }}" --pull-request "${{ github.event.number }}"
+        run: pip3 install -r ./base/.github/scripts/add_unsafe_reviewers/requirements.txt && python3 ./base/.github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py ./head-repo "${{ env.MERGE_BASE }}" --token "${{ secrets.GITHUB_TOKEN }}" --pull-request "${{ github.event.number }}"
         shell: bash


### PR DESCRIPTION
#503 tried to re-enable the unsafe reviewers script but had it had a few issues:
1. It was diffing with `origin/main`, which meant that if a PR hadn't merged main the diff could contain changes that weren't introduced in the PR.
2. When assigning the review, it was unable to find the `openvmm-unsafe-approvers` team.

To try and fix those issues this change does the following:
1. It computes the merge base of the PR using `git merge-base` to more accurately replicate the GitHub diff
2. The team has been changed from `openvmm-unsafe-approvers` to `@microsoft/openvmm-unsafe-approvers`

I tested this on my fork by pushing a change to my main with unsafe changes and running the action without merging main on a PR on my fork. I verified that the unsafe change on main wasn't triggering the unsafe review on a PR without unsafe changes. I'm unable to test the team change on my fork because `@microsoft/openvmm-unsafe-approvers` isn't a collaborator. I've also verified that a PR with unsafe changes still correctly triggers the reviewer assignment.