### PR TITLE
Update OHCL kernel to 6.6.63.1 & TDX: Add support for kernel interrupt offloading

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -5449,7 +5449,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 8 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.51.9-arm64.tar.gz
+    - name: unpack kernel package
       run: flowey e 8 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var
@@ -5539,7 +5539,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-arm64.tar.gz
+    - name: unpack kernel package
       run: flowey e 8 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -5857,7 +5857,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 9 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.51.9-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 9 flowey_lib_hvlite::download_openhcl_kernel_package 2
       shell: bash
     - name: 🌼 write_into Var
@@ -5953,7 +5953,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 9 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -6055,7 +6055,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-cvm-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 9 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -5508,7 +5508,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 8 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.51.9-arm64.tar.gz
+    - name: unpack kernel package
       run: flowey e 8 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var
@@ -5598,7 +5598,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 8 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-arm64.tar.gz
+    - name: unpack kernel package
       run: flowey e 8 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -5916,7 +5916,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 9 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.51.9-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 9 flowey_lib_hvlite::download_openhcl_kernel_package 2
       shell: bash
     - name: 🌼 write_into Var
@@ -6012,7 +6012,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 9 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -6114,7 +6114,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 9 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.51.7-main-cvm-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 9 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -26,8 +26,8 @@ pub const RUSTUP_TOOLCHAIN: &str = "1.82.0";
 pub const MU_MSVM: &str = "24.0.4";
 pub const NEXTEST: &str = "0.9.74";
 pub const NODEJS: &str = "18.x";
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.6.51.9";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.6.51.7";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.6.63.1";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.6.63.1";
 pub const OPENVMM_DEPS: &str = "0.1.0-20241014.2";
 pub const PROTOC: &str = "27.1";
 

--- a/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
@@ -99,10 +99,8 @@ impl FlowNode for Node {
                 },
                 version,
                 match kind {
-                    OpenhclKernelPackageKind::Main => "-main",
-                    OpenhclKernelPackageKind::Cvm => "-main-cvm",
-                    OpenhclKernelPackageKind::Dev => "",
-                    OpenhclKernelPackageKind::CvmDev => "-cvm",
+                    OpenhclKernelPackageKind::Main | OpenhclKernelPackageKind::Dev => "",
+                    OpenhclKernelPackageKind::Cvm | OpenhclKernelPackageKind::CvmDev => "-cvm",
                 },
                 match arch {
                     OpenhclKernelPackageArch::X86_64 => "x64",

--- a/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
@@ -120,7 +120,7 @@ impl FlowNode for Node {
                     path: v,
                 });
 
-            ctx.emit_rust_step(format!("unpack {file_name}"), |ctx| {
+            ctx.emit_rust_step("unpack kernel package", |ctx| {
                 let extract_zip_deps = extract_zip_deps.clone().claim(ctx);
                 let out_vars = out_vars.claim(ctx);
                 let kernel_package_tar_gz = kernel_package_tar_gz.claim(ctx);

--- a/openhcl/hcl/src/protocol.rs
+++ b/openhcl/hcl/src/protocol.rs
@@ -113,19 +113,42 @@ pub const R15: usize = 15;
 
 pub const VTL_RETURN_ACTION_SIZE: usize = 256;
 
+/// Kernel IPI offloading flags
+#[bitfield(u8)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
+pub struct hcl_intr_offload_flags {
+    /// Enable the base level of kernel offloading support. Requires vAPIC to be enabled.
+    /// HLT and Idle are accelerated by the kernel. When halted, an interrupt may be injected
+    /// entirely in kernel, bypassing user-space.
+    pub offload_intr_inject: bool,
+    /// Handle the X2 APIC ICR register in kernel
+    pub offload_x2apic: bool,
+    #[bits(3)]
+    reserved: u8,
+    /// Halt, due to other reason. Kernel cannot clear this state.
+    pub halted_other: bool,
+    /// Halt, due to HLT instruction. Kernel can clear this state.
+    pub halted_hlt: bool,
+    /// Halt, due to guest idle. Kernel can clear this state.
+    pub halted_idle: bool,
+}
+
 #[repr(C)]
 pub struct hcl_run {
     pub cancel: u32,
     pub vtl_ret_action_size: u32,
     pub flags: u32,
     pub scan_proxy_irr: u8,
-    pub pad: [u8; 2],
+    pub offload_flags: hcl_intr_offload_flags,
+    pub pad: [u8; 1],
     pub mode: EnterModes,
     pub exit_message: [u8; HV_MESSAGE_SIZE],
     pub context: [u8; 1024],
     pub vtl_ret_actions: [u8; VTL_RETURN_ACTION_SIZE],
     pub proxy_irr: [u32; 8],
     pub target_vtl: HvInputVtl,
+    pub proxy_irr_blocked: [u32; 8],
+    pub proxy_irr_exit: [u32; 8],
 }
 
 // The size of hcl_run must be less than or equal to a single 4K page.

--- a/vmm_core/virt_support_apic/src/lib.rs
+++ b/vmm_core/virt_support_apic/src/lib.rs
@@ -1422,7 +1422,8 @@ impl LocalApic {
         self.hardware_enabled() && !self.x2apic_enabled()
     }
 
-    fn x2apic_enabled(&self) -> bool {
+    /// X2APIC is enabled on this local APIC
+    pub fn x2apic_enabled(&self) -> bool {
         ApicBase::from(self.apic_base).x2apic()
     }
 


### PR DESCRIPTION
flowey: Remove kernel version from step name
CP from (#617)
No changes.

Update OHCL kernel to 6.6.63.1
CP from (#568)
YAML change in original commit ignored. No other changes.

TDX: Add support for kernel interrupt offloading
CP from (#124)
Changed to use `LapicState`'s `halted`, `idle`, `startup_suspend` fields instead of the `MpState` enum, as (#470) is not present in this branch.