### PR TITLE
Disable hardware debug for TDX VMs in 2411

### DIFF
--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -247,7 +247,6 @@ impl IgvmLoaderRegister for X86Register {
                 if u64::from(policy) != 0 {
                     // NOTE: In 2411 branch, disable host debugging independent
                     // of enable_debug to enable PMK release for public preview.
-
                     let no_debug_policy = policy.with_debug_allowed(0);
 
                     init_headers.push(IgvmInitializationHeader::GuestPolicy {

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -245,8 +245,13 @@ impl IgvmLoaderRegister for X86Register {
 
                 let mut init_headers = Vec::new();
                 if u64::from(policy) != 0 {
+                    // NOTE: In 2411 branch, disable host debugging independent
+                    // of enable_debug to enable PMK release for public preview.
+
+                    let no_debug_policy = policy.with_debug_allowed(0);
+
                     init_headers.push(IgvmInitializationHeader::GuestPolicy {
-                        policy: policy.into(),
+                        policy: no_debug_policy.into(),
                         compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
                     });
                 }


### PR DESCRIPTION
In 2411 branch, disable host debugging independent of enable_debug to enable PMK release for public preview.