### PR TITLE
user_driver: use ramfs to allocate DMA buffers

### DIFF
--- a/openhcl/underhill_init/src/lib.rs
+++ b/openhcl/underhill_init/src/lib.rs
@@ -547,6 +547,14 @@ fn do_main() -> anyhow::Result<()> {
             libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_RELATIME,
             c"",
         ),
+        // Used to allocate non-movable DMA buffers.
+        FilesystemMount::new(
+            c"ramfs",
+            c"/ramfs",
+            c"ramfs",
+            libc::MS_NOSUID | libc::MS_NOEXEC | libc::MS_RELATIME,
+            c"",
+        ),
     ];
 
     setup(&stat_files, &options, writes, &filesystems)?;


### PR DESCRIPTION
When allocating DMA buffers for noiommu VFIO devices, we need to ensure that the kernel will not move the buffers in physical memory. In some cases, we achieve that by managing the memory entirely in user mode. In others, we allocate memory from the kernel on demand and then lock it with `mlock`.

The `mlock` approach apparently does not always work--since we are locking pages allocated for an anonymous mapping, the kernel is still free to _move_ the allocation between physical pages. `mlock`'s only guarantee seems to be that the kernel will not swap the page out to the swap file (which doesn't exist in the OpenHCL environment anyway). It looks like pages are indeed being moved with the ARM64 kernel for a reason that is not yet completely understood.

To fix this, switch to using a temporary file in ramfs instead of using an anonymous mapping. This should guarantee the allocation does not move between physical pages since ramfs pages are allocated as immovable in the kernel.

Also, update the init process to mount ramfs. This has no resource usage effect by itself--ramfs allocates memory only as required.