### PR TITLE
pal_async: handle ERROR_PIPE_NOT_CONNECTED as EOF

### DIFF
--- a/support/pal/pal_async/src/windows/pipe.rs
+++ b/support/pal/pal_async/src/windows/pipe.rs
@@ -215,8 +215,27 @@ impl AsyncRead for PolledPipe {
                     }
                     break n;
                 }
-                Err(err) if err.raw_os_error() == Some(ERROR_BROKEN_PIPE as i32) => {
-                    // EOF.
+                Err(err)
+                    if matches!(
+                        err.raw_os_error().map(|v| v as u32),
+                        Some(ERROR_BROKEN_PIPE | ERROR_PIPE_NOT_CONNECTED)
+                    ) =>
+                {
+                    // ERROR_BROKEN_PIPE is returned when the handle is closed.
+                    // ERROR_PIPE_NOT_CONNECTED is returned when the server
+                    // explicltly calls DisconnectNamedPipe. Either way, the
+                    // pipe is closed, so treat it as EOF.
+                    //
+                    // Note that in either case there may have been data loss,
+                    // since Windows named pipes drop all queued data when one
+                    // endpoint closes the pipe. It's not possible to detect
+                    // this, so there is no way to distinguish between clean and
+                    // unclean close.
+                    //
+                    // (Well, there is a trick, which is to put the pipe into
+                    // message mode and send a zero-length message to the other
+                    // end before closing. That operating mode not currently
+                    // supported by this crate.)
                     break 0;
                 }
                 Err(err) if err.raw_os_error() == Some(ERROR_NO_DATA as i32) => {


### PR DESCRIPTION
In Windows `PolledPipe`, treat `ERROR_PIPE_NOT_CONNECTED` the same as `ERROR_BROKEN_PIPE` on reads, and return EOF. This error code is returned if the server forces the pipe closed via `DisconnectedNamedPipe`, without closing its handle. Hyper-V does this for serial port pipes.

This fixes `hypestv`'s serial handling across VM reboots.