### PR TITLE
ide: mark PRD as exhausted eeven if on buffer boundary

### DIFF
--- a/vm/devices/storage/ide/src/drive/hard_drive.rs
+++ b/vm/devices/storage/ide/src/drive/hard_drive.rs
@@ -1308,7 +1308,12 @@ impl HardDrive {
     fn write_media_sectors_complete(&mut self) -> Result<(), IdeError> {
         let command = self.state.command.as_mut().unwrap();
         let sectors_written = command.sectors_before_interrupt;
-        command.sectors_remaining -= sectors_written;
+        if self.state.prd_exhausted {
+            // If no more PRDs, no more to write
+            command.sectors_remaining = 0;
+        } else {
+            command.sectors_remaining -= sectors_written;
+        }
         command.next_lba += sectors_written as u64;
         // Update the registers with the last written LBA.
         self.state

--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -771,6 +771,7 @@ impl Channel {
                 dma.descriptor_idx += 1;
                 if dma.transfer_complete {
                     dma.descriptor_idx = 0;
+                    drive.set_prd_exhausted();
                 }
             }
 


### PR DESCRIPTION
The PRD table can become exhausted early without the exhaustion flag being set because the buffer is not fully exhausted, leaving the disk waiting for remaining data that will never come. Additionally, the exhaustion logic for reads needs to also be copied for writes.