### PR TITLE
mesh_channel_core: use transparent enum variant encodings

### DIFF
--- a/support/mesh/mesh_channel_core/src/mpsc.rs
+++ b/support/mesh/mesh_channel_core/src/mpsc.rs
@@ -772,8 +772,8 @@ type EncodeFn = unsafe fn(MessagePtr) -> Message;
 #[derive(Protobuf)]
 #[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
 enum ChannelPayload<T> {
-    Message(T),
-    Port(Port),
+    #[mesh(transparent)] Message(T),
+    #[mesh(transparent)] Port(Port),
 }
 
 struct RemotePortHandler {

--- a/support/mesh/mesh_channel_core/src/mpsc.rs
+++ b/support/mesh/mesh_channel_core/src/mpsc.rs
@@ -772,8 +772,10 @@ type EncodeFn = unsafe fn(MessagePtr) -> Message;
 #[derive(Protobuf)]
 #[mesh(bound = "T: MeshField", resource = "mesh_node::resource::Resource")]
 enum ChannelPayload<T> {
-    #[mesh(transparent)] Message(T),
-    #[mesh(transparent)] Port(Port),
+    #[mesh(transparent)]
+    Message(T),
+    #[mesh(transparent)]
+    Port(Port),
 }
 
 struct RemotePortHandler {


### PR DESCRIPTION
Improve the mesh encoding of channel messages with `#[mesh(transparent)]`. This improves perf for in-proc encoded send/recv by about 15%.