### PR TITLE
guestmem: skip sparse_mmap init under miri

### DIFF
--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -946,8 +946,13 @@ impl GuestMemory {
     /// `debug_name` is used to specify which guest memory is being accessed in
     /// error messages.
     pub fn new(debug_name: impl Into<Arc<str>>, imp: impl GuestMemoryAccess) -> Self {
-        // Install signal handlers on unix.
-        sparse_mmap::initialize_try_copy();
+        // Install signal handlers on unix if a mapping is present.
+        //
+        // Skip this on miri even when there is a mapping, since the mapping may
+        // never be accessed by the code under test.
+        if imp.mapping().is_some() && !cfg!(miri) {
+            sparse_mmap::initialize_try_copy();
+        }
 
         let regions = vec![MemoryRegion::new(&imp)];
         Self {


### PR DESCRIPTION
When running tests under miri, the `sparse_mmap` try-copy functionality can't work. However, some tests allocate `GuestMemory` objects and then never access the memory. Allow these tests to run under miri by skipping `sparse_mmap` initialization.