### PR TITLE
flowey: Remove rustdocflags override, set -Dwarnings in config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -112,3 +112,10 @@ rustflags = [
   # Treat warnings as errors in CI.
 ### ENABLE_IN_CI "-Dwarnings",
 ]
+
+# Specify a common set of rustdocflags for all targets.
+[build]
+rustdocflags = [
+  # Treat warnings as errors in CI.
+### ENABLE_IN_CI "-Dwarnings",
+]

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -201,7 +201,6 @@ impl IntoPipeline for CheckinGatesCli {
                 pub_rustdoc_linux,
             ),
         ] {
-            let deny_warnings = !matches!(backend_hint, PipelineBackendHint::Local);
             let job = pipeline
                 .new_job(
                     platform,
@@ -211,9 +210,6 @@ impl IntoPipeline for CheckinGatesCli {
                 .gh_set_pool(crate::pipelines_shared::gh_pools::default_x86_pool(
                     platform,
                 ))
-                .dep_on(|_ctx| {
-                    flowey_lib_hvlite::build_rustdoc::Request::SetDenyWarnings(deny_warnings)
-                })
                 .dep_on(
                     |ctx| flowey_lib_hvlite::_jobs::build_and_publish_rustdoc::Params {
                         target_triple: target.as_triple(),


### PR DESCRIPTION
This allows us to set arbitrary custom rustdocflags. Because the rustdoc job already depends on install_openvmm_rust_build_essential, which depends on init_openvmm_cargo_config_deny_warnings, no code changes are needed to enable this.