### PR TITLE
openhcl/tdx: shrink minimum release memory size to 64 MB

### DIFF
--- a/vm/loader/manifests/openhcl-x64-cvm-release.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-release.json
@@ -33,7 +33,7 @@
             "image": {
                 "openhcl": {
                     "command_line": "",
-                    "memory_page_count": 32768,
+                    "memory_page_count": 16384,
                     "memory_page_base": 32768,
                     "uefi": true
                 }


### PR DESCRIPTION
Shrink the minimum memory required to 64 MB, which matches non-confidential builds. 

Leave VBS and SNP alone for now. 