### PR TITLE
mesh_rpc: fix client failure paths

### DIFF
--- a/support/mesh/mesh_rpc/src/service.rs
+++ b/support/mesh/mesh_rpc/src/service.rs
@@ -48,6 +48,17 @@ pub(crate) struct GenericRpc {
     pub port: Port, // TODO: transparent mesh::OneshotSender<std::result::Result<Vec<u8>, Status>>,
 }
 
+impl GenericRpc {
+    pub(crate) fn respond_status(self, status: Status) {
+        let sender =
+            mesh::OneshotSender::<std::result::Result<std::convert::Infallible, Status>>::from(
+                self.port,
+            );
+
+        sender.send(Err(status));
+    }
+}
+
 /// A generic RPC value, using borrows instead of owning types.
 #[derive(mesh::MeshPayload)]
 struct GenericRpcView<'a> {


### PR DESCRIPTION
Fix the mesh message format for client-initiated failure paths, and fix the timeout deadline check. Use a helper function everywhere to construct `Status` values. Add some basic test coverage of the client failure paths.

This fixes the client code handling of deadlines and connection failures.