### PR TITLE
flowey: Remove kernel version from step name

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1408,7 +1408,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.63.1-arm64.tar.gz
+    - name: unpack kernel package
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var
@@ -1498,7 +1498,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-arm64.tar.gz
+    - name: unpack kernel package
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -1817,7 +1817,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 13 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.63.1-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 2
       shell: bash
     - name: 🌼 write_into Var
@@ -1913,7 +1913,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -2015,7 +2015,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-cvm-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1055,7 +1055,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.63.1-arm64.tar.gz
+    - name: unpack kernel package
       run: flowey e 11 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var
@@ -1145,7 +1145,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-arm64.tar.gz
+    - name: unpack kernel package
       run: flowey e 11 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -1464,7 +1464,7 @@ jobs:
     - name: report built openhcl_boot
       run: flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.Dev.6.6.63.1-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 2
       shell: bash
     - name: 🌼 write_into Var
@@ -1560,7 +1560,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
@@ -1662,7 +1662,7 @@ jobs:
     - name: 🌼 write_into Var
       run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
       shell: bash
-    - name: unpack Microsoft.OHCL.Kernel.6.6.63.1-cvm-x64.tar.gz
+    - name: unpack kernel package
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 1
       shell: bash
     - name: 🌼 write_into Var

--- a/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
@@ -118,7 +118,7 @@ impl FlowNode for Node {
                     path: v,
                 });
 
-            ctx.emit_rust_step(format!("unpack {file_name}"), |ctx| {
+            ctx.emit_rust_step(format!("unpack kernel package"), |ctx| {
                 let extract_zip_deps = extract_zip_deps.clone().claim(ctx);
                 let out_vars = out_vars.claim(ctx);
                 let kernel_package_tar_gz = kernel_package_tar_gz.claim(ctx);

--- a/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openhcl_kernel_package.rs
@@ -118,7 +118,7 @@ impl FlowNode for Node {
                     path: v,
                 });
 
-            ctx.emit_rust_step(format!("unpack kernel package"), |ctx| {
+            ctx.emit_rust_step("unpack kernel package", |ctx| {
                 let extract_zip_deps = extract_zip_deps.clone().claim(ctx);
                 let out_vars = out_vars.claim(ctx);
                 let kernel_package_tar_gz = kernel_package_tar_gz.claim(ctx);


### PR DESCRIPTION
Remove the kernel version from the step name, so kernel updates no longer require YAML regeneration.