### PR TITLE
mesh_node: remove 'static+Send bounds from MeshField and MeshPayload

### DIFF
--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -191,7 +191,7 @@ pub struct LoadedVmState<T> {
 
 impl LoadedVm {
     /// Start running the VM which will start running VTL0.
-    pub async fn run<T: MeshPayload>(
+    pub async fn run<T: 'static + MeshPayload + Send>(
         mut self,
         threadpool: &AffinitizedThreadpool,
         autostart_vps: bool,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -240,7 +240,7 @@ impl VmService {
         r: anyhow::Result<F>,
     ) where
         F: 'static + Future<Output = anyhow::Result<R>> + Send,
-        R: MeshPayload,
+        R: 'static + MeshPayload + Send,
     {
         match r {
             Ok(fut) => {

--- a/support/mesh/mesh_channel/src/bidir.rs
+++ b/support/mesh/mesh_channel/src/bidir.rs
@@ -71,7 +71,7 @@ impl From<GenericChannel> for Port {
     }
 }
 
-impl<T: MeshPayload, U: MeshPayload> From<Channel<T, U>> for Port {
+impl<T: 'static + MeshPayload, U: 'static + MeshPayload> From<Channel<T, U>> for Port {
     fn from(channel: Channel<T, U>) -> Self {
         channel
             .change_types::<SerializedMessage, SerializedMessage>()
@@ -80,7 +80,7 @@ impl<T: MeshPayload, U: MeshPayload> From<Channel<T, U>> for Port {
     }
 }
 
-impl<T: MeshPayload, U: MeshPayload> From<Port> for Channel<T, U> {
+impl<T: 'static + MeshPayload, U: 'static + MeshPayload> From<Port> for Channel<T, U> {
     fn from(port: Port) -> Self {
         <Channel<SerializedMessage, SerializedMessage>>::new(GenericChannel::new(port))
             .change_types()
@@ -255,7 +255,7 @@ impl<T: 'static + Send, U: 'static + Send> Channel<T, U> {
     }
 }
 
-impl<T: MeshPayload, U: MeshPayload> Channel<T, U> {
+impl<T: 'static + MeshPayload, U: 'static + MeshPayload> Channel<T, U> {
     /// Changes the message types for the port.
     ///
     /// The old and new types must be serializable since the port's peer is
@@ -265,7 +265,9 @@ impl<T: MeshPayload, U: MeshPayload> Channel<T, U> {
     ///
     /// The caller must therefore ensure that the new message type is compatible
     /// with the message encoding.
-    pub fn change_types<NewT: MeshPayload, NewU: MeshPayload>(self) -> Channel<NewT, NewU> {
+    pub fn change_types<NewT: 'static + MeshPayload, NewU: 'static + MeshPayload>(
+        self,
+    ) -> Channel<NewT, NewU> {
         // Ensure all the types are serializable so that the peer port can
         // convert between them as necessary.
         ensure_serializable::<T>();

--- a/support/mesh/mesh_channel/src/lazy.rs
+++ b/support/mesh/mesh_channel/src/lazy.rs
@@ -112,7 +112,7 @@ static SERIALIZED_MESSAGE_SERIALIZE: SerializeFn<SerializedMessage> =
     SerializeFn(static_ref::StaticRef::new(&DynEncoder::<
         SerializedMessageEncoder,
     >(PhantomData)));
-pub fn ensure_serializable<T: MeshPayload>() -> (SerializeFn<T>, DeserializeFn<T>) {
+pub fn ensure_serializable<T: 'static + MeshPayload>() -> (SerializeFn<T>, DeserializeFn<T>) {
     let id = TypeId::of::<T>();
     if id == TypeId::of::<SerializedMessage>() {
         (

--- a/support/mesh/mesh_channel/src/lib.rs
+++ b/support/mesh/mesh_channel/src/lib.rs
@@ -96,7 +96,7 @@ impl<T> Debug for Sender<T> {
     }
 }
 
-impl<T: MeshField> DefaultEncoding for Sender<T> {
+impl<T: 'static + MeshField + Send> DefaultEncoding for Sender<T> {
     type Encoding = PortField;
 }
 
@@ -303,17 +303,17 @@ impl<T> Debug for OneshotSender<T> {
     }
 }
 
-impl<T: MeshField> DefaultEncoding for OneshotSender<T> {
+impl<T: 'static + MeshField + Send> DefaultEncoding for OneshotSender<T> {
     type Encoding = PortField;
 }
 
-impl<T: MeshField> From<Port> for OneshotSender<T> {
+impl<T: 'static + MeshField + Send> From<Port> for OneshotSender<T> {
     fn from(port: Port) -> Self {
         Self(port.into())
     }
 }
 
-impl<T: MeshField> From<OneshotSender<T>> for Port {
+impl<T: 'static + MeshField + Send> From<OneshotSender<T>> for Port {
     fn from(v: OneshotSender<T>) -> Self {
         v.0.into()
     }
@@ -337,7 +337,7 @@ impl<T> Debug for OneshotReceiver<T> {
     }
 }
 
-impl<T: MeshField> DefaultEncoding for OneshotReceiver<T> {
+impl<T: 'static + MeshField + Send> DefaultEncoding for OneshotReceiver<T> {
     type Encoding = PortField;
 }
 
@@ -350,13 +350,13 @@ impl<T: 'static + Send> Future for OneshotReceiver<T> {
     }
 }
 
-impl<T: MeshField> From<Port> for OneshotReceiver<T> {
+impl<T: 'static + MeshField + Send> From<Port> for OneshotReceiver<T> {
     fn from(port: Port) -> Self {
         Self(port.into())
     }
 }
 
-impl<T: MeshField> From<OneshotReceiver<T>> for Port {
+impl<T: 'static + MeshField + Send> From<OneshotReceiver<T>> for Port {
     fn from(v: OneshotReceiver<T>) -> Self {
         v.0.into()
     }

--- a/support/mesh/mesh_channel/src/lib.rs
+++ b/support/mesh/mesh_channel/src/lib.rs
@@ -109,17 +109,17 @@ impl<T> Debug for Receiver<T> {
     }
 }
 
-impl<T: MeshField> DefaultEncoding for Receiver<T> {
+impl<T: 'static + MeshField + Send> DefaultEncoding for Receiver<T> {
     type Encoding = PortField;
 }
 
-impl<T: MeshField> From<Port> for Sender<T> {
+impl<T: 'static + MeshField + Send> From<Port> for Sender<T> {
     fn from(port: Port) -> Self {
         Self(port.into())
     }
 }
 
-impl<T: MeshField> From<Sender<T>> for Port {
+impl<T: 'static + MeshField + Send> From<Sender<T>> for Port {
     fn from(v: Sender<T>) -> Self {
         v.0.into()
     }
@@ -179,13 +179,13 @@ impl<T: 'static + Send> Sender<T> {
     }
 }
 
-impl<T: MeshField> From<Port> for Receiver<T> {
+impl<T: 'static + MeshField + Send> From<Port> for Receiver<T> {
     fn from(port: Port) -> Self {
         Self(port.into())
     }
 }
 
-impl<T: MeshField> From<Receiver<T>> for Port {
+impl<T: 'static + MeshField + Send> From<Receiver<T>> for Port {
     fn from(v: Receiver<T>) -> Self {
         v.0.into()
     }
@@ -420,7 +420,10 @@ pub fn mpsc_channel<T: 'static + Send>() -> (MpscSender<T>, MpscReceiver<T>) {
 }
 
 #[derive(Debug, Protobuf)]
-#[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
+#[mesh(
+    bound = "T: 'static + MeshField + Send",
+    resource = "mesh_node::resource::Resource"
+)]
 enum MpscMessage<T> {
     Data(T),
     Clone(Channel<(), MpscMessage<T>>),
@@ -428,7 +431,10 @@ enum MpscMessage<T> {
 
 /// Receiver type for [`mpsc_channel()`].
 #[derive(Protobuf)]
-#[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
+#[mesh(
+    bound = "T: 'static + MeshField + Send",
+    resource = "mesh_node::resource::Resource"
+)]
 pub struct MpscReceiver<T> {
     receivers: Vec<Channel<(), MpscMessage<T>>>,
 }
@@ -535,7 +541,10 @@ impl<T: 'static + Send> futures_core::stream::Stream for MpscReceiver<T> {
 // process are cheap. When this is encoded for sending to a remote process, only
 // then will the receiver be notified of a new mesh port.
 #[derive(Protobuf)]
-#[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
+#[mesh(
+    bound = "T: 'static + MeshField + Send",
+    resource = "mesh_node::resource::Resource"
+)]
 pub struct MpscSender<T>(Arc<MpscSenderInner<T>>);
 
 impl<T> Debug for MpscSender<T> {
@@ -553,7 +562,10 @@ impl<T> Clone for MpscSender<T> {
 
 /// Wrapper that implements Clone.
 #[derive(Protobuf)]
-#[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
+#[mesh(
+    bound = "T: 'static + MeshField + Send",
+    resource = "mesh_node::resource::Resource"
+)]
 struct MpscSenderInner<T>(Channel<MpscMessage<T>, ()>);
 
 impl<T: 'static + Send> Clone for MpscSenderInner<T> {

--- a/support/mesh/mesh_channel/src/rpc.rs
+++ b/support/mesh/mesh_channel/src/rpc.rs
@@ -24,7 +24,7 @@ use std::task::Poll;
 /// via the `Sender<R>`.
 #[derive(Debug, Protobuf)]
 #[mesh(
-    bound = "I: MeshField, R: MeshField",
+    bound = "I: 'static + MeshField + Send, R: 'static + MeshField + Send",
     resource = "mesh_node::resource::Resource"
 )]
 pub struct Rpc<I, R>(pub I, pub OneshotSender<R>);

--- a/support/mesh/mesh_node/src/local_node.rs
+++ b/support/mesh/mesh_node/src/local_node.rs
@@ -2216,7 +2216,7 @@ pub mod tests {
         }
     }
 
-    impl<T: MeshField, U: MeshField> Channel<T, U> {
+    impl<T: 'static + MeshField + Send, U: 'static + MeshField + Send> Channel<T, U> {
         fn new_pair() -> (Self, Channel<U, T>) {
             let (left, right) = Port::new_pair();
             (left.into(), right.into())

--- a/support/mesh/mesh_process/src/lib.rs
+++ b/support/mesh/mesh_process/src/lib.rs
@@ -84,7 +84,7 @@ static PROCESS_NAME: DebugPtr<String> = DebugPtr::new();
 /// the mesh.
 pub fn try_run_mesh_host<U, Fut, F, T>(base_name: &str, f: F) -> anyhow::Result<()>
 where
-    U: MeshPayload,
+    U: 'static + MeshPayload + Send,
     F: FnOnce(U) -> Fut,
     Fut: Future<Output = anyhow::Result<T>>,
 {
@@ -445,7 +445,7 @@ impl Mesh {
     ///
     /// The initial message will be provided to the closure passed to
     /// [`try_run_mesh_host()`].
-    pub async fn launch_host<T: MeshField>(
+    pub async fn launch_host<T: 'static + MeshField + Send>(
         &self,
         config: ProcessConfig,
         initial_message: T,

--- a/support/mesh/mesh_rpc/src/client.rs
+++ b/support/mesh/mesh_rpc/src/client.rs
@@ -224,7 +224,7 @@ impl CallBuilder<'_> {
     where
         F: FnOnce(T, mesh::OneshotSender<Result<U, Status>>) -> R,
         R: ServiceRpc,
-        U: MeshPayload,
+        U: 'static + MeshPayload + Send,
     {
         let (send, recv) = mesh::oneshot();
 

--- a/support/mesh/mesh_worker/src/worker.rs
+++ b/support/mesh/mesh_worker/src/worker.rs
@@ -52,7 +52,7 @@ pub trait Worker: 'static + Sized {
     type Parameters: 'static + Send;
 
     /// State used to implement hot restart. Used with [`Worker::restart`].
-    type State: MeshPayload;
+    type State: 'static + MeshPayload + Send;
 
     /// String identifying the Worker. Used when launching workers in separate processes
     /// to specify which workers are supported and which worker to launch.
@@ -79,7 +79,7 @@ pub trait Worker: 'static + Sized {
 
 /// Common requests for workers.
 #[derive(Debug, MeshPayload)]
-#[mesh(bound = "T: MeshPayload")]
+#[mesh(bound = "T: 'static + MeshPayload + Send")]
 pub enum WorkerRpc<T> {
     /// Tear down.
     Stop,
@@ -292,7 +292,7 @@ impl WorkerHost {
     /// start.
     pub fn start_worker<T>(&self, id: WorkerId<T>, params: T) -> anyhow::Result<WorkerHandle>
     where
-        T: MeshPayload,
+        T: 'static + MeshPayload + Send,
     {
         self.start_worker_inner(id.id(), mesh::Message::new(params))
     }
@@ -316,7 +316,7 @@ impl WorkerHost {
     /// start running.
     pub async fn launch_worker<T>(&self, id: WorkerId<T>, params: T) -> anyhow::Result<WorkerHandle>
     where
-        T: MeshPayload,
+        T: 'static + MeshPayload + Send,
     {
         let mut handle = self.start_worker_inner(id.id(), mesh::Message::new(params))?;
         match handle.next().await.context("failed to launch worker")? {

--- a/support/mesh_tracing/src/bounded.rs
+++ b/support/mesh_tracing/src/bounded.rs
@@ -70,7 +70,7 @@ struct ReceiverState {
     waker: Option<Waker>,
 }
 
-impl<T: MeshField> BoundedReceiver<T> {
+impl<T: 'static + MeshField + Send> BoundedReceiver<T> {
     fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
         let mut old_waker = None;
         self.port.with_port_and_handler(|port, state| {
@@ -99,7 +99,7 @@ impl<T: MeshField> BoundedReceiver<T> {
     }
 }
 
-impl<T: MeshField> Stream for BoundedReceiver<T> {
+impl<T: 'static + MeshField + Send> Stream for BoundedReceiver<T> {
     type Item = T;
 
     fn poll_next(
@@ -176,7 +176,7 @@ pub enum TrySendError {
     Closed,
 }
 
-impl<T: MeshField> BoundedSender<T> {
+impl<T: 'static + MeshField + Send> BoundedSender<T> {
     fn poll_send(&mut self, cx: &mut Context<'_>, message: &mut Option<T>) -> Poll<()> {
         let mut old_waker = None;
         self.port.with_port_and_handler(|port, state| {

--- a/vm/devices/input_core/src/mesh_input.rs
+++ b/vm/devices/input_core/src/mesh_input.rs
@@ -10,7 +10,7 @@ use std::pin::Pin;
 
 /// An input source that receives input over a mesh channel.
 #[derive(MeshPayload)]
-#[mesh(bound = "T: MeshField")]
+#[mesh(bound = "T: 'static + MeshField + Send")]
 pub struct MeshInputSource<T> {
     recv: mesh::Receiver<T>,
     active: mesh::CellUpdater<bool>,
@@ -42,7 +42,7 @@ impl<T: 'static + Send> futures::Stream for MeshInputSource<T> {
 
 /// The sending side of the [`MeshInputSource`].
 #[derive(MeshPayload)]
-#[mesh(bound = "T: MeshField")]
+#[mesh(bound = "T: 'static + MeshField + Send")]
 pub struct MeshInputSink<T> {
     send: mesh::Sender<T>,
     active: mesh::Cell<bool>,

--- a/vm/vmcore/vm_resource/src/lib.rs
+++ b/vm/vmcore/vm_resource/src/lib.rs
@@ -86,7 +86,7 @@ pub trait IntoResource<K: ResourceKind> {
     fn into_resource(self) -> Resource<K>;
 }
 
-impl<T: ResourceId<K> + MeshPayload, K: ResourceKind> IntoResource<K> for T {
+impl<T: 'static + ResourceId<K> + MeshPayload + Send, K: ResourceKind> IntoResource<K> for T {
     fn into_resource(self) -> Resource<K> {
         Resource::new(self)
     }
@@ -94,7 +94,7 @@ impl<T: ResourceId<K> + MeshPayload, K: ResourceKind> IntoResource<K> for T {
 
 impl<K: ResourceKind> Resource<K> {
     /// Wraps `value` as an opaque resource.
-    pub fn new<T: ResourceId<K> + MeshPayload>(value: T) -> Self {
+    pub fn new<T: 'static + ResourceId<K> + MeshPayload + Send>(value: T) -> Self {
         Self {
             id: Cow::Borrowed(T::ID),
             message: Message::new(value),
@@ -208,7 +208,7 @@ where
     K: CanResolveTo<O>,
     O: 'static,
     R: ResolveResource<K, T, Output = O>,
-    T: MeshPayload + ResourceId<K>,
+    T: 'static + MeshPayload + ResourceId<K> + Send,
 {
     async fn dyn_resolve(
         &self,
@@ -244,7 +244,7 @@ where
     K: CanResolveTo<O>,
     O: 'static,
     R: AsyncResolveResource<K, T, Output = O>,
-    T: MeshPayload + ResourceId<K>,
+    T: 'static + MeshPayload + ResourceId<K> + Send,
 {
     async fn dyn_resolve(
         &self,
@@ -430,7 +430,7 @@ pub mod private {
     impl<K: CanResolveTo<O>, O> UntypedStaticResolver<K, O> {
         pub const fn new<T, R>(resolver: &'static R) -> Self
         where
-            T: ResourceId<K> + MeshPayload,
+            T: 'static + ResourceId<K> + MeshPayload + Send,
             R: ResolveResource<K, T, Output = O>,
         {
             // SAFETY: TypedResolver<T, R> contains a &'static R and is transparent.
@@ -442,7 +442,7 @@ pub mod private {
 
         pub const fn new_async<T, R>(resolver: &'static R) -> Self
         where
-            T: ResourceId<K> + MeshPayload,
+            T: 'static + ResourceId<K> + MeshPayload + Send,
             R: AsyncResolveResource<K, T, Output = O>,
         {
             // SAFETY: TypedAsyncResolver<T, R> contains a &'static R and is transparent.
@@ -534,7 +534,7 @@ impl ResourceResolver {
     where
         K: CanResolveTo<O>,
         O: 'static,
-        T: ResourceId<K> + MeshPayload,
+        T: 'static + ResourceId<K> + MeshPayload + Send,
         R: 'static + ResolveResource<K, T, Output = O>,
     {
         let key = ResolverKey {
@@ -559,7 +559,7 @@ impl ResourceResolver {
     where
         K: CanResolveTo<O>,
         O: 'static,
-        T: ResourceId<K> + MeshPayload,
+        T: 'static + ResourceId<K> + MeshPayload + Send,
         R: 'static + AsyncResolveResource<K, T, Output = O>,
     {
         let key = ResolverKey {

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -82,7 +82,7 @@ impl Worker for VncWorker<vmsocket::VmListener> {
     }
 }
 
-impl<T: Listener + MeshField> VncWorker<T> {
+impl<T: 'static + Listener + MeshField + Send> VncWorker<T> {
     fn new_inner(params: VncParameters<T>) -> anyhow::Result<Self> {
         Ok(Self {
             listener: params.listener,


### PR DESCRIPTION
Mesh values need to be `'static` and `Send` because of implementation details in the current channel and `LocalNode` implementations. This is conceptually unnecessary since if we are dealing with a message at the "mesh" level, we are going to serialize it to protobuf. So, we should not have to constrain the lifetime or cross-thread safety requirements of such a value.

Upcoming improvements will make these bounds unnecessary. Remove them from the `MeshField` and `MeshPayload` traits now in anticipation of these changes.  Update existing code to make these bounds explicit where required; most are harmless, others some can be removed later as necessary.