### PR TITLE
hv1_hypercall: simplify hypercall output handling

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -983,12 +983,12 @@ impl MshvHvcall {
 
             match result.result() {
                 Ok(()) => {
-                    assert_eq!(result.elements_processed() as usize, n);
+                    assert_eq!({ result.elements_processed() }, n);
                 }
                 Err(HvError::Timeout) => {}
                 Err(e) => return Err(e),
             }
-            gpns = &gpns[result.elements_processed() as usize..];
+            gpns = &gpns[result.elements_processed()..];
         }
         Ok(())
     }
@@ -2727,7 +2727,7 @@ impl Hcl {
                     .expect("submitting pin/unpin hypercall should not fail")
             };
 
-            ranges_processed += output.elements_processed() as usize;
+            ranges_processed += output.elements_processed();
 
             output.result().map_err(|e| PinUnpinError {
                 ranges_processed,

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1209,7 +1209,7 @@ impl MshvHvcall {
 
         let control = hvdef::hypercall::Control::new()
             .with_code(code.0)
-            .with_rep_count(count as u16);
+            .with_rep_count(count);
 
         let call_object = protocol::hcl_hvcall {
             control,
@@ -1273,7 +1273,7 @@ impl MshvHvcall {
 
         let control = hvdef::hypercall::Control::new()
             .with_code(code.0)
-            .with_variable_header_size((variable_input.len() / 8) as u16);
+            .with_variable_header_size(variable_input.len() / 8);
 
         let call_object = protocol::hcl_hvcall {
             control,

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1047,7 +1047,7 @@ impl MshvHvcall {
                 // This applies to both simple and rep hypercalls.
                 call_object
                     .control
-                    .set_rep_start(call_object.status.elements_processed().into());
+                    .set_rep_start(call_object.status.elements_processed());
             } else {
                 if call_object.control.rep_count() == 0 {
                     // For non-rep hypercalls, the elements processed field should be 0.
@@ -1059,10 +1059,10 @@ impl MshvHvcall {
                     assert!(
                         (call_object.status.result().is_ok()
                             && call_object.control.rep_count()
-                                == call_object.status.elements_processed().into())
+                                == call_object.status.elements_processed())
                             || (call_object.status.result().is_err()
                                 && call_object.control.rep_count()
-                                    > call_object.status.elements_processed().into())
+                                    > call_object.status.elements_processed())
                     );
                 }
 

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -338,7 +338,7 @@ enum HvcallRepInput<'a, T> {
     /// The actual elements to rep over
     Elements(&'a [T]),
     /// The elements for the rep are implied and only a count is needed
-    Count(usize),
+    Count(u16),
 }
 
 mod ioctls {
@@ -926,7 +926,7 @@ impl MshvHvcall {
                 self.hvcall_rep::<hvdef::hypercall::AcceptGpaPages, u8, u8>(
                     HypercallCode::HvCallAcceptGpaPages,
                     &header,
-                    HvcallRepInput::Count(count as usize),
+                    HvcallRepInput::Count(count as u16),
                     None,
                 )
                 .expect("kernel hypercall submission should always succeed")
@@ -1182,7 +1182,7 @@ impl MshvHvcall {
             HvcallRepInput::Elements(e) => {
                 ([input_header.as_bytes(), e.as_bytes()].concat(), e.len())
             }
-            HvcallRepInput::Count(c) => (input_header.as_bytes().to_vec(), c),
+            HvcallRepInput::Count(c) => (input_header.as_bytes().to_vec(), c.into()),
         };
 
         if input.len() > HV_PAGE_SIZE as usize {
@@ -1209,7 +1209,7 @@ impl MshvHvcall {
 
         let control = hvdef::hypercall::Control::new()
             .with_code(code.0)
-            .with_rep_count(count);
+            .with_rep_count(count as u16);
 
         let call_object = protocol::hcl_hvcall {
             control,
@@ -1273,7 +1273,7 @@ impl MshvHvcall {
 
         let control = hvdef::hypercall::Control::new()
             .with_code(code.0)
-            .with_variable_header_size(variable_input.len() / 8);
+            .with_variable_header_size((variable_input.len() / 8) as u16);
 
         let call_object = protocol::hcl_hvcall {
             control,

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -133,7 +133,7 @@ impl HvCall {
     fn dispatch_hvcall(
         &mut self,
         code: hvdef::HypercallCode,
-        rep_count: Option<usize>,
+        rep_count: Option<u16>,
     ) -> hvdef::hypercall::HypercallOutput {
         self.init_if_needed();
 
@@ -235,7 +235,7 @@ impl HvCall {
 
             let output = self.dispatch_hvcall(
                 hvdef::HypercallCode::HvCallModifyVtlProtectionMask,
-                Some(count as usize),
+                Some(count as u16),
             );
 
             output.result()?;
@@ -300,7 +300,7 @@ impl HvCall {
 
             let output = self.dispatch_hvcall(
                 hvdef::HypercallCode::HvCallAcceptGpaPages,
-                Some(count as usize),
+                Some(count as u16),
             );
 
             output.result()?;
@@ -339,7 +339,7 @@ impl HvCall {
             //         The hypercall output is validated right after the hypercall is issued.
             let r = self.dispatch_hvcall(
                 hvdef::HypercallCode::HvCallGetVpIndexFromApicId,
-                Some(hw_ids.len()),
+                Some(hw_ids.len() as u16),
             );
 
             let n = r.elements_processed() as usize;

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -133,7 +133,7 @@ impl HvCall {
     fn dispatch_hvcall(
         &mut self,
         code: hvdef::HypercallCode,
-        rep_count: Option<u16>,
+        rep_count: Option<usize>,
     ) -> hvdef::hypercall::HypercallOutput {
         self.init_if_needed();
 
@@ -222,25 +222,25 @@ impl HvCall {
         let mut current_page = range.start_4k_gpn();
         while current_page < range.end_4k_gpn() {
             let remaining_pages = range.end_4k_gpn() - current_page;
-            let count = remaining_pages.min(MAX_INPUT_ELEMENTS as u64);
+            let count = remaining_pages.min(MAX_INPUT_ELEMENTS as u64) as usize;
 
             header.write_to_prefix(Self::input_page().buffer.as_mut_slice());
 
             let mut input_offset = HEADER_SIZE;
             for i in 0..count {
-                let page_num = current_page + i;
+                let page_num = current_page + i as u64;
                 page_num.write_to_prefix(&mut Self::input_page().buffer[input_offset..]);
                 input_offset += size_of::<u64>();
             }
 
             let output = self.dispatch_hvcall(
                 hvdef::HypercallCode::HvCallModifyVtlProtectionMask,
-                Some(count as u16),
+                Some(count),
             );
 
             output.result()?;
 
-            current_page += count;
+            current_page += count as u64;
         }
 
         Ok(())
@@ -294,18 +294,16 @@ impl HvCall {
             };
 
             let remaining_pages = range.end_4k_gpn() - current_page;
-            let count = remaining_pages.min(MAX_INPUT_ELEMENTS as u64);
+            let count = remaining_pages.min(MAX_INPUT_ELEMENTS as u64) as usize;
 
             header.write_to_prefix(Self::input_page().buffer.as_mut_slice());
 
-            let output = self.dispatch_hvcall(
-                hvdef::HypercallCode::HvCallAcceptGpaPages,
-                Some(count as u16),
-            );
+            let output =
+                self.dispatch_hvcall(hvdef::HypercallCode::HvCallAcceptGpaPages, Some(count));
 
             output.result()?;
 
-            current_page += count;
+            current_page += count as u64;
         }
 
         Ok(())
@@ -339,7 +337,7 @@ impl HvCall {
             //         The hypercall output is validated right after the hypercall is issued.
             let r = self.dispatch_hvcall(
                 hvdef::HypercallCode::HvCallGetVpIndexFromApicId,
-                Some(hw_ids.len() as u16),
+                Some(hw_ids.len()),
             );
 
             let n = r.elements_processed() as usize;

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -340,7 +340,7 @@ impl HvCall {
                 Some(hw_ids.len()),
             );
 
-            let n = r.elements_processed() as usize;
+            let n = r.elements_processed();
             output.extend(
                 u32::slice_from(&Self::output_page().buffer[..n * 4])
                     .unwrap()

--- a/openhcl/sidecar/src/arch/x86_64/mod.rs
+++ b/openhcl/sidecar/src/arch/x86_64/mod.rs
@@ -216,7 +216,7 @@ impl Write for CommandErrorWriter<'_> {
     }
 }
 
-fn hypercall(code: HypercallCode, rep_count: u16) -> Result<(), HvError> {
+fn hypercall(code: HypercallCode, rep_count: usize) -> Result<(), HvError> {
     let control = hvdef::hypercall::Control::new()
         .with_code(code.0)
         .with_rep_count(rep_count);

--- a/openhcl/sidecar/src/arch/x86_64/mod.rs
+++ b/openhcl/sidecar/src/arch/x86_64/mod.rs
@@ -219,7 +219,7 @@ impl Write for CommandErrorWriter<'_> {
 fn hypercall(code: HypercallCode, rep_count: u16) -> Result<(), HvError> {
     let control = hvdef::hypercall::Control::new()
         .with_code(code.0)
-        .with_rep_count(rep_count.into());
+        .with_rep_count(rep_count);
 
     // SAFETY: the caller guarantees the safety of the hypercall, including that
     // the input and output pages are not concurrently accessed.

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -36,7 +36,6 @@ mod mapping {
     use hvdef::hypercall::HvInputVtl;
     use hvdef::HvError;
     use hvdef::HvMapGpaFlags;
-    use hvdef::HvRepResult;
     use hvdef::HypercallCode;
     use hvdef::Vtl;
     use hvdef::HV_MAP_GPA_PERMISSIONS_ALL;
@@ -820,7 +819,11 @@ mod mapping {
     }
 
     impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
-        fn change_host_visibility(&self, shared: bool, gpns: &[u64]) -> HvRepResult {
+        fn change_host_visibility(
+            &self,
+            shared: bool,
+            gpns: &[u64],
+        ) -> Result<(), (HvError, usize)> {
             // Validate the ranges are RAM.
             for &gpn in gpns {
                 if !self
@@ -962,7 +965,7 @@ mod mapping {
             &self,
             gpns: &[u64],
             host_visibility: &mut [HostVisibilityType],
-        ) -> HvRepResult {
+        ) -> Result<(), (HvError, usize)> {
             // Validate the ranges are RAM.
             for (i, &gpn) in gpns.iter().enumerate() {
                 if !self
@@ -1051,7 +1054,7 @@ mod mapping {
             vtl: GuestVtl,
             gpns: &[u64],
             protections: HvMapGpaFlags,
-        ) -> HvRepResult {
+        ) -> Result<(), (HvError, usize)> {
             // Validate the ranges are RAM.
             for &gpn in gpns {
                 if !self

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -68,7 +68,6 @@ use hvdef::HvMapGpaFlags;
 use hvdef::HvRegisterName;
 use hvdef::HvRegisterVsmPartitionConfig;
 use hvdef::HvRegisterVsmPartitionStatus;
-use hvdef::HvRepResult;
 use hvdef::Vtl;
 use hvdef::HV_PAGE_SIZE;
 use inspect::Inspect;
@@ -1240,14 +1239,14 @@ pub struct UhLateParams<'a> {
 /// Trait for CVM-related protections on guest memory.
 pub trait ProtectIsolatedMemory: Send + Sync {
     /// Changes host visibility on guest memory.
-    fn change_host_visibility(&self, shared: bool, gpns: &[u64]) -> HvRepResult;
+    fn change_host_visibility(&self, shared: bool, gpns: &[u64]) -> Result<(), (HvError, usize)>;
 
     /// Queries host visibility on guest memory.
     fn query_host_visibility(
         &self,
         gpns: &[u64],
         host_visibility: &mut [HostVisibilityType],
-    ) -> HvRepResult;
+    ) -> Result<(), (HvError, usize)>;
 
     /// Gets the default protections/permissions for VTL 0.
     fn default_vtl0_protections(&self) -> HvMapGpaFlags;
@@ -1267,7 +1266,7 @@ pub trait ProtectIsolatedMemory: Send + Sync {
         vtl: GuestVtl,
         gpns: &[u64],
         protections: HvMapGpaFlags,
-    ) -> HvRepResult;
+    ) -> Result<(), (HvError, usize)>;
 
     /// Retrieves a protector for the hypercall code page overlay for a target
     /// VTL.

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -17,6 +17,7 @@ use crate::GuestVtl;
 use crate::WakeReason;
 use guestmem::GuestMemory;
 use hv1_emulator::RequestInterrupt;
+use hv1_hypercall::HvRepResult;
 use hvdef::hypercall::HvFlushFlags;
 use hvdef::hypercall::TranslateGvaResultCode;
 use hvdef::HvCacheType;
@@ -810,7 +811,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::GetVpRegisters
         vtl: Option<Vtl>,
         registers: &[hvdef::HvRegisterName],
         output: &mut [hvdef::HvRegisterValue],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != hvdef::HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
         }
@@ -840,7 +841,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::SetVpRegisters
         vp_index: u32,
         vtl: Option<Vtl>,
         registers: &[hvdef::hypercall::HvRegisterAssoc],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != hvdef::HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
         }
@@ -951,7 +952,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::ModifyVtlProtectionMask
         map_flags: HvMapGpaFlags,
         target_vtl: Option<Vtl>,
         gpa_pages: &[u64],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != hvdef::HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
         }

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -42,6 +42,7 @@ use crate::WakeReason;
 use hcl::ioctl;
 use hcl::ioctl::ProcessorRunner;
 use hv1_emulator::message_queues::MessageQueues;
+use hv1_hypercall::HvRepResult;
 use hvdef::hypercall::HostVisibilityType;
 use hvdef::HvError;
 use hvdef::HvMessage;
@@ -1249,7 +1250,7 @@ impl<T, B: Backing> hv1_hypercall::GetVpIndexFromApicId for UhHypercallHandler<'
         target_vtl: Vtl,
         apic_ids: &[u32],
         vp_indices: &mut [u32],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         tracing::debug!(partition_id, ?target_vtl, "HvGetVpIndexFromApicId");
 
         if partition_id != hvdef::HV_PARTITION_ID_SELF {
@@ -1421,7 +1422,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::ModifySparseGpaPageHostVisibility
         partition_id: u64,
         visibility: HostVisibilityType,
         gpa_pages: &[u64],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != hvdef::HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
         }
@@ -1459,7 +1460,7 @@ impl<T: CpuIo, B: Backing> hv1_hypercall::QuerySparseGpaPageHostVisibility
         partition_id: u64,
         gpa_pages: &[u64],
         host_visibility: &mut [HostVisibilityType],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != hvdef::HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
         }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -35,6 +35,7 @@ use hcl::ioctl::ProcessorRunner;
 use hcl::protocol;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::synic::ProcessorSynic;
+use hv1_hypercall::HvRepResult;
 use hvdef::hypercall;
 use hvdef::HvDeliverabilityNotificationsRegister;
 use hvdef::HvError;
@@ -2004,7 +2005,7 @@ impl<T> hv1_hypercall::SetVpRegisters for UhHypercallHandler<'_, '_, T, Hypervis
         vp_index: u32,
         vtl: Option<Vtl>,
         registers: &[hypercall::HvRegisterAssoc],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != hvdef::HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
         }
@@ -2041,7 +2042,7 @@ impl<T> hv1_hypercall::ModifyVtlProtectionMask
         _map_flags: HvMapGpaFlags,
         target_vtl: Option<Vtl>,
         gpa_pages: &[u64],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != hvdef::HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
         }

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -741,7 +741,7 @@ impl<T> HypercallIo for GhcbEnlightenedHypercall<'_, '_, T> {
         let control = Control::from(control);
         self.set_result(
             HypercallOutput::from(HvError::Timeout)
-                .with_elements_processed(control.rep_start() as u16)
+                .with_elements_processed(control.rep_start())
                 .into(),
         );
     }

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -26,6 +26,7 @@ use crate::WakeReason;
 use hcl::vmsa::VmsaWrapper;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::synic::ProcessorSynic;
+use hv1_hypercall::HvRepResult;
 use hv1_hypercall::HypercallIo;
 use hvdef::hypercall::Control;
 use hvdef::hypercall::HvFlushFlags;
@@ -2297,7 +2298,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressList for UhHypercallHandler<'_,
         processor_set: Vec<u32>,
         flags: HvFlushFlags,
         gva_ranges: &[HvGvaRange],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         hv1_hypercall::FlushVirtualAddressListEx::flush_virtual_address_list_ex(
             self,
             processor_set,
@@ -2315,7 +2316,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressListEx
         processor_set: Vec<u32>,
         flags: HvFlushFlags,
         gva_ranges: &[HvGvaRange],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         self.hcvm_validate_flush_inputs(&processor_set, flags, true)
             .map_err(|e| (e, 0))?;
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -28,6 +28,7 @@ use hcl::protocol::tdx_tdg_vp_enter_exit_info;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::synic::ProcessorSynic;
 use hv1_hypercall::AsHandler;
+use hv1_hypercall::HvRepResult;
 use hv1_hypercall::HypercallIo;
 use hvdef::hypercall::HvFlushFlags;
 use hvdef::hypercall::HvGvaRange;
@@ -3419,7 +3420,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressList for UhHypercallHandler<'_,
         processor_set: Vec<u32>,
         flags: HvFlushFlags,
         gva_ranges: &[HvGvaRange],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         hv1_hypercall::FlushVirtualAddressListEx::flush_virtual_address_list_ex(
             self,
             processor_set,
@@ -3437,7 +3438,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressListEx
         processor_set: Vec<u32>,
         flags: HvFlushFlags,
         gva_ranges: &[HvGvaRange],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         self.hcvm_validate_flush_inputs(&processor_set, flags, true)
             .map_err(|e| (e, 0))?;
 

--- a/vm/hv1/hv1_hypercall/src/lib.rs
+++ b/vm/hv1/hv1_hypercall/src/lib.rs
@@ -33,6 +33,7 @@ pub use self::aarch64::Arm64RegisterState;
 pub use self::imp::*;
 pub use self::support::AsHandler;
 pub use self::support::Dispatcher;
+pub use self::support::HvRepResult;
 pub use self::support::HypercallDefinition;
 pub use self::support::HypercallHandler;
 pub use self::support::HypercallIo;

--- a/vm/hv1/hv1_hypercall/src/support.rs
+++ b/vm/hv1/hv1_hypercall/src/support.rs
@@ -206,7 +206,7 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
                     return Err(HypercallParseError::InvalidControl(control).into());
                 }
 
-                let input_size = input_size + control.variable_header_size() as usize * 8;
+                let input_size = input_size + control.variable_header_size() * 8;
                 (input_size, 0, output_size, 0)
             }
             HypercallData::Rep {
@@ -223,10 +223,10 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
                 }
 
                 let input_len = header_size
-                    + control.variable_header_size() as usize * 8
-                    + input_element_size * control.rep_count() as usize;
-                let output_start = output_element_size * control.rep_start() as usize;
-                let output_len = output_element_size * control.rep_count() as usize;
+                    + control.variable_header_size() * 8
+                    + input_element_size * control.rep_count();
+                let output_start = output_element_size * control.rep_start();
+                let output_len = output_element_size * control.rep_count();
                 (input_len, output_start, output_len, output_element_size)
             }
         };
@@ -281,7 +281,7 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
             // For simple hypercalls, on success write back all output. On failure (and timeout,
             // which is handled as a failure), nothing is written back.
             let output_end = if out_elem_size > 0 {
-                out_elem_size * ret.elements_processed() as usize
+                out_elem_size * ret.elements_processed()
             } else if ret.call_status() == 0 {
                 output_len
             } else {
@@ -337,7 +337,7 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
             // For simple hypercalls, on success write back all output. On failure (and timeout,
             // which is handled as a failure), nothing is written back.
             let output_end = if out_elem_size > 0 {
-                out_elem_size * ret.elements_processed() as usize
+                out_elem_size * ret.elements_processed()
             } else if ret.call_status() == 0 {
                 output_len
             } else {
@@ -577,12 +577,12 @@ where
         let input = if size_of::<In>() == 0 {
             &[]
         } else {
-            &In::slice_from(rest).unwrap()[params.control.rep_start() as usize..]
+            &In::slice_from(rest).unwrap()[params.control.rep_start()..]
         };
         let output = if size_of::<Out>() == 0 {
             &mut []
         } else {
-            &mut Out::mut_slice_from(params.output).unwrap()[params.control.rep_start() as usize..]
+            &mut Out::mut_slice_from(params.output).unwrap()[params.control.rep_start()..]
         };
 
         (header.into_ref(), input, output)
@@ -598,10 +598,10 @@ where
             Ok(()) => HypercallOutput::SUCCESS.with_elements_processed(control.rep_count()),
             Err((e, reps)) => {
                 assert!(
-                    control.rep_start() as usize + reps < control.rep_count() as usize,
+                    control.rep_start() + reps < control.rep_count(),
                     "more reps processed than requested"
                 );
-                HypercallOutput::from(e).with_elements_processed(control.rep_start() + reps as u16)
+                HypercallOutput::from(e).with_elements_processed(control.rep_start() + reps)
             }
         }
     }
@@ -631,16 +631,16 @@ where
     pub fn parse(params: HypercallParameters<'_>) -> (&Hdr, &[u64], &[In], &mut [Out]) {
         let (header, rest) = Ref::<_, Hdr>::new_from_prefix(params.input).unwrap();
         let (var_header, rest) =
-            u64::slice_from_prefix(rest, params.control.variable_header_size() as usize).unwrap();
+            u64::slice_from_prefix(rest, params.control.variable_header_size()).unwrap();
         let input = if size_of::<In>() == 0 {
             &[]
         } else {
-            &In::slice_from(rest).unwrap()[params.control.rep_start() as usize..]
+            &In::slice_from(rest).unwrap()[params.control.rep_start()..]
         };
         let output = if size_of::<Out>() == 0 {
             &mut []
         } else {
-            &mut Out::mut_slice_from(params.output).unwrap()[params.control.rep_start() as usize..]
+            &mut Out::mut_slice_from(params.output).unwrap()[params.control.rep_start()..]
         };
         (header.into_ref(), var_header, input, output)
     }
@@ -655,10 +655,10 @@ where
             Ok(()) => HypercallOutput::SUCCESS.with_elements_processed(control.rep_count()),
             Err((e, reps)) => {
                 assert!(
-                    control.rep_start() as usize + reps < control.rep_count() as usize,
+                    control.rep_start() + reps < control.rep_count(),
                     "more reps processed than requested"
                 );
-                HypercallOutput::from(e).with_elements_processed(control.rep_start() + reps as u16)
+                HypercallOutput::from(e).with_elements_processed(control.rep_start() + reps)
             }
         }
     }

--- a/vm/hv1/hv1_hypercall/src/support.rs
+++ b/vm/hv1/hv1_hypercall/src/support.rs
@@ -8,6 +8,7 @@ use guestmem::GuestMemoryError;
 use hvdef::hypercall::Control;
 use hvdef::hypercall::HypercallOutput;
 use hvdef::HvError;
+use hvdef::HvResult;
 use hvdef::HypercallCode;
 use hvdef::HV_PAGE_SIZE;
 use hvdef::HV_PAGE_SIZE_USIZE;
@@ -49,7 +50,6 @@ pub struct HypercallParameters<'a> {
     control: Control,
     input: &'a [u8],
     output: &'a mut [u8],
-    elements_processed: Option<&'a mut usize>,
 }
 
 /// `[u64; 2]` buffer aligned to 16 bytes for hypercall inputs.
@@ -145,15 +145,23 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
     /// Complete hypercall handling.
     fn complete(&mut self, output: Option<HypercallOutput>) {
         if let Some(output) = output {
-            self.handler.set_result(output.into());
-            self.handler.advance_ip();
+            if output.call_status() == HvError::Timeout.0 {
+                self.handler.retry(
+                    self.control
+                        .with_rep_start(output.elements_processed())
+                        .into(),
+                );
+            } else {
+                self.handler.set_result(output.into());
+                self.handler.advance_ip();
+            }
         }
     }
 
     fn dispatch_dyn<H>(
         &mut self,
         data: &HypercallData,
-        dispatch: fn(&mut H, HypercallParameters<'_>) -> hvdef::HvResult<()>,
+        dispatch: fn(&mut H, HypercallParameters<'_>) -> HypercallOutput,
     ) -> Option<HypercallOutput>
     where
         T: AsHandler<H>,
@@ -165,7 +173,7 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
     fn dispatch_inner<H>(
         &mut self,
         data: &HypercallData,
-        dispatch: fn(&mut H, HypercallParameters<'_>) -> hvdef::HvResult<()>,
+        dispatch: fn(&mut H, HypercallParameters<'_>) -> HypercallOutput,
     ) -> Result<Option<HypercallOutput>, HvError>
     where
         T: AsHandler<H>,
@@ -173,63 +181,55 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
         tracing::trace!(code = ?self.code(), "hypercall");
         let control = self.control;
 
-        let (input_len, output_start, output_len, out_elem_size, mut elements_processed) =
-            match *data {
-                HypercallData::Vtl => {
-                    let input = self.handler.vtl_input();
-                    let _ = (dispatch)(
-                        self.handler.as_handler(),
-                        HypercallParameters {
-                            control,
-                            input: input.as_bytes(),
-                            output: &mut [],
-                            elements_processed: None,
-                        },
-                    );
-                    return Ok(None);
+        let (input_len, output_start, output_len, out_elem_size) = match *data {
+            HypercallData::Vtl => {
+                let input = self.handler.vtl_input();
+                let _ = (dispatch)(
+                    self.handler.as_handler(),
+                    HypercallParameters {
+                        control,
+                        input: input.as_bytes(),
+                        output: &mut [],
+                    },
+                );
+                return Ok(None);
+            }
+            HypercallData::Simple {
+                input_size,
+                output_size,
+                is_variable,
+            } => {
+                if control.rep_count() != 0
+                    || control.rep_start() != 0
+                    || (!is_variable && control.variable_header_size() != 0)
+                {
+                    return Err(HypercallParseError::InvalidControl(control).into());
                 }
-                HypercallData::Simple {
-                    input_size,
-                    output_size,
-                    is_variable,
-                } => {
-                    if control.rep_count() != 0
-                        || control.rep_start() != 0
-                        || (!is_variable && control.variable_header_size() != 0)
-                    {
-                        return Err(HypercallParseError::InvalidControl(control).into());
-                    }
 
-                    let input_size = input_size + control.variable_header_size() * 8;
-                    (input_size, 0, output_size, 0, None)
+                let input_size = input_size + control.variable_header_size() as usize * 8;
+                (input_size, 0, output_size, 0)
+            }
+            HypercallData::Rep {
+                header_size,
+                input_element_size,
+                output_element_size,
+                is_variable,
+            } => {
+                if control.rep_count() == 0
+                    || (!is_variable && control.variable_header_size() != 0)
+                    || control.rep_start() >= control.rep_count()
+                {
+                    return Err(HypercallParseError::InvalidControl(control).into());
                 }
-                HypercallData::Rep {
-                    header_size,
-                    input_element_size,
-                    output_element_size,
-                    is_variable,
-                } => {
-                    if control.rep_count() == 0
-                        || (!is_variable && control.variable_header_size() != 0)
-                        || control.rep_start() >= control.rep_count()
-                    {
-                        return Err(HypercallParseError::InvalidControl(control).into());
-                    }
 
-                    let input_len = header_size
-                        + control.variable_header_size() * 8
-                        + input_element_size * control.rep_count();
-                    let output_start = output_element_size * control.rep_start();
-                    let output_len = output_element_size * control.rep_count();
-                    (
-                        input_len,
-                        output_start,
-                        output_len,
-                        output_element_size,
-                        Some(0),
-                    )
-                }
-            };
+                let input_len = header_size
+                    + control.variable_header_size() as usize * 8
+                    + input_element_size * control.rep_count() as usize;
+                let output_start = output_element_size * control.rep_start() as usize;
+                let output_len = output_element_size * control.rep_count() as usize;
+                (input_len, output_start, output_len, output_element_size)
+            }
+        };
 
         let mut input_buffer = HypercallAlignedPage::new_zeroed();
         let mut output_buffer = HypercallAlignedPage::new_zeroed();
@@ -247,12 +247,10 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
             let input = &mut input_buffer.0[..input_regpairs];
             let output = &mut output_buffer.0[..output_regpairs];
 
-            let completed_output_size = out_elem_size * control.rep_start();
-
             // Read in the input.
             let output_start_index = self.handler.fast_input(input, output_regpairs);
-            let completed_output_pairs = completed_output_size / 16;
-            let (new_output_index, completed_output_pairs) = match completed_output_size % 16 {
+            let completed_output_pairs = output_start / 16;
+            let (new_output_index, completed_output_pairs) = match output_start % 16 {
                 0 => (
                     output_start_index + completed_output_pairs,
                     completed_output_pairs,
@@ -276,19 +274,21 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
                     control,
                     input: &input.as_bytes()[..input_len],
                     output: &mut output.as_bytes_mut()[..output_len],
-                    elements_processed: elements_processed.as_mut(),
                 },
             );
 
             // For rep hypercalls, always write back the completed number of reps (which may be 0).
             // For simple hypercalls, on success write back all output. On failure (and timeout,
             // which is handled as a failure), nothing is written back.
-            let current_output_size = elements_processed.map_or_else(
-                || if ret.is_ok() { output_len } else { 0 }, // Simple calls.
-                |n| n * out_elem_size,                       // Rep calls.
-            );
+            let output_end = if out_elem_size > 0 {
+                out_elem_size * ret.elements_processed() as usize
+            } else if ret.call_status() == 0 {
+                output_len
+            } else {
+                0
+            };
 
-            let output_regpairs = (current_output_size + completed_output_size + 15) / 16;
+            let output_regpairs = (output_end + 15) / 16;
 
             // Only need to write back output regpairs that were not previously completely written
             // out, at the new output location.
@@ -330,19 +330,20 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
                     control,
                     input,
                     output,
-                    elements_processed: elements_processed.as_mut(),
                 },
             );
 
             // For rep hypercalls, always write back the completed number of reps (which may be 0).
             // For simple hypercalls, on success write back all output. On failure (and timeout,
             // which is handled as a failure), nothing is written back.
-            let current_output_size = elements_processed.map_or_else(
-                || if ret.is_ok() { output_len } else { 0 }, // Simple calls.
-                |n| n * out_elem_size,                       // Rep calls.
-            );
+            let output_end = if out_elem_size > 0 {
+                out_elem_size * ret.elements_processed() as usize
+            } else if ret.call_status() == 0 {
+                output_len
+            } else {
+                0
+            };
 
-            let output_end = output_start + current_output_size;
             self.guest_memory
                 .write_at(
                     output_gpa.wrapping_add(output_start as u64),
@@ -353,34 +354,11 @@ impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
             ret
         };
 
-        if ret.is_ok() {
-            debug_assert_eq!(
-                elements_processed.unwrap_or(0),
-                control.rep_count() - control.rep_start()
-            );
+        if ret.call_status() == 0 {
+            debug_assert_eq!(ret.elements_processed(), control.rep_count());
         }
 
-        let ret = match ret {
-            Err(HvError::Timeout) => {
-                self.handler.retry(
-                    control
-                        .with_rep_start(control.rep_start() + elements_processed.unwrap_or(0))
-                        .into(),
-                );
-                None
-            }
-            _ => Some(
-                HypercallOutput::new()
-                    .with_call_status(ret.map_or_else(|e| e.0, |_| 0))
-                    .with_elements_processed(
-                        (control.rep_start() + elements_processed.unwrap_or(0)) as u16,
-                    ),
-            ),
-        };
-
-        // Even failures are wrapped with Ok here since the error has already been transformed into
-        // a HypercallOutput.
-        Ok(ret)
+        Ok(Some(ret))
     }
 }
 
@@ -491,7 +469,7 @@ pub trait HypercallDefinition {
 /// A trait to dispatch an individual hypercall.
 pub trait HypercallDispatch<T> {
     /// Dispatch this hypercall.
-    fn dispatch(&mut self, params: HypercallParameters<'_>) -> hvdef::HvResult<()>;
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput;
 }
 
 /// A simple, non-variable hypercall.
@@ -508,6 +486,20 @@ where
             FromBytes::ref_from_prefix(params.input).unwrap(),
             FromBytes::mut_from_prefix(params.output).unwrap(),
         )
+    }
+
+    pub fn run(
+        params: HypercallParameters<'_>,
+        f: impl FnOnce(&In) -> HvResult<Out>,
+    ) -> HypercallOutput {
+        let (input, output) = Self::parse(params);
+        match f(input) {
+            Ok(r) => {
+                *output = r;
+                HypercallOutput::SUCCESS
+            }
+            Err(e) => HypercallOutput::from(e),
+        }
     }
 }
 
@@ -538,6 +530,20 @@ where
             Out::mut_from_prefix(params.output).unwrap(),
         )
     }
+
+    pub fn run(
+        params: HypercallParameters<'_>,
+        f: impl FnOnce(&In, &[u64]) -> HvResult<Out>,
+    ) -> HypercallOutput {
+        let (input, var_header, output) = Self::parse(params);
+        match f(input, var_header) {
+            Ok(r) => {
+                *output = r;
+                HypercallOutput::SUCCESS
+            }
+            Err(e) => HypercallOutput::from(e),
+        }
+    }
 }
 
 impl<In, Out, const CODE: u16> HypercallDefinition for VariableHypercall<In, Out, CODE> {
@@ -553,6 +559,12 @@ impl<In, Out, const CODE: u16> HypercallDefinition for VariableHypercall<In, Out
 /// A rep hypercall.
 pub struct RepHypercall<Hdr, In, Out, const CODE: u16>(PhantomData<(Hdr, In, Out)>);
 
+/// Hypervisor result type for rep hypercalls. These hypercalls have either no or only rep output
+/// data, which is passed separately from the result. The error is an a tuple consisting of an
+/// `HvError` and the number of elements successfully processed prior to the error being returned.
+/// An `Ok` result implies that all input elements were processed successfully.
+pub type HvRepResult = Result<(), (HvError, usize)>;
+
 impl<Hdr, In, Out, const CODE: u16> RepHypercall<Hdr, In, Out, CODE>
 where
     Hdr: AsBytes + FromBytes,
@@ -560,25 +572,38 @@ where
     Out: AsBytes + FromBytes,
 {
     /// Parses the hypercall parameters to input and output types.
-    pub fn parse(params: HypercallParameters<'_>) -> (&Hdr, &[In], &mut [Out], &mut usize) {
+    pub fn parse(params: HypercallParameters<'_>) -> (&Hdr, &[In], &mut [Out]) {
         let (header, rest) = Ref::<_, Hdr>::new_from_prefix(params.input).unwrap();
         let input = if size_of::<In>() == 0 {
             &[]
         } else {
-            &In::slice_from(rest).unwrap()[params.control.rep_start()..]
+            &In::slice_from(rest).unwrap()[params.control.rep_start() as usize..]
         };
         let output = if size_of::<Out>() == 0 {
             &mut []
         } else {
-            &mut Out::mut_slice_from(params.output).unwrap()[params.control.rep_start()..]
+            &mut Out::mut_slice_from(params.output).unwrap()[params.control.rep_start() as usize..]
         };
 
-        (
-            header.into_ref(),
-            input,
-            output,
-            params.elements_processed.unwrap(),
-        )
+        (header.into_ref(), input, output)
+    }
+
+    pub fn run(
+        params: HypercallParameters<'_>,
+        f: impl FnOnce(&Hdr, &[In], &mut [Out]) -> HvRepResult,
+    ) -> HypercallOutput {
+        let control = params.control;
+        let (header, input, output) = Self::parse(params);
+        match f(header, input, output) {
+            Ok(()) => HypercallOutput::SUCCESS.with_elements_processed(control.rep_count()),
+            Err((e, reps)) => {
+                assert!(
+                    control.rep_start() as usize + reps < control.rep_count() as usize,
+                    "more reps processed than requested"
+                );
+                HypercallOutput::from(e).with_elements_processed(control.rep_start() + reps as u16)
+            }
+        }
     }
 }
 
@@ -603,28 +628,39 @@ where
     Out: AsBytes + FromBytes,
 {
     /// Parses the hypercall parameters to input and output types.
-    pub fn parse(params: HypercallParameters<'_>) -> (&Hdr, &[u64], &[In], &mut [Out], &mut usize) {
+    pub fn parse(params: HypercallParameters<'_>) -> (&Hdr, &[u64], &[In], &mut [Out]) {
         let (header, rest) = Ref::<_, Hdr>::new_from_prefix(params.input).unwrap();
         let (var_header, rest) =
-            u64::slice_from_prefix(rest, params.control.variable_header_size()).unwrap();
+            u64::slice_from_prefix(rest, params.control.variable_header_size() as usize).unwrap();
         let input = if size_of::<In>() == 0 {
             &[]
         } else {
-            &In::slice_from(rest).unwrap()[params.control.rep_start()..]
+            &In::slice_from(rest).unwrap()[params.control.rep_start() as usize..]
         };
         let output = if size_of::<Out>() == 0 {
             &mut []
         } else {
-            &mut Out::mut_slice_from(params.output).unwrap()[params.control.rep_start()..]
+            &mut Out::mut_slice_from(params.output).unwrap()[params.control.rep_start() as usize..]
         };
+        (header.into_ref(), var_header, input, output)
+    }
 
-        (
-            header.into_ref(),
-            var_header,
-            input,
-            output,
-            params.elements_processed.unwrap(),
-        )
+    pub fn run(
+        params: HypercallParameters<'_>,
+        f: impl FnOnce(&Hdr, &[u64], &[In], &mut [Out]) -> HvRepResult,
+    ) -> HypercallOutput {
+        let control = params.control;
+        let (header, var_header, input, output) = Self::parse(params);
+        match f(header, var_header, input, output) {
+            Ok(()) => HypercallOutput::SUCCESS.with_elements_processed(control.rep_count()),
+            Err((e, reps)) => {
+                assert!(
+                    control.rep_start() as usize + reps < control.rep_count() as usize,
+                    "more reps processed than requested"
+                );
+                HypercallOutput::from(e).with_elements_processed(control.rep_start() + reps as u16)
+            }
+        }
     }
 }
 
@@ -647,6 +683,12 @@ pub struct VtlHypercall<const CODE: u16>(());
 impl<const CODE: u16> VtlHypercall<CODE> {
     pub fn parse(params: HypercallParameters<'_>) -> (u64, Control) {
         (u64::read_from(params.input).unwrap(), params.control)
+    }
+
+    pub fn run(params: HypercallParameters<'_>, f: impl FnOnce(u64, Control)) -> HypercallOutput {
+        let (input, control) = Self::parse(params);
+        f(input, control);
+        HypercallOutput::SUCCESS
     }
 }
 
@@ -697,7 +739,7 @@ pub struct Dispatcher<H> {
 #[doc(hidden)]
 pub struct HypercallHandler<H> {
     data: &'static HypercallData,
-    f: fn(&mut H, HypercallParameters<'_>) -> hvdef::HvResult<()>,
+    f: fn(&mut H, HypercallParameters<'_>) -> HypercallOutput,
 }
 
 impl<H> HypercallHandler<H> {

--- a/vm/hv1/hv1_hypercall/src/tests.rs
+++ b/vm/hv1/hv1_hypercall/src/tests.rs
@@ -20,7 +20,6 @@ use guestmem::PAGE_SIZE;
 use hvdef::hypercall::Control;
 use hvdef::hypercall::HypercallOutput;
 use hvdef::HvError;
-use hvdef::HvRepResult;
 use hvdef::HvResult;
 use hvdef::HV_PAGE_SIZE_USIZE;
 use open_enum::open_enum;
@@ -316,33 +315,6 @@ impl From<TestResult> for HypercallOutput {
     }
 }
 
-trait MapToHypercallResult {
-    fn map_to_hypercall_result(
-        &self,
-        rep_count: usize,
-        elements_processed: &mut usize,
-    ) -> HvResult<()>;
-}
-
-impl MapToHypercallResult for HvRepResult {
-    fn map_to_hypercall_result(
-        &self,
-        rep_count: usize,
-        elements_processed: &mut usize,
-    ) -> HvResult<()> {
-        match self {
-            Ok(()) => {
-                *elements_processed = rep_count;
-                Ok(())
-            }
-            Err((e, reps)) => {
-                *elements_processed = *reps;
-                Err(*e)
-            }
-        }
-    }
-}
-
 // Test controller object for vtl switch calls.
 #[derive(Default, Debug)]
 struct VtlTestController {
@@ -389,9 +361,8 @@ struct TestOutput([u8; 16]);
 // Simple hypercall with no input or output.
 type TestNull = SimpleHypercall<(), (), { TestHypercallCode::CallNull.0 }>;
 impl HypercallDispatch<TestNull> for TestHypercallHandler<'_> {
-    fn dispatch(&mut self, _params: HypercallParameters<'_>) -> HvResult<()> {
-        self.ctrl.simple_null()?;
-        Ok(())
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        TestNull::run(params, |()| self.ctrl.simple_null())
     }
 }
 
@@ -400,10 +371,8 @@ type TestSimpleNoOutput =
     SimpleHypercall<TestInput, (), { TestHypercallCode::CallSimpleNoOutput.0 }>;
 
 impl HypercallDispatch<TestSimpleNoOutput> for TestHypercallHandler<'_> {
-    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HvResult<()> {
-        let (input, _) = TestSimpleNoOutput::parse(params);
-        self.ctrl.simple_no_output(input)?;
-        Ok(())
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        TestSimpleNoOutput::run(params, |input| self.ctrl.simple_no_output(input))
     }
 }
 
@@ -411,10 +380,8 @@ impl HypercallDispatch<TestSimpleNoOutput> for TestHypercallHandler<'_> {
 type TestSimple = SimpleHypercall<TestInput, TestOutput, { TestHypercallCode::CallSimple.0 }>;
 
 impl HypercallDispatch<TestSimple> for TestHypercallHandler<'_> {
-    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HvResult<()> {
-        let (input, output) = TestSimple::parse(params);
-        *output = self.ctrl.simple(input)?;
-        Ok(())
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        TestSimple::run(params, |input| self.ctrl.simple(input))
     }
 }
 
@@ -422,22 +389,20 @@ impl HypercallDispatch<TestSimple> for TestHypercallHandler<'_> {
 type TestRepNoOutput = RepHypercall<TestInput, u64, (), { TestHypercallCode::CallRepNoOutput.0 }>;
 
 impl HypercallDispatch<TestRepNoOutput> for TestHypercallHandler<'_> {
-    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HvResult<()> {
-        let (header, input, _, elements_processed) = TestRepNoOutput::parse(params);
-        self.ctrl
-            .rep_no_output(header, input)
-            .map_to_hypercall_result(input.len(), elements_processed)
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        TestRepNoOutput::run(params, |header, input, _output| {
+            self.ctrl.rep_no_output(header, input)
+        })
     }
 }
 
 // Rep hypercall with input and output.
 type TestRep = RepHypercall<TestInput, u64, u64, { TestHypercallCode::CallRep.0 }>;
 impl HypercallDispatch<TestRep> for TestHypercallHandler<'_> {
-    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HvResult<()> {
-        let (header, input, output, elements_processed) = TestRep::parse(params);
-        self.ctrl
-            .rep(header, input, output)
-            .map_to_hypercall_result(input.len(), elements_processed)
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        TestRep::run(params, |header, input, output| {
+            self.ctrl.rep(header, input, output)
+        })
     }
 }
 
@@ -446,10 +411,10 @@ type TestVariableNoOutput =
     VariableHypercall<TestInput, (), { TestHypercallCode::CallVariableNoOutput.0 }>;
 
 impl HypercallDispatch<TestVariableNoOutput> for TestHypercallHandler<'_> {
-    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HvResult<()> {
-        let (input, var_header, _) = TestVariableNoOutput::parse(params);
-        self.ctrl.variable_no_output(input, var_header)?;
-        Ok(())
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        TestVariableNoOutput::run(params, |input, var_header| {
+            self.ctrl.variable_no_output(input, var_header)
+        })
     }
 }
 
@@ -457,10 +422,10 @@ impl HypercallDispatch<TestVariableNoOutput> for TestHypercallHandler<'_> {
 type TestVariable = VariableHypercall<TestInput, TestOutput, { TestHypercallCode::CallVariable.0 }>;
 
 impl HypercallDispatch<TestVariable> for TestHypercallHandler<'_> {
-    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HvResult<()> {
-        let (input, var_header, output) = TestVariable::parse(params);
-        *output = self.ctrl.variable(input, var_header)?;
-        Ok(())
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        TestVariable::run(params, |input, var_header| {
+            self.ctrl.variable(input, var_header)
+        })
     }
 }
 
@@ -469,12 +434,10 @@ type TestVariableRep =
     VariableRepHypercall<TestInput, u64, u64, { TestHypercallCode::CallVariableRep.0 }>;
 
 impl HypercallDispatch<TestVariableRep> for TestHypercallHandler<'_> {
-    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HvResult<()> {
-        let (header, var_header, input, output, elements_processed) =
-            TestVariableRep::parse(params);
-        self.ctrl
-            .variable_rep(header, var_header, input, output)
-            .map_to_hypercall_result(input.len(), elements_processed)
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        TestVariableRep::run(params, |header, var_header, input, output| {
+            self.ctrl.variable_rep(header, var_header, input, output)
+        })
     }
 }
 
@@ -482,10 +445,10 @@ impl HypercallDispatch<TestVariableRep> for TestHypercallHandler<'_> {
 pub type TestVtl = VtlHypercall<{ TestHypercallCode::CallVtl.0 }>;
 
 impl HypercallDispatch<TestVtl> for TestHypercallHandler<'_> {
-    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HvResult<()> {
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
         let (input, _) = TestVtl::parse(params);
         self.ctrl.vtl_switch(input);
-        Ok(())
+        HypercallOutput::SUCCESS
     }
 }
 
@@ -1205,7 +1168,7 @@ fn check_test_result(test_params: &TestParams, result: HypercallOutput, control:
             _ => 0,
         };
 
-        assert_eq!(control.rep_start(), reps);
+        assert_eq!(control.rep_start() as usize, reps);
     }
 }
 
@@ -1334,9 +1297,9 @@ where
         Control::new()
             .with_code(call_code.0)
             .with_fast(params.fast)
-            .with_rep_start(ctrl.reps.unwrap_or((0, 0)).0)
-            .with_rep_count(input_reps.len())
-            .with_variable_header_size(var_header.len() / 8)
+            .with_rep_start(ctrl.reps.unwrap_or((0, 0)).0.try_into().unwrap())
+            .with_rep_count(input_reps.len().try_into().unwrap())
+            .with_variable_header_size((var_header.len() / 8).try_into().unwrap())
     });
 
     println!("input control: {:?}", input_control);

--- a/vm/hv1/hv1_hypercall/src/tests.rs
+++ b/vm/hv1/hv1_hypercall/src/tests.rs
@@ -305,11 +305,11 @@ impl From<TestResult> for HypercallOutput {
                 HypercallOutput::new().with_call_status(err.0)
             }
             TestResult::Rep(RepResult::Success(rep_count)) => {
-                HypercallOutput::new().with_elements_processed(rep_count as u16)
+                HypercallOutput::new().with_elements_processed(rep_count)
             }
             TestResult::Rep(RepResult::Failure(err, rep_count)) => HypercallOutput::new()
                 .with_call_status(err.0)
-                .with_elements_processed(rep_count as u16),
+                .with_elements_processed(rep_count),
             _ => panic!("Should not be invoked for VTL"),
         }
     }
@@ -1168,7 +1168,7 @@ fn check_test_result(test_params: &TestParams, result: HypercallOutput, control:
             _ => 0,
         };
 
-        assert_eq!(control.rep_start() as usize, reps);
+        assert_eq!({ control.rep_start() }, reps);
     }
 }
 
@@ -1297,9 +1297,9 @@ where
         Control::new()
             .with_code(call_code.0)
             .with_fast(params.fast)
-            .with_rep_start(ctrl.reps.unwrap_or((0, 0)).0.try_into().unwrap())
-            .with_rep_count(input_reps.len().try_into().unwrap())
-            .with_variable_header_size((var_header.len() / 8).try_into().unwrap())
+            .with_rep_start(ctrl.reps.unwrap_or((0, 0)).0)
+            .with_rep_count(input_reps.len())
+            .with_variable_header_size(var_header.len() / 8)
     });
 
     println!("input control: {:?}", input_control);

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -484,12 +484,6 @@ impl core::error::Error for HvError {}
 /// The error is an `HvError` and the success value `T` is the output data of the hypercall.
 pub type HvResult<T> = Result<T, HvError>;
 
-/// Hypervisor result type for rep hypercalls. These hypercalls have either no or only rep output
-/// data, which is passed separately from the result. The error is an a tuple consisting of an
-/// `HvError` and the number of elements successfully processed prior to the error being returned.
-/// An `Ok` result implies that all input elements were processed successfully.
-pub type HvRepResult = Result<(), (HvError, usize)>;
-
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Vtl {
@@ -744,24 +738,21 @@ pub mod hypercall {
         pub fast: bool,
         /// The variable header size, in qwords.
         #[bits(10)]
-        pub variable_header_size: usize,
-        /// Reserved, must be zero.
+        pub variable_header_size: u16,
         #[bits(4)]
-        pub _rsvd0: usize,
+        _rsvd0: u8,
         /// Specifies that the hypercall should be handled by the L0 hypervisor in a nested environment.
         pub nested: bool,
         /// The element count for rep hypercalls.
         #[bits(12)]
-        pub rep_count: usize,
-        /// Reserved, must be zero.
+        pub rep_count: u16,
         #[bits(4)]
-        pub _rsvd1: usize,
+        _rsvd1: u8,
         /// The first element to start processing in a rep hypercall.
         #[bits(12)]
-        pub rep_start: usize,
-        /// Reserved, must be zero.
+        pub rep_start: u16,
         #[bits(4)]
-        pub _rsvd2: usize,
+        _rsvd2: u8,
     }
 
     /// The hypercall output value returned to the guest.

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -738,19 +738,19 @@ pub mod hypercall {
         pub fast: bool,
         /// The variable header size, in qwords.
         #[bits(10)]
-        pub variable_header_size: u16,
+        pub variable_header_size: usize,
         #[bits(4)]
         _rsvd0: u8,
         /// Specifies that the hypercall should be handled by the L0 hypervisor in a nested environment.
         pub nested: bool,
         /// The element count for rep hypercalls.
         #[bits(12)]
-        pub rep_count: u16,
+        pub rep_count: usize,
         #[bits(4)]
         _rsvd1: u8,
         /// The first element to start processing in a rep hypercall.
         #[bits(12)]
-        pub rep_start: u16,
+        pub rep_start: usize,
         #[bits(4)]
         _rsvd2: u8,
     }
@@ -764,7 +764,7 @@ pub mod hypercall {
         pub call_status: u16,
         pub rsvd: u16,
         #[bits(12)]
-        pub elements_processed: u16,
+        pub elements_processed: usize,
         #[bits(20)]
         pub rsvd2: u32,
     }

--- a/vmm_core/virt_hvf/src/hypercall.rs
+++ b/vmm_core/virt_hvf/src/hypercall.rs
@@ -7,6 +7,7 @@ use crate::abi;
 use crate::HvfProcessor;
 use hv1_hypercall::Arm64RegisterState;
 use hv1_hypercall::GetVpRegisters;
+use hv1_hypercall::HvRepResult;
 use hv1_hypercall::PostMessage;
 use hv1_hypercall::SetVpRegisters;
 use hv1_hypercall::SignalEvent;
@@ -69,7 +70,7 @@ impl<T> GetVpRegisters for HvfHypercallHandler<'_, '_, T> {
         _vtl: Option<Vtl>,
         registers: &[hvdef::HvRegisterName],
         output: &mut [hvdef::HvRegisterValue],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != hvdef::HV_PARTITION_ID_SELF || vp_index != hvdef::HV_VP_INDEX_SELF {
             return Err((HvError::InvalidParameter, 0));
         }
@@ -118,7 +119,7 @@ impl<T> SetVpRegisters for HvfHypercallHandler<'_, '_, T> {
         vp_index: u32,
         _vtl: Option<Vtl>,
         registers: &[HvRegisterAssoc],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != hvdef::HV_PARTITION_ID_SELF || vp_index != hvdef::HV_VP_INDEX_SELF {
             return Err((HvError::InvalidParameter, 0));
         }

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -7,6 +7,7 @@ use crate::Hv1State;
 use crate::WhpProcessor;
 #[cfg(guest_arch = "aarch64")]
 use aarch64 as arch;
+use hv1_hypercall::HvRepResult;
 use hvdef::hypercall::HostVisibilityType;
 use hvdef::hypercall::HvInterceptType;
 use hvdef::HvError;
@@ -234,7 +235,7 @@ impl<T: CpuIo> hv1_hypercall::GetVpRegisters for WhpHypercallExit<'_, '_, T> {
         vtl: Option<Vtl>,
         registers: &[hvdef::HvRegisterName],
         output: &mut [hvdef::HvRegisterValue],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         tracing::trace!(partition_id, vp_index, ?vtl, ?registers, "get_vp_registers");
         if partition_id != HV_PARTITION_ID_SELF || vp_index != HV_VP_INDEX_SELF {
             return Err((HvError::InvalidParameter, 0));
@@ -263,7 +264,7 @@ impl<T: CpuIo> hv1_hypercall::SetVpRegisters for WhpHypercallExit<'_, '_, T> {
         vp_index: u32,
         vtl: Option<Vtl>,
         registers: &[hvdef::hypercall::HvRegisterAssoc],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         tracing::trace!(partition_id, vp_index, ?vtl, ?registers, "set_vp_registers");
         if partition_id != HV_PARTITION_ID_SELF || vp_index != HV_VP_INDEX_SELF {
             return Err((HvError::InvalidParameter, 0));
@@ -394,7 +395,7 @@ impl<T: CpuIo> hv1_hypercall::ModifyVtlProtectionMask for WhpHypercallExit<'_, '
         map_flags: HvMapGpaFlags,
         target_vtl: Option<Vtl>,
         gpa_pages: &[u64],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
         }
@@ -579,7 +580,7 @@ impl<T: CpuIo> hv1_hypercall::AcceptGpaPages for WhpHypercallExit<'_, '_, T> {
         vtl_permission_set: hvdef::hypercall::VtlPermissionSet,
         gpa_page_base: u64,
         page_count: usize,
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
         }
@@ -642,7 +643,7 @@ impl<T: CpuIo> hv1_hypercall::ModifySparseGpaPageHostVisibility for WhpHypercall
         partition_id: u64,
         visibility: HostVisibilityType,
         gpa_pages: &[u64],
-    ) -> hvdef::HvRepResult {
+    ) -> HvRepResult {
         if partition_id != HV_PARTITION_ID_SELF {
             return Err((HvError::AccessDenied, 0));
         }
@@ -689,6 +690,7 @@ mod x86 {
     use crate::WhpRunVpError;
     use arrayvec::ArrayVec;
     use hv1_hypercall::HvInterruptParameters;
+    use hv1_hypercall::HvRepResult;
     use hv1_hypercall::HypercallIo;
     use hv1_hypercall::SignalEventDirect;
     use hv1_hypercall::TranslateVirtualAddressExX64;
@@ -701,7 +703,6 @@ mod x86 {
     use hvdef::HvRegisterName;
     use hvdef::HvRegisterValue;
     use hvdef::HvRegisterVsmVpSecureVtlConfig;
-    use hvdef::HvRepResult;
     use hvdef::HvResult;
     use hvdef::HvVpAssistPageActionSignalEvent;
     use hvdef::HvX64RegisterName;


### PR DESCRIPTION
Get rid of the weird sidecar `elements_processed` field and have the hypercall infra code construct the hypercall output directly.