### PR TITLE
Fix lints for Rust 1.84

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -591,12 +591,17 @@ rust-2024-compatibility = { level = "warn", priority = -1 }
 edition_2024_expr_fragment_specifier = "allow"
 impl_trait_overcaptures = "allow"
 deprecated-safe-2024 = "allow"
+tail-expr-drop-order = "allow"
+if-let-rescope = "allow"
 
 unused_qualifications = "warn"
 
 # Code that needs unsafe should opt-in via a module-scoped allow.
 unsafe_code = "deny"
 unsafe_op_in_unsafe_fn = "forbid"
+
+# TODO: Needed for xshell compatibility, fixed in v0.2.7
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)'] }
 
 [workspace.lints.clippy]
 dbg_macro = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -603,6 +603,9 @@ unsafe_op_in_unsafe_fn = "forbid"
 # TODO: Needed for xshell compatibility, fixed in v0.2.7
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)'] }
 
+# TODO: Remove when we update to Rust 1.84, needed for if-let-rescope
+unknown_lints = "allow"
+
 [workspace.lints.clippy]
 dbg_macro = "warn"
 debug_assert_with_mut_call = "warn"

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -825,7 +825,7 @@ fn validate_vp_hw_ids(partition_info: &PartitionInfo) {
     if let Some((i, &vp_index)) = vp_indexes
         .iter()
         .enumerate()
-        .find(|(i, &vp_index)| *i as u32 != vp_index)
+        .find(|&(i, vp_index)| i as u32 != *vp_index)
     {
         panic!(
             "CPU hardware ID {:#x} does not correspond to VP index {}",

--- a/openhcl/sidecar_client/src/lib.rs
+++ b/openhcl/sidecar_client/src/lib.rs
@@ -572,7 +572,7 @@ impl<'a> SidecarVp<'a> {
             match &mut *vp {
                 VpState::Stopped => unreachable!(),
                 VpState::Running(waker) => {
-                    if !waker.as_ref().map_or(false, |w| cx.waker().will_wake(w)) {
+                    if !waker.as_ref().is_some_and(|w| cx.waker().will_wake(w)) {
                         *waker = Some(cx.waker().clone());
                     }
                     Poll::Pending

--- a/openhcl/sidecar_client/src/lib.rs
+++ b/openhcl/sidecar_client/src/lib.rs
@@ -572,7 +572,7 @@ impl<'a> SidecarVp<'a> {
             match &mut *vp {
                 VpState::Stopped => unreachable!(),
                 VpState::Running(waker) => {
-                    if !waker.as_ref().is_some_and(|w| cx.waker().will_wake(w)) {
+                    if waker.as_ref().is_none_or(|w| !cx.waker().will_wake(w)) {
                         *waker = Some(cx.waker().clone());
                     }
                     Poll::Pending

--- a/openhcl/underhill_confidentiality/src/getters.rs
+++ b/openhcl/underhill_confidentiality/src/getters.rs
@@ -7,7 +7,7 @@ static CONFIDENTIAL: OnceLock<bool> = OnceLock::new();
 static CONFIDENTIAL_DEBUG: OnceLock<bool> = OnceLock::new();
 
 fn get_bool_env_var(name: &str) -> bool {
-    std::env::var_os(name).map_or(false, |v| !v.is_empty() && v != "0")
+    std::env::var_os(name).is_some_and(|v| !v.is_empty() && v != "0")
 }
 
 /// Gets whether the current VM is a confidential VM.

--- a/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
+++ b/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
@@ -541,7 +541,7 @@ pub(crate) async fn handle_vtl2_config_rpc(
     }
 }
 
-pub async fn disk_from_disk_type<'a>(
+pub async fn disk_from_disk_type(
     disk_type: Resource<DiskHandleKind>,
     read_only: bool,
     resolver: &ResourceResolver,

--- a/openhcl/underhill_core/src/get_tracing.rs
+++ b/openhcl/underhill_core/src/get_tracing.rs
@@ -185,7 +185,7 @@ impl GetTracingBackend {
 
 /// Enables tracing output to the tracing task and to stderr.
 pub fn init_tracing(spawn: impl Spawn, tracer: RemoteTracer) -> anyhow::Result<()> {
-    if legacy_openvmm_env("OPENVMM_DISABLE_TRACING_RATELIMITS").map_or(false, |v| !v.is_empty()) {
+    if legacy_openvmm_env("OPENVMM_DISABLE_TRACING_RATELIMITS").is_some_and(|v| !v.is_empty()) {
         tracelimit::disable_rate_limiting(true);
     }
 

--- a/openhcl/underhill_core/src/get_tracing.rs
+++ b/openhcl/underhill_core/src/get_tracing.rs
@@ -185,7 +185,7 @@ impl GetTracingBackend {
 
 /// Enables tracing output to the tracing task and to stderr.
 pub fn init_tracing(spawn: impl Spawn, tracer: RemoteTracer) -> anyhow::Result<()> {
-    if legacy_openvmm_env("OPENVMM_DISABLE_TRACING_RATELIMITS").is_some_and(|v| !v.is_empty()) {
+    if legacy_openvmm_env("OPENVMM_DISABLE_TRACING_RATELIMITS").is_ok_and(|v| !v.is_empty()) {
         tracelimit::disable_rate_limiting(true);
     }
 

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -151,7 +151,7 @@ impl Options {
 
         fn parse_bool(value: Option<&OsString>) -> bool {
             value
-                .map(|v| v.to_ascii_lowercase() == "true" || v == "1")
+                .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
                 .unwrap_or_default()
         }
 

--- a/openhcl/underhill_crash/src/options.rs
+++ b/openhcl/underhill_crash/src/options.rs
@@ -62,7 +62,7 @@ impl Options {
         );
 
         let verbose_var = std::env::var("UNDERHILL_CRASH_VERBOSE").unwrap_or_default();
-        let verbose = verbose_var == "1" || verbose_var.to_ascii_lowercase() == "true";
+        let verbose = verbose_var == "1" || verbose_var.eq_ignore_ascii_case("true");
 
         Self {
             pid,

--- a/openhcl/underhill_dump/src/lib.rs
+++ b/openhcl/underhill_dump/src/lib.rs
@@ -37,7 +37,7 @@ pub fn main() -> ! {
 pub fn do_main() -> anyhow::Result<()> {
     let mut args = std::env::args().skip(1).peekable();
 
-    let level = if args.peek().map_or(false, |x| x == "-v") {
+    let level = if args.peek().is_some_and(|x| x == "-v") {
         args.next();
         Level::DEBUG
     } else {

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -669,7 +669,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                 // Ensure the waker is set.
                 if !last_waker
                     .as_ref()
-                    .map_or(false, |waker| cx.waker().will_wake(waker))
+                    .is_some_and(|waker| cx.waker().will_wake(waker))
                 {
                     last_waker = Some(cx.waker().clone());
                     self.inner.waker.write().clone_from(&last_waker);

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1329,9 +1329,9 @@ fn cleanup_socket(path: &Path) {
     #[cfg(windows)]
     let is_socket = pal::windows::fs::is_unix_socket(path).unwrap_or(false);
     #[cfg(not(windows))]
-    let is_socket = path.metadata().map_or(false, |meta| {
-        std::os::unix::fs::FileTypeExt::is_socket(&meta.file_type())
-    });
+    let is_socket = path
+        .metadata()
+        .is_ok_and(|meta| std::os::unix::fs::FileTypeExt::is_socket(&meta.file_type()));
 
     if is_socket {
         let _ = std::fs::remove_file(path);

--- a/openvmm/openvmm_entry/src/tracing_init.rs
+++ b/openvmm/openvmm_entry/src/tracing_init.rs
@@ -37,7 +37,7 @@ pub fn enable_tracing() -> anyhow::Result<()> {
             .add_directive(base.parse().unwrap())
     };
 
-    if legacy_openvmm_env("OPENVMM_DISABLE_TRACING_RATELIMITS").map_or(false, |v| !v.is_empty()) {
+    if legacy_openvmm_env("OPENVMM_DISABLE_TRACING_RATELIMITS").is_ok_and(|v| !v.is_empty()) {
         tracelimit::disable_rate_limiting(true);
     }
 

--- a/support/cache_topology/src/lib.rs
+++ b/support/cache_topology/src/lib.rs
@@ -190,7 +190,7 @@ mod linux {
                         .file_name()
                         .unwrap()
                         .to_str()
-                        .map_or(false, |s| s.starts_with("index"))
+                        .is_some_and(|s| s.starts_with("index"))
                     {
                         continue;
                     }

--- a/support/console_relay/src/lib.rs
+++ b/support/console_relay/src/lib.rs
@@ -99,7 +99,7 @@ fn choose_terminal_apps(app: Option<&Path>) -> Vec<App<'_>> {
 
     let mut apps = Vec::new();
 
-    let env_set = |key| std::env::var_os(key).map_or(false, |x| !x.is_empty());
+    let env_set = |key| std::env::var_os(key).is_some_and(|x| !x.is_empty());
 
     // If we're running in tmux, use tmux.
     if env_set("TMUX") {

--- a/support/inspect_derive/src/lib.rs
+++ b/support/inspect_derive/src/lib.rs
@@ -264,7 +264,7 @@ fn parse_attr_list<T: Parse>(input: ParseStream<'_>) -> syn::Result<Punctuated<A
 fn parse_attrs<T: Parse>(attrs: &[Attribute]) -> syn::Result<Vec<Attr<T>>> {
     let mut idents = Vec::new();
     for attr in attrs {
-        if !attr.path().get_ident().map_or(false, |x| x == "inspect") {
+        if attr.path().get_ident().is_none_or(|x| x != "inspect") {
             continue;
         }
         let attrs = attr.parse_args_with(parse_attr_list)?;
@@ -276,7 +276,7 @@ fn parse_attrs<T: Parse>(attrs: &[Attribute]) -> syn::Result<Vec<Attr<T>>> {
 /// Parses a `bitfield(u32)` style attribute, returning the bitfield type.
 fn parse_bitfield_attr(attrs: &[Attribute]) -> syn::Result<Option<Ident>> {
     for attr in attrs {
-        if attr.path().get_ident().map_or(false, |x| x == "bitfield") {
+        if attr.path().get_ident().is_some_and(|x| x == "bitfield") {
             return Ok(Some(attr.parse_args()?));
         }
     }
@@ -403,7 +403,7 @@ fn fields_response(
                     && field
                         .ident
                         .as_ref()
-                        .map_or(false, |id| id.to_string().starts_with('_'));
+                        .is_some_and(|id| id.to_string().starts_with('_'));
 
                 (!skip).then(|| {
                     let ident = field.ident.as_ref().map_or_else(

--- a/support/mesh/mesh_channel_core/src/mpsc.rs
+++ b/support/mesh/mesh_channel_core/src/mpsc.rs
@@ -510,7 +510,7 @@ impl ReceiverCore {
                         if !local
                             .waker
                             .as_ref()
-                            .map_or(false, |waker| waker.will_wake(cx.waker()))
+                            .is_some_and(|waker| waker.will_wake(cx.waker()))
                             && !this.is_closed()
                         {
                             local.waker = Some(cx.waker().clone());

--- a/support/mesh/mesh_node/src/common.rs
+++ b/support/mesh/mesh_node/src/common.rs
@@ -74,7 +74,7 @@ mod debug {
 
         pub fn next(&self) -> Option<Uuid> {
             CHECK_ONCE.call_once(|| {
-                if std::env::var_os("__MESH_UNSAFE_DEBUG_IDS__").map_or(false, |x| !x.is_empty()) {
+                if std::env::var_os("__MESH_UNSAFE_DEBUG_IDS__").is_some_and(|x| !x.is_empty()) {
                     tracing::error!("using unsafe debugging mesh IDs--this mesh could be compromised by external callers");
                     USE_LINEAR_IDS.store(true, Ordering::Relaxed);
                 }

--- a/support/mesh/mesh_protobuf/src/encoding.rs
+++ b/support/mesh/mesh_protobuf/src/encoding.rs
@@ -1071,7 +1071,7 @@ impl<T, R, E: FieldEncode<T, R>> FieldEncode<Vec<T>, R> for VecField<E> {
         // Other packed sequences may still get a bytes value at runtime, but
         // they also support non-packed encodings and so must be wrapped when
         // they're nested in another sequence.
-        let bytes = E::packed().map_or(false, |p| p.must_pack());
+        let bytes = E::packed().is_some_and(|p| p.must_pack());
         !bytes
     }
 }
@@ -1116,7 +1116,7 @@ impl<'a, T, R, E: FieldDecode<'a, T, R>> FieldDecode<'a, Vec<T>, R> for VecField
         // Other packed sequences may still get a bytes value at runtime, but
         // they also support non-packed encodings and so must be wrapped when
         // they're nested in another sequence.
-        let bytes = E::packed::<Vec<T>>().map_or(false, |p| p.must_pack());
+        let bytes = E::packed::<Vec<T>>().is_some_and(|p| p.must_pack());
         !bytes
     }
 }

--- a/support/mesh/mesh_protobuf/src/protofile/writer.rs
+++ b/support/mesh/mesh_protobuf/src/protofile/writer.rs
@@ -80,7 +80,7 @@ impl<'a> DescriptorWriter<'a> {
                 let mut n = 0;
                 while descriptors
                     .peek()
-                    .map_or(false, |d| d.package == first.package)
+                    .is_some_and(|d| d.package == first.package)
                 {
                     let desc = descriptors.next().unwrap();
                     desc.message.collect_imports(&mut writer, &mut imports)?;
@@ -376,7 +376,7 @@ impl FieldDescriptor<'_> {
             .collect::<Vec<_>>();
         let fields = fields
             .iter()
-            .map(|(&ty, number, name)| FieldDescriptor::new("", ty, name.as_ref(), *number))
+            .map(|&(ty, number, ref name)| FieldDescriptor::new("", *ty, name.as_ref(), number))
             .collect::<Vec<_>>();
         MessageDescriptor::new(&self.name.to_upper_camel_case(), "", &fields, &[], &[]).fmt(w)?;
         Ok(())

--- a/support/openssl_kdf/src/params.rs
+++ b/support/openssl_kdf/src/params.rs
@@ -117,7 +117,7 @@ impl ParamsBuilder {
         // Data is allocated by the openssl allocator, so assumed in a memory stable realm.
         // It's important the data does not move from the time we create the "output" slice and the
         // moment it's read by the EVP_KDF_CTX_set_params functions.
-        for (name, ref mut p) in &mut params.fixed {
+        for (name, p) in &mut params.fixed {
             use Param::*;
             // SAFETY: Name is guaranteed to be a valid C string, and the bufs are only constructed by alloc_slice_inner,
             // which makes sure they are valid and have correct lengths.

--- a/support/pal/pal_async/src/interest.rs
+++ b/support/pal/pal_async/src/interest.rs
@@ -261,7 +261,7 @@ impl PollInterestSet {
             if !interest
                 .waker
                 .as_ref()
-                .map_or(false, |w| w.will_wake(cx.waker()))
+                .is_some_and(|w| w.will_wake(cx.waker()))
             {
                 interest.waker = Some(cx.waker().clone());
             }

--- a/support/pal/pal_async/src/multi_waker.rs
+++ b/support/pal/pal_async/src/multi_waker.rs
@@ -29,7 +29,7 @@ impl<const N: usize> Inner<N> {
     /// Sets the waker for index `i`.
     fn set(&self, i: usize, waker: &Waker) {
         let mut wakers = self.wakers.lock();
-        if !wakers[i].as_ref().map_or(false, |old| old.will_wake(waker)) {
+        if !wakers[i].as_ref().is_some_and(|old| old.will_wake(waker)) {
             let _old = wakers[i].replace(waker.clone());
             drop(wakers);
         }

--- a/support/pal/pal_async/src/windows/local.rs
+++ b/support/pal/pal_async/src/windows/local.rs
@@ -111,7 +111,7 @@ impl State {
             if !entry
                 .waker
                 .as_ref()
-                .map_or(false, |old| old.will_wake(cx.waker()))
+                .is_some_and(|old| old.will_wake(cx.waker()))
             {
                 entry.waker = Some(cx.waker().clone());
             }

--- a/support/task_control/src/lib.rs
+++ b/support/task_control/src/lib.rs
@@ -77,7 +77,7 @@ impl<T: AsyncRun<S>, S> PollReady for StopTaskInner<'_, T, S> {
         if !shared
             .inner_waker
             .as_ref()
-            .map_or(false, |waker| cx.waker().will_wake(waker))
+            .is_some_and(|waker| cx.waker().will_wake(waker))
         {
             shared.inner_waker = Some(cx.waker().clone());
         }
@@ -468,9 +468,10 @@ impl<T: AsyncRun<S>, S: 'static + Send> TaskControl<T, S> {
         loop {
             let (mut task_and_state, stop) = poll_fn(|cx| {
                 let mut shared = shared.lock();
-                let has_work = shared.task_and_state.as_ref().map_or(false, |ts| {
-                    !shared.calls.is_empty() || (!shared.stop && !ts.done)
-                });
+                let has_work = shared
+                    .task_and_state
+                    .as_ref()
+                    .is_some_and(|ts| !shared.calls.is_empty() || (!shared.stop && !ts.done));
                 if !has_work {
                     shared.inner_waker = Some(cx.waker().clone());
                     return Poll::Pending;

--- a/support/task_control/src/lib.rs
+++ b/support/task_control/src/lib.rs
@@ -74,10 +74,10 @@ impl<T: AsyncRun<S>, S> PollReady for StopTaskInner<'_, T, S> {
         if !shared.calls.is_empty() || shared.stop {
             return Poll::Ready(());
         }
-        if !shared
+        if shared
             .inner_waker
             .as_ref()
-            .is_some_and(|waker| cx.waker().will_wake(waker))
+            .is_none_or(|waker| !cx.waker().will_wake(waker))
         {
             shared.inner_waker = Some(cx.waker().clone());
         }

--- a/support/uevent/src/lib.rs
+++ b/support/uevent/src/lib.rs
@@ -83,8 +83,8 @@ impl UeventListener {
                     || (kvs.get("RESIZE") == Some("1")
                         && kvs.get("SUBSYSTEM") == Some("block")
                         && kvs.get("ACTION") == Some("change")
-                        && kvs.get("MAJOR").map_or(false, |x| x.parse() == Ok(major))
-                        && kvs.get("MINOR").map_or(false, |x| x.parse() == Ok(minor)))
+                        && kvs.get("MAJOR").is_some_and(|x| x.parse() == Ok(major))
+                        && kvs.get("MINOR").is_some_and(|x| x.parse() == Ok(minor)))
                 {
                     notify();
                 }

--- a/vm/devices/chipset/src/i8042/ps2mouse.rs
+++ b/vm/devices/chipset/src/i8042/ps2mouse.rs
@@ -65,7 +65,7 @@ mod save_restore {
         type SavedState = state::SavedState;
 
         fn save(&mut self) -> Result<Self::SavedState, SaveError> {
-            let Self { ref output_buffer } = self;
+            let Self { output_buffer } = self;
 
             let saved_state = state::SavedState {
                 output_buffer: output_buffer.iter().copied().collect(),

--- a/vm/devices/serial/serial_core/src/serial_io.rs
+++ b/vm/devices/serial/serial_core/src/serial_io.rs
@@ -161,7 +161,7 @@ impl<T: SerialIo + Unpin> SerialIo for DetachableIo<T> {
         self.inner
             .lock()
             .as_ref()
-            .map_or(false, |s| s.is_connected())
+            .is_some_and(|s| s.is_connected())
     }
 
     fn poll_connect(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/vm/devices/serial/serial_core/src/serial_io.rs
+++ b/vm/devices/serial/serial_core/src/serial_io.rs
@@ -158,10 +158,7 @@ impl<T: SerialIo + Unpin> IoDetacher<T> {
 
 impl<T: SerialIo + Unpin> SerialIo for DetachableIo<T> {
     fn is_connected(&self) -> bool {
-        self.inner
-            .lock()
-            .as_ref()
-            .is_some_and(|s| s.is_connected())
+        self.inner.lock().as_ref().is_some_and(|s| s.is_connected())
     }
 
     fn poll_connect(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/vm/devices/storage/disk_layered/src/bitmap.rs
+++ b/vm/devices/storage/disk_layered/src/bitmap.rs
@@ -28,7 +28,7 @@ impl Bitmap {
             .filter_map(move |bits| {
                 let start = n;
                 n += bits.len();
-                if bits.first().map_or(false, |&x| !x) {
+                if bits.first().is_some_and(|&x| !x) {
                     Some(SectorBitmapRange {
                         bits,
                         start_sector: sector + start as u64,

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -492,7 +492,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
             .per_cpu
             .iter()
             .enumerate()
-            .filter(|&(cpu, c)| c.get().map_or(false, |c| c.cpu != cpu as u32))
+            .filter(|&(cpu, c)| c.get().is_some_and(|c| c.cpu != cpu as u32))
             .count()
     }
 

--- a/vm/devices/support/fs/lxutil/src/windows/util.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/util.rs
@@ -373,7 +373,7 @@ pub fn dos_to_nt_path(
     let path = if root.is_none() {
         // Windows has legacy behavior where specifying just a drive letter will return the last path on that drive
         // from the current cmd.exe instance. This is likely not the intended behavior and is generally not safe.
-        if path.as_os_str().len() == 2 && path.to_str().map_or(false, |s| s.ends_with(':')) {
+        if path.as_os_str().len() == 2 && path.to_str().is_some_and(|s| s.ends_with(':')) {
             windows::dos_to_nt_path(path.join("\\"))?
         } else {
             windows::dos_to_nt_path(path)?

--- a/vm/devices/virtio/virtio_p9/src/lib.rs
+++ b/vm/devices/virtio/virtio_p9/src/lib.rs
@@ -28,7 +28,7 @@ pub struct VirtioPlan9Device {
 impl VirtioPlan9Device {
     pub fn new(tag: &str, fs: Plan9FileSystem, memory: GuestMemory) -> VirtioPlan9Device {
         // The tag uses the same format as 9p protocol strings (2 byte length followed by string).
-        let length = tag.as_bytes().len() + size_of::<u16>();
+        let length = tag.len() + size_of::<u16>();
 
         // Round the length up to a multiple of 4 to make the read function simpler.
         let length = (length + 3) & !3;
@@ -38,9 +38,7 @@ impl VirtioPlan9Device {
         {
             use std::io::Write;
             let mut cursor = std::io::Cursor::new(&mut tag_buffer);
-            cursor
-                .write_all(&(tag.as_bytes().len() as u16).to_le_bytes())
-                .unwrap();
+            cursor.write_all(&(tag.len() as u16).to_le_bytes()).unwrap();
             cursor.write_all(tag.as_bytes()).unwrap();
         }
 

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -74,7 +74,7 @@ impl VirtioFsDevice {
         };
 
         // Copy the tag into the config space (truncate it for now if too long).
-        let length = std::cmp::min(tag.as_bytes().len(), config.tag.len());
+        let length = std::cmp::min(tag.len(), config.tag.len());
         config.tag[..length].copy_from_slice(&tag.as_bytes()[..length]);
 
         Self {

--- a/vm/devices/vmbus/vmbus_ring/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_ring/src/lib.rs
@@ -1155,7 +1155,7 @@ pub fn inspect_ring<M: RingMem>(mem: M, req: inspect::Request<'_>) {
 /// Returns whether a ring buffer is in a state where the receiving end might
 /// need a signal.
 pub fn reader_needs_signal<M: RingMem>(mem: M) -> bool {
-    InnerRing::new(mem).map_or(false, |ring| {
+    InnerRing::new(mem).is_ok_and(|ring| {
         let control = ring.control();
         control.interrupt_mask().load(Ordering::Relaxed) == 0
             && (control.inp().load(Ordering::Relaxed) != control.outp().load(Ordering::Relaxed))
@@ -1165,7 +1165,7 @@ pub fn reader_needs_signal<M: RingMem>(mem: M) -> bool {
 /// Returns whether a ring buffer is in a state where the sending end might need
 /// a signal.
 pub fn writer_needs_signal<M: RingMem>(mem: M) -> bool {
-    InnerRing::new(mem).map_or(false, |ring| {
+    InnerRing::new(mem).is_ok_and(|ring| {
         let control = ring.control();
         let pending_size = control.pending_send_size().load(Ordering::Relaxed);
         pending_size != 0

--- a/vm/vmcore/src/line_interrupt.rs
+++ b/vm/vmcore/src/line_interrupt.rs
@@ -459,7 +459,7 @@ pub mod test_helpers {
         }
 
         pub fn is_high(&self, vector: u32) -> bool {
-            self.state.lock().get(&vector).map_or(false, |s| s.is_high)
+            self.state.lock().get(&vector).is_some_and(|s| s.is_high)
         }
 
         pub fn poll_high(&self, cx: &mut Context<'_>, vector: u32) -> Poll<()> {

--- a/vm/vmcore/src/vmtime.rs
+++ b/vm/vmcore/src/vmtime.rs
@@ -289,7 +289,7 @@ impl TimerState {
         }
 
         // Update the timer if needed.
-        if self.next.map_or(false, |next| next.is_before(time)) {
+        if self.next.is_some_and(|next| next.is_before(time)) {
             return;
         }
         self.set_next(time);
@@ -305,7 +305,7 @@ impl TimerState {
     ) -> Poll<Timestamp> {
         let now = self.now(now_os);
         let state = &mut self.waiters[index];
-        if next.map_or(false, |next| next.is_before(now.vmtime)) {
+        if next.is_some_and(|next| next.is_before(now.vmtime)) {
             state.waker = None;
             state.next = None;
             return Poll::Ready(now);

--- a/vm/x86/x86emu/src/emulator/arith.rs
+++ b/vm/x86/x86emu/src/emulator/arith.rs
@@ -9,7 +9,7 @@ use iced_x86::Instruction;
 use iced_x86::Register;
 use x86defs::RFlags;
 
-impl<'a, T: Cpu> Emulator<'a, T> {
+impl<T: Cpu> Emulator<'_, T> {
     // <op> rm instructions
     pub(super) async fn unary_arith<Op: UnaryArithOp>(
         &mut self,

--- a/vm/x86/x86emu/src/emulator/bt.rs
+++ b/vm/x86/x86emu/src/emulator/bt.rs
@@ -8,7 +8,7 @@ use super::InternalError;
 use crate::Cpu;
 use iced_x86::Instruction;
 
-impl<'a, T: Cpu> Emulator<'a, T> {
+impl<T: Cpu> Emulator<'_, T> {
     // bt/btc/btr/bts m, r/imm
     pub(super) async fn bt_m<Op: BitOp>(
         &mut self,

--- a/vm/x86/x86emu/src/emulator/cmpxchg816.rs
+++ b/vm/x86/x86emu/src/emulator/cmpxchg816.rs
@@ -8,7 +8,7 @@ use crate::Cpu;
 use iced_x86::Instruction;
 use iced_x86::Register;
 
-impl<'a, T: Cpu> Emulator<'a, T> {
+impl<T: Cpu> Emulator<'_, T> {
     // cmpxchg8/16 rm
     pub(super) async fn cmpxchg8_16(
         &mut self,

--- a/vm/x86/x86emu/src/emulator/cond.rs
+++ b/vm/x86/x86emu/src/emulator/cond.rs
@@ -8,7 +8,7 @@ use iced_x86::ConditionCode;
 use iced_x86::Instruction;
 use x86defs::RFlags;
 
-impl<'a, T: Cpu> Emulator<'a, T> {
+impl<T: Cpu> Emulator<'_, T> {
     pub(super) async fn setcc(
         &mut self,
         instr: &Instruction,

--- a/vm/x86/x86emu/src/emulator/mov.rs
+++ b/vm/x86/x86emu/src/emulator/mov.rs
@@ -10,7 +10,7 @@ use iced_x86::Instruction;
 use iced_x86::OpKind;
 use iced_x86::Register;
 
-impl<'a, T: Cpu> Emulator<'a, T> {
+impl<T: Cpu> Emulator<'_, T> {
     pub(super) async fn mov(&mut self, instr: &Instruction) -> Result<(), InternalError<T::Error>> {
         let value = self.op_value(instr, 1).await?;
         self.write_op_0(instr, value).await?;

--- a/vm/x86/x86emu/src/emulator/muldiv.rs
+++ b/vm/x86/x86emu/src/emulator/muldiv.rs
@@ -8,7 +8,7 @@ use crate::Cpu;
 use iced_x86::Instruction;
 use iced_x86::Register;
 
-impl<'a, T: Cpu> Emulator<'a, T> {
+impl<T: Cpu> Emulator<'_, T> {
     // MUL rm instructions
     pub(super) async fn unary_mul(
         &mut self,

--- a/vm/x86/x86emu/src/emulator/rep.rs
+++ b/vm/x86/x86emu/src/emulator/rep.rs
@@ -91,7 +91,7 @@ fn sized_rsi(op_kind: OpKind) -> Register {
     }
 }
 
-impl<'a, T: Cpu> Emulator<'a, T> {
+impl<T: Cpu> Emulator<'_, T> {
     /// Generic function for handling the optional REP op for instructions.
     fn rep_op(
         &mut self,

--- a/vm/x86/x86emu/src/emulator/shift_rotate.rs
+++ b/vm/x86/x86emu/src/emulator/shift_rotate.rs
@@ -10,7 +10,7 @@ use x86defs::RFlags;
 
 const LSB_MASK: u64 = 0x1;
 
-impl<'a, T: Cpu> Emulator<'a, T> {
+impl<T: Cpu> Emulator<'_, T> {
     // shr/shl/sal/rol/ror/rcl/rcr rm, 1/imm/cl
     pub(super) async fn shift_sign_unextended<Op: ShiftingOp>(
         &mut self,

--- a/vmm_core/src/vmotherboard_adapter.rs
+++ b/vmm_core/src/vmotherboard_adapter.rs
@@ -58,38 +58,38 @@ impl CpuIo for ChipsetPlusSynic {
             .on_post_message(vtl, connection_id, secure, message)
     }
 
-    fn read_mmio<'a>(
+    fn read_mmio(
         &self,
         vp: VpIndex,
         address: u64,
-        data: &'a mut [u8],
+        data: &mut [u8],
     ) -> impl std::future::Future<Output = ()> {
         self.chipset.mmio_read(vp.index(), address, data)
     }
 
-    fn write_mmio<'a>(
+    fn write_mmio(
         &self,
         vp: VpIndex,
         address: u64,
-        data: &'a [u8],
+        data: &[u8],
     ) -> impl std::future::Future<Output = ()> {
         self.chipset.mmio_write(vp.index(), address, data)
     }
 
-    fn read_io<'a>(
+    fn read_io(
         &self,
         vp: VpIndex,
         port: u16,
-        data: &'a mut [u8],
+        data: &mut [u8],
     ) -> impl std::future::Future<Output = ()> {
         self.chipset.io_read(vp.index(), port, data)
     }
 
-    fn write_io<'a>(
+    fn write_io(
         &self,
         vp: VpIndex,
         port: u16,
-        data: &'a [u8],
+        data: &[u8],
     ) -> impl std::future::Future<Output = ()> {
         self.chipset.io_write(vp.index(), port, data)
     }

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -772,7 +772,7 @@ impl<'p> Processor for HvfProcessor<'p> {
 
                 if !last_waker
                     .as_ref()
-                    .map_or(false, |waker| cx.waker().will_wake(waker))
+                    .is_some_and(|waker| cx.waker().will_wake(waker))
                 {
                     last_waker = Some(cx.waker().clone());
                     self.inner.waker.write().clone_from(&last_waker);

--- a/vmm_core/virt_support_gic/src/lib.rs
+++ b/vmm_core/virt_support_gic/src/lib.rs
@@ -144,7 +144,7 @@ mod gicd {
                 .iter_mut()
                 .zip(&mut state.active)
                 .enumerate()
-                .find(|(_, (&mut p, &mut a))| p & !a != 0)
+                .find(|(_, (p, a))| **p & !**a != 0)
             {
                 let v = 31 - (*p & !*a).leading_zeros();
                 *p &= !(1 << v);

--- a/vmm_core/virt_support_x86emu/tests/tests/common.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/common.rs
@@ -69,25 +69,25 @@ impl CpuIo for MockCpu {
         todo!()
     }
 
-    async fn read_mmio<'a>(&self, _vp: VpIndex, address: u64, _data: &'a mut [u8]) {
+    async fn read_mmio(&self, _vp: VpIndex, address: u64, _data: &mut [u8]) {
         panic!(
             "Attempt to read MMIO when test environment has no MMIO. address: {:x}",
             address
         )
     }
 
-    async fn write_mmio<'a>(&self, _vp: VpIndex, address: u64, data: &'a [u8]) {
+    async fn write_mmio(&self, _vp: VpIndex, address: u64, data: &[u8]) {
         panic!(
             "Attempt to write MMIO when test environment has no MMIO. address: {:x}, data: {:x?}",
             address, data
         )
     }
 
-    async fn read_io<'a>(&self, _vp: VpIndex, _port: u16, _data: &'a mut [u8]) {
+    async fn read_io(&self, _vp: VpIndex, _port: u16, _data: &mut [u8]) {
         todo!()
     }
 
-    async fn write_io<'a>(&self, _vp: VpIndex, _port: u16, _data: &'a [u8]) {
+    async fn write_io(&self, _vp: VpIndex, _port: u16, _data: &[u8]) {
         todo!()
     }
 }

--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -465,7 +465,7 @@ impl WhpProcessor<'_> {
             .vtls
             .lapic(self.state.runnable_vtls.highest_set().unwrap())
             .as_ref()
-            .map_or(false, |lapic| self.state.halted || lapic.startup_suspend);
+            .is_some_and(|lapic| self.state.halted || lapic.startup_suspend);
 
         Ok(!halted)
     }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -747,7 +747,7 @@ impl virt::Hypervisor for Whp {
         let vtl2 = if config
             .hv_config
             .as_ref()
-            .map_or(false, |cfg| cfg.vtl2.is_some())
+            .is_some_and(|cfg| cfg.vtl2.is_some())
         {
             Some(VtlPartition::new(&config, vendor, Vtl::Vtl2)?)
         } else {
@@ -1137,13 +1137,13 @@ impl VtlPartition {
                 .hv_config
                 .as_ref()
                 .and_then(|hv_config| hv_config.vtl2.as_ref())
-                .map_or(false, |cfg| cfg.vtl2_emulates_apic);
+                .is_some_and(|cfg| cfg.vtl2_emulates_apic);
 
         let user_mode_apic = config.user_mode_apic
             || config
                 .hv_config
                 .as_ref()
-                .map_or(false, |cfg| !cfg.offload_enlightenments);
+                .is_some_and(|cfg| !cfg.offload_enlightenments);
 
         #[cfg(guest_arch = "x86_64")]
         let lapic = if apic_in_vtl2 {
@@ -1451,7 +1451,7 @@ impl VtlPartition {
 impl Hv1State {
     fn reset(&self) {
         match self {
-            Hv1State::Emulated(ref hv) => hv.reset(),
+            Hv1State::Emulated(hv) => hv.reset(),
             Hv1State::Offloaded => {}
             Hv1State::Disabled => {}
         }

--- a/vmm_core/vmotherboard/src/chipset/io_ranges/address_filter.rs
+++ b/vmm_core/vmotherboard/src/chipset/io_ranges/address_filter.rs
@@ -84,7 +84,7 @@ where
             .unwrap_or_else(|x| x);
         self.ranges
             .get(i)
-            .map_or(false, |(start, end)| address >= start && address <= end)
+            .is_some_and(|(start, end)| address >= start && address <= end)
     }
 }
 


### PR DESCRIPTION
The biggest two here are changing `map_or(false,` to `is_some_and` or `is_ok_and`, and the changing of rules around how refs in patterns work (which is technically a future-compat lint, but its easy enough to take now), but there's also some elided lifetimes and other general cleanups.