### PR TITLE
mesh_channel: remove `Unpin` from `Receiver::recv`

### DIFF
--- a/support/mesh/mesh_channel/src/lib.rs
+++ b/support/mesh/mesh_channel/src/lib.rs
@@ -261,10 +261,8 @@ mod spsc {
         /// assert!(matches!(recv.recv().await.unwrap_err(), RecvError::Closed));
         /// # });
         /// ```
-        pub fn recv(&mut self) -> impl Future<Output = Result<T, RecvError>> + Unpin + '_ {
-            // This is implemented manually instead of using an async fn to allow
-            // the result to be Unpin, which is more flexible for callers.
-            core::future::poll_fn(|cx| self.poll_recv(cx))
+        pub async fn recv(&mut self) -> Result<T, RecvError> {
+            core::future::poll_fn(|cx| self.poll_recv(cx)).await
         }
 
         /// Polls for the next message.

--- a/support/mesh/mesh_remote/src/unix_node.rs
+++ b/support/mesh/mesh_remote/src/unix_node.rs
@@ -206,7 +206,9 @@ async fn run_leader(
         if receivers.is_empty() {
             return;
         }
-        let recvs = receivers.iter_mut().map(|(_, recv)| poll_fn(|cx| recv.poll_recv(cx)));
+        let recvs = receivers
+            .iter_mut()
+            .map(|(_, recv)| poll_fn(|cx| recv.poll_recv(cx)));
         let (req, index, _) = futures::select! { // merge semantics
             r = resign_recv.next() => break r,
             r = future::select_all(recvs).fuse() => r,

--- a/support/mesh/mesh_remote/src/unix_node.rs
+++ b/support/mesh/mesh_remote/src/unix_node.rs
@@ -206,7 +206,7 @@ async fn run_leader(
         if receivers.is_empty() {
             return;
         }
-        let recvs = receivers.iter_mut().map(|(_, recv)| recv.recv());
+        let recvs = receivers.iter_mut().map(|(_, recv)| poll_fn(|cx| recv.poll_recv(cx)));
         let (req, index, _) = futures::select! { // merge semantics
             r = resign_recv.next() => break r,
             r = future::select_all(recvs).fuse() => r,


### PR DESCRIPTION
Make the future returned by `recv` `!Unpin` and fix the one place in the codebase that cares.

This gives us flexibility to optimize the implementation in the future.