### PR TITLE
petri, diag_client: pass -NoProfile to powershell invocations

### DIFF
--- a/openhcl/diag_client/src/lib.rs
+++ b/openhcl/diag_client/src/lib.rs
@@ -125,6 +125,7 @@ pub mod hyperv {
         let path = match port {
             ComPortAccessInfo::PortNumber(num) => {
                 let output = Command::new("powershell.exe")
+                    .arg("-NoProfile")
                     .arg(format!(
                         r#"$x = Get-VMComPort "{vm}" -Number {num} -ErrorAction Stop; $x.Path"#,
                     ))

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -365,6 +365,7 @@ fn run_powershell(
     f: impl FnOnce(&mut Command) -> &mut Command,
 ) -> anyhow::Result<()> {
     let mut cmd = Command::new("powershell.exe");
+    cmd.arg("-NoProfile");
     f(&mut cmd);
     let cmdlet = cmd
         .get_args()
@@ -388,6 +389,7 @@ fn run_powershell_cmdlet_output(
     f: impl FnOnce(&mut Command) -> &mut Command,
 ) -> anyhow::Result<String> {
     let mut cmd = Command::new("powershell.exe");
+    cmd.arg("-NoProfile");
     cmd.arg(cmdlet);
     f(&mut cmd);
     let output = cmd


### PR DESCRIPTION
For our use of PowerShell, we should not need user profile customizations (which are sometimes quite expensive and/or chatty). Pass `-NoProfile` to disable loading of the user profile.