### PR TITLE
Include found and expected response size in `AkCertError::SizeTooSmall`

### DIFF
--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -37,8 +37,6 @@ pub fn parse_response(response: &[u8]) -> Result<Vec<u8>, AkCertError> {
         })?
     };
 
-    println!("header: {:x?}", header);
-
     let size = header.data_size as usize;
     if size > response.len() {
         Err(AkCertError::SizeMismatch {

--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -12,7 +12,7 @@ use zerocopy::FromBytes;
 /// AkCertError is returned by parse_ak_cert_response() in emuplat/tpm.rs
 #[derive(Debug, Error)]
 pub enum AkCertError {
-    #[error("AK cert response is too small to parse. Expected at least {expected} bytes but found {found}")]
+    #[error("AK cert response is too small to parse. Found {size} bytes but expected at least {expected_size}")]
     SizeTooSmall { size: usize, expected_size: usize },
     #[error(
         "AK cert response size {specified_size} specified in the header is larger then the actual size {size}"
@@ -72,7 +72,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            "AK cert response is too small to parse. Expected at least 8 bytes but found 0"
+            "AK cert response is too small to parse. Found 0 bytes but expected at least 8"
         );
 
         // Response has to be at least `HEADER_SIZE` bytes long, so `HEADER_SIZE - 1` bytes is too small.
@@ -81,9 +81,9 @@ mod tests {
         assert_eq!(
             undersized_parse_.unwrap_err().to_string(),
             format!(
-                "AK cert response is too small to parse. Expected at least {} bytes but found {}",
-                HEADER_SIZE,
-                HEADER_SIZE - 1
+                "AK cert response is too small to parse. Found {} bytes but expected at least {}",
+                HEADER_SIZE - 1,
+                HEADER_SIZE
             )
         );
 

--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -12,8 +12,8 @@ use zerocopy::FromBytes;
 /// AkCertError is returned by parse_ak_cert_response() in emuplat/tpm.rs
 #[derive(Debug, Error)]
 pub enum AkCertError {
-    #[error("AK cert response is too small to parse. Found {size} bytes but expected at least {expected_size}")]
-    SizeTooSmall { size: usize, expected_size: usize },
+    #[error("AK cert response is too small to parse. Found {size} bytes but expected at least {minimum_size}")]
+    SizeTooSmall { size: usize, minimum_size: usize },
     #[error(
         "AK cert response size {specified_size} specified in the header is larger then the actual size {size}"
     )]
@@ -33,7 +33,7 @@ pub fn parse_response(response: &[u8]) -> Result<Vec<u8>, AkCertError> {
     let Some(header) = IgvmAttestAkCertResponseHeader::read_from_prefix(response) else {
         Err(AkCertError::SizeTooSmall {
             size: response.len(),
-            expected_size: HEADER_SIZE,
+            minimum_size: HEADER_SIZE,
         })?
     };
 

--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -13,7 +13,7 @@ use zerocopy::FromBytes;
 #[derive(Debug, Error)]
 pub enum AkCertError {
     #[error("AK cert response is too small to parse. Expected at least {expected} bytes but found {found}")]
-    SizeTooSmall { found: usize, expected: usize },
+    SizeTooSmall { size: usize, expected_size: usize },
     #[error(
         "AK cert response size {specified_size} specified in the header is larger then the actual size {size}"
     )]
@@ -32,8 +32,8 @@ pub fn parse_response(response: &[u8]) -> Result<Vec<u8>, AkCertError> {
 
     let Some(header) = IgvmAttestAkCertResponseHeader::read_from_prefix(response) else {
         Err(AkCertError::SizeTooSmall {
-            found: response.len(),
-            expected: HEADER_SIZE,
+            size: response.len(),
+            expected_size: HEADER_SIZE,
         })?
     };
 


### PR DESCRIPTION
This PR:
* Adds `size` and `expected size to `AkCertError::SizeTooSmall` to enrich the error message when failing to parse an AkCert response
* Replaces the `test_empty_response` test with `test_undersized_response`, where an empty response is tested as a special case of an undersized response