### PR TITLE
Enable the output of tracing span events across the codebase

### DIFF
--- a/openhcl/underhill_core/src/get_tracing.rs
+++ b/openhcl/underhill_core/src/get_tracing.rs
@@ -194,7 +194,6 @@ pub fn init_tracing(spawn: impl Spawn, tracer: RemoteTracer) -> anyhow::Result<(
         .map_or("", |v| v.as_str())
     {
         "close" => FmtSpan::CLOSE,
-        "full" => FmtSpan::FULL,
         "1" | "true" => FmtSpan::NEW | FmtSpan::CLOSE,
         "0" | "false" | "" => FmtSpan::NONE,
         x => anyhow::bail!("invalid OPENVMM_SHOW_SPANS value: {x}"),

--- a/openhcl/underhill_core/src/get_tracing.rs
+++ b/openhcl/underhill_core/src/get_tracing.rs
@@ -42,7 +42,7 @@ use mesh_tracing::Type;
 use pal_async::driver::SpawnDriver;
 use pal_async::task::Spawn;
 use tracing_helpers::formatter::FieldFormatter;
-use tracing_subscriber::fmt;
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::fmt::format::Format;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -193,9 +193,9 @@ pub fn init_tracing(spawn: impl Spawn, tracer: RemoteTracer) -> anyhow::Result<(
         .as_ref()
         .map_or("", |v| v.as_str())
     {
-        "close" => fmt::format::FmtSpan::CLOSE,
-        "1" | "true" => fmt::format::FmtSpan::NEW | fmt::format::FmtSpan::CLOSE,
-        "0" | "false" | "" => fmt::format::FmtSpan::NONE,
+        "close" => FmtSpan::CLOSE,
+        "1" | "true" => FmtSpan::NEW | FmtSpan::CLOSE,
+        "0" | "false" | "" => FmtSpan::NONE,
         x => anyhow::bail!("invalid OPENVMM_SHOW_SPANS value: {x}"),
     };
 
@@ -203,7 +203,7 @@ pub fn init_tracing(spawn: impl Spawn, tracer: RemoteTracer) -> anyhow::Result<(
     let json_fmt_layer = json_layer::JsonMeshLayer::new(tracer.trace_writer);
 
     // Output nicely readable events to kmsg (and therefore also serial).
-    let kmsg_layer = fmt::layer()
+    let kmsg_layer = tracing_subscriber::fmt::layer()
         .event_format(
             Format::default()
                 .without_time()

--- a/openhcl/underhill_core/src/get_tracing.rs
+++ b/openhcl/underhill_core/src/get_tracing.rs
@@ -195,7 +195,7 @@ pub fn init_tracing(spawn: impl Spawn, tracer: RemoteTracer) -> anyhow::Result<(
     {
         "close" => fmt::format::FmtSpan::CLOSE,
         "1" | "true" => fmt::format::FmtSpan::NEW | fmt::format::FmtSpan::CLOSE,
-        "" => fmt::format::FmtSpan::NONE,
+        "0" | "false" | "" => fmt::format::FmtSpan::NONE,
         x => anyhow::bail!("invalid OPENVMM_SHOW_SPANS value: {x}"),
     };
 

--- a/openhcl/underhill_core/src/get_tracing.rs
+++ b/openhcl/underhill_core/src/get_tracing.rs
@@ -194,6 +194,7 @@ pub fn init_tracing(spawn: impl Spawn, tracer: RemoteTracer) -> anyhow::Result<(
         .map_or("", |v| v.as_str())
     {
         "close" => FmtSpan::CLOSE,
+        "full" => FmtSpan::FULL,
         "1" | "true" => FmtSpan::NEW | FmtSpan::CLOSE,
         "0" | "false" | "" => FmtSpan::NONE,
         x => anyhow::bail!("invalid OPENVMM_SHOW_SPANS value: {x}"),

--- a/openvmm/openvmm_entry/src/tracing_init.rs
+++ b/openvmm/openvmm_entry/src/tracing_init.rs
@@ -4,6 +4,7 @@
 use anyhow::anyhow;
 use anyhow::Context as _;
 use std::io::IsTerminal;
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::fmt::format::Format;
 use tracing_subscriber::fmt::time::uptime;
 
@@ -53,6 +54,7 @@ pub fn enable_tracing() -> anyhow::Result<()> {
         .with_ansi(is_terminal);
     let fmt_layer = tracing_subscriber::fmt::layer()
         .event_format(format)
+        .with_span_events(FmtSpan::FULL)
         .fmt_fields(tracing_helpers::formatter::FieldFormatter)
         .log_internal_errors(true)
         .with_writer(writer);

--- a/openvmm/openvmm_entry/src/tracing_init.rs
+++ b/openvmm/openvmm_entry/src/tracing_init.rs
@@ -54,7 +54,7 @@ pub fn enable_tracing() -> anyhow::Result<()> {
         .with_ansi(is_terminal);
     let fmt_layer = tracing_subscriber::fmt::layer()
         .event_format(format)
-        .with_span_events(FmtSpan::FULL)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .fmt_fields(tracing_helpers::formatter::FieldFormatter)
         .log_internal_errors(true)
         .with_writer(writer);

--- a/petri/pipette/src/trace.rs
+++ b/petri/pipette/src/trace.rs
@@ -24,7 +24,7 @@ pub fn init_tracing() -> mesh::pipe::ReadPipe {
         .with_timer(tracing_subscriber::fmt::time::uptime())
         .with_writer(Arc::new(TracingWriter(log_write)))
         .with_max_level(tracing::level_filters::LevelFilter::DEBUG)
-        .with_span_events(FmtSpan::FULL)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .log_internal_errors(true)
         .finish()
         .with(targets)

--- a/petri/pipette/src/trace.rs
+++ b/petri/pipette/src/trace.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 use tracing_subscriber::filter::Targets;
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
@@ -23,6 +24,7 @@ pub fn init_tracing() -> mesh::pipe::ReadPipe {
         .with_timer(tracing_subscriber::fmt::time::uptime())
         .with_writer(Arc::new(TracingWriter(log_write)))
         .with_max_level(tracing::level_filters::LevelFilter::DEBUG)
+        .with_span_events(FmtSpan::FULL)
         .log_internal_errors(true)
         .finish()
         .with(targets)

--- a/petri/src/tracing.rs
+++ b/petri/src/tracing.rs
@@ -33,7 +33,7 @@ pub(crate) fn try_init_tracing(
         .with_ansi(false) // avoid polluting logs with escape sequences
         .log_internal_errors(true)
         .with_writer(PetriWriter::new(log_file))
-        .with_span_events(FmtSpan::FULL)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .with_max_level(LevelFilter::TRACE)
         .finish()
         .with(targets)

--- a/petri/src/tracing.rs
+++ b/petri/src/tracing.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::path::Path;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::filter::Targets;
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::fmt::writer::EitherWriter;
 use tracing_subscriber::fmt::writer::Tee;
 use tracing_subscriber::fmt::MakeWriter;
@@ -32,6 +33,7 @@ pub(crate) fn try_init_tracing(
         .with_ansi(false) // avoid polluting logs with escape sequences
         .log_internal_errors(true)
         .with_writer(PetriWriter::new(log_file))
+        .with_span_events(FmtSpan::FULL)
         .with_max_level(LevelFilter::TRACE)
         .finish()
         .with(targets)

--- a/petri/src/vm/construct.rs
+++ b/petri/src/vm/construct.rs
@@ -593,13 +593,18 @@ impl PetriVmConfigSetupCore<'_> {
     }
 
     fn load_firmware(&self) -> anyhow::Result<LoadMode> {
-        // Forward OPENVMM_LOG to OpenHCL if it's set.
+        // Forward OPENVMM_LOG and OPENVMM_SHOW_SPANS to OpenHCL if they're set.
         let openhcl_tracing =
             if let Ok(x) = std::env::var("OPENVMM_LOG").or_else(|_| std::env::var("HVLITE_LOG")) {
                 format!("OPENVMM_LOG={x}")
             } else {
                 "OPENVMM_LOG=debug".to_owned()
             };
+        let openhcl_show_spans = if let Ok(x) = std::env::var("OPENVMM_SHOW_SPANS") {
+            format!("OPENVMM_SHOW_SPANS={x}")
+        } else {
+            "OPENVMM_SHOW_SPANS=1".to_owned()
+        };
 
         Ok(match (self.arch, &self.firmware) {
             (MachineArch::X86_64, Firmware::LinuxDirect { .. }) => {
@@ -681,7 +686,8 @@ impl PetriVmConfigSetupCore<'_> {
                 MachineArch::X86_64,
                 Firmware::OpenhclLinuxDirect { .. } | Firmware::OpenhclUefi { .. },
             ) => {
-                let mut cmdline = format!("panic=-1 reboot=triple {openhcl_tracing}");
+                let mut cmdline =
+                    format!("panic=-1 reboot=triple {openhcl_tracing} {openhcl_show_spans}");
 
                 let (igvm_artifact, isolated) = match self.firmware {
                     Firmware::OpenhclLinuxDirect { .. } => {

--- a/petri/src/vm/construct.rs
+++ b/petri/src/vm/construct.rs
@@ -603,7 +603,7 @@ impl PetriVmConfigSetupCore<'_> {
         let openhcl_show_spans = if let Ok(x) = std::env::var("OPENVMM_SHOW_SPANS") {
             format!("OPENVMM_SHOW_SPANS={x}")
         } else {
-            "OPENVMM_SHOW_SPANS=1".to_owned()
+            "OPENVMM_SHOW_SPANS=full".to_owned()
         };
 
         Ok(match (self.arch, &self.firmware) {

--- a/petri/src/vm/construct.rs
+++ b/petri/src/vm/construct.rs
@@ -603,7 +603,7 @@ impl PetriVmConfigSetupCore<'_> {
         let openhcl_show_spans = if let Ok(x) = std::env::var("OPENVMM_SHOW_SPANS") {
             format!("OPENVMM_SHOW_SPANS={x}")
         } else {
-            "OPENVMM_SHOW_SPANS=full".to_owned()
+            "OPENVMM_SHOW_SPANS=true".to_owned()
         };
 
         Ok(match (self.arch, &self.firmware) {

--- a/support/test_with_tracing/src/lib.rs
+++ b/support/test_with_tracing/src/lib.rs
@@ -29,7 +29,7 @@ pub fn init() {
             .log_internal_errors(true)
             .with_test_writer()
             .with_max_level(LevelFilter::TRACE)
-            .with_span_events(FmtSpan::FULL)
+            .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
             .finish()
             .with(targets)
             .init();

--- a/support/test_with_tracing/src/lib.rs
+++ b/support/test_with_tracing/src/lib.rs
@@ -9,6 +9,7 @@ extern crate self as test_with_tracing;
 pub use test_with_tracing_macro::test;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::filter::Targets;
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 
 #[doc(hidden)]
@@ -28,6 +29,7 @@ pub fn init() {
             .log_internal_errors(true)
             .with_test_writer()
             .with_max_level(LevelFilter::TRACE)
+            .with_span_events(FmtSpan::FULL)
             .finish()
             .with(targets)
             .init();

--- a/xtask/xtask_fuzz/src/lib.rs
+++ b/xtask/xtask_fuzz/src/lib.rs
@@ -22,6 +22,7 @@ pub fn init_tracing_if_repro() {
     use std::sync::Once;
     use tracing_subscriber::filter::LevelFilter;
     use tracing_subscriber::filter::Targets;
+    use tracing_subscriber::fmt::format::FmtSpan;
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
@@ -60,7 +61,6 @@ macro_rules! fuzz_eprintln {
 
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub use libfuzzer_sys::fuzz_target;
-use tracing_subscriber::fmt::format::FmtSpan;
 
 #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 #[macro_export]

--- a/xtask/xtask_fuzz/src/lib.rs
+++ b/xtask/xtask_fuzz/src/lib.rs
@@ -40,6 +40,7 @@ pub fn init_tracing_if_repro() {
                 .compact()
                 .log_internal_errors(true)
                 .with_max_level(LevelFilter::TRACE)
+                .with_span_events(FmtSpan::FULL)
                 .finish()
                 .with(targets)
                 .init();
@@ -59,6 +60,7 @@ macro_rules! fuzz_eprintln {
 
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub use libfuzzer_sys::fuzz_target;
+use tracing_subscriber::fmt::format::FmtSpan;
 
 #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 #[macro_export]

--- a/xtask/xtask_fuzz/src/lib.rs
+++ b/xtask/xtask_fuzz/src/lib.rs
@@ -41,7 +41,7 @@ pub fn init_tracing_if_repro() {
                 .compact()
                 .log_internal_errors(true)
                 .with_max_level(LevelFilter::TRACE)
-                .with_span_events(FmtSpan::FULL)
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                 .finish()
                 .with(targets)
                 .init();


### PR DESCRIPTION
Feels like kind of a footgun that tracing has these completely disabled by default. I went through everywhere we're creating a tracing_subscriber::fmt::layer and enabled them where I thought it made sense. Along with some small cleanups.