### PR TITLE
VmBus: cleanly exit when vmbusproxy is in use.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7939,12 +7939,14 @@ dependencies = [
 name = "vmbus_proxy"
 version = "0.0.0"
 dependencies = [
+ "futures",
  "guestmem",
  "mesh",
  "ntapi",
  "pal",
  "pal_async",
  "pal_event",
+ "tracing",
  "vmbus_core",
  "winapi",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8110,6 +8110,7 @@ dependencies = [
  "vmbus_proxy",
  "vmbus_ring",
  "vmcore",
+ "winapi",
  "zerocopy",
  "zerocopy_helpers",
 ]

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -60,7 +60,6 @@ use mesh::error::RemoteError;
 use mesh::payload::message::ProtobufMessage;
 use mesh::payload::Protobuf;
 use mesh::rpc::Rpc;
-use mesh::Cancel;
 use mesh::MeshPayload;
 use mesh_worker::Worker;
 use mesh_worker::WorkerId;
@@ -508,7 +507,7 @@ struct LoadedVmInner {
     vmbus_server: Option<VmbusServerHandle>,
     vtl2_vmbus_server: Option<VmbusServerHandle>,
     #[cfg(windows)]
-    _vmbus_handle: Option<Cancel>,
+    _vmbus_proxy: Option<vmbus_server::ProxyIntegration>,
     #[cfg(windows)]
     _kernel_vmnics: Vec<vmswitch::kernel::KernelVmNic>,
     memory_cfg: MemoryConfig,
@@ -1610,7 +1609,7 @@ impl InitializedVm {
         let mut scsi_devices = Vec::new();
         let mut vtl0_hvsock_relay = None;
         #[cfg(windows)]
-        let mut vmbus_handle = None;
+        let mut vmbus_proxy = None;
         #[cfg(windows)]
         let mut kernel_vmnics = Vec::new();
         let mut vpci_serial: Option<virtio_serial::SerialIo> = None;
@@ -1686,7 +1685,7 @@ impl InitializedVm {
             // Start the vmbus kernel proxy if it's in use.
             #[cfg(windows)]
             if let Some(proxy_handle) = vmbus_cfg.vmbusproxy_handle {
-                vmbus_handle = Some(
+                vmbus_proxy = Some(
                     vmbus
                         .start_kernel_proxy(&vmbus_driver, proxy_handle)
                         .await
@@ -1811,10 +1810,10 @@ impl InitializedVm {
                     "nic",
                     nic_config.mac_address.into(),
                     &nic_config.instance_id,
-                    &vmbus_handle
+                    vmbus_proxy
                         .as_ref()
                         .context("missing vmbusproxy handle")?
-                        .1,
+                        .handle(),
                 )
                 .context("failed to create a kernel vmnic")?;
 
@@ -2215,7 +2214,7 @@ impl InitializedVm {
                 vtl2_framebuffer_gpa_base,
                 virtio_serial: virtio_serial_dup,
                 #[cfg(windows)]
-                _vmbus_handle: vmbus_handle.map(|x| x.0),
+                _vmbus_proxy: vmbus_proxy,
                 #[cfg(windows)]
                 _kernel_vmnics: kernel_vmnics,
                 vmbus_devices,

--- a/support/pal/pal_async/src/windows/overlapped.rs
+++ b/support/pal/pal_async/src/windows/overlapped.rs
@@ -89,6 +89,7 @@ impl OverlappedFile {
 
     /// Cancels all IO for this file.
     pub fn cancel(&self) {
+        /// SAFETY: File handle is owned by self.
         unsafe {
             CancelIoEx(self.file.as_raw_handle(), null_mut());
         }

--- a/support/pal/pal_async/src/windows/overlapped.rs
+++ b/support/pal/pal_async/src/windows/overlapped.rs
@@ -89,7 +89,7 @@ impl OverlappedFile {
 
     /// Cancels all IO for this file.
     pub fn cancel(&self) {
-        /// SAFETY: File handle is owned by self.
+        // SAFETY: File handle is owned by self.
         unsafe {
             CancelIoEx(self.file.as_raw_handle(), null_mut());
         }

--- a/support/pal/pal_async/src/windows/overlapped.rs
+++ b/support/pal/pal_async/src/windows/overlapped.rs
@@ -86,6 +86,13 @@ impl OverlappedFile {
     pub fn get(&self) -> &File {
         &self.file
     }
+
+    /// Cancels all IO for this file.
+    pub fn cancel(&self) {
+        unsafe {
+            CancelIoEx(self.file.as_raw_handle(), null_mut());
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/vm/devices/vmbus/vmbus_proxy/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_proxy/Cargo.toml
@@ -15,7 +15,9 @@ pal.workspace = true
 pal_event.workspace = true
 pal_async.workspace = true
 
+futures.workspace = true
 ntapi.workspace = true
+tracing.workspace = true
 winapi = { workspace = true, features = ["debug", "winioctl"] }
 zerocopy.workspace = true
 

--- a/vm/devices/vmbus/vmbus_server/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_server/Cargo.toml
@@ -38,6 +38,7 @@ zerocopy.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 vmbus_proxy.workspace = true
+winapi.workspace = true
 
 [dev-dependencies]
 test_with_tracing.workspace = true

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -39,11 +39,11 @@ use mesh::error::RemoteResultExt;
 use mesh::payload::Protobuf;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
-use mesh::Cancel;
 use mesh::RecvError;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
 use pal_event::Event;
+pub use proxyintegration::ProxyIntegration;
 use ring::PAGE_SIZE;
 use std::collections::HashMap;
 use std::future::Future;
@@ -564,8 +564,8 @@ impl VmbusServer {
         &self,
         driver: &(impl pal_async::driver::SpawnDriver + Clone),
         handle: ProxyHandle,
-    ) -> Result<(Cancel, std::os::windows::io::OwnedHandle), std::io::Error> {
-        proxyintegration::start_proxy(driver, handle, self.control(), &self.control.mem).await
+    ) -> std::io::Result<ProxyIntegration> {
+        ProxyIntegration::start(driver, handle, self.control(), &self.control.mem).await
     }
 
     /// Returns an object that can be used to offer channels.

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -39,6 +39,7 @@ use mesh::error::RemoteResultExt;
 use mesh::payload::Protobuf;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
+use mesh::Cancel;
 use mesh::RecvError;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
@@ -563,7 +564,7 @@ impl VmbusServer {
         &self,
         driver: &(impl pal_async::driver::SpawnDriver + Clone),
         handle: ProxyHandle,
-    ) -> Result<std::os::windows::io::OwnedHandle, std::io::Error> {
+    ) -> Result<(Cancel, std::os::windows::io::OwnedHandle), std::io::Error> {
         proxyintegration::start_proxy(driver, handle, self.control(), &self.control.mem).await
     }
 

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -43,6 +43,7 @@ use mesh::RecvError;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
 use pal_event::Event;
+#[cfg(windows)]
 pub use proxyintegration::ProxyIntegration;
 use ring::PAGE_SIZE;
 use std::collections::HashMap;

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -42,27 +42,45 @@ use vmbus_proxy::vmbusioctl::VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS;
 use vmbus_proxy::ProxyAction;
 use vmbus_proxy::VmbusProxy;
 use vmcore::interrupt::Interrupt;
+use winapi::shared::winerror::ERROR_CANCELLED;
 use zerocopy::AsBytes;
 
-pub(crate) async fn start_proxy(
-    driver: &(impl SpawnDriver + Clone),
-    handle: ProxyHandle,
-    server: Arc<VmbusServerControl>,
-    mem: &GuestMemory,
-) -> io::Result<(Cancel, OwnedHandle)> {
-    let mut proxy = VmbusProxy::new(driver, handle)?;
-    let handle = proxy.handle().try_clone_to_owned()?;
-    proxy.set_memory(mem).await?;
+pub struct ProxyIntegration {
+    cancel: Cancel,
+    handle: OwnedHandle,
+}
 
-    let (cancel_ctx, cancel) = CancelContext::new().with_cancel();
-    driver
-        .spawn(
-            "vmbus_proxy",
-            proxy_thread(driver.clone(), proxy, server, cancel_ctx),
-        )
-        .detach();
+impl ProxyIntegration {
+    /// Cancels the vmbus proxy.
+    pub fn cancel(&mut self) {
+        self.cancel.cancel();
+    }
 
-    Ok((cancel, handle))
+    /// Returns the handle to the vmbus proxy driver.
+    pub fn handle(&self) -> &OwnedHandle {
+        &self.handle
+    }
+
+    pub(crate) async fn start(
+        driver: &(impl SpawnDriver + Clone),
+        handle: ProxyHandle,
+        server: Arc<VmbusServerControl>,
+        mem: &GuestMemory,
+    ) -> io::Result<Self> {
+        let mut proxy = VmbusProxy::new(driver, handle)?;
+        let handle = proxy.handle().try_clone_to_owned()?;
+        proxy.set_memory(mem).await?;
+
+        let (cancel_ctx, cancel) = CancelContext::new().with_cancel();
+        driver
+            .spawn(
+                "vmbus_proxy",
+                proxy_thread(driver.clone(), proxy, server, cancel_ctx),
+            )
+            .detach();
+
+        Ok(Self { cancel, handle })
+    }
 }
 
 struct Channel {
@@ -350,16 +368,22 @@ impl ProxyTask {
                     if !gpadls.is_empty() {
                         tracing::warn!(proxy_id, "closed while some gpadls are still registered");
                         for gpadl_id in gpadls {
-                            self.proxy
-                                .delete_gpadl(proxy_id, gpadl_id.0)
-                                .await
-                                .expect("delete gpadl failed");
+                            if let Err(e) = self.proxy.delete_gpadl(proxy_id, gpadl_id.0).await {
+                                if e.raw_os_error() == Some(ERROR_CANCELLED as i32) {
+                                    // No further IOs will succeed if one was cancelled. This can
+                                    // happen here if we're in the process of shutting down.
+                                    tracing::debug!("gpadl delete cancelled");
+                                    break;
+                                }
+
+                                tracing::error!(error = ?e, "failed to delete gpadl");
+                            }
                         }
                     }
                 }
 
                 // We cannot release the channel with the driver here because it may be in the wrong
-                // state.
+                // state. We must wait for the driver to revoke it first.
             }
         }
     }


### PR DESCRIPTION
When the vmbusproxy driver is being used (e.g. using the `--kernel-vmnic` parameter, only available on Windows), OpenVMM would either panic or hang during exit, because the thread that issues ioctls to the proxy driver is never terminated.

This change adds a `CancelContext` to the `proxyintegration` module so that any outstanding IO can be cancelled, and the thread can exit cleanly when OpenVMM is terminated.