### PR TITLE
Flowey: Use explicit parameter names instead of auto generated.

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -6,7 +6,7 @@ name: '[flowey] OpenVMM CI'
 on:
   workflow_dispatch:
     inputs:
-      param0:
+      verbose:
         description: Run with verbose output
         default: false
         required: false
@@ -103,8 +103,8 @@ jobs:
         echo '"debug"' | flowey.exe v 0 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 0 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 0 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 0 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -292,8 +292,8 @@ jobs:
         echo '"debug"' | flowey v 1 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 1 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 1 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 1 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -492,8 +492,8 @@ jobs:
         echo '"debug"' | flowey.exe v 10 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 10 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 10 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 10 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -816,8 +816,8 @@ jobs:
         echo '"debug"' | flowey v 11 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 11 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 11 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 11 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -1188,8 +1188,8 @@ jobs:
         echo '"debug"' | flowey v 12 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 12 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 12 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -1558,8 +1558,8 @@ jobs:
         echo '"debug"' | flowey.exe v 13 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 13 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 13 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 13 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: report common cargo flags
@@ -1815,8 +1815,8 @@ jobs:
         echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 14 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 14 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 14 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 14 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -2173,8 +2173,8 @@ jobs:
         echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 15 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 15 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 15 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 15 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -2525,8 +2525,8 @@ jobs:
         echo '"debug"' | flowey v 16 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 16 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 16 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 16 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 16 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -2889,8 +2889,8 @@ jobs:
         echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 17 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 17 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 17 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 17 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -3269,8 +3269,8 @@ jobs:
         echo '"debug"' | flowey v 18 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 18 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 18 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -3398,8 +3398,8 @@ jobs:
         echo '"debug"' | flowey.exe v 2 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 2 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 2 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 2 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-igvmfilegen"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-igvmfilegen' --update-from-stdin --is-raw-string
@@ -3672,8 +3672,8 @@ jobs:
         echo '"debug"' | flowey.exe v 3 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 3 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 3 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 3 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
@@ -3966,8 +3966,8 @@ jobs:
         echo '"debug"' | flowey.exe v 4 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 4 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 4 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 4 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_x64-windows-igvmfilegen' --update-from-stdin --is-raw-string
@@ -4243,8 +4243,8 @@ jobs:
         echo '"debug"' | flowey.exe v 5 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 5 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 5 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 5 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
@@ -4538,8 +4538,8 @@ jobs:
         echo '"debug"' | flowey v 6 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 6 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 6 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 6 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
@@ -4898,8 +4898,8 @@ jobs:
         echo '"debug"' | flowey v 7 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 7 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 7 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 7 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 7 'artifact_publish_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
@@ -5321,8 +5321,8 @@ jobs:
         echo '"debug"' | flowey v 8 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 8 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 8 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 8 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -5735,8 +5735,8 @@ jobs:
         echo '"debug"' | flowey v 9 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 9 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 9 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -6,7 +6,7 @@ name: '[flowey] OpenVMM PR'
 on:
   workflow_dispatch:
     inputs:
-      param0:
+      verbose:
         description: Run with verbose output
         default: false
         required: false
@@ -106,8 +106,8 @@ jobs:
         echo '"debug"' | flowey.exe v 0 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 0 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 0 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 0 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -295,8 +295,8 @@ jobs:
         echo '"debug"' | flowey v 1 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 1 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 1 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 1 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -495,8 +495,8 @@ jobs:
         echo '"debug"' | flowey.exe v 10 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 10 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 10 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 10 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -819,8 +819,8 @@ jobs:
         echo '"debug"' | flowey v 11 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 11 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 11 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 11 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -1191,8 +1191,8 @@ jobs:
         echo '"debug"' | flowey v 12 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 12 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 12 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: install Rust
@@ -1561,8 +1561,8 @@ jobs:
         echo '"debug"' | flowey.exe v 13 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 13 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 13 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 13 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: report common cargo flags
@@ -1818,8 +1818,8 @@ jobs:
         echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 14 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 14 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 14 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 14 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -2176,8 +2176,8 @@ jobs:
         echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 15 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 15 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 15 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 15 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -2528,8 +2528,8 @@ jobs:
         echo '"debug"' | flowey v 16 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 16 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 16 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 16 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 16 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 16 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -2892,8 +2892,8 @@ jobs:
         echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 17 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 17 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 17 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 17 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -3272,8 +3272,8 @@ jobs:
         echo '"debug"' | flowey v 18 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 18 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 18 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if hvlite needs to be cloned
@@ -3363,8 +3363,8 @@ jobs:
         echo '"debug"' | flowey v 19 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 19 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 19 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: Check if any jobs failed
@@ -3457,8 +3457,8 @@ jobs:
         echo '"debug"' | flowey.exe v 2 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 2 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 2 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 2 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-igvmfilegen"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-igvmfilegen' --update-from-stdin --is-raw-string
@@ -3731,8 +3731,8 @@ jobs:
         echo '"debug"' | flowey.exe v 3 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 3 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 3 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 3 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
@@ -4025,8 +4025,8 @@ jobs:
         echo '"debug"' | flowey.exe v 4 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 4 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 4 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 4 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_x64-windows-igvmfilegen' --update-from-stdin --is-raw-string
@@ -4302,8 +4302,8 @@ jobs:
         echo '"debug"' | flowey.exe v 5 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 5 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 5 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey.exe v 5 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
@@ -4597,8 +4597,8 @@ jobs:
         echo '"debug"' | flowey v 6 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 6 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 6 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 6 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
@@ -4957,8 +4957,8 @@ jobs:
         echo '"debug"' | flowey v 7 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 7 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 7 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 7 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
         echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 7 'artifact_publish_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
@@ -5380,8 +5380,8 @@ jobs:
         echo '"debug"' | flowey v 8 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 8 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 8 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 8 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
@@ -5794,8 +5794,8 @@ jobs:
         echo '"debug"' | flowey v 9 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 9 'param0' --update-from-stdin
-        ${{ inputs.param0 != '' && inputs.param0 || 'false' }}
+        cat <<'EOF' | flowey v 9 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string

--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -283,6 +283,8 @@ echo "$(FLOWEY_TEMP_DIR)/work" | {var_db_insert_working_dir}
                 flowey_core::pipeline::internal::Parameter::Bool { .. }
             );
 
+            let name = parameters[*pipeline_param_idx].name();
+
             // ADO resolves bools as `True` and `False`, _sigh_
             let with_lowercase = if is_bool {
                 r#" | tr '[:upper:]' '[:lower:]'"#
@@ -295,7 +297,7 @@ echo "$(FLOWEY_TEMP_DIR)/work" | {var_db_insert_working_dir}
             let cmd = format!(
                 r#"
 cat <<'EOF'{with_lowercase} | {var_db_inject_cmd}
-${{{{ parameters.param{pipeline_param_idx} }}}}
+${{{{ parameters.{name} }}}}
 EOF
 "#
             )
@@ -523,20 +525,26 @@ EOF
                     })
                     .collect()
             },
-            variables:  {
-                let mut ado_variables: Vec<schema_ado_yaml::Variable> = ado_variables.clone().into_iter()
-                        .map(|(name, value)| schema_ado_yaml::Variable { name, value })
-                        .collect();
+            variables: {
+                let mut ado_variables: Vec<schema_ado_yaml::Variable> = ado_variables
+                    .clone()
+                    .into_iter()
+                    .map(|(name, value)| schema_ado_yaml::Variable { name, value })
+                    .collect();
 
-                ado_variables.push(schema_ado_yaml::Variable {name: "FLOWEY_TEMP_DIR".into(), value: FLOWEY_TEMP_DIR.into()});
+                ado_variables.push(schema_ado_yaml::Variable {
+                    name: "FLOWEY_TEMP_DIR".into(),
+                    value: FLOWEY_TEMP_DIR.into(),
+                });
 
-                Some(
-                    ado_variables
-                )
+                Some(ado_variables)
             },
             steps: ado_steps,
             condition: Some(if let Some(cond_param_idx) = cond_param_idx {
-                format!("and(eq('${{{{ parameters.param{cond_param_idx} }}}}', 'true'), succeeded(), not(canceled()))")
+                format!(
+                    "and(eq('${{{{ parameters.{} }}}}', 'true'), succeeded(), not(canceled()))",
+                    parameters[cond_param_idx].name()
+                )
             } else {
                 "and(succeeded(), not(canceled()))".into()
             }),
@@ -637,23 +645,27 @@ EOF
         parameters: if !parameters.is_empty() {
             Some(
                 parameters
+                    .clone()
                     .into_iter()
-                    .enumerate()
-                    .map(|(idx, param)| match param {
+                    .map(|param| match param {
                         flowey_core::pipeline::internal::Parameter::Bool {
+                            name,
                             description,
+                            kind: _,
                             default,
                         } => schema_ado_yaml::Parameter {
-                            name: format!("param{idx}"),
+                            name,
                             display_name: description,
                             ty: schema_ado_yaml::ParameterType::Boolean { default },
                         },
                         flowey_core::pipeline::internal::Parameter::String {
+                            name,
                             description,
+                            kind: _,
                             default,
                             possible_values,
                         } => schema_ado_yaml::Parameter {
-                            name: format!("param{idx}"),
+                            name,
                             display_name: description,
                             ty: schema_ado_yaml::ParameterType::String {
                                 default,
@@ -661,11 +673,13 @@ EOF
                             },
                         },
                         flowey_core::pipeline::internal::Parameter::Num {
+                            name,
                             description,
+                            kind: _,
                             default,
                             possible_values,
                         } => schema_ado_yaml::Parameter {
-                            name: format!("param{idx}"),
+                            name,
                             display_name: description,
                             ty: schema_ado_yaml::ParameterType::Number {
                                 default,
@@ -703,7 +717,8 @@ EOF
                                     r#ref: match git_ref {
                                         AdoResourcesRepositoryRef::Fixed(s) => s,
                                         AdoResourcesRepositoryRef::Parameter(idx) => {
-                                            format!("${{{{ parameters.param{idx} }}}}")
+                                            let name = parameters[idx].name();
+                                            format!("${{{{ parameters.{name} }}}}")
                                         }
                                     },
                                     r#type: match repo_type {

--- a/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
@@ -220,14 +220,18 @@ fn direct_run_do_work(
         {
             let (desc, value) = match &parameters[*pipeline_param_idx] {
                 Parameter::Bool {
+                    name: _,
                     description,
+                    kind: _,
                     default,
                 } => (
                     description,
                     default.as_ref().map(|v| serde_json::to_vec(v).unwrap()),
                 ),
                 Parameter::String {
+                    name: _,
                     description,
+                    kind: _,
                     default,
                     possible_values: _,
                 } => (
@@ -235,7 +239,9 @@ fn direct_run_do_work(
                     default.as_ref().map(|v| serde_json::to_vec(v).unwrap()),
                 ),
                 Parameter::Num {
+                    name: _,
                     description,
+                    kind: _,
                     default,
                     possible_values: _,
                 } => (
@@ -301,7 +307,9 @@ fn direct_run_do_work(
 
         if let Some(cond_param_idx) = cond_param_idx {
             let Parameter::Bool {
+                name: _,
                 description: _,
+                kind: _,
                 default,
             } = &parameters[cond_param_idx]
             else {

--- a/flowey/flowey_cli/src/pipeline_resolver/generic.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/generic.rs
@@ -200,9 +200,7 @@ pub fn resolve_pipeline(pipeline: Pipeline) -> anyhow::Result<ResolvedPipeline> 
         let parameters_used: Vec<_> = parameters_used
             .into_iter()
             .map(|param_idx| ResolvedJobUseParameter {
-                flowey_var: flowey_core::pipeline::internal::consistent_param_runtime_var_name(
-                    param_idx,
-                ),
+                flowey_var: parameters[param_idx].name().to_string(),
                 pipeline_param_idx: param_idx,
             })
             .collect();

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -364,10 +364,12 @@ echo "{RUNNER_TEMP}/work" | {var_db_insert_working_dir}
 
             let var_db_inject_cmd = bootstrap_bash_var_db_inject(flowey_var, is_string);
 
+            let name = parameters[*pipeline_param_idx].name();
+
             let cmd = format!(
                 r#"
 cat <<'EOF' | {var_db_inject_cmd}
-${{{{ inputs.param{pipeline_param_idx} != '' && inputs.param{pipeline_param_idx} || '{default}' }}}}
+${{{{ inputs.{name} != '' && inputs.{name} || '{default}' }}}}
 EOF
 "#
             )
@@ -584,13 +586,14 @@ EOF
             inputs: github_yaml_defs::Inputs {
                 inputs: parameters
                     .into_iter()
-                    .enumerate()
-                    .map(|(idx, param)| {
+                    .map(|param| {
                         (
-                            format!("param{idx}"),
+                            param.name().to_string(),
                             match param {
                                 flowey_core::pipeline::internal::Parameter::Bool {
+                                    name: _,
                                     description,
+                                    kind: _,
                                     default,
                                 } => github_yaml_defs::Input {
                                     description: Some(description.clone()),
@@ -599,7 +602,9 @@ EOF
                                     ty: github_yaml_defs::InputType::Boolean,
                                 },
                                 flowey_core::pipeline::internal::Parameter::String {
+                                    name: _,
                                     description,
+                                    kind: _,
                                     default,
                                     possible_values: _,
                                 } => github_yaml_defs::Input {
@@ -611,7 +616,9 @@ EOF
                                     ty: github_yaml_defs::InputType::String,
                                 },
                                 flowey_core::pipeline::internal::Parameter::Num {
+                                    name: _,
                                     description,
+                                    kind: _,
                                     default,
                                     possible_values: _,
                                 } => github_yaml_defs::Input {

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -41,6 +41,7 @@ pub mod user_facing {
     pub use super::GhScheduleTriggers;
     pub use super::HostExt;
     pub use super::IntoPipeline;
+    pub use super::ParameterKind;
     pub use super::Pipeline;
     pub use super::PipelineBackendHint;
     pub use super::PipelineJob;
@@ -287,6 +288,17 @@ pub enum GhRunner {
     // See <https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners>
     // for more details.
     RunnerGroup { group: String, labels: Vec<String> },
+}
+
+/// Parameter type (unstable / stable).
+#[derive(Debug, Clone)]
+pub enum ParameterKind {
+    // The parameter is considered an unstable API, and should not be
+    // taken as a dependency.
+    Unstable,
+    // The parameter is considered a stable API, and can be used by
+    // external pipelines to control behavior of the pipeline.
+    Stable,
 }
 
 #[derive(Clone, Debug)]
@@ -662,7 +674,12 @@ impl Pipeline {
     /// To obtain a [`ReadVar<bool>`] that can be used within a node, use the
     /// [`PipelineJobCtx::use_parameter`] method.
     ///
+    /// `name` is the name of the parameter.
+    ///
     /// `description` is an arbitrary string, which will be be shown to users.
+    ///
+    /// `kind` is the type of parameter and if it should be treated as a stable
+    /// external API to callers of the pipeline.
     ///
     /// `default` is the default value for the parameter. If none is provided,
     /// the parameter _must_ be specified in order for the pipeline to run.
@@ -671,13 +688,18 @@ impl Pipeline {
     /// parameter accepts.
     pub fn new_parameter_bool(
         &mut self,
+        name: impl AsRef<str>,
         description: impl AsRef<str>,
+        kind: ParameterKind,
         default: Option<bool>,
     ) -> UseParameter<bool> {
         let idx = self.parameters.len();
+        let name = new_parameter_name(name, kind.clone());
         self.parameters.push(ParameterMeta {
             parameter: Parameter::Bool {
+                name,
                 description: description.as_ref().into(),
+                kind,
                 default,
             },
             used_by_jobs: BTreeSet::new(),
@@ -694,7 +716,12 @@ impl Pipeline {
     /// To obtain a [`ReadVar<i64>`] that can be used within a node, use the
     /// [`PipelineJobCtx::use_parameter`] method.
     ///
+    /// `name` is the name of the parameter.
+    ///
     /// `description` is an arbitrary string, which will be be shown to users.
+    ///
+    /// `kind` is the type of parameter and if it should be treated as a stable
+    /// external API to callers of the pipeline.
     ///
     /// `default` is the default value for the parameter. If none is provided,
     /// the parameter _must_ be specified in order for the pipeline to run.
@@ -703,14 +730,19 @@ impl Pipeline {
     /// parameter accepts.
     pub fn new_parameter_num(
         &mut self,
+        name: impl AsRef<str>,
         description: impl AsRef<str>,
+        kind: ParameterKind,
         default: Option<i64>,
         possible_values: Option<Vec<i64>>,
     ) -> UseParameter<i64> {
         let idx = self.parameters.len();
+        let name = new_parameter_name(name, kind.clone());
         self.parameters.push(ParameterMeta {
             parameter: Parameter::Num {
+                name,
                 description: description.as_ref().into(),
+                kind,
                 default,
                 possible_values,
             },
@@ -728,7 +760,12 @@ impl Pipeline {
     /// To obtain a [`ReadVar<String>`] that can be used within a node, use the
     /// [`PipelineJobCtx::use_parameter`] method.
     ///
+    /// `name` is the name of the parameter.
+    ///
     /// `description` is an arbitrary string, which will be be shown to users.
+    ///
+    /// `kind` is the type of parameter and if it should be treated as a stable
+    /// external API to callers of the pipeline.
     ///
     /// `default` is the default value for the parameter. If none is provided,
     /// the parameter _must_ be specified in order for the pipeline to run.
@@ -739,14 +776,19 @@ impl Pipeline {
     /// then any string is allowed.
     pub fn new_parameter_string(
         &mut self,
+        name: impl AsRef<str>,
         description: impl AsRef<str>,
+        kind: ParameterKind,
         default: Option<impl AsRef<str>>,
         possible_values: Option<Vec<String>>,
     ) -> UseParameter<String> {
         let idx = self.parameters.len();
+        let name = new_parameter_name(name, kind.clone());
         self.parameters.push(ParameterMeta {
             parameter: Parameter::String {
+                name,
                 description: description.as_ref().into(),
+                kind,
                 default: default.map(|x| x.as_ref().into()),
                 possible_values,
             },
@@ -816,7 +858,13 @@ impl PipelineJobCtx<'_> {
             .used_by_jobs
             .insert(self.job_idx);
 
-        crate::node::thin_air_read_runtime_var(format!("param{}", param.idx), false)
+        crate::node::thin_air_read_runtime_var(
+            self.pipeline.parameters[param.idx]
+                .parameter
+                .name()
+                .to_string(),
+            false,
+        )
     }
 
     /// Shortcut which allows defining a bool pipeline parameter within a Job.
@@ -825,10 +873,14 @@ impl PipelineJobCtx<'_> {
     /// - use [`Pipeline::new_parameter_bool`] + [`Self::use_parameter`] instead.
     pub fn new_parameter_bool(
         &mut self,
+        name: impl AsRef<str>,
         description: impl AsRef<str>,
+        kind: ParameterKind,
         default: Option<bool>,
     ) -> ReadVar<bool> {
-        let param = self.pipeline.new_parameter_bool(description, default);
+        let param = self
+            .pipeline
+            .new_parameter_bool(name, description, kind, default);
         self.use_parameter(param)
     }
 
@@ -838,13 +890,15 @@ impl PipelineJobCtx<'_> {
     /// - use [`Pipeline::new_parameter_num`] + [`Self::use_parameter`] instead.
     pub fn new_parameter_num(
         &mut self,
+        name: impl AsRef<str>,
         description: impl AsRef<str>,
+        kind: ParameterKind,
         default: Option<i64>,
         possible_values: Option<Vec<i64>>,
     ) -> ReadVar<i64> {
-        let param = self
-            .pipeline
-            .new_parameter_num(description, default, possible_values);
+        let param =
+            self.pipeline
+                .new_parameter_num(name, description, kind, default, possible_values);
         self.use_parameter(param)
     }
 
@@ -854,13 +908,15 @@ impl PipelineJobCtx<'_> {
     /// - use [`Pipeline::new_parameter_string`] + [`Self::use_parameter`] instead.
     pub fn new_parameter_string(
         &mut self,
+        name: impl AsRef<str>,
         description: impl AsRef<str>,
+        kind: ParameterKind,
         default: Option<String>,
         possible_values: Option<Vec<String>>,
     ) -> ReadVar<String> {
-        let param = self
-            .pipeline
-            .new_parameter_string(description, default, possible_values);
+        let param =
+            self.pipeline
+                .new_parameter_string(name, description, kind, default, possible_values);
         self.use_parameter(param)
     }
 }
@@ -1093,6 +1149,13 @@ pub trait IntoPipeline {
     fn into_pipeline(self, backend_hint: PipelineBackendHint) -> anyhow::Result<Pipeline>;
 }
 
+fn new_parameter_name(name: impl AsRef<str>, kind: ParameterKind) -> String {
+    match kind {
+        ParameterKind::Unstable => format!("__unstable_{}", name.as_ref()),
+        ParameterKind::Stable => name.as_ref().into(),
+    }
+}
+
 /// Structs which should only be used by top-level flowey emitters. If you're a
 /// pipeline author, these are not types you need to care about!
 pub mod internal {
@@ -1105,10 +1168,6 @@ pub mod internal {
             if is_use { "use_from" } else { "publish_from" },
             artifact.as_ref()
         )
-    }
-
-    pub fn consistent_param_runtime_var_name(idx: usize) -> String {
-        format!("param{idx}")
     }
 
     #[derive(Debug)]
@@ -1252,18 +1311,34 @@ pub mod internal {
     #[derive(Debug, Clone)]
     pub enum Parameter {
         Bool {
+            name: String,
             description: String,
+            kind: ParameterKind,
             default: Option<bool>,
         },
         String {
+            name: String,
             description: String,
             default: Option<String>,
+            kind: ParameterKind,
             possible_values: Option<Vec<String>>,
         },
         Num {
+            name: String,
             description: String,
             default: Option<i64>,
+            kind: ParameterKind,
             possible_values: Option<Vec<i64>>,
         },
+    }
+
+    impl Parameter {
+        pub fn name(&self) -> &str {
+            match self {
+                Parameter::Bool { name, .. } => name,
+                Parameter::String { name, .. } => name,
+                Parameter::Num { name, .. } => name,
+            }
+        }
     }
 }

--- a/flowey/flowey_hvlite/src/pipelines_shared/cfg_common_params.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/cfg_common_params.rs
@@ -71,7 +71,12 @@ fn get_params_local(
 fn get_params_cloud(
     pipeline: &mut Pipeline,
 ) -> anyhow::Result<FulfillCommonRequestsParamsResolver> {
-    let param_verbose = pipeline.new_parameter_bool("Run with verbose output", Some(false));
+    let param_verbose = pipeline.new_parameter_bool(
+        "verbose",
+        "Run with verbose output",
+        ParameterKind::Stable,
+        Some(false),
+    );
 
     Ok(Box::new(move |ctx: &mut PipelineJobCtx<'_>| {
         flowey_lib_hvlite::_jobs::cfg_common::Params {


### PR DESCRIPTION
This change moves from auto-generated parameter names to requiring the caller to specify a variable name. This makes for easier to read generated pipeline files and allows for better behavior if another pipeline wants to use queue-time variables to control pipeline behavior.

---------