### PR TITLE
openhcl_boot: Get alias map from device tree

### DIFF
--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -236,9 +236,8 @@ pub struct ParsedDeviceTree<
     pub device_dma_page_count: Option<u64>,
     /// Indicates that Host does support NVMe keep-alive.
     pub nvme_keepalive: bool,
-    /// Physical address width. Used to calculate the alias map bit on
-    /// systems that don't reliably report this value architecturally (ARM).
-    pub physical_address_width: Option<u32>,
+    /// The physical address of the VTL0 alias mapping, if one is configured.
+    pub vtl0_alias_map: Option<u64>,
 }
 
 /// The memory allocation mode provided by the host. This determines how OpenHCL
@@ -319,7 +318,7 @@ impl<
             entropy: None,
             device_dma_page_count: None,
             nvme_keepalive: false,
-            physical_address_width: None,
+            vtl0_alias_map: None,
         }
     }
 
@@ -487,10 +486,10 @@ impl<
                         }
                     }
 
-                    storage.physical_address_width = child
-                        .find_property("physical-address-width")
+                    storage.vtl0_alias_map = child
+                        .find_property("vtl0-alias-map")
                         .map_err(ErrorKind::Prop)?
-                        .map(|p| p.read_u32(0))
+                        .map(|p| p.read_u64(0))
                         .transpose()
                         .map_err(ErrorKind::Prop)?;
 
@@ -738,7 +737,7 @@ impl<
             entropy: _,
             device_dma_page_count: _,
             nvme_keepalive: _,
-            physical_address_width: _,
+            vtl0_alias_map: _,
         } = storage;
 
         *device_tree_size = parser.total_size;

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -510,12 +510,9 @@ impl PartitionInfo {
             storage.vtl2_pool_memory = pool;
         }
 
-        // If we can trust the host, use the provided physical address width
-        // to determine the alias map
+        // If we can trust the host, use the provided alias map
         if can_trust_host {
-            storage.vtl0_alias_map = parsed
-                .physical_address_width
-                .map(|x| 1 << x.checked_sub(1).expect("invalid physical address width"));
+            storage.vtl0_alias_map = parsed.vtl0_alias_map;
         }
 
         // Set remaining struct fields before returning.

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -513,7 +513,9 @@ impl PartitionInfo {
         // If we can trust the host, use the provided physical address width
         // to determine the alias map
         if can_trust_host {
-            storage.vtl0_alias_map = parsed.physical_address_width.map(|x| 1 << (x - 1));
+            storage.vtl0_alias_map = parsed
+                .physical_address_width
+                .map(|x| 1 << x.checked_sub(1).expect("invalid physical address width"));
         }
 
         // Set remaining struct fields before returning.

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -510,6 +510,12 @@ impl PartitionInfo {
             storage.vtl2_pool_memory = pool;
         }
 
+        // If we can trust the host, use the provided physical address width
+        // to determine the alias map
+        if can_trust_host {
+            storage.vtl0_alias_map = parsed.physical_address_width.map(|x| 1 << (x - 1));
+        }
+
         // Set remaining struct fields before returning.
         let Self {
             vtl2_ram: _,

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -605,18 +605,23 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
         )
         .vtl0_alias_map_available()
     {
-        // On ARM, use the physical address width reported via device tree since
-        // it is not reliably reported architecturally. Since the position of
-        // the alias map bit is inferred from address size, the alias map is
-        // broken when the PA size is wrong.
-        if !cfg!(target_arch = "aarch64") {
-            let vtl0_alias_map = 1 << (arch::physical_address_bits(p.isolation_type) - 1);
-            if let Some(dt_vtl0_alias_map) = partition_info.vtl0_alias_map {
-                // if we got the alias map via device tree, it should match.
-                assert_eq!(dt_vtl0_alias_map, vtl0_alias_map);
-            }
-            partition_info.vtl0_alias_map = Some(vtl0_alias_map);
+        // If the vtl0 alias map was not provided in the devicetree, attempt to
+        // derive it from the architectural physical address bits.
+        //
+        // The value in the ID_AA64MMFR0_EL1 register used to determine the
+        // physical address bits can only represent multiples of 4. As a result,
+        // the Surface Pro X (and systems with similar CPUs) cannot properly
+        // report their address width of 39 bits. This causes the calculated
+        // alias map to be incorrect, which results in panics when trying to
+        // read memory and getting invalid data.
+        if partition_info.vtl0_alias_map.is_none() {
+            partition_info.vtl0_alias_map =
+                Some(1 << (arch::physical_address_bits(p.isolation_type) - 1));
         }
+    } else {
+        // Ignore any devicetree-provided alias map if the conditions above
+        // aren't met.
+        partition_info.vtl0_alias_map = None;
     }
 
     if can_trust_host {

--- a/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
@@ -325,7 +325,6 @@ fn build_device_tree(
     let p_clock_frequency = builder.add_string("clock-frequency")?;
     let p_current_speed = builder.add_string("current-speed")?;
     let p_interrupts = builder.add_string("interrupts")?;
-    let p_vtl0_alias_map = builder.add_string("vtl0-alias-map")?;
 
     let mut cpus = builder
         .start_node("")?
@@ -487,11 +486,6 @@ fn build_device_tree(
     };
 
     openhcl = openhcl.add_str(p_memory_allocation_mode, memory_allocation_mode)?;
-
-    openhcl = openhcl.add_u32(
-        p_vtl0_alias_map,
-        1 << (mem_layout.physical_address_size() - 1),
-    )?;
 
     if let Some(entropy) = entropy {
         openhcl = openhcl

--- a/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
@@ -325,6 +325,7 @@ fn build_device_tree(
     let p_clock_frequency = builder.add_string("clock-frequency")?;
     let p_current_speed = builder.add_string("current-speed")?;
     let p_interrupts = builder.add_string("interrupts")?;
+    let p_vtl0_alias_map = builder.add_string("vtl0-alias-map")?;
 
     let mut cpus = builder
         .start_node("")?
@@ -486,6 +487,11 @@ fn build_device_tree(
     };
 
     openhcl = openhcl.add_str(p_memory_allocation_mode, memory_allocation_mode)?;
+
+    openhcl = openhcl.add_u32(
+        p_vtl0_alias_map,
+        1 << (mem_layout.physical_address_size() - 1),
+    )?;
 
     if let Some(entropy) = entropy {
         openhcl = openhcl


### PR DESCRIPTION
Get the physical address width via device tree to determine the alias map on systems that don't reliably report the physical address width architecturally (ARM).