### PR TITLE
mesh_channel: new channel implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,11 +3738,27 @@ dependencies = [
  "futures-concurrency",
  "futures-core",
  "futures-io",
+ "mesh_channel_core",
  "mesh_node",
  "mesh_protobuf",
  "pal_async",
  "pal_event",
  "parking_lot",
+ "test_with_tracing",
+ "thiserror 2.0.0",
+ "tracing",
+]
+
+[[package]]
+name = "mesh_channel_core"
+version = "0.0.0"
+dependencies = [
+ "futures",
+ "futures-core",
+ "mesh_node",
+ "mesh_protobuf",
+ "parking_lot",
+ "static_assertions",
  "test_with_tracing",
  "thiserror 2.0.0",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ local_clock = { path = "support/local_clock" }
 mesh = { path = "support/mesh" }
 mesh_build = { path = "support/mesh/mesh_build" }
 mesh_channel = { path = "support/mesh/mesh_channel" }
+mesh_channel_core = { path = "support/mesh/mesh_channel_core" }
 mesh_derive = { path = "support/mesh/mesh_derive" }
 mesh_node = { path = "support/mesh/mesh_node" }
 mesh_process = { path = "support/mesh/mesh_process" }

--- a/support/mesh/mesh_channel/Cargo.toml
+++ b/support/mesh/mesh_channel/Cargo.toml
@@ -6,7 +6,16 @@ name = "mesh_channel"
 edition = "2021"
 rust-version.workspace = true
 
+[features]
+default = ["newchan_mpsc", "newchan_spsc"]
+newchan = ["dep:mesh_channel_core"]
+# Use the new channel implementation for MPSC channels.
+newchan_mpsc = ["newchan"]
+# Use the new channel implementatino for SPSC channels.
+newchan_spsc = ["newchan"]
+
 [dependencies]
+mesh_channel_core = { workspace = true, optional = true }
 mesh_node.workspace = true
 mesh_protobuf = { workspace = true, features = ["std"] }
 

--- a/support/mesh/mesh_channel/src/lib.rs
+++ b/support/mesh/mesh_channel/src/lib.rs
@@ -124,8 +124,9 @@ mod spsc {
     use crate::RecvError;
     use crate::TryRecvError;
     use mesh_node::local_node::Port;
+    use mesh_node::local_node::PortField;
     use mesh_node::message::MeshField;
-    use mesh_protobuf::Protobuf;
+    use mesh_protobuf::DefaultEncoding;
     use std::fmt::Debug;
     use std::future::Future;
     use std::pin::Pin;

--- a/support/mesh/mesh_channel/src/lib.rs
+++ b/support/mesh/mesh_channel/src/lib.rs
@@ -10,288 +10,334 @@ mod lazy;
 pub mod pipe;
 pub mod rpc;
 
+#[cfg(feature = "newchan")]
+pub use error_newchan::*;
+#[cfg(not(feature = "newchan"))]
+pub use error_oldchan::*;
+
+#[cfg(not(feature = "newchan_mpsc"))]
+pub use mpsc::*;
+#[cfg(feature = "newchan_mpsc")]
+pub use mpsc_newchan::*;
+#[cfg(not(feature = "newchan_spsc"))]
+pub use spsc::*;
+#[cfg(feature = "newchan_spsc")]
+pub use spsc_newchan::*;
+
 use bidir::Channel;
 use mesh_node::local_node::Port;
 use mesh_node::local_node::PortField;
 use mesh_node::message::MeshField;
 use mesh_protobuf::DefaultEncoding;
-use mesh_protobuf::Protobuf;
 use std::fmt::Debug;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
-use thiserror::Error;
 
-/// An error representing a failure of a channel.
-#[derive(Debug, Error)]
-#[error(transparent)]
-pub struct ChannelError(Box<ChannelErrorInner>);
-
-/// The kind of channel failure.
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum ChannelErrorKind {
-    /// The peer node failed.
-    NodeFailure,
-    /// The received message contents are invalid.
-    Corruption,
+#[cfg(feature = "newchan")]
+mod error_newchan {
+    pub use mesh_channel_core::ChannelError;
+    pub use mesh_channel_core::ChannelErrorKind;
+    pub use mesh_channel_core::RecvError;
+    pub use mesh_channel_core::TryRecvError;
 }
 
-impl ChannelError {
-    /// Returns the kind of channel failure that occurred.
-    pub fn kind(&self) -> ChannelErrorKind {
-        match &*self.0 {
-            ChannelErrorInner::NodeFailure(_) => ChannelErrorKind::NodeFailure,
-            ChannelErrorInner::Corruption(_) => ChannelErrorKind::Corruption,
+#[cfg(not(feature = "newchan"))]
+mod error_oldchan {
+    use thiserror::Error;
+
+    /// An error representing a failure of a channel.
+    #[derive(Debug, Error)]
+    #[error(transparent)]
+    pub struct ChannelError(Box<ChannelErrorInner>);
+
+    /// The kind of channel failure.
+    #[derive(Debug)]
+    #[non_exhaustive]
+    pub enum ChannelErrorKind {
+        /// The peer node failed.
+        NodeFailure,
+        /// The received message contents are invalid.
+        Corruption,
+    }
+
+    impl ChannelError {
+        /// Returns the kind of channel failure that occurred.
+        pub fn kind(&self) -> ChannelErrorKind {
+            match &*self.0 {
+                ChannelErrorInner::NodeFailure(_) => ChannelErrorKind::NodeFailure,
+                ChannelErrorInner::Corruption(_) => ChannelErrorKind::Corruption,
+            }
         }
     }
-}
 
-impl From<mesh_protobuf::Error> for ChannelError {
-    fn from(err: mesh_protobuf::Error) -> Self {
-        Self(Box::new(ChannelErrorInner::Corruption(err)))
+    impl From<mesh_protobuf::Error> for ChannelError {
+        fn from(err: mesh_protobuf::Error) -> Self {
+            Self(Box::new(ChannelErrorInner::Corruption(err)))
+        }
+    }
+
+    impl From<mesh_node::local_node::NodeError> for ChannelError {
+        fn from(value: mesh_node::local_node::NodeError) -> Self {
+            Self(Box::new(ChannelErrorInner::NodeFailure(value)))
+        }
+    }
+
+    #[derive(Debug, Error)]
+    enum ChannelErrorInner {
+        #[error("node failure")]
+        NodeFailure(#[source] mesh_node::local_node::NodeError),
+        #[error("message corruption")]
+        Corruption(#[source] mesh_protobuf::Error),
+    }
+
+    #[derive(Debug, Error)]
+    pub enum TryRecvError {
+        #[error("channel empty")]
+        Empty,
+        #[error("channel closed")]
+        Closed,
+        #[error("channel failure")]
+        Error(#[from] ChannelError),
+    }
+
+    #[derive(Debug, Error)]
+    pub enum RecvError {
+        #[error("channel closed")]
+        Closed,
+        #[error("channel failure")]
+        Error(#[from] ChannelError),
     }
 }
 
-impl From<mesh_node::local_node::NodeError> for ChannelError {
-    fn from(value: mesh_node::local_node::NodeError) -> Self {
-        Self(Box::new(ChannelErrorInner::NodeFailure(value)))
+#[cfg(feature = "newchan_spsc")]
+mod spsc_newchan {
+    pub use mesh_channel_core::channel;
+    pub use mesh_channel_core::Receiver;
+    pub use mesh_channel_core::Sender;
+}
+
+#[cfg(not(feature = "newchan_spsc"))]
+mod spsc {
+    use crate::bidir::Channel;
+    use crate::RecvError;
+    use crate::TryRecvError;
+    use mesh_node::local_node::Port;
+    use mesh_node::message::MeshField;
+    use mesh_protobuf::Protobuf;
+    use std::fmt::Debug;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::Context;
+    use std::task::Poll;
+
+    /// The sending half of a channel returned by [`channel`].
+    pub struct Sender<T>(Channel<(T,), ()>);
+
+    impl<T> Debug for Sender<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            Debug::fmt(&self.0, f)
+        }
     }
-}
 
-#[derive(Debug, Error)]
-enum ChannelErrorInner {
-    #[error("node failure")]
-    NodeFailure(#[source] mesh_node::local_node::NodeError),
-    #[error("message corruption")]
-    Corruption(#[source] mesh_protobuf::Error),
-}
-
-#[derive(Debug, Error)]
-pub enum TryRecvError {
-    #[error("channel empty")]
-    Empty,
-    #[error("channel closed")]
-    Closed,
-    #[error("channel failure")]
-    Error(#[from] ChannelError),
-}
-
-#[derive(Debug, Error)]
-pub enum RecvError {
-    #[error("channel closed")]
-    Closed,
-    #[error("channel failure")]
-    Error(#[from] ChannelError),
-}
-
-/// The sending half of a channel returned by [`channel`].
-pub struct Sender<T>(Channel<(T,), ()>);
-
-impl<T> Debug for Sender<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.0, f)
+    impl<T: 'static + MeshField + Send> DefaultEncoding for Sender<T> {
+        type Encoding = PortField;
     }
-}
 
-impl<T: 'static + MeshField + Send> DefaultEncoding for Sender<T> {
-    type Encoding = PortField;
-}
+    /// The receiving half of a channel returned by [`channel`].
+    pub struct Receiver<T>(Channel<(), (T,)>);
 
-/// The receiving half of a channel returned by [`channel`].
-pub struct Receiver<T>(Channel<(), (T,)>);
-
-impl<T> Debug for Receiver<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.0, f)
+    impl<T> Debug for Receiver<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            Debug::fmt(&self.0, f)
+        }
     }
-}
 
-impl<T: 'static + MeshField + Send> DefaultEncoding for Receiver<T> {
-    type Encoding = PortField;
-}
-
-impl<T: 'static + MeshField + Send> From<Port> for Sender<T> {
-    fn from(port: Port) -> Self {
-        Self(port.into())
+    impl<T: 'static + MeshField + Send> DefaultEncoding for Receiver<T> {
+        type Encoding = PortField;
     }
-}
 
-impl<T: 'static + MeshField + Send> From<Sender<T>> for Port {
-    fn from(v: Sender<T>) -> Self {
-        v.0.into()
+    impl<T: 'static + MeshField + Send> From<Port> for Sender<T> {
+        fn from(port: Port) -> Self {
+            Self(port.into())
+        }
     }
-}
 
-impl<T: 'static + Send> Sender<T> {
-    /// Sends a message to the associated [`Receiver<T>`].
+    impl<T: 'static + MeshField + Send> From<Sender<T>> for Port {
+        fn from(v: Sender<T>) -> Self {
+            v.0.into()
+        }
+    }
+
+    impl<T: 'static + Send> Sender<T> {
+        /// Sends a message to the associated [`Receiver<T>`].
+        ///
+        /// Does not return a result, so messages can be silently dropped if the
+        /// receiver has closed or failed. To detect such conditions, include
+        /// another sender in the message you send so that the receiving thread can
+        /// use it to send a response.
+        ///
+        /// ```rust
+        /// # use mesh_channel::*;
+        /// # futures::executor::block_on(async {
+        /// let (send, mut recv) = channel();
+        /// let (response_send, mut response_recv) = channel::<bool>();
+        /// send.send((3, response_send));
+        /// let (val, response_send) = recv.recv().await.unwrap();
+        /// response_send.send(val == 3);
+        /// assert_eq!(response_recv.recv().await.unwrap(), true);
+        /// # });
+        /// ```
+        pub fn send(&self, msg: T) {
+            self.0.send((msg,));
+        }
+
+        /// Bridges this and `recv` together, consuming both `self` and `recv`. This
+        /// makes it so that anything sent to `recv` will be directly sent to this
+        /// channel's peer receiver, without a separate relay step. This includes
+        /// any data that was previously sent but not yet consumed.
+        ///
+        /// ```rust
+        /// # use mesh_channel::*;
+        /// let (outer_send, inner_recv) = channel::<u32>();
+        /// let (inner_send, mut outer_recv) = channel::<u32>();
+        ///
+        /// outer_send.send(2);
+        /// inner_send.send(1);
+        /// inner_send.bridge(inner_recv);
+        /// assert_eq!(outer_recv.try_recv().unwrap(), 1);
+        /// assert_eq!(outer_recv.try_recv().unwrap(), 2);
+        /// ```
+        pub fn bridge(self, recv: Receiver<T>) {
+            self.0.bridge(recv.0)
+        }
+
+        /// Returns whether the receiving side of the channel is known to be closed
+        /// (or failed).
+        ///
+        /// This is useful to determine if there is any point in sending more data
+        /// via this port. But even if this returns `false` messages may still fail
+        /// to reach the destination.
+        pub fn is_closed(&self) -> bool {
+            self.0.is_peer_closed()
+        }
+    }
+
+    impl<T: 'static + MeshField + Send> From<Port> for Receiver<T> {
+        fn from(port: Port) -> Self {
+            Self(port.into())
+        }
+    }
+
+    impl<T: 'static + MeshField + Send> From<Receiver<T>> for Port {
+        fn from(v: Receiver<T>) -> Self {
+            v.0.into()
+        }
+    }
+
+    impl<T: 'static + Send> Receiver<T> {
+        /// Consumes and returns the next message, if there is one.
+        ///
+        /// Otherwise, returns whether the channel is empty, closed, or failed.
+        ///
+        /// ```rust
+        /// # use mesh_channel::*;
+        /// let (send, mut recv) = channel();
+        /// send.send(5u32);
+        /// drop(send);
+        /// assert_eq!(recv.try_recv().unwrap(), 5);
+        /// assert!(matches!(recv.try_recv().unwrap_err(), TryRecvError::Closed));
+        /// ```
+        pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+            Ok(self.0.try_recv()?.0)
+        }
+
+        /// Consumes and returns the next message, waiting until one is available.
+        ///
+        /// Returns immediately when the channel is closed or failed.
+        ///
+        /// ```rust
+        /// # use mesh_channel::*;
+        /// # futures::executor::block_on(async {
+        /// let (send, mut recv) = channel();
+        /// send.send(5u32);
+        /// drop(send);
+        /// assert_eq!(recv.recv().await.unwrap(), 5);
+        /// assert!(matches!(recv.recv().await.unwrap_err(), RecvError::Closed));
+        /// # });
+        /// ```
+        pub fn recv(&mut self) -> impl Future<Output = Result<T, RecvError>> + Unpin + '_ {
+            // This is implemented manually instead of using an async fn to allow
+            // the result to be Unpin, which is more flexible for callers.
+            core::future::poll_fn(|cx| self.poll_recv(cx))
+        }
+
+        /// Polls for the next message.
+        pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
+            self.0.poll_recv(cx).map_ok(|x| x.0)
+        }
+
+        /// See [`Sender::bridge`].
+        pub fn bridge(self, send: Sender<T>) {
+            self.0.bridge(send.0)
+        }
+    }
+
+    /// `Stream` implementation for a channel.
     ///
-    /// Does not return a result, so messages can be silently dropped if the
-    /// receiver has closed or failed. To detect such conditions, include
-    /// another sender in the message you send so that the receiving thread can
-    /// use it to send a response.
+    /// Note that the output item from this throws away the distinction between the
+    /// channel being closed and the channel failing due to a node error or decoding
+    /// error. This simplifies most code that does not care about this distinction.
+    ///
+    /// If you need to distinguish between these cases, use [`Receiver::recv`] or
+    /// [`Receiver::poll_recv`].
+    impl<T: 'static + Send> futures_core::stream::Stream for Receiver<T> {
+        type Item = T;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(match std::task::ready!(self.0.poll_recv(cx)) {
+                Ok((t,)) => Some(t),
+                Err(RecvError::Closed) => None,
+                Err(RecvError::Error(err)) => {
+                    tracing::error!(
+                        error = &err as &dyn std::error::Error,
+                        "channel closed due to error"
+                    );
+                    None
+                }
+            })
+        }
+    }
+
+    impl<T: 'static + Send> futures_core::stream::FusedStream for Receiver<T> {
+        fn is_terminated(&self) -> bool {
+            self.0.is_queue_drained()
+        }
+    }
+
+    /// Creates a unidirectional channel for sending objects of type `T`.
+    ///
+    /// Use [`Sender::send`] and [`Receiver::recv`] to communicate between the ends
+    /// of the channel.
+    ///
+    /// Both channel endpoints are initially local to this process, but either or
+    /// both endpoints may be sent to other processes via a cross-process channel
+    /// that has already been established.
     ///
     /// ```rust
     /// # use mesh_channel::*;
     /// # futures::executor::block_on(async {
-    /// let (send, mut recv) = channel();
-    /// let (response_send, mut response_recv) = channel::<bool>();
-    /// send.send((3, response_send));
-    /// let (val, response_send) = recv.recv().await.unwrap();
-    /// response_send.send(val == 3);
-    /// assert_eq!(response_recv.recv().await.unwrap(), true);
+    /// let (send, mut recv) = channel::<u32>();
+    /// send.send(5);
+    /// let n = recv.recv().await.unwrap();
+    /// assert_eq!(n, 5);
     /// # });
     /// ```
-    pub fn send(&self, msg: T) {
-        self.0.send((msg,));
+    pub fn channel<T: 'static + Send>() -> (Sender<T>, Receiver<T>) {
+        let (left, right) = Channel::new_pair();
+        (Sender(left), Receiver(right))
     }
-
-    /// Bridges this and `recv` together, consuming both `self` and `recv`. This
-    /// makes it so that anything sent to `recv` will be directly sent to this
-    /// channel's peer receiver, without a separate relay step. This includes
-    /// any data that was previously sent but not yet consumed.
-    ///
-    /// ```rust
-    /// # use mesh_channel::*;
-    /// let (outer_send, inner_recv) = channel::<u32>();
-    /// let (inner_send, mut outer_recv) = channel::<u32>();
-    ///
-    /// outer_send.send(2);
-    /// inner_send.send(1);
-    /// inner_send.bridge(inner_recv);
-    /// assert_eq!(outer_recv.try_recv().unwrap(), 1);
-    /// assert_eq!(outer_recv.try_recv().unwrap(), 2);
-    /// ```
-    pub fn bridge(self, recv: Receiver<T>) {
-        self.0.bridge(recv.0)
-    }
-
-    /// Returns whether the receiving side of the channel is known to be closed
-    /// (or failed).
-    ///
-    /// This is useful to determine if there is any point in sending more data
-    /// via this port. But even if this returns `false` messages may still fail
-    /// to reach the destination.
-    pub fn is_closed(&self) -> bool {
-        self.0.is_peer_closed()
-    }
-}
-
-impl<T: 'static + MeshField + Send> From<Port> for Receiver<T> {
-    fn from(port: Port) -> Self {
-        Self(port.into())
-    }
-}
-
-impl<T: 'static + MeshField + Send> From<Receiver<T>> for Port {
-    fn from(v: Receiver<T>) -> Self {
-        v.0.into()
-    }
-}
-
-impl<T: 'static + Send> Receiver<T> {
-    /// Consumes and returns the next message, if there is one.
-    ///
-    /// Otherwise, returns whether the channel is empty, closed, or failed.
-    ///
-    /// ```rust
-    /// # use mesh_channel::*;
-    /// let (send, mut recv) = channel();
-    /// send.send(5u32);
-    /// drop(send);
-    /// assert_eq!(recv.try_recv().unwrap(), 5);
-    /// assert!(matches!(recv.try_recv().unwrap_err(), TryRecvError::Closed));
-    /// ```
-    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
-        Ok(self.0.try_recv()?.0)
-    }
-
-    /// Consumes and returns the next message, waiting until one is available.
-    ///
-    /// Returns immediately when the channel is closed or failed.
-    ///
-    /// ```rust
-    /// # use mesh_channel::*;
-    /// # futures::executor::block_on(async {
-    /// let (send, mut recv) = channel();
-    /// send.send(5u32);
-    /// drop(send);
-    /// assert_eq!(recv.recv().await.unwrap(), 5);
-    /// assert!(matches!(recv.recv().await.unwrap_err(), RecvError::Closed));
-    /// # });
-    /// ```
-    pub fn recv(&mut self) -> impl Future<Output = Result<T, RecvError>> + Unpin + '_ {
-        // This is implemented manually instead of using an async fn to allow
-        // the result to be Unpin, which is more flexible for callers.
-        core::future::poll_fn(|cx| self.poll_recv(cx))
-    }
-
-    /// Polls for the next message.
-    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
-        self.0.poll_recv(cx).map_ok(|x| x.0)
-    }
-
-    /// See [`Sender::bridge`].
-    pub fn bridge(self, send: Sender<T>) {
-        self.0.bridge(send.0)
-    }
-}
-
-/// `Stream` implementation for a channel.
-///
-/// Note that the output item from this throws away the distinction between the
-/// channel being closed and the channel failing due to a node error or decoding
-/// error. This simplifies most code that does not care about this distinction.
-///
-/// If you need to distinguish between these cases, use [`Receiver::recv`] or
-/// [`Receiver::poll_recv`].
-impl<T: 'static + Send> futures_core::stream::Stream for Receiver<T> {
-    type Item = T;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Poll::Ready(match std::task::ready!(self.0.poll_recv(cx)) {
-            Ok((t,)) => Some(t),
-            Err(RecvError::Closed) => None,
-            Err(RecvError::Error(err)) => {
-                tracing::error!(
-                    error = &err as &dyn std::error::Error,
-                    "channel closed due to error"
-                );
-                None
-            }
-        })
-    }
-}
-
-impl<T: 'static + Send> futures_core::stream::FusedStream for Receiver<T> {
-    fn is_terminated(&self) -> bool {
-        self.0.is_queue_drained()
-    }
-}
-
-/// Creates a unidirectional channel for sending objects of type `T`.
-///
-/// Use [`Sender::send`] and [`Receiver::recv`] to communicate between the ends
-/// of the channel.
-///
-/// Both channel endpoints are initially local to this process, but either or
-/// both endpoints may be sent to other processes via a cross-process channel
-/// that has already been established.
-///
-/// ```rust
-/// # use mesh_channel::*;
-/// # futures::executor::block_on(async {
-/// let (send, mut recv) = channel::<u32>();
-/// send.send(5);
-/// let n = recv.recv().await.unwrap();
-/// assert_eq!(n, 5);
-/// # });
-/// ```
-pub fn channel<T: 'static + Send>() -> (Sender<T>, Receiver<T>) {
-    let (left, right) = Channel::new_pair();
-    (Sender(left), Receiver(right))
 }
 
 /// The sending half of a channel returned by [`oneshot`].
@@ -393,194 +439,215 @@ pub fn oneshot<T: 'static + Send>() -> (OneshotSender<T>, OneshotReceiver<T>) {
     (OneshotSender(left), OneshotReceiver(right))
 }
 
-/// Creates a multi-producer, single-consumer channel for sending objects of
-/// type `T`.
-///
-/// The main difference between these channels and those returned by [`channel`]
-/// is that the sender can be cloned and sent to remote processes. This is
-/// useful when you are collating data from multiple sources.
-///
-/// # Performance
-///
-/// Care must be taken to avoid scaling problems with this type. Internally this
-/// uses multiple ports between the receiving end and the sending ends, and
-/// receiving is linear in the number of ports.
-///
-/// An ordinary call to `clone` won't allocate a new port, nor will sending a
-/// clone within a process. But sending a clone to a different process will
-/// allocate a new port.
-pub fn mpsc_channel<T: 'static + Send>() -> (MpscSender<T>, MpscReceiver<T>) {
-    let (send, recv) = Channel::new_pair();
-    (
-        MpscSender(Arc::new(MpscSenderInner(send))),
-        MpscReceiver {
-            receivers: vec![recv],
-        },
-    )
+#[cfg(feature = "newchan_mpsc")]
+mod mpsc_newchan {
+    pub use mesh_channel_core::channel as mpsc_channel;
+    pub use mesh_channel_core::Receiver as MpscReceiver;
+    pub use mesh_channel_core::Sender as MpscSender;
 }
 
-#[derive(Debug, Protobuf)]
-#[mesh(
-    bound = "T: 'static + MeshField + Send",
-    resource = "mesh_node::resource::Resource"
-)]
-enum MpscMessage<T> {
-    Data(T),
-    Clone(Channel<(), MpscMessage<T>>),
-}
+#[cfg(not(feature = "newchan_mpsc"))]
+mod mpsc {
+    use crate::bidir::Channel;
+    use crate::RecvError;
+    use mesh_node::message::MeshField;
+    use mesh_protobuf::Protobuf;
+    use std::fmt::Debug;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::Context;
+    use std::task::Poll;
 
-/// Receiver type for [`mpsc_channel()`].
-#[derive(Protobuf)]
-#[mesh(
-    bound = "T: 'static + MeshField + Send",
-    resource = "mesh_node::resource::Resource"
-)]
-pub struct MpscReceiver<T> {
-    receivers: Vec<Channel<(), MpscMessage<T>>>,
-}
-
-impl<T> Debug for MpscReceiver<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MpscReceiver")
-            .field("receivers", &self.receivers)
-            .finish()
-    }
-}
-
-impl<T: 'static + Send> MpscReceiver<T> {
-    /// Creates a new receiver with no senders.
+    /// Creates a multi-producer, single-consumer channel for sending objects of
+    /// type `T`.
     ///
-    /// Receives will fail with [`RecvError::Closed`] until [`Self::sender`] is
-    /// called.
-    pub fn new() -> Self {
-        MpscReceiver {
-            receivers: Vec::new(),
+    /// The main difference between these channels and those returned by [`channel`]
+    /// is that the sender can be cloned and sent to remote processes. This is
+    /// useful when you are collating data from multiple sources.
+    ///
+    /// # Performance
+    ///
+    /// Care must be taken to avoid scaling problems with this type. Internally this
+    /// uses multiple ports between the receiving end and the sending ends, and
+    /// receiving is linear in the number of ports.
+    ///
+    /// An ordinary call to `clone` won't allocate a new port, nor will sending a
+    /// clone within a process. But sending a clone to a different process will
+    /// allocate a new port.
+    pub fn mpsc_channel<T: 'static + Send>() -> (MpscSender<T>, MpscReceiver<T>) {
+        let (send, recv) = Channel::new_pair();
+        (
+            MpscSender(Arc::new(MpscSenderInner(send))),
+            MpscReceiver {
+                receivers: vec![recv],
+            },
+        )
+    }
+
+    #[derive(Debug, Protobuf)]
+    #[mesh(
+        bound = "T: 'static + MeshField + Send",
+        resource = "mesh_node::resource::Resource"
+    )]
+    enum MpscMessage<T> {
+        Data(T),
+        Clone(Channel<(), MpscMessage<T>>),
+    }
+
+    /// Receiver type for [`mpsc_channel()`].
+    #[derive(Protobuf)]
+    #[mesh(
+        bound = "T: 'static + MeshField + Send",
+        resource = "mesh_node::resource::Resource"
+    )]
+    pub struct MpscReceiver<T> {
+        receivers: Vec<Channel<(), MpscMessage<T>>>,
+    }
+
+    impl<T> Debug for MpscReceiver<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("MpscReceiver")
+                .field("receivers", &self.receivers)
+                .finish()
         }
     }
 
-    /// Creates a new sender for sending data to this receiver.
-    ///
-    /// Note that this may transition the channel from the closed to open state.
-    pub fn sender(&mut self) -> MpscSender<T> {
-        let (send, recv) = Channel::new_pair();
-        self.receivers.push(recv);
-        MpscSender(Arc::new(MpscSenderInner(send)))
-    }
-
-    /// Consumes and returns the next message, waiting until one is available.
-    ///
-    /// Returns immediately when the channel is closed or failed.
-    ///
-    /// ```rust
-    /// # use mesh_channel::*;
-    /// # futures::executor::block_on(async {
-    /// let (send, mut recv) = mpsc_channel();
-    /// send.send(5u32);
-    /// drop(send);
-    /// assert_eq!(recv.recv().await.unwrap(), 5);
-    /// assert!(matches!(recv.recv().await.unwrap_err(), RecvError::Closed));
-    /// # });
-    /// ```
-    pub fn recv(&mut self) -> impl Future<Output = Result<T, RecvError>> + '_ {
-        std::future::poll_fn(move |cx| self.poll_recv(cx))
-    }
-
-    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
-        let receivers = &mut self.receivers;
-        let mut i = 0;
-        while i < receivers.len() {
-            let recv = &mut receivers[i];
-            match recv.poll_recv(cx) {
-                Poll::Ready(Ok(message)) => match message {
-                    MpscMessage::Data(inner_message) => {
-                        return Poll::Ready(Ok(inner_message));
-                    }
-                    MpscMessage::Clone(new_recv) => {
-                        receivers.push(new_recv);
-                    }
-                },
-                Poll::Ready(Err(_)) => {
-                    receivers.swap_remove(i);
-                }
-                Poll::Pending => {
-                    i += 1;
-                }
+    impl<T: 'static + Send> MpscReceiver<T> {
+        /// Creates a new receiver with no senders.
+        ///
+        /// Receives will fail with [`RecvError::Closed`] until [`Self::sender`] is
+        /// called.
+        pub fn new() -> Self {
+            MpscReceiver {
+                receivers: Vec::new(),
             }
         }
-        if receivers.is_empty() {
-            Poll::Ready(Err(RecvError::Closed))
-        } else {
-            Poll::Pending
+
+        /// Creates a new sender for sending data to this receiver.
+        ///
+        /// Note that this may transition the channel from the closed to open state.
+        pub fn sender(&mut self) -> MpscSender<T> {
+            let (send, recv) = Channel::new_pair();
+            self.receivers.push(recv);
+            MpscSender(Arc::new(MpscSenderInner(send)))
+        }
+
+        /// Consumes and returns the next message, waiting until one is available.
+        ///
+        /// Returns immediately when the channel is closed or failed.
+        ///
+        /// ```rust
+        /// # use mesh_channel::*;
+        /// # futures::executor::block_on(async {
+        /// let (send, mut recv) = mpsc_channel();
+        /// send.send(5u32);
+        /// drop(send);
+        /// assert_eq!(recv.recv().await.unwrap(), 5);
+        /// assert!(matches!(recv.recv().await.unwrap_err(), RecvError::Closed));
+        /// # });
+        /// ```
+        pub fn recv(&mut self) -> impl Future<Output = Result<T, RecvError>> + '_ {
+            std::future::poll_fn(move |cx| self.poll_recv(cx))
+        }
+
+        fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
+            let receivers = &mut self.receivers;
+            let mut i = 0;
+            while i < receivers.len() {
+                let recv = &mut receivers[i];
+                match recv.poll_recv(cx) {
+                    Poll::Ready(Ok(message)) => match message {
+                        MpscMessage::Data(inner_message) => {
+                            return Poll::Ready(Ok(inner_message));
+                        }
+                        MpscMessage::Clone(new_recv) => {
+                            receivers.push(new_recv);
+                        }
+                    },
+                    Poll::Ready(Err(_)) => {
+                        receivers.swap_remove(i);
+                    }
+                    Poll::Pending => {
+                        i += 1;
+                    }
+                }
+            }
+            if receivers.is_empty() {
+                Poll::Ready(Err(RecvError::Closed))
+            } else {
+                Poll::Pending
+            }
         }
     }
-}
 
-impl<T: 'static + Send> Default for MpscReceiver<T> {
-    fn default() -> Self {
-        Self::new()
+    impl<T: 'static + Send> Default for MpscReceiver<T> {
+        fn default() -> Self {
+            Self::new()
+        }
     }
-}
 
-impl<T: 'static + Send> futures_core::stream::FusedStream for MpscReceiver<T> {
-    fn is_terminated(&self) -> bool {
-        self.receivers.is_empty()
+    impl<T: 'static + Send> futures_core::stream::FusedStream for MpscReceiver<T> {
+        fn is_terminated(&self) -> bool {
+            self.receivers.is_empty()
+        }
     }
-}
 
-impl<T: 'static + Send> futures_core::stream::Stream for MpscReceiver<T> {
-    type Item = T;
+    impl<T: 'static + Send> futures_core::stream::Stream for MpscReceiver<T> {
+        type Item = T;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Poll::Ready(std::task::ready!(self.poll_recv(cx)).ok())
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            Poll::Ready(std::task::ready!(self.poll_recv(cx)).ok())
+        }
     }
-}
 
-/// Sender type for [`mpsc_channel()`].
-//
-// This wraps the actual sender in an Arc to ensure that clones within the same
-// process are cheap. When this is encoded for sending to a remote process, only
-// then will the receiver be notified of a new mesh port.
-#[derive(Protobuf)]
-#[mesh(
-    bound = "T: 'static + MeshField + Send",
-    resource = "mesh_node::resource::Resource"
-)]
-pub struct MpscSender<T>(Arc<MpscSenderInner<T>>);
+    /// Sender type for [`mpsc_channel()`].
+    //
+    // This wraps the actual sender in an Arc to ensure that clones within the same
+    // process are cheap. When this is encoded for sending to a remote process, only
+    // then will the receiver be notified of a new mesh port.
+    #[derive(Protobuf)]
+    #[mesh(
+        bound = "T: 'static + MeshField + Send",
+        resource = "mesh_node::resource::Resource"
+    )]
+    pub struct MpscSender<T>(Arc<MpscSenderInner<T>>);
 
-impl<T> Debug for MpscSender<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.0 .0, f)
+    impl<T> Debug for MpscSender<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            Debug::fmt(&self.0 .0, f)
+        }
     }
-}
 
-// Manual implementation since T might not be Clone.
-impl<T> Clone for MpscSender<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
+    // Manual implementation since T might not be Clone.
+    impl<T> Clone for MpscSender<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
     }
-}
 
-/// Wrapper that implements Clone.
-#[derive(Protobuf)]
-#[mesh(
-    bound = "T: 'static + MeshField + Send",
-    resource = "mesh_node::resource::Resource"
-)]
-struct MpscSenderInner<T>(Channel<MpscMessage<T>, ()>);
+    /// Wrapper that implements Clone.
+    #[derive(Protobuf)]
+    #[mesh(
+        bound = "T: 'static + MeshField + Send",
+        resource = "mesh_node::resource::Resource"
+    )]
+    struct MpscSenderInner<T>(Channel<MpscMessage<T>, ()>);
 
-impl<T: 'static + Send> Clone for MpscSenderInner<T> {
-    fn clone(&self) -> Self {
-        // Clone the sender by sending a new port to the receiver.
-        let (send, recv) = Channel::new_pair();
-        self.0.send(MpscMessage::Clone(recv));
-        Self(send)
+    impl<T: 'static + Send> Clone for MpscSenderInner<T> {
+        fn clone(&self) -> Self {
+            // Clone the sender by sending a new port to the receiver.
+            let (send, recv) = Channel::new_pair();
+            self.0.send(MpscMessage::Clone(recv));
+            Self(send)
+        }
     }
-}
 
-impl<T: 'static + Send> MpscSender<T> {
-    /// Sends a message to the receiver.
-    pub fn send(&self, msg: T) {
-        (self.0).0.send(MpscMessage::Data(msg))
+    impl<T: 'static + Send> MpscSender<T> {
+        /// Sends a message to the receiver.
+        pub fn send(&self, msg: T) {
+            (self.0).0.send(MpscMessage::Data(msg))
+        }
     }
 }
 
@@ -638,7 +705,7 @@ mod tests {
     async fn test_mpsc() {
         let (send, mut recv) = mpsc_channel::<u32>();
         send.send(5);
-        roundtrip(send.clone()).send(6);
+        roundtrip((send.clone(),)).0.send(6);
         drop(send);
         let a = recv.recv().await.unwrap();
         let b = recv.recv().await.unwrap();

--- a/support/mesh/mesh_channel_core/Cargo.toml
+++ b/support/mesh/mesh_channel_core/Cargo.toml
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "mesh_channel_core"
+edition = "2021"
+rust-version.workspace = true
+
+[dependencies]
+mesh_protobuf.workspace = true
+mesh_node.workspace = true
+
+futures-core.workspace = true
+parking_lot.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+static_assertions.workspace = true
+test_with_tracing.workspace = true
+
+futures.workspace = true
+
+[lints]
+workspace = true

--- a/support/mesh/mesh_channel_core/src/deque.rs
+++ b/support/mesh/mesh_channel_core/src/deque.rs
@@ -4,7 +4,7 @@
 //! Implementation of a type-erased vector-based queue.
 
 // UNSAFETY: Needed to erase types to avoid monomorphization overhead.
-#![allow(unsafe_code)]
+#![expect(unsafe_code)]
 
 use core::fmt;
 use std::alloc::Layout;
@@ -166,6 +166,10 @@ impl ErasedVecDeque {
     /// # Safety
     /// The caller must ensure that `value` is a valid owned pointer to the
     /// element type that this queue was created with.
+    ///
+    /// Additionally, once at least one element has been pushed to this
+    /// queue, the caller must ensure that the queue is not sent/shared across
+    /// threads unless the element type is `Send` and `Sync`.
     pub unsafe fn push_back(&mut self, value: *const ()) {
         let dst = self.reserve_one();
         // SAFETY: the caller ensures that `value` is a valid owned pointer to the

--- a/support/mesh/mesh_channel_core/src/deque.rs
+++ b/support/mesh/mesh_channel_core/src/deque.rs
@@ -86,6 +86,10 @@ impl ElementVtable {
     }
 }
 
+/// A reference to a type-erased element in the queue.
+///
+/// This is used instead of a raw pointer to ensure the queue storage is not
+/// reused while the element is still in use.
 pub struct InPlaceElement<'a>(NonNull<()>, PhantomData<&'a mut ErasedVecDeque>);
 
 impl InPlaceElement<'_> {

--- a/support/mesh/mesh_channel_core/src/deque.rs
+++ b/support/mesh/mesh_channel_core/src/deque.rs
@@ -1,0 +1,351 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Implementation of a type-erased vector-based queue.
+
+// UNSAFETY: Needed to erase types to avoid monomorphization overhead.
+#![allow(unsafe_code)]
+
+use core::fmt;
+use std::alloc::Layout;
+use std::marker::PhantomData;
+use std::ptr::drop_in_place;
+use std::ptr::NonNull;
+
+/// A type-erased vector-based queue.
+///
+/// This is used instead of `VecDeque<T>` to avoid monomorphization overhead.
+///
+/// # Safety
+/// The use of this type is precarious, because the various operations are not
+/// type-checked with the element type. Use with care.
+///
+/// Additionally, this type is `Send` and `Sync` even though the underlying
+/// element types may not be. It is the caller's responsibility to ensure that
+/// this is wrapped in something with the appropriate `PhantomData` to prevent
+/// it from being `Send` or `Sync` when it shouldn't be.
+pub struct ErasedVecDeque {
+    buf: NonNull<u8>,
+    cap: usize,
+    head: usize,
+    len: usize,
+    vtable: &'static ElementVtable,
+}
+
+impl fmt::Debug for ErasedVecDeque {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ErasedVecDeque")
+            .field("cap", &self.cap)
+            .field("head", &self.head)
+            .field("len", &self.len)
+            .finish()
+    }
+}
+
+// SAFETY: `ErasedVecDeque` is `Send` and `Sync` even though the underlying
+// element types may not be. It is the caller's responsibility to ensure that
+// they don't send or share this across threads when it shouldn't be.
+unsafe impl Send for ErasedVecDeque {}
+// SAFETY: see above.
+unsafe impl Sync for ErasedVecDeque {}
+
+/// The vtable for a type-erased element type.
+pub struct ElementVtable {
+    layout: Layout,
+    element_len: usize, // different from layout.size() for ZSTs
+    drop: Option<unsafe fn(*mut ())>,
+}
+
+impl ElementVtable {
+    /// Creates a new vtable for the given element type.
+    pub const fn new<T>() -> Self {
+        Self {
+            layout: Layout::new::<T>(),
+            element_len: if size_of::<T>() == 0 {
+                align_of::<T>()
+            } else {
+                assert!(size_of::<T>() >= align_of::<T>());
+                size_of::<T>()
+            },
+            drop: if std::mem::needs_drop::<T>() {
+                Some(Self::drop_fn::<T>)
+            } else {
+                None
+            },
+        }
+    }
+
+    /// # Safety
+    /// The caller must ensure that `p` is a valid pointer to a `T`, the type
+    /// that this vtable was created with.
+    unsafe fn drop_fn<T>(p: *mut ()) {
+        // SAFETY: `p` is a valid owned pointer to a `T`.
+        unsafe {
+            drop_in_place(p.cast::<T>());
+        }
+    }
+}
+
+pub struct InPlaceElement<'a>(NonNull<()>, PhantomData<&'a mut ErasedVecDeque>);
+
+impl InPlaceElement<'_> {
+    pub fn as_ptr(&self) -> *mut () {
+        self.0.as_ptr()
+    }
+}
+
+impl ErasedVecDeque {
+    /// Creates a new empty `ErasedVecDeque` with the given element vtable.
+    pub fn new(vtable: &'static ElementVtable) -> Self {
+        Self {
+            buf: NonNull::dangling(),
+            cap: if vtable.layout.size() == 0 {
+                isize::MAX as usize
+            } else {
+                0
+            },
+            head: 0,
+            len: 0,
+            vtable,
+        }
+    }
+
+    /// Returns whether the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    fn offset(&self, i: usize) -> usize {
+        if self.vtable.layout.size() == 0 {
+            return 0;
+        }
+        let offset = self.head.wrapping_add(i);
+        let offset = if offset >= self.cap {
+            offset - self.cap
+        } else {
+            offset
+        };
+        debug_assert!(offset + self.vtable.layout.size() <= self.cap);
+        offset
+    }
+
+    /// # Safety
+    /// The caller must ensure that `i` is in bounds.
+    unsafe fn buf_at(&mut self, i: usize) -> InPlaceElement<'_> {
+        let offset = self.offset(i);
+        // SAFETY: `i` is a valid index into `buf`.
+        let ptr = unsafe { self.buf.add(offset).cast() };
+        InPlaceElement(ptr, PhantomData)
+    }
+
+    /// Reserves space for one element and returns a pointer to it.
+    pub fn reserve_one(&mut self) -> InPlaceElement<'_> {
+        if self.len >= self.cap {
+            self.grow();
+        }
+        // SAFETY: We just grew the buffer if necessary.
+        unsafe { self.buf_at(self.len) }
+    }
+
+    /// Commits the next element. Used after calling `reserve_one` and writing
+    /// to the buffer.
+    ///
+    /// # Safety
+    /// The caller must ensure that the element has been written to the buffer.
+    pub unsafe fn commit_one(&mut self) {
+        self.len += self.vtable.element_len;
+        debug_assert!(self.len <= self.cap);
+    }
+
+    /// Pushes a new element to the back of the queue.
+    ///
+    /// # Safety
+    /// The caller must ensure that `value` is a valid owned pointer to the
+    /// element type that this queue was created with.
+    pub unsafe fn push_back(&mut self, value: *const ()) {
+        let dst = self.reserve_one();
+        // SAFETY: the caller ensures that `value` is a valid owned pointer to the
+        // element type.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                value.cast(),
+                dst.as_ptr().cast::<u8>(),
+                self.vtable.layout.size(),
+            );
+            self.commit_one();
+        }
+    }
+
+    /// Pops the front element from the queue and returns a pointer to it.
+    ///
+    /// The caller is responsible for taking ownership of the element to ensure
+    /// that it is properly dropped.
+    pub fn pop_front_in_place(&mut self) -> Option<InPlaceElement<'_>> {
+        if self.len == 0 {
+            return None;
+        };
+        let head = self.head;
+        self.head = self.offset(self.vtable.layout.size());
+        self.len -= self.vtable.element_len;
+        // SAFETY: `head` is a valid index into `buf`.
+        let ptr = unsafe { self.buf.add(head).cast() };
+        Some(InPlaceElement(ptr, PhantomData))
+    }
+
+    /// Pops the front element from the queue and writes it to `dst`.
+    ///
+    /// # Safety
+    /// The caller must ensure that `dst` is valid for writing the element.
+    pub unsafe fn pop_front(&mut self, dst: *mut ()) {
+        let src = self.pop_front_in_place().unwrap();
+        // SAFETY: the caller ensures that `dst` is valid for writing the
+        // element.
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                src.as_ptr().cast::<u8>(),
+                dst.cast(),
+                self.vtable.layout.size(),
+            );
+        }
+    }
+
+    /// Clears the queue of elements.
+    pub fn clear(&mut self) {
+        let mut i = 0;
+        if let Some(drop_fn) = self.vtable.drop {
+            while i < self.len {
+                // SAFETY: the element at `i` is valid.
+                unsafe {
+                    drop_fn(self.buf_at(i).as_ptr());
+                }
+                i += self.vtable.layout.size();
+            }
+        }
+        self.len = 0;
+    }
+
+    /// Clears the queue and frees the underlying buffer.
+    pub fn clear_and_shrink(&mut self) {
+        self.clear();
+        if self.cap > 0 && self.vtable.layout.size() != 0 {
+            // SAFETY: `buf` contains a valid unaliased allocation with the
+            // given size and alignment.
+            unsafe {
+                std::alloc::dealloc(
+                    self.buf.as_ptr(),
+                    Layout::from_size_align_unchecked(self.cap, self.vtable.layout.align()),
+                );
+            }
+            self.cap = 0;
+        }
+    }
+
+    fn grow(&mut self) {
+        assert!(self.vtable.layout.size() != 0, "zst overflow");
+        let align = self.vtable.layout.align();
+        let (new_cap, buf) = if self.cap == 0 {
+            let element_size = self.vtable.layout.size();
+            let new_cap = if element_size >= 256 {
+                element_size
+            } else {
+                element_size * 4
+            };
+            // SAFETY: `new_cap` is non-zero and at least as big as `align`,
+            // which is a power of 2.
+            let buf =
+                unsafe { std::alloc::alloc(Layout::from_size_align_unchecked(new_cap, align)) };
+            (new_cap, buf)
+        } else {
+            let new_cap = self.cap.checked_mul(2).unwrap();
+            // SAFETY: `buf` is a valid allocation with the given layout, and
+            // `new_cap` is non-zero.
+            let buf = unsafe {
+                std::alloc::realloc(
+                    self.buf.as_ptr(),
+                    Layout::from_size_align_unchecked(self.cap, align),
+                    new_cap,
+                )
+            };
+            (new_cap, buf)
+        };
+        let Some(buf) = NonNull::new(buf) else {
+            // SAFETY: these layout parameters were validated above.
+            let layout = unsafe { Layout::from_size_align_unchecked(new_cap, align) };
+            std::alloc::handle_alloc_error(layout);
+        };
+        // Move the trailing elements to the end of the new buffer.
+        if self.len > 0 && self.head + self.len > self.cap {
+            let n = self.cap - self.head;
+            let new_head = new_cap - n;
+            // SAFETY: `buf` is valid for reads and writes at the given offsets.
+            unsafe {
+                std::ptr::copy(buf.as_ptr().add(self.head), buf.as_ptr().add(new_head), n);
+            }
+            self.head = new_head;
+        }
+        self.buf = buf;
+        self.cap = new_cap;
+    }
+}
+
+impl Drop for ErasedVecDeque {
+    fn drop(&mut self) {
+        self.clear_and_shrink();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ElementVtable;
+    use super::ErasedVecDeque;
+    use std::mem::MaybeUninit;
+
+    #[test]
+    fn test_erased_vecdeque() {
+        let mut deque = ErasedVecDeque::new(const { &ElementVtable::new::<String>() });
+        assert!(deque.is_empty());
+        for _ in 0..1000 {
+            for _ in 0..7 {
+                // SAFETY: providing a valid owned pointer to the element type.
+                unsafe {
+                    deque.push_back(MaybeUninit::new(String::from("foo")).as_ptr().cast());
+                }
+            }
+            for _ in 0..3 {
+                // SAFETY: providing valid pointers for writing the element, which is
+                // then guaranteed to be initialized.
+                let result = unsafe {
+                    let mut result = MaybeUninit::<String>::uninit();
+                    deque.pop_front(result.as_mut_ptr().cast());
+                    result.assume_init()
+                };
+                assert_eq!(&result, "foo");
+            }
+        }
+        drop(deque);
+    }
+
+    #[test]
+    fn test_zst() {
+        let mut deque = ErasedVecDeque::new(const { &ElementVtable::new::<()>() });
+        assert!(deque.is_empty());
+        for _ in 0..1000 {
+            for _ in 0..7 {
+                // SAFETY: providing a valid owned pointer to the element type.
+                unsafe {
+                    deque.push_back(MaybeUninit::new(()).as_ptr().cast());
+                }
+            }
+            for _ in 0..3 {
+                // SAFETY: providing valid pointers for writing the element, which is
+                // then guaranteed to be initialized.
+                unsafe {
+                    let mut result = MaybeUninit::<()>::uninit();
+                    deque.pop_front(result.as_mut_ptr().cast());
+                    result.assume_init()
+                };
+            }
+        }
+        drop(deque);
+    }
+}

--- a/support/mesh/mesh_channel_core/src/deque.rs
+++ b/support/mesh/mesh_channel_core/src/deque.rs
@@ -267,6 +267,8 @@ impl ErasedVecDeque {
         let align = self.vtable.layout.align();
         let (new_cap, buf) = if self.cap == 0 {
             let element_size = self.vtable.layout.size();
+            // Start with 4 elements, but only if the element size is not too
+            // big (these constants are arbitrary).
             let new_cap = if element_size >= 256 {
                 element_size
             } else {
@@ -278,6 +280,8 @@ impl ErasedVecDeque {
                 unsafe { std::alloc::alloc(Layout::from_size_align_unchecked(new_cap, align)) };
             (new_cap, buf)
         } else {
+            // Double the capacity (geometric growth) to ensure amortized O(1)
+            // push_back.
             let new_cap = self.cap.checked_mul(2).unwrap();
             // SAFETY: `buf` is a valid allocation with the given layout, and
             // `new_cap` is non-zero.

--- a/support/mesh/mesh_channel_core/src/error.rs
+++ b/support/mesh/mesh_channel_core/src/error.rs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use thiserror::Error;
+
+/// An error representing a failure of a channel.
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct ChannelError(Box<ChannelErrorInner>);
+
+/// The kind of channel failure.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ChannelErrorKind {
+    /// The peer node failed.
+    NodeFailure,
+    /// The received message contents are invalid.
+    Corruption,
+}
+
+impl ChannelError {
+    /// Returns the kind of channel failure that occurred.
+    pub fn kind(&self) -> ChannelErrorKind {
+        match &*self.0 {
+            ChannelErrorInner::NodeFailure(_) => ChannelErrorKind::NodeFailure,
+            ChannelErrorInner::Corruption(_) => ChannelErrorKind::Corruption,
+        }
+    }
+}
+
+impl From<mesh_protobuf::Error> for ChannelError {
+    fn from(err: mesh_protobuf::Error) -> Self {
+        Self(Box::new(ChannelErrorInner::Corruption(err)))
+    }
+}
+
+impl From<mesh_node::local_node::NodeError> for ChannelError {
+    fn from(value: mesh_node::local_node::NodeError) -> Self {
+        Self(Box::new(ChannelErrorInner::NodeFailure(value)))
+    }
+}
+
+#[derive(Debug, Error)]
+enum ChannelErrorInner {
+    #[error("node failure")]
+    NodeFailure(#[source] mesh_node::local_node::NodeError),
+    #[error("message corruption")]
+    Corruption(#[source] mesh_protobuf::Error),
+}
+
+/// An error when trying to receive a message from a channel.
+#[derive(Debug, Error)]
+pub enum TryRecvError {
+    /// The channel is empty.
+    #[error("channel empty")]
+    Empty,
+    /// The channel is closed.
+    #[error("channel closed")]
+    Closed,
+    /// The channel has failed.
+    #[error("channel failure")]
+    Error(#[from] ChannelError),
+}
+
+/// An error when receiving a message from a channel.
+#[derive(Debug, Error)]
+pub enum RecvError {
+    /// The channel is closed.
+    #[error("channel closed")]
+    Closed,
+    /// The channel has failed.
+    #[error("channel failure")]
+    Error(#[from] ChannelError),
+}

--- a/support/mesh/mesh_channel_core/src/lib.rs
+++ b/support/mesh/mesh_channel_core/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Core mesh channel functionality.
+
+#![warn(missing_docs)]
+
+mod deque;
+mod error;
+mod mpsc;
+
+pub use error::*;
+pub use mpsc::*;

--- a/support/mesh/mesh_channel_core/src/lib.rs
+++ b/support/mesh/mesh_channel_core/src/lib.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Core mesh channel functionality.
+//! Core mesh channel functionality, supporting sending and receiving messages
+//! within and between nodes.
+//!
+//! This contains only the basic channel implementations, not the extra utility
+//! types on top that `mesh_channel` provides.
 
 #![warn(missing_docs)]
 

--- a/support/mesh/mesh_channel_core/src/mpsc.rs
+++ b/support/mesh/mesh_channel_core/src/mpsc.rs
@@ -6,7 +6,7 @@
 //!
 //! The main design requirements of this channel are:
 //! * It roughly follows the semantics of the Rust standard library's
-//!  `std::sync::mpsc` channel, but with async support.
+//!   `std::sync::mpsc` channel, but with async support.
 //! * It is efficient enough for single process use that it can be used as a
 //!   general purpose channel.
 //! * It leverages `mesh_node` ports and `mesh_protobuf` serialization to allow

--- a/support/mesh/mesh_channel_core/src/mpsc.rs
+++ b/support/mesh/mesh_channel_core/src/mpsc.rs
@@ -1,8 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Implementation of a multi-producer, single-consumer (MPSC) channel that can
-//! be used to communicate between mesh nodes.
+//! Implementation of an async multi-producer, single-consumer (MPSC) channel
+//! that can be used to communicate between mesh nodes.
+//!
+//! The main design requirements of this channel are:
+//! * It roughly follows the semantics of the Rust standard library's
+//!  `std::sync::mpsc` channel, but with async support.
+//! * It is efficient enough for single process use that it can be used as a
+//!   general purpose channel.
+//! * It leverages `mesh_node` ports and `mesh_protobuf` serialization to allow
+//!   communication between mesh nodes, which can be on different processes or
+//!   machines.
+//! * Its contribution to binary size is minimal.
+//!
+//! To achieve the binary size goal, this implementation avoids generics where
+//! practical. This has the tradeoff of requiring a fair amount of unsafe code,
+//! but this makes it practical to use this channel in space-constrained
+//! environments.
 
 // UNSAFETY: Needed to erase types to avoid monomorphization overhead.
 #![expect(unsafe_code)]

--- a/support/mesh/mesh_channel_core/src/mpsc.rs
+++ b/support/mesh/mesh_channel_core/src/mpsc.rs
@@ -1,0 +1,935 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Implementation of a multi-producer, single-consumer (MPSC) channel that can
+//! be used to communicate between mesh nodes.
+
+// UNSAFETY: Needed to erase types to avoid monomorphization overhead.
+#![allow(unsafe_code)]
+
+use crate::deque::ElementVtable;
+use crate::deque::ErasedVecDeque;
+use crate::error::ChannelError;
+use crate::error::RecvError;
+use crate::error::TryRecvError;
+use core::fmt::Debug;
+use core::future::Future;
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::mem::MaybeUninit;
+use core::task::Context;
+use core::task::Poll;
+use core::task::Waker;
+use mesh_node::local_node::HandleMessageError;
+use mesh_node::local_node::HandlePortEvent;
+use mesh_node::local_node::Port;
+use mesh_node::local_node::PortField;
+use mesh_node::local_node::PortWithHandler;
+use mesh_node::message::MeshField;
+use mesh_node::message::Message;
+use mesh_protobuf::DefaultEncoding;
+use mesh_protobuf::Protobuf;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+/// Creates a new channel for sending messages of type `T`, returning the sender
+/// and receiver ends.
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let (sender, receiver) = channel_core(const { &ElementVtable::new::<T>() });
+    (Sender(sender, PhantomData), Receiver(receiver, PhantomData))
+}
+
+fn channel_core(vtable: &'static ElementVtable) -> (SenderCore, ReceiverCore) {
+    let mut receiver = ReceiverCore::new(vtable);
+    let sender = receiver.sender();
+    (sender, receiver)
+}
+
+/// The sending half of a channel returned by [`channel`].
+///
+/// The sender can be cloned to send messages from multiple threads or
+/// processes.
+pub struct Sender<T>(SenderCore, PhantomData<Arc<Mutex<[T]>>>);
+
+#[derive(Debug, Clone)]
+struct SenderCore(Arc<Queue>);
+
+impl<T> Debug for Sender<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<T> Sender<T> {
+    /// Sends a message to the associated [`Receiver<T>`].
+    ///
+    /// Does not return a result, so messages can be silently dropped if the
+    /// receiver has closed or failed. To detect such conditions, include
+    /// another sender in the message you send so that the receiving thread can
+    /// use it to send a response.
+    ///
+    /// ```rust
+    /// # use mesh_channel_core::*;
+    /// # futures::executor::block_on(async {
+    /// let (send, mut recv) = channel();
+    /// let (response_send, mut response_recv) = channel::<bool>();
+    /// send.send((3, response_send));
+    /// let (val, response_send) = recv.recv().await.unwrap();
+    /// response_send.send(val == 3);
+    /// assert_eq!(response_recv.recv().await.unwrap(), true);
+    /// # });
+    /// ```
+    pub fn send(&self, message: T) {
+        let message = MaybeUninit::new(message);
+        // SAFETY: the queue is for `T` and `message` is a valid owned `T`.
+        unsafe { self.0.send(message.as_ptr().cast()) }
+    }
+
+    /// Returns whether the receiving side of the channel is known to be closed
+    /// (or failed).
+    ///
+    /// This is useful to determine if there is any point in sending more data
+    /// via this port. But even if this returns `false` messages may still fail
+    /// to reach the destination.
+    pub fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+}
+
+impl SenderCore {
+    /// Sends `message`, taking ownership of it.
+    ///
+    /// # Safety
+    /// The caller must ensure that the message is a valid owned `T` for the `T`
+    /// the queue was created with.
+    unsafe fn send(&self, message: *const ()) {
+        loop {
+            if let Some(remote) = self.0.remote.get() {
+                // SAFETY: The caller guarantees `message` is a valid owned `T`.
+                let message = unsafe { (remote.encode)(message) };
+                remote.port.send(message);
+                break;
+            }
+            let mut local = self.0.local.lock();
+            if !local.remote {
+                if !local.receiver_gone {
+                    // SAFETY: The caller guarantees `message` is a valid owned `T`.
+                    unsafe { local.messages.push_back(message) };
+                    if let Some(waker) = local.waker.take() {
+                        drop(local);
+                        waker.wake();
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        loop {
+            if let Some(remote) = self.0.remote.get() {
+                return remote.port.is_closed().unwrap_or(true);
+            }
+            let local = self.0.local.lock();
+            if !local.remote {
+                return local.receiver_gone;
+            }
+        }
+    }
+
+    fn into_queue(self) -> Arc<Queue> {
+        match *ManuallyDrop::new(self) {
+            Self(ref queue) => {
+                // SAFETY: copying from a field that won't be dropped.
+                unsafe { <*const _>::read(queue) }
+            }
+        }
+    }
+
+    /// Creates a new queue for sending to `port`.
+    ///
+    /// # Safety
+    /// The caller must ensure that both `vtable` and `encode` are for a queue
+    /// with the same type.
+    unsafe fn from_port(port: Port, vtable: &'static ElementVtable, encode: EncodeFn) -> Self {
+        let queue = Arc::new(Queue {
+            local: Mutex::new(LocalQueue {
+                remote: true,
+                ..LocalQueue::new(vtable)
+            }),
+            remote: OnceLock::from(RemoteQueueState { port, encode }),
+        });
+        Self(queue)
+    }
+
+    /// Converts this sender into a port.
+    ///
+    /// # Safety
+    /// The caller must ensure that `new_handler` is for a queue with the same
+    /// element type as this sender.
+    unsafe fn into_port(self, new_handler: NewHandlerFn) -> Port {
+        match Arc::try_unwrap(self.into_queue()) {
+            Ok(mut queue) => {
+                if let Some(remote) = queue.remote.into_inner() {
+                    // This is the unique owner of the port.
+                    remote.port
+                } else {
+                    assert!(queue.local.get_mut().receiver_gone);
+                    let (send, _recv) = Port::new_pair();
+                    send
+                }
+            }
+            Err(queue) => {
+                // There is a receiver or at least one other sender.
+                let (send, recv) = Port::new_pair();
+                loop {
+                    if let Some(remote) = queue.remote.get() {
+                        remote
+                            .port
+                            .send(Message::new(ChannelPayload::<()>::Port(recv)));
+                        break;
+                    }
+                    let mut local = queue.local.lock();
+                    if local.remote {
+                        continue;
+                    }
+                    if !local.receiver_gone {
+                        local.new_handler = new_handler;
+                        local.ports.push(recv);
+                        if let Some(waker) = local.waker.take() {
+                            drop(local);
+                            waker.wake();
+                        }
+                    }
+                    break;
+                }
+                send
+            }
+        }
+    }
+}
+
+impl Drop for SenderCore {
+    fn drop(&mut self) {
+        if self.0.remote.get().is_some() {
+            return;
+        }
+        let mut local = self.0.local.lock();
+        // TODO: keep a sender count to avoid needing to wake.
+        let waker = local.waker.take();
+        drop(local);
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+}
+
+impl<T: MeshField> DefaultEncoding for Sender<T> {
+    type Encoding = PortField;
+}
+
+impl<T: MeshField> From<Port> for Sender<T> {
+    fn from(port: Port) -> Self {
+        Self::from_port(port)
+    }
+}
+
+impl<T: MeshField> From<Sender<T>> for Port {
+    fn from(sender: Sender<T>) -> Self {
+        sender.into_port()
+    }
+}
+
+impl<T: MeshField> Sender<T> {
+    /// Bridges this and `recv` together, consuming both `self` and `recv`. This
+    /// makes it so that anything sent to `recv` will be directly sent to this
+    /// channel's peer receiver, without a separate relay step. This includes
+    /// any data that was previously sent but not yet consumed.
+    ///
+    /// ```rust
+    /// # use mesh_channel_core::*;
+    /// let (outer_send, inner_recv) = channel::<u32>();
+    /// let (inner_send, mut outer_recv) = channel::<u32>();
+    ///
+    /// outer_send.send(2);
+    /// inner_send.send(1);
+    /// inner_send.bridge(inner_recv);
+    /// assert_eq!(outer_recv.try_recv().unwrap(), 1);
+    /// assert_eq!(outer_recv.try_recv().unwrap(), 2);
+    /// ```
+    pub fn bridge(self, receiver: Receiver<T>) {
+        let sender = self.into_port();
+        let receiver = receiver.into_port();
+        sender.bridge(receiver);
+    }
+
+    /// Encodes `ChannelPayload::Message(message)` into a [`Message`].
+    ///
+    /// # Safety
+    /// The caller must ensure that `message` is a valid owned `T`.
+    unsafe fn encode_message(message: *const ()) -> Message {
+        // SAFETY: The caller guarantees `message` is a valid owned `T`.
+        unsafe { Message::new(ChannelPayload::Message(message.cast::<T>().read())) }
+    }
+
+    fn from_port(port: Port) -> Self {
+        Self(
+            // SAFETY: the vtable and encode function are for a queue with type
+            // `T`.
+            unsafe {
+                SenderCore::from_port(
+                    port,
+                    const { &ElementVtable::new::<T>() },
+                    Self::encode_message,
+                )
+            },
+            PhantomData,
+        )
+    }
+
+    fn into_port(self) -> Port {
+        // SAFETY: the new handler function is for a queue with type `T`.
+        unsafe { self.0.into_port(RemotePortHandler::new::<T>) }
+    }
+}
+
+/// The receiving half of a channel returned by [`channel`].
+pub struct Receiver<T>(ReceiverCore, PhantomData<Arc<Mutex<[T]>>>);
+
+impl<T> Debug for Receiver<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl<T> Default for Receiver<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+struct ReceiverCore {
+    queue: ReceiverQueue,
+    ports: PortHandlerList,
+    terminated: bool,
+}
+
+#[derive(Debug)]
+struct ReceiverQueue(Arc<Queue>);
+
+impl Drop for ReceiverQueue {
+    fn drop(&mut self) {
+        let mut local = self.0.local.lock();
+        local.receiver_gone = true;
+        let _waker = std::mem::take(&mut local.waker);
+        local.messages.clear_and_shrink();
+        let _ports = std::mem::take(&mut local.ports);
+    }
+}
+
+impl<T> Receiver<T> {
+    /// Creates a new receiver with no senders.
+    ///
+    /// Receives will fail with [`RecvError::Closed`] until [`Self::sender`] is
+    /// called.
+    pub fn new() -> Self {
+        Self(
+            ReceiverCore::new(const { &ElementVtable::new::<T>() }),
+            PhantomData,
+        )
+    }
+
+    /// Consumes and returns the next message, waiting until one is available.
+    ///
+    /// Returns immediately when the channel is closed or failed.
+    ///
+    /// ```rust
+    /// # use mesh_channel_core::*;
+    /// # futures::executor::block_on(async {
+    /// let (send, mut recv) = channel();
+    /// send.send(5u32);
+    /// drop(send);
+    /// assert_eq!(recv.recv().await.unwrap(), 5);
+    /// assert!(matches!(recv.recv().await.unwrap_err(), RecvError::Closed));
+    /// # });
+    /// ```
+    pub fn recv(&mut self) -> Recv<'_, T> {
+        Recv(self)
+    }
+
+    /// Consumes and returns the next message, if there is one.
+    ///
+    /// Otherwise, returns whether the channel is empty, closed, or failed.
+    ///
+    /// ```rust
+    /// # use mesh_channel_core::*;
+    /// let (send, mut recv) = channel();
+    /// send.send(5u32);
+    /// drop(send);
+    /// assert_eq!(recv.try_recv().unwrap(), 5);
+    /// assert!(matches!(recv.try_recv().unwrap_err(), TryRecvError::Closed));
+    /// ```
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        let mut v = MaybeUninit::<T>::uninit();
+        // SAFETY: `v` is a valid uninitialized `T`.
+        let r = unsafe { self.0.try_poll_recv(None, v.as_mut_ptr().cast()) };
+        match r {
+            Poll::Ready(Ok(())) => {
+                // SAFETY: `try_poll_recv` guarantees `v` is now initialized.
+                Ok(unsafe { v.assume_init() })
+            }
+            Poll::Ready(Err(RecvError::Closed)) => Err(TryRecvError::Closed),
+            Poll::Ready(Err(RecvError::Error(e))) => Err(TryRecvError::Error(e)),
+            Poll::Pending => Err(TryRecvError::Empty),
+        }
+    }
+
+    /// Polls for the next message.
+    ///
+    /// If one is available, consumes and returns it. If the
+    /// channel is closed or failed, fails. Otherwise, registers the current task to wake
+    /// when a message is available or the channel is closed or fails.
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
+        let mut v = MaybeUninit::<T>::uninit();
+        // SAFETY: `v` is a valid uninitialized `T`.
+        let r = unsafe { self.0.try_poll_recv(Some(cx), v.as_mut_ptr().cast()) };
+        r.map(|r| {
+            r.map(|()| {
+                // SAFETY: `try_poll_recv` guarantees `v` is now initialized.
+                unsafe { v.assume_init() }
+            })
+        })
+    }
+
+    /// Creates a new sender for sending data to this receiver.
+    ///
+    /// Note that this may transition the channel from the closed to open state.
+    pub fn sender(&mut self) -> Sender<T> {
+        Sender(self.0.sender(), PhantomData)
+    }
+}
+
+/// The future returned by [`Receiver::recv`].
+pub struct Recv<'a, T>(&'a mut Receiver<T>);
+
+impl<T> Future for Recv<'_, T> {
+    type Output = Result<T, RecvError>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.get_mut().0.poll_recv(cx)
+    }
+}
+
+impl ReceiverCore {
+    fn new(vtable: &'static ElementVtable) -> Self {
+        Self {
+            queue: ReceiverQueue(Arc::new(Queue {
+                local: Mutex::new(LocalQueue::new(vtable)),
+                remote: OnceLock::new(),
+            })),
+            ports: PortHandlerList::new(),
+            terminated: true,
+        }
+    }
+
+    // Polls for a message.
+    //
+    // # Safety
+    // `dst` must be be valid for writing a `T`, the element type of the queue.
+    unsafe fn try_poll_recv(
+        &mut self,
+        cx: Option<&mut Context<'_>>,
+        dst: *mut (),
+    ) -> Poll<Result<(), RecvError>> {
+        loop {
+            debug_assert!(self.queue.0.remote.get().is_none());
+            let mut local = self.queue.0.local.lock();
+            if local.remove_closed {
+                local.remove_closed = false;
+                drop(local);
+                if let Err(err) = self.ports.remove_closed() {
+                    // Propagate the error to the caller only if there
+                    // are no more senders. Otherwise, the caller might
+                    // stop receiving messages from the remaining
+                    // senders.
+                    let local = self.queue.0.local.lock();
+                    if local.messages.is_empty() && local.ports.is_empty() && self.is_closed() {
+                        self.terminated = true;
+                        return Poll::Ready(Err(RecvError::Error(err)));
+                    } else {
+                        trace_channel_error(&err);
+                    }
+                }
+            } else if !local.ports.is_empty() {
+                let new_handler = local.new_handler;
+                let ports = std::mem::take(&mut local.ports);
+                drop(local);
+                self.ports.0.extend(ports.into_iter().map(|port| {
+                    // SAFETY: `new_handler` has been set to a function whose
+                    // element type matches the queue's element type.
+                    let handler = unsafe { new_handler(self.queue.0.clone()) };
+                    port.set_handler(handler)
+                }));
+                continue;
+            } else if local.messages.is_empty() {
+                if let Some(cx) = cx {
+                    if !local
+                        .waker
+                        .as_ref()
+                        .map_or(false, |waker| waker.will_wake(cx.waker()))
+                        && !self.is_closed()
+                    {
+                        local.waker = Some(cx.waker().clone());
+                    }
+                }
+                if self.is_closed() {
+                    self.terminated = true;
+                    return Poll::Ready(Err(RecvError::Closed));
+                } else {
+                    return Poll::Pending;
+                }
+            } else {
+                // SAFETY: the caller guarantees `dst` is valid for writing a
+                // `T`.
+                unsafe { local.messages.pop_front(dst) };
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        Arc::strong_count(&self.queue.0) == 1
+    }
+
+    fn sender(&mut self) -> SenderCore {
+        self.terminated = false;
+        SenderCore(self.queue.0.clone())
+    }
+
+    /// Converts this receiver into a port.
+    ///
+    /// # Safety
+    /// The caller must ensure that `encode` is for `T`, the element type of
+    /// this receiver.
+    unsafe fn into_port(mut self, encode: EncodeFn) -> Port {
+        let ports = self.ports.into_ports();
+        if ports.len() == 1 {
+            if let Some(queue) = Arc::get_mut(&mut self.queue.0) {
+                let local = queue.local.get_mut();
+                if local.messages.is_empty() && local.ports.is_empty() {
+                    return ports.into_iter().next().unwrap();
+                }
+            }
+        }
+        let (send, recv) = Port::new_pair();
+        for port in ports {
+            send.send(Message::new(ChannelPayload::<()>::Port(port)));
+        }
+        let mut local = self.queue.0.local.lock();
+        for port in local.ports.drain(..) {
+            send.send(Message::new(ChannelPayload::<()>::Port(port)));
+        }
+        while let Some(message) = local.messages.pop_front_in_place() {
+            // SAFETY: `message` is a valid owned `T`.
+            let message = unsafe { encode(message.as_ptr()) };
+            send.send(message);
+        }
+        local.remote = true;
+        self.queue
+            .0
+            .remote
+            .set(RemoteQueueState { port: send, encode })
+            .ok()
+            .unwrap();
+
+        recv
+    }
+
+    /// Creates a new queue for receiving from `port`.
+    ///
+    /// # Safety
+    /// The caller must ensure that `vtable` and `new_handler` are for a
+    /// consistent queue element type.
+    unsafe fn from_port(
+        port: Port,
+        vtable: &'static ElementVtable,
+        new_handler: NewHandlerFn,
+    ) -> Self {
+        let queue = Arc::new(Queue {
+            local: Mutex::new(LocalQueue {
+                ports: vec![port],
+                new_handler,
+                ..LocalQueue::new(vtable)
+            }),
+            remote: OnceLock::new(),
+        });
+        Self {
+            queue: ReceiverQueue(queue),
+            ports: PortHandlerList::new(),
+            terminated: false,
+        }
+    }
+}
+
+fn trace_channel_error(err: &ChannelError) {
+    tracing::error!(
+        error = err as &dyn std::error::Error,
+        "channel closed due to error"
+    );
+}
+
+impl<T> futures_core::Stream for Receiver<T> {
+    type Item = T;
+
+    fn poll_next(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(match std::task::ready!(self.get_mut().poll_recv(cx)) {
+            Ok(t) => Some(t),
+            Err(RecvError::Closed) => None,
+            Err(RecvError::Error(err)) => {
+                trace_channel_error(&err);
+                None
+            }
+        })
+    }
+}
+
+impl<T> futures_core::FusedStream for Receiver<T> {
+    fn is_terminated(&self) -> bool {
+        self.0.terminated
+    }
+}
+
+#[derive(Debug)]
+struct PortHandlerList(Vec<PortWithHandler<RemotePortHandler>>);
+
+impl PortHandlerList {
+    fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    fn remove_closed(&mut self) -> Result<(), ChannelError> {
+        let mut r = Ok(());
+        self.0.retain(|port| match port.is_closed() {
+            Ok(true) => false,
+            Ok(false) => true,
+            Err(err) => {
+                let err = ChannelError::from(err);
+                if r.is_ok() {
+                    r = Err(err);
+                } else {
+                    trace_channel_error(&err);
+                }
+                false
+            }
+        });
+        r
+    }
+
+    fn into_ports(self) -> Vec<Port> {
+        self.0
+            .into_iter()
+            .map(|port| port.remove_handler().0)
+            .collect()
+    }
+}
+
+impl<T: MeshField> DefaultEncoding for Receiver<T> {
+    type Encoding = PortField;
+}
+
+impl<T: MeshField> From<Port> for Receiver<T> {
+    fn from(port: Port) -> Self {
+        Self::from_port(port)
+    }
+}
+
+impl<T: MeshField> From<Receiver<T>> for Port {
+    fn from(receiver: Receiver<T>) -> Self {
+        receiver.into_port()
+    }
+}
+
+impl<T: MeshField> Receiver<T> {
+    /// Bridges this and `sender` together, consuming both `self` and `sender`.
+    ///
+    /// See [`Sender::bridge`] for more details.
+    pub fn bridge(self, sender: Sender<T>) {
+        sender.bridge(self)
+    }
+
+    fn into_port(self) -> Port {
+        // SAFETY: the encode function is for `T`.
+        unsafe { self.0.into_port(Sender::<T>::encode_message) }
+    }
+
+    fn from_port(port: Port) -> Self {
+        Self(
+            // SAFETY: the vtable and new handler function are for a queue with
+            // type `T`.
+            unsafe {
+                ReceiverCore::from_port(
+                    port,
+                    const { &ElementVtable::new::<T>() },
+                    RemotePortHandler::new::<T>,
+                )
+            },
+            PhantomData,
+        )
+    }
+}
+
+#[derive(Debug)]
+struct Queue {
+    remote: OnceLock<RemoteQueueState>,
+    local: Mutex<LocalQueue>,
+}
+
+#[derive(Debug)]
+struct LocalQueue {
+    messages: ErasedVecDeque,
+    ports: Vec<Port>,
+    waker: Option<Waker>,
+    remote: bool,
+    receiver_gone: bool,
+    remove_closed: bool,
+    new_handler: NewHandlerFn,
+}
+
+type NewHandlerFn = unsafe fn(Arc<Queue>) -> RemotePortHandler;
+
+impl LocalQueue {
+    fn new(vtable: &'static ElementVtable) -> Self {
+        Self {
+            messages: ErasedVecDeque::new(vtable),
+            ports: Vec::new(),
+            waker: None,
+            remote: false,
+            receiver_gone: false,
+            remove_closed: false,
+            new_handler: missing_handler,
+        }
+    }
+}
+
+fn missing_handler(_: Arc<Queue>) -> RemotePortHandler {
+    unreachable!("handler function not set")
+}
+
+#[derive(Debug)]
+struct RemoteQueueState {
+    port: Port,
+    encode: EncodeFn,
+}
+
+type EncodeFn = unsafe fn(*const ()) -> Message;
+
+#[derive(Protobuf)]
+#[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
+enum ChannelPayload<T> {
+    Message(T),
+    Port(Port),
+}
+
+#[derive(Debug)]
+struct RemotePortHandler {
+    queue: Arc<Queue>,
+    parse: unsafe fn(Message, *mut ()) -> Result<Option<Port>, ChannelError>,
+}
+
+impl RemotePortHandler {
+    /// Creates a new handler for a queue with element type `T`.
+    ///
+    /// # Safety
+    /// The caller must ensure that `queue` has element type `T`.
+    unsafe fn new<T: MeshField>(queue: Arc<Queue>) -> Self {
+        Self {
+            queue,
+            parse: Self::parse::<T>,
+        }
+    }
+
+    /// Parses a message into a `T` or a `Port`.
+    ///
+    /// # Safety
+    /// The caller must ensure that `p` is valid for writing a `T`.
+    unsafe fn parse<T: MeshField>(
+        message: Message,
+        p: *mut (),
+    ) -> Result<Option<Port>, ChannelError> {
+        match message.parse::<ChannelPayload<T>>() {
+            Ok(ChannelPayload::Message(message)) => {
+                // SAFETY: The caller guarantees `p` is valid for writing a `T`.
+                unsafe { p.cast::<T>().write(message) };
+                Ok(None)
+            }
+            Ok(ChannelPayload::Port(port)) => Ok(Some(port)),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+impl HandlePortEvent for RemotePortHandler {
+    fn message(
+        &mut self,
+        control: &mut mesh_node::local_node::PortControl<'_>,
+        message: Message,
+    ) -> Result<(), HandleMessageError> {
+        let mut local = self.queue.local.lock();
+        assert!(!local.receiver_gone);
+        assert!(!local.remote);
+        // Decode directly into the queue.
+        let p = local.messages.reserve_one();
+        // SAFETY: `p` is valid for writing a `T`, the element type of the
+        // queue.
+        let r = unsafe { (self.parse)(message, p.as_ptr()) };
+        let port = r.map_err(HandleMessageError::new)?;
+        match port {
+            None => {
+                // SAFETY: `p` has been written to.
+                unsafe { local.messages.commit_one() };
+            }
+            Some(port) => {
+                local.ports.push(port);
+            }
+        }
+        let waker = local.waker.take();
+        drop(local);
+        if let Some(waker) = waker {
+            control.wake(waker);
+        }
+        Ok(())
+    }
+
+    fn close(&mut self, control: &mut mesh_node::local_node::PortControl<'_>) {
+        let waker = {
+            let mut local = self.queue.local.lock();
+            local.remove_closed = true;
+            local.waker.take()
+        };
+        if let Some(waker) = waker {
+            control.wake(waker);
+        }
+    }
+
+    fn fail(
+        &mut self,
+        control: &mut mesh_node::local_node::PortControl<'_>,
+        _err: mesh_node::local_node::NodeError,
+    ) {
+        self.close(control);
+    }
+
+    fn drain(&mut self) -> Vec<Message> {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::channel;
+    use super::Receiver;
+    use super::Sender;
+    use crate::RecvError;
+    use futures::executor::block_on;
+    use futures::StreamExt;
+    use futures_core::FusedStream;
+    use mesh_node::local_node::Port;
+    use std::cell::Cell;
+    use test_with_tracing::test;
+
+    // Ensure `Send` and `Sync` are implemented correctly.
+    static_assertions::assert_impl_all!(Sender<i32>: Send, Sync);
+    static_assertions::assert_impl_all!(Receiver<i32>: Send, Sync);
+    static_assertions::assert_impl_all!(Sender<Cell<i32>>: Send, Sync);
+    static_assertions::assert_impl_all!(Receiver<Cell<i32>>: Send, Sync);
+    static_assertions::assert_not_impl_any!(Sender<*const ()>: Send, Sync);
+    static_assertions::assert_not_impl_any!(Receiver<*const ()>: Send, Sync);
+
+    #[test]
+    fn test_basic() {
+        block_on(async {
+            let (sender, mut receiver) = channel();
+            sender.send(String::from("test"));
+            assert_eq!(receiver.next().await.as_deref(), Some("test"));
+            drop(sender);
+            assert_eq!(receiver.next().await, None);
+        })
+    }
+
+    #[test]
+    fn test_convert_sender_port() {
+        block_on(async {
+            let (sender, mut receiver) = channel::<String>();
+            let sender = Sender::<String>::from(Port::from(sender));
+            sender.send(String::from("test"));
+            assert_eq!(receiver.next().await.as_deref(), Some("test"));
+            drop(sender);
+            assert_eq!(receiver.next().await, None);
+        })
+    }
+
+    #[test]
+    fn test_convert_receiver_port() {
+        block_on(async {
+            let (sender, receiver) = channel();
+            let mut receiver = Receiver::<String>::from(Port::from(receiver));
+            sender.send(String::from("test"));
+            assert_eq!(receiver.next().await.as_deref(), Some("test"));
+            drop(sender);
+            assert_eq!(receiver.next().await, None);
+        })
+    }
+
+    #[test]
+    fn test_non_port_and_port_sender() {
+        block_on(async {
+            let (sender, mut receiver) = channel();
+            let sender2 = Sender::<String>::from(Port::from(sender.clone()));
+            sender.send(String::from("test"));
+            sender2.send(String::from("tset"));
+            assert_eq!(receiver.next().await.as_deref(), Some("test"));
+            assert_eq!(receiver.next().await.as_deref(), Some("tset"));
+            drop(sender);
+            drop(sender2);
+            assert_eq!(receiver.next().await, None);
+        })
+    }
+
+    #[test]
+    fn test_port_receiver_with_senders_and_messages() {
+        block_on(async {
+            let (sender, receiver) = channel();
+            let sender2 = Sender::<String>::from(Port::from(sender.clone()));
+            sender.send(String::from("test"));
+            sender2.send(String::from("tset"));
+            let mut receiver = Receiver::<String>::from(Port::from(receiver));
+            assert_eq!(receiver.next().await.as_deref(), Some("test"));
+            assert_eq!(receiver.next().await.as_deref(), Some("tset"));
+            drop(sender);
+            drop(sender2);
+            assert_eq!(receiver.next().await, None);
+        })
+    }
+
+    #[test]
+    fn test_message_corruption() {
+        block_on(async {
+            let (sender, receiver) = channel();
+            let mut receiver = Receiver::<i32>::from(Port::from(receiver));
+            sender.send("text".to_owned());
+            let RecvError::Error(err) = receiver.recv().await.unwrap_err() else {
+                panic!()
+            };
+            tracing::info!(error = &err as &dyn std::error::Error, "expected error");
+            assert!(receiver.is_terminated());
+        })
+    }
+}

--- a/support/mesh/mesh_channel_core/src/mpsc.rs
+++ b/support/mesh/mesh_channel_core/src/mpsc.rs
@@ -830,7 +830,7 @@ impl HandlePortEvent for RemotePortHandler {
         match port {
             None => {
                 // SAFETY: `p` has been written to.
-                unsafe { local.messages.commit_one() };
+                unsafe { p.commit() };
             }
             Some(port) => {
                 local.ports.push(port);


### PR DESCRIPTION
This change adds a new crate, `mesh_channel_core`, with a new MPSC (multi-producer, single-consumer) channel implementation. It replaces the existing SPSC and MPSC channels in `mesh_channel` with this single implementation. This has several advantages:

* The new channel supports MPSC semantics without any downsides, so we can offer just a single (non-oneshot) channel type instead of requiring users to choose between SPSC and MPSC.
* The generated code size is slightly smaller than the old SPSC channel.
* The new channel is much more efficient for in-process use, since the messages no longer have to flow through the `mesh_node` machinery.
* The new channel is more efficient and has better fairness for multi-process MPSC use, since there is a single queue on the receiver side instead of a queue per port.
* The new channel doesn't require the element type be `Send` or `'static` (except when sending the channel between mesh nodes--this restriction can be lifted later).
* The new channel is designed so that we can make the mesh node support optional, reducing compile time dependencies for things like `inspect`.

The main idea is to have a single queue but to support backing it with a variable number of in-process senders and cross-node ports.

In order to keep the code size small, I had to use a lot of unsafe code to avoid significant monomorphization overhead. Originally I did this without unsafe code, but it increased the openvmm_hcl binary size by about 250KB. I ran the unit tests under miri to get some confidence that the unsafe code is correct.

Fixes #596.
