### PR TITLE
CI: Update mirror refresh script to update submodule in new staging branch

### DIFF
--- a/.github/scripts/refresh_mirror/refresh-mirror.py
+++ b/.github/scripts/refresh_mirror/refresh-mirror.py
@@ -16,7 +16,7 @@ def main(pipeline_id: str, token: str, organization: str, project: str, debug: b
 
         build = {
                     'definition': {'id': pipeline_id},
-                    'templateParameters': {'branchToMirror': 'release/2411', 'branchToUpdateSubmodule': 'release/1.5.2411', 'updateSubmodule': 'true'},
+                    'templateParameters': {'branchToMirror': 'release/2411', 'branchToUpdateSubmodule': 'staging/1.5.2411', 'updateSubmodule': 'true'},
                 }
         build = client.queue_build(build, project=project)
         print(f'Scheduled build: {build.id}. Url: {organization}/{project}/_build/results?buildId={build.id}&view=results', file=sys.stderr)


### PR DESCRIPTION
This change updates the script that invokes the mirror refresh pipeline to use the new staging branch for the upcoming 2411 OpenHCL release. This branch will be used to validate 2411 payload before being pulled into the release branch.