### PR TITLE
page_pool_alloc: fix features so cargo check works correctly

### DIFF
--- a/openhcl/page_pool_alloc/Cargo.toml
+++ b/openhcl/page_pool_alloc/Cargo.toml
@@ -7,11 +7,12 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-vfio = ["user_driver/vfio"]
+# Enable mapping support, using the MshvVtlLow.
+hcl_mapping = ["hcl"]
+# Enable user_driver vfio trait support.
+vfio = ["hcl_mapping", "user_driver/vfio"]
 
 [dependencies]
-hcl.workspace = true
-
 user_driver.workspace = true
 hvdef.workspace = true
 sparse_mmap.workspace = true
@@ -26,6 +27,9 @@ parking_lot.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+hcl = { workspace = true, optional = true}
 
 [lints]
 workspace = true

--- a/openhcl/page_pool_alloc/src/lib.rs
+++ b/openhcl/page_pool_alloc/src/lib.rs
@@ -13,7 +13,7 @@ pub use device_dma::PagePoolDmaBuffer;
 
 #[cfg(all(feature = "vfio", target_os = "linux"))]
 use anyhow::Context;
-#[cfg(all(feature = "vfio", target_os = "linux"))]
+#[cfg(all(feature = "hcl_mapping", target_os = "linux"))]
 use hcl::ioctl::MshvVtlLow;
 use hvdef::HV_PAGE_SIZE;
 use inspect::Inspect;
@@ -623,9 +623,7 @@ impl PagePoolAllocator {
         })
     }
 
-    // TODO: Feature gate this in the future to remove the always dependency on
-    // MshvVtlLow.
-    #[cfg(target_os = "linux")]
+    #[cfg(all(feature = "hcl_mapping", target_os = "linux"))]
     fn create_mapping(
         base_pfn: u64,
         page_count: u64,
@@ -657,7 +655,7 @@ impl PagePoolAllocator {
         Ok(mapping)
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(all(feature = "hcl_mapping", target_os = "linux")))]
     fn create_mapping(
         _base_pfn: u64,
         _page_count: u64,
@@ -763,6 +761,7 @@ impl PagePoolAllocator {
     /// The same as [`Self::alloc`], but also creates an associated mapping for
     /// the allocation so the user can use the mapping via
     /// [`PagePoolHandle::mapping`].
+    #[cfg(all(feature = "hcl_mapping", target_os = "linux"))]
     pub fn alloc_with_mapping(
         &self,
         size_pages: NonZeroU64,

--- a/openhcl/virt_mshv_vtl/Cargo.toml
+++ b/openhcl/virt_mshv_vtl/Cargo.toml
@@ -13,7 +13,7 @@ gdb = []
 aarch64emu.workspace = true
 aarch64defs.workspace = true
 hcl.workspace = true
-page_pool_alloc.workspace = true
+page_pool_alloc = { workspace = true, features = ["hcl_mapping"] }
 virt.workspace = true
 virt_support_aarch64emu.workspace = true
 virt_support_apic.workspace = true


### PR DESCRIPTION
Add a new feature that correctly gates `alloc_with_mapping` so `cargo check` with no features on linux works correctly again. 