### PR TITLE
loan_cell: add primitive for lending thread-local data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,6 +3568,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "loan_cell"
+version = "0.0.0"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "local_clock"
 version = "0.0.0"
 dependencies = [
@@ -4876,6 +4883,7 @@ dependencies = [
  "futures",
  "getrandom",
  "libc",
+ "loan_cell",
  "once_cell",
  "pal",
  "pal_async_test",
@@ -4919,6 +4927,7 @@ dependencies = [
  "inspect",
  "io-uring",
  "libc",
+ "loan_cell",
  "once_cell",
  "pal",
  "pal_async",
@@ -7204,6 +7213,7 @@ version = "0.0.0"
 dependencies = [
  "fs-err",
  "inspect",
+ "loan_cell",
  "pal",
  "pal_async",
  "pal_uring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ members = [
   "petri/make_imc_hive",
   "vm/loader/igvmfilegen",
   "vm/vmgs/vmgs_lib",
-  "vm/vmgs/vmgstool", "support/loan_cell",
+  "vm/vmgs/vmgstool",
 ]
 exclude = [
   "xsync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ members = [
   "petri/make_imc_hive",
   "vm/loader/igvmfilegen",
   "vm/vmgs/vmgs_lib",
-  "vm/vmgs/vmgstool",
+  "vm/vmgs/vmgstool", "support/loan_cell",
 ]
 exclude = [
   "xsync",
@@ -103,6 +103,7 @@ inspect_proto = { path = "support/inspect_proto" }
 inspect_rlimit = { path = "support/inspect_rlimit" }
 inspect_task = { path = "support/inspect_task" }
 kmsg = { path = "support/kmsg" }
+loan_cell = { path = "support/loan_cell" }
 local_clock = { path = "support/local_clock" }
 mesh = { path = "support/mesh" }
 mesh_build = { path = "support/mesh/mesh_build" }

--- a/openhcl/underhill_core/src/vp.rs
+++ b/openhcl/underhill_core/src/vp.rs
@@ -81,13 +81,14 @@ impl VpSpawner {
     where
         for<'a> virt_mshv_vtl::UhProcessor<'a, T>: vmcore::save_restore::ProtobufSaveRestore,
     {
-        let thread = underhill_threadpool::Thread::current().unwrap();
+        let thread: underhill_threadpool::Thread = underhill_threadpool::Thread::current().unwrap();
         // TODO propagate this error back earlier. This is easiest if
         // set_idle_task is fixed to take a non-Send fn.
-        let mut vp = self
-            .vp
-            .bind_processor::<T>(thread.driver(), control)
-            .context("failed to initialize VP")?;
+        let mut vp = thread.with_driver(|driver| {
+            self.vp
+                .bind_processor::<T>(driver, control)
+                .context("failed to initialize VP")
+        })?;
 
         if let Some(saved_state) = saved_state {
             vmcore::save_restore::ProtobufSaveRestore::restore(&mut vp, saved_state)
@@ -166,7 +167,7 @@ impl VpSpawner {
                     self.vp.set_sidecar_exit_due_to_task(
                         thread
                             .first_task()
-                            .map_or_else(|| "<unknown>".into(), |t| t.name.clone()),
+                            .map_or_else(|| "<unknown>".into(), |t| t.name),
                     );
                 }
 

--- a/openhcl/underhill_core/src/vp.rs
+++ b/openhcl/underhill_core/src/vp.rs
@@ -81,7 +81,7 @@ impl VpSpawner {
     where
         for<'a> virt_mshv_vtl::UhProcessor<'a, T>: vmcore::save_restore::ProtobufSaveRestore,
     {
-        let thread: underhill_threadpool::Thread = underhill_threadpool::Thread::current().unwrap();
+        let thread = underhill_threadpool::Thread::current().unwrap();
         // TODO propagate this error back earlier. This is easiest if
         // set_idle_task is fixed to take a non-Send fn.
         let mut vp = thread.with_driver(|driver| {

--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -469,8 +469,7 @@ async fn apply_vtl2_protections(
                         tracing::debug!(
                             cpu = underhill_threadpool::Thread::current()
                                 .unwrap()
-                                .driver()
-                                .target_cpu(),
+                                .with_driver(|driver| driver.target_cpu()),
                             %range,
                             "applying protections"
                         );

--- a/openhcl/underhill_threadpool/Cargo.toml
+++ b/openhcl/underhill_threadpool/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 inspect = { workspace = true, features = ["std"] }
+loan_cell.workspace = true
 pal.workspace = true
 pal_async.workspace = true
 pal_uring.workspace = true

--- a/openhcl/underhill_threadpool/src/lib.rs
+++ b/openhcl/underhill_threadpool/src/lib.rs
@@ -8,8 +8,7 @@
 //! This is built on top of [`pal_uring`] and [`pal_async`].
 
 #![warn(missing_docs)]
-// UNSAFETY: needed for saving per-thread state.
-#![expect(unsafe_code)]
+#![forbid(unsafe_code)]
 
 use inspect::Inspect;
 use loan_cell::LoanCell;
@@ -215,11 +214,12 @@ impl ThreadpoolBuilder {
                 send.send(Ok(pool.client().clone())).ok();
 
                 // Store the current thread's driver so that spawned tasks can
-                // find it via `Thread::current()`.
-                CURRENT_THREADPOOL_CPU.with(|current| {
+                // find it via `Thread::current()`. Do this via a loan instead
+                // of storing it directly in TLS to avoid the overhead of
+                // registering a destructor.
+                CURRENT_THREAD_DRIVER.with(|current| {
                     current.lend(&driver, || pool.run());
                 });
-                drop(driver);
             })?;
 
         // Wait for the pool to be initialized.
@@ -356,39 +356,27 @@ impl Initiate for AffinitizedThreadpool {
 /// The state for the thread pool thread for the currently running CPU.
 #[derive(Debug, Copy, Clone)]
 pub struct Thread {
-    driver: &'static ThreadpoolDriver,
     _not_send_sync: PhantomData<*const ()>,
 }
 
 impl Thread {
-    /// Returns a new driver for the current CPU.
+    /// Returns an instance for the current CPU.
     pub fn current() -> Option<Self> {
-        let inner = CURRENT_THREADPOOL_CPU.with(|current| {
-            current.borrow(|current| {
-                // SAFETY: since the `ThreadpoolDriver` is loaned at the bottom
-                // of the thread stack, and because `Thread` is not `Send` or
-                // `Sync`, it is impossible for this reference to be accessed
-                // after the driver has been dropped, since any task that can
-                // construct a `Thread` will have been completed by that time.
-                // So it's OK for this reference to live as long as `Thread`.
-                unsafe {
-                    Some(std::mem::transmute::<
-                        &ThreadpoolDriver,
-                        &'static ThreadpoolDriver,
-                    >(current?))
-                }
-            })
-        })?;
+        if !CURRENT_THREAD_DRIVER.with(|current| current.is_lent()) {
+            return None;
+        }
         Some(Self {
-            driver: inner,
             _not_send_sync: PhantomData,
         })
     }
 
-    fn once(&self) -> &ThreadpoolDriverOnce {
-        // Since we are on the thread, the thread is guaranteed to have been
-        // initialized.
-        self.driver.inner.once.get().unwrap()
+    /// Calls `f` with the driver for the current thread.
+    pub fn with_driver<R>(&self, f: impl FnOnce(&ThreadpoolDriver) -> R) -> R {
+        CURRENT_THREAD_DRIVER.with(|current| current.borrow(|driver| f(driver.unwrap())))
+    }
+
+    fn with_once<R>(&self, f: impl FnOnce(&ThreadpoolDriver, &ThreadpoolDriverOnce) -> R) -> R {
+        self.with_driver(|driver| f(driver, driver.inner.once.get().unwrap()))
     }
 
     /// Sets the idle task to run. The task is returned by `f`, which receives
@@ -402,56 +390,52 @@ impl Thread {
         F: 'static + Send + FnOnce(IdleControl) -> Fut,
         Fut: std::future::Future<Output = ()>,
     {
-        self.once().client.set_idle_task(f)
-    }
-
-    /// Returns the driver for the current thread.
-    pub fn driver(&self) -> &ThreadpoolDriver {
-        self.driver
+        self.with_once(|_, once| once.client.set_idle_task(f))
     }
 
     /// Tries to set the affinity to this thread's intended CPU, if it has not
     /// already been set. Returns `Ok(false)` if the intended CPU is still
     /// offline.
     pub fn try_set_affinity(&self) -> Result<bool, SetAffinityError> {
-        let mut state = self.driver.inner.state.lock();
-        if matches!(state.affinity, AffinityState::Set) {
-            return Ok(true);
-        }
-        if !is_cpu_online(self.driver.inner.cpu).map_err(SetAffinityError::Online)? {
-            return Ok(false);
-        }
-
-        let mut affinity = CpuSet::new();
-        affinity.set(self.driver.inner.cpu);
-
-        pal::unix::affinity::set_current_thread_affinity(&affinity)
-            .map_err(SetAffinityError::Thread)?;
-        self.once()
-            .client
-            .set_iowq_affinity(&affinity)
-            .map_err(SetAffinityError::Ring)?;
-
-        let old_affinity_state = std::mem::replace(&mut state.affinity, AffinityState::Set);
-        self.driver.inner.affinity_set.store(true, Relaxed);
-        drop(state);
-
-        match old_affinity_state {
-            AffinityState::Waiting(wakers) => {
-                for waker in wakers {
-                    waker.wake();
-                }
+        self.with_once(|driver, once| {
+            let mut state = driver.inner.state.lock();
+            if matches!(state.affinity, AffinityState::Set) {
+                return Ok(true);
             }
-            AffinityState::Set => unreachable!(),
-        }
-        Ok(true)
+            if !is_cpu_online(driver.inner.cpu).map_err(SetAffinityError::Online)? {
+                return Ok(false);
+            }
+
+            let mut affinity = CpuSet::new();
+            affinity.set(driver.inner.cpu);
+
+            pal::unix::affinity::set_current_thread_affinity(&affinity)
+                .map_err(SetAffinityError::Thread)?;
+            once.client
+                .set_iowq_affinity(&affinity)
+                .map_err(SetAffinityError::Ring)?;
+
+            let old_affinity_state = std::mem::replace(&mut state.affinity, AffinityState::Set);
+            driver.inner.affinity_set.store(true, Relaxed);
+            drop(state);
+
+            match old_affinity_state {
+                AffinityState::Waiting(wakers) => {
+                    for waker in wakers {
+                        waker.wake();
+                    }
+                }
+                AffinityState::Set => unreachable!(),
+            }
+            Ok(true)
+        })
     }
 
     /// Returns the that caused this thread to spawn.
     ///
     /// Returns `None` if the thread was spawned to issue IO.
-    pub fn first_task(&self) -> Option<&TaskInfo> {
-        self.once().first_task.as_ref()
+    pub fn first_task(&self) -> Option<TaskInfo> {
+        self.with_once(|_, once| once.first_task.clone())
     }
 }
 
@@ -470,12 +454,12 @@ pub enum SetAffinityError {
 }
 
 thread_local! {
-    static CURRENT_THREADPOOL_CPU: LoanCell<ThreadpoolDriver> = const { LoanCell::new() };
+    static CURRENT_THREAD_DRIVER: LoanCell<ThreadpoolDriver> = const { LoanCell::new() };
 }
 
 impl SpawnLocal for Thread {
     fn scheduler_local(&self, metadata: &TaskMetadata) -> Arc<dyn Schedule> {
-        self.driver.scheduler(metadata).clone()
+        self.with_driver(|driver| driver.scheduler(metadata).clone())
     }
 }
 
@@ -508,7 +492,7 @@ struct ThreadpoolDriverOnce {
 }
 
 /// Information about a task that caused a thread to spawn.
-#[derive(Debug, Inspect)]
+#[derive(Debug, Clone, Inspect)]
 pub struct TaskInfo {
     /// The name of the task.
     pub name: Arc<str>,

--- a/support/loan_cell/Cargo.toml
+++ b/support/loan_cell/Cargo.toml
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "loan_cell"
+rust-version.workspace = true
+edition.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+static_assertions.workspace = true
+
+[lints]
+workspace = true

--- a/support/loan_cell/src/lib.rs
+++ b/support/loan_cell/src/lib.rs
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! This crate provides a [`LoanCell`] type that allows for lending a reference
+//! to a value for a limited scope.
+//!
+//! This is useful for publishing a reference to an on-stack value into a
+//! thread-local variable for the lifetime of a function call. This can be
+//! useful when you can't or don't want to temporarily move the value to the
+//! thread-local variable:
+//!   - The value is not sized (e.g., it is a slice or a dyn trait object), so
+//!     you can't move it.
+//!   - The value is large, so it would be inefficient to move it.
+//!   - The value has a destructor, so putting it in TLS would use the
+//!     inefficient form of Rust TLS that registers a destructor for the value.
+//!
+//! [`LoanCell`] is not `Sync` or `Send`, so it can only be used within a single
+//! thread. This is necessary to ensure that the loaned value is not accessed
+//! after the function that loaned it returns.
+//!
+//! # Example
+//!
+//! ```rust
+//! use loan_cell::LoanCell;
+//!
+//! thread_local! {
+//!    static CONTEXT: LoanCell<str> = const { LoanCell::new() };
+//! }
+//!
+//! fn print_name() -> String {
+//!     CONTEXT.with(|name| {
+//!         name.borrow(|name| {
+//!             format!("stored {}", name.unwrap_or("nowhere"))
+//!         })
+//!     })
+//! }
+//!
+//! CONTEXT.with(|v| {
+//!     assert_eq!(v.lend(&String::from("in the heap"), || print_name()), "stored in the heap");
+//!     assert_eq!(v.lend("statically", || print_name()), "stored statically");
+//! });
+//! assert_eq!(print_name(), "stored nowhere");
+//! ```
+
+// UNSAFETY: this is needed to work around the borrow checker.
+#![allow(unsafe_code)]
+#![warn(missing_docs)]
+#![no_std]
+
+use core::cell::Cell;
+use core::panic::RefUnwindSafe;
+use core::panic::UnwindSafe;
+use core::ptr::NonNull;
+
+/// A cell that allows lending a reference to a value for a limited scope.
+///
+/// See the [module-level documentation](crate) for more information.
+#[derive(Default)]
+pub struct LoanCell<T: ?Sized>(Cell<Option<NonNull<T>>>);
+
+impl<T: RefUnwindSafe + ?Sized> UnwindSafe for LoanCell<T> {}
+impl<T: RefUnwindSafe + ?Sized> RefUnwindSafe for LoanCell<T> {}
+
+impl<T: ?Sized> LoanCell<T> {
+    /// Creates a `LoanCell` with no loaned data.
+    pub const fn new() -> Self {
+        Self(Cell::new(None))
+    }
+
+    /// Lends `value` for the lifetime of `f`. `f` or any function it calls can
+    /// access the loaned value via `LoanCell::with`.
+    ///
+    /// If a value is already lent, it is replaced with `value` for the duration
+    /// of `f` and restored afterwards.
+    pub fn lend<R>(&self, value: &T, f: impl FnOnce() -> R) -> R {
+        // Use a guard to restore the old value after `f` returns or panics.
+        struct RestoreOnDrop<'a, T: ?Sized>(&'a LoanCell<T>, Option<NonNull<T>>);
+        impl<T: ?Sized> Drop for RestoreOnDrop<'_, T> {
+            fn drop(&mut self) {
+                self.0 .0.set(self.1);
+            }
+        }
+
+        // SAFETY: `value` cannot be null.
+        // FUTURE: use `NonNull::from_ref` when it becomes stable.
+        let value = unsafe { NonNull::new_unchecked(core::ptr::from_ref(value).cast_mut()) };
+        let old = self.0.replace(Some(value));
+        let _guard = RestoreOnDrop(self, old);
+        f()
+    }
+
+    /// Borrows the lent value for the duration of `f`. If no value is currently
+    /// lent, `f` is called with `None`.
+    pub fn borrow<R>(&self, f: impl FnOnce(Option<&T>) -> R) -> R {
+        // SAFETY: the inner value is alive as long as the corresponding `loan`
+        // call is running, and the value is only dropped when the function
+        // passed to `loan` returns. Since `LoadCell` is not `Sync`, this cannot
+        // happen while `f` is running.
+        let v = unsafe { self.0.get().map(|v| v.as_ref()) };
+        f(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LoanCell;
+
+    extern crate std;
+
+    static_assertions::assert_not_impl_any!(LoanCell<()>: Sync, Send);
+
+    #[test]
+    fn loan() {
+        struct NoCopy<T>(T);
+        let cell = LoanCell::new();
+        cell.borrow(|v| assert!(v.is_none()));
+        let result = cell.lend(&NoCopy(42), || {
+            cell.borrow(|v| {
+                assert_eq!(v.unwrap().0, 42);
+            });
+            42
+        });
+        assert_eq!(result, 42);
+        cell.borrow(|v| assert!(v.is_none()));
+    }
+
+    #[test]
+    fn nested_loan() {
+        let cell = LoanCell::new();
+        cell.lend(&42, || {
+            cell.lend(&52, || {
+                cell.borrow(|v| {
+                    assert_eq!(v.unwrap(), &52);
+                });
+            });
+            cell.borrow(|v| {
+                assert_eq!(v.unwrap(), &42);
+            });
+        });
+    }
+
+    #[test]
+    fn unsized_loan() {
+        let cell = LoanCell::new();
+        let value = "hello";
+        cell.lend(value, || {
+            cell.borrow(|v| {
+                assert_eq!(v.unwrap(), value);
+            });
+        });
+    }
+
+    #[test]
+    fn panicked_loan() {
+        let cell = LoanCell::new();
+        let result = std::panic::catch_unwind(|| {
+            cell.lend(&42, || {
+                panic!();
+            });
+        });
+        assert!(result.is_err());
+        cell.borrow(|v| assert!(v.is_none()));
+    }
+}

--- a/support/pal/pal_async/Cargo.toml
+++ b/support/pal/pal_async/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 tests = ["dep:tempfile"]
 
 [dependencies]
+loan_cell.workspace = true
 pal.workspace = true
 unix_socket.workspace = true
 pal_event.workspace = true

--- a/support/pal/pal_async/src/task.rs
+++ b/support/pal/pal_async/src/task.rs
@@ -351,7 +351,7 @@ thread_local! {
 
 /// Calls `f` with the current task metadata, if there is a current task.
 pub fn with_current_task_metadata<F: FnOnce(Option<&TaskMetadata>) -> R, R>(f: F) -> R {
-    CURRENT_TASK.with(|task| task.borrow(|task| f(task)))
+    CURRENT_TASK.with(|task| task.borrow(f))
 }
 
 impl<T: ?Sized + Spawn> Spawn for &'_ T {

--- a/support/pal/pal_async/src/task.rs
+++ b/support/pal/pal_async/src/task.rs
@@ -6,15 +6,14 @@
 // UNSAFETY: Managing information stored as pointers for debugging purposes.
 #![expect(unsafe_code)]
 
+use loan_cell::LoanCell;
 use parking_lot::Mutex;
 use slab::Slab;
-use std::cell::Cell;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::future::Future;
 use std::panic::Location;
 use std::pin::Pin;
-use std::ptr::null;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::AtomicUsize;
@@ -76,22 +75,16 @@ impl TaskMetadata {
         self.id.store(id, Ordering::Relaxed);
     }
 
-    fn pend(&self, old_task: *const Self) {
+    fn pend(&self) {
         self.state.store(TASK_STATE_WAITING, Ordering::Relaxed);
-        CURRENT_TASK.with(|task| {
-            let this_task = task.replace(old_task);
-            assert_eq!(this_task, std::ptr::from_ref(self));
-        })
     }
 
     fn done(&self) {
         self.state.store(TASK_STATE_DONE, Ordering::Relaxed);
     }
 
-    fn run(&self) -> *const Self {
-        let old_task = CURRENT_TASK.with(|task| task.replace(std::ptr::from_ref(self)));
+    fn run(&self) {
         self.state.store(TASK_STATE_RUNNING, Ordering::Relaxed);
-        old_task
     }
 
     /// The name of the spawned task.
@@ -265,12 +258,12 @@ impl<Fut: Future> Future for TaskFuture<'_, Fut> {
         // SAFETY: projecting this type for pinned access to the future. The
         // future will not be moved or dropped.
         let this = unsafe { self.get_unchecked_mut() };
-        let old_task = this.metadata.run();
+        this.metadata.run();
         // SAFETY: the future is pinned since `self` is pinned.
         let future = unsafe { Pin::new_unchecked(&mut this.future) };
-        let r = future.poll(cx);
+        let r = CURRENT_TASK.with(|task| task.lend(this.metadata, || future.poll(cx)));
         if r.is_pending() {
-            this.metadata.pend(old_task);
+            this.metadata.pend();
         } else {
             this.metadata.done();
         }
@@ -353,23 +346,12 @@ pub trait SpawnLocal {
 }
 
 thread_local! {
-    static CURRENT_TASK: Cell<*const TaskMetadata> = const { Cell::new(null()) };
+    static CURRENT_TASK: LoanCell<TaskMetadata> = const { LoanCell::new() };
 }
 
 /// Calls `f` with the current task metadata, if there is a current task.
 pub fn with_current_task_metadata<F: FnOnce(Option<&TaskMetadata>) -> R, R>(f: F) -> R {
-    CURRENT_TASK.with(|task| {
-        let task = task.get();
-        let metadata = if !task.is_null() {
-            // SAFETY: `CURRENT_TASK` is set if and only if a task is actively
-            // running, so it is safe to dereference (as long as it is not accessed
-            // across an await point)).
-            Some(unsafe { &*task })
-        } else {
-            None
-        };
-        f(metadata)
-    })
+    CURRENT_TASK.with(|task| task.borrow(|task| f(task)))
 }
 
 impl<T: ?Sized + Spawn> Spawn for &'_ T {

--- a/support/pal/pal_async/src/windows/tp.rs
+++ b/support/pal/pal_async/src/windows/tp.rs
@@ -72,7 +72,7 @@ thread_local! {
 fn wake_locally(f: impl FnOnce()) {
     DEFERRED_RUNNABLE.with(|slot| {
         let deferred = Cell::new(None);
-        slot.lend(&deferred, || f());
+        slot.lend(&deferred, f);
         if let Some(runnable) = deferred.into_inner() {
             runnable.schedule();
         }

--- a/support/pal/pal_async/src/windows/tp.rs
+++ b/support/pal/pal_async/src/windows/tp.rs
@@ -22,6 +22,7 @@ use crate::timer::TimerDriver;
 use crate::wait::PollWait;
 use crate::wait::WaitDriver;
 use crate::waker::WakerList;
+use loan_cell::LoanCell;
 use once_cell::sync::OnceCell;
 use pal::windows::afd;
 use pal::windows::disassociate_completion_port;
@@ -64,34 +65,16 @@ impl TpPool {
     }
 }
 
-/// The thread local threadpool state.
-enum TpThreadState {
-    /// This thread either is not a threadpool thread, or another task is
-    /// running on it and so new wakeups should wake up another threadpool
-    /// thread.
-    NotOnTpThread,
-    /// This thread is a threadpool thread that is about to return to the
-    /// system after calling wakers associated with completed IOs.
-    Waking,
-    /// This thread is a threadpool thread that will run the attached task after
-    /// it finishes its current work.
-    Deferred(Runnable),
-}
-
 thread_local! {
-    static TP_THREAD_STATE: Cell<TpThreadState> = const { Cell::new(TpThreadState::NotOnTpThread) };
+    static DEFERRED_RUNNABLE: LoanCell<Cell<Option<Runnable>>> = const { LoanCell::new() };
 }
 
 fn wake_locally(f: impl FnOnce()) {
-    TP_THREAD_STATE.with(|state| {
-        state.set(TpThreadState::Waking);
-        f();
-        match state.replace(TpThreadState::NotOnTpThread) {
-            TpThreadState::NotOnTpThread => unreachable!(),
-            TpThreadState::Waking => {}
-            TpThreadState::Deferred(runnable) => {
-                runnable.run();
-            }
+    DEFERRED_RUNNABLE.with(|slot| {
+        let deferred = Cell::new(None);
+        slot.lend(&deferred, || f());
+        if let Some(runnable) = deferred.into_inner() {
+            runnable.schedule();
         }
     })
 }
@@ -106,23 +89,23 @@ struct NextRunnable(Mutex<Option<Runnable>>);
 
 impl Schedule for TpScheduler {
     fn schedule(&self, runnable: Runnable) {
-        TP_THREAD_STATE.with(|state| match state.replace(TpThreadState::NotOnTpThread) {
-            TpThreadState::NotOnTpThread => {
-                {
-                    let mut next = self.next.0.lock();
-                    assert!(next.is_none());
-                    *next = Some(runnable);
+        DEFERRED_RUNNABLE.with(|slot| {
+            slot.borrow(|slot| {
+                if let Some(slot) = slot {
+                    let old_runnable = slot.replace(Some(runnable));
+                    if let Some(runnable) = old_runnable {
+                        runnable.schedule();
+                    }
+                } else {
+                    {
+                        let mut next = self.next.0.lock();
+                        assert!(next.is_none());
+                        *next = Some(runnable);
+                    }
+                    let _ = Arc::into_raw(self.next.clone());
+                    self.work.submit();
                 }
-                let _ = Arc::into_raw(self.next.clone());
-                self.work.submit();
-            }
-            TpThreadState::Waking => {
-                state.set(TpThreadState::Deferred(runnable));
-            }
-            TpThreadState::Deferred(old_runnable) => {
-                old_runnable.schedule();
-                state.set(TpThreadState::Deferred(runnable));
-            }
+            })
         })
     }
 

--- a/support/pal/pal_uring/Cargo.toml
+++ b/support/pal/pal_uring/Cargo.toml
@@ -12,6 +12,7 @@ ci = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
 inspect.workspace = true
+loan_cell.workspace = true
 pal.workspace = true
 pal_async.workspace = true
 


### PR DESCRIPTION
Add a safe abstraction for temporarily lending on-stack data into thread local storage. Use it in various places across the stack.

This fixes a use-after-free in `pal_async`, and it reduces the overhead of TLS in `pal_async` and `underhill_threadpool`.