### PR TITLE
fuzz_storvsp: forward progress with invalid packets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,6 +2147,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "disklayer_ram",
+ "futures",
  "guestmem",
  "libfuzzer-sys",
  "pal_async",

--- a/vm/devices/storage/storvsp/fuzz/Cargo.toml
+++ b/vm/devices/storage/storvsp/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 anyhow.workspace = true
 arbitrary = { workspace = true, features = ["derive"] }
 disklayer_ram.workspace = true
+futures.workspace = true
 guestmem.workspace = true
 pal_async.workspace = true
 scsi_defs = {workspace = true, features = ["arbitrary"]}

--- a/vm/devices/storage/storvsp/src/test_helpers.rs
+++ b/vm/devices/storage/storvsp/src/test_helpers.rs
@@ -50,6 +50,7 @@ impl TestWorker {
     /// Like `teardown`, but ignore the result. Nice for the fuzzer,
     /// so that the `storvsp` crate doesn't need to expose `WorkerError`
     /// as pub.
+    #[cfg(feature = "fuzz_helpers")]
     pub async fn teardown_ignore(self) {
         let _ = self.task.await;
     }

--- a/vm/devices/storage/storvsp/src/test_helpers.rs
+++ b/vm/devices/storage/storvsp/src/test_helpers.rs
@@ -47,6 +47,13 @@ impl TestWorker {
         self.task.await
     }
 
+    /// Like `teardown`, but ignore the result. Nice for the fuzzer,
+    /// so that the `storvsp` crate doesn't need to expose `WorkerError`
+    /// as pub.
+    pub async fn teardown_ignore(self) {
+        let _ = self.task.await;
+    }
+
     pub fn start<T: ring::RingMem + 'static + Sync>(
         controller: ScsiController,
         spawner: impl Spawn,


### PR DESCRIPTION
Refactor the storvsp fuzzer to allow for forward progress: split the fuzzing loop into its own async function, and have the fuzz executor wait for either the fuzzing loop to run out of arbitrary data, or for the thread parsing storvsp packets (the test worker's task) to finish.

This is necessary because storvsp stops packet processing if the guest sends storvsp a corrupted or invalid packet. This is correct behavior, and the fuzzer must accommodate.

Tested by running running the fuzzer for some time and inspecting code coverage. There is a noticeable increase in code coverage on the paths that process IOs (where these were previously not hit). Also ran `cargo xtask fuzz run fuzz_storvsp -- -- -timeout=1` to catch when this likely hangs, with no hangs seen.