### PR TITLE
Add a new boolean cxl_memory_enabled to the platform config json.

### DIFF
--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -604,6 +604,8 @@ pub fn write_uefi_config(
             flags.set_enable_imc_when_isolated(platform_config.general.imc_enabled);
         }
 
+        flags.set_cxl_memory_enabled(platform_config.general.cxl_memory_enabled);
+
         // Some settings do not depend on host config
 
         // All OpenHCL vTPMs must opt-in to these settings

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2947,6 +2947,7 @@ fn validate_isolated_configuration(dps: &DevicePlatformSettings) -> Result<(), a
         nvdimm_count: _,
         watchdog_enabled: _,
         vtl2_settings: _,
+        cxl_memory_enabled: _,
     } = &dps.general;
 
     if *hibernation_enabled {

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -131,6 +131,8 @@ pub struct HclDevicePlatformSettingsV2Static {
     pub always_relay_host_mmio: bool,
     #[serde(default)]
     pub imc_enabled: bool,
+    #[serde(default)]
+    pub cxl_memory_enabled: bool,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -1201,6 +1201,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     watchdog_enabled: false,
                     always_relay_host_mmio: false,
                     imc_enabled: false,
+                    cxl_memory_enabled: false,
                 },
                 dynamic: get_protocol::dps_json::HclDevicePlatformSettingsV2Dynamic {
                     is_servicing_scenario: state.save_restore_buf.is_some(),

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -114,6 +114,7 @@ pub mod platform_settings {
         pub watchdog_enabled: bool,
         pub firmware_mode_is_pcat: bool,
         pub imc_enabled: bool,
+        pub cxl_memory_enabled: bool,
     }
 
     #[derive(Copy, Clone, Debug, Inspect)]

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -333,6 +333,7 @@ impl GuestEmulationTransportClient {
                 is_servicing_scenario: json.v2.dynamic.is_servicing_scenario,
                 firmware_mode_is_pcat: json.v2.r#static.firmware_mode_is_pcat,
                 imc_enabled: json.v2.r#static.imc_enabled,
+                cxl_memory_enabled: json.v2.r#static.cxl_memory_enabled,
             },
         })
     }


### PR DESCRIPTION
Adds a new boolean cxl_memory_enabled that gets passed to mu_msvm via config flags and indicates that the CXL root device ACPI0017 should be exposed in the DSDT ACPI table.