### PR TITLE
vmbus_async: don't panic on empty external data

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -76,6 +76,7 @@ use task_control::StopTask;
 use task_control::TaskControl;
 use thiserror::Error;
 use vmbus_async::queue;
+use vmbus_async::queue::ExternalDataError;
 use vmbus_async::queue::IncomingPacket;
 use vmbus_async::queue::Queue;
 use vmbus_channel::bus::OfferParams;
@@ -1856,6 +1857,8 @@ enum PacketError {
     UnknownType(u32),
     #[error("Access")]
     Access(#[from] AccessError),
+    #[error("ExternalData")]
+    ExternalData(#[from] ExternalDataError),
     #[error("InvalidSendBufferIndex")]
     InvalidSendBufferIndex,
 }
@@ -2011,7 +2014,9 @@ fn parse_packet<'a, T: RingMem>(
     Ok(Packet {
         data,
         transaction_id: packet.transaction_id(),
-        external_data: packet.read_external_ranges().map_err(PacketError::Access)?,
+        external_data: packet
+            .read_external_ranges()
+            .map_err(PacketError::ExternalData)?,
         send_buffer_suballocation,
     })
 }

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -2261,9 +2261,7 @@ impl<T: RingMem> NetChannel<T> {
             .find(|r| !r.is_empty())
             .ok_or(WorkerError::RndisMessageTooSmall)?;
         let mut data = reader.into_inner();
-        let request: rndisprot::Packet = headers
-            .reader(mem)
-            .read_plain()?;
+        let request: rndisprot::Packet = headers.reader(mem).read_plain()?;
         if request.num_oob_data_elements != 0
             || request.oob_data_length != 0
             || request.oob_data_offset != 0
@@ -2296,8 +2294,7 @@ impl<T: RingMem> NetChannel<T> {
                 )
                 .ok_or(WorkerError::RndisMessageTooSmall)?;
             while !ppi.is_empty() {
-                let h: rndisprot::PerPacketInfo =
-                    ppi.reader(mem).read_plain()?;
+                let h: rndisprot::PerPacketInfo = ppi.reader(mem).read_plain()?;
                 if h.size == 0 {
                     return Err(WorkerError::RndisMessageTooSmall);
                 }
@@ -2309,8 +2306,7 @@ impl<T: RingMem> NetChannel<T> {
                     .ok_or(WorkerError::RndisMessageTooSmall)?;
                 match h.typ {
                     rndisprot::PPI_TCP_IP_CHECKSUM => {
-                        let n: rndisprot::TxTcpIpChecksumInfo =
-                            d.reader(mem).read_plain()?;
+                        let n: rndisprot::TxTcpIpChecksumInfo = d.reader(mem).read_plain()?;
 
                         metadata.offload_tcp_checksum =
                             (n.is_ipv4() || n.is_ipv6()) && n.tcp_checksum();
@@ -2330,11 +2326,9 @@ impl<T: RingMem> NetChannel<T> {
                                 n.tcp_header_offset() - metadata.l2_len as u16
                             } else if n.is_ipv4() {
                                 let mut reader = data.clone().reader(mem);
-                                reader
-                                    .skip(metadata.l2_len as usize)?;
+                                reader.skip(metadata.l2_len as usize)?;
                                 let mut b = 0;
-                                reader
-                                    .read(std::slice::from_mut(&mut b))?;
+                                reader.read(std::slice::from_mut(&mut b))?;
                                 (b as u16 >> 4) * 4
                             } else {
                                 // Hope there are no extensions.
@@ -2343,8 +2337,7 @@ impl<T: RingMem> NetChannel<T> {
                         }
                     }
                     rndisprot::PPI_LSO => {
-                        let n: rndisprot::TcpLsoInfo =
-                            d.reader(mem).read_plain()?;
+                        let n: rndisprot::TcpLsoInfo = d.reader(mem).read_plain()?;
 
                         metadata.offload_tcp_segmentation = true;
                         metadata.offload_tcp_checksum = true;
@@ -2364,8 +2357,7 @@ impl<T: RingMem> NetChannel<T> {
                             reader
                                 .skip(metadata.l2_len as usize + metadata.l3_len as usize + 12)?;
                             let mut b = 0;
-                            reader
-                                .read(std::slice::from_mut(&mut b))?;
+                            reader.read(std::slice::from_mut(&mut b))?;
                             (b >> 4) * 4
                         };
                         metadata.max_tcp_segment_size = n.mss() as u16;
@@ -2656,8 +2648,7 @@ impl<T: RingMem> NetChannel<T> {
                     return Err(WorkerError::InvalidRndisState);
                 }
 
-                let request: rndisprot::InitializeRequest =
-                    reader.read_plain()?;
+                let request: rndisprot::InitializeRequest = reader.read_plain()?;
 
                 tracing::trace!(
                     ?request,
@@ -2714,8 +2705,7 @@ impl<T: RingMem> NetChannel<T> {
                 }
             }
             rndisprot::MESSAGE_TYPE_QUERY_MSG => {
-                let request: rndisprot::QueryRequest =
-                    reader.read_plain()?;
+                let request: rndisprot::QueryRequest = reader.read_plain()?;
 
                 tracing::trace!(?request, "handling control message MESSAGE_TYPE_QUERY_MSG");
 
@@ -2749,8 +2739,7 @@ impl<T: RingMem> NetChannel<T> {
                 self.send_rndis_control_message(buffers, id, message_length)?;
             }
             rndisprot::MESSAGE_TYPE_SET_MSG => {
-                let request: rndisprot::SetRequest =
-                    reader.read_plain()?;
+                let request: rndisprot::SetRequest = reader.read_plain()?;
 
                 tracing::trace!(?request, "handling control message MESSAGE_TYPE_SET_MSG");
 
@@ -2787,8 +2776,7 @@ impl<T: RingMem> NetChannel<T> {
                 return Err(WorkerError::RndisMessageTypeNotImplemented)
             }
             rndisprot::MESSAGE_TYPE_KEEPALIVE_MSG => {
-                let request: rndisprot::KeepaliveRequest =
-                    reader.read_plain()?;
+                let request: rndisprot::KeepaliveRequest = reader.read_plain()?;
 
                 tracing::trace!(
                     ?request,
@@ -2907,12 +2895,7 @@ impl<T: RingMem> NetChannel<T> {
             || (primary.pending_offload_change && primary.rndis_state == RndisState::Operational)
         {
             // Ensure the ring buffer has enough room to successfully complete control message handling.
-            if !self
-                .queue
-                .split()
-                .1
-                .can_write(MIN_CONTROL_RING_SIZE)?
-            {
+            if !self.queue.split().1.can_write(MIN_CONTROL_RING_SIZE)? {
                 self.pending_send_size = MIN_CONTROL_RING_SIZE;
                 break;
             }
@@ -4726,8 +4709,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
             // backend drop packets.
             let ring_full = {
                 let (_, mut send) = self.queue.split();
-                !send
-                    .can_write(ring_spare_capacity)?
+                !send.can_write(ring_spare_capacity)?
             };
 
             let did_some_work = (!ring_full
@@ -5179,8 +5161,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
         // message.
         while reader.len() > 0 {
             let mut this_reader = reader.clone();
-            let header: rndisprot::MessageHeader =
-                this_reader.read_plain()?;
+            let header: rndisprot::MessageHeader = this_reader.read_plain()?;
             if self.handle_rndis_message(
                 buffers,
                 state,
@@ -5191,8 +5172,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
             )? {
                 num_packets += 1;
             }
-            reader
-                .skip(header.message_length as usize)?;
+            reader.skip(header.message_length as usize)?;
         }
 
         Ok(num_packets)

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -653,11 +653,10 @@ impl<'a> TestNicChannel<'a> {
                         let external_ranges = if let Some(id) = data.transfer_buffer_id() {
                             assert_eq!(id, 0);
 
-                            data.read_transfer_ranges(recv_buf.iter())
+                            data.read_transfer_ranges(recv_buf.iter()).unwrap()
                         } else {
-                            data.read_external_ranges()
-                        }
-                        .unwrap();
+                            data.read_external_ranges().unwrap()
+                        };
                         let mut direct_reader =
                             PagedRanges::new(external_ranges.iter()).reader(&mem);
 

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -64,10 +64,10 @@ use thiserror::Error;
 use tracing_helpers::ErrorValueExt;
 use unicycle::FuturesUnordered;
 use vmbus_async::queue;
+use vmbus_async::queue::ExternalDataError;
 use vmbus_async::queue::IncomingPacket;
 use vmbus_async::queue::OutgoingPacket;
 use vmbus_async::queue::Queue;
-use vmbus_async::queue::ExternalDataError;
 use vmbus_channel::bus::ChannelType;
 use vmbus_channel::bus::OfferParams;
 use vmbus_channel::bus::OpenRequest;
@@ -392,9 +392,7 @@ fn parse_packet<T: RingMem>(
                 let request_buf = &mut full_request.request.as_bytes_mut()[..request_size];
                 reader.read(request_buf).map_err(PacketError::Access)?;
 
-                let buf = packet
-                    .read_external_ranges()
-                    .map_err(PacketError::Range)?;
+                let buf = packet.read_external_ranges().map_err(PacketError::Range)?;
 
                 full_request.external_data = Range::new(buf, &full_request.request)
                     .ok_or(PacketError::InvalidDataTransferLength)?;

--- a/vm/devices/vmbus/vmbus_async/src/queue.rs
+++ b/vm/devices/vmbus/vmbus_async/src/queue.rs
@@ -296,8 +296,11 @@ impl<T: RingMem> DataPacket<'_, T> {
         let mut reader = self.external_data.1.reader(self.ring);
         let len = reader.len() / 8;
         let mut buf = zeroed_gpn_list(len);
-        reader.read(buf.as_bytes_mut()).map_err(ExternalDataError::Access)?;
-        Ok(MultiPagedRangeBuf::new(self.external_data.0 as usize, buf).map_err(ExternalDataError::GpaRange)?)
+        reader
+            .read(buf.as_bytes_mut())
+            .map_err(ExternalDataError::Access)?;
+        MultiPagedRangeBuf::new(self.external_data.0 as usize, buf)
+            .map_err(ExternalDataError::GpaRange)
     }
 
     /// Reads the transfer buffer ID from the packet, or None if this is not a transfer packet.
@@ -861,7 +864,7 @@ mod tests {
                     let external_data_result = data.read_external_ranges();
                     assert_eq!(data.read_external_ranges().is_err(), true);
                     match external_data_result {
-                        Err(ExternalDataError::PacketCorrupt(_)) => Ok(()),
+                        Err(ExternalDataError::GpaRange(_)) => Ok(()),
                         _ => Err("should be out of range"),
                     }
                 }

--- a/vm/devices/vmbus/vmbus_async/src/queue.rs
+++ b/vm/devices/vmbus/vmbus_async/src/queue.rs
@@ -101,20 +101,21 @@ pub enum TryWriteError {
     Queue(#[source] Error),
 }
 
-/// An error returned by `read_external_data`
+/// An error returned by `read_external_ranges`
 #[derive(Debug, Error)]
 pub enum ExternalDataError {
     /// The packet is corrupted in some way (e.g. it does not specify a reasonable set of GPA ranges).
-    #[error("packet contains invalid data")]
-    PacketCorrupt(#[from] vmbus_ring::gparange::Error),
+    #[error("invalid gpa ranges")]
+    GpaRange(#[source] vmbus_ring::gparange::Error),
 
     /// The packet specifies memory that this vmbus cannot read, for some reason.
-    #[error("cannot access specified guest memory")]
-    GuestAccessError(#[from] AccessError),
+    #[error("access error")]
+    Access(#[source] AccessError),
 
-    /// The packet specifies a buffer id when it should not.
-    #[error("packet contains invalid buffer id contents")]
-    InvalidBufferId,
+    /// Caller used `read_external_ranges` when the packet contains a buffer id,
+    /// and the caller should have called `read_transfer_ranges`
+    #[error("external data should have been read by calling read_transfer_ranges")]
+    WrongExternalDataType,
 }
 
 /// An incoming packet batch reader.
@@ -287,16 +288,16 @@ impl<T: RingMem> DataPacket<'_, T> {
     /// Reads the GPA direct range descriptors from the packet.
     pub fn read_external_ranges(&self) -> Result<MultiPagedRangeBuf<GpnList>, ExternalDataError> {
         if self.buffer_id.is_some() {
-            return Err(ExternalDataError::InvalidBufferId);
+            return Err(ExternalDataError::WrongExternalDataType);
         } else if self.external_data.0 == 0 {
-            return Ok(MultiPagedRangeBuf::new(0, GpnList::new())?);
+            return Ok(MultiPagedRangeBuf::empty());
         }
 
         let mut reader = self.external_data.1.reader(self.ring);
         let len = reader.len() / 8;
         let mut buf = zeroed_gpn_list(len);
-        reader.read(buf.as_bytes_mut())?;
-        Ok(MultiPagedRangeBuf::new(self.external_data.0 as usize, buf)?)
+        reader.read(buf.as_bytes_mut()).map_err(ExternalDataError::Access)?;
+        Ok(MultiPagedRangeBuf::new(self.external_data.0 as usize, buf).map_err(ExternalDataError::GpaRange)?)
     }
 
     /// Reads the transfer buffer ID from the packet, or None if this is not a transfer packet.
@@ -314,7 +315,7 @@ impl<T: RingMem> DataPacket<'_, T> {
         I: Iterator<Item = PagedRange<'a>>,
     {
         if self.external_data.0 == 0 {
-            return Ok(MultiPagedRangeBuf::new(0, GpnList::new()).unwrap());
+            return Ok(MultiPagedRangeBuf::empty());
         }
 
         let buf: MultiPagedRangeBuf<GpnList> = transfer_buf.collect();

--- a/vm/devices/vmbus/vmbus_async/src/queue.rs
+++ b/vm/devices/vmbus/vmbus_async/src/queue.rs
@@ -296,7 +296,7 @@ impl<T: RingMem> DataPacket<'_, T> {
         let len = reader.len() / 8;
         let mut buf = zeroed_gpn_list(len);
         reader.read(buf.as_bytes_mut())?;
-        return Ok(MultiPagedRangeBuf::new(self.external_data.0 as usize, buf)?);
+        Ok(MultiPagedRangeBuf::new(self.external_data.0 as usize, buf)?)
     }
 
     /// Reads the transfer buffer ID from the packet, or None if this is not a transfer packet.


### PR DESCRIPTION
Don't `panic` when a GpaDirect packet contains a pointer to empty GPA ranges. This data is guest controlled and not a programmer error, so `panic` is not correct. Consumers of `read_external_ranges` already handle errors gracefully, so this is not a significant change for them.

As a drive-by code improvement, also change some cases of `#[from]` to `#[source]` in error definitions, and add the requisite `.map_err` changes.