### PR TITLE
mesh_channel: new oneshot channel implementation

### DIFF
--- a/support/mesh/mesh_channel/Cargo.toml
+++ b/support/mesh/mesh_channel/Cargo.toml
@@ -8,11 +8,14 @@ rust-version.workspace = true
 
 [features]
 #default = ["newchan_mpsc", "newchan_spsc"]
+default = ["newchan_oneshot"]
 newchan = ["dep:mesh_channel_core"]
 # Use the new channel implementation for MPSC channels.
 newchan_mpsc = ["newchan"]
 # Use the new channel implementatino for SPSC channels.
 newchan_spsc = ["newchan"]
+# Use the new oneshot implementation
+newchan_oneshot = ["newchan"]
 
 [dependencies]
 mesh_channel_core = { workspace = true, optional = true }

--- a/support/mesh/mesh_channel/Cargo.toml
+++ b/support/mesh/mesh_channel/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [features]
-default = ["newchan_mpsc", "newchan_spsc"]
+#default = ["newchan_mpsc", "newchan_spsc"]
 newchan = ["dep:mesh_channel_core"]
 # Use the new channel implementation for MPSC channels.
 newchan_mpsc = ["newchan"]

--- a/support/mesh/mesh_channel/Cargo.toml
+++ b/support/mesh/mesh_channel/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 rust-version.workspace = true
 
 [features]
-#default = ["newchan_mpsc", "newchan_spsc"]
-default = ["newchan_oneshot"]
+default = ["newchan_mpsc", "newchan_spsc", "newchan_oneshot"]
+#default = ["newchan_oneshot"]
 newchan = ["dep:mesh_channel_core"]
 # Use the new channel implementation for MPSC channels.
 newchan_mpsc = ["newchan"]

--- a/support/mesh/mesh_channel/Cargo.toml
+++ b/support/mesh/mesh_channel/Cargo.toml
@@ -8,11 +8,10 @@ rust-version.workspace = true
 
 [features]
 default = ["newchan_mpsc", "newchan_spsc", "newchan_oneshot"]
-#default = ["newchan_oneshot"]
 newchan = ["dep:mesh_channel_core"]
 # Use the new channel implementation for MPSC channels.
 newchan_mpsc = ["newchan"]
-# Use the new channel implementatino for SPSC channels.
+# Use the new channel implementation for SPSC channels.
 newchan_spsc = ["newchan"]
 # Use the new oneshot implementation
 newchan_oneshot = ["newchan"]

--- a/support/mesh/mesh_channel/src/lib.rs
+++ b/support/mesh/mesh_channel/src/lib.rs
@@ -339,8 +339,9 @@ mod oneshot {
     use crate::bidir::Channel;
     use crate::RecvError;
     use mesh_node::local_node::Port;
+    use mesh_node::local_node::PortField;
     use mesh_node::message::MeshField;
-    use mesh_protobuf::Protobuf;
+    use mesh_protobuf::DefaultEncoding;
     use std::fmt::Debug;
     use std::future::Future;
     use std::pin::Pin;

--- a/support/mesh/mesh_channel/src/lib.rs
+++ b/support/mesh/mesh_channel/src/lib.rs
@@ -706,7 +706,7 @@ mod tests {
         event.wait();
     }
 
-    #[cfg(not(feature = "newchan_oneshot"))]
+    #[cfg(not(feature = "newchan_oneshot"))] // This test reaches into the implementation.
     #[async_test]
     async fn test_oneshot() {
         let (send, mut recv) = oneshot::<u32>();

--- a/support/mesh/mesh_channel/src/lib.rs
+++ b/support/mesh/mesh_channel/src/lib.rs
@@ -19,21 +19,14 @@ pub use error_oldchan::*;
 pub use mpsc::*;
 #[cfg(feature = "newchan_mpsc")]
 pub use mpsc_newchan::*;
+#[cfg(not(feature = "newchan_oneshot"))]
+pub use oneshot::*;
+#[cfg(feature = "newchan_oneshot")]
+pub use oneshot_newchan::*;
 #[cfg(not(feature = "newchan_spsc"))]
 pub use spsc::*;
 #[cfg(feature = "newchan_spsc")]
 pub use spsc_newchan::*;
-
-use bidir::Channel;
-use mesh_node::local_node::Port;
-use mesh_node::local_node::PortField;
-use mesh_node::message::MeshField;
-use mesh_protobuf::DefaultEncoding;
-use std::fmt::Debug;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::Context;
-use std::task::Poll;
 
 #[cfg(feature = "newchan")]
 mod error_newchan {
@@ -341,103 +334,124 @@ mod spsc {
     }
 }
 
-/// The sending half of a channel returned by [`oneshot`].
-pub struct OneshotSender<T>(Channel<(T,), ()>);
+#[cfg(not(feature = "newchan_oneshot"))]
+mod oneshot {
+    use crate::bidir::Channel;
+    use crate::RecvError;
+    use mesh_node::local_node::Port;
+    use mesh_node::message::MeshField;
+    use mesh_protobuf::Protobuf;
+    use std::fmt::Debug;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::Context;
+    use std::task::Poll;
 
-impl<T> Debug for OneshotSender<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.0, f)
+    /// The sending half of a channel returned by [`oneshot`].
+    pub struct OneshotSender<T>(Channel<(T,), ()>);
+
+    impl<T> Debug for OneshotSender<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            Debug::fmt(&self.0, f)
+        }
+    }
+
+    impl<T: 'static + MeshField + Send> DefaultEncoding for OneshotSender<T> {
+        type Encoding = PortField;
+    }
+
+    impl<T: 'static + MeshField + Send> From<Port> for OneshotSender<T> {
+        fn from(port: Port) -> Self {
+            Self(port.into())
+        }
+    }
+
+    impl<T: 'static + MeshField + Send> From<OneshotSender<T>> for Port {
+        fn from(v: OneshotSender<T>) -> Self {
+            v.0.into()
+        }
+    }
+
+    impl<T: 'static + Send> OneshotSender<T> {
+        /// Sends `value` to the receiving endpoint of the channel.
+        pub fn send(self, value: T) {
+            self.0.send_and_close((value,));
+        }
+    }
+
+    /// The receiving half of a channel returned by [`oneshot`].
+    ///
+    /// A value is received by `poll`ing or `await`ing the channel.
+    pub struct OneshotReceiver<T>(pub(super) Channel<(), (T,)>);
+
+    impl<T> Debug for OneshotReceiver<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            Debug::fmt(&self.0, f)
+        }
+    }
+
+    impl<T: 'static + MeshField + Send> DefaultEncoding for OneshotReceiver<T> {
+        type Encoding = PortField;
+    }
+
+    impl<T: 'static + Send> Future for OneshotReceiver<T> {
+        type Output = Result<T, RecvError>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let (message,) = std::task::ready!(self.0.poll_recv(cx))?;
+            Poll::Ready(Ok(message))
+        }
+    }
+
+    impl<T: 'static + MeshField + Send> From<Port> for OneshotReceiver<T> {
+        fn from(port: Port) -> Self {
+            Self(port.into())
+        }
+    }
+
+    impl<T: 'static + MeshField + Send> From<OneshotReceiver<T>> for Port {
+        fn from(v: OneshotReceiver<T>) -> Self {
+            v.0.into()
+        }
+    }
+
+    /// Creates a unidirection channel for sending a single value of type `T`.
+    ///
+    /// The channel is automatically closed after the value is sent. Use this
+    /// instead of [`channel`] when only one value ever needs to be sent to avoid
+    /// programming errors where the channel is left open longer than necessary.
+    /// This is also more efficient.
+    ///
+    /// Use [`OneshotSender::send`] and [`OneshotReceiver`] (directly as a future)
+    /// to communicate between the ends of the channel.
+    ///
+    /// `T` must implement [`MeshField`]. Most typically this is done by
+    /// deriving [`MeshPayload`](mesh_node::message::MeshPayload).
+    ///
+    /// Both channel endpoints are initially local to this process, but either or
+    /// both endpoints may be sent to other processes via a cross-process channel
+    /// that has already been established.
+    ///
+    /// ```rust
+    /// # use mesh_channel::*;
+    /// # futures::executor::block_on(async {
+    /// let (send, recv) = oneshot::<u32>();
+    /// send.send(5);
+    /// let n = recv.await.unwrap();
+    /// assert_eq!(n, 5);
+    /// # });
+    /// ```
+    pub fn oneshot<T: 'static + Send>() -> (OneshotSender<T>, OneshotReceiver<T>) {
+        let (left, right) = Channel::new_pair();
+        (OneshotSender(left), OneshotReceiver(right))
     }
 }
 
-impl<T: 'static + MeshField + Send> DefaultEncoding for OneshotSender<T> {
-    type Encoding = PortField;
-}
-
-impl<T: 'static + MeshField + Send> From<Port> for OneshotSender<T> {
-    fn from(port: Port) -> Self {
-        Self(port.into())
-    }
-}
-
-impl<T: 'static + MeshField + Send> From<OneshotSender<T>> for Port {
-    fn from(v: OneshotSender<T>) -> Self {
-        v.0.into()
-    }
-}
-
-impl<T: 'static + Send> OneshotSender<T> {
-    /// Sends `value` to the receiving endpoint of the channel.
-    pub fn send(self, value: T) {
-        self.0.send_and_close((value,));
-    }
-}
-
-/// The receiving half of a channel returned by [`oneshot`].
-///
-/// A value is received by `poll`ing or `await`ing the channel.
-pub struct OneshotReceiver<T>(Channel<(), (T,)>);
-
-impl<T> Debug for OneshotReceiver<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.0, f)
-    }
-}
-
-impl<T: 'static + MeshField + Send> DefaultEncoding for OneshotReceiver<T> {
-    type Encoding = PortField;
-}
-
-impl<T: 'static + Send> Future for OneshotReceiver<T> {
-    type Output = Result<T, RecvError>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let (message,) = std::task::ready!(self.0.poll_recv(cx))?;
-        Poll::Ready(Ok(message))
-    }
-}
-
-impl<T: 'static + MeshField + Send> From<Port> for OneshotReceiver<T> {
-    fn from(port: Port) -> Self {
-        Self(port.into())
-    }
-}
-
-impl<T: 'static + MeshField + Send> From<OneshotReceiver<T>> for Port {
-    fn from(v: OneshotReceiver<T>) -> Self {
-        v.0.into()
-    }
-}
-
-/// Creates a unidirection channel for sending a single value of type `T`.
-///
-/// The channel is automatically closed after the value is sent. Use this
-/// instead of [`channel`] when only one value ever needs to be sent to avoid
-/// programming errors where the channel is left open longer than necessary.
-/// This is also more efficient.
-///
-/// Use [`OneshotSender::send`] and [`OneshotReceiver`] (directly as a future)
-/// to communicate between the ends of the channel.
-///
-/// `T` must implement [`MeshField`]. Most typically this is done by
-/// deriving [`MeshPayload`](mesh_node::message::MeshPayload).
-///
-/// Both channel endpoints are initially local to this process, but either or
-/// both endpoints may be sent to other processes via a cross-process channel
-/// that has already been established.
-///
-/// ```rust
-/// # use mesh_channel::*;
-/// # futures::executor::block_on(async {
-/// let (send, recv) = oneshot::<u32>();
-/// send.send(5);
-/// let n = recv.await.unwrap();
-/// assert_eq!(n, 5);
-/// # });
-/// ```
-pub fn oneshot<T: 'static + Send>() -> (OneshotSender<T>, OneshotReceiver<T>) {
-    let (left, right) = Channel::new_pair();
-    (OneshotSender(left), OneshotReceiver(right))
+#[cfg(feature = "newchan_oneshot")]
+mod oneshot_newchan {
+    pub use mesh_channel_core::oneshot;
+    pub use mesh_channel_core::OneshotReceiver;
+    pub use mesh_channel_core::OneshotSender;
 }
 
 #[cfg(feature = "newchan_mpsc")]
@@ -691,6 +705,7 @@ mod tests {
         event.wait();
     }
 
+    #[cfg(not(feature = "newchan_oneshot"))]
     #[async_test]
     async fn test_oneshot() {
         let (send, mut recv) = oneshot::<u32>();

--- a/support/mesh/mesh_channel_core/src/lib.rs
+++ b/support/mesh/mesh_channel_core/src/lib.rs
@@ -12,6 +12,8 @@
 mod deque;
 mod error;
 mod mpsc;
+mod oneshot;
 
 pub use error::*;
 pub use mpsc::*;
+pub use oneshot::*;

--- a/support/mesh/mesh_channel_core/src/mpsc.rs
+++ b/support/mesh/mesh_channel_core/src/mpsc.rs
@@ -776,7 +776,6 @@ enum ChannelPayload<T> {
     Port(Port),
 }
 
-#[derive(Debug)]
 struct RemotePortHandler {
     queue: Arc<Queue>,
     parse: unsafe fn(Message, *mut ()) -> Result<Option<Port>, ChannelError>,

--- a/support/mesh/mesh_channel_core/src/oneshot.rs
+++ b/support/mesh/mesh_channel_core/src/oneshot.rs
@@ -129,6 +129,9 @@ fn decode_message<T: 'static + MeshField + Send>(
 }
 
 #[derive(Debug)]
+struct Slot(Mutex<SlotState>);
+
+#[derive(Debug)]
 struct OneshotSenderCore(Arc<Slot>);
 
 impl Drop for OneshotSenderCore {
@@ -470,17 +473,14 @@ impl BoxedValue {
     }
 }
 
-#[derive(Debug)]
-struct Slot(Mutex<SlotState>);
+#[derive(Debug, Error)]
+#[error("unexpected oneshot message")]
+struct UnexpectedMessage;
 
 struct SlotHandler {
     slot: Arc<Slot>,
     decode: DecodeFn,
 }
-
-#[derive(Debug, Error)]
-#[error("unexpected oneshot message")]
-struct UnexpectedMessage;
 
 impl SlotHandler {
     fn close_or_fail(&mut self, control: &mut mesh_node::local_node::PortControl<'_>, fail: bool) {

--- a/support/mesh/mesh_channel_core/src/oneshot.rs
+++ b/support/mesh/mesh_channel_core/src/oneshot.rs
@@ -1,0 +1,559 @@
+#![allow(unsafe_code)]
+
+use crate::ChannelError;
+use crate::RecvError;
+use mesh_node::local_node::HandleMessageError;
+use mesh_node::local_node::HandlePortEvent;
+use mesh_node::local_node::Port;
+use mesh_node::local_node::PortField;
+use mesh_node::local_node::PortWithHandler;
+use mesh_node::message::MeshField;
+use mesh_node::message::Message;
+use mesh_protobuf::DefaultEncoding;
+use parking_lot::Mutex;
+use std::fmt::Debug;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
+use std::sync::Arc;
+use std::task::ready;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
+use thiserror::Error;
+
+/// Creates a unidirection channel for sending a single value of type `T`.
+///
+/// The channel is automatically closed after the value is sent. Use this
+/// instead of [`channel`] when only one value ever needs to be sent to avoid
+/// programming errors where the channel is left open longer than necessary.
+/// This is also more efficient.
+///
+/// Use [`OneshotSender::send`] and [`OneshotReceiver`] (directly as a future)
+/// to communicate between the ends of the channel.
+///
+/// Both channel endpoints are initially local to this process, but either or
+/// both endpoints may be sent to other processes via a cross-process channel
+/// that has already been established.
+///
+/// ```rust
+/// # use mesh_channel_core::*;
+/// # futures::executor::block_on(async {
+/// let (send, recv) = oneshot::<u32>();
+/// send.send(5);
+/// let n = recv.await.unwrap();
+/// assert_eq!(n, 5);
+/// # });
+/// ```
+pub fn oneshot<T>() -> (OneshotSender<T>, OneshotReceiver<T>) {
+    let (sender, receiver) = oneshot_core();
+    (
+        OneshotSender(sender, PhantomData),
+        OneshotReceiver(receiver, PhantomData),
+    )
+}
+
+fn oneshot_core() -> (OneshotSenderCore, OneshotReceiverCore) {
+    let slot = Arc::new(Slot(Mutex::new(SlotState::Waiting(None))));
+    (
+        OneshotSenderCore(slot.clone()),
+        OneshotReceiverCore {
+            slot: Some(slot),
+            port: None,
+        },
+    )
+}
+
+/// The sending half of a channel returned by [`oneshot`].
+pub struct OneshotSender<T>(OneshotSenderCore, PhantomData<Arc<Mutex<T>>>);
+
+impl<T> Debug for OneshotSender<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl<T> OneshotSender<T> {
+    /// Sends `value` to the receiving endpoint of the channel.
+    pub fn send(self, value: T) {
+        unsafe { self.0.send(BoxedValue::new(Box::new(value))) }
+    }
+}
+
+impl<T: MeshField> DefaultEncoding for OneshotSender<T> {
+    type Encoding = PortField;
+}
+
+impl<T: MeshField> From<OneshotSender<T>> for Port {
+    fn from(sender: OneshotSender<T>) -> Self {
+        sender.into_port()
+    }
+}
+
+impl<T: MeshField> From<Port> for OneshotSender<T> {
+    fn from(port: Port) -> Self {
+        Self::from_port(port)
+    }
+}
+
+impl<T: MeshField> OneshotSender<T> {
+    fn into_port(self) -> Port {
+        unsafe { self.0.into_port(decode_message::<T>) }
+    }
+
+    fn from_port(port: Port) -> Self {
+        Self(
+            OneshotSenderCore::from_port(port, encode_message::<T>),
+            PhantomData,
+        )
+    }
+}
+
+unsafe fn encode_message<T: MeshField>(value: BoxedValue) -> Message {
+    let value = unsafe { value.cast::<T>() };
+    Message::new((value,))
+}
+
+unsafe fn decode_message<T: MeshField>(message: Message) -> Result<BoxedValue, ChannelError> {
+    let (value,) = message.parse::<(Box<T>,)>()?;
+    Ok(unsafe { BoxedValue::new(value) })
+}
+
+#[derive(Debug)]
+struct OneshotSenderCore(Arc<Slot>);
+
+impl Drop for OneshotSenderCore {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+impl OneshotSenderCore {
+    fn into_slot(self) -> Arc<Slot> {
+        match *ManuallyDrop::new(self) {
+            Self(ref slot) => unsafe { <*const _>::read(slot) },
+        }
+    }
+
+    fn close(&self) {
+        let mut state = self.0 .0.lock();
+        match std::mem::replace(&mut *state, SlotState::Done) {
+            SlotState::Waiting(waker) => {
+                drop(state);
+                if let Some(waker) = waker {
+                    waker.wake();
+                }
+            }
+            SlotState::Sent(v) => {
+                *state = SlotState::Sent(v);
+            }
+            SlotState::Done => {}
+            SlotState::SenderRemote { .. } => unreachable!(),
+            SlotState::ReceiverRemote(port, _) => {
+                drop(port);
+            }
+        }
+    }
+
+    unsafe fn send(self, value: BoxedValue) {
+        let slot = self.into_slot();
+        let mut state = slot.0.lock();
+        match std::mem::replace(&mut *state, SlotState::Done) {
+            SlotState::ReceiverRemote(port, encode) => {
+                port.send(unsafe { encode(value) });
+            }
+            SlotState::Waiting(waker) => {
+                *state = SlotState::Sent(value);
+                drop(state);
+                if let Some(waker) = waker {
+                    waker.wake();
+                }
+            }
+            SlotState::Done => {}
+            SlotState::Sent { .. } | SlotState::SenderRemote { .. } => unreachable!(),
+        }
+    }
+
+    unsafe fn into_port(self, decode: DecodeFn) -> Port {
+        let slot = self.into_slot();
+        let mut state = slot.0.lock();
+        match std::mem::replace(&mut *state, SlotState::Done) {
+            SlotState::Waiting(waker) => {
+                let (send, recv) = Port::new_pair();
+                *state = SlotState::SenderRemote(recv, decode);
+                drop(state);
+                if let Some(waker) = waker {
+                    waker.wake();
+                }
+                send
+            }
+            SlotState::ReceiverRemote(port, _) => port,
+            SlotState::Done => Port::new_pair().0,
+            SlotState::Sent(_) | SlotState::SenderRemote { .. } => unreachable!(),
+        }
+    }
+
+    fn from_port(port: Port, encode: EncodeFn) -> Self {
+        let slot = Arc::new(Slot(Mutex::new(SlotState::ReceiverRemote(port, encode))));
+        Self(slot)
+    }
+}
+
+/// The receiving half of a channel returned by [`oneshot`].
+///
+/// A value is received by `poll`ing or `await`ing the channel.
+pub struct OneshotReceiver<T>(OneshotReceiverCore, PhantomData<Arc<Mutex<T>>>);
+
+impl<T> OneshotReceiver<T> {
+    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
+        let v = ready!(self.0.poll_recv(cx))?;
+        let v = unsafe { v.cast::<T>() };
+        Ok(*v).into()
+    }
+
+    fn into_core(self) -> OneshotReceiverCore {
+        match *ManuallyDrop::new(self) {
+            Self(ref core, _) => unsafe { <*const _>::read(core) },
+        }
+    }
+}
+
+impl<T> Drop for OneshotReceiver<T> {
+    fn drop(&mut self) {
+        // Drop the value if it exists.
+        if let Some(v) = self.0.clear() {
+            let _v = unsafe { v.cast::<T>() };
+        }
+    }
+}
+
+impl<T> Future for OneshotReceiver<T> {
+    type Output = Result<T, RecvError>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.get_mut().poll_recv(cx)
+    }
+}
+
+impl<T: MeshField> DefaultEncoding for OneshotReceiver<T> {
+    type Encoding = PortField;
+}
+
+impl<T: MeshField> From<OneshotReceiver<T>> for Port {
+    fn from(receiver: OneshotReceiver<T>) -> Self {
+        receiver.into_port()
+    }
+}
+
+impl<T: MeshField> From<Port> for OneshotReceiver<T> {
+    fn from(port: Port) -> Self {
+        Self::from_port(port)
+    }
+}
+
+impl<T: MeshField> OneshotReceiver<T> {
+    fn into_port(self) -> Port {
+        unsafe { self.into_core().into_port(encode_message::<T>) }
+    }
+
+    fn from_port(port: Port) -> Self {
+        Self(
+            OneshotReceiverCore::from_port(port, decode_message::<T>),
+            PhantomData,
+        )
+    }
+}
+
+struct OneshotReceiverCore {
+    slot: Option<Arc<Slot>>,
+    port: Option<PortWithHandler<SlotHandler>>,
+}
+
+impl OneshotReceiverCore {
+    #[must_use]
+    fn clear(&mut self) -> Option<BoxedValue> {
+        let slot = self.slot.take()?;
+        let v = if let SlotState::Sent(value) =
+            std::mem::replace(&mut *slot.0.lock(), SlotState::Done)
+        {
+            Some(value)
+        } else {
+            None
+        };
+        v
+    }
+
+    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<BoxedValue, RecvError>> {
+        let Some(slot) = &self.slot else {
+            return Poll::Ready(Err(RecvError::Closed));
+        };
+        let v = loop {
+            let mut state = slot.0.lock();
+            break match std::mem::replace(&mut *state, SlotState::Done) {
+                SlotState::SenderRemote(port, decode) => {
+                    *state = SlotState::Waiting(None);
+                    drop(state);
+                    assert!(self.port.is_none());
+                    self.port = Some(port.set_handler(SlotHandler {
+                        slot: slot.clone(),
+                        decode,
+                    }));
+                    continue;
+                }
+                SlotState::Waiting(mut waker) => {
+                    if let Some(waker) = &mut waker {
+                        waker.clone_from(cx.waker());
+                    } else {
+                        waker = Some(cx.waker().clone());
+                    }
+                    *state = SlotState::Waiting(waker);
+                    return Poll::Pending;
+                }
+                SlotState::Sent(data) => Ok(data),
+                SlotState::Done => {
+                    let err = self.port.as_ref().map_or(RecvError::Closed, |port| {
+                        port.is_closed()
+                            .map(|_| RecvError::Closed)
+                            .unwrap_or_else(|err| RecvError::Error(err.into()))
+                    });
+                    Err(err)
+                }
+                SlotState::ReceiverRemote { .. } => {
+                    unreachable!()
+                }
+            };
+        };
+        Poll::Ready(v)
+    }
+
+    unsafe fn into_port(mut self, encode: EncodeFn) -> Port {
+        let existing = self.port.take().map(|port| port.remove_handler().0);
+        let Some(slot) = self.slot.take() else {
+            return existing.unwrap_or_else(|| Port::new_pair().0);
+        };
+        let mut state = slot.0.lock();
+        match std::mem::replace(&mut *state, SlotState::Done) {
+            SlotState::SenderRemote(port, _) => {
+                assert!(existing.is_none());
+                port
+            }
+            SlotState::Waiting(_) => {
+                let (send, recv) = Port::new_pair();
+                *state = SlotState::ReceiverRemote(recv, encode);
+                send
+            }
+            SlotState::Sent(value) => {
+                let (send, recv) = Port::new_pair();
+                send.send(unsafe { encode(value) });
+                if let Some(existing) = existing {
+                    existing.bridge(send);
+                }
+                recv
+            }
+            SlotState::Done => existing.unwrap_or_else(|| Port::new_pair().0),
+            SlotState::ReceiverRemote { .. } => unreachable!(),
+        }
+    }
+
+    fn from_port(port: Port, decode: DecodeFn) -> Self {
+        let slot = Arc::new(Slot(Mutex::new(SlotState::SenderRemote(port, decode))));
+        Self {
+            slot: Some(slot),
+            port: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum SlotState {
+    Done,
+    Waiting(Option<Waker>),
+    Sent(BoxedValue),
+    SenderRemote(Port, DecodeFn),
+    ReceiverRemote(Port, EncodeFn),
+}
+
+type EncodeFn = unsafe fn(BoxedValue) -> Message;
+type DecodeFn = unsafe fn(Message) -> Result<BoxedValue, ChannelError>;
+
+#[derive(Debug)]
+struct BoxedValue(*mut ());
+
+unsafe impl Send for BoxedValue {}
+unsafe impl Sync for BoxedValue {}
+
+impl BoxedValue {
+    unsafe fn new<T>(value: Box<T>) -> Self {
+        Self(Box::into_raw(value).cast())
+    }
+
+    unsafe fn cast<T>(self) -> Box<T> {
+        unsafe { Box::from_raw(self.0.cast::<T>()) }
+    }
+}
+
+#[derive(Debug)]
+struct Slot(Mutex<SlotState>);
+
+struct SlotHandler {
+    slot: Arc<Slot>,
+    decode: DecodeFn,
+}
+
+#[derive(Debug, Error)]
+#[error("unexpected oneshot message")]
+struct UnexpectedMessage;
+
+impl SlotHandler {
+    fn close_or_fail(&mut self, control: &mut mesh_node::local_node::PortControl<'_>, fail: bool) {
+        let mut state = self.slot.0.lock();
+        match std::mem::replace(&mut *state, SlotState::Done) {
+            SlotState::Waiting(waker) => {
+                if let Some(waker) = waker {
+                    control.wake(waker);
+                }
+            }
+            SlotState::Sent(v) => {
+                if !fail {
+                    *state = SlotState::Sent(v);
+                }
+            }
+            SlotState::Done => {}
+            SlotState::SenderRemote { .. } | SlotState::ReceiverRemote { .. } => unreachable!(),
+        }
+    }
+}
+
+impl HandlePortEvent for SlotHandler {
+    fn message(
+        &mut self,
+        control: &mut mesh_node::local_node::PortControl<'_>,
+        message: Message,
+    ) -> Result<(), HandleMessageError> {
+        let mut state = self.slot.0.lock();
+        match std::mem::replace(&mut *state, SlotState::Done) {
+            SlotState::Waiting(waker) => {
+                let value = unsafe { (self.decode)(message) }.map_err(HandleMessageError::new)?;
+                *state = SlotState::Sent(value);
+                drop(state);
+                if let Some(waker) = waker {
+                    control.wake(waker);
+                }
+            }
+            SlotState::Sent(v) => {
+                *state = SlotState::Sent(v);
+                return Err(HandleMessageError::new(UnexpectedMessage));
+            }
+            SlotState::Done => {
+                *state = SlotState::Done;
+            }
+            SlotState::SenderRemote { .. } | SlotState::ReceiverRemote { .. } => unreachable!(),
+        }
+        Ok(())
+    }
+
+    fn close(&mut self, control: &mut mesh_node::local_node::PortControl<'_>) {
+        self.close_or_fail(control, false);
+    }
+
+    fn fail(
+        &mut self,
+        control: &mut mesh_node::local_node::PortControl<'_>,
+        _err: mesh_node::local_node::NodeError,
+    ) {
+        self.close_or_fail(control, true);
+    }
+
+    fn drain(&mut self) -> Vec<Message> {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::oneshot;
+    use crate::OneshotReceiver;
+    use crate::OneshotSender;
+    use crate::RecvError;
+    use futures::executor::block_on;
+    use mesh_node::local_node::Port;
+    use mesh_node::message::Message;
+    use std::cell::Cell;
+    use test_with_tracing::test;
+
+    // Ensure `Send` and `Sync` are implemented correctly.
+    static_assertions::assert_impl_all!(OneshotSender<i32>: Send, Sync);
+    static_assertions::assert_impl_all!(OneshotReceiver<i32>: Send, Sync);
+    static_assertions::assert_impl_all!(OneshotSender<Cell<i32>>: Send, Sync);
+    static_assertions::assert_impl_all!(OneshotReceiver<Cell<i32>>: Send, Sync);
+    static_assertions::assert_not_impl_any!(OneshotSender<*const ()>: Send, Sync);
+    static_assertions::assert_not_impl_any!(OneshotReceiver<*const ()>: Send, Sync);
+
+    #[test]
+    fn test_oneshot() {
+        block_on(async {
+            let (sender, receiver) = oneshot();
+            sender.send(String::from("foo"));
+            assert_eq!(receiver.await.unwrap(), "foo");
+        })
+    }
+
+    #[test]
+    fn test_oneshot_convert_sender_port() {
+        block_on(async {
+            let (sender, receiver) = oneshot::<String>();
+            let sender = OneshotSender::<String>::from(Port::from(sender));
+            sender.send(String::from("foo"));
+            assert_eq!(receiver.await.unwrap(), "foo");
+        })
+    }
+
+    #[test]
+    fn test_oneshot_convert_receiver_port() {
+        block_on(async {
+            let (sender, receiver) = oneshot::<String>();
+            let receiver = OneshotReceiver::<String>::from(Port::from(receiver));
+            sender.send(String::from("foo"));
+            assert_eq!(receiver.await.unwrap(), "foo");
+        })
+    }
+
+    #[test]
+    fn test_oneshot_message_corruption() {
+        block_on(async {
+            let (sender, receiver) = oneshot();
+            let receiver = OneshotReceiver::<i32>::from(Port::from(receiver));
+            sender.send("text".to_owned());
+            let RecvError::Error(err) = receiver.await.unwrap_err() else {
+                panic!()
+            };
+            tracing::info!(error = &err as &dyn std::error::Error, "expected error");
+        })
+    }
+
+    #[test]
+    fn test_oneshot_extra_messages() {
+        block_on(async {
+            let (sender, mut receiver) = oneshot::<()>();
+            let sender = Port::from(sender);
+            assert!(futures::poll!(&mut receiver).is_pending());
+            sender.send(Message::new(()));
+            sender.send(Message::new(()));
+            let RecvError::Error(err) = receiver.await.unwrap_err() else {
+                panic!()
+            };
+            tracing::info!(error = &err as &dyn std::error::Error, "expected error");
+        })
+    }
+
+    #[test]
+    fn test_oneshot_closed() {
+        block_on(async {
+            let (sender, receiver) = oneshot::<()>();
+            drop(sender);
+            let RecvError::Closed = receiver.await.unwrap_err() else {
+                panic!()
+            };
+        })
+    }
+}

--- a/support/mesh/mesh_channel_core/src/oneshot.rs
+++ b/support/mesh/mesh_channel_core/src/oneshot.rs
@@ -80,6 +80,10 @@ pub fn oneshot<T>() -> (OneshotSender<T>, OneshotReceiver<T>) {
 }
 
 /// The sending half of a channel returned by [`oneshot`].
+//
+// Note that the `PhantomData` here is necessary to ensure `Send/Sync` traits
+// are only implemented when `T` is `Send`, since the `OneshotSenderCore` is
+// always `Send+Sync`. This behavior is verified in the unit tests.
 pub struct OneshotSender<T>(OneshotSenderCore, PhantomData<Arc<Mutex<T>>>);
 
 impl<T> Debug for OneshotSender<T> {
@@ -235,6 +239,10 @@ impl OneshotSenderCore {
 /// The receiving half of a channel returned by [`oneshot`].
 ///
 /// A value is received by `poll`ing or `await`ing the channel.
+//
+// Note that the `PhantomData` here is necessary to ensure `Send/Sync` traits
+// are only implemented when `T` is `Send`, since the `OneshotReceiverCore` is
+// always `Send+Sync`. This behavior is verified in the unit tests.
 pub struct OneshotReceiver<T>(
     ManuallyDrop<OneshotReceiverCore>,
     PhantomData<Arc<Mutex<T>>>,

--- a/support/mesh/mesh_channel_core/src/oneshot.rs
+++ b/support/mesh/mesh_channel_core/src/oneshot.rs
@@ -204,6 +204,12 @@ impl OneshotSenderCore {
 /// A value is received by `poll`ing or `await`ing the channel.
 pub struct OneshotReceiver<T>(OneshotReceiverCore, PhantomData<Arc<Mutex<T>>>);
 
+impl<T> Debug for OneshotReceiver<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
 impl<T> OneshotReceiver<T> {
     fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
         let v = ready!(self.0.poll_recv(cx))?;
@@ -264,6 +270,7 @@ impl<T: MeshField> OneshotReceiver<T> {
     }
 }
 
+#[derive(Debug)]
 struct OneshotReceiverCore {
     slot: Option<Arc<Slot>>,
     port: Option<PortWithHandler<SlotHandler>>,

--- a/support/mesh/mesh_channel_core/src/oneshot.rs
+++ b/support/mesh/mesh_channel_core/src/oneshot.rs
@@ -1,3 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Implementation of a channel for sending a single value, usable across mesh
+//! nodes.
+//!
+//! The implementation intends to be:
+//!
+//! * Efficient enough for general-purpose single-process use.
+//! * Possible for use across mesh processes, using `mesh_protobuf` to serialize
+//!   the message and `mesh_node` to send it.
+//! * Small in binary size.
+//!
+//! To achieve the binary size goal, the implementation avoids monomorphism.
+//! This comes at a cost of using `unsafe` code internally.
+
+// UNSAFETY: needed to avoid monomorphization.
 #![allow(unsafe_code)]
 
 use crate::ChannelError;

--- a/support/mesh/mesh_channel_core/src/oneshot.rs
+++ b/support/mesh/mesh_channel_core/src/oneshot.rs
@@ -43,7 +43,7 @@ use thiserror::Error;
 /// Creates a unidirection channel for sending a single value of type `T`.
 ///
 /// The channel is automatically closed after the value is sent. Use this
-/// instead of [`channel`] when only one value ever needs to be sent to avoid
+/// instead of [`channel`][] when only one value ever needs to be sent to avoid
 /// programming errors where the channel is left open longer than necessary.
 /// This is also more efficient.
 ///
@@ -63,6 +63,8 @@ use thiserror::Error;
 /// assert_eq!(n, 5);
 /// # });
 /// ```
+///
+/// [`channel`]: crate::mpsc::channel
 pub fn oneshot<T>() -> (OneshotSender<T>, OneshotReceiver<T>) {
     fn oneshot_core() -> (OneshotSenderCore, OneshotReceiverCore) {
         let slot = Arc::new(Slot(Mutex::new(SlotState::Waiting(None))));

--- a/support/mesh/mesh_node/src/local_node.rs
+++ b/support/mesh/mesh_node/src/local_node.rs
@@ -319,10 +319,17 @@ impl Port {
 /// A [`Port`] that has a registered message handler.
 ///
 /// Created by [`Port::set_handler`].
-#[derive(Debug)]
 pub struct PortWithHandler<T> {
     raw: Port,
     _phantom: PhantomData<Arc<Mutex<T>>>,
+}
+
+impl<T> Debug for PortWithHandler<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PortWithHandler")
+            .field("raw", &self.raw)
+            .finish()
+    }
 }
 
 impl<T> Drop for PortWithHandler<T> {


### PR DESCRIPTION
Take a similar approach to #594 but for oneshot channels.

This reduces openvmm_hcl binary size by a few hundred KB, and it improves oneshot channel overhead by an unmeasured amount.