### PR TITLE
virt_mshv_vtl/mshv_x64: Remove support for emulating APIC

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -315,7 +315,6 @@ async fn launch_workers(
         force_load_vtl0_image: opt.force_load_vtl0_image,
         nvme_vfio: opt.nvme_vfio,
         mcr: opt.mcr,
-        emulate_apic: opt.emulate_apic,
         enable_shared_visibility_pool: opt.enable_shared_visibility_pool,
         cvm_guest_vsm: opt.cvm_guest_vsm,
         halt_on_guest_halt: opt.halt_on_guest_halt,

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -89,10 +89,6 @@ pub struct Options {
     /// MCR Device Enable
     pub mcr: bool, // TODO MCR: support closed-source ENV vars
 
-    /// (OPENHCL_EMULATE_APIC=1)
-    /// Enable an APIC emulator.
-    pub emulate_apic: bool,
-
     /// (OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1)
     /// Enable the shared visibility pool. This is enabled by default on
     /// hardware isolated platforms, but can be enabled for testing. Hardware
@@ -192,7 +188,6 @@ impl Options {
         let vtl0_starts_paused = parse_legacy_env_bool("OPENHCL_VTL0_STARTS_PAUSED");
         let serial_wait_for_rts = parse_legacy_env_bool("OPENHCL_SERIAL_WAIT_FOR_RTS");
         let nvme_vfio = parse_legacy_env_bool("OPENHCL_NVME_VFIO");
-        let emulate_apic = parse_legacy_env_bool("OPENHCL_EMULATE_APIC");
         let mcr = parse_legacy_env_bool("OPENHCL_MCR_DEVICE");
         let enable_shared_visibility_pool =
             parse_legacy_env_bool("OPENHCL_ENABLE_SHARED_VISIBILITY_POOL");
@@ -250,7 +245,6 @@ impl Options {
             force_load_vtl0_image,
             nvme_vfio,
             mcr,
-            emulate_apic,
             enable_shared_visibility_pool,
             cvm_guest_vsm,
             hide_isolation,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -282,8 +282,6 @@ pub struct UnderhillEnvCfg {
     // TODO MCR: support closed-source configuration logic for MCR device
     pub mcr: bool,
 
-    /// Enable an APIC emulator.
-    pub emulate_apic: bool,
     /// Enable the shared visibility pool. This is enabled by default on
     /// hardware isolated platforms, but can be enabled for testing. Hardware
     /// devices will use the shared pool for DMA if enabled.
@@ -1740,8 +1738,6 @@ async fn new_underhill_vm(
         vmm_core::cpuid::hyperv_cpuid_leaves(extended_ioapic_rte).collect::<Vec<_>>()
     };
 
-    let emulate_apic = cfg!(guest_arch = "x86_64") && (env_cfg.emulate_apic || hardware_isolated);
-
     let (crash_notification_send, crash_notification_recv) = mesh::channel();
 
     let state_units = StateUnits::new();
@@ -1771,7 +1767,6 @@ async fn new_underhill_vm(
         #[cfg(guest_arch = "x86_64")]
         cpuid,
         crash_notification_send,
-        emulate_apic,
         vmtime: &vmtime_source,
         isolated_memory_protector: gm.isolated_memory_protector()?,
         shared_vis_pages_pool: shared_vis_pages_pool.as_ref().map(|p| {

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1052,10 +1052,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::TranslateVirtualAddressX64
                 // description. However, for full correctness this should be
                 // extended to check for all overlay pages.
                 let overlay_page = hvdef::hypercall::MsrHypercallContents::from(
-                    self.vp
-                        .backing
-                        .hv(target_vtl)
-                        .expect("has an hv emulator")
+                    self.vp.backing.cvm_state_mut().hv[target_vtl]
                         .msr_read(hvdef::HV_X64_MSR_HYPERCALL)
                         .unwrap(),
                 )

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -232,13 +232,6 @@ mod private {
         /// This is used for hypervisor-managed and untrusted SINTs.
         fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16);
 
-        /// Returns whether this VP should be put to sleep in usermode, or
-        /// whether it's ready to proceed into the kernel.
-        fn halt_in_usermode(this: &mut UhProcessor<'_, Self>, target_vtl: GuestVtl) -> bool {
-            let _ = (this, target_vtl);
-            false
-        }
-
         /// Checks interrupt status for all VTLs, and handles cross VTL interrupt preemption and VINA.
         /// Returns whether interrupt reprocessing is required.
         fn handle_cross_vtl_interrupts(
@@ -712,12 +705,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                     }
                 }
 
-                // TODO WHP GUEST VSM: This should be next_vtl
-                if T::halt_in_usermode(self, GuestVtl::Vtl0) {
-                    break Poll::Pending;
-                } else {
-                    return <Result<_, VpHaltReason<_>>>::Ok(()).into();
-                }
+                return <Result<_, VpHaltReason<_>>>::Ok(()).into();
             })
             .await?;
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -76,10 +76,9 @@ use zerocopy::FromZeroes;
 /// software-isolated).
 #[derive(InspectMut)]
 pub struct HypervisorBackedX86 {
-    // TODO WHP GUEST VSM: To be completely correct here, when emulating the APICs
-    // we would need two sets of deliverability notifications too. However currently
-    // we don't support VTL 1 on WHP, and on the hypervisor we don't emulate the APIC,
-    // so this can wait.
+    // TODO WHP GUEST VSM: To be completely correct here we would need two sets of
+    // deliverability notifications too. However currently we don't support VTL 1
+    // on WHP so this can wait.
     #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
     deliverability_notifications: HvDeliverabilityNotificationsRegister,
     /// Next set of deliverability notifications. See register definition for details.
@@ -1316,7 +1315,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
     }
 
     fn lapic_base_address(&self) -> Option<u64> {
-        unimplemented!()
+        None
     }
 
     fn lapic_read(&mut self, _address: u64, _data: &mut [u8]) {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -14,7 +14,6 @@ use super::super::vp_state::UhVpStateAccess;
 use super::super::BackingPrivate;
 use super::super::UhEmulationState;
 use super::super::UhRunVpError;
-use crate::processor::LapicState;
 use crate::processor::SidecarExitReason;
 use crate::processor::SidecarRemoveExit;
 use crate::processor::UhHypercallHandler;
@@ -25,12 +24,9 @@ use crate::Error;
 use crate::GuestVsmState;
 use crate::GuestVsmVtl1State;
 use crate::GuestVtl;
-use crate::UhPartitionInner;
-use crate::WakeReason;
 use hcl::ioctl;
 use hcl::ioctl::x64::MshvX64;
 use hcl::ioctl::ApplyVtlProtectionsError;
-use hcl::ioctl::ProcessorRunner;
 use hcl::protocol;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::synic::ProcessorSynic;
@@ -43,10 +39,7 @@ use hvdef::HvMessageType;
 use hvdef::HvRegisterValue;
 use hvdef::HvRegisterVsmPartitionConfig;
 use hvdef::HvX64InterceptMessageHeader;
-use hvdef::HvX64InterruptStateRegister;
 use hvdef::HvX64PendingEvent;
-use hvdef::HvX64PendingEventReg0;
-use hvdef::HvX64PendingInterruptionRegister;
 use hvdef::HvX64PendingInterruptionType;
 use hvdef::HvX64RegisterName;
 use hvdef::Vtl;
@@ -60,22 +53,14 @@ use virt::state::HvRegisterState;
 use virt::state::StateElement;
 use virt::vp;
 use virt::vp::AccessVpState;
-use virt::vp::MpState;
 use virt::x86::MsrError;
-use virt::x86::MsrErrorExt;
-use virt::Processor;
 use virt::StopVp;
 use virt::VpHaltReason;
 use virt::VpIndex;
-use virt_support_apic::ApicClient;
-use virt_support_apic::ApicWork;
 use virt_support_x86emu::emulate::EmuCheckVtlAccessError;
 use virt_support_x86emu::emulate::EmuTranslateError;
 use virt_support_x86emu::emulate::EmuTranslateResult;
 use virt_support_x86emu::emulate::EmulatorSupport;
-use vmcore::vmtime::VmTime;
-use vmcore::vmtime::VmTimeAccess;
-use vtl_array::VtlArray;
 use vtl_array::VtlSet;
 use x86defs::xsave::Fxsave;
 use x86defs::xsave::XsaveHeader;
@@ -91,8 +76,6 @@ use zerocopy::FromZeroes;
 /// software-isolated).
 #[derive(InspectMut)]
 pub struct HypervisorBackedX86 {
-    pub(super) lapics: Option<VtlArray<LapicState, 2>>,
-    hv: Option<VtlArray<ProcessorVtlHv, 2>>,
     // TODO WHP GUEST VSM: To be completely correct here, when emulating the APICs
     // we would need two sets of deliverability notifications too. However currently
     // we don't support VTL 1 on WHP, and on the hypervisor we don't emulate the APIC,
@@ -160,28 +143,7 @@ impl BackingPrivate for HypervisorBackedX86 {
             reserved: [0; 384],
         };
 
-        // This VP may have been running on the sidecar, so we need to check if the apic
-        // base has moved from the reset value.
-        let lapics = if let Some(mut lapics) = params.lapics {
-            let apic_base = params
-                .runner
-                // TODO GUEST VSM
-                .get_vp_register(GuestVtl::Vtl0, HvX64RegisterName::ApicBase)
-                .unwrap()
-                .as_u64();
-
-            lapics.each_mut().map(|state| {
-                state.lapic.set_apic_base(apic_base).unwrap();
-            });
-
-            lapics.into()
-        } else {
-            None
-        };
-
         Ok(Self {
-            lapics,
-            hv: params.hv,
             deliverability_notifications: Default::default(),
             next_deliverability_notifications: Default::default(),
             stats: Default::default(),
@@ -289,7 +251,7 @@ impl BackingPrivate for HypervisorBackedX86 {
                     &mut this.backing.stats.cpuid
                 }
                 HvMessageType::HvMessageTypeMsrIntercept => {
-                    intercept_handler.handle_msr_intercept(dev)?;
+                    intercept_handler.handle_msr_intercept()?;
                     &mut this.backing.stats.msr
                 }
                 HvMessageType::HvMessageTypeX64ApicEoi => {
@@ -299,10 +261,6 @@ impl BackingPrivate for HypervisorBackedX86 {
                 HvMessageType::HvMessageTypeUnrecoverableException => {
                     intercept_handler.handle_unrecoverable_exception()?;
                     &mut this.backing.stats.unrecoverable_exception
-                }
-                HvMessageType::HvMessageTypeX64Halt => {
-                    intercept_handler.handle_halt()?;
-                    &mut this.backing.stats.halt
                 }
                 HvMessageType::HvMessageTypeExceptionIntercept => {
                     intercept_handler.handle_exception()?;
@@ -331,60 +289,11 @@ impl BackingPrivate for HypervisorBackedX86 {
     }
 
     fn poll_apic(
-        this: &mut UhProcessor<'_, Self>,
-        vtl: GuestVtl,
-        scan_irr: bool,
+        _this: &mut UhProcessor<'_, Self>,
+        _vtl: GuestVtl,
+        _scan_irr: bool,
     ) -> Result<(), UhRunVpError> {
-        let Some(lapics) = this.backing.lapics.as_mut() else {
-            return Ok(());
-        };
-
-        let ApicWork {
-            init,
-            extint,
-            sipi,
-            nmi,
-            interrupt,
-        } = lapics[vtl].lapic.scan(&mut this.vmtime, scan_irr);
-
-        // TODO WHP GUEST VSM: An INIT/SIPI targeted at a VP with more than one guest VTL enabled is ignored.
-        if init {
-            this.handle_init(vtl)?;
-        }
-
-        if let Some(vector) = sipi {
-            this.handle_sipi(vtl, vector)?;
-        }
-
-        let Some(lapics) = this.backing.lapics.as_mut() else {
-            unreachable!()
-        };
-
-        // Interrupts are ignored while waiting for SIPI.
-        if lapics[vtl].activity != MpState::WaitForSipi {
-            if nmi || lapics[vtl].nmi_pending {
-                lapics[vtl].nmi_pending = true;
-                this.handle_nmi(vtl)?;
-            }
-
-            if let Some(vector) = interrupt {
-                this.handle_interrupt(vtl, vector)?;
-            }
-
-            if extint {
-                todo!();
-            }
-        }
-
         Ok(())
-    }
-
-    fn halt_in_usermode(this: &mut UhProcessor<'_, Self>, target_vtl: GuestVtl) -> bool {
-        if let Some(lapics) = this.backing.lapics.as_ref() {
-            lapics[target_vtl].activity != MpState::Running
-        } else {
-            false
-        }
     }
 
     fn handle_cross_vtl_interrupts(
@@ -407,12 +316,12 @@ impl BackingPrivate for HypervisorBackedX86 {
             .set_sints(this.backing.next_deliverability_notifications.sints() | sints);
     }
 
-    fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv> {
-        self.hv.as_ref().map(|arr| &arr[vtl])
+    fn hv(&self, _vtl: GuestVtl) -> Option<&ProcessorVtlHv> {
+        None
     }
 
-    fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
-        self.hv.as_mut().map(|arr| &mut arr[vtl])
+    fn hv_mut(&mut self, _vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
+        None
     }
 
     fn untrusted_synic(&self) -> Option<&ProcessorSynic> {
@@ -839,7 +748,7 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         self.vp.set_rip(self.intercepted_vtl, next_rip)
     }
 
-    fn handle_msr_intercept(&mut self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
+    fn handle_msr_intercept(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64MsrInterceptMessage::ref_from_prefix(
             self.vp.runner.exit_message().payload(),
         )
@@ -851,23 +760,7 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         let msr = message.msr_number;
         match message.header.intercept_access_type {
             HvInterceptAccessType::READ => {
-                let r = if let Some(lapics) = &mut self.vp.backing.lapics {
-                    lapics[self.intercepted_vtl]
-                        .lapic
-                        .access(&mut UhApicClient {
-                            partition: self.vp.partition,
-                            runner: &mut self.vp.runner,
-                            vmtime: &self.vp.vmtime,
-                            dev,
-                            vtl: self.intercepted_vtl,
-                        })
-                        .msr_read(msr)
-                } else {
-                    Err(MsrError::Unknown)
-                };
-                let r = r.or_else_if_unknown(|| self.vp.read_msr(msr, self.intercepted_vtl));
-
-                let value = match r {
+                let value = match self.vp.read_msr(msr, self.intercepted_vtl) {
                     Ok(v) => v,
                     Err(MsrError::Unknown) => {
                         tracing::trace!(msr, "unknown msr read");
@@ -885,23 +778,7 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
             }
             HvInterceptAccessType::WRITE => {
                 let value = (message.rax & 0xffff_ffff) | (message.rdx << 32);
-                let r = if let Some(lapic) = &mut self.vp.backing.lapics {
-                    lapic[self.intercepted_vtl]
-                        .lapic
-                        .access(&mut UhApicClient {
-                            partition: self.vp.partition,
-                            runner: &mut self.vp.runner,
-                            vmtime: &self.vp.vmtime,
-                            dev,
-                            vtl: self.intercepted_vtl,
-                        })
-                        .msr_write(msr, value)
-                } else {
-                    Err(MsrError::Unknown)
-                };
-                let r =
-                    r.or_else_if_unknown(|| self.vp.write_msr(msr, value, self.intercepted_vtl));
-                match r {
+                match self.vp.write_msr(msr, value, self.intercepted_vtl) {
                     Ok(()) => {}
                     Err(MsrError::Unknown) => {
                         tracing::trace!(msr, value, "unknown msr write");
@@ -936,11 +813,6 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         })
     }
 
-    fn handle_halt(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
-        self.vp.backing.lapics.as_mut().unwrap()[self.intercepted_vtl].activity = MpState::Halted;
-        Ok(())
-    }
-
     fn handle_exception(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
         let message = hvdef::HvX64ExceptionInterceptMessage::ref_from_prefix(
             self.vp.runner.exit_message().payload(),
@@ -958,180 +830,6 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
 }
 
 impl UhProcessor<'_, HypervisorBackedX86> {
-    fn handle_interrupt(&mut self, vtl: GuestVtl, vector: u8) -> Result<(), UhRunVpError> {
-        const NAMES: &[HvX64RegisterName] = &[
-            HvX64RegisterName::Rflags,
-            HvX64RegisterName::Cr8,
-            HvX64RegisterName::InterruptState,
-            HvX64RegisterName::PendingInterruption,
-            HvX64RegisterName::PendingEvent0,
-        ];
-        let mut values = [0u32.into(); NAMES.len()];
-        self.runner
-            .get_vp_registers(vtl, NAMES, &mut values)
-            .map_err(UhRunVpError::EmulationState)?;
-
-        let &[rflags, cr8, interrupt_state, pending_interruption, pending_event] = &values;
-        let pending_interruption =
-            HvX64PendingInterruptionRegister::from(pending_interruption.as_u64());
-        let pending_event = HvX64PendingEventReg0::from(pending_event.as_u128());
-        let interrupt_state = HvX64InterruptStateRegister::from(interrupt_state.as_u64());
-        let rflags = RFlags::from(rflags.as_u64());
-        let cr8 = cr8.as_u64();
-
-        let priority = vector >> 4;
-
-        let lapic_state = &mut self.backing.lapics.as_mut().unwrap()[vtl];
-
-        // Exit idle when an interrupt is pending
-        if lapic_state.activity == MpState::Idle {
-            lapic_state.activity = MpState::Running;
-        }
-
-        if pending_interruption.interruption_pending()
-            || interrupt_state.interrupt_shadow()
-            || !rflags.interrupt_enable()
-            || cr8 >= priority as u64
-            || pending_event.event_pending()
-        {
-            if !self
-                .backing
-                .next_deliverability_notifications
-                .interrupt_notification()
-                || (self
-                    .backing
-                    .next_deliverability_notifications
-                    .interrupt_priority()
-                    != 0
-                    && self
-                        .backing
-                        .next_deliverability_notifications
-                        .interrupt_priority()
-                        < priority)
-            {
-                self.backing
-                    .next_deliverability_notifications
-                    .set_interrupt_notification(true);
-                self.backing
-                    .next_deliverability_notifications
-                    .set_interrupt_priority(priority);
-            }
-
-            return Ok(());
-        }
-
-        let interruption = HvX64PendingInterruptionRegister::new()
-            .with_interruption_type(HvX64PendingInterruptionType::HV_X64_PENDING_INTERRUPT.0)
-            .with_interruption_vector(vector.into())
-            .with_interruption_pending(true);
-
-        self.runner
-            .set_vp_register(
-                vtl,
-                HvX64RegisterName::PendingInterruption,
-                u64::from(interruption).into(),
-            )
-            .map_err(UhRunVpError::EmulationState)?;
-
-        lapic_state.activity = MpState::Running;
-        tracing::trace!(vector, "interrupted");
-        lapic_state.lapic.acknowledge_interrupt(vector);
-
-        Ok(())
-    }
-
-    fn handle_nmi(&mut self, vtl: GuestVtl) -> Result<(), UhRunVpError> {
-        const NAMES: &[HvX64RegisterName] = &[
-            HvX64RegisterName::InterruptState,
-            HvX64RegisterName::PendingInterruption,
-            HvX64RegisterName::PendingEvent0,
-        ];
-        let mut values = [0u32.into(); NAMES.len()];
-        self.runner
-            .get_vp_registers(vtl, NAMES, &mut values)
-            .map_err(UhRunVpError::EmulationState)?;
-
-        let &[interrupt_state, pending_interruption, pending_event] = &values;
-        let pending_interruption =
-            HvX64PendingInterruptionRegister::from(pending_interruption.as_u64());
-        let pending_event = HvX64PendingEventReg0::from(pending_event.as_u128());
-        let interrupt_state = HvX64InterruptStateRegister::from(interrupt_state.as_u64());
-        let lapic = &mut self.backing.lapics.as_mut().unwrap()[vtl];
-
-        // Exit idle when an interrupt is pending
-        if lapic.activity == MpState::Idle {
-            lapic.activity = MpState::Running;
-        }
-
-        if pending_interruption.interruption_pending()
-            || interrupt_state.nmi_masked()
-            || interrupt_state.interrupt_shadow()
-            || pending_event.event_pending()
-        {
-            if !self
-                .backing
-                .next_deliverability_notifications
-                .nmi_notification()
-            {
-                self.backing
-                    .next_deliverability_notifications
-                    .set_nmi_notification(true);
-            }
-
-            return Ok(());
-        }
-
-        let interruption = HvX64PendingInterruptionRegister::new()
-            .with_interruption_type(HvX64PendingInterruptionType::HV_X64_PENDING_NMI.0)
-            .with_interruption_vector(2)
-            .with_interruption_pending(true);
-
-        self.runner
-            .set_vp_register(
-                vtl,
-                HvX64RegisterName::PendingInterruption,
-                u64::from(interruption).into(),
-            )
-            .map_err(UhRunVpError::EmulationState)?;
-
-        lapic.activity = MpState::Running;
-        lapic.nmi_pending = false;
-
-        tracing::trace!("nmi");
-
-        Ok(())
-    }
-
-    fn handle_init(&mut self, vtl: GuestVtl) -> Result<(), UhRunVpError> {
-        let vp_info = self.inner.vp_info;
-        let mut access = self.access_state(vtl.into());
-        vp::x86_init(&mut access, &vp_info).map_err(UhRunVpError::State)
-    }
-
-    fn handle_sipi(&mut self, vtl: GuestVtl, vector: u8) -> Result<(), UhRunVpError> {
-        let lapic = &mut self.backing.lapics.as_mut().unwrap()[vtl];
-        if lapic.activity == MpState::WaitForSipi {
-            let address = (vector as u64) << 12;
-            let cs: hvdef::HvX64SegmentRegister = hvdef::HvX64SegmentRegister {
-                base: address,
-                limit: 0xffff,
-                selector: (address >> 4) as u16,
-                attributes: 0x9b,
-            };
-            self.runner
-                .set_vp_registers(
-                    vtl,
-                    [
-                        (HvX64RegisterName::Cs, HvRegisterValue::from(cs)),
-                        (HvX64RegisterName::Rip, 0u64.into()),
-                    ],
-                )
-                .map_err(UhRunVpError::EmulationState)?;
-            lapic.activity = MpState::Running;
-        }
-        Ok(())
-    }
-
     fn set_rip(&mut self, vtl: GuestVtl, rip: u64) -> Result<(), VpHaltReason<UhRunVpError>> {
         self.runner
             .set_vp_register(vtl, HvX64RegisterName::Rip, rip.into())
@@ -1618,37 +1316,15 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
     }
 
     fn lapic_base_address(&self) -> Option<u64> {
-        self.vp
-            .backing
-            .lapics
-            .as_ref()
-            .and_then(|lapic| lapic[self.vtl].lapic.base_address())
+        unimplemented!()
     }
 
-    fn lapic_read(&mut self, address: u64, data: &mut [u8]) {
-        self.vp.backing.lapics.as_mut().unwrap()[self.vtl]
-            .lapic
-            .access(&mut UhApicClient {
-                partition: self.vp.partition,
-                runner: &mut self.vp.runner,
-                vmtime: &self.vp.vmtime,
-                dev: self.devices,
-                vtl: self.vtl,
-            })
-            .mmio_read(address, data);
+    fn lapic_read(&mut self, _address: u64, _data: &mut [u8]) {
+        unimplemented!()
     }
 
-    fn lapic_write(&mut self, address: u64, data: &[u8]) {
-        self.vp.backing.lapics.as_mut().unwrap()[self.vtl]
-            .lapic
-            .access(&mut UhApicClient {
-                partition: self.vp.partition,
-                runner: &mut self.vp.runner,
-                vmtime: &self.vp.vmtime,
-                dev: self.devices,
-                vtl: self.vtl,
-            })
-            .mmio_write(address, data);
+    fn lapic_write(&mut self, _address: u64, _data: &[u8]) {
+        unimplemented!()
     }
 }
 
@@ -2096,55 +1772,6 @@ impl<T> hv1_hypercall::ModifyVtlProtectionMask
         }
 
         Ok(())
-    }
-}
-
-struct UhApicClient<'a, 'b, T> {
-    partition: &'a UhPartitionInner,
-    runner: &'a mut ProcessorRunner<'b, MshvX64>,
-    dev: &'a T,
-    vmtime: &'a VmTimeAccess,
-    vtl: GuestVtl,
-}
-
-impl<T: CpuIo> ApicClient for UhApicClient<'_, '_, T> {
-    fn cr8(&mut self) -> u32 {
-        self.runner
-            .get_vp_register(self.vtl, HvX64RegisterName::Cr8)
-            .unwrap()
-            .as_u32()
-    }
-
-    fn set_cr8(&mut self, value: u32) {
-        self.runner
-            .set_vp_register(self.vtl, HvX64RegisterName::Cr8, value.into())
-            .unwrap();
-    }
-
-    fn set_apic_base(&mut self, value: u64) {
-        self.runner
-            .set_vp_register(self.vtl, HvX64RegisterName::ApicBase, value.into())
-            .unwrap();
-    }
-
-    fn wake(&mut self, vp_index: VpIndex) {
-        self.partition
-            .vp(vp_index)
-            .unwrap()
-            .wake(self.vtl, WakeReason::INTCON);
-    }
-
-    fn eoi(&mut self, vector: u8) {
-        debug_assert_eq!(self.vtl, GuestVtl::Vtl0);
-        self.dev.handle_eoi(vector.into())
-    }
-
-    fn now(&mut self) -> VmTime {
-        self.vmtime.now()
-    }
-
-    fn pull_offload(&mut self) -> ([u32; 8], [u32; 8]) {
-        unreachable!()
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -76,9 +76,8 @@ use zerocopy::FromZeroes;
 /// software-isolated).
 #[derive(InspectMut)]
 pub struct HypervisorBackedX86 {
-    // TODO WHP GUEST VSM: To be completely correct here we would need two sets of
-    // deliverability notifications too. However currently we don't support VTL 1
-    // on WHP so this can wait.
+    // VTL0 only, used for synic message and extint readiness notifications.
+    // We do not currently support synic message ports or extint interrupts for VTL1.
     #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
     deliverability_notifications: HvDeliverabilityNotificationsRegister,
     /// Next set of deliverability notifications. See register definition for details.

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -627,7 +627,6 @@ fn convert_vtl2_config(
     let config = virt::Vtl2Config {
         vtl0_alias_map: vtl2_cfg.vtl0_alias_map,
         late_map_vtl0_memory,
-        vtl2_emulates_apic: vtl2_cfg.vtl2_emulates_apic,
     };
 
     Ok(Some(config))

--- a/openvmm/hvlite_defs/src/config.rs
+++ b/openvmm/hvlite_defs/src/config.rs
@@ -348,8 +348,6 @@ pub struct Vtl2Config {
     /// heuristic is to defer mapping VTL0 memory until the first
     /// `HvModifyVtlProtectionMask` hypercall is made.
     pub late_map_vtl0_memory: Option<LateMapVtl0MemoryPolicy>,
-    /// Defer VTL0 APIC emulation to VTL2.
-    pub vtl2_emulates_apic: bool,
 }
 
 // Isolation type for a partition.

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -102,11 +102,6 @@ pub struct Options {
     #[clap(long, requires("vtl2"))]
     pub no_alias_map: bool,
 
-    /// The vtl2 paravisor has an APIC emulator, so do not emulate lower VTL
-    /// APICs on the host.
-    #[clap(long, requires("vtl2"))]
-    pub vtl2_emulates_apic: bool,
-
     /// enable isolation emulation
     #[clap(long, requires("vtl2"))]
     pub isolation: Option<IsolationCli>,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1275,7 +1275,6 @@ fn vm_config_from_command_line(
                         Some(LateMapVtl0MemoryPolicy::InjectException)
                     }
                 },
-                vtl2_emulates_apic: opt.vtl2_emulates_apic,
             }),
             with_isolation,
             user_mode_hv_enlightenments: opt.no_enlightenments,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -183,7 +183,6 @@ impl PetriVmConfigOpenVmm {
                     Some(Vtl2Config {
                         vtl0_alias_map: false, // TODO: enable when OpenVMM supports it for DMA
                         late_map_vtl0_memory: Some(LateMapVtl0MemoryPolicy::InjectException),
-                        vtl2_emulates_apic: false,
                     }),
                     Some(VmbusConfig {
                         vsock_listener: Some(vtl2_vsock_listener),

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -14,7 +14,6 @@ const MAX_CPUS: usize = 2048;
 /// Provides the values for the synthetic hypervisor cpuid leaves.
 pub fn hv_cpuid_leaves(
     topology: &ProcessorTopology<X86Topology>,
-    emulate_apic: bool,
     isolation: IsolationType,
     access_vsm: bool,
     hv_version: [u32; 4],
@@ -124,15 +123,12 @@ pub fn hv_cpuid_leaves(
                 .with_use_apic_msrs(use_apic_msrs);
 
             if hardware_isolated {
-                enlightenments =
-                    enlightenments.with_use_hypercall_for_remote_flush_and_local_flush_entire(true);
+                enlightenments = enlightenments
+                    .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
+                    .with_long_spin_wait_count(0xffffffff); // no spin wait notifications;
 
                 // TODO HCVM:
                 //    .with_use_synthetic_cluster_ipi(true);
-
-                if emulate_apic {
-                    enlightenments.set_long_spin_wait_count(0xffffffff); // no spin wait notifications
-                }
             };
             split_u128(enlightenments.into())
         }),

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -125,7 +125,7 @@ pub fn hv_cpuid_leaves(
             if hardware_isolated {
                 enlightenments = enlightenments
                     .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
-                    .with_long_spin_wait_count(0xffffffff); // no spin wait notifications;
+                    .with_long_spin_wait_count(!0); // no spin wait notifications;
 
                 // TODO HCVM:
                 //    .with_use_synthetic_cluster_ipi(true);

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -231,8 +231,6 @@ pub struct Vtl2Config {
     ///
     /// Accesses before memory is mapped is determined by the specified config.
     pub late_map_vtl0_memory: Option<LateMapVtl0MemoryConfig>,
-    /// Defer VTL0 APIC emulation to VTL2.
-    pub vtl2_emulates_apic: bool,
 }
 
 /// Hypervisor configuration.

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -684,7 +684,6 @@ mod x86 {
     use super::WhpHypercallExit;
     use crate::regs;
     use crate::vtl2;
-    use crate::LocalApicKind;
     use crate::WhpProcessor;
     use crate::WhpRunVpError;
     use arrayvec::ArrayVec;
@@ -1606,14 +1605,9 @@ mod x86 {
                         return Err(HvError::AccessDenied);
                     }
 
-                    let mut supported = hvdef::HvDeliverabilityNotificationsRegister::new()
+                    let supported = hvdef::HvDeliverabilityNotificationsRegister::new()
                         .with_sints(!0)
                         .with_interrupt_notification(true);
-
-                    if let LocalApicKind::InVtl2 = self.vp.partition.vtl0.lapic {
-                        supported.set_nmi_notification(true);
-                        supported.set_interrupt_priority(0xf);
-                    }
 
                     if value.as_u64() & !u64::from(supported) != 0 {
                         return Err(HvError::InvalidParameter);

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -920,7 +920,6 @@ impl WhpPartitionInner {
                 if !hv_config.offload_enlightenments || proto_config.user_mode_apic {
                     cpuid.extend(hv1_emulator::cpuid::hv_cpuid_leaves(
                         proto_config.processor_topology,
-                        proto_config.user_mode_apic,
                         IsolationType::None,
                         false,
                         [0; 4],

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -135,8 +135,6 @@ enum LocalApicKind {
     #[inspect(transparent)]
     Emulated(virt_support_apic::LocalApicSet),
     Offloaded,
-    #[cfg(guest_arch = "x86_64")]
-    InVtl2,
 }
 
 #[derive(Inspect)]
@@ -1132,13 +1130,6 @@ impl VtlPartition {
     fn new(config: &ProtoPartitionConfig<'_>, vendor: Vendor, vtl: Vtl) -> Result<Self, Error> {
         let mut hypervisor_enlightened = false;
 
-        let apic_in_vtl2 = vtl != Vtl::Vtl2
-            && config
-                .hv_config
-                .as_ref()
-                .and_then(|hv_config| hv_config.vtl2.as_ref())
-                .is_some_and(|cfg| cfg.vtl2_emulates_apic);
-
         let user_mode_apic = config.user_mode_apic
             || config
                 .hv_config
@@ -1146,9 +1137,7 @@ impl VtlPartition {
                 .is_some_and(|cfg| !cfg.offload_enlightenments);
 
         #[cfg(guest_arch = "x86_64")]
-        let lapic = if apic_in_vtl2 {
-            LocalApicKind::InVtl2
-        } else if user_mode_apic {
+        let lapic = if user_mode_apic {
             let x2apic_capable = !matches!(
                 config.processor_topology.apic_mode(),
                 vm_topology::processor::x86::ApicMode::XApic
@@ -1177,7 +1166,7 @@ impl VtlPartition {
         {
             use vm_topology::processor::x86::ApicMode;
 
-            let apic_mode = if !user_mode_apic && !apic_in_vtl2 {
+            let apic_mode = if !user_mode_apic {
                 match config.processor_topology.apic_mode() {
                     ApicMode::XApic => whp::abi::WHvX64LocalApicEmulationModeXApic,
                     ApicMode::X2ApicSupported | ApicMode::X2ApicEnabled => {
@@ -1193,7 +1182,7 @@ impl VtlPartition {
                 .for_op("set apic emulation mode")?;
 
             extended_exits |= whp::abi::WHV_EXTENDED_VM_EXITS::X64MsrExit;
-            if user_mode_apic || apic_in_vtl2 {
+            if user_mode_apic {
                 whp_config
                     .set_property(whp::PartitionProperty::X64MsrExitBitmap(
                         whp::abi::WHV_X64_MSR_EXIT_BITMAP::ApicBaseMsrWrite
@@ -1254,7 +1243,6 @@ impl VtlPartition {
                 .for_op("get synth processor features")?;
             if hv_config.offload_enlightenments
                 && !user_mode_apic
-                && !apic_in_vtl2
                 && supported_synth_features
                     .bank0
                     .is_set(whp::abi::WHV_SYNTHETIC_PROCESSOR_FEATURES::HypervisorPresent)
@@ -1351,7 +1339,7 @@ impl VtlPartition {
             whp.create_vp(index).create().for_op("create vp")?;
         }
 
-        let hvstate = if config.hv_config.is_some() && !apic_in_vtl2 {
+        let hvstate = if config.hv_config.is_some() {
             if hypervisor_enlightened {
                 Hv1State::Offloaded
             } else {
@@ -1592,7 +1580,7 @@ mod x86 {
                             .wake()
                     });
                 }
-                LocalApicKind::Offloaded | LocalApicKind::InVtl2 => unreachable!(),
+                LocalApicKind::Offloaded => unreachable!(),
             }
         }
     }


### PR DESCRIPTION
This operating mode was originally added so that we could get automated CI test coverage of our APIC emulation without needing to run a full CVM. However, CVM CI tests are now just around the corner. And, as it turns out, we accidentally weren't using this in our current tests at all, and it's now broken. Seeing as we haven't been hit with any APIC bugs in a very long time, and that proper coverage will be coming soon, just remove it.

More cleanup is definitely possible here, such as removing support for certain hypercalls that are no longer needed, or moving trait functions off of Backing and onto HardwareIsolatedBacking. That can all come as follow ups.