### PR TITLE
hypestv: fix kmsg and serial failure paths

### DIFF
--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -237,7 +237,11 @@ impl Vm {
                     )),
                 };
                 if let Some(target) = target {
-                    if task.as_ref().is_some_and(|task| task.task.is_finished()) {
+                    if self
+                        .pv_kmsg
+                        .as_ref()
+                        .is_some_and(|task| task.task.is_finished())
+                    {
                         self.pv_kmsg = None;
                     }
                     if let Some(task) = &mut self.pv_kmsg {

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -398,7 +398,6 @@ impl VmInner {
                 }
 
                 writeln!(self.printer.out(), "com{port} disconnected").ok();
-                current_serial = None;
                 Ok(())
             };
 
@@ -406,7 +405,10 @@ impl VmInner {
                 .race()
                 .await;
             match event {
-                Event::TaskDone(r) => r?,
+                Event::TaskDone(r) => {
+                    r?;
+                    current_serial = None;
+                }
                 Event::Request(Some(y)) => match y {
                     IoRequest::NewTarget(new_target) => {
                         target = new_target;

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -184,6 +184,9 @@ impl Vm {
                     )),
                 };
                 if let Some(target) = target {
+                    if task.as_ref().is_some_and(|task| task.task.is_finished()) {
+                        *task = None;
+                    }
                     if let Some(task) = task {
                         task.mode = mode;
                         task.req.send(IoRequest::NewTarget(target));
@@ -192,7 +195,7 @@ impl Vm {
                         let inner = self.inner.clone();
                         let t = self.inner.driver.spawn("serial", async move {
                             if let Err(err) = inner.handle_serial(recv, target, port).await {
-                                writeln!(inner.printer.out(), "COM{port} failed: {:#}", err).ok();
+                                writeln!(inner.printer.out(), "com{port} failed: {:#}", err).ok();
                             }
                         });
                         *task = Some(SerialTask { task: t, mode, req });
@@ -234,6 +237,9 @@ impl Vm {
                     )),
                 };
                 if let Some(target) = target {
+                    if task.as_ref().is_some_and(|task| task.task.is_finished()) {
+                        self.pv_kmsg = None;
+                    }
                     if let Some(task) = &mut self.pv_kmsg {
                         task.mode = mode;
                         task.req.send(IoRequest::NewTarget(target));
@@ -468,15 +474,22 @@ impl VmInner {
                                 }
                             }
                         }
+                        Err(err) if err.kind() == std::io::ErrorKind::ConnectionReset => {
+                            break;
+                        }
                         Err(err) => {
-                            eprintln!("kmsg failure: {:#}", anyhow::Error::from(err));
+                            writeln!(
+                                self.printer.out(),
+                                "kmsg failure: {:#}",
+                                anyhow::Error::from(err)
+                            )
+                            .ok();
                             return Ok(());
                         }
                     }
                 }
 
                 writeln!(self.printer.out(), "kmsg disconnected").ok();
-                current = None;
                 Ok(())
             };
 
@@ -484,7 +497,10 @@ impl VmInner {
                 .race()
                 .await;
             match event {
-                Event::TaskDone(r) => r?,
+                Event::TaskDone(r) => {
+                    current = None;
+                    r?;
+                }
                 Event::Request(Some(y)) => match y {
                     IoRequest::NewTarget(new_target) => {
                         target = new_target;


### PR DESCRIPTION
For kmsg, reconnect after a failure, and silently ignore connection reset.

For both serial and kmsg, respawn the underlying task during a configuration change if the task has failed.

This fixes some issues where serial/kmsg connections get into bad states across VM restarts.