### PR TITLE
Increase `underhill_attestation` `vmgs` unit test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6872,6 +6872,8 @@ dependencies = [
  "base64 0.21.7",
  "base64-serde",
  "cvm_tracing",
+ "disk_backend",
+ "disklayer_ram",
  "getrandom",
  "guest_emulation_transport",
  "guid",

--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -33,5 +33,9 @@ thiserror.workspace = true
 time = { workspace = true, features = ["macros"] }
 zerocopy.workspace = true
 
+[target.'cfg(target_os = "linux")'.dev_dependencies]
+disklayer_ram = { path = "../../vm/devices/storage/disklayer_ram" }
+disk_backend = { path = "../../vm/devices/storage/disk_backend" }
+
 [lints]
 workspace = true

--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -33,7 +33,7 @@ thiserror.workspace = true
 time = { workspace = true, features = ["macros"] }
 zerocopy.workspace = true
 
-[target.'cfg(target_os = "linux")'.dev_dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 disklayer_ram = { path = "../../vm/devices/storage/disklayer_ram" }
 disk_backend = { path = "../../vm/devices/storage/disk_backend" }
 

--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -34,8 +34,8 @@ time = { workspace = true, features = ["macros"] }
 zerocopy.workspace = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-disklayer_ram = { path = "../../vm/devices/storage/disklayer_ram" }
-disk_backend = { path = "../../vm/devices/storage/disk_backend" }
+disklayer_ram.workspace = true
+disk_backend.workspace = true
 
 [lints]
 workspace = true

--- a/openhcl/underhill_attestation/src/vmgs.rs
+++ b/openhcl/underhill_attestation/src/vmgs.rs
@@ -363,7 +363,7 @@ mod tests {
             pad: [0; 3],
         };
 
-        // try to read the `key_protector_by_id` from the VMGS file which doesn't have a `key_protector_by_id` entry
+        // Try to read the `key_protector_by_id` from the VMGS file which doesn't have a `key_protector_by_id` entry
         let found_key_protector_by_id_result = read_key_protector_by_id(&mut vmgs).await;
         assert!(found_key_protector_by_id_result.is_err());
         assert_eq!(
@@ -371,12 +371,12 @@ mod tests {
             "entry does not exist, file id: VM_UNIQUE_ID"
         );
 
-        // populate the VMGS file with `key_protector_by_id`
+        // Populate the VMGS file with `key_protector_by_id`
         write_key_protector_by_id(&mut key_protector_by_id, &mut vmgs, true, kp_guid)
             .await
             .unwrap();
 
-        // without using force, write the same `kp_guid` to the VMGS file and find that nothing changes
+        // Without using force, write the same `kp_guid` to the VMGS file and find that nothing changes
         write_key_protector_by_id(&mut key_protector_by_id, &mut vmgs, false, kp_guid)
             .await
             .unwrap();
@@ -384,7 +384,7 @@ mod tests {
         let found_key_protector_by_id = read_key_protector_by_id(&mut vmgs).await.unwrap();
         assert_eq!(found_key_protector_by_id.id_guid, kp_guid);
 
-        // without using force, write a new `Guid` to the VMGS file and find that the `key_protector_by_id` is updated
+        // Without using force, write a new `Guid` to the VMGS file and find that the `key_protector_by_id` is updated
         let bios_guid = Guid::new_random();
         write_key_protector_by_id(&mut key_protector_by_id, &mut vmgs, false, bios_guid)
             .await
@@ -393,7 +393,7 @@ mod tests {
         let found_key_protector_by_id = read_key_protector_by_id(&mut vmgs).await.unwrap();
         assert_eq!(found_key_protector_by_id.id_guid, bios_guid);
 
-        // read a key protector by id from the VMGS file that is undersized
+        // Read a key protector by id from the VMGS file that is undersized
         // ported and pad fields are expected to be zeroed
         let mut undersized_key_protector_by_id = key_protector_by_id.as_bytes();
         undersized_key_protector_by_id =

--- a/openhcl/underhill_attestation/src/vmgs.rs
+++ b/openhcl/underhill_attestation/src/vmgs.rs
@@ -392,6 +392,23 @@ mod tests {
         // `key_protector_by_id` should now hold `new_guid`
         let found_key_protector_by_id = read_key_protector_by_id(&mut vmgs).await.unwrap();
         assert_eq!(found_key_protector_by_id.id_guid, bios_guid);
+
+        // read a key protector by id from the VMGS file that is undersized
+        // ported and pad fields are expected to be zeroed
+        let mut undersized_key_protector_by_id = key_protector_by_id.as_bytes();
+        undersized_key_protector_by_id =
+            &undersized_key_protector_by_id[..undersized_key_protector_by_id.len() - 1];
+        vmgs.write_file(FileId::VM_UNIQUE_ID, &undersized_key_protector_by_id)
+            .await
+            .unwrap();
+
+        let found_key_protector_by_id = read_key_protector_by_id(&mut vmgs).await.unwrap();
+        assert_eq!(
+            found_key_protector_by_id.id_guid,
+            key_protector_by_id.id_guid
+        );
+        assert_eq!(found_key_protector_by_id.ported, 0);
+        assert_eq!(found_key_protector_by_id.pad, [0, 0, 0]);
     }
 
     #[async_test]

--- a/openhcl/underhill_attestation/src/vmgs.rs
+++ b/openhcl/underhill_attestation/src/vmgs.rs
@@ -450,7 +450,7 @@ mod tests {
         let undersized_key_protector_by_id = key_protector_by_id.as_bytes();
         let undersized_key_protector_by_id =
             &undersized_key_protector_by_id[..undersized_key_protector_by_id.len() - 1];
-        vmgs.write_file(FileId::VM_UNIQUE_ID, &undersized_key_protector_by_id)
+        vmgs.write_file(FileId::VM_UNIQUE_ID, undersized_key_protector_by_id)
             .await
             .unwrap();
 

--- a/openhcl/underhill_attestation/src/vmgs.rs
+++ b/openhcl/underhill_attestation/src/vmgs.rs
@@ -288,6 +288,12 @@ mod tests {
         ram_disk(4 * ONE_MEGA_BYTE, false).unwrap()
     }
 
+    async fn new_formatted_vmgs() -> Vmgs {
+        let disk = new_test_file();
+
+        Vmgs::format_new(disk).await.unwrap()
+    }
+
     fn new_hardware_key_protector() -> HardwareKeyProtector {
         let header = HardwareKeyProtectorHeader::new(1, HW_KEY_PROTECTOR_SIZE as u32, 2);
         let iv = [3; AES_CBC_IV_LENGTH];
@@ -329,9 +335,7 @@ mod tests {
 
     #[async_test]
     async fn write_read_vmgs_key_protector() {
-        let disk = new_test_file();
-
-        let mut vmgs = Vmgs::format_new(disk).await.unwrap();
+        let mut vmgs = new_formatted_vmgs().await;
         let key_protector = new_key_protector();
         write_key_protector(&key_protector, &mut vmgs)
             .await
@@ -404,9 +408,7 @@ mod tests {
     async fn write_vmgs_key_protector_by_id() {
         let kp_guid = Guid::new_random();
 
-        let disk = new_test_file();
-
-        let mut vmgs = Vmgs::format_new(disk).await.unwrap();
+        let mut vmgs = new_formatted_vmgs().await;
         let mut key_protector_by_id = KeyProtectorById {
             id_guid: kp_guid,
             ported: 1,
@@ -463,9 +465,7 @@ mod tests {
 
     #[async_test]
     async fn read_security_profile_from_vmgs() {
-        let disk = new_test_file();
-
-        let mut vmgs = Vmgs::format_new(disk).await.unwrap();
+        let mut vmgs = new_formatted_vmgs().await;
         let found_security_profile = read_security_profile(&mut vmgs).await.unwrap();
 
         // When no security profile exists, a zeroed security profile will be written to the VMGS
@@ -517,9 +517,7 @@ mod tests {
 
     #[async_test]
     async fn write_read_hardware_key_protector() {
-        let disk = new_test_file();
-
-        let mut vmgs = Vmgs::format_new(disk).await.unwrap();
+        let mut vmgs = new_formatted_vmgs().await;
         let hardware_key_protector = new_hardware_key_protector();
         write_hardware_key_protector(&hardware_key_protector, &mut vmgs)
             .await
@@ -556,9 +554,7 @@ mod tests {
 
     #[async_test]
     async fn read_guest_secret_key_from_vmgs() {
-        let disk = new_test_file();
-
-        let mut vmgs = Vmgs::format_new(disk).await.unwrap();
+        let mut vmgs = new_formatted_vmgs().await;
 
         // When no guest secret key exists, an error should be returned
         let found_guest_secret_key_result = read_guest_secret_key(&mut vmgs).await;

--- a/openhcl/underhill_attestation/src/vmgs.rs
+++ b/openhcl/underhill_attestation/src/vmgs.rs
@@ -261,3 +261,8 @@ pub async fn read_guest_secret_key(vmgs: &mut Vmgs) -> Result<GuestSecretKey, Re
         Err(vmgs_err) => Err(ReadFromVmgsError::ReadFromVmgs { file_id, vmgs_err }),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}


### PR DESCRIPTION
This PR:
* Adds unit tests to the `underhill_attestation` crate's `vmgs` module
  * Covers all functions in the `vmgs` module