### PR TITLE
pal_async: support running under miri

### DIFF
--- a/support/pal/pal_async/src/unix/epoll.rs
+++ b/support/pal/pal_async/src/unix/epoll.rs
@@ -54,6 +54,9 @@ impl Default for EpollBackend {
     fn default() -> Self {
         let epfd = EpollFd::new().expect("epoll not functional");
         let wake_event = Event::new();
+        // Register for notifications when the wake event is signaled. Use
+        // edge-triggered mode because we can (we immediately consume the event
+        // when it is signaled) and because miri requires it.
         epfd.add(
             wake_event.as_fd().as_raw_fd(),
             libc::EPOLLIN | libc::EPOLLET,

--- a/support/pal/pal_async/src/unix/epoll.rs
+++ b/support/pal/pal_async/src/unix/epoll.rs
@@ -54,8 +54,12 @@ impl Default for EpollBackend {
     fn default() -> Self {
         let epfd = EpollFd::new().expect("epoll not functional");
         let wake_event = Event::new();
-        epfd.add(wake_event.as_fd().as_raw_fd(), libc::EPOLLIN, 0)
-            .expect("could not add wake event");
+        epfd.add(
+            wake_event.as_fd().as_raw_fd(),
+            libc::EPOLLIN | libc::EPOLLET,
+            0,
+        )
+        .expect("could not add wake event");
         Self {
             epfd,
             wake_event,


### PR DESCRIPTION
The epoll backend for `pal_async` registers an eventfd for waking up due to a waker, but it neglects to pass the `EPOLLET` (edge triggered) flag when registering it. Miri, it turns out, supports epoll, but it only supports `EPOLLET` registrations.

Pass `EPOLLET` for the wake event. This works fine--we are already handling the wake event in an edge-triggered compatible way.

This allows `#[async_test]` tests to run under miri on Linux.