### PR TITLE
mesh_channel: use port encoding for channels

### DIFF
--- a/support/mesh/mesh_channel/src/lib.rs
+++ b/support/mesh/mesh_channel/src/lib.rs
@@ -12,7 +12,9 @@ pub mod rpc;
 
 use bidir::Channel;
 use mesh_node::local_node::Port;
+use mesh_node::local_node::PortField;
 use mesh_node::message::MeshField;
+use mesh_protobuf::DefaultEncoding;
 use mesh_protobuf::Protobuf;
 use std::fmt::Debug;
 use std::future::Future;
@@ -86,8 +88,6 @@ pub enum RecvError {
 }
 
 /// The sending half of a channel returned by [`channel`].
-#[derive(Protobuf)]
-#[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
 pub struct Sender<T>(Channel<(T,), ()>);
 
 impl<T> Debug for Sender<T> {
@@ -96,15 +96,21 @@ impl<T> Debug for Sender<T> {
     }
 }
 
+impl<T: MeshField> DefaultEncoding for Sender<T> {
+    type Encoding = PortField;
+}
+
 /// The receiving half of a channel returned by [`channel`].
-#[derive(Protobuf)]
-#[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
 pub struct Receiver<T>(Channel<(), (T,)>);
 
 impl<T> Debug for Receiver<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Debug::fmt(&self.0, f)
     }
+}
+
+impl<T: MeshField> DefaultEncoding for Receiver<T> {
+    type Encoding = PortField;
 }
 
 impl<T: MeshField> From<Port> for Sender<T> {
@@ -289,14 +295,16 @@ pub fn channel<T: 'static + Send>() -> (Sender<T>, Receiver<T>) {
 }
 
 /// The sending half of a channel returned by [`oneshot`].
-#[derive(Protobuf)]
-#[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
 pub struct OneshotSender<T>(Channel<(T,), ()>);
 
 impl<T> Debug for OneshotSender<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Debug::fmt(&self.0, f)
     }
+}
+
+impl<T: MeshField> DefaultEncoding for OneshotSender<T> {
+    type Encoding = PortField;
 }
 
 impl<T: MeshField> From<Port> for OneshotSender<T> {
@@ -321,14 +329,16 @@ impl<T: 'static + Send> OneshotSender<T> {
 /// The receiving half of a channel returned by [`oneshot`].
 ///
 /// A value is received by `poll`ing or `await`ing the channel.
-#[derive(Protobuf)]
-#[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
 pub struct OneshotReceiver<T>(Channel<(), (T,)>);
 
 impl<T> Debug for OneshotReceiver<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Debug::fmt(&self.0, f)
     }
+}
+
+impl<T: MeshField> DefaultEncoding for OneshotReceiver<T> {
+    type Encoding = PortField;
 }
 
 impl<T: 'static + Send> Future for OneshotReceiver<T> {

--- a/support/mesh/mesh_process/src/lib.rs
+++ b/support/mesh/mesh_process/src/lib.rs
@@ -16,6 +16,7 @@ use futures::StreamExt;
 use futures_concurrency::future::Race;
 use inspect::Inspect;
 use inspect::SensitivityLevel;
+use mesh::message::MeshField;
 use mesh::payload::Protobuf;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
@@ -444,7 +445,7 @@ impl Mesh {
     ///
     /// The initial message will be provided to the closure passed to
     /// [`try_run_mesh_host()`].
-    pub async fn launch_host<T: MeshPayload>(
+    pub async fn launch_host<T: MeshField>(
         &self,
         config: ProcessConfig,
         initial_message: T,


### PR DESCRIPTION
Instead of deriving a protobuf message encoding for oneshot and SPSC channels, use the port field encoding.

This makes messages smaller and reduces codegen size. There's reason to believe it should improve compile times and runtime performance as well.

MPSC channels still require a message encoding. This could be fixed, but soon we will just replace the implementation entirely.
