### PR TITLE
openhcl: use shared visibility pool for aarch64 dma

### DIFF
--- a/vm/loader/manifests/openhcl-aarch64-dev.json
+++ b/vm/loader/manifests/openhcl-aarch64-dev.json
@@ -8,7 +8,7 @@
             "image": {
                 "openhcl": {
                     "memory_page_count": 24576,
-                    "command_line": "console=null",
+                    "command_line": "console=null OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1",
                     "uefi": true
                 }
             }

--- a/vm/loader/manifests/openhcl-aarch64-release.json
+++ b/vm/loader/manifests/openhcl-aarch64-release.json
@@ -8,7 +8,7 @@
             "image": {
                 "openhcl": {
                     "memory_page_count": 12288,
-                    "command_line": "console=null",
+                    "command_line": "console=null OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1",
                     "uefi": true
                 }
             }


### PR DESCRIPTION
Use the Shared Visibility pool on aarch64. For reasons that we do not yet fully understand, we think the kernel running in OpenHCL is moving the physical pages that the locked memory allocator queried at boot.

This shows up in two ways:
* the nvme_driver reads completed `cid`s that it did not send, and
* the nvme device thinks that the driver sent it invalid prp lists. IO fails with `PRP_OFFSET_INVALID`.

This change makes the symptoms go away, and we will continue to investigate to get root cause.

By passing `OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1` in the openhcl command line, a shared
visibility pool will exist and consequently dma devices will use it.