### PR TITLE
hcl: fix multiple calls to `flush_deferred_actions`

### DIFF
--- a/openhcl/hcl/src/ioctl/deferred.rs
+++ b/openhcl/hcl/src/ioctl/deferred.rs
@@ -27,6 +27,10 @@ impl DeferredActions {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.actions.is_empty()
+    }
+
     /// Copies the queued actions to the slots in the run page. Issues any
     /// immediately that won't fit in the run page.
     pub fn copy_to_slots(&mut self, slots: &mut DeferredActionSlots, hcl: &Hcl) {


### PR DESCRIPTION
Don't remove the deferred action list from TLS until the `ProcessorRunner` is actually dropped.

This fixes crashes after a failed servicing operation.