### PR TITLE
xtask: Add support for running fuzzers on a stable toolchain

### DIFF
--- a/xtask/src/tasks/fuzz/cargo_fuzz.rs
+++ b/xtask/src/tasks/fuzz/cargo_fuzz.rs
@@ -89,7 +89,10 @@ impl CargoFuzzCommand {
             log::warn!(
                 "Running on a stable toolchain in a `cargo xtask` invocation, disabling sanitizers"
             );
-            log::warn!("To enable sanitizers, run `xtask` directly from your target directory, or switch to a nightly toolchain");
+            log::warn!(
+                "To enable sanitizers, run {} directly, or switch to a nightly toolchain",
+                std::env::current_exe()?.display()
+            );
             cmd = cmd.args(["-s", "none"]);
         } else {
             // Non-cargo invocation, sanitizers can be enabled via RUSTC_BOOTSTRAP

--- a/xtask/src/tasks/fuzz/cargo_fuzz.rs
+++ b/xtask/src/tasks/fuzz/cargo_fuzz.rs
@@ -3,6 +3,7 @@
 
 //! Glue to invoke external `cargo-fuzz` commands
 
+use anyhow::Context;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -51,53 +52,57 @@ impl CargoFuzzCommand {
         toolchain: Option<&str>,
         extra: &[String],
     ) -> anyhow::Result<()> {
-        let sh = xshell::Shell::new()?;
+        if which::which("cargo-fuzz").is_err() {
+            anyhow::bail!("could not find cargo-fuzz! did you run `cargo install cargo-fuzz`?");
+        }
 
+        let sh = xshell::Shell::new()?;
         if matches!(&self, CargoFuzzCommand::Run { artifact: Some(_) }) {
             sh.set_var("XTASK_FUZZ_REPRO", "1");
         }
 
-        let toolchain = toolchain.unwrap_or("nightly");
-        let cmd_args = self.to_args(target_name);
-
-        let mut trailing_args = Vec::new();
-
-        if !extra.is_empty() {
-            trailing_args.extend_from_slice(extra);
+        let mut toolchain_check_cmd = xshell::cmd!(sh, "rustc");
+        if let Some(toolchain_override) = toolchain {
+            toolchain_check_cmd = toolchain_check_cmd.arg(format!("+{}", toolchain_override));
         }
+        let result = toolchain_check_cmd
+            .arg("-V")
+            .output()
+            .context("could not detect toolchain! did you run `rustup toolchain install`?")?;
+        let output = std::str::from_utf8(&result.stdout)?.to_ascii_lowercase();
+        let is_nightly = output.contains("-nightly") || output.contains("-dev");
 
-        if self.supports_target_options() && !target_options.is_empty() {
-            if trailing_args.is_empty() {
-                trailing_args.push("--".into());
-            }
-            trailing_args.extend_from_slice(target_options);
+        let mut cmd = xshell::cmd!(sh, "cargo");
+        if let Some(toolchain_override) = toolchain {
+            cmd = cmd.arg(format!("+{}", toolchain_override));
         }
+        cmd = cmd.arg("fuzz");
+        cmd = cmd.args(self.to_args(target_name));
+        cmd = cmd.arg("--fuzz-dir").arg(fuzz_dir);
 
-        let cmd = if toolchain != "default" {
-            let toolchain_arg = format!("+{}", toolchain);
-
-            if xshell::cmd!(sh, "cargo {toolchain_arg}")
-                .quiet()
-                .ignore_stderr()
-                .ignore_stdout()
-                .run()
-                .is_err()
-            {
-                anyhow::bail!("could not detect {toolchain} toolchain! did you run `rustup toolchain install {toolchain}`?");
-            }
-            xshell::cmd!(
-                sh,
-                "cargo {toolchain_arg} fuzz {cmd_args...} --fuzz-dir {fuzz_dir} {trailing_args...}"
-            )
+        if is_nightly {
+            // Sanitizers can be enabled, leave defaults alone
+        } else if std::env::var_os("CARGO").is_some() {
+            // We are running in a stable toolchain `cargo xtask` invocation.
+            // Cargo prevents us from setting RUSTC_BOOTSTRAP for a nested
+            // invocation, so we can't enable sanitizers.
+            log::warn!(
+                "Running on a stable toolchain in a `cargo xtask` invocation, disabling sanitizers"
+            );
+            log::warn!("To enable sanitizers, run `xtask` directly from your target directory, or switch to a nightly toolchain");
+            cmd = cmd.args(["-s", "none"]);
         } else {
-            xshell::cmd!(
-                sh,
-                "cargo fuzz {cmd_args...} --fuzz-dir {fuzz_dir} {trailing_args...}"
-            )
-        };
+            // Non-cargo invocation, sanitizers can be enabled via RUSTC_BOOTSTRAP
+            log::warn!("Running on a stable toolchain, enabling sanitizers via RUSTC_BOOTSTRAP");
+            cmd = cmd.env("RUSTC_BOOTSTRAP", "1");
+        }
 
-        if which::which("cargo-fuzz").is_err() {
-            anyhow::bail!("could not find cargo-fuzz! did you run `cargo install cargo-fuzz`?");
+        cmd = cmd.args(extra);
+        if self.supports_target_options() && !target_options.is_empty() {
+            if !extra.iter().any(|x| x == "--") {
+                cmd = cmd.arg("--");
+            }
+            cmd = cmd.args(target_options);
         }
 
         cmd.run()?;

--- a/xtask/src/tasks/fuzz/mod.rs
+++ b/xtask/src/tasks/fuzz/mod.rs
@@ -83,8 +83,7 @@ enum FuzzCommand {
         /// targets.
         targets: Vec<String>,
 
-        /// The Rust toolchain to use. Defaults to 'nightly'. Specify 'default'
-        /// to use the environment's default toolchain.
+        /// The Rust toolchain to use. Defaults to the environment's default toolchain.
         #[clap(long)]
         toolchain: Option<String>,
 
@@ -100,8 +99,7 @@ enum FuzzCommand {
         /// Path to specific repro case
         artifact: Option<PathBuf>,
 
-        /// The Rust toolchain to use. Defaults to 'nightly'. Specify 'default'
-        /// to use the environment's default toolchain.
+        /// The Rust toolchain to use. Defaults to the environment's default toolchain.
         #[clap(long)]
         toolchain: Option<String>,
 
@@ -135,8 +133,7 @@ enum FuzzCommand {
         /// Path to input file.
         input: PathBuf,
 
-        /// The Rust toolchain to use. Defaults to 'nightly'. Specify 'default'
-        /// to use the environment's default toolchain.
+        /// The Rust toolchain to use. Defaults to the environment's default toolchain.
         #[clap(long)]
         toolchain: Option<String>,
 
@@ -149,8 +146,7 @@ enum FuzzCommand {
         /// Fuzzing target to minify the corpus of.
         target: String,
 
-        /// The Rust toolchain to use. Defaults to 'nightly'. Specify 'default'
-        /// to use the environment's default toolchain.
+        /// The Rust toolchain to use. Defaults to the environment's default toolchain.
         #[clap(long)]
         toolchain: Option<String>,
 
@@ -166,8 +162,7 @@ enum FuzzCommand {
         /// Path to test case file.
         test_case: PathBuf,
 
-        /// The Rust toolchain to use. Defaults to 'nightly'. Specify 'default'
-        /// to use the environment's default toolchain.
+        /// The Rust toolchain to use. Defaults to the environment's default toolchain.
         #[clap(long)]
         toolchain: Option<String>,
 
@@ -188,8 +183,7 @@ enum FuzzCommand {
         #[clap(long, requires = "with_html_report")]
         only_report: bool,
 
-        /// The Rust toolchain to use. Defaults to 'nightly'. Specify 'default'
-        /// to use the environment's default toolchain.
+        /// The Rust toolchain to use. Defaults to the environment's default toolchain.
         #[clap(long)]
         toolchain: Option<String>,
 
@@ -209,8 +203,7 @@ enum FuzzCommand {
         /// targets.
         target: Vec<String>,
 
-        /// The Rust toolchain to use. Defaults to 'nightly'. Specify 'default'
-        /// to use the environment's default toolchain.
+        /// The Rust toolchain to use. Defaults to the environment's default toolchain.
         #[clap(long)]
         toolchain: Option<String>,
     },


### PR DESCRIPTION
The nested cargo invocation limitation is unfortunate, but unavoidable according to Wesley. At least we can tell people about it.

Also refactor all the argument handling here to be more robust.