### PR TITLE
fuzz_storvsp: remove last round of TODO: [use-arbitrary-input]

### DIFF
--- a/vm/devices/storage/scsi_defs/src/lib.rs
+++ b/vm/devices/storage/scsi_defs/src/lib.rs
@@ -18,6 +18,7 @@ type U64BE = zerocopy::byteorder::U64<zerocopy::byteorder::BigEndian>;
 
 open_enum! {
     #[derive(AsBytes, FromBytes, FromZeroes)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub enum ScsiOp: u8 {
         TEST_UNIT_READY = 0x00,
         REZERO_UNIT = 0x01,
@@ -233,7 +234,7 @@ pub const MEDIUM_NOT_PRESENT_TRAY_OPEN: u8 = 0x02;
 #[repr(C)]
 #[derive(AsBytes, FromBytes, FromZeroes)]
 pub struct CdbInquiry {
-    pub operation_code: u8, // 0x12 - SCSIOP_INQUIRY
+    pub operation_code: ScsiOp, // 0x12 - SCSIOP_INQUIRY
     pub flags: InquiryFlags,
     pub page_code: u8,
     pub allocation_length: U16BE,
@@ -995,7 +996,7 @@ pub struct Cdb10 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, AsBytes, FromBytes, FromZeroes)]
 pub struct Cdb6ReadWrite {
-    pub operation_code: u8, // 0x08, 0x0A - SCSIOP_READ, SCSIOP_WRITE
+    pub operation_code: ScsiOp, // 0x08, 0x0A - SCSIOP_READ, SCSIOP_WRITE
     pub logical_block: [u8; 3],
     pub transfer_blocks: u8,
     pub control: u8,
@@ -1025,6 +1026,7 @@ pub struct Cdb16 {
 
 #[bitfield(u8)]
 #[derive(AsBytes, FromBytes, FromZeroes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CdbFlags {
     pub relative_address: bool,
     #[bits(2)]
@@ -1037,6 +1039,7 @@ pub struct CdbFlags {
 
 #[bitfield(u8)]
 #[derive(AsBytes, FromBytes, FromZeroes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Cdb16Flags {
     #[bits(3)]
     pub reserved1: u8,

--- a/vm/devices/storage/storvsp/fuzz/fuzz_storvsp.rs
+++ b/vm/devices/storage/storvsp/fuzz/fuzz_storvsp.rs
@@ -11,6 +11,10 @@ use guestmem::ranges::PagedRange;
 use guestmem::GuestMemory;
 use pal_async::DefaultPool;
 use scsi_defs::Cdb10;
+use scsi_defs::Cdb12;
+use scsi_defs::Cdb16;
+use scsi_defs::Cdb6ReadWrite;
+use scsi_defs::CdbInquiry;
 use scsi_defs::ScsiOp;
 use std::pin::pin;
 use std::sync::Arc;
@@ -27,19 +31,135 @@ use vmbus_ring::OutgoingPacketType;
 use vmbus_ring::PAGE_SIZE;
 use xtask_fuzz::fuzz_target;
 use zerocopy::AsBytes;
+use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
+/// Various fuzzer actions for storvsp. At the most generic, we expect
+/// `SendRawPacket` to be the most basic primitive: this will send a vmbus
+/// packet that is a series of bytes. This, combined with `ReadCompletion`
+/// and `AttachDisk`/`DetachDisk` should be enough to exercise most of the
+/// storvsp code paths that we care about. That being said, we can also
+/// improve the efficiency of the search by making the packets more well
+/// formed in two ways:
+/// 1. `SendNiceReadWritePacket` will send a read or write packet, with
+///   a reasonable CDB, SRB, etc. This is likely to get to the common
+///   read / write paths.
+/// 2. `SendTargetScsiOp` will send an arbitrary SRB with the correct
+///   CDB length for some SCSI operations that are particularly handled
+///   in storvsp. For example, we should quickly see `REPORT LUNS` and
+///   `INQUIRY` scsi ops, where many hours of running without this special
+///   case didn't cover those paths.
 #[derive(Arbitrary)]
 enum StorvspFuzzAction {
-    SendReadWritePacket,
+    SendNiceReadWritePacket,
+    SendTargetScsiOp(TargetScsiOp),
     SendRawPacket(FuzzOutgoingPacketType),
     ReadCompletion,
+    AttachDisk(ScsiPath),
+    DetachDisk(ScsiPath),
 }
 
+/// What type of VMBUS packet to put in the ring;
+/// special case `GpaDirectPacket` because that needs
+/// different handling to reference GPAs.
 #[derive(Arbitrary)]
 enum FuzzOutgoingPacketType {
     AnyOutgoingPacket,
     GpaDirectPacket,
+}
+
+/// Key SCSI operations that storvsp would handle.
+#[derive(Arbitrary)]
+enum TargetScsiOp {
+    Inquiry,
+    ReportLuns,
+    ReadWrite6,
+    ReadWrite10,
+    ReadWrite12,
+    ReadWrite16,
+}
+
+/// Creates an SRB with a CDB that is reasonably well formed for
+/// the given `TargetScsiOp`.
+fn create_targeted_scsi_packet(
+    u: &mut Unstructured<'_>,
+    op: TargetScsiOp,
+) -> Result<protocol::ScsiRequest, arbitrary::Error> {
+    let mut scsi_req: protocol::ScsiRequest = u.arbitrary()?;
+
+    match op {
+        TargetScsiOp::Inquiry => {
+            let mut bytes = vec![0; size_of::<CdbInquiry>()];
+            u.fill_buffer(&mut bytes)?;
+
+            let cdb = CdbInquiry::mut_from(bytes.as_mut_slice())
+                .ok_or(arbitrary::Error::IncorrectFormat)?;
+
+            cdb.operation_code = ScsiOp::INQUIRY;
+
+            scsi_req.payload[0..(bytes.len())].copy_from_slice(bytes.as_slice());
+        }
+        TargetScsiOp::ReportLuns => {
+            let mut bytes = vec![0; size_of::<Cdb10>()];
+            u.fill_buffer(&mut bytes)?;
+
+            let cdb =
+                Cdb10::mut_from(bytes.as_mut_slice()).ok_or(arbitrary::Error::IncorrectFormat)?;
+            cdb.operation_code = ScsiOp::REPORT_LUNS;
+
+            scsi_req.payload[0..(bytes.len())].copy_from_slice(bytes.as_slice());
+        }
+        TargetScsiOp::ReadWrite6 => {
+            let mut bytes = vec![0; size_of::<Cdb6ReadWrite>()];
+            u.fill_buffer(&mut bytes)?;
+
+            let cdb = Cdb6ReadWrite::mut_from(bytes.as_mut_slice())
+                .ok_or(arbitrary::Error::IncorrectFormat)?;
+
+            cdb.operation_code = ScsiOp::READ;
+            cdb.transfer_blocks = (arbitrary_byte_len(u)? / 512) as u8;
+
+            scsi_req.payload[0..(bytes.len())].copy_from_slice(bytes.as_slice());
+        }
+        TargetScsiOp::ReadWrite10 => {
+            let mut bytes = vec![0; size_of::<Cdb10>()];
+            u.fill_buffer(&mut bytes)?;
+
+            let cdb =
+                Cdb10::mut_from(bytes.as_mut_slice()).ok_or(arbitrary::Error::IncorrectFormat)?;
+
+            cdb.operation_code = ScsiOp::READ;
+            cdb.transfer_blocks = ((arbitrary_byte_len(u)? / 512) as u16).into();
+
+            scsi_req.payload[0..(bytes.len())].copy_from_slice(bytes.as_slice());
+        }
+        TargetScsiOp::ReadWrite12 => {
+            let mut bytes = vec![0; size_of::<Cdb12>()];
+            u.fill_buffer(&mut bytes)?;
+
+            let cdb =
+                Cdb12::mut_from(bytes.as_mut_slice()).ok_or(arbitrary::Error::IncorrectFormat)?;
+
+            cdb.operation_code = ScsiOp::READ;
+            cdb.transfer_blocks = ((arbitrary_byte_len(u)? / 512) as u32).into();
+
+            scsi_req.payload[0..(bytes.len())].copy_from_slice(bytes.as_slice());
+        }
+        TargetScsiOp::ReadWrite16 => {
+            let mut bytes = vec![0; size_of::<Cdb16>()];
+            u.fill_buffer(&mut bytes)?;
+
+            let cdb =
+                Cdb16::mut_from(bytes.as_mut_slice()).ok_or(arbitrary::Error::IncorrectFormat)?;
+
+            cdb.operation_code = ScsiOp::READ;
+            cdb.transfer_blocks = ((arbitrary_byte_len(u)? / 512) as u32).into();
+
+            scsi_req.payload[0..(bytes.len())].copy_from_slice(bytes.as_slice());
+        }
+    };
+
+    Ok(scsi_req)
 }
 
 /// Return an arbitrary byte length that can be sent in a GPA direct
@@ -104,7 +224,6 @@ async fn send_arbitrary_readwrite_packet(
         status: protocol::NtStatus::SUCCESS,
     };
 
-    // TODO: read6, read12, read16, write6, write12, write16, etc. (READ is read10, WRITE is write10)
     let scsiop_choices = [ScsiOp::READ, ScsiOp::WRITE];
     let cdb = Cdb10 {
         operation_code: *(u.choose(&scsiop_choices)?),
@@ -120,7 +239,11 @@ async fn send_arbitrary_readwrite_packet(
         length: protocol::SCSI_REQUEST_LEN_V2 as u16,
         cdb_length: size_of::<Cdb10>() as u8,
         data_transfer_length: byte_len.try_into()?,
-        data_in: 1,
+        data_in: if cdb.operation_code == ScsiOp::READ {
+            1
+        } else {
+            0
+        },
         ..FromZeroes::new_zeroed()
     };
 
@@ -136,55 +259,132 @@ async fn send_arbitrary_readwrite_packet(
     .await
 }
 
+/// Sometimes, replace the completely valid packet with an arbitrary one.
+fn swizzle_packet(
+    u: &mut Unstructured<'_>,
+    packet: protocol::Packet,
+) -> Result<protocol::Packet, arbitrary::Error> {
+    if u.ratio(9, 10)? {
+        Ok(packet)
+    } else {
+        u.arbitrary()
+    }
+}
+
+/// Main fuzzing loop. Separate out into an async function so that the top-level
+/// `do_fuzz` routine can wait for either this to complete or for the test worker
+/// task to complete.
+///
+/// This function will run until the Unstructured is exhausted, but can get stuck
+/// if the ring is full or if the storvsp worker terminates because of some sort
+/// of guest -> host packet corruption.
 async fn do_fuzz_loop(
     u: &mut Unstructured<'_>,
     guest: &mut TestGuest,
+    controller: &ScsiController,
 ) -> Result<(), anyhow::Error> {
     if u.ratio(9, 10)? {
-        // TODO: [use-arbitrary-input] (e.g., munge the negotiation packets)
-        guest.perform_protocol_negotiation().await;
+        let negotiate_packet = swizzle_packet(
+            u,
+            protocol::Packet {
+                operation: protocol::Operation::BEGIN_INITIALIZATION,
+                flags: 0,
+                status: protocol::NtStatus::SUCCESS,
+            },
+        )?;
+        guest
+            .send_data_packet_sync(&[negotiate_packet.as_bytes()])
+            .await;
+        guest.queue.split().0.read().await?;
+
+        let version_packet = swizzle_packet(
+            u,
+            protocol::Packet {
+                operation: protocol::Operation::QUERY_PROTOCOL_VERSION,
+                flags: 0,
+                status: protocol::NtStatus::SUCCESS,
+            },
+        )?;
+        let version = if u.ratio(9, 10)? {
+            protocol::ProtocolVersion {
+                major_minor: protocol::VERSION_BLUE,
+                reserved: 0,
+            }
+        } else {
+            u.arbitrary()?
+        };
+        guest
+            .send_data_packet_sync(&[version_packet.as_bytes(), version.as_bytes()])
+            .await;
+        guest.queue.split().0.read().await?;
+
+        let properties_packet = swizzle_packet(
+            u,
+            protocol::Packet {
+                operation: protocol::Operation::QUERY_PROPERTIES,
+                flags: 0,
+                status: protocol::NtStatus::SUCCESS,
+            },
+        )?;
+        guest
+            .send_data_packet_sync(&[properties_packet.as_bytes()])
+            .await;
+        guest.queue.split().0.read().await?;
+
+        let negotiate_packet = swizzle_packet(
+            u,
+            protocol::Packet {
+                operation: protocol::Operation::END_INITIALIZATION,
+                flags: 0,
+                status: protocol::NtStatus::SUCCESS,
+            },
+        )?;
+        guest
+            .send_data_packet_sync(&[negotiate_packet.as_bytes()])
+            .await;
+        guest.queue.split().0.read().await?;
     }
 
     while !u.is_empty() {
         let action = u.arbitrary::<StorvspFuzzAction>()?;
         match action {
-            StorvspFuzzAction::SendReadWritePacket => {
+            StorvspFuzzAction::SendNiceReadWritePacket => {
                 send_arbitrary_readwrite_packet(u, guest).await?;
             }
-            StorvspFuzzAction::SendRawPacket(packet_type) => {
-                match packet_type {
-                    FuzzOutgoingPacketType::AnyOutgoingPacket => {
-                        let packet_types = [
-                            OutgoingPacketType::InBandNoCompletion,
-                            OutgoingPacketType::InBandWithCompletion,
-                            OutgoingPacketType::Completion,
-                        ];
-                        let payload = u.arbitrary::<protocol::Packet>()?;
-                        // TODO: [use-arbitrary-input] (send a byte blob of arbitrary length rather
-                        // than a fixed-size arbitrary packet)
-                        let packet = OutgoingPacket {
-                            transaction_id: u.arbitrary()?,
-                            packet_type: *u.choose(&packet_types)?,
-                            payload: &[payload.as_bytes()], // TODO: [use-arbitrary-input]
-                        };
+            StorvspFuzzAction::SendRawPacket(packet_type) => match packet_type {
+                FuzzOutgoingPacketType::AnyOutgoingPacket => {
+                    let packet_types = [
+                        OutgoingPacketType::InBandNoCompletion,
+                        OutgoingPacketType::InBandWithCompletion,
+                        OutgoingPacketType::Completion,
+                    ];
 
-                        guest.queue.split().1.write(packet).await?;
-                    }
-                    FuzzOutgoingPacketType::GpaDirectPacket => {
-                        let header = u.arbitrary::<protocol::Packet>()?;
-                        let scsi_req = u.arbitrary::<protocol::ScsiRequest>()?;
+                    let payload: Vec<Vec<u8>> = u.arbitrary()?;
+                    let payload_vec = payload.iter().map(|x| x.as_slice()).collect::<Vec<&[u8]>>();
+                    let payload_slice = payload_vec.as_slice();
 
-                        send_gpa_direct_packet(
-                            guest,
-                            &[header.as_bytes(), scsi_req.as_bytes()],
-                            u.arbitrary()?,
-                            arbitrary_byte_len(u)?,
-                            u.arbitrary()?,
-                        )
-                        .await?
-                    }
+                    let packet = OutgoingPacket {
+                        transaction_id: u.arbitrary()?,
+                        packet_type: *u.choose(&packet_types)?,
+                        payload: payload_slice,
+                    };
+
+                    guest.queue.split().1.write(packet).await?;
                 }
-            }
+                FuzzOutgoingPacketType::GpaDirectPacket => {
+                    let header = u.arbitrary::<protocol::Packet>()?;
+                    let scsi_req = u.arbitrary::<protocol::ScsiRequest>()?;
+
+                    send_gpa_direct_packet(
+                        guest,
+                        &[header.as_bytes(), scsi_req.as_bytes()],
+                        u.arbitrary()?,
+                        arbitrary_byte_len(u)?,
+                        u.arbitrary()?,
+                    )
+                    .await?
+                }
+            },
             StorvspFuzzAction::ReadCompletion => {
                 // Read completion(s) from the storvsp -> guest queue. This shouldn't
                 // evoke any specific storvsp behavior, but is important to eventually
@@ -193,6 +393,35 @@ async fn do_fuzz_loop(
                 // Ignore the result, since vmbus returns error if the queue is empty,
                 // but that's fine for the fuzzer ...
                 let _ = guest.queue.split().0.try_read();
+            }
+            StorvspFuzzAction::AttachDisk(path) => {
+                let disk_len_sectors = u.int_in_range(1..=8192)?; // up to 4mb in 512 byte sectors
+                let disk = scsidisk::SimpleScsiDisk::new(
+                    disklayer_ram::ram_disk(disk_len_sectors * 512, false).unwrap(),
+                    Default::default(),
+                );
+
+                let _ = controller.attach(path, ScsiControllerDisk::new(Arc::new(disk)));
+            }
+            StorvspFuzzAction::DetachDisk(path) => {
+                let _ = controller.remove(path);
+            }
+            StorvspFuzzAction::SendTargetScsiOp(op) => {
+                let packet = protocol::Packet {
+                    operation: protocol::Operation::EXECUTE_SRB,
+                    flags: 0,
+                    status: protocol::NtStatus::SUCCESS,
+                };
+
+                let scsi_req = create_targeted_scsi_packet(u, op)?;
+                send_gpa_direct_packet(
+                    guest,
+                    &[packet.as_bytes(), scsi_req.as_bytes()],
+                    u.arbitrary()?,
+                    arbitrary_byte_len(u)?,
+                    u.arbitrary()?,
+                )
+                .await?;
             }
         }
     }
@@ -206,20 +435,29 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> Result<(), anyhow::Error> {
         let guest_queue = Queue::new(guest_channel).unwrap();
 
         let test_guest_mem = GuestMemory::allocate(u.int_in_range(1..=256)? * PAGE_SIZE);
-        let controller = ScsiController::new();
-        let disk_len_sectors = u.int_in_range(1..=1048576)?; // up to 512mb in 512 byte sectors
-        let disk = scsidisk::SimpleScsiDisk::new(
-            disklayer_ram::ram_disk(disk_len_sectors * 512, false).unwrap(),
-            Default::default(),
-        );
-        controller.attach(u.arbitrary()?, ScsiControllerDisk::new(Arc::new(disk)))?;
 
+        let controller = Arc::new(ScsiController::new());
+
+        // Most of the time, start up with one attached disk.
+        if u.ratio(9, 10)? {
+            let disk_len_sectors = u.int_in_range(1..=262144)?; // up to 128mb in 512 byte sectors
+            let disk = scsidisk::SimpleScsiDisk::new(
+                disklayer_ram::ram_disk(disk_len_sectors * 512, false).unwrap(),
+                Default::default(),
+            );
+
+            controller.attach(u.arbitrary()?, ScsiControllerDisk::new(Arc::new(disk)))?;
+        }
+
+        // storvsp's worker will try to allocate a Slab with `io_queue_depth` entries
+        // of `ScsiRequestState`, each of which is essentially 2 x `u64`.
+        let io_queue_depth: Option<u32> = Some((u.arbitrary_len::<u64>()? / 2) as u32);
         let test_worker = TestWorker::start(
-            controller,
+            &controller,
             driver.clone(),
             test_guest_mem.clone(),
             host,
-            None,
+            io_queue_depth,
         );
 
         let mut guest = TestGuest {
@@ -227,7 +465,7 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> Result<(), anyhow::Error> {
             transaction_id: 0,
         };
 
-        let mut fuzz_loop = pin!(do_fuzz_loop(u, &mut guest).fuse());
+        let mut fuzz_loop = pin!(do_fuzz_loop(u, &mut guest, &controller).fuse());
         let mut teardown = pin!(test_worker.teardown_ignore().fuse());
 
         select! {

--- a/vm/devices/storage/storvsp/src/ioperf.rs
+++ b/vm/devices/storage/storvsp/src/ioperf.rs
@@ -29,7 +29,7 @@ impl PerfTester {
     pub async fn new(driver: impl SpawnDriver + Clone) -> Self {
         let io_queue_depth = None;
         let device = ram_disk(64 * 1024, true).unwrap();
-        let controller = ScsiController::new();
+        let controller = Arc::new(ScsiController::new());
         let disk =
             ScsiControllerDisk::new(Arc::new(SimpleScsiDisk::new(device, Default::default())));
         controller
@@ -54,7 +54,7 @@ impl PerfTester {
         let test_guest_mem = GuestMemory::allocate(16 * 1024);
 
         let worker = TestWorker::start(
-            controller,
+            &controller,
             driver,
             test_guest_mem.clone(),
             host,

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -1425,7 +1425,7 @@ impl StorageDevice {
             lun: 0,
         };
 
-        let controller = ScsiController::new();
+        let controller = Arc::new(ScsiController::new());
         controller.attach(path, disk).unwrap();
 
         // Construct the specific GUID that drivers in the guest expect for this
@@ -1760,7 +1760,7 @@ mod tests {
         let guest_queue = Queue::new(guest).unwrap();
 
         let test_guest_mem = GuestMemory::allocate(16384);
-        let controller = ScsiController::new();
+        let controller = Arc::new(ScsiController::new());
         let disk = scsidisk::SimpleScsiDisk::new(
             disklayer_ram::ram_disk(10 * 1024 * 1024, false).unwrap(),
             Default::default(),
@@ -1777,7 +1777,7 @@ mod tests {
             .unwrap();
 
         let test_worker = TestWorker::start(
-            controller.clone(),
+            &controller,
             driver.clone(),
             test_guest_mem.clone(),
             host,
@@ -1829,15 +1829,9 @@ mod tests {
         let guest_queue = Queue::new(guest).unwrap();
 
         let test_guest_mem = GuestMemory::allocate(1024);
-        let controller = ScsiController::new();
+        let controller = Arc::new(ScsiController::new());
 
-        let _worker = TestWorker::start(
-            controller.clone(),
-            driver.clone(),
-            test_guest_mem,
-            host,
-            None,
-        );
+        let _worker = TestWorker::start(&controller, driver.clone(), test_guest_mem, host, None);
 
         let mut guest = test_helpers::TestGuest {
             queue: guest_queue,
@@ -1900,15 +1894,9 @@ mod tests {
         let guest_queue = Queue::new(guest).unwrap();
 
         let test_guest_mem = GuestMemory::allocate(1024);
-        let controller = ScsiController::new();
+        let controller = Arc::new(ScsiController::new());
 
-        let _worker = TestWorker::start(
-            controller.clone(),
-            driver.clone(),
-            test_guest_mem,
-            host,
-            None,
-        );
+        let _worker = TestWorker::start(&controller, driver.clone(), test_guest_mem, host, None);
 
         let mut guest = test_helpers::TestGuest {
             queue: guest_queue,
@@ -1950,15 +1938,9 @@ mod tests {
         let guest_queue = Queue::new(guest).unwrap();
 
         let test_guest_mem = GuestMemory::allocate(1024);
-        let controller = ScsiController::new();
+        let controller = Arc::new(ScsiController::new());
 
-        let worker = TestWorker::start(
-            controller.clone(),
-            driver.clone(),
-            test_guest_mem,
-            host,
-            None,
-        );
+        let worker = TestWorker::start(&controller, driver.clone(), test_guest_mem, host, None);
 
         let mut guest = test_helpers::TestGuest {
             queue: guest_queue,
@@ -1990,15 +1972,9 @@ mod tests {
         let guest_queue = Queue::new(guest).unwrap();
 
         let test_guest_mem = GuestMemory::allocate(1024);
-        let controller = ScsiController::new();
+        let controller = Arc::new(ScsiController::new());
 
-        let _worker = TestWorker::start(
-            controller.clone(),
-            driver.clone(),
-            test_guest_mem,
-            host,
-            None,
-        );
+        let _worker = TestWorker::start(&controller, driver.clone(), test_guest_mem, host, None);
 
         let mut guest = test_helpers::TestGuest {
             queue: guest_queue,
@@ -2075,15 +2051,9 @@ mod tests {
         let guest_queue = Queue::new(guest).unwrap();
 
         let test_guest_mem = GuestMemory::allocate(1024);
-        let controller = ScsiController::new();
+        let controller = Arc::new(ScsiController::new());
 
-        let _worker = TestWorker::start(
-            controller.clone(),
-            driver.clone(),
-            test_guest_mem,
-            host,
-            None,
-        );
+        let _worker = TestWorker::start(&controller, driver.clone(), test_guest_mem, host, None);
 
         let mut guest = test_helpers::TestGuest {
             queue: guest_queue,
@@ -2117,10 +2087,10 @@ mod tests {
 
         let test_guest_mem = GuestMemory::allocate(16384);
         // create a controller with no disk yet.
-        let controller = ScsiController::new();
+        let controller = Arc::new(ScsiController::new());
 
         let test_worker = TestWorker::start(
-            controller.clone(),
+            &controller,
             driver.clone(),
             test_guest_mem.clone(),
             host,
@@ -2275,7 +2245,7 @@ mod tests {
     #[async_test]
     pub async fn test_async_disk(driver: DefaultDriver) {
         let device = disklayer_ram::ram_disk(64 * 1024, false).unwrap();
-        let controller = ScsiController::new();
+        let controller = Arc::new(ScsiController::new());
         let disk = ScsiControllerDisk::new(Arc::new(scsidisk::SimpleScsiDisk::new(
             device,
             Default::default(),
@@ -2300,13 +2270,7 @@ mod tests {
         };
 
         let test_guest_mem = GuestMemory::allocate(16384);
-        let worker = TestWorker::start(
-            controller.clone(),
-            &driver,
-            test_guest_mem.clone(),
-            host,
-            None,
-        );
+        let worker = TestWorker::start(&controller, &driver, test_guest_mem.clone(), host, None);
 
         let negotiate_packet = protocol::Packet {
             operation: protocol::Operation::BEGIN_INITIALIZATION,

--- a/vm/devices/storage/storvsp/src/protocol.rs
+++ b/vm/devices/storage/storvsp/src/protocol.rs
@@ -155,6 +155,7 @@ pub const STORAGE_CHANNEL_SUPPORTS_MULTI_CHANNEL: u32 = 0x1;
 
 #[repr(C)]
 #[derive(Copy, Clone, AsBytes, FromBytes, FromZeroes)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ProtocolVersion {
     // Major (MSB) and minor (LSB) version numbers.
     pub major_minor: u16,

--- a/vm/devices/storage/storvsp/src/test_helpers.rs
+++ b/vm/devices/storage/storvsp/src/test_helpers.rs
@@ -56,15 +56,17 @@ impl TestWorker {
     }
 
     pub fn start<T: ring::RingMem + 'static + Sync>(
-        controller: ScsiController,
+        controller: &ScsiController,
         spawner: impl Spawn,
         mem: GuestMemory,
         channel: RawAsyncChannel<T>,
         io_queue_depth: Option<u32>,
     ) -> Self {
+        let controller_state = controller.state.clone();
+
         let task = spawner.spawn("test", async move {
             let mut worker = Worker::new(
-                controller.state.clone(),
+                controller_state,
                 channel,
                 0,
                 mem,


### PR DESCRIPTION
Changes in storvsp fuzzer to increase code coverage in key areas and remove some `TODO: [use-arbitrary-input]`.