### PR TITLE
virt_mshv_vtl: Added debug exception intercept handler for TDX.

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -228,6 +228,7 @@ struct UhPartitionInner {
     no_sidecar_hotplug: AtomicBool,
     use_mmio_hypercalls: bool,
     backing_shared: BackingShared,
+    intercept_debug_exceptions: bool,
     #[cfg(guest_arch = "x86_64")]
     // N.B For now, only one device vector table i.e. for VTL0 only
     #[inspect(with = "|x| inspect::iter_by_index(x.read().into_inner().map(inspect::AsHex))")]
@@ -1399,13 +1400,15 @@ impl<'a> UhProtoPartition<'a> {
 
             cfg_if::cfg_if! {
                 if #[cfg(guest_arch = "x86_64")] {
-                    let debug_exception_vector = 0x1;
-                    hcl.register_intercept(
-                        HvInterceptType::HvInterceptTypeException,
-                        HV_INTERCEPT_ACCESS_MASK_EXECUTE,
-                        HvInterceptParameters::new_exception(debug_exception_vector),
-                    )
-                    .map_err(|err| Error::InstallIntercept(HvInterceptType::HvInterceptTypeException, err))?;
+                    if isolation != IsolationType::Tdx {
+                        let debug_exception_vector = 0x1;
+                        hcl.register_intercept(
+                            HvInterceptType::HvInterceptTypeException,
+                            HV_INTERCEPT_ACCESS_MASK_EXECUTE,
+                            HvInterceptParameters::new_exception(debug_exception_vector),
+                        )
+                        .map_err(|err| Error::InstallIntercept(HvInterceptType::HvInterceptTypeException, err))?;
+                    }
                 } else {
                     return Err(Error::InvalidDebugConfiguration);
                 }
@@ -1656,6 +1659,7 @@ impl<'a> UhProtoPartition<'a> {
             backing_shared: BackingShared::new(isolation, BackingSharedParams { cvm_state })?,
             #[cfg(guest_arch = "x86_64")]
             device_vector_table: RwLock::new(IrrBitmap::new(Default::default())),
+            intercept_debug_exceptions: params.intercept_debug_exceptions,
         });
 
         if cfg!(guest_arch = "x86_64") {

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1389,10 +1389,10 @@ impl<'a> UhProtoPartition<'a> {
         let is_hardware_isolated = isolation.is_hardware_isolated();
 
         // Intercept Debug Exceptions
-        // TODO TDX: This currently works on TDX because all Underhill TDs today
-        // have the debug policy bit set, allowing the hypervisor to install the
-        // intercept on behalf of the guest. In the future, Underhill should
-        // register for these intercepts itself.
+        // On TDX because all OpenHCL TDs today have the debug policy bit set,
+        // OpenHCL registers for the intercepts itself.
+        // However, on non-TDX platforms hypervisor installs the
+        // intercept on behalf of the guest.
         if params.intercept_debug_exceptions {
             if !cfg!(feature = "gdb") {
                 return Err(Error::InvalidDebugConfiguration);

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -473,6 +473,7 @@ pub struct ExitStats {
     pub hlt: Counter,
     pub pause: Counter,
     pub needs_interrupt_reinject: Counter,
+    pub exception: Counter,
 }
 
 /// The number of shared pages required per cpu.
@@ -703,6 +704,25 @@ impl BackingPrivate for TdxBacked {
             .untrusted_synic
             .as_ref()
             .map(|synic| synic.add_vp(params.vp_info.base.vp_index));
+
+        // Set the exception bitmap for VTL0.
+        if params.partition.intercept_debug_exceptions {
+            if cfg!(feature = "gdb") {
+                let initial_exception_bitmap = params
+                    .runner
+                    .read_vmcs32(GuestVtl::Vtl0, VmcsField::VMX_VMCS_EXCEPTION_BITMAP);
+
+                let exception_bitmap =
+                    initial_exception_bitmap | (1 << x86defs::Exception::DEBUG.0);
+
+                params.runner.write_vmcs32(
+                    GuestVtl::Vtl0,
+                    VmcsField::VMX_VMCS_EXCEPTION_BITMAP,
+                    !0,
+                    exception_bitmap,
+                );
+            }
+        }
 
         Ok(Self {
             vtls: VtlArray::from_fn(|vtl| TdxVtl {
@@ -1869,6 +1889,14 @@ impl UhProcessor<'_, TdxBacked> {
                             .with_interruption_type(INTERRUPT_TYPE_HARDWARE_EXCEPTION);
                 }
                 &mut self.backing.vtls[intercepted_vtl].exit_stats.tdcall
+            }
+            VmxExit::EXCEPTION => {
+                tracing::info!(
+                    "Caught Exception: {:?}",
+                    exit_info._exit_interruption_info()
+                );
+                breakpoint_debug_exception = true;
+                &mut self.backing.vtls[intercepted_vtl].exit_stats.exception
             }
             VmxExit::TRIPLE_FAULT => {
                 return Err(VpHaltReason::TripleFault {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -721,6 +721,8 @@ impl BackingPrivate for TdxBacked {
                     !0,
                     exception_bitmap,
                 );
+            } else {
+                return Err(super::Error::InvalidDebugConfiguration);
             }
         }
 
@@ -1891,7 +1893,7 @@ impl UhProcessor<'_, TdxBacked> {
                 &mut self.backing.vtls[intercepted_vtl].exit_stats.tdcall
             }
             VmxExit::EXCEPTION => {
-                tracing::info!(
+                tracing::trace!(
                     "Caught Exception: {:?}",
                     exit_info._exit_interruption_info()
                 );


### PR DESCRIPTION
Registering the intercept handler with OHCL instead of allowing the hypervisor to register the handler for the guest. Addresses issue #558.