### PR TITLE
Flowey: Use explicit parameter names instead of auto generated.

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -6,7 +6,7 @@ name: '[flowey] OpenVMM CI'
 on:
   workflow_dispatch:
     inputs:
-      param0:
+      verbose:
         description: Run with verbose output
         default: false
         required: false
@@ -102,8 +102,8 @@ jobs:
         echo '"debug"' | flowey v 0 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 0 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 0 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 0 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/guide"
         echo "$AgentTempDirNormal/publish_artifacts/guide" | flowey v 0 'artifact_publish_from_guide' --update-from-stdin --is-raw-string
@@ -292,8 +292,8 @@ jobs:
         echo '"debug"' | flowey.exe v 1 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 1 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 1 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 1 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-rustdoc"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-rustdoc" | flowey.exe v 1 'artifact_publish_from_x64-windows-rustdoc' --update-from-stdin --is-raw-string
@@ -495,8 +495,8 @@ jobs:
         echo '"debug"' | flowey v 10 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 10 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 10 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 10 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 10 'artifact_publish_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
@@ -856,8 +856,8 @@ jobs:
         echo '"debug"' | flowey v 11 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 11 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 11 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 11 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 11 'artifact_publish_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
@@ -1280,8 +1280,8 @@ jobs:
         echo '"debug"' | flowey v 12 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 12 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 12 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 12 'artifact_publish_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -1695,8 +1695,8 @@ jobs:
         echo '"debug"' | flowey v 13 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 13 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 13 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 13 'artifact_publish_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -2282,8 +2282,8 @@ jobs:
         echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 14 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 14 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -2607,8 +2607,8 @@ jobs:
         echo '"debug"' | flowey v 15 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 15 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 15 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -2980,8 +2980,8 @@ jobs:
         echo '"debug"' | flowey v 16 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 16 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 16 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -3351,8 +3351,8 @@ jobs:
         echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 17 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 17 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: report common cargo flags
@@ -3609,8 +3609,8 @@ jobs:
         echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 18 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 18 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -3968,8 +3968,8 @@ jobs:
         echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 19 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 19 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -4349,8 +4349,8 @@ jobs:
         echo '"debug"' | flowey v 2 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 2 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 2 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 2 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc" | flowey v 2 'artifact_publish_from_x64-linux-rustdoc' --update-from-stdin --is-raw-string
@@ -4538,8 +4538,8 @@ jobs:
         echo '"debug"' | flowey v 20 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 20 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 20 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 20 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 20 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -4903,8 +4903,8 @@ jobs:
         echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 21 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 21 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -5284,8 +5284,8 @@ jobs:
         echo '"debug"' | flowey v 22 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 22 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 22 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -5373,8 +5373,8 @@ jobs:
         echo '"debug"' | flowey v 3 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 3 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 3 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 3 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/guide" | flowey v 3 'artifact_use_from_guide' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-rustdoc" | flowey v 3 'artifact_use_from_x64-linux-rustdoc' --update-from-stdin --is-raw-string
@@ -5495,8 +5495,8 @@ jobs:
         echo '"debug"' | flowey.exe v 4 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 4 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 4 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 4 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -5685,8 +5685,8 @@ jobs:
         echo '"debug"' | flowey v 5 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 5 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 5 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 5 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -5886,8 +5886,8 @@ jobs:
         echo '"debug"' | flowey.exe v 6 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 6 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 6 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 6 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-hypestv"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 6 'artifact_publish_from_aarch64-windows-hypestv' --update-from-stdin --is-raw-string
@@ -6186,8 +6186,8 @@ jobs:
         echo '"debug"' | flowey.exe v 7 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 7 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 7 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 7 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 7 'artifact_publish_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
@@ -6481,8 +6481,8 @@ jobs:
         echo '"debug"' | flowey.exe v 8 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 8 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 8 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 8 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 8 'artifact_publish_from_x64-windows-hypestv' --update-from-stdin --is-raw-string
@@ -6784,8 +6784,8 @@ jobs:
         echo '"debug"' | flowey.exe v 9 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 9 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 9 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 9 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 9 'artifact_publish_from_x64-windows-openvmm' --update-from-stdin --is-raw-string

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -6,7 +6,7 @@ name: '[flowey] OpenVMM PR'
 on:
   workflow_dispatch:
     inputs:
-      param0:
+      verbose:
         description: Run with verbose output
         default: false
         required: false
@@ -110,8 +110,8 @@ jobs:
         echo '"debug"' | flowey v 0 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 0 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 0 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 0 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/guide"
         echo "$AgentTempDirNormal/publish_artifacts/guide" | flowey v 0 'artifact_publish_from_guide' --update-from-stdin --is-raw-string
@@ -300,8 +300,8 @@ jobs:
         echo '"debug"' | flowey.exe v 1 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 1 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 1 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 1 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-rustdoc"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-rustdoc" | flowey.exe v 1 'artifact_publish_from_x64-windows-rustdoc' --update-from-stdin --is-raw-string
@@ -503,8 +503,8 @@ jobs:
         echo '"debug"' | flowey v 10 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 10 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 10 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 10 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 10 'artifact_publish_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
@@ -927,8 +927,8 @@ jobs:
         echo '"debug"' | flowey v 11 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 11 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 11 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 11 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 11 'artifact_publish_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -1342,8 +1342,8 @@ jobs:
         echo '"debug"' | flowey v 12 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 12 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 12 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 12 'artifact_publish_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -1929,8 +1929,8 @@ jobs:
         echo '"debug"' | flowey.exe v 13 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 13 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 13 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 13 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -2254,8 +2254,8 @@ jobs:
         echo '"debug"' | flowey v 14 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 14 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 14 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 14 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -2627,8 +2627,8 @@ jobs:
         echo '"debug"' | flowey v 15 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 15 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 15 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 15 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -2998,8 +2998,8 @@ jobs:
         echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 16 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 16 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: report common cargo flags
@@ -3256,8 +3256,8 @@ jobs:
         echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 17 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 17 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 17 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 17 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -3615,8 +3615,8 @@ jobs:
         echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 18 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 18 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -3968,8 +3968,8 @@ jobs:
         echo '"debug"' | flowey v 19 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 19 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 19 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 19 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 19 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -4354,8 +4354,8 @@ jobs:
         echo '"debug"' | flowey v 2 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 2 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 2 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 2 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc" | flowey v 2 'artifact_publish_from_x64-linux-rustdoc' --update-from-stdin --is-raw-string
@@ -4542,8 +4542,8 @@ jobs:
         echo '"debug"' | flowey.exe v 20 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 20 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 20 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 20 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 20 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -4923,8 +4923,8 @@ jobs:
         echo '"debug"' | flowey v 21 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 21 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 21 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -5017,8 +5017,8 @@ jobs:
         echo '"debug"' | flowey v 22 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 22 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 22 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: Check if any jobs failed
@@ -5112,8 +5112,8 @@ jobs:
         echo '"debug"' | flowey.exe v 3 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 3 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 3 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 3 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -5302,8 +5302,8 @@ jobs:
         echo '"debug"' | flowey v 4 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 4 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 4 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 4 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -5503,8 +5503,8 @@ jobs:
         echo '"debug"' | flowey.exe v 5 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 5 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 5 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 5 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-hypestv"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-hypestv' --update-from-stdin --is-raw-string
@@ -5803,8 +5803,8 @@ jobs:
         echo '"debug"' | flowey.exe v 6 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 6 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 6 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 6 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 6 'artifact_publish_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
@@ -6098,8 +6098,8 @@ jobs:
         echo '"debug"' | flowey.exe v 7 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 7 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 7 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 7 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 7 'artifact_publish_from_x64-windows-hypestv' --update-from-stdin --is-raw-string
@@ -6401,8 +6401,8 @@ jobs:
         echo '"debug"' | flowey.exe v 8 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 8 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 8 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 8 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 8 'artifact_publish_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
@@ -6697,8 +6697,8 @@ jobs:
         echo '"debug"' | flowey v 9 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 9 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 9 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 9 'artifact_publish_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string

--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -654,48 +654,45 @@ EOF
                 parameters
                     .clone()
                     .into_iter()
-                    .map(|param| {
-                        let name = param.name();
-                        match param {
-                            flowey_core::pipeline::internal::Parameter::Bool {
-                                name: _,
-                                description,
-                                kind: _,
+                    .map(|param| match param {
+                        flowey_core::pipeline::internal::Parameter::Bool {
+                            name,
+                            description,
+                            kind: _,
+                            default,
+                        } => schema_ado_yaml::Parameter {
+                            name,
+                            display_name: description,
+                            ty: schema_ado_yaml::ParameterType::Boolean { default },
+                        },
+                        flowey_core::pipeline::internal::Parameter::String {
+                            name,
+                            description,
+                            kind: _,
+                            default,
+                            possible_values,
+                        } => schema_ado_yaml::Parameter {
+                            name,
+                            display_name: description,
+                            ty: schema_ado_yaml::ParameterType::String {
                                 default,
-                            } => schema_ado_yaml::Parameter {
-                                name,
-                                display_name: description,
-                                ty: schema_ado_yaml::ParameterType::Boolean { default },
+                                values: possible_values,
                             },
-                            flowey_core::pipeline::internal::Parameter::String {
-                                name: _,
-                                description,
-                                kind: _,
+                        },
+                        flowey_core::pipeline::internal::Parameter::Num {
+                            name,
+                            description,
+                            kind: _,
+                            default,
+                            possible_values,
+                        } => schema_ado_yaml::Parameter {
+                            name,
+                            display_name: description,
+                            ty: schema_ado_yaml::ParameterType::Number {
                                 default,
-                                possible_values,
-                            } => schema_ado_yaml::Parameter {
-                                name,
-                                display_name: description,
-                                ty: schema_ado_yaml::ParameterType::String {
-                                    default,
-                                    values: possible_values,
-                                },
+                                values: possible_values,
                             },
-                            flowey_core::pipeline::internal::Parameter::Num {
-                                name: _,
-                                description,
-                                kind: _,
-                                default,
-                                possible_values,
-                            } => schema_ado_yaml::Parameter {
-                                name,
-                                display_name: description,
-                                ty: schema_ado_yaml::ParameterType::Number {
-                                    default,
-                                    values: possible_values,
-                                },
-                            },
-                        }
+                        },
                     })
                     .collect(),
             )

--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -658,6 +658,7 @@ EOF
                         flowey_core::pipeline::internal::Parameter::Bool {
                             name,
                             description,
+                            kind: _,
                             default,
                         } => schema_ado_yaml::Parameter {
                             name,
@@ -667,6 +668,7 @@ EOF
                         flowey_core::pipeline::internal::Parameter::String {
                             name,
                             description,
+                            kind: _,
                             default,
                             possible_values,
                         } => schema_ado_yaml::Parameter {
@@ -680,6 +682,7 @@ EOF
                         flowey_core::pipeline::internal::Parameter::Num {
                             name,
                             description,
+                            kind: _,
                             default,
                             possible_values,
                         } => schema_ado_yaml::Parameter {

--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -284,6 +284,8 @@ echo "$(FLOWEY_TEMP_DIR)/work" | {var_db_insert_working_dir}
                 flowey_core::pipeline::internal::Parameter::Bool { .. }
             );
 
+            let name = parameters[*pipeline_param_idx].name();
+
             // ADO resolves bools as `True` and `False`, _sigh_
             let with_lowercase = if is_bool {
                 r#" | tr '[:upper:]' '[:lower:]'"#
@@ -296,7 +298,7 @@ echo "$(FLOWEY_TEMP_DIR)/work" | {var_db_insert_working_dir}
             let cmd = format!(
                 r#"
 cat <<'EOF'{with_lowercase} | {var_db_inject_cmd}
-${{{{ parameters.param{pipeline_param_idx} }}}}
+${{{{ parameters.{name} }}}}
 EOF
 "#
             )
@@ -530,20 +532,26 @@ EOF
                     })
                     .collect()
             },
-            variables:  {
-                let mut ado_variables: Vec<schema_ado_yaml::Variable> = ado_variables.clone().into_iter()
-                        .map(|(name, value)| schema_ado_yaml::Variable { name, value })
-                        .collect();
+            variables: {
+                let mut ado_variables: Vec<schema_ado_yaml::Variable> = ado_variables
+                    .clone()
+                    .into_iter()
+                    .map(|(name, value)| schema_ado_yaml::Variable { name, value })
+                    .collect();
 
-                ado_variables.push(schema_ado_yaml::Variable {name: "FLOWEY_TEMP_DIR".into(), value: FLOWEY_TEMP_DIR.into()});
+                ado_variables.push(schema_ado_yaml::Variable {
+                    name: "FLOWEY_TEMP_DIR".into(),
+                    value: FLOWEY_TEMP_DIR.into(),
+                });
 
-                Some(
-                    ado_variables
-                )
+                Some(ado_variables)
             },
             steps: ado_steps,
             condition: Some(if let Some(cond_param_idx) = cond_param_idx {
-                format!("and(eq('${{{{ parameters.param{cond_param_idx} }}}}', 'true'), succeeded(), not(canceled()))")
+                format!(
+                    "and(eq('${{{{ parameters.{} }}}}', 'true'), succeeded(), not(canceled()))",
+                    parameters[cond_param_idx].name()
+                )
             } else {
                 "and(succeeded(), not(canceled()))".into()
             }),
@@ -644,23 +652,25 @@ EOF
         parameters: if !parameters.is_empty() {
             Some(
                 parameters
+                    .clone()
                     .into_iter()
-                    .enumerate()
-                    .map(|(idx, param)| match param {
+                    .map(|param| match param {
                         flowey_core::pipeline::internal::Parameter::Bool {
+                            name,
                             description,
                             default,
                         } => schema_ado_yaml::Parameter {
-                            name: format!("param{idx}"),
+                            name,
                             display_name: description,
                             ty: schema_ado_yaml::ParameterType::Boolean { default },
                         },
                         flowey_core::pipeline::internal::Parameter::String {
+                            name,
                             description,
                             default,
                             possible_values,
                         } => schema_ado_yaml::Parameter {
-                            name: format!("param{idx}"),
+                            name,
                             display_name: description,
                             ty: schema_ado_yaml::ParameterType::String {
                                 default,
@@ -668,11 +678,12 @@ EOF
                             },
                         },
                         flowey_core::pipeline::internal::Parameter::Num {
+                            name,
                             description,
                             default,
                             possible_values,
                         } => schema_ado_yaml::Parameter {
-                            name: format!("param{idx}"),
+                            name,
                             display_name: description,
                             ty: schema_ado_yaml::ParameterType::Number {
                                 default,
@@ -710,7 +721,8 @@ EOF
                                     r#ref: match git_ref {
                                         AdoResourcesRepositoryRef::Fixed(s) => s,
                                         AdoResourcesRepositoryRef::Parameter(idx) => {
-                                            format!("${{{{ parameters.param{idx} }}}}")
+                                            let name = parameters[idx].name();
+                                            format!("${{{{ parameters.{name} }}}}")
                                         }
                                     },
                                     r#type: match repo_type {

--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -654,45 +654,48 @@ EOF
                 parameters
                     .clone()
                     .into_iter()
-                    .map(|param| match param {
-                        flowey_core::pipeline::internal::Parameter::Bool {
-                            name,
-                            description,
-                            kind: _,
-                            default,
-                        } => schema_ado_yaml::Parameter {
-                            name,
-                            display_name: description,
-                            ty: schema_ado_yaml::ParameterType::Boolean { default },
-                        },
-                        flowey_core::pipeline::internal::Parameter::String {
-                            name,
-                            description,
-                            kind: _,
-                            default,
-                            possible_values,
-                        } => schema_ado_yaml::Parameter {
-                            name,
-                            display_name: description,
-                            ty: schema_ado_yaml::ParameterType::String {
+                    .map(|param| {
+                        let name = param.name();
+                        match param {
+                            flowey_core::pipeline::internal::Parameter::Bool {
+                                name: _,
+                                description,
+                                kind: _,
                                 default,
-                                values: possible_values,
+                            } => schema_ado_yaml::Parameter {
+                                name,
+                                display_name: description,
+                                ty: schema_ado_yaml::ParameterType::Boolean { default },
                             },
-                        },
-                        flowey_core::pipeline::internal::Parameter::Num {
-                            name,
-                            description,
-                            kind: _,
-                            default,
-                            possible_values,
-                        } => schema_ado_yaml::Parameter {
-                            name,
-                            display_name: description,
-                            ty: schema_ado_yaml::ParameterType::Number {
+                            flowey_core::pipeline::internal::Parameter::String {
+                                name: _,
+                                description,
+                                kind: _,
                                 default,
-                                values: possible_values,
+                                possible_values,
+                            } => schema_ado_yaml::Parameter {
+                                name,
+                                display_name: description,
+                                ty: schema_ado_yaml::ParameterType::String {
+                                    default,
+                                    values: possible_values,
+                                },
                             },
-                        },
+                            flowey_core::pipeline::internal::Parameter::Num {
+                                name: _,
+                                description,
+                                kind: _,
+                                default,
+                                possible_values,
+                            } => schema_ado_yaml::Parameter {
+                                name,
+                                display_name: description,
+                                ty: schema_ado_yaml::ParameterType::Number {
+                                    default,
+                                    values: possible_values,
+                                },
+                            },
+                        }
                     })
                     .collect(),
             )

--- a/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
@@ -221,6 +221,7 @@ fn direct_run_do_work(
         {
             let (desc, value) = match &parameters[*pipeline_param_idx] {
                 Parameter::Bool {
+                    name: _,
                     description,
                     default,
                 } => (
@@ -228,6 +229,7 @@ fn direct_run_do_work(
                     default.as_ref().map(|v| serde_json::to_vec(v).unwrap()),
                 ),
                 Parameter::String {
+                    name: _,
                     description,
                     default,
                     possible_values: _,
@@ -236,6 +238,7 @@ fn direct_run_do_work(
                     default.as_ref().map(|v| serde_json::to_vec(v).unwrap()),
                 ),
                 Parameter::Num {
+                    name: _,
                     description,
                     default,
                     possible_values: _,
@@ -302,6 +305,7 @@ fn direct_run_do_work(
 
         if let Some(cond_param_idx) = cond_param_idx {
             let Parameter::Bool {
+                name: _,
                 description: _,
                 default,
             } = &parameters[cond_param_idx]

--- a/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
@@ -223,6 +223,7 @@ fn direct_run_do_work(
                 Parameter::Bool {
                     name: _,
                     description,
+                    kind: _,
                     default,
                 } => (
                     description,
@@ -231,6 +232,7 @@ fn direct_run_do_work(
                 Parameter::String {
                     name: _,
                     description,
+                    kind: _,
                     default,
                     possible_values: _,
                 } => (
@@ -240,6 +242,7 @@ fn direct_run_do_work(
                 Parameter::Num {
                     name: _,
                     description,
+                    kind: _,
                     default,
                     possible_values: _,
                 } => (
@@ -307,6 +310,7 @@ fn direct_run_do_work(
             let Parameter::Bool {
                 name: _,
                 description: _,
+                kind: _,
                 default,
             } = &parameters[cond_param_idx]
             else {

--- a/flowey/flowey_cli/src/pipeline_resolver/generic.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/generic.rs
@@ -202,9 +202,7 @@ pub fn resolve_pipeline(pipeline: Pipeline) -> anyhow::Result<ResolvedPipeline> 
         let parameters_used: Vec<_> = parameters_used
             .into_iter()
             .map(|param_idx| ResolvedJobUseParameter {
-                flowey_var: flowey_core::pipeline::internal::consistent_param_runtime_var_name(
-                    param_idx,
-                ),
+                flowey_var: parameters[param_idx].name().to_string(),
                 pipeline_param_idx: param_idx,
             })
             .collect();

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -596,6 +596,7 @@ EOF
                                 flowey_core::pipeline::internal::Parameter::Bool {
                                     name: _,
                                     description,
+                                    kind: _,
                                     default,
                                 } => github_yaml_defs::Input {
                                     description: Some(description.clone()),
@@ -606,6 +607,7 @@ EOF
                                 flowey_core::pipeline::internal::Parameter::String {
                                     name: _,
                                     description,
+                                    kind: _,
                                     default,
                                     possible_values: _,
                                 } => github_yaml_defs::Input {
@@ -619,6 +621,7 @@ EOF
                                 flowey_core::pipeline::internal::Parameter::Num {
                                     name: _,
                                     description,
+                                    kind: _,
                                     default,
                                     possible_values: _,
                                 } => github_yaml_defs::Input {

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -365,10 +365,12 @@ echo "{RUNNER_TEMP}/work" | {var_db_insert_working_dir}
 
             let var_db_inject_cmd = bootstrap_bash_var_db_inject(flowey_var, is_string);
 
+            let name = parameters[*pipeline_param_idx].name();
+
             let cmd = format!(
                 r#"
 cat <<'EOF' | {var_db_inject_cmd}
-${{{{ inputs.param{pipeline_param_idx} != '' && inputs.param{pipeline_param_idx} || '{default}' }}}}
+${{{{ inputs.{name} != '' && inputs.{name} || '{default}' }}}}
 EOF
 "#
             )
@@ -587,12 +589,12 @@ EOF
             inputs: github_yaml_defs::Inputs {
                 inputs: parameters
                     .into_iter()
-                    .enumerate()
-                    .map(|(idx, param)| {
+                    .map(|param| {
                         (
-                            format!("param{idx}"),
+                            param.name().to_string(),
                             match param {
                                 flowey_core::pipeline::internal::Parameter::Bool {
+                                    name: _,
                                     description,
                                     default,
                                 } => github_yaml_defs::Input {
@@ -602,6 +604,7 @@ EOF
                                     ty: github_yaml_defs::InputType::Boolean,
                                 },
                                 flowey_core::pipeline::internal::Parameter::String {
+                                    name: _,
                                     description,
                                     default,
                                     possible_values: _,
@@ -614,6 +617,7 @@ EOF
                                     ty: github_yaml_defs::InputType::String,
                                 },
                                 flowey_core::pipeline::internal::Parameter::Num {
+                                    name: _,
                                     description,
                                     default,
                                     possible_values: _,

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -1350,15 +1350,15 @@ pub mod internal {
             match self {
                 Parameter::Bool { name, kind, .. } => match kind {
                     ParameterKind::Unstable => format!("__unstable_{name}"),
-                    ParameterKind::Stable => format!("{name}"),
+                    ParameterKind::Stable => name.to_string(),
                 },
                 Parameter::String { name, kind, .. } => match kind {
                     ParameterKind::Unstable => format!("__unstable_{name}"),
-                    ParameterKind::Stable => format!("{name}"),
+                    ParameterKind::Stable => name.to_string(),
                 },
                 Parameter::Num { name, kind, .. } => match kind {
                     ParameterKind::Unstable => format!("__unstable_{name}"),
-                    ParameterKind::Stable => format!("{name}"),
+                    ParameterKind::Stable => name.to_string(),
                 },
             }
         }

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -865,10 +865,7 @@ impl PipelineJobCtx<'_> {
             .insert(self.job_idx);
 
         crate::node::thin_air_read_runtime_var(
-            self.pipeline.parameters[param.idx]
-                .parameter
-                .name()
-                .to_string(),
+            self.pipeline.parameters[param.idx].parameter.name(),
             false,
         )
     }

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -701,7 +701,7 @@ impl Pipeline {
         default: Option<bool>,
     ) -> UseParameter<bool> {
         let idx = self.parameters.len();
-        let name = Parameter::new_parameter_name(name, kind.clone());
+        let name = new_parameter_name(name, kind.clone());
         self.parameters.push(ParameterMeta {
             parameter: Parameter::Bool {
                 name,
@@ -744,7 +744,7 @@ impl Pipeline {
         possible_values: Option<Vec<i64>>,
     ) -> UseParameter<i64> {
         let idx = self.parameters.len();
-        let name = Parameter::new_parameter_name(name, kind.clone());
+        let name = new_parameter_name(name, kind.clone());
         self.parameters.push(ParameterMeta {
             parameter: Parameter::Num {
                 name,
@@ -790,7 +790,7 @@ impl Pipeline {
         possible_values: Option<Vec<String>>,
     ) -> UseParameter<String> {
         let idx = self.parameters.len();
-        let name = Parameter::new_parameter_name(name, kind.clone());
+        let name = new_parameter_name(name, kind.clone());
         self.parameters.push(ParameterMeta {
             parameter: Parameter::String {
                 name,
@@ -1167,6 +1167,13 @@ pub trait IntoPipeline {
     fn into_pipeline(self, backend_hint: PipelineBackendHint) -> anyhow::Result<Pipeline>;
 }
 
+fn new_parameter_name(name: impl AsRef<str>, kind: ParameterKind) -> String {
+    match kind {
+        ParameterKind::Unstable => format!("__unstable_{}", name.as_ref()),
+        ParameterKind::Stable => name.as_ref().into(),
+    }
+}
+
 /// Structs which should only be used by top-level flowey emitters. If you're a
 /// pipeline author, these are not types you need to care about!
 pub mod internal {
@@ -1352,13 +1359,6 @@ pub mod internal {
                 Parameter::Bool { name, .. } => name,
                 Parameter::String { name, .. } => name,
                 Parameter::Num { name, .. } => name,
-            }
-        }
-
-        pub fn new_parameter_name(name: impl AsRef<str>, kind: ParameterKind) -> String {
-            match kind {
-                ParameterKind::Unstable => format!("__unstable_{}", name.as_ref()),
-                ParameterKind::Stable => name.as_ref().into(),
             }
         }
     }

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -676,19 +676,6 @@ impl Pipeline {
         self
     }
 
-    /// Format a parameter name based on it's kind (stable / unstable).
-    ///
-    /// `name` is the name of the parameter.
-    ///
-    /// `kind` is the type of parameter and if it should be treated as a stable
-    /// external API to callers of the pipeline.
-    fn new_parameter_name(&mut self, name: impl AsRef<str>, kind: ParameterKind) -> String {
-        match kind {
-            ParameterKind::Unstable => format!("__unstable_{}", name.as_ref()),
-            ParameterKind::Stable => name.as_ref().into(),
-        }
-    }
-
     /// Declare a pipeline-level runtime parameter with type `bool`.
     ///
     /// To obtain a [`ReadVar<bool>`] that can be used within a node, use the
@@ -714,7 +701,7 @@ impl Pipeline {
         default: Option<bool>,
     ) -> UseParameter<bool> {
         let idx = self.parameters.len();
-        let name = self.new_parameter_name(name, kind.clone());
+        let name = Parameter::new_parameter_name(name, kind.clone());
         self.parameters.push(ParameterMeta {
             parameter: Parameter::Bool {
                 name,
@@ -757,7 +744,7 @@ impl Pipeline {
         possible_values: Option<Vec<i64>>,
     ) -> UseParameter<i64> {
         let idx = self.parameters.len();
-        let name = self.new_parameter_name(name, kind.clone());
+        let name = Parameter::new_parameter_name(name, kind.clone());
         self.parameters.push(ParameterMeta {
             parameter: Parameter::Num {
                 name,
@@ -803,7 +790,7 @@ impl Pipeline {
         possible_values: Option<Vec<String>>,
     ) -> UseParameter<String> {
         let idx = self.parameters.len();
-        let name = self.new_parameter_name(name, kind.clone());
+        let name = Parameter::new_parameter_name(name, kind.clone());
         self.parameters.push(ParameterMeta {
             parameter: Parameter::String {
                 name,
@@ -1365,6 +1352,13 @@ pub mod internal {
                 Parameter::Bool { name, .. } => name,
                 Parameter::String { name, .. } => name,
                 Parameter::Num { name, .. } => name,
+            }
+        }
+
+        pub fn new_parameter_name(name: impl AsRef<str>, kind: ParameterKind) -> String {
+            match kind {
+                ParameterKind::Unstable => format!("__unstable_{}", name.as_ref()),
+                ParameterKind::Stable => name.as_ref().into(),
             }
         }
     }

--- a/flowey/flowey_hvlite/src/pipelines_shared/cfg_common_params.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/cfg_common_params.rs
@@ -72,7 +72,8 @@ fn get_params_local(
 fn get_params_cloud(
     pipeline: &mut Pipeline,
 ) -> anyhow::Result<FulfillCommonRequestsParamsResolver> {
-    let param_verbose = pipeline.new_parameter_bool("Run with verbose output", Some(false));
+    let param_verbose =
+        pipeline.new_parameter_bool("verbose", "Run with verbose output", Some(false));
 
     Ok(Box::new(move |ctx: &mut PipelineJobCtx<'_>| {
         flowey_lib_hvlite::_jobs::cfg_common::Params {

--- a/flowey/flowey_hvlite/src/pipelines_shared/cfg_common_params.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/cfg_common_params.rs
@@ -72,8 +72,12 @@ fn get_params_local(
 fn get_params_cloud(
     pipeline: &mut Pipeline,
 ) -> anyhow::Result<FulfillCommonRequestsParamsResolver> {
-    let param_verbose =
-        pipeline.new_parameter_bool("verbose", "Run with verbose output", Some(false));
+    let param_verbose = pipeline.new_parameter_bool(
+        "verbose",
+        "Run with verbose output",
+        ParameterKind::Stable,
+        Some(false),
+    );
 
     Ok(Box::new(move |ctx: &mut PipelineJobCtx<'_>| {
         flowey_lib_hvlite::_jobs::cfg_common::Params {


### PR DESCRIPTION
This change moves from auto-generated parameter names to requiring the caller to specify a variable name. This makes for easier to read generated pipeline files and allows for better behavior if another pipeline wants to use queue-time variables to control pipeline behavior.