### PR TITLE
vmbus_client: use existing mesh channels to send revoke

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8025,6 +8025,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "futures",
+ "futures-concurrency",
  "guid",
  "inspect",
  "mesh",

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/Cargo.toml
@@ -25,6 +25,7 @@ user_driver.workspace = true
 
 anyhow.workspace = true
 futures.workspace = true
+futures-concurrency.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true


### PR DESCRIPTION
In the vmbus client, instead of sending a revoke over the general notify channel (which is hard to multiplex between multiple users of the vmbus client), notify a user of a revoke by closing the per-channel notification channel.

This is the last non-offer use of the notify channel. Change the notify channel to just an offer channel.