### PR TITLE
[2411] Add generic ACPI tables from DPS to UEFI config

### DIFF
--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -25,6 +25,7 @@ use vm_topology::memory::MemoryRangeWithNode;
 use vm_topology::processor::ProcessorTopology;
 use vmm_core::acpi_builder::AcpiTablesBuilder;
 use zerocopy::AsBytes;
+use zerocopy::FromBytes;
 
 pub mod vtl0_config;
 pub mod vtl2_config;
@@ -71,6 +72,10 @@ pub enum Error {
     LinuxSupport,
     #[error("finalizing boot")]
     Finalize(#[source] vtl0_config::Error),
+    #[error("invalid acpi table: too short")]
+    InvalidAcpiTableLength,
+    #[error("invalid acpi table: unknown header signature {0:?}")]
+    InvalidAcpiTableSignature([u8; 4]),
 }
 
 pub const PV_CONFIG_BASE_PAGE: u64 = if cfg!(guest_arch = "x86_64") {
@@ -621,6 +626,22 @@ pub fn write_uefi_config(
             gic_distributor_base: processor_topology.gic_distributor_base(),
             gic_redistributors_base: processor_topology.gic_redistributors_base(),
         });
+    }
+
+    // ACPI tables that come from the DevicePlatformSettings
+    // We can only trust these tables from the host if this is not an isolated VM
+    if !isolated {
+        for table in &platform_config.acpi_tables {
+            let header =
+                acpi_spec::Header::ref_from_prefix(table).ok_or(Error::InvalidAcpiTableLength)?;
+            match &header.signature {
+                b"HMAT" => cfg.add_raw(config::BlobStructureType::Hmat, table),
+                b"IORT" => cfg.add_raw(config::BlobStructureType::Iort, table),
+                b"MCFG" => cfg.add_raw(config::BlobStructureType::Mcfg, table),
+                b"SSDT" => cfg.add_raw(config::BlobStructureType::Ssdt, table),
+                _ => return Err(Error::InvalidAcpiTableSignature(header.signature)),
+            };
+        }
     }
 
     // Finally, with the bios config constructed, we can inject it into guest memory

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -155,6 +155,9 @@ pub struct HclDevicePlatformSettingsV2Dynamic {
     pub generation_id_high: u64,
     pub smbios: HclDevicePlatformSettingsV2DynamicSmbios,
     pub is_servicing_scenario: bool,
+
+    #[serde(default)]
+    pub acpi_tables: Vec<Vec<u8>>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -157,6 +157,7 @@ pub struct HclDevicePlatformSettingsV2Dynamic {
     pub is_servicing_scenario: bool,
 
     #[serde(default)]
+    #[serde(with = "serde_helpers::vec_base64_vec")]
     pub acpi_tables: Vec<Vec<u8>>,
 }
 

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -33,6 +33,8 @@ pub mod platform_settings {
     pub struct DevicePlatformSettings {
         pub smbios: Smbios,
         pub general: General,
+        #[inspect(with = "inspect::iter_by_index")]
+        pub acpi_tables: Vec<Vec<u8>>,
     }
 
     /// All available SMBIOS related config.

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -355,6 +355,7 @@ impl GuestEmulationTransportClient {
                 firmware_mode_is_pcat: json.v2.r#static.firmware_mode_is_pcat,
                 imc_enabled: json.v2.r#static.imc_enabled,
             },
+            acpi_tables: json.v2.dynamic.acpi_tables,
         })
     }
 

--- a/vm/loader/src/uefi/config.rs
+++ b/vm/loader/src/uefi/config.rs
@@ -179,6 +179,10 @@ pub enum BlobStructureType {
     Aspt = 0x21,
     Pptt = 0x22,
     Gic = 0x23,
+    Mcfg = 0x24,
+    Ssdt = 0x25,
+    Hmat = 0x26,
+    Iort = 0x27,
 }
 
 //


### PR DESCRIPTION
Backport for 2411. 

Add generic ACPI tables from DevicePlatformSettings to the UEFI config
blob. UEFI currently only supports specific tables, so this is limited
to HMAT, IORT, MCFG, and SSDT for now.