### PR TITLE
virt_mshv_vtl: Scope startvp handling to CVMs

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -655,6 +655,7 @@ impl WakeReason {
     // Convenient constants.
     const EXTINT: Self = Self::new().with_extint(true);
     const MESSAGE_QUEUES: Self = Self::new().with_message_queues(true);
+    #[cfg(guest_arch = "x86_64")]
     const HV_START_ENABLE_VP_VTL: Self = Self::new().with_hv_start_enable_vtl_vp(true); // StartVp/EnableVpVtl handling
     const INTCON: Self = Self::new().with_intcon(true);
     #[cfg(guest_arch = "x86_64")]

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -943,6 +943,45 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlReturn for UhHypercallHand
     }
 }
 
+impl<T, B: HardwareIsolatedBacking>
+    hv1_hypercall::StartVirtualProcessor<hvdef::hypercall::InitialVpContextX64>
+    for UhHypercallHandler<'_, '_, T, B>
+{
+    fn start_virtual_processor(
+        &mut self,
+        partition_id: u64,
+        target_vp: u32,
+        target_vtl: Vtl,
+        vp_context: &hvdef::hypercall::InitialVpContextX64,
+    ) -> HvResult<()> {
+        tracing::debug!(
+            vp_index = self.vp.vp_index().index(),
+            target_vp,
+            ?target_vtl,
+            "HvStartVirtualProcessor"
+        );
+
+        if partition_id != hvdef::HV_PARTITION_ID_SELF {
+            return Err(HvError::InvalidPartitionId);
+        }
+
+        if target_vp == self.vp.vp_index().index()
+            || target_vp as usize >= self.vp.partition.vps.len()
+        {
+            return Err(HvError::InvalidVpIndex);
+        }
+
+        let target_vtl = self.target_vtl_no_higher(target_vtl)?;
+        let target_vp = &self.vp.partition.vps[target_vp as usize];
+
+        // TODO CVM GUEST VSM: probably some validation on vtl1_enabled
+        *target_vp.hv_start_enable_vtl_vp[target_vtl].lock() = Some(Box::new(*vp_context));
+        target_vp.wake(target_vtl, WakeReason::HV_START_ENABLE_VP_VTL);
+
+        Ok(())
+    }
+}
+
 impl<T, B: HardwareIsolatedBacking> hv1_hypercall::ModifyVtlProtectionMask
     for UhHypercallHandler<'_, '_, T, B>
 {
@@ -1210,6 +1249,34 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         }
 
         Ok(reprocessing_required)
+    }
+
+    pub(crate) fn hcvm_handle_vp_start_enable_vtl(
+        &mut self,
+        vtl: GuestVtl,
+    ) -> Result<(), UhRunVpError> {
+        if let Some(context) = self.inner.hv_start_enable_vtl_vp[vtl].lock().take() {
+            tracing::debug!(
+                vp_index = self.inner.cpu_index,
+                ?vtl,
+                "starting vp with initial registers"
+            );
+            hv1_emulator::hypercall::set_x86_vp_context(
+                &mut self.access_state(vtl.into()),
+                &context,
+            )
+            .map_err(UhRunVpError::State)?;
+
+            if vtl == GuestVtl::Vtl1 {
+                assert!(self.partition.isolation.is_hardware_isolated());
+                // Should have already initialized the hv emulator for this vtl
+                assert!(self.backing.hv(vtl).is_some());
+
+                // TODO CVM GUEST VSM: Revisit during AP startup if we need to exit to VTL 1 here
+            }
+        }
+
+        Ok(())
     }
 
     fn get_vsm_vp_secure_config_vtl(

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -242,9 +242,7 @@ mod private {
         fn handle_vp_start_enable_vtl_wake(
             _this: &mut UhProcessor<'_, Self>,
             _vtl: GuestVtl,
-        ) -> Result<(), UhRunVpError> {
-            Ok(())
-        }
+        ) -> Result<(), UhRunVpError>;
 
         fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -239,6 +239,13 @@ mod private {
             dev: &impl CpuIo,
         ) -> Result<bool, UhRunVpError>;
 
+        fn handle_vp_start_enable_vtl_wake(
+            _this: &mut UhProcessor<'_, Self>,
+            _vtl: GuestVtl,
+        ) -> Result<(), UhRunVpError> {
+            Ok(())
+        }
+
         fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}
 
         fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv>;
@@ -902,26 +909,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
 
             #[cfg(guest_arch = "x86_64")]
             if wake_reasons.hv_start_enable_vtl_vp() {
-                if let Some(context) = self.inner.hv_start_enable_vtl_vp[vtl].lock().take() {
-                    tracing::debug!(
-                        vp_index = self.inner.cpu_index,
-                        ?vtl,
-                        "starting vp with initial registers"
-                    );
-                    hv1_emulator::hypercall::set_x86_vp_context(
-                        &mut self.access_state(vtl.into()),
-                        &context,
-                    )
-                    .map_err(UhRunVpError::State)?;
-
-                    if vtl == GuestVtl::Vtl1 {
-                        assert!(self.partition.isolation.is_hardware_isolated());
-                        // Should have already initialized the hv emulator for this vtl
-                        assert!(self.backing.hv(vtl).is_some());
-
-                        // TODO CVM GUEST VSM: Revisit during AP startup if we need to exit to VTL 1 here
-                    }
-                }
+                T::handle_vp_start_enable_vtl_wake(self, vtl)?;
             }
 
             #[cfg(guest_arch = "x86_64")]
@@ -1298,44 +1286,6 @@ impl<T: CpuIo, B: Backing> Arm64RegisterState for UhHypercallHandler<'_, '_, T, 
                 v.into(),
             )
             .expect("set vp register cannot fail")
-    }
-}
-
-impl<T, B: Backing> hv1_hypercall::StartVirtualProcessor<hvdef::hypercall::InitialVpContextX64>
-    for UhHypercallHandler<'_, '_, T, B>
-{
-    fn start_virtual_processor(
-        &mut self,
-        partition_id: u64,
-        target_vp: u32,
-        target_vtl: Vtl,
-        vp_context: &hvdef::hypercall::InitialVpContextX64,
-    ) -> hvdef::HvResult<()> {
-        tracing::debug!(
-            vp_index = self.vp.vp_index().index(),
-            target_vp,
-            ?target_vtl,
-            "HvStartVirtualProcessor"
-        );
-
-        if partition_id != hvdef::HV_PARTITION_ID_SELF {
-            return Err(HvError::InvalidPartitionId);
-        }
-
-        if target_vp == self.vp.vp_index().index()
-            || target_vp as usize >= self.vp.partition.vps.len()
-        {
-            return Err(HvError::InvalidVpIndex);
-        }
-
-        let target_vtl = self.target_vtl_no_higher(target_vtl)?;
-        let target_vp = &self.vp.partition.vps[target_vp as usize];
-
-        // TODO CVM GUEST VSM: probably some validation on vtl1_enabled
-        *target_vp.hv_start_enable_vtl_vp[target_vtl].lock() = Some(Box::new(*vp_context));
-        target_vp.wake(target_vtl, WakeReason::HV_START_ENABLE_VP_VTL);
-
-        Ok(())
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -705,7 +705,6 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, HypervisorBackedArm64> {
             hv1_hypercall::HvPostMessage,
             hv1_hypercall::HvSignalEvent,
             hv1_hypercall::HvRetargetDeviceInterrupt,
-            hv1_hypercall::HvX64StartVirtualProcessor,
             hv1_hypercall::HvGetVpIndexFromApicId,
         ]
     );

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -221,6 +221,13 @@ impl BackingPrivate for HypervisorBackedArm64 {
     fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
         None
     }
+
+    fn handle_vp_start_enable_vtl_wake(
+        _this: &mut UhProcessor<'_, Self>,
+        _vtl: GuestVtl,
+    ) -> Result<(), UhRunVpError> {
+        unimplemented!()
+    }
 }
 
 impl UhProcessor<'_, HypervisorBackedArm64> {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1333,7 +1333,6 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, HypervisorBackedX86> {
             hv1_hypercall::HvPostMessage,
             hv1_hypercall::HvSignalEvent,
             hv1_hypercall::HvRetargetDeviceInterrupt,
-            hv1_hypercall::HvX64StartVirtualProcessor,
             hv1_hypercall::HvGetVpIndexFromApicId,
             hv1_hypercall::HvSetVpRegisters,
             hv1_hypercall::HvModifyVtlProtectionMask

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -329,6 +329,13 @@ impl BackingPrivate for HypervisorBackedX86 {
     fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
         None
     }
+
+    fn handle_vp_start_enable_vtl_wake(
+        _this: &mut UhProcessor<'_, Self>,
+        _vtl: GuestVtl,
+    ) -> Result<(), UhRunVpError> {
+        unimplemented!()
+    }
 }
 
 fn parse_sidecar_exit(message: &hvdef::HvMessage) -> SidecarRemoveExit {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -502,6 +502,13 @@ impl BackingPrivate for SnpBacked {
     fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
         None
     }
+
+    fn handle_vp_start_enable_vtl_wake(
+        this: &mut UhProcessor<'_, Self>,
+        vtl: GuestVtl,
+    ) -> Result<(), UhRunVpError> {
+        this.hcvm_handle_vp_start_enable_vtl(vtl)
+    }
 }
 
 fn virt_seg_to_snp(val: SegmentRegister) -> SevSelector {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -901,6 +901,13 @@ impl BackingPrivate for TdxBacked {
     fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
         self.untrusted_synic.as_mut()
     }
+
+    fn handle_vp_start_enable_vtl_wake(
+        this: &mut UhProcessor<'_, Self>,
+        vtl: GuestVtl,
+    ) -> Result<(), UhRunVpError> {
+        this.hcvm_handle_vp_start_enable_vtl(vtl)
+    }
 }
 
 impl UhProcessor<'_, TdxBacked> {

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -41,7 +41,7 @@ pub fn hv_cpuid_leaves(
             .with_access_apic_msrs(true)
             .with_access_vp_runtime_msr(true)
             .with_access_partition_reference_tsc(true)
-            .with_start_virtual_processor(hardware_isolated)
+            .with_start_virtual_processor(true)
             .with_access_vsm(access_vsm)
             .with_enable_extended_gva_ranges_flush_va_list(true);
 

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -41,7 +41,7 @@ pub fn hv_cpuid_leaves(
             .with_access_apic_msrs(true)
             .with_access_vp_runtime_msr(true)
             .with_access_partition_reference_tsc(true)
-            .with_start_virtual_processor(true)
+            .with_start_virtual_processor(hardware_isolated)
             .with_access_vsm(access_vsm)
             .with_enable_extended_gva_ranges_flush_va_list(true);
 


### PR DESCRIPTION
Refactoring work so that the startvp hypercall is not handled by OpenHCL for non-CVMs. Will help to keep future CVM-only work isolated to the CVM backings.

Tested:
- SNP VMs boot
- x86 and aarch64 TVMs boot
- TDX VMs boot