### PR TITLE
openhcl: revert #540 (use shared visibility pool for aarch64 dma)

### DIFF
--- a/vm/loader/manifests/openhcl-aarch64-dev.json
+++ b/vm/loader/manifests/openhcl-aarch64-dev.json
@@ -8,7 +8,7 @@
             "image": {
                 "openhcl": {
                     "memory_page_count": 24576,
-                    "command_line": "console=null OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1",
+                    "command_line": "console=null",
                     "uefi": true
                 }
             }

--- a/vm/loader/manifests/openhcl-aarch64-release.json
+++ b/vm/loader/manifests/openhcl-aarch64-release.json
@@ -8,7 +8,7 @@
             "image": {
                 "openhcl": {
                     "memory_page_count": 12288,
-                    "command_line": "console=null OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1",
+                    "command_line": "console=null",
                     "uefi": true
                 }
             }


### PR DESCRIPTION
Revert "Use the Shared Visibilty pool on aarch64. For reasons that we do not yet"

This reverts commit 94e1d09516ebbe1073b0413a2d1a54cef3f7a91c.