### PR TITLE
xsync: Tolerate arbitrary base workspace metadata

### DIFF
--- a/xsync/xsync/src/tasks/cargo_toml.rs
+++ b/xsync/xsync/src/tasks/cargo_toml.rs
@@ -51,8 +51,9 @@ impl Cmd for CargoToml {
 
         // parse the Cargo.toml to sync with
         let base_cargo_toml = fs_err::read_to_string(ctx.base_workspace.join("Cargo.toml"))?;
-        let base_cargo_toml =
-            cargo_toml::Manifest::<()>::from_slice_with_metadata(base_cargo_toml.as_bytes())?;
+        let base_cargo_toml = cargo_toml::Manifest::<cargo_toml::Value>::from_slice_with_metadata(
+            base_cargo_toml.as_bytes(),
+        )?;
 
         //
         // handle simple inherited Cargo.toml fields


### PR DESCRIPTION
I added workspace metadata for openvmm for the first time in https://github.com/microsoft/openvmm/pull/593. This broke xsync, as it was expecting there to be no metadata. Instead, allow it to take arbitrary toml as metadata, then just do nothing with it. This should restore the internal mirror functionality.