### PR TITLE
automatic cargo xtask fmt fixups

### DIFF
--- a/openvmm/hvlite_core/src/partition.rs
+++ b/openvmm/hvlite_core/src/partition.rs
@@ -301,7 +301,10 @@ impl<T: InspectMut> InspectMut for WrappedVp<'_, T> {
 impl<T: Processor> Processor for WrappedVp<'_, T> {
     type Error = T::Error;
     type RunVpError = T::RunVpError;
-    type StateAccess<'a> = T::StateAccess<'a> where Self: 'a;
+    type StateAccess<'a>
+        = T::StateAccess<'a>
+    where
+        Self: 'a;
 
     fn set_debug_state(
         &mut self,

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -381,7 +381,8 @@ impl virt::PartitionMemoryMap for HvfPartitionInner {
 }
 
 impl virt::PartitionAccessState for HvfPartition {
-    type StateAccess<'a> = HvfPartitionStateAccess<'a>
+    type StateAccess<'a>
+        = HvfPartitionStateAccess<'a>
     where
         Self: 'a;
 
@@ -742,7 +743,8 @@ impl<'p> Processor for HvfProcessor<'p> {
     type Error = Error;
     type RunVpError = Error;
 
-    type StateAccess<'a> = vp_state::HvfVpStateAccess<'a, 'p>
+    type StateAccess<'a>
+        = vp_state::HvfVpStateAccess<'a, 'p>
     where
         Self: 'a;
 

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -968,7 +968,10 @@ impl<T: CpuIo> hv1_hypercall::SignalEvent for KvmHypercallExit<'_, T> {
 impl Processor for KvmProcessor<'_> {
     type Error = KvmError;
     type RunVpError = KvmRunVpError;
-    type StateAccess<'a> = KvmVpStateAccess<'a> where Self: 'a;
+    type StateAccess<'a>
+        = KvmVpStateAccess<'a>
+    where
+        Self: 'a;
 
     fn set_debug_state(
         &mut self,

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -386,7 +386,10 @@ pub struct MshvProcessorBinder {
 }
 
 impl virt::BindProcessor for MshvProcessorBinder {
-    type Processor<'a> = MshvProcessor<'a> where Self: 'a;
+    type Processor<'a>
+        = MshvProcessor<'a>
+    where
+        Self: 'a;
     type Error = Error;
 
     fn bind(&mut self) -> Result<Self::Processor<'_>, Self::Error> {
@@ -1265,7 +1268,10 @@ impl InspectMut for MshvProcessor<'_> {
 impl virt::Processor for MshvProcessor<'_> {
     type Error = Error;
     type RunVpError = MshvRunVpError;
-    type StateAccess<'a> = &'a mut Self where Self: 'a;
+    type StateAccess<'a>
+        = &'a mut Self
+    where
+        Self: 'a;
 
     fn set_debug_state(
         &mut self,

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1468,7 +1468,10 @@ impl Drop for WhpProcessor<'_> {
 impl<'p> virt::Processor for WhpProcessor<'p> {
     type Error = Error;
     type RunVpError = WhpRunVpError;
-    type StateAccess<'a> = WhpVpStateAccess<'a, 'p> where Self: 'a;
+    type StateAccess<'a>
+        = WhpVpStateAccess<'a, 'p>
+    where
+        Self: 'a;
 
     fn set_debug_state(
         &mut self,


### PR DESCRIPTION
Taking suggestions from running `cargo xtask fmt --fix`. I'm a little surprised that others aren't running into this (and I thought our CI required `cargo xtask fmt` to be clean); please let me know if you suspect some non-determinism.