### PR TITLE
Update OHCL kernel to 6.6.63.1

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1408,7 +1408,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.51.9-arm64.tar.gz
+    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.63.1-arm64.tar.gz
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var
@@ -1498,7 +1498,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-arm64.tar.gz
+    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-arm64.tar.gz
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -1817,7 +1817,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 13 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.51.9-x64.tar.gz
+    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.63.1-x64.tar.gz
       run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 2
       shell: bash
     - name: 🌼 write_into Var
@@ -1913,7 +1913,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-x64.tar.gz
+    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-x64.tar.gz
       run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -2015,7 +2015,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-cvm-x64.tar.gz
+    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-cvm-x64.tar.gz
       run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1055,7 +1055,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.51.9-arm64.tar.gz
+    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.63.1-arm64.tar.gz
       run: flowey e 11 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var
@@ -1145,7 +1145,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-arm64.tar.gz
+    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-arm64.tar.gz
       run: flowey e 11 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -1464,7 +1464,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.51.9-x64.tar.gz
+    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.63.1-x64.tar.gz
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 2
       shell: bash
     - name: 🌼 write_into Var
@@ -1560,7 +1560,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-x64.tar.gz
+    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-x64.tar.gz
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -1662,7 +1662,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-cvm-x64.tar.gz
+    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-cvm-x64.tar.gz
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -26,8 +26,8 @@ pub const RUSTUP_TOOLCHAIN: &str = "1.82.0";
 pub const MU_MSVM: &str = "24.0.4";
 pub const NEXTEST: &str = "0.9.74";
 pub const NODEJS: &str = "18.x";
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.6.51.9";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.6.51.7";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.6.63.1";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.6.63.1";
 pub const OPENVMM_DEPS: &str = "0.1.0-20241014.2";
 pub const PROTOC: &str = "27.1";
 

--- a/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
@@ -99,10 +99,8 @@ impl FlowNode for Node {
                 },
                 version,
                 match kind {
-                    OpenhclKernelPackageKind::Main => "-main",
-                    OpenhclKernelPackageKind::Cvm => "-main-cvm",
-                    OpenhclKernelPackageKind::Dev => "",
-                    OpenhclKernelPackageKind::CvmDev => "-cvm",
+                    OpenhclKernelPackageKind::Main | OpenhclKernelPackageKind::Dev => "",
+                    OpenhclKernelPackageKind::Cvm | OpenhclKernelPackageKind::CvmDev => "-cvm",
                 },
                 match arch {
                     OpenhclKernelPackageArch::X86_64 => "x64",


### PR DESCRIPTION
This change updates the Linux kernel to the latest release which contains upstream latest stable fixes.