### PR TITLE
Remove the global allow for deprecated_safe_2024, add an exclusion in mesh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -590,7 +590,6 @@ rust_2018_idioms = { level = "deny", priority = -2 }
 rust-2024-compatibility = { level = "warn", priority = -1 }
 edition_2024_expr_fragment_specifier = "allow"
 # TODO: Fix all of the below, https://github.com/microsoft/openvmm/issues/288
-deprecated-safe-2024 = "allow"
 tail-expr-drop-order = "allow"
 if-let-rescope = "allow"
 

--- a/support/mesh/mesh_process/src/lib.rs
+++ b/support/mesh/mesh_process/src/lib.rs
@@ -161,6 +161,7 @@ async fn node_from_environment() -> anyhow::Result<Option<NodeResult>> {
     // current edition), either this function and its callers need to become
     // `unsafe`, or we need to avoid using the environment to propagate the
     // invitation so that we can avoid this call.
+    #[expect(deprecated_safe_2024)]
     std::env::remove_var(INVITATION_ENV_NAME);
 
     let invitation: Invitation = mesh::payload::decode(


### PR DESCRIPTION
This will prevent any new uses of set/remove_env from coming into the codebase. This one case in mesh requires nontrivial work to remove. Tracked by #288.