### PR TITLE
disklayer_sqlite: add auto-cache resource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,6 +1370,7 @@ dependencies = [
  "disk_backend",
  "disk_backend_resources",
  "disk_layered",
+ "fs-err",
  "futures",
  "guestmem",
  "inspect",

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -639,7 +639,7 @@ pub enum DiskCliKind {
     },
     // autocache:[key]:<kind>
     AutoCacheSqlite {
-        key: String,
+        key: Option<String>,
         disk: Box<DiskCliKind>,
     },
     // prwrap:<kind>
@@ -723,7 +723,7 @@ impl FromStr for DiskCliKind {
                 "autocache" => {
                     let (key, kind) = arg.split_once(':').context("expected [key]:kind")?;
                     DiskCliKind::AutoCacheSqlite {
-                        key: key.to_string(),
+                        key: (!key.is_empty()).then(|| key.to_string()),
                         disk: Box::new(kind.parse()?),
                     }
                 }

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -639,6 +639,7 @@ pub enum DiskCliKind {
     },
     // autocache:[key]:<kind>
     AutoCacheSqlite {
+        cache_path: String,
         key: Option<String>,
         disk: Box<DiskCliKind>,
     },
@@ -722,7 +723,10 @@ impl FromStr for DiskCliKind {
                 }
                 "autocache" => {
                     let (key, kind) = arg.split_once(':').context("expected [key]:kind")?;
+                    let cache_path = std::env::var("OPENVMM_AUTO_CACHE_PATH")
+                        .context("must set cache path via OPENVMM_AUTO_CACHE_PATH")?;
                     DiskCliKind::AutoCacheSqlite {
+                        cache_path,
                         key: (!key.is_empty()).then(|| key.to_string()),
                         disk: Box::new(kind.parse()?),
                     }

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -637,6 +637,11 @@ pub enum DiskCliKind {
         create: bool,
         disk: Box<DiskCliKind>,
     },
+    // autocache:[key]:<kind>
+    AutoCacheSqlite {
+        key: String,
+        disk: Box<DiskCliKind>,
+    },
     // prwrap:<kind>
     PersistentReservationsWrapper(Box<DiskCliKind>),
     // file:<path>
@@ -713,6 +718,13 @@ impl FromStr for DiskCliKind {
                             create: false,
                             disk,
                         },
+                    }
+                }
+                "autocache" => {
+                    let (key, kind) = arg.split_once(':').context("expected [key]:kind")?;
+                    DiskCliKind::AutoCacheSqlite {
+                        key: key.to_string(),
+                        disk: Box::new(kind.parse()?),
                     }
                 }
                 "prwrap" => DiskCliKind::PersistentReservationsWrapper(Box::new(arg.parse()?)),

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1582,13 +1582,16 @@ fn disk_open_inner(
             }));
             disk_open_inner(disk, true, layers)?;
         }
-        DiskCliKind::AutoCacheSqlite { key, disk } => {
+        DiskCliKind::AutoCacheSqlite {
+            cache_path,
+            key,
+            disk,
+        } => {
             layers.push(LayerOrDisk::Layer(DiskLayerDescription {
                 read_cache: true,
                 write_through: false,
                 layer: SqliteAutoCacheDiskLayerHandle {
-                    cache_path: std::env::var("OPENVMM_AUTO_CACHE_PATH")
-                        .context("must set cache path environment variable")?,
+                    cache_path: cache_path.clone(),
                     cache_key: key.clone(),
                 }
                 .into_resource(),

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1598,11 +1598,7 @@ fn disk_open_inner(
                 layer: SqliteAutoCacheDiskLayerHandle {
                     cache_path: std::env::var("OPENVMM_AUTO_CACHE_PATH")
                         .context("must set cache path environment variable")?,
-                    cache_key: if key.is_empty() {
-                        None
-                    } else {
-                        Some(key.clone())
-                    },
+                    cache_key: key.clone(),
                 }
                 .into_resource(),
             }));

--- a/vm/devices/storage/disk_backend_resources/src/layer.rs
+++ b/vm/devices/storage/disk_backend_resources/src/layer.rs
@@ -56,3 +56,18 @@ pub struct SqliteDiskLayerHandle {
 impl ResourceId<DiskLayerHandleKind> for SqliteDiskLayerHandle {
     const ID: &'static str = "sqlite";
 }
+
+/// A handle for a disk layer that automatically selects a dbhd file to use as a
+/// cache for lower layers.
+#[derive(MeshPayload)]
+pub struct SqliteAutoCacheDiskLayerHandle {
+    /// Path to the root directory for the cache.
+    pub cache_path: String,
+    /// The key to use to select the cache file. If `None`, use the next layer's
+    /// disk ID.
+    pub cache_key: Option<String>,
+}
+
+impl ResourceId<DiskLayerHandleKind> for SqliteAutoCacheDiskLayerHandle {
+    const ID: &'static str = "sqlite-autocache";
+}

--- a/vm/devices/storage/disk_layered/src/lib.rs
+++ b/vm/devices/storage/disk_layered/src/lib.rs
@@ -435,7 +435,7 @@ impl<T: LayerAttach> DynLayerAttach for T {
                         physical_sector_size: backing.physical_sector_size(),
                         unmap_behavior: backing.unmap_behavior(),
                         optimal_unmap_sectors: backing.optimal_unmap_sectors(),
-                        read_only: backing.is_read_only(),
+                        read_only: backing.is_logically_read_only(),
                         can_read_cache,
                     },
                     backing: Box::new(backing),
@@ -519,7 +519,7 @@ pub trait LayerIo: 'static + Send + Sync + Inspect {
     ///
     /// If this returns true, the layer might still be writable via
     /// `write_no_overwrite`, used to populate the layer as a read cache.
-    fn is_read_only(&self) -> bool;
+    fn is_logically_read_only(&self) -> bool;
 
     /// Issues an asynchronous flush operation to the disk.
     fn sync_cache(&self) -> impl Future<Output = Result<(), DiskError>> + Send;
@@ -863,7 +863,7 @@ impl LayerIo for DiskAsLayer {
         self.0.is_fua_respected()
     }
 
-    fn is_read_only(&self) -> bool {
+    fn is_logically_read_only(&self) -> bool {
         self.0.is_read_only()
     }
 

--- a/vm/devices/storage/disk_layered/src/lib.rs
+++ b/vm/devices/storage/disk_layered/src/lib.rs
@@ -113,9 +113,6 @@ pub enum InvalidLayer {
     /// Read caching was requested but is not supported.
     #[error("read caching was requested but is not supported")]
     ReadCacheNotSupported,
-    /// Caching was requested but the layer is read only.
-    #[error("caching was requested but the layer is read only")]
-    ReadOnlyCache,
     /// The sector size is invalid.
     #[error("sector size {0} is invalid")]
     InvalidSectorSize(u32),
@@ -204,9 +201,6 @@ impl LayeredDisk {
                 // perform some layer validation prior to attaching subsequent layers
                 if read_cache && !layer_meta.can_read_cache {
                     return Err(layer_error(InvalidLayer::ReadCacheNotSupported));
-                }
-                if (read_cache || write_through) && layer_meta.read_only {
-                    return Err(layer_error(InvalidLayer::ReadOnlyCache));
                 }
                 if !layer_meta.sector_size.is_power_of_two() {
                     return Err(layer_error(InvalidLayer::InvalidSectorSize(
@@ -413,7 +407,7 @@ impl<T: LayerIo> DynLayerIo for T {
     }
 }
 
-trait DynLayerAttach: Send + Sync + Inspect {
+trait DynLayerAttach: Send + Sync {
     fn attach(
         self: Box<Self>,
         lower_layer_metadata: Option<DiskLayerMetadata>,
@@ -458,7 +452,7 @@ impl<T: LayerAttach> DynLayerAttach for T {
 /// which are pre-initialized with a fixed set of metadata) can simply implement
 /// `LayerIo` directly, and leverage the blanket-impl of `impl<T: LayerIo>
 /// LayerAttach for T` which simply returns `Self` during the state transition.
-pub trait LayerAttach: 'static + Send + Sync + Inspect {
+pub trait LayerAttach: 'static + Send + Sync {
     /// Error returned if on attach failure.
     type Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>;
     /// Object implementating [`LayerIo`] after being attached.
@@ -521,7 +515,10 @@ pub trait LayerIo: 'static + Send + Sync + Inspect {
     /// committed to disk.
     fn is_fua_respected(&self) -> bool;
 
-    /// Returns true if the layer is read only.
+    /// Returns true if the layer is logically read only.
+    ///
+    /// If this returns true, the layer might still be writable via
+    /// `write_no_overwrite`, used to populate the layer as a read cache.
     fn is_read_only(&self) -> bool;
 
     /// Issues an asynchronous flush operation to the disk.

--- a/vm/devices/storage/disk_layered/src/lib.rs
+++ b/vm/devices/storage/disk_layered/src/lib.rs
@@ -970,7 +970,7 @@ mod tests {
             false
         }
 
-        fn is_read_only(&self) -> bool {
+        fn is_logically_read_only(&self) -> bool {
             false
         }
 

--- a/vm/devices/storage/disk_layered/src/resolver.rs
+++ b/vm/devices/storage/disk_layered/src/resolver.rs
@@ -64,7 +64,7 @@ impl AsyncResolveResource<DiskHandleKind, LayeredDiskHandle> for LayeredDiskReso
             .into_iter()
             .enumerate()
             .map(|(i, desc)| {
-                let this_read_only = read_only && !desc.write_through && !desc.read_cache;
+                let this_read_only = read_only && !desc.read_cache;
                 if !desc.write_through {
                     read_only = true;
                 }

--- a/vm/devices/storage/disklayer_ram/src/lib.rs
+++ b/vm/devices/storage/disklayer_ram/src/lib.rs
@@ -214,7 +214,7 @@ impl LayerIo for RamDiskLayer {
         SECTOR_SIZE
     }
 
-    fn is_read_only(&self) -> bool {
+    fn is_logically_read_only(&self) -> bool {
         false
     }
 

--- a/vm/devices/storage/disklayer_ram/src/lib.rs
+++ b/vm/devices/storage/disklayer_ram/src/lib.rs
@@ -34,7 +34,6 @@ use thiserror::Error;
 
 /// A disk layer backed by RAM, which lazily infers its topology from the layer
 /// it is being stacked on-top of
-#[derive(Inspect)]
 #[non_exhaustive]
 pub struct LazyRamDiskLayer {}
 

--- a/vm/devices/storage/disklayer_sqlite/Cargo.toml
+++ b/vm/devices/storage/disklayer_sqlite/Cargo.toml
@@ -18,6 +18,7 @@ inspect = { workspace = true, features = ["filepath"] }
 
 anyhow.workspace = true
 blocking.workspace = true
+fs-err.workspace = true
 futures.workspace = true
 # NOTE: this crate does not rely on any particularly "modern" sqlite features at
 # the moment, and does not require the use of the "bundled" feature to build +

--- a/vm/devices/storage/disklayer_sqlite/src/auto_cache.rs
+++ b/vm/devices/storage/disklayer_sqlite/src/auto_cache.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! [`LayerAttach`] implementation for automatically opening a dbhd to use as a
+//! read cache, based on the identity of the next layer.
+
+use crate::FormatParams;
+use crate::SqliteDiskLayer;
+use anyhow::Context;
+use disk_layered::LayerAttach;
+use disk_layered::LayerIo;
+use fs_err::PathExt;
+use std::path::PathBuf;
+
+pub struct AutoCacheSqliteDiskLayer {
+    path: PathBuf,
+    key: Option<String>,
+    read_only: bool,
+}
+
+impl AutoCacheSqliteDiskLayer {
+    pub fn new(path: PathBuf, key: Option<String>, read_only: bool) -> Self {
+        Self {
+            path,
+            key,
+            read_only,
+        }
+    }
+}
+
+impl LayerAttach for AutoCacheSqliteDiskLayer {
+    type Error = anyhow::Error;
+    type Layer = SqliteDiskLayer;
+
+    async fn attach(
+        self,
+        lower_layer_metadata: Option<disk_layered::DiskLayerMetadata>,
+    ) -> Result<Self::Layer, Self::Error> {
+        let metadata = lower_layer_metadata.context("no layer to cache")?;
+        let key = self.key.map_or_else(
+            || {
+                let disk_id = metadata
+                    .disk_id
+                    .context("cannot cache without a disk ID to use as a key")?;
+                Ok(disk_id.map(|b| format!("{b:2x}")).join(""))
+            },
+            anyhow::Ok,
+        )?;
+        if key.is_empty() {
+            anyhow::bail!("empty cache key");
+        }
+        let path = self.path.join(key).join("cache.dbhd");
+        let format_dbhd = if path.fs_err_try_exists()? || self.read_only {
+            None
+        } else {
+            fs_err::create_dir_all(path.parent().unwrap())?;
+            Some(FormatParams {
+                logically_read_only: true,
+                len: metadata.sector_count * metadata.sector_size as u64,
+                sector_size: metadata.sector_size,
+            })
+        };
+        let layer = SqliteDiskLayer::new(&path, self.read_only, format_dbhd)?;
+        if layer.sector_count() != metadata.sector_count {
+            anyhow::bail!(
+                "cache layer has different sector count: {} vs {}",
+                layer.sector_count(),
+                metadata.sector_count
+            );
+        }
+        Ok(layer)
+    }
+}

--- a/vm/devices/storage/disklayer_sqlite/src/lib.rs
+++ b/vm/devices/storage/disklayer_sqlite/src/lib.rs
@@ -299,7 +299,7 @@ impl LayerIo for SqliteDiskLayer {
         self.meta.sector_size
     }
 
-    fn is_read_only(&self) -> bool {
+    fn is_logically_read_only(&self) -> bool {
         self.meta.logically_read_only
     }
 

--- a/vm/devices/storage/disklayer_sqlite/src/lib.rs
+++ b/vm/devices/storage/disklayer_sqlite/src/lib.rs
@@ -62,6 +62,7 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+mod auto_cache;
 pub mod resolver;
 
 use anyhow::Context;

--- a/vm/devices/storage/disklayer_sqlite/src/resolver.rs
+++ b/vm/devices/storage/disklayer_sqlite/src/resolver.rs
@@ -5,10 +5,17 @@
 
 use super::SqliteDiskLayer;
 use crate::FormatOnAttachSqliteDiskLayer;
+use crate::FormatParams;
+use anyhow::Context as _;
+use disk_backend_resources::layer::SqliteAutoCacheDiskLayerHandle;
 use disk_backend_resources::layer::SqliteDiskLayerFormatParams;
 use disk_backend_resources::layer::SqliteDiskLayerHandle;
 use disk_layered::resolve::ResolveDiskLayerParameters;
 use disk_layered::resolve::ResolvedDiskLayer;
+use disk_layered::LayerAttach;
+use disk_layered::LayerIo;
+use fs_err::PathExt;
+use std::path::PathBuf;
 use vm_resource::declare_static_resolver;
 use vm_resource::kind::DiskLayerHandleKind;
 use vm_resource::ResolveResource;
@@ -18,7 +25,8 @@ pub struct SqliteDiskLayerResolver;
 
 declare_static_resolver!(
     SqliteDiskLayerResolver,
-    (DiskLayerHandleKind, SqliteDiskLayerHandle)
+    (DiskLayerHandleKind, SqliteDiskLayerHandle),
+    (DiskLayerHandleKind, SqliteAutoCacheDiskLayerHandle)
 );
 
 impl ResolveResource<DiskLayerHandleKind, SqliteDiskLayerHandle> for SqliteDiskLayerResolver {
@@ -41,17 +49,91 @@ impl ResolveResource<DiskLayerHandleKind, SqliteDiskLayerHandle> for SqliteDiskL
         }) = format_dbhd
         {
             ResolvedDiskLayer::new(FormatOnAttachSqliteDiskLayer::new(
-                dbhd_path,
+                dbhd_path.into(),
                 input.read_only,
                 crate::IncompleteFormatParams {
                     logically_read_only,
                     len,
                 },
-            )?)
+            ))
         } else {
-            ResolvedDiskLayer::new(SqliteDiskLayer::new(dbhd_path, input.read_only, None)?)
+            ResolvedDiskLayer::new(SqliteDiskLayer::new(
+                dbhd_path.as_ref(),
+                input.read_only,
+                None,
+            )?)
         };
 
+        Ok(layer)
+    }
+}
+
+impl ResolveResource<DiskLayerHandleKind, SqliteAutoCacheDiskLayerHandle>
+    for SqliteDiskLayerResolver
+{
+    type Output = ResolvedDiskLayer;
+    type Error = anyhow::Error;
+
+    fn resolve(
+        &self,
+        rsrc: SqliteAutoCacheDiskLayerHandle,
+        input: ResolveDiskLayerParameters<'_>,
+    ) -> Result<Self::Output, Self::Error> {
+        let layer = ResolvedDiskLayer::new(AutoCacheSqliteDiskLayer {
+            path: rsrc.cache_path.into(),
+            key: rsrc.cache_key,
+            read_only: input.read_only,
+        });
+        Ok(layer)
+    }
+}
+
+struct AutoCacheSqliteDiskLayer {
+    path: PathBuf,
+    key: Option<String>,
+    read_only: bool,
+}
+
+impl LayerAttach for AutoCacheSqliteDiskLayer {
+    type Error = anyhow::Error;
+    type Layer = SqliteDiskLayer;
+
+    async fn attach(
+        self,
+        lower_layer_metadata: Option<disk_layered::DiskLayerMetadata>,
+    ) -> Result<Self::Layer, Self::Error> {
+        let metadata = lower_layer_metadata.context("no layer to cache")?;
+        let key = self.key.map_or_else(
+            || {
+                let disk_id = metadata
+                    .disk_id
+                    .context("cannot cache without a disk ID to use as a key")?;
+                Ok(disk_id.map(|b| format!("{b:2x}")).join(""))
+            },
+            anyhow::Ok,
+        )?;
+        if key.is_empty() {
+            anyhow::bail!("empty cache key");
+        }
+        let path = self.path.join(key).join("cache.dbhd");
+        let format_dbhd = if path.fs_err_try_exists()? || self.read_only {
+            None
+        } else {
+            fs_err::create_dir_all(path.parent().unwrap())?;
+            Some(FormatParams {
+                logically_read_only: true,
+                len: metadata.sector_count * metadata.sector_size as u64,
+                sector_size: metadata.sector_size,
+            })
+        };
+        let layer = SqliteDiskLayer::new(&path, self.read_only, format_dbhd)?;
+        if layer.sector_count() != metadata.sector_count {
+            anyhow::bail!(
+                "cache layer has different sector count: {} vs {}",
+                layer.sector_count(),
+                metadata.sector_count
+            );
+        }
         Ok(layer)
     }
 }

--- a/vm/devices/storage/disklayer_sqlite/src/resolver.rs
+++ b/vm/devices/storage/disklayer_sqlite/src/resolver.rs
@@ -4,18 +4,13 @@
 //! Resource resolver for sqlite-backed disk layers.
 
 use super::SqliteDiskLayer;
+use crate::auto_cache::AutoCacheSqliteDiskLayer;
 use crate::FormatOnAttachSqliteDiskLayer;
-use crate::FormatParams;
-use anyhow::Context as _;
 use disk_backend_resources::layer::SqliteAutoCacheDiskLayerHandle;
 use disk_backend_resources::layer::SqliteDiskLayerFormatParams;
 use disk_backend_resources::layer::SqliteDiskLayerHandle;
 use disk_layered::resolve::ResolveDiskLayerParameters;
 use disk_layered::resolve::ResolvedDiskLayer;
-use disk_layered::LayerAttach;
-use disk_layered::LayerIo;
-use fs_err::PathExt;
-use std::path::PathBuf;
 use vm_resource::declare_static_resolver;
 use vm_resource::kind::DiskLayerHandleKind;
 use vm_resource::ResolveResource;
@@ -79,61 +74,10 @@ impl ResolveResource<DiskLayerHandleKind, SqliteAutoCacheDiskLayerHandle>
         rsrc: SqliteAutoCacheDiskLayerHandle,
         input: ResolveDiskLayerParameters<'_>,
     ) -> Result<Self::Output, Self::Error> {
-        let layer = ResolvedDiskLayer::new(AutoCacheSqliteDiskLayer {
-            path: rsrc.cache_path.into(),
-            key: rsrc.cache_key,
-            read_only: input.read_only,
-        });
-        Ok(layer)
-    }
-}
-
-struct AutoCacheSqliteDiskLayer {
-    path: PathBuf,
-    key: Option<String>,
-    read_only: bool,
-}
-
-impl LayerAttach for AutoCacheSqliteDiskLayer {
-    type Error = anyhow::Error;
-    type Layer = SqliteDiskLayer;
-
-    async fn attach(
-        self,
-        lower_layer_metadata: Option<disk_layered::DiskLayerMetadata>,
-    ) -> Result<Self::Layer, Self::Error> {
-        let metadata = lower_layer_metadata.context("no layer to cache")?;
-        let key = self.key.map_or_else(
-            || {
-                let disk_id = metadata
-                    .disk_id
-                    .context("cannot cache without a disk ID to use as a key")?;
-                Ok(disk_id.map(|b| format!("{b:2x}")).join(""))
-            },
-            anyhow::Ok,
-        )?;
-        if key.is_empty() {
-            anyhow::bail!("empty cache key");
-        }
-        let path = self.path.join(key).join("cache.dbhd");
-        let format_dbhd = if path.fs_err_try_exists()? || self.read_only {
-            None
-        } else {
-            fs_err::create_dir_all(path.parent().unwrap())?;
-            Some(FormatParams {
-                logically_read_only: true,
-                len: metadata.sector_count * metadata.sector_size as u64,
-                sector_size: metadata.sector_size,
-            })
-        };
-        let layer = SqliteDiskLayer::new(&path, self.read_only, format_dbhd)?;
-        if layer.sector_count() != metadata.sector_count {
-            anyhow::bail!(
-                "cache layer has different sector count: {} vs {}",
-                layer.sector_count(),
-                metadata.sector_count
-            );
-        }
-        Ok(layer)
+        Ok(ResolvedDiskLayer::new(AutoCacheSqliteDiskLayer::new(
+            rsrc.cache_path.into(),
+            rsrc.cache_key,
+            input.read_only,
+        )))
     }
 }


### PR DESCRIPTION
Add a new sqlite disk type that chooses a cache dbhd file based on the next layer's disk ID (or an optional key). This makes it easy to use a dbhd file as a cache over an HTTP-backed blob.

Also fix a few related issues with `LayeredDisk`, and make `openvmm_entry` better at constructing layered disks.

Note that `LayeredDisk` doesn't actually populate the read cache yet. That will be a separate change.

Example usage:

```bash
export OPENVMM_AUTO_CACHE_PATH=$HOME/.cache/openvmm/dbhd
openvmm --disk memdiff:autocache::blob:vhd1:https://url/to/my/vhd
```