### PR TITLE
Add safety comments to unsafe attributes

### DIFF
--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -64,7 +64,9 @@ impl BuildInfo {
 #[expect(unsafe_code)]
 // SAFETY: The build_info section is custom and carries no safety requirements.
 #[unsafe(link_section = ".build_info")]
-// SAFETY: The name "BUILD_INFO" does not collide with any other symbols.
+// SAFETY: The name "BUILD_INFO" is only declared here in OpenHCL and shouldn't
+// collide with any other symbols. It is a special symbol intended for
+// post-mortem debugging, and no runtime functionality should depend on it.
 #[unsafe(export_name = "BUILD_INFO")]
 static BUILD_INFO: BuildInfo = BuildInfo::new();
 

--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -60,9 +60,11 @@ impl BuildInfo {
 // a debugger. With a debugger, the non-mangled name is easier
 // to use.
 
-// UNSAFETY: link_section and export_name are considered unsafe.
+// UNSAFETY: link_section and export_name are unsafe.
 #[expect(unsafe_code)]
+// SAFETY: The build_info section is custom and carries no safety requirements.
 #[unsafe(link_section = ".build_info")]
+// SAFETY: The name "BUILD_INFO" does not collide with any other symbols.
 #[unsafe(export_name = "BUILD_INFO")]
 static BUILD_INFO: BuildInfo = BuildInfo::new();
 

--- a/openhcl/minimal_rt/src/arch/aarch64/intrinsics.rs
+++ b/openhcl/minimal_rt/src/arch/aarch64/intrinsics.rs
@@ -5,6 +5,8 @@
 
 /// Hand rolled implementation of memcpy.
 #[cfg(minimal_rt)]
+// SAFETY: The minimal_rt_build crate ensures that when this code is compiled
+// there is no libc for this to conflict with.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *mut u8 {
     // SAFETY: the caller guarantees the pointers and length are correct.
@@ -31,6 +33,8 @@ unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *m
 
 /// Hand rolled implementation of memset.
 #[cfg(minimal_rt)]
+// SAFETY: The minimal_rt_build crate ensures that when this code is compiled
+// there is no libc for this to conflict with.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
     // SAFETY: the caller guarantees the pointer and length are correct.

--- a/openhcl/minimal_rt/src/arch/x86_64/intrinsics.rs
+++ b/openhcl/minimal_rt/src/arch/x86_64/intrinsics.rs
@@ -5,6 +5,8 @@
 
 /// Hand rolled implementation of memset.
 #[cfg(minimal_rt)]
+// SAFETY: The minimal_rt_build crate ensures that when this code is compiled
+// there is no libc for this to conflict with.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
     // SAFETY: The caller guarantees that the pointer and length are correct.
@@ -22,6 +24,8 @@ unsafe extern "C" fn memset(mut ptr: *mut u8, val: i32, len: usize) -> *mut u8 {
 
 /// Hand rolled implementation of memcpy.
 #[cfg(minimal_rt)]
+// SAFETY: The minimal_rt_build crate ensures that when this code is compiled
+// there is no libc for this to conflict with.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn memcpy(mut dest: *mut u8, src: *const u8, len: usize) -> *mut u8 {
     // SAFETY: The caller guarantees that the pointers and length are correct.

--- a/openhcl/minimal_rt/src/rt.rs
+++ b/openhcl/minimal_rt/src/rt.rs
@@ -23,10 +23,10 @@ mod instead_of_builtins {
         fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
     }
 
+    /// Implementation cribbed from compiler_builtins.
     // SAFETY: The minimal_rt_build crate ensures that when this code is compiled
     // there is no libc for this to conflict with.
     #[unsafe(no_mangle)]
-    /// Implementation cribbed from compiler_builtins.
     unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
         let delta = (dest as usize).wrapping_sub(src as usize);
         if delta >= n {
@@ -46,12 +46,12 @@ mod instead_of_builtins {
         dest
     }
 
-    // SAFETY: The minimal_rt_build crate ensures that when this code is compiled
-    // there is no libc for this to conflict with.
-    #[unsafe(no_mangle)]
     /// This implementation is cribbed from compiler_builtins. It would be nice to
     /// use those implementation for all the above functions, but those require
     /// nightly as these are not yet stabilized.
+    // SAFETY: The minimal_rt_build crate ensures that when this code is compiled
+    // there is no libc for this to conflict with.
+    #[unsafe(no_mangle)]
     unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
         // SAFETY: The caller guarantees that the pointers and length are correct.
         unsafe {

--- a/openhcl/minimal_rt/src/rt.rs
+++ b/openhcl/minimal_rt/src/rt.rs
@@ -23,8 +23,10 @@ mod instead_of_builtins {
         fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
     }
 
-    /// Implementation cribbed from compiler_builtins.
+    // SAFETY: The minimal_rt_build crate ensures that when this code is compiled
+    // there is no libc for this to conflict with.
     #[unsafe(no_mangle)]
+    /// Implementation cribbed from compiler_builtins.
     unsafe extern "C" fn memmove(dest: *mut u8, src: *const u8, n: usize) -> *mut u8 {
         let delta = (dest as usize).wrapping_sub(src as usize);
         if delta >= n {
@@ -44,10 +46,12 @@ mod instead_of_builtins {
         dest
     }
 
+    // SAFETY: The minimal_rt_build crate ensures that when this code is compiled
+    // there is no libc for this to conflict with.
+    #[unsafe(no_mangle)]
     /// This implementation is cribbed from compiler_builtins. It would be nice to
     /// use those implementation for all the above functions, but those require
     /// nightly as these are not yet stabilized.
-    #[unsafe(no_mangle)]
     unsafe extern "C" fn bcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
         // SAFETY: The caller guarantees that the pointers and length are correct.
         unsafe {

--- a/support/openssl_crypto_only/src/lib.rs
+++ b/support/openssl_crypto_only/src/lib.rs
@@ -30,12 +30,12 @@ unsafe extern "C" {
 #[macro_export]
 macro_rules! openssl_crypto_only {
     () => {
-        // SAFETY: We are purposefully overriding this symbol and we have made
-        // sure the definition is compatible with the original.
-        #[unsafe(no_mangle)]
         /// # Safety
         ///
         /// The caller must call as documented for `OPENSSL_init_ssl`.
+        // SAFETY: We are purposefully overriding this symbol and we have made
+        // sure the definition is compatible with the original.
+        #[unsafe(no_mangle)]
         unsafe extern "C" fn OPENSSL_init_ssl(
             opts: u64,
             settings: *const ::core::ffi::c_void,

--- a/support/openssl_crypto_only/src/lib.rs
+++ b/support/openssl_crypto_only/src/lib.rs
@@ -30,10 +30,12 @@ unsafe extern "C" {
 #[macro_export]
 macro_rules! openssl_crypto_only {
     () => {
+        // SAFETY: We are purposefully overriding this symbol and we have made
+        // sure the definition is compatible with the original.
+        #[unsafe(no_mangle)]
         /// # Safety
         ///
         /// The caller must call as documented for `OPENSSL_init_ssl`.
-        #[unsafe(no_mangle)]
         unsafe extern "C" fn OPENSSL_init_ssl(
             opts: u64,
             settings: *const ::core::ffi::c_void,

--- a/support/win_prng_support/src/lib.rs
+++ b/support/win_prng_support/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 //! Support for running in smaller Windows editions such as Win1.
+//!
 //! This crate purposefully overrides symbols normally provided by system DLLs.
 //! In order for this to be safe the definitions are compatible with the originals.
 

--- a/support/win_prng_support/src/lib.rs
+++ b/support/win_prng_support/src/lib.rs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 //! Support for running in smaller Windows editions such as Win1.
+//! This crate purposefully overrides symbols normally provided by system DLLs.
+//! In order for this to be safe the definitions are compatible with the originals.
 
 #![cfg(windows)]
 // UNSAFETY: needed to call internal Windows functions and to export unmangled
@@ -25,25 +27,22 @@ macro_rules! use_win10_prng_apis {
         $($crate::use_win10_prng_apis!(@x $lib);)*
     };
     (@x advapi32) => {
-        // SAFETY: We are purposefully overriding this symbol and we have made
-        // sure the definition is compatible with the original.
+        // SAFETY: see module level safety justification
         #[unsafe(no_mangle)]
         pub unsafe extern "system" fn SystemFunction036(data: *mut u8, len: u32) -> u8 {
             // SAFETY: passing through guarantees.
             unsafe { $crate::private::SystemFunction036(data, len) }
         }
 
-        // SAFETY: We are purposefully overriding this symbol and we have made
-        // sure the definition is compatible with the original.
-        #[unsafe(no_mangle)]
         /// If a call to SystemFunction036 is marked as a dllimport, then it may be an indirect call
         /// through __imp_SystemFunction036 instead.
+        // SAFETY: see module level safety justification
+        #[unsafe(no_mangle)]
         pub static __imp_SystemFunction036: unsafe extern "system" fn(*mut u8, u32) -> u8 =
             SystemFunction036;
     };
     (@x bcrypt) => {
-        // SAFETY: We are purposefully overriding this symbol and we have made
-        // sure the definition is compatible with the original.
+        // SAFETY: see module level safety justification
         #[unsafe(no_mangle)]
         pub unsafe extern "system" fn BCryptOpenAlgorithmProvider(
             handle: *mut ::core::ffi::c_void,
@@ -62,8 +61,7 @@ macro_rules! use_win10_prng_apis {
             }
         }
 
-        // SAFETY: We are purposefully overriding this symbol and we have made
-        // sure the definition is compatible with the original.
+        // SAFETY: see module level safety justification
         #[unsafe(no_mangle)]
         pub unsafe extern "system" fn BCryptCloseAlgorithmProvider(
             handle: *mut ::core::ffi::c_void,
@@ -73,8 +71,7 @@ macro_rules! use_win10_prng_apis {
             unsafe { $crate::private::BCryptCloseAlgorithmProvider(handle, flags) }
         }
 
-        // SAFETY: We are purposefully overriding this symbol and we have made
-        // sure the definition is compatible with the original.
+        // SAFETY: see module level safety justification
         #[unsafe(no_mangle)]
         pub unsafe extern "system" fn BCryptGenRandom(
             algorithm: usize,
@@ -86,11 +83,11 @@ macro_rules! use_win10_prng_apis {
             unsafe { $crate::private::BCryptGenRandom(algorithm, data, len, flags) }
         }
 
-        // SAFETY: We are purposefully overriding this symbol and we have made
-        // sure the definition is compatible with the original.
-        #[unsafe(no_mangle)]
+
         /// If a call to BCryptGenRandom is marked as a dllimport, then it may be an indirect call
         /// through __imp_BCryptGenRandom instead.
+        // SAFETY: see module level safety justification
+        #[unsafe(no_mangle)]
         pub static __imp_BCryptGenRandom: unsafe extern "system" fn(
             usize,
             *mut u8,
@@ -98,8 +95,7 @@ macro_rules! use_win10_prng_apis {
             u32,
         ) -> u32 = BCryptGenRandom;
 
-        // SAFETY: We are purposefully overriding this symbol and we have made
-        // sure the definition is compatible with the original.
+        // SAFETY: see module level safety justification
         #[unsafe(no_mangle)]
         pub static __imp_BCryptOpenAlgorithmProvider: unsafe extern "system" fn(
             *mut ::core::ffi::c_void,
@@ -108,8 +104,7 @@ macro_rules! use_win10_prng_apis {
             u32,
         ) -> u32 = BCryptOpenAlgorithmProvider;
 
-        // SAFETY: We are purposefully overriding this symbol and we have made
-        // sure the definition is compatible with the original.
+        // SAFETY: see module level safety justification
         #[unsafe(no_mangle)]
         pub static __imp_BCryptCloseAlgorithmProvider: unsafe extern "system" fn(
             *mut ::core::ffi::c_void,

--- a/support/win_prng_support/src/lib.rs
+++ b/support/win_prng_support/src/lib.rs
@@ -83,7 +83,6 @@ macro_rules! use_win10_prng_apis {
             unsafe { $crate::private::BCryptGenRandom(algorithm, data, len, flags) }
         }
 
-
         /// If a call to BCryptGenRandom is marked as a dllimport, then it may be an indirect call
         /// through __imp_BCryptGenRandom instead.
         // SAFETY: see module level safety justification

--- a/support/win_prng_support/src/lib.rs
+++ b/support/win_prng_support/src/lib.rs
@@ -25,19 +25,25 @@ macro_rules! use_win10_prng_apis {
         $($crate::use_win10_prng_apis!(@x $lib);)*
     };
     (@x advapi32) => {
+        // SAFETY: We are purposefully overriding this symbol and we have made
+        // sure the definition is compatible with the original.
         #[unsafe(no_mangle)]
         pub unsafe extern "system" fn SystemFunction036(data: *mut u8, len: u32) -> u8 {
             // SAFETY: passing through guarantees.
             unsafe { $crate::private::SystemFunction036(data, len) }
         }
 
+        // SAFETY: We are purposefully overriding this symbol and we have made
+        // sure the definition is compatible with the original.
+        #[unsafe(no_mangle)]
         /// If a call to SystemFunction036 is marked as a dllimport, then it may be an indirect call
         /// through __imp_SystemFunction036 instead.
-        #[unsafe(no_mangle)]
         pub static __imp_SystemFunction036: unsafe extern "system" fn(*mut u8, u32) -> u8 =
             SystemFunction036;
     };
     (@x bcrypt) => {
+        // SAFETY: We are purposefully overriding this symbol and we have made
+        // sure the definition is compatible with the original.
         #[unsafe(no_mangle)]
         pub unsafe extern "system" fn BCryptOpenAlgorithmProvider(
             handle: *mut ::core::ffi::c_void,
@@ -56,6 +62,8 @@ macro_rules! use_win10_prng_apis {
             }
         }
 
+        // SAFETY: We are purposefully overriding this symbol and we have made
+        // sure the definition is compatible with the original.
         #[unsafe(no_mangle)]
         pub unsafe extern "system" fn BCryptCloseAlgorithmProvider(
             handle: *mut ::core::ffi::c_void,
@@ -65,6 +73,8 @@ macro_rules! use_win10_prng_apis {
             unsafe { $crate::private::BCryptCloseAlgorithmProvider(handle, flags) }
         }
 
+        // SAFETY: We are purposefully overriding this symbol and we have made
+        // sure the definition is compatible with the original.
         #[unsafe(no_mangle)]
         pub unsafe extern "system" fn BCryptGenRandom(
             algorithm: usize,
@@ -76,9 +86,11 @@ macro_rules! use_win10_prng_apis {
             unsafe { $crate::private::BCryptGenRandom(algorithm, data, len, flags) }
         }
 
+        // SAFETY: We are purposefully overriding this symbol and we have made
+        // sure the definition is compatible with the original.
+        #[unsafe(no_mangle)]
         /// If a call to BCryptGenRandom is marked as a dllimport, then it may be an indirect call
         /// through __imp_BCryptGenRandom instead.
-        #[unsafe(no_mangle)]
         pub static __imp_BCryptGenRandom: unsafe extern "system" fn(
             usize,
             *mut u8,
@@ -86,6 +98,8 @@ macro_rules! use_win10_prng_apis {
             u32,
         ) -> u32 = BCryptGenRandom;
 
+        // SAFETY: We are purposefully overriding this symbol and we have made
+        // sure the definition is compatible with the original.
         #[unsafe(no_mangle)]
         pub static __imp_BCryptOpenAlgorithmProvider: unsafe extern "system" fn(
             *mut ::core::ffi::c_void,
@@ -94,6 +108,8 @@ macro_rules! use_win10_prng_apis {
             u32,
         ) -> u32 = BCryptOpenAlgorithmProvider;
 
+        // SAFETY: We are purposefully overriding this symbol and we have made
+        // sure the definition is compatible with the original.
         #[unsafe(no_mangle)]
         pub static __imp_BCryptCloseAlgorithmProvider: unsafe extern "system" fn(
             *mut ::core::ffi::c_void,

--- a/vm/vmgs/vmgs_lib/src/lib.rs
+++ b/vm/vmgs/vmgs_lib/src/lib.rs
@@ -42,13 +42,15 @@ pub enum VmgsError {
     FileExists = 14,
 }
 
+// SAFETY: We are exporting our own C-compatible API. In this library
+// this function name is unique.
+#[unsafe(no_mangle)]
 /// Read the contents of a `FileId` in a VMGS file
 ///
 /// # Safety
 ///
 /// `file_path` must point to a valid null-terminated utf-8 string.
 /// `in_len` must be the size of `in_buf` in bytes and match the value returned from query_size_vmgs
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn read_vmgs(
     file_path: *const c_char,
     file_id: FileId,
@@ -146,13 +148,15 @@ async fn do_read(
     Ok(data)
 }
 
+// SAFETY: We are exporting our own C-compatible API. In this library
+// this function name is unique.
+#[unsafe(no_mangle)]
 /// Write from a data file to a `FileId` in a VMGS file
 ///
 /// # Safety
 ///
 /// `file_path` and `data_path` must point to valid null-terminated utf-8 strings.
 /// `encryption_key` must be null-terminated and nonnull if using encryption
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn write_vmgs(
     file_path: *const c_char,
     data_path: *const c_char,
@@ -229,6 +233,9 @@ async fn do_write(
     Ok(())
 }
 
+// SAFETY: We are exporting our own C-compatible API. In this library
+// this function name is unique.
+#[unsafe(no_mangle)]
 /// Create a VMGS file
 ///
 /// If `file_size` is zero, default size of 4MB is used
@@ -239,7 +246,6 @@ async fn do_write(
 /// # Safety
 ///
 /// `path` must point to a valid null-terminated utf-8 string.
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn create_vmgs(
     path: *const c_char,
     file_size: u64,
@@ -329,13 +335,15 @@ async fn do_create(
     Ok(())
 }
 
+// SAFETY: We are exporting our own C-compatible API. In this library
+// this function name is unique.
+#[unsafe(no_mangle)]
 /// Get the size of a `FileId` in a VMGS file
 ///
 /// # Safety
 ///
 /// `path` pointer must point to a valid, null-terminated utf-8 string.
 /// `out_size` pointer must be nonnull
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn query_size_vmgs(
     path: *const c_char,
     file_id: FileId,

--- a/vm/vmgs/vmgs_lib/src/lib.rs
+++ b/vm/vmgs/vmgs_lib/src/lib.rs
@@ -48,8 +48,7 @@ pub enum VmgsError {
 ///
 /// `file_path` must point to a valid null-terminated utf-8 string.
 /// `in_len` must be the size of `in_buf` in bytes and match the value returned from query_size_vmgs
-// SAFETY: We are exporting our own C-compatible API. In this library
-// this function name is unique.
+// SAFETY: In this library this function name is unique.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn read_vmgs(
     file_path: *const c_char,
@@ -154,8 +153,7 @@ async fn do_read(
 ///
 /// `file_path` and `data_path` must point to valid null-terminated utf-8 strings.
 /// `encryption_key` must be null-terminated and nonnull if using encryption
-// SAFETY: We are exporting our own C-compatible API. In this library
-// this function name is unique.
+// SAFETY: In this library this function name is unique.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn write_vmgs(
     file_path: *const c_char,
@@ -243,8 +241,7 @@ async fn do_write(
 /// # Safety
 ///
 /// `path` must point to a valid null-terminated utf-8 string.
-// SAFETY: We are exporting our own C-compatible API. In this library
-// this function name is unique.
+// SAFETY: In this library this function name is unique.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn create_vmgs(
     path: *const c_char,
@@ -341,8 +338,7 @@ async fn do_create(
 ///
 /// `path` pointer must point to a valid, null-terminated utf-8 string.
 /// `out_size` pointer must be nonnull
-// SAFETY: We are exporting our own C-compatible API. In this library
-// this function name is unique.
+// SAFETY: In this library this function name is unique.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn query_size_vmgs(
     path: *const c_char,

--- a/vm/vmgs/vmgs_lib/src/lib.rs
+++ b/vm/vmgs/vmgs_lib/src/lib.rs
@@ -42,15 +42,15 @@ pub enum VmgsError {
     FileExists = 14,
 }
 
-// SAFETY: We are exporting our own C-compatible API. In this library
-// this function name is unique.
-#[unsafe(no_mangle)]
 /// Read the contents of a `FileId` in a VMGS file
 ///
 /// # Safety
 ///
 /// `file_path` must point to a valid null-terminated utf-8 string.
 /// `in_len` must be the size of `in_buf` in bytes and match the value returned from query_size_vmgs
+// SAFETY: We are exporting our own C-compatible API. In this library
+// this function name is unique.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn read_vmgs(
     file_path: *const c_char,
     file_id: FileId,
@@ -148,15 +148,15 @@ async fn do_read(
     Ok(data)
 }
 
-// SAFETY: We are exporting our own C-compatible API. In this library
-// this function name is unique.
-#[unsafe(no_mangle)]
 /// Write from a data file to a `FileId` in a VMGS file
 ///
 /// # Safety
 ///
 /// `file_path` and `data_path` must point to valid null-terminated utf-8 strings.
 /// `encryption_key` must be null-terminated and nonnull if using encryption
+// SAFETY: We are exporting our own C-compatible API. In this library
+// this function name is unique.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn write_vmgs(
     file_path: *const c_char,
     data_path: *const c_char,
@@ -233,9 +233,6 @@ async fn do_write(
     Ok(())
 }
 
-// SAFETY: We are exporting our own C-compatible API. In this library
-// this function name is unique.
-#[unsafe(no_mangle)]
 /// Create a VMGS file
 ///
 /// If `file_size` is zero, default size of 4MB is used
@@ -246,6 +243,9 @@ async fn do_write(
 /// # Safety
 ///
 /// `path` must point to a valid null-terminated utf-8 string.
+// SAFETY: We are exporting our own C-compatible API. In this library
+// this function name is unique.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn create_vmgs(
     path: *const c_char,
     file_size: u64,
@@ -335,15 +335,15 @@ async fn do_create(
     Ok(())
 }
 
-// SAFETY: We are exporting our own C-compatible API. In this library
-// this function name is unique.
-#[unsafe(no_mangle)]
 /// Get the size of a `FileId` in a VMGS file
 ///
 /// # Safety
 ///
 /// `path` pointer must point to a valid, null-terminated utf-8 string.
 /// `out_size` pointer must be nonnull
+// SAFETY: We are exporting our own C-compatible API. In this library
+// this function name is unique.
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn query_size_vmgs(
     path: *const c_char,
     file_id: FileId,


### PR DESCRIPTION
Part of #288. This is not yet enforced by clippy (https://github.com/rust-lang/rust-clippy/issues/13316), but we should be doing it anyways.