### PR TITLE
Add igvm V2 RPC interfaces to propagate igvm error info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4472,6 +4472,7 @@ version = "0.0.0"
 dependencies = [
  "base64 0.21.7",
  "base64-serde",
+ "bitfield-struct",
  "guid",
  "hex",
  "mesh",

--- a/openhcl/openhcl_attestation_protocol/Cargo.toml
+++ b/openhcl/openhcl_attestation_protocol/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
+bitfield-struct.workspace = true
 open_enum.workspace = true
 guid.workspace = true
 mesh.workspace = true

--- a/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
+++ b/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
@@ -5,6 +5,7 @@
 //! sent to and received from the IGVm agent runs on the host via GET
 //! `IGVM_ATTEST` host request.
 
+use bitfield_struct::bitfield;
 use open_enum::open_enum;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
@@ -136,10 +137,18 @@ impl IgvmAttestRequestHeader {
 
 const IGVM_ATTEST_VERSION_CURRENT: u32 = 2;
 
-pub const IGVM_REQUEST_ERROR_CODE_BIT: u32 = 1 << 0;
-pub const IGVM_REQUEST_RETRY_ON_FAILURE_BIT: u32 = 1 << 1;
+/// Bitmap of additional Igvm request attributes.
+/// [0] error_code: Requesting IGVM Agent Error code
+/// [1] retry: Retry preference
+#[bitfield(u32)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
+pub struct IgvmCapabilityBitMap {
+    pub error_code: bool,
+    pub retry: bool,
+    #[bits(30)]
+    _reserved: u32,
+}
 
-/// Unmeasured user data, used for host attestation requests (C-style struct)
 #[repr(C)]
 #[derive(Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct IgvmAttestRequestData {
@@ -153,10 +162,8 @@ pub struct IgvmAttestRequestData {
     pub report_data_hash_type: IgvmAttestHashType,
     /// Size of the appended raw runtime claims
     pub variable_data_size: u32,
-    // Bitmap of additional request attributes.
-    // [0] IGVM_REQUEST_ERROR_CODE_BIT: Requesting IGVM Agent Error code
-    // [1] IGVM_REQUEST_RETRY_ON_FAILURE_BIT: Retry preference
-    pub capability_bitmap: u32,
+    /// Bitmap of additional request attributes
+    pub capability_bitmap: IgvmCapabilityBitMap,
 }
 
 impl IgvmAttestRequestData {
@@ -166,7 +173,7 @@ impl IgvmAttestRequestData {
         report_type: IgvmAttestReportType,
         report_data_hash_type: IgvmAttestHashType,
         variable_data_size: u32,
-        capability_bitmap: u32,
+        capability_bitmap: IgvmCapabilityBitMap,
     ) -> Self {
         Self {
             data_size,
@@ -179,28 +186,31 @@ impl IgvmAttestRequestData {
     }
 }
 
-pub const IGVM_SIGNAL_RETRY_RCOMMENDED_BIT: u32 = 1 << 0;
+/// Bitmap indicates a signal to requestor
+/// [0] IGVM_SIGNAL_RETRY_RCOMMENDED_BIT: Retry recommendation
+#[bitfield(u32)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
+pub struct IgvmSignal {
+    pub retry: bool,
+    #[bits(31)]
+    _reserved: u32,
+}
 
-/// The response header for `IGVM_RESULT_INFO` (C-style struct)
-///
-/// reSearch query: `IGVM_RESULT_INFO`
+/// The response header for `IGVM_ERROR_INFO` (C-style struct)
 #[repr(C)]
 #[derive(Default, Debug, AsBytes, FromBytes, FromZeroes)]
-pub struct IgvmResultInfo {
+pub struct IgvmErrorInfo {
     /// ErrorCode propogated from IgvmAgent
-    pub igvmagent_error_code: u32,
+    pub error_code: u32,
     /// HttpStatusCode propogated from IgvmAgent that enhances the ErrorCode
-    pub igvmagent_http_status_code: u32,
-    /// An uint32 bitmap indicates a signal to requestor
-    /// [0] IGVM_SIGNAL_RETRY_RCOMMENDED_BIT: Retry recommendation
-    pub igvmagent_signal: u32,
+    pub http_status_code: u32,
+    /// Igvm signal from response
+    pub igvm_signal: IgvmSignal,
     /// Reserved
     pub reserved: [u32; 3],
 }
 
 /// The response header for `KEY_RELEASE_REQUEST` (C-style struct)
-///
-/// reSearch query: `IGVM_KEY_MESSAGE_HEADER`
 #[repr(C)]
 #[derive(Default, Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct IgvmAttestKeyReleaseResponseHeader {
@@ -208,14 +218,12 @@ pub struct IgvmAttestKeyReleaseResponseHeader {
     pub data_size: u32,
     /// Version
     pub version: u32,
-    /// IgvmResultInfo that contains RPC result and retry recommendation
-    pub result_info: IgvmResultInfo,
+    /// IgvmErrorInfo that contains RPC result and retry recommendation
+    pub error_info: IgvmErrorInfo,
 }
 
 /// The response header for `WRAPPED_KEY_REQUEST` (C-style struct)
 /// Currently the definition is the same as [`IgvmAttestKeyReleaseResponseHeader`].
-///
-/// reSearch query: `IGVM_KEY_MESSAGE_HEADER`
 #[repr(C)]
 #[derive(Default, Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct IgvmAttestWrappedKeyResponseHeader {
@@ -223,13 +231,11 @@ pub struct IgvmAttestWrappedKeyResponseHeader {
     pub data_size: u32,
     /// Version
     pub version: u32,
-    /// IgvmResultInfo that contains RPC result and retry recommendation
-    pub result_info: IgvmResultInfo,
+    /// IgvmErrorInfo that contains RPC result and retry recommendation
+    pub error_info: IgvmErrorInfo,
 }
 
 /// The response header for `AK_CERT_REQUEST` (C-style struct)
-///
-/// reSearch query: `IGVM_CERT_MESSAGE_HEADER`
 #[repr(C)]
 #[derive(Default, Debug, AsBytes, FromBytes, FromZeroes)]
 pub struct IgvmAttestAkCertResponseHeader {
@@ -237,8 +243,8 @@ pub struct IgvmAttestAkCertResponseHeader {
     pub data_size: u32,
     /// Version
     pub version: u32,
-    /// IgvmResultInfo that contains RPC result and retry recommendation
-    pub result_info: IgvmResultInfo,
+    /// IgvmErrorInfo that contains RPC result and retry recommendation
+    pub error_info: IgvmErrorInfo,
 }
 
 /// Definition of the runt-time claims, which will be appended to the

--- a/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
+++ b/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
@@ -196,6 +196,20 @@ pub struct IgvmSignal {
     _reserved: u32,
 }
 
+/// The common response header that comply with both V1 and V2 Igvm attest response
+#[repr(C)]
+#[derive(Default, Debug, AsBytes, FromBytes, FromZeroes)]
+pub struct IgvmAttestCommonResponseHeader {
+    /// Data size
+    pub data_size: u32,
+    /// Version
+    pub version: u32,
+}
+
+pub const IGVM_ATTEST_RESPONSE_VERSION_1: u32 = 1;
+pub const IGVM_ATTEST_RESPONSE_VERSION_2: u32 = 2;
+pub const IGVM_ATTEST_RESPONSE_CURRENT_VERSION: u32 = IGVM_ATTEST_RESPONSE_VERSION_2;
+
 /// The response header for `IGVM_ERROR_INFO` (C-style struct)
 #[repr(C)]
 #[derive(Default, Debug, AsBytes, FromBytes, FromZeroes)]

--- a/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/ak_cert.rs
@@ -3,11 +3,9 @@
 
 //! The module for `AK_CERT_REQUEST` request type that supports parsing the
 //! response.
-
-use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestAkCertResponseHeader;
-use openhcl_attestation_protocol::igvm_attest::get::AK_CERT_RESPONSE_HEADER_VERSION;
+use crate::igvm_attest::parse_response_header;
+use crate::igvm_attest::Error as CommonError;
 use thiserror::Error;
-use zerocopy::FromBytes;
 
 /// AkCertError is returned by parse_ak_cert_response() in emuplat/tpm.rs
 #[derive(Debug, Error)]
@@ -22,44 +20,44 @@ pub enum AkCertError {
         "AK cert response header version {version} does match the expected version {expected_version}"
     )]
     HeaderVersionMismatch { version: u32, expected_version: u32 },
+    #[error("error in response header")]
+    ParseHeader(#[source] CommonError),
 }
 
 /// Parse a `AK_CERT_REQUEST` response and return the payload (i.e., the AK cert).
 ///
 /// Returns `Ok(Vec<u8>)` on successfully validating the response, otherwise returns an error.
 pub fn parse_response(response: &[u8]) -> Result<Vec<u8>, AkCertError> {
-    const HEADER_SIZE: usize = size_of::<IgvmAttestAkCertResponseHeader>();
+    use openhcl_attestation_protocol::igvm_attest::get::IGVM_ATTEST_RESPONSE_VERSION_1;
+    use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestAkCertResponseHeader;
+    use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestCommonResponseHeader;
 
-    let Some(header) = IgvmAttestAkCertResponseHeader::read_from_prefix(response) else {
-        Err(AkCertError::SizeTooSmall)?
+    let header = parse_response_header(response).map_err(AkCertError::ParseHeader)?;
+
+    // Extract payload as per header version
+    let header_size = match header.version {
+        IGVM_ATTEST_RESPONSE_VERSION_1 => size_of::<IgvmAttestCommonResponseHeader>(),
+        _ => size_of::<IgvmAttestAkCertResponseHeader>(),
     };
-
-    let size = header.data_size as usize;
-    if size > response.len() {
-        Err(AkCertError::SizeMismatch {
-            size: response.len(),
-            specified_size: size,
-        })?
-    }
-
-    if header.version != AK_CERT_RESPONSE_HEADER_VERSION {
-        Err(AkCertError::HeaderVersionMismatch {
-            version: header.version,
-            expected_version: AK_CERT_RESPONSE_HEADER_VERSION,
-        })?
-    }
-
-    Ok(response[HEADER_SIZE..size].to_vec())
+    Ok(response[header_size..header.data_size as usize].to_vec())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestCommonResponseHeader;
+    use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestAkCertResponseHeader;
+    use zerocopy::FromBytes;
 
     #[test]
     fn test_empty_response() {
         let result = parse_response(&[]);
         assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            AkCertError::ParseHeader(CommonError::ResponseSizeTooSmall { response_size: 0 })
+                .to_string()
+        );
     }
 
     #[test]
@@ -71,21 +69,19 @@ mod tests {
             0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b, 0x05, 0x00, 0x30, 0x25,
         ];
 
-        const HEADER_SIZE: usize = size_of::<IgvmAttestAkCertResponseHeader>();
-
+        const HEADER_SIZE: usize = size_of::<IgvmAttestCommonResponseHeader>();
         let result = IgvmAttestAkCertResponseHeader::read_from_prefix(&VALID_RESPONSE);
         assert!(result.is_some());
-        let header = result.unwrap();
 
         let result = parse_response(&VALID_RESPONSE);
         assert!(result.is_ok());
 
         let payload = result.unwrap();
-        assert_eq!(payload.len(), header.data_size as usize - HEADER_SIZE);
-        assert_eq!(
-            payload,
-            &VALID_RESPONSE[HEADER_SIZE..header.data_size as usize]
-        );
+        let data_size = parse_response_header(&VALID_RESPONSE)
+            .unwrap()
+            .data_size as usize;
+        assert_eq!(payload.len(), data_size - HEADER_SIZE);
+        assert_eq!(payload, &VALID_RESPONSE[HEADER_SIZE..data_size]);
     }
 
     #[test]
@@ -97,46 +93,19 @@ mod tests {
             0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b, 0x05, 0x00, 0x30, 0x25,
         ];
 
-        const HEADER_SIZE: usize = size_of::<IgvmAttestAkCertResponseHeader>();
+        const HEADER_SIZE: usize = size_of::<IgvmAttestCommonResponseHeader>();
 
         let result = IgvmAttestAkCertResponseHeader::read_from_prefix(&VALID_RESPONSE);
         assert!(result.is_some());
-        let header = result.unwrap();
 
         let result = parse_response(&VALID_RESPONSE);
         assert!(result.is_ok());
 
         let payload = result.unwrap();
-        assert_eq!(payload.len(), header.data_size as usize - HEADER_SIZE);
-        assert_eq!(
-            payload,
-            &VALID_RESPONSE[HEADER_SIZE..header.data_size as usize]
-        );
-    }
-
-    #[test]
-    fn test_invalid_header_version() {
-        const INVALID_RESPONSE: [u8; 56] = [
-            0x38, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x30, 0x82, 0x03, 0xeb, 0x30, 0x82,
-            0x02, 0xd3, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x10, 0x3b, 0xa3, 0x33, 0x97, 0xef,
-            0x2f, 0x9e, 0xef, 0xbd, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
-            0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b, 0x05, 0x00, 0x30, 0x25,
-        ];
-
-        let result = parse_response(&INVALID_RESPONSE);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_invalid_response_size() {
-        const INVALID_RESPONSE: [u8; 56] = [
-            0x39, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x30, 0x82, 0x03, 0xeb, 0x30, 0x82,
-            0x02, 0xd3, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x10, 0x3b, 0xa3, 0x33, 0x97, 0xef,
-            0x2f, 0x9e, 0xef, 0xbd, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
-            0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b, 0x05, 0x00, 0x30, 0x25,
-        ];
-
-        let result = parse_response(&INVALID_RESPONSE);
-        assert!(result.is_err());
+        let data_size = parse_response_header(&VALID_RESPONSE)
+            .unwrap()
+            .data_size as usize;
+        assert_eq!(payload.len(), data_size - HEADER_SIZE);
+        assert_eq!(payload, &VALID_RESPONSE[HEADER_SIZE..data_size]);
     }
 }

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -7,13 +7,18 @@
 
 use base64_serde::base64_serde_type;
 use openhcl_attestation_protocol::igvm_attest::get::runtime_claims::AttestationVmConfig;
+use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestCommonResponseHeader;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestHashType;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestReportType;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestType;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmCapabilityBitMap;
+use openhcl_attestation_protocol::igvm_attest::get::IgvmErrorInfo;
+use openhcl_attestation_protocol::igvm_attest::get::IGVM_ATTEST_RESPONSE_CURRENT_VERSION;
+use openhcl_attestation_protocol::igvm_attest::get::IGVM_ATTEST_RESPONSE_VERSION_2;
 use tee_call::TeeType;
 use thiserror::Error;
 use zerocopy::AsBytes;
+use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
 pub mod ak_cert;
@@ -31,6 +36,22 @@ pub enum Error {
     InvalidAttestationReportSize {
         report_size: usize,
         expected_size: usize,
+    },
+    #[error("the size of the attestation response {response_size} is too small to parse")]
+    ResponseSizeTooSmall { response_size: usize },
+    #[error(
+        "response size {specified_size} specified in the header not match the actual size {size}"
+    )]
+    ResponseSizeMismatch { size: usize, specified_size: usize },
+    #[error("response header version {version} larger than current version {latest_version}")]
+    InvalidResponseHeaderVersion { version: u32, latest_version: u32 },
+    #[error(
+        "attest failed ({error_code}-{http_status_code}), retry recommendation ({retry_signal})"
+    )]
+    Attestation {
+        error_code: u32,
+        http_status_code: u32,
+        retry_signal: bool,
     },
 }
 
@@ -171,6 +192,54 @@ impl IgvmAttestRequestHelper {
             self.hash_type,
         )
     }
+}
+
+// Verify response header and try to extract IgvmErrorInfo from the header
+pub fn parse_response_header(response: &[u8]) -> Result<IgvmAttestCommonResponseHeader, Error> {
+    // Extract common header fields regardless of header version or request type
+    // For V1 request, response buffer should be empty in case of attestation failure
+    let header = IgvmAttestCommonResponseHeader::read_from_prefix(&response).ok_or(
+        Error::ResponseSizeTooSmall {
+            response_size: response.len(),
+        },
+    )?;
+
+    // Check header data_size and version
+    if header.data_size as usize > response.len() {
+        Err(Error::ResponseSizeMismatch {
+            size: response.len(),
+            specified_size: header.data_size as usize,
+        })?
+    }
+    if header.version > IGVM_ATTEST_RESPONSE_CURRENT_VERSION {
+        Err(Error::InvalidResponseHeaderVersion {
+            version: header.version,
+            latest_version: IGVM_ATTEST_RESPONSE_CURRENT_VERSION,
+        })?
+    }
+
+    // IgvmErrorInfo is added in response header since IGVM_ATTEST_RESPONSE_VERSION_2
+    if header.version >= IGVM_ATTEST_RESPONSE_VERSION_2 {
+        // Extract result info from response header
+        let error_info = IgvmErrorInfo::read_from_prefix(
+            &response[size_of::<IgvmAttestCommonResponseHeader>()..],
+        )
+        .ok_or(Error::ResponseSizeTooSmall {
+            response_size: response.len(),
+        })?;
+
+        if 0 != error_info.error_code {
+            Err(Error::Attestation {
+                error_code: error_info.error_code,
+                http_status_code: error_info.http_status_code,
+                retry_signal: error_info.igvm_signal.retry(),
+            })?
+        }
+    }
+    Ok(IgvmAttestCommonResponseHeader {
+        data_size: header.data_size,
+        version: header.version,
+    })
 }
 
 /// Create a request in raw bytes.
@@ -325,5 +394,204 @@ mod tests {
 
         let vm_config = result.unwrap();
         assert_eq!(vm_config, EXPECTED_JWK);
+    }
+
+    #[test]
+    fn test_empty_response() {
+        let result = parse_response_header(&[]);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            Error::ResponseSizeTooSmall { response_size: 0 }.to_string()
+        );
+    }
+
+    #[test]
+    fn test_invalid_response_size_smaller_than_header_size() {
+        const INVALID_RESPONSE: [u8; 4] = [0x04, 0x00, 0x00, 0x00];
+        let result = parse_response_header(&INVALID_RESPONSE);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            Error::ResponseSizeTooSmall { response_size: 4 }.to_string()
+        );
+    }
+
+    #[test]
+    fn test_valid_v1_response_size_match() {
+        const VALID_RESPONSE: [u8; 42] = [
+            0x2a, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x30, 0x82, 0x03, 0xeb, 0x30, 0x82,
+            0x02, 0xd3, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x10, 0x3b, 0xa3, 0x33, 0x97, 0xef,
+            0x2f, 0x9e, 0xef, 0xbd, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
+        ];
+
+        let result = parse_response_header(&VALID_RESPONSE);
+        assert!(result.is_ok());
+        let header = result.unwrap();
+        assert_eq!(VALID_RESPONSE.len(), header.data_size as usize);
+        assert_eq!(1, header.version);
+    }
+
+    #[test]
+    fn test_valid_v2_response_size_match() {
+        const VALID_RESPONSE: [u8; 42] = [
+            0x2a, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
+        ];
+
+        let result = parse_response_header(&VALID_RESPONSE);
+        assert!(result.is_ok());
+        let header = result.unwrap();
+        assert_eq!(VALID_RESPONSE.len(), header.data_size as usize);
+        assert_eq!(2, header.version);
+    }
+
+    #[test]
+    fn test_valid_v1_response_size_smaller_than_specified() {
+        const VALID_RESPONSE: [u8; 42] = [
+            0x29, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x30, 0x82, 0x03, 0xeb, 0x30, 0x82,
+            0x02, 0xd3, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x10, 0x3b, 0xa3, 0x33, 0x97, 0xef,
+            0x2f, 0x9e, 0xef, 0xbd, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
+        ];
+
+        let header = parse_response_header(&VALID_RESPONSE);
+        assert!(header.is_ok());
+        assert_eq!(0x29, header.unwrap().data_size as usize);
+    }
+
+    #[test]
+    fn test_valid_v2_response_size_smaller_than_specified() {
+        const VALID_RESPONSE: [u8; 42] = [
+            0x29, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
+        ];
+
+        let header = parse_response_header(&VALID_RESPONSE);
+        assert!(header.is_ok());
+        assert_eq!(0x29, header.unwrap().data_size as usize);
+    }
+
+    #[test]
+    fn test_invalid_v1_response_size() {
+        const INVALID_RESPONSE: [u8; 42] = [
+            0x2b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x30, 0x82, 0x03, 0xeb, 0x30, 0x82,
+            0x02, 0xd3, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x10, 0x3b, 0xa3, 0x33, 0x97, 0xef,
+            0x2f, 0x9e, 0xef, 0xbd, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
+        ];
+
+        let result = parse_response_header(&INVALID_RESPONSE);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            Error::ResponseSizeMismatch {
+                size: INVALID_RESPONSE.len(),
+                specified_size: 0x2b
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn test_invalid_v2_response_size() {
+        const INVALID_RESPONSE: [u8; 42] = [
+            0x2b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x30, 0x82, 0x03, 0xeb, 0x30, 0x82,
+            0x02, 0xd3, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x10, 0x3b, 0xa3, 0x33, 0x97, 0xef,
+            0x2f, 0x9e, 0xef, 0xbd, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
+        ];
+
+        let result = parse_response_header(&INVALID_RESPONSE);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            Error::ResponseSizeMismatch {
+                size: INVALID_RESPONSE.len(),
+                specified_size: 0x2b
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn test_invalid_header_version() {
+        const INVALID_RESPONSE: [u8; 42] = [
+            0x2a, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x30, 0x82, 0x03, 0xeb, 0x30, 0x82,
+            0x02, 0xd3, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x10, 0x3b, 0xa3, 0x33, 0x97, 0xef,
+            0x2f, 0x9e, 0xef, 0xbd, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
+        ];
+
+        let result = parse_response_header(&INVALID_RESPONSE);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            Error::InvalidResponseHeaderVersion {
+                version: 3,
+                latest_version: IGVM_ATTEST_RESPONSE_CURRENT_VERSION
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn test_invalid_v2_response_size_smaller_than_specified_header_size() {
+        const INVALID_RESPONSE: [u8; 28] = [
+            0x1c, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        let result = parse_response_header(&INVALID_RESPONSE);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            Error::ResponseSizeTooSmall {
+                response_size: 0x1c
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn test_failed_response_with_retryable_error() {
+        // error_code: 1103 (0x44f), http_status_code: 403 (0x193), retryable
+        const INVALID_RESPONSE: [u8; 42] = [
+            0x2a, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x4f, 0x04, 0x00, 0x00, 0x93, 0x01,
+            0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
+        ];
+
+        let result = parse_response_header(&INVALID_RESPONSE);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            Error::Attestation {
+                error_code: 1103,
+                http_status_code: 403,
+                retry_signal: true
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn test_failed_response_with_non_retryable_error() {
+        // error_code: 1103 (0x44f), http_status_code: 503 (0x1f7), not retryable
+        const INVALID_RESPONSE: [u8; 42] = [
+            0x2a, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x4f, 0x04, 0x00, 0x00, 0xf7, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x35, 0x5e, 0xda, 0xdd, 0x27, 0x38, 0x42, 0x30, 0x0d, 0x06,
+        ];
+
+        let result = parse_response_header(&INVALID_RESPONSE);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            Error::Attestation {
+                error_code: 1103,
+                http_status_code: 503,
+                retry_signal: false
+            }
+            .to_string()
+        );
     }
 }

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -10,6 +10,8 @@ use openhcl_attestation_protocol::igvm_attest::get::runtime_claims::AttestationV
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestHashType;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestReportType;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestType;
+use openhcl_attestation_protocol::igvm_attest::get::IGVM_REQUEST_ERROR_CODE_BIT;
+use openhcl_attestation_protocol::igvm_attest::get::IGVM_REQUEST_RETRY_ON_FAILURE_BIT;
 use tee_call::TeeType;
 use thiserror::Error;
 use zerocopy::AsBytes;
@@ -197,6 +199,7 @@ fn create_request(
     let report_size = size_of::<IgvmAttestRequest>() + runtime_claims.len();
     let user_data_size = size_of::<IgvmAttestRequestData>() + runtime_claims.len();
     let mut request = IgvmAttestRequest::new_zeroed();
+    let request_capability_map = IGVM_REQUEST_ERROR_CODE_BIT | IGVM_REQUEST_RETRY_ON_FAILURE_BIT;
 
     request.header = IgvmAttestRequestHeader::new(report_size as u32, request_type, 0);
 
@@ -207,6 +210,7 @@ fn create_request(
         report_type.to_external_type(),
         hash_type,
         runtime_claims.len() as u32,
+        request_capability_map,
     );
 
     Ok([request.as_bytes(), runtime_claims].concat())

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -10,8 +10,7 @@ use openhcl_attestation_protocol::igvm_attest::get::runtime_claims::AttestationV
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestHashType;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestReportType;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestType;
-use openhcl_attestation_protocol::igvm_attest::get::IGVM_REQUEST_ERROR_CODE_BIT;
-use openhcl_attestation_protocol::igvm_attest::get::IGVM_REQUEST_RETRY_ON_FAILURE_BIT;
+use openhcl_attestation_protocol::igvm_attest::get::IgvmCapabilityBitMap;
 use tee_call::TeeType;
 use thiserror::Error;
 use zerocopy::AsBytes;
@@ -199,7 +198,6 @@ fn create_request(
     let report_size = size_of::<IgvmAttestRequest>() + runtime_claims.len();
     let user_data_size = size_of::<IgvmAttestRequestData>() + runtime_claims.len();
     let mut request = IgvmAttestRequest::new_zeroed();
-    let request_capability_map = IGVM_REQUEST_ERROR_CODE_BIT | IGVM_REQUEST_RETRY_ON_FAILURE_BIT;
 
     request.header = IgvmAttestRequestHeader::new(report_size as u32, request_type, 0);
 
@@ -210,7 +208,9 @@ fn create_request(
         report_type.to_external_type(),
         hash_type,
         runtime_claims.len() as u32,
-        request_capability_map,
+        IgvmCapabilityBitMap::new()
+            .with_error_code(true)
+            .with_retry(true),
     );
 
     Ok([request.as_bytes(), runtime_claims].concat())

--- a/openhcl/underhill_attestation/src/igvm_attest/wrapped_key.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/wrapped_key.rs
@@ -4,6 +4,8 @@
 //! The module for `WRAPPED_KEY_REQUEST` request type that supports parsing the
 //! response in JSON format defined by Azure CVM Provisioning Service (CPS).
 
+use crate::igvm_attest::parse_response_header;
+use crate::igvm_attest::Error as CommonError;
 use openhcl_attestation_protocol::igvm_attest::cps;
 use thiserror::Error;
 
@@ -16,8 +18,10 @@ pub(crate) enum WrappedKeyError {
         json_err: serde_json::Error,
         json_data: String,
     },
-    #[error("the response size is too small to parse")]
-    ResponseSizeTooSmall,
+    #[error("the response payload size is too small to parse")]
+    PayloadSizeTooSmall,
+    #[error("error in response header)")]
+    ParseHeader(#[source] CommonError),
 }
 
 /// Return value of the [`parse_response`].
@@ -33,20 +37,27 @@ pub struct IgvmWrappedKeyParsedResponse {
 /// Returns `Ok(IgvmWrappedKeyParsedResponse)` on successfully extracting a wrapped DiskEncryptionSettings
 /// key from `response`, otherwise returns an error.
 pub fn parse_response(response: &[u8]) -> Result<IgvmWrappedKeyParsedResponse, WrappedKeyError> {
+    use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestCommonResponseHeader;
+    use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestWrappedKeyResponseHeader;
+    use openhcl_attestation_protocol::igvm_attest::get::IGVM_ATTEST_RESPONSE_VERSION_1;
+
+    let header = parse_response_header(response).map_err(WrappedKeyError::ParseHeader)?;
+
+    // Extract payload as per header version
+    let header_size = match header.version {
+        IGVM_ATTEST_RESPONSE_VERSION_1 => size_of::<IgvmAttestCommonResponseHeader>(),
+        _ => size_of::<IgvmAttestWrappedKeyResponseHeader>(),
+    };
+    let payload = &response[header_size..header.data_size as usize];
+
+    // Minimum acceptable payload would look like {"ciphertext":"base64URL wrapped key"}
     const CIPHER_TEXT_KEY: &str = r#"{"ciphertext":""}"#;
     const MINIMUM_WRAPPED_KEY_SIZE: usize = 256;
     const MINIMUM_WRAPPED_KEY_BASE64_URL_SIZE: usize = MINIMUM_WRAPPED_KEY_SIZE / 3 * 4;
-    const HEADER_SIZE: usize = size_of::<
-        openhcl_attestation_protocol::igvm_attest::get::IgvmAttestWrappedKeyResponseHeader,
-    >();
-    const MINIMUM_RESPONSE_SIZE: usize =
-        CIPHER_TEXT_KEY.len() + MINIMUM_WRAPPED_KEY_BASE64_URL_SIZE + HEADER_SIZE;
-
-    if response.is_empty() || response.len() < MINIMUM_RESPONSE_SIZE {
-        Err(WrappedKeyError::ResponseSizeTooSmall)?
+    const MINIMUM_PAYLOAD_SIZE: usize = CIPHER_TEXT_KEY.len() + MINIMUM_WRAPPED_KEY_BASE64_URL_SIZE;
+    if payload.len() < MINIMUM_PAYLOAD_SIZE {
+        Err(WrappedKeyError::PayloadSizeTooSmall)?
     }
-
-    let payload = &response[HEADER_SIZE..];
     let payload = String::from_utf8_lossy(payload);
     let payload: cps::VmmdBlob = serde_json::from_str(&payload).map_err(|json_err| {
         WrappedKeyError::WrappedKeyResponsePayloadToJson {
@@ -77,8 +88,8 @@ pub fn parse_response(response: &[u8]) -> Result<IgvmWrappedKeyParsedResponse, W
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openhcl_attestation_protocol::igvm_attest::get::IgvmErrorInfo;
     use zerocopy::AsBytes;
-    use zerocopy::FromZeroes;
 
     const KEY_REFERENCE: &str = r#"{
     "key_info": {
@@ -158,6 +169,9 @@ mod tests {
     }
 
     fn mock_response() -> Vec<u8> {
+        use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestWrappedKeyResponseHeader;
+        use openhcl_attestation_protocol::igvm_attest::get::IGVM_ATTEST_RESPONSE_CURRENT_VERSION;
+
         const WRAPPED_KEY: [u8; 256] = [
             0x9d, 0x72, 0x81, 0xbc, 0x6d, 0x0c, 0xeb, 0x8f, 0x32, 0xb9, 0xc3, 0xd0, 0xd2, 0x58,
             0x89, 0x2f, 0x49, 0xb4, 0x40, 0xb1, 0x3d, 0xb1, 0x2f, 0x1e, 0x9c, 0xb5, 0x46, 0x4a,
@@ -201,7 +215,11 @@ mod tests {
         assert!(result.is_ok());
         let payload = result.unwrap();
 
-        let header = openhcl_attestation_protocol::igvm_attest::get::IgvmAttestWrappedKeyResponseHeader::new_zeroed();
+        let header = IgvmAttestWrappedKeyResponseHeader {
+            data_size: (payload.len() + size_of::<IgvmAttestWrappedKeyResponseHeader>()) as u32,
+            version: IGVM_ATTEST_RESPONSE_CURRENT_VERSION,
+            error_info: IgvmErrorInfo::default(),
+        };
         let response = [header.as_bytes(), payload.as_bytes()].concat();
 
         response

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -52,13 +52,6 @@ pub(crate) enum RequestVmgsEncryptionKeysError {
     ParseIgvmAttestKeyReleaseResponse(#[source] igvm_attest::key_release::KeyReleaseError),
     #[error("PKCS11 RSA AES key unwrap failed")]
     Pkcs11RsaAesKeyUnwrap(#[source] crypto::Pkcs11RsaAesKeyUnwrapError),
-    #[error("IgvmAttest request({request_type}) failed")]
-    IgvmAttest {
-        request_type: IgvmAttestRequestType,
-        error_code: u32,
-        http_status_code: u32,
-        retry_signal: bool,
-    },
 }
 
 /// The return values of [`make_igvm_attest_requests`].
@@ -180,55 +173,44 @@ pub async fn request_vmgs_encryption_keys(
                     "Failed to get VMGS key-encryption due to invalid key format"
                 )
             }
-            Err(e) => match e {
-                RequestVmgsEncryptionKeysError::IgvmAttest {
-                    request_type,
-                    error_code,
-                    http_status_code,
-                    retry_signal,
-                } if retry_signal && i < (max_retry - 1) => {
-                    tracing::error!(
-                        CVM_ALLOWED,
-                        igvm_request_type = request_type.0,
-                        igvm_error_code = error_code,
-                        igvm_http_status_code = http_status_code,
-                        error = &e as &dyn std::error::Error,
-                        "VMGS key-encryption failed due to igvm attest retryable error, will retry"
-                    )
-                }
-                RequestVmgsEncryptionKeysError::IgvmAttest {
-                    request_type,
-                    error_code,
-                    http_status_code,
-                    retry_signal: _,
-                } => {
-                    tracing::error!(
-                        CVM_ALLOWED,
-                        igvm_request_type = request_type.0,
-                        igvm_error_code = error_code,
-                        igvm_http_status_code = http_status_code,
-                        error = &e as &dyn std::error::Error,
-                        "VMGS key-encryption failed due to igvm attest error, will not retry"
-                    );
+            Err(
+                e @ RequestVmgsEncryptionKeysError::ParseIgvmAttestKeyReleaseResponse(
+                    igvm_attest::key_release::KeyReleaseError::IgvmAttestation {
+                        error_code,
+                        http_status_code,
+                        retry_signal,
+                    },
+                ),
+            ) => {
+                tracing::error!(
+                    CVM_ALLOWED,
+                    retry = i,
+                    igvm_error_code = error_code,
+                    igvm_http_status_code = http_status_code,
+                    retry_signal = retry_signal,
+                    error = &e as &dyn std::error::Error,
+                    "VMGS key-encryption failed due to igvm attest retryable error, will retry"
+                );
+                if !retry_signal || i == (max_retry - 1) {
                     Err(e)?
                 }
-                _ if i == (max_retry - 1) => {
-                    tracing::error!(
-                        CVM_ALLOWED,
-                        error = &e as &dyn std::error::Error,
-                        "VMGS key-encryption failed due to error, max number of attempts reached"
-                    );
-                    Err(e)?
-                }
-                _ => {
-                    tracing::error!(
-                        CVM_ALLOWED,
-                        retry = i,
-                        error = &e as &dyn std::error::Error,
-                        "VMGS key-encryption key request failed due to error",
-                    )
-                }
-            },
+            }
+            Err(e) if i == (max_retry - 1) => {
+                tracing::error!(
+                    CVM_ALLOWED,
+                    error = &e as &dyn std::error::Error,
+                    "VMGS key-encryption failed due to error, max number of attempts reached"
+                );
+                Err(e)?
+            }
+            Err(e) => {
+                tracing::error!(
+                    CVM_ALLOWED,
+                    retry = i,
+                    error = &e as &dyn std::error::Error,
+                    "VMGS key-encryption key request failed due to error",
+                )
+            }
         }
 
         // Stall on retries
@@ -350,23 +332,13 @@ async fn make_igvm_attest_requests(
             rsa_aes_wrapped_key: Some(rsa_aes_wrapped_key),
             wrapped_des_key,
         }),
-        Err(igvm_attest::key_release::KeyReleaseError::ResponseSizeTooSmall) => {
+        Err(igvm_attest::key_release::KeyReleaseError::PayloadSizeTooSmall) => {
             // The request does not succeed
             Ok(WrappedKeyVmgsEncryptionKeys {
                 rsa_aes_wrapped_key: None,
                 wrapped_des_key: None,
             })
         }
-        Err(igvm_attest::key_release::KeyReleaseError::IgvmAttestation {
-            error_code,
-            http_status_code,
-            retry_signal,
-        }) => Err(RequestVmgsEncryptionKeysError::IgvmAttest {
-            request_type: IgvmAttestRequestType::KEY_RELEASE_REQUEST,
-            error_code,
-            http_status_code,
-            retry_signal,
-        }),
         Err(e) => Err(RequestVmgsEncryptionKeysError::ParseIgvmAttestKeyReleaseResponse(e))?,
     }
 }

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -49,6 +49,7 @@ use mesh::rpc::Rpc;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestAkCertResponseHeader;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestHeader;
 use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestType;
+use openhcl_attestation_protocol::igvm_attest::get::IgvmErrorInfo;
 use openhcl_attestation_protocol::igvm_attest::get::AK_CERT_RESPONSE_HEADER_VERSION;
 use power_resources::PowerRequest;
 use power_resources::PowerRequestClient;
@@ -833,7 +834,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                 let header = IgvmAttestAkCertResponseHeader {
                     data_size: (data.len() + size_of::<IgvmAttestAkCertResponseHeader>()) as u32,
                     version: AK_CERT_RESPONSE_HEADER_VERSION,
-                    result_info: IgvmResultInfo::default(),
+                    error_info: IgvmErrorInfo::default(),
                 };
                 let payload = [header.as_bytes(), &data].concat();
 

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -833,6 +833,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                 let header = IgvmAttestAkCertResponseHeader {
                     data_size: (data.len() + size_of::<IgvmAttestAkCertResponseHeader>()) as u32,
                     version: AK_CERT_RESPONSE_HEADER_VERSION,
+                    result_info: IgvmResultInfo::default(),
                 };
                 let payload = [header.as_bytes(), &data].concat();
 


### PR DESCRIPTION
Add igvm V2 RPC request and response headers to propagate igvm attest error info
Interface design doc: https://microsoft-my.sharepoint.com/:w:/p/sewong/EV-0pMDOBnJMmavopIcywzUBw4zNT5rigszs8-Kl5xZUKA?e=2QNETF