### PR TITLE
Increase the vmm test timeouts (#623)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -36,7 +36,7 @@ filter = 'package(~vmm_tests)'
 # Allow VMM tests longer timeouts.
 # Important Note: Petri's watchdogs need to know this value too.
 # If you change it here then change it there!
-slow-timeout = { period = "2m", terminate-after = 2 }
+slow-timeout = { period = "3m", terminate-after = 2 }
 
 # Add retries for known flaky tests.
 # TODO: Fix these tests and remove the retries.

--- a/petri/src/vm/start.rs
+++ b/petri/src/vm/start.rs
@@ -248,7 +248,7 @@ impl PetriVmConfig {
     ) -> anyhow::Result<Vec<Task<()>>> {
         // Our CI environment will kill tests after some time. We want to save
         // some information about the VM if it's still running at that point.
-        const TIMEOUT_DURATION_MINUTES: u64 = 4;
+        const TIMEOUT_DURATION_MINUTES: u64 = 6;
         const TIMER_DURATION: Duration = Duration::from_secs(TIMEOUT_DURATION_MINUTES * 60 - 10);
 
         let inspect_log_path = output_dir.join("timeout_inspect.log");


### PR DESCRIPTION
The ubuntu + tpm test is bumping right up against our timeouts. Increase them. If we can bring the test time back down we may revert this in the future.