### PR TITLE
Revert "Don't install nodejs in CI (#543)"

### DIFF
--- a/flowey/flowey_lib_common/src/install_nodejs.rs
+++ b/flowey/flowey_lib_common/src/install_nodejs.rs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Globally install `nodejs`
+
+use flowey::node::prelude::*;
+
+flowey_request! {
+    pub enum Request {
+        /// Automatically install all required nodejs tools and components.
+        ///
+        /// This must be set to true/false when running locally.
+        AutoInstall(bool),
+        /// Which version of nodejs to install (e.g: `6.0.0`)
+        Version(String),
+        /// Ensure node is installed
+        EnsureInstalled(WriteVar<SideEffect>),
+    }
+}
+
+new_flow_node!(struct Node);
+
+impl FlowNode for Node {
+    type Request = Request;
+
+    fn imports(ctx: &mut ImportCtx<'_>) {
+        ctx.import::<crate::ado_task_npm_authenticate::Node>();
+    }
+
+    fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
+        let mut auto_install = None;
+        let mut version = None;
+        let mut done = Vec::new();
+
+        for req in requests {
+            match req {
+                Request::AutoInstall(v) => {
+                    same_across_all_reqs("AutoInstall", &mut auto_install, v)?
+                }
+                Request::Version(v) => same_across_all_reqs("Version", &mut version, v)?,
+                Request::EnsureInstalled(v) => done.push(v),
+            }
+        }
+
+        // don't require specifying a NodeVersion if no one requested node to be
+        // installed
+        if done.is_empty() {
+            return Ok(());
+        }
+
+        let auto_install = auto_install;
+        let version = version.ok_or(anyhow::anyhow!("Missing essential request: NodeVersion"))?;
+        let done = done;
+
+        // -- end of req processing -- //
+
+        let is_installed = match ctx.backend() {
+            FlowBackend::Local => {
+                let auto_install = auto_install
+                    .ok_or(anyhow::anyhow!("Missing essential request: AutoInstall"))?;
+
+                let check_nodejs_install = {
+                    move |_: &mut RustRuntimeServices<'_>| {
+                        if which::which("node").is_err() {
+                            anyhow::bail!("did not find `node` on $PATH");
+                        }
+
+                        // FUTURE: we should also be performing version checks
+                        //
+                        // FUTURE: check if `nvm` is available, and if so, hook
+                        // into `nvm` infra to check for the node version
+                        // (instead of just relying on whatever `node` is
+                        // currently on the $PATH)
+
+                        anyhow::Ok(())
+                    }
+                };
+
+                if auto_install {
+                    ctx.emit_rust_step("installing nodejs", |_vars| {
+                        move |rt| {
+                            if check_nodejs_install(rt).is_ok() {
+                                return Ok(());
+                            }
+
+                            log::warn!("automatic nodejs installation is not supported yet!");
+                            log::warn!(
+                                "follow the guide, and manually ensure you have nodejs installed"
+                            );
+                            log::warn!("  ensure you have nodejs version {version} installed");
+                            log::warn!("press <enter> to continue");
+                            let _ = std::io::stdin().read_line(&mut String::new());
+
+                            check_nodejs_install(rt)?;
+                            Ok(())
+                        }
+                    })
+                } else {
+                    ctx.emit_rust_step("detecting nodejs install", |_vars| {
+                        move |rt| {
+                            check_nodejs_install(rt)?;
+                            Ok(())
+                        }
+                    })
+                }
+            }
+            FlowBackend::Ado => {
+                if !auto_install.unwrap_or(true) {
+                    anyhow::bail!("AutoInstall must be `true` when running on ADO")
+                }
+
+                let auth_done = ctx.reqv(crate::ado_task_npm_authenticate::Request::Done);
+
+                let (did_install, claim_did_install) = ctx.new_var();
+                ctx.emit_ado_step("Install nodejs", |ctx| {
+                    auth_done.claim(ctx);
+                    claim_did_install.claim(ctx);
+                    move |_| {
+                        format!(
+                            r#"
+                                - task: UseNode@1
+                                  inputs:
+                                    version: '{version}'
+                            "#
+                        )
+                    }
+                });
+                did_install
+            }
+            FlowBackend::Github => {
+                if !auto_install.unwrap_or(true) {
+                    anyhow::bail!("AutoInstall must be `true` when running on Github")
+                }
+
+                ctx.emit_gh_step("Install nodejs", "actions/setup-node@v4")
+                    .with("node-version", version)
+                    .finish(ctx)
+            }
+        };
+
+        ctx.emit_side_effect_step([is_installed], done);
+
+        Ok(())
+    }
+}

--- a/flowey/flowey_lib_common/src/lib.rs
+++ b/flowey/flowey_lib_common/src/lib.rs
@@ -36,6 +36,7 @@ pub mod git_checkout;
 pub mod install_azure_cli;
 pub mod install_dist_pkg;
 pub mod install_git;
+pub mod install_nodejs;
 pub mod install_nuget_azure_credential_provider;
 pub mod install_rust;
 pub mod nuget_install_package;

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_common.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_common.rs
@@ -59,6 +59,7 @@ impl SimpleFlowNode for Node {
         ctx.import::<flowey_lib_common::install_dist_pkg::Node>();
         ctx.import::<flowey_lib_common::install_azure_cli::Node>();
         ctx.import::<flowey_lib_common::install_git::Node>();
+        ctx.import::<flowey_lib_common::install_nodejs::Node>();
         ctx.import::<flowey_lib_common::install_nuget_azure_credential_provider::Node>();
         ctx.import::<flowey_lib_common::install_rust::Node>();
         ctx.import::<flowey_lib_common::nuget_install_package::Node>();
@@ -144,6 +145,9 @@ impl SimpleFlowNode for Node {
                         !auto_install,
                     ),
                 );
+                ctx.req(flowey_lib_common::install_nodejs::Request::AutoInstall(
+                    auto_install,
+                ));
                 ctx.req(flowey_lib_common::install_azure_cli::Request::AutoInstall(
                     auto_install,
                 ));

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -25,6 +25,7 @@ pub const MDBOOK_MERMAID: &str = "0.14.0";
 pub const RUSTUP_TOOLCHAIN: &str = "1.82.0";
 pub const MU_MSVM: &str = "24.0.4";
 pub const NEXTEST: &str = "0.9.74";
+pub const NODEJS: &str = "18.x";
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.6.51.9";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.6.51.7";
 pub const OPENVMM_DEPS: &str = "0.1.0-20241014.2";
@@ -54,6 +55,7 @@ impl FlowNode for Node {
         ctx.import::<flowey_lib_common::download_mdbook::Node>();
         ctx.import::<flowey_lib_common::download_protoc::Node>();
         ctx.import::<flowey_lib_common::install_azure_cli::Node>();
+        ctx.import::<flowey_lib_common::install_nodejs::Node>();
         ctx.import::<flowey_lib_common::install_rust::Node>();
     }
 
@@ -75,6 +77,7 @@ impl FlowNode for Node {
         ctx.req(flowey_lib_common::download_mdbook_mermaid::Request::Version(MDBOOK_MERMAID.into()));
         ctx.req(flowey_lib_common::download_protoc::Request::Version(PROTOC.into()));
         ctx.req(flowey_lib_common::install_azure_cli::Request::Version(AZURE_CLI.into()));
+        ctx.req(flowey_lib_common::install_nodejs::Request::Version(NODEJS.into()));
         if !matches!(ctx.backend(), FlowBackend::Ado) {
             ctx.req(flowey_lib_common::install_rust::Request::Version(RUSTUP_TOOLCHAIN.into()));
         }


### PR DESCRIPTION
The internal repo doesn't have its own versioning for nodejs, but instead relies on this. So leave it in the open, even though it appears to be dead code in isolation.