### PR TITLE
mana_driver: verify BAR0 size during startup

### DIFF
--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -352,7 +352,7 @@ impl<T: DeviceBacking> Vport<T> {
             .await
             .context("failed to create eq")?;
         Ok(BnicEq {
-            doorbell: DoorbellPage::new(self.inner.doorbell.clone(), self.inner.dev_data.db_id),
+            doorbell: DoorbellPage::new(self.inner.doorbell.clone(), self.inner.dev_data.db_id)?,
             mem,
             id,
             interrupt,
@@ -391,6 +391,7 @@ impl<T: DeviceBacking> Vport<T> {
         } else {
             GdmaQueueType::GDMA_RQ
         };
+        let doorbell = DoorbellPage::new(self.inner.doorbell.clone(), self.inner.dev_data.db_id)?;
         let resp = BnicDriver::new(&mut *gdma, self.inner.dev_id)
             .create_wq_obj(
                 arena,
@@ -408,7 +409,7 @@ impl<T: DeviceBacking> Vport<T> {
             .await?;
 
         Ok(BnicWq {
-            doorbell: DoorbellPage::new(self.inner.doorbell.clone(), self.inner.dev_data.db_id),
+            doorbell,
             wq_mem,
             cq_mem,
             wq_id: resp.wq_id,

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -21,6 +21,7 @@ use guestmem::GuestMemoryAccess;
 use inspect::Inspect;
 use inspect::InspectMut;
 use parking_lot::Mutex;
+use pci_core::chipset_device_ext::PciChipsetDeviceExt;
 use pci_core::msi::MsiControl;
 use pci_core::msi::MsiInterruptSet;
 use pci_core::msi::MsiInterruptTarget;
@@ -34,6 +35,7 @@ pub struct EmulatedDevice<T> {
     device: Arc<Mutex<T>>,
     controller: MsiController,
     shared_mem: DeviceSharedMemory,
+    bar0_len: usize,
 }
 
 impl<T: InspectMut> Inspect for EmulatedDevice<T> {
@@ -76,6 +78,9 @@ impl<T: PciConfigSpace + MmioIntercept> EmulatedDevice<T> {
         let controller = MsiController::new(msi_set.len());
         msi_set.connect(&controller);
 
+        let bars = device.probe_bar_masks();
+        let bar0_len = !(bars[0] & !0xf) as usize + 1;
+
         // Enable BAR0 at 0, BAR4 at X.
         device.pci_cfg_write(0x20, 0).unwrap();
         device.pci_cfg_write(0x24, 0x1).unwrap();
@@ -103,6 +108,7 @@ impl<T: PciConfigSpace + MmioIntercept> EmulatedDevice<T> {
             device: Arc::new(Mutex::new(device)),
             controller,
             shared_mem,
+            bar0_len,
         }
     }
 }
@@ -113,6 +119,7 @@ pub struct Mapping<T> {
     #[inspect(skip)]
     device: Arc<Mutex<T>>,
     addr: u64,
+    len: usize,
 }
 
 #[repr(C, align(4096))]
@@ -298,9 +305,13 @@ impl<T: 'static + Send + InspectMut + MmioIntercept> DeviceBacking for EmulatedD
     }
 
     fn map_bar(&mut self, n: u8) -> anyhow::Result<Self::Registers> {
+        if n != 0 {
+            anyhow::bail!("invalid bar {n}");
+        }
         Ok(Mapping {
             device: self.device.clone(),
             addr: (n as u64) << 32,
+            len: self.bar0_len,
         })
     }
 
@@ -326,6 +337,10 @@ impl<T: 'static + Send + InspectMut + MmioIntercept> DeviceBacking for EmulatedD
 }
 
 impl<T: MmioIntercept + Send> DeviceRegisterIo for Mapping<T> {
+    fn len(&self) -> usize {
+        self.len
+    }
+
     fn read_u32(&self, offset: usize) -> u32 {
         let mut n = [0; 4];
         self.device

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -50,6 +50,8 @@ pub trait DeviceBacking: 'static + Send + Inspect {
 
 /// Access to device registers.
 pub trait DeviceRegisterIo: Send + Sync {
+    /// Returns the length of the register space.
+    fn len(&self) -> usize;
     /// Reads a `u32` register.
     fn read_u32(&self, offset: usize) -> u32;
     /// Reads a `u64` register.

--- a/vm/devices/user_driver/src/vfio.rs
+++ b/vm/devices/user_driver/src/vfio.rs
@@ -148,6 +148,7 @@ impl VfioDevice {
         Ok(MappedRegionWithFallback {
             device: self.device.clone(),
             mapping,
+            len: info.size as usize,
             offset: info.offset,
             read_fallback: SharedCounter::new(),
             write_fallback: SharedCounter::new(),
@@ -167,6 +168,7 @@ pub struct MappedRegionWithFallback {
     #[inspect(skip)]
     mapping: vfio_sys::MappedRegion,
     offset: u64,
+    len: usize,
     read_fallback: SharedCounter,
     write_fallback: SharedCounter,
 }
@@ -333,6 +335,10 @@ fn set_irq_affinity(irq: u32, cpu: u32) -> std::io::Result<()> {
 }
 
 impl DeviceRegisterIo for vfio_sys::MappedRegion {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
     fn read_u32(&self, offset: usize) -> u32 {
         self.read_u32(offset)
     }
@@ -403,6 +409,10 @@ impl MappedRegionWithFallback {
 }
 
 impl DeviceRegisterIo for MappedRegionWithFallback {
+    fn len(&self) -> usize {
+        self.len
+    }
+
     fn read_u32(&self, offset: usize) -> u32 {
         self.read_from_mapping(offset).unwrap_or_else(|_| {
             let mut buf = [0u8; 4];


### PR DESCRIPTION
Make it easier to diagnose missized device BARs by validating the size and returning an error, rather than waiting for a BAR access method to panic.