### PR TITLE
ci: use azcopy latest

### DIFF
--- a/flowey/flowey_lib_common/src/download_azcopy.rs
+++ b/flowey/flowey_lib_common/src/download_azcopy.rs
@@ -107,7 +107,7 @@ impl FlowNode for Node {
                     };
                     match rt.platform().kind() {
                         FlowPlatformKind::Windows => {
-                            xshell::cmd!(sh, "curl --fail -L https://azcopyvnext.azureedge.net/releases/release-{version_with_date}/azcopy_windows_{arch}_{version_without_date}.zip -o azcopy.zip").run()?;
+                            xshell::cmd!(sh, "curl --fail -L https://azcopyvnext-awgzd8g7aagqhzhe.b02.azurefd.net/releases/release-{version_with_date}/azcopy_windows_{arch}_{version_without_date}.zip -o azcopy.zip").run()?;
 
                             let bsdtar = crate::_util::bsdtar_name(rt);
                             xshell::cmd!(sh, "{bsdtar} -xf azcopy.zip --strip-components=1").run()?;
@@ -118,7 +118,7 @@ impl FlowNode for Node {
                                 FlowPlatform::MacOs => "darwin",
                                 platform => anyhow::bail!("unhandled platform {platform}"),
                             };
-                            xshell::cmd!(sh, "curl --fail -L https://azcopyvnext.azureedge.net/releases/release-{version_with_date}/azcopy_{os}_{arch}_{version_without_date}.tar.gz -o azcopy.tar.gz").run()?;
+                            xshell::cmd!(sh, "curl --fail -L https://azcopyvnext-awgzd8g7aagqhzhe.b02.azurefd.net/releases/release-{version_with_date}/azcopy_{os}_{arch}_{version_without_date}.tar.gz -o azcopy.tar.gz").run()?;
                             xshell::cmd!(sh, "tar -xf azcopy.tar.gz --strip-components=1").run()?;
                         }
                     };

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -14,7 +14,6 @@ use flowey::node::prelude::*;
 //
 // This would require nodes that currently accept a `Version(String)` to accept
 // a `Version(ReadVar<String>)`, but that shouldn't be a serious blocker.
-pub const AZCOPY: &str = "10.27.0-20241030";
 pub const AZURE_CLI: &str = "2.56.0";
 pub const FUZZ: &str = "0.12.0";
 pub const GH_CLI: &str = "2.52.0";
@@ -68,7 +67,6 @@ impl FlowNode for Node {
         ctx.req(crate::download_openhcl_kernel_package::Request::Version(OpenhclKernelPackageKind::CvmDev, OPENHCL_KERNEL_DEV_VERSION.into()));
         ctx.req(crate::download_openvmm_deps::Request::Version(OPENVMM_DEPS.into()));
         ctx.req(crate::download_uefi_mu_msvm::Request::Version(MU_MSVM.into()));
-        ctx.req(flowey_lib_common::download_azcopy::Request::Version(AZCOPY.into()));
         ctx.req(flowey_lib_common::download_cargo_fuzz::Request::Version(FUZZ.into()));
         ctx.req(flowey_lib_common::download_cargo_nextest::Request::Version(NEXTEST.into()));
         ctx.req(flowey_lib_common::download_gh_cli::Request::Version(GH_CLI.into()));


### PR DESCRIPTION
Use the latest azcopy rather than hard coding a version. We had pinned to a specific version to work around a prior bug. That bug is no longer relevant, so just stay up to date with the latest.

This is a follow-up to #663 . I took the smallest change to get things back up in #663 . I'd like to see a clean ci run before we complete this PR.