### PR TITLE
cherry-pick: Updated topology builder with correct vps_per_socket calculation (#532)

### DIFF
--- a/vm/vmcore/vm_topology/src/processor/x86.rs
+++ b/vm/vmcore/vm_topology/src/processor/x86.rs
@@ -168,8 +168,8 @@ impl TopologyBuilder<X86Topology> {
                 let eax = CacheParametersEax::from(eax);
                 if eax.cache_level() == 1 {
                     found_topology = true;
-                    vps_per_socket = eax.cores_per_socket_minus_one() + 1;
                     threads_per_core = eax.threads_sharing_cache_minus_one() + 1;
+                    vps_per_socket = (eax.cores_per_socket_minus_one() + 1) * threads_per_core;
                     break;
                 }
             }


### PR DESCRIPTION
Implements issue: [TDX VMs with hyperthreading getting incorrect thread count #481](https://github.com/microsoft/openvmm/issues/481)