### PR TITLE
Increase `underhill_attestation` `lib` unit test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6906,6 +6906,7 @@ dependencies = [
  "time",
  "tracing",
  "vmgs",
+ "vmgs_format",
  "zerocopy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6890,6 +6890,7 @@ dependencies = [
  "cvm_tracing",
  "disk_backend",
  "disklayer_ram",
+ "get_protocol",
  "getrandom",
  "guest_emulation_transport",
  "guid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6888,6 +6888,8 @@ dependencies = [
  "base64 0.21.7",
  "base64-serde",
  "cvm_tracing",
+ "disk_backend",
+ "disklayer_ram",
  "getrandom",
  "guest_emulation_transport",
  "guid",

--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -33,5 +33,9 @@ thiserror.workspace = true
 time = { workspace = true, features = ["macros"] }
 zerocopy.workspace = true
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+disklayer_ram.workspace = true
+disk_backend.workspace = true
+
 [lints]
 workspace = true

--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -36,6 +36,7 @@ zerocopy.workspace = true
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 disklayer_ram.workspace = true
 disk_backend.workspace = true
+get_protocol.workspace = true
 
 [lints]
 workspace = true

--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -37,6 +37,7 @@ zerocopy.workspace = true
 disklayer_ram.workspace = true
 disk_backend.workspace = true
 get_protocol.workspace = true
+vmgs_format.workspace = true
 
 [lints]
 workspace = true

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1129,7 +1129,7 @@ mod tests {
             }
         }
 
-        return true;
+        true
     }
 
     fn new_key_protector() -> KeyProtector {
@@ -1163,7 +1163,7 @@ mod tests {
         found_id: bool,
     ) -> KeyProtectorById {
         let key_protector_by_id = openhcl_attestation_protocol::vmgs::KeyProtectorById {
-            id_guid: id_guid.unwrap_or_else(|| Guid::new_random()),
+            id_guid: id_guid.unwrap_or_else(Guid::new_random),
             ported: ported.unwrap_or(0),
             pad: [0; 3],
         };
@@ -1483,7 +1483,7 @@ mod tests {
 
         let gsp_response_by_id = GuestStateProtectionById {
             seed: guest_emulation_transport::api::GspCleartextContent {
-                length: GSP_CLEARTEXT_MAX as u32,
+                length: GSP_CLEARTEXT_MAX,
                 buffer: [1; GSP_CLEARTEXT_MAX as usize * 2],
             },
             extended_status_flags: GspExtendedStatusFlags::from_bits(0),
@@ -1530,16 +1530,15 @@ mod tests {
     }
 
     #[async_test]
-    async fn persist_all_key_protectors_pass_through() {
+    async fn pass_through_persist_all_key_protectors() {
         let mut vmgs = new_formatted_vmgs().await;
         let mut key_protector = new_key_protector();
         let mut key_protector_by_id = new_key_protector_by_id(None, None, false);
         let bios_guid = Guid::new_random();
 
         // Copied/cloned bits used for comparison later
-        let active_kp_dek_buffer_clone = key_protector.dek[key_protector.active_kp as usize]
-            .dek_buffer
-            .clone();
+        let active_kp_dek_buffer_clone =
+            key_protector.dek[key_protector.active_kp as usize].dek_buffer;
         let active_kp_copy = key_protector.active_kp;
         let active_kp_gsp_length_copy =
             key_protector.gsp[key_protector.active_kp as usize].gsp_length;
@@ -1590,9 +1589,8 @@ mod tests {
         let bios_guid = Guid::new_random();
 
         // Copied/cloned bits used for comparison later
-        let active_kp_dek_buffer_clone = key_protector.dek[key_protector.active_kp as usize]
-            .dek_buffer
-            .clone();
+        let active_kp_dek_buffer_clone =
+            key_protector.dek[key_protector.active_kp as usize].dek_buffer;
         let active_kp_copy = key_protector.active_kp;
         let active_kp_gsp_length_copy =
             key_protector.gsp[key_protector.active_kp as usize].gsp_length;

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1316,7 +1316,7 @@ mod tests {
         // After the VMGS has been unlocked, the VMGS encryption key should be rotated from ingress to egress
         vmgs.unlock_with_encryption_key(&ingress).await.unwrap_err();
         let egress_index = vmgs.unlock_with_encryption_key(&egress).await.unwrap();
-        // The ingress key is still present and in the 0th slot, so the egress key will be in the 1th slot
+        // The ingress key was removed, but not before the egress key was added in the 0th slot
         assert_eq!(egress_index, 1);
 
         // Since both `should_write_kp` and `use_gsp_by_id` are true, both key protectors should be updated
@@ -1333,7 +1333,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn unlock_vmgs_failed_to_persist_kp() {
+    async fn failed_to_persist_ingress_key_so_use_egress_key_to_unlock_vmgs() {
         let mut vmgs = new_formatted_vmgs().await;
 
         let mut key_protector = new_key_protector();

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1239,7 +1239,7 @@ mod tests {
         let bios_guid = Guid::new_random();
 
         // Without encryption implies the provision path
-        // The VMGS will be encrypted using the egress key
+        // The VMGS will be locked using the egress key
         unlock_vmgs_data_store(
             &mut vmgs,
             false,

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1166,7 +1166,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn do_nothing_without_derived_keys() {
+    async fn unlock_unencrypted_vmgs_without_derived_keys() {
         let mut vmgs = new_formatted_vmgs().await;
 
         let mut key_protector = new_key_protector();
@@ -1206,37 +1206,6 @@ mod tests {
         unlock_vmgs_data_store(
             &mut vmgs,
             true,
-            &mut key_protector,
-            &mut key_protector_by_id,
-            None,
-            key_protector_settings,
-            bios_guid,
-        )
-        .await
-        .unwrap();
-
-        assert!(key_protector_is_empty(&mut vmgs).await);
-        assert!(key_protector_by_id_is_empty(&mut vmgs).await);
-    }
-
-    #[async_test]
-    async fn unlock_unencrypted_vmgs_without_derived_keys() {
-        let mut vmgs = new_formatted_vmgs().await;
-
-        let mut key_protector = new_key_protector();
-        let mut key_protector_by_id = new_key_protector_by_id(None, None, false);
-
-        let key_protector_settings = KeyProtectorSettings {
-            should_write_kp: false,
-            use_gsp_by_id: false,
-            use_hardware_unlock: false,
-        };
-
-        let bios_guid = Guid::new_random();
-
-        unlock_vmgs_data_store(
-            &mut vmgs,
-            false,
             &mut key_protector,
             &mut key_protector_by_id,
             None,

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1166,7 +1166,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn unlock_unencrypted_vmgs_without_derived_keys() {
+    async fn do_nothing_without_derived_keys() {
         let mut vmgs = new_formatted_vmgs().await;
 
         let mut key_protector = new_key_protector();

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1042,7 +1042,7 @@ async fn persist_all_key_protectors(
                 .dek_buffer
                 .fill(0);
             key_protector.gsp[key_protector.active_kp as usize % NUMBER_KP].gsp_length = 0;
-            key_protector.active_kp += 1; // TODO: This is vulnerable to overflows
+            key_protector.active_kp += 1;
 
             vmgs::write_key_protector(key_protector, vmgs)
                 .await
@@ -1733,31 +1733,5 @@ mod tests {
             found_key_protector_by_id.id_guid,
             key_protector_by_id.inner.id_guid
         );
-    }
-
-    #[should_panic(expected = "attempt to add with overflow")]
-    #[async_test]
-    async fn persist_all_key_protectors_with_max_kp_index_overflows() {
-        let mut vmgs = new_formatted_vmgs().await;
-        let mut key_protector = new_key_protector();
-        // Set the active KP to u32::MAX to observe overflow behavior
-        key_protector.active_kp = u32::MAX;
-        let mut key_protector_by_id = new_key_protector_by_id(None, None, false);
-        let bios_guid = Guid::new_random();
-        let key_protector_settings = KeyProtectorSettings {
-            should_write_kp: true,
-            use_gsp_by_id: false,
-            use_hardware_unlock: false,
-        };
-
-        persist_all_key_protectors(
-            &mut vmgs,
-            &mut key_protector,
-            &mut key_protector_by_id,
-            bios_guid,
-            key_protector_settings,
-        )
-        .await
-        .unwrap();
     }
 }

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1042,7 +1042,7 @@ async fn persist_all_key_protectors(
                 .dek_buffer
                 .fill(0);
             key_protector.gsp[key_protector.active_kp as usize % NUMBER_KP].gsp_length = 0;
-            key_protector.active_kp += 1;
+            key_protector.active_kp += 1; // TODO: This is vulnerable to overflows
 
             vmgs::write_key_protector(key_protector, vmgs)
                 .await
@@ -1111,7 +1111,7 @@ mod tests {
         KeyProtector {
             dek: [ingress_dek, egress_dek],
             gsp: [ingress_gsp, egress_gsp],
-            active_kp: u32::MAX,
+            active_kp: 0,
         }
     }
 
@@ -1207,5 +1207,54 @@ mod tests {
             derived_keys_response.unwrap_err().to_string(),
             "failed to derive an egress key based on current vm bios guid".to_string()
         );
+    }
+
+    #[async_test]
+    async fn test_persist_all_key_protectors() {
+        let mut vmgs = new_formatted_vmgs().await;
+        let mut key_protector = new_key_protector();
+        let mut key_protector_by_id = new_key_protector_by_id(None);
+        let bios_guid = Guid::new_random();
+        let key_protector_settings = KeyProtectorSettings {
+            should_write_kp: true,
+            use_gsp_by_id: false,
+            use_hardware_unlock: false,
+        };
+
+        persist_all_key_protectors(
+            &mut vmgs,
+            &mut key_protector,
+            &mut key_protector_by_id,
+            bios_guid,
+            key_protector_settings,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[should_panic(expected = "attempt to add with overflow")]
+    #[async_test]
+    async fn persist_all_key_protectors_with_max_kp_index_overflows() {
+        let mut vmgs = new_formatted_vmgs().await;
+        let mut key_protector = new_key_protector();
+        // Set the active KP to u32::MAX to observe overflow behavior
+        key_protector.active_kp = u32::MAX;
+        let mut key_protector_by_id = new_key_protector_by_id(None);
+        let bios_guid = Guid::new_random();
+        let key_protector_settings = KeyProtectorSettings {
+            should_write_kp: true,
+            use_gsp_by_id: false,
+            use_hardware_unlock: false,
+        };
+
+        persist_all_key_protectors(
+            &mut vmgs,
+            &mut key_protector,
+            &mut key_protector_by_id,
+            bios_guid,
+            key_protector_settings,
+        )
+        .await
+        .unwrap();
     }
 }

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1466,6 +1466,7 @@ mod tests {
             egress: ingress,
         };
 
+        // Add two random keys to the VMGS to simulate unlock failure when ingress and egress keys are the same
         let additional_key = [2; AES_GCM_KEY_LENGTH];
         let yet_another_key = [3; AES_GCM_KEY_LENGTH];
 
@@ -1518,6 +1519,7 @@ mod tests {
             egress: [2; AES_GCM_KEY_LENGTH],
         };
 
+        // Add two random keys to the VMGS to simulate unlock failure when ingress and egress keys are *not* the same
         let additional_key = [3; AES_GCM_KEY_LENGTH];
         let yet_another_key = [4; AES_GCM_KEY_LENGTH];
 

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1187,5 +1187,25 @@ mod tests {
                 .unwrap();
 
         assert_ne!(derived_keys.ingress, derived_keys.egress);
+
+        // When the `gsp_response_by_id` seed length is 0, deriving a key will fail.
+        let gsp_response_by_id_with_0_length_seed = GuestStateProtectionById {
+            seed: guest_emulation_transport::api::GspCleartextContent {
+                length: 0,
+                buffer: [1; GSP_CLEARTEXT_MAX as usize * 2],
+            },
+            extended_status_flags: GspExtendedStatusFlags::from_bits(0),
+        };
+
+        let derived_keys_response = get_derived_keys_by_id(
+            &mut key_protector_by_id,
+            bios_guid,
+            gsp_response_by_id_with_0_length_seed,
+        );
+        assert!(derived_keys_response.is_err());
+        assert_eq!(
+            derived_keys_response.unwrap_err().to_string(),
+            "failed to derive an egress key based on current vm bios guid".to_string()
+        );
     }
 }

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1374,6 +1374,58 @@ mod tests {
     }
 
     #[async_test]
+    async fn fail_to_unlock_vmgs_with_existing_ingress_key() {
+        let mut vmgs = new_formatted_vmgs().await;
+
+        let mut key_protector = new_key_protector();
+        let mut key_protector_by_id = new_key_protector_by_id(None, None, false);
+
+        let derived_keys = Keys {
+            ingress: [1; AES_GCM_KEY_LENGTH],
+            egress: [1; AES_GCM_KEY_LENGTH],
+        };
+
+        let additional_key = [2; AES_GCM_KEY_LENGTH];
+        let yet_another_key = [3; AES_GCM_KEY_LENGTH];
+
+        let additional_key_index = vmgs
+            .add_new_encryption_key(&additional_key, EncryptionAlgorithm::AES_GCM)
+            .await
+            .unwrap();
+        assert_eq!(additional_key_index, 0);
+
+        let yet_another_key_index = vmgs
+            .add_new_encryption_key(&yet_another_key, EncryptionAlgorithm::AES_GCM)
+            .await
+            .unwrap();
+        assert_eq!(yet_another_key_index, 1);
+
+        let key_protector_settings = KeyProtectorSettings {
+            should_write_kp: true,
+            use_gsp_by_id: true,
+            use_hardware_unlock: false,
+        };
+
+        let bios_guid = Guid::new_random();
+
+        let unlock_result = unlock_vmgs_data_store(
+            &mut vmgs,
+            true,
+            &mut key_protector,
+            &mut key_protector_by_id,
+            Some(derived_keys),
+            key_protector_settings,
+            bios_guid,
+        )
+        .await;
+        assert!(unlock_result.is_err());
+        assert_eq!(
+            unlock_result.unwrap_err().to_string(),
+            "failed to unlock vmgs with the existing ingress key".to_string()
+        );
+    }
+
+    #[async_test]
     async fn fail_to_unlock_vmgs_with_new_ingress_key() {
         let mut vmgs = new_formatted_vmgs().await;
 

--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -1217,7 +1217,7 @@ impl Vmgs {
 
             // Initialize a new extended file table.
             let new_extended_file_table = VmgsExtendedFileTable::new_zeroed();
-            // Write the extende file table to the newly allocated space
+            // Write the extended file table to the newly allocated space
             self.write_file_internal(
                 FileId::EXTENDED_FILE_TABLE,
                 new_extended_file_table.as_bytes(),


### PR DESCRIPTION
This PR:
* Adds unit tests to the `underhill_attestation` crate's `lib`
  * Covers all functions in `lib` that don't expect a `GuestEmulationTransportClient` parameter (any guidance on how to construct this in a test would be appreciated)