### PR TITLE
TDX: Make sure we don't access kernel-shared state for the wrong VTL

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1852,7 +1852,9 @@ impl<'a, T: Backing> ProcessorRunner<'a, T> {
     }
 
     /// Gets the proxied interrupt request bitmap from the hypervisor.
-    pub fn proxy_irr(&mut self) -> Option<[u32; 8]> {
+    pub fn proxy_irr(&mut self, vtl: GuestVtl) -> Option<[u32; 8]> {
+        // We only support proxying interrupts for VTL 0 today.
+        assert_eq!(vtl, GuestVtl::Vtl0);
         // SAFETY: the `scan_proxy_irr` and `proxy_irr` fields of the run page
         // are concurrently updated by the kernel on multiple processors. They
         // are accessed atomically everywhere.
@@ -1876,7 +1878,9 @@ impl<'a, T: Backing> ProcessorRunner<'a, T> {
     }
 
     /// Update the `proxy_irr_blocked` in run page
-    pub fn update_proxy_irr_filter(&mut self, irr_filter: &[u32; 8]) {
+    pub fn update_proxy_irr_filter(&mut self, irr_filter: &[u32; 8], vtl: GuestVtl) {
+        // We only support proxying interrupts for VTL 0 today.
+        assert_eq!(vtl, GuestVtl::Vtl0);
         // SAFETY: `proxy_irr_blocked` is accessed by current VP only, but could
         // be concurrently accessed by kernel too, hence accessing as Atomic
         let proxy_irr_blocked = unsafe {

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1896,13 +1896,17 @@ impl<'a, T: Backing> ProcessorRunner<'a, T> {
     /// the masked interrupts always exit to user-space, and cannot
     /// be injected in the kernel. Interrupts matching this condition
     /// will be left on the proxy_irr field.
-    pub fn proxy_irr_exit_mut(&mut self) -> &mut [u32; 8] {
+    pub fn proxy_irr_exit_mut(&mut self, vtl: GuestVtl) -> &mut [u32; 8] {
+        // We only support proxying interrupts for VTL 0 today.
+        assert_eq!(vtl, GuestVtl::Vtl0);
         // SAFETY: The `proxy_irr_exit` field of the run page will not be concurrently updated.
         unsafe { &mut (*self.run.as_ptr()).proxy_irr_exit }
     }
 
     /// Gets the current offload_flags from the run page.
-    pub fn offload_flags_mut(&mut self) -> &mut hcl_intr_offload_flags {
+    pub fn offload_flags_mut(&mut self, vtl: GuestVtl) -> &mut hcl_intr_offload_flags {
+        // We only support interrupt offloading for VTL 0 today.
+        assert_eq!(vtl, GuestVtl::Vtl0);
         // SAFETY: The `offload_flags` field of the run page will not be concurrently updated.
         unsafe { &mut (*self.run.as_ptr()).offload_flags }
     }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
@@ -39,7 +39,7 @@ pub(crate) fn poll_apic_core<'b, B: HardwareIsolatedBacking, T: ApicBacking<'b, 
 ) -> Result<(), UhRunVpError> {
     // Check for interrupt requests from the host and kernel offload.
     if vtl == GuestVtl::Vtl0 {
-        if let Some(irr) = apic_backing.vp().runner.proxy_irr() {
+        if let Some(irr) = apic_backing.vp().runner.proxy_irr(vtl) {
             // We can't put the interrupts directly into offload (where supported) because we might need
             // to clear the tmr state. This can happen if a vector was previously used for a level
             // triggered interrupt, and is now being used for an edge-triggered interrupt.

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -1157,7 +1157,8 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
         self.partition.fill_device_vectors(vtl, &mut irr_bits);
 
         // Update `proxy_irr_blocked` filter in run page
-        self.runner.update_proxy_irr_filter(&irr_bits.into_inner());
+        self.runner
+            .update_proxy_irr_filter(&irr_bits.into_inner(), vtl);
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -102,7 +102,7 @@ impl UhProcessor<'_, TdxBacked> {
         // flush counters to indicate that a complete flush has been accomplished.
         if flush_entire_required {
             *self_flush_state = partition_flush_state.s.clone();
-            Self::do_flush_entire(false, &mut self.runner);
+            Self::do_flush_entire(target_vtl, false, &mut self.runner);
         }
         // If no flush entire is required, then check to see whether a full
         // non-global flush is required.
@@ -111,7 +111,7 @@ impl UhProcessor<'_, TdxBacked> {
         {
             self_flush_state.flush_entire_non_global_counter =
                 partition_flush_state.s.flush_entire_non_global_counter;
-            Self::do_flush_entire(true, &mut self.runner);
+            Self::do_flush_entire(target_vtl, true, &mut self.runner);
         }
     }
 
@@ -179,8 +179,12 @@ impl UhProcessor<'_, TdxBacked> {
         true
     }
 
-    fn do_flush_entire(non_global: bool, runner: &mut ProcessorRunner<'_, Tdx>) {
-        let vp_flags = runner.tdx_vp_entry_flags_mut();
+    fn do_flush_entire(
+        target_vtl: GuestVtl,
+        non_global: bool,
+        runner: &mut ProcessorRunner<'_, Tdx>,
+    ) {
+        let vp_flags = runner.tdx_vp_entry_flags_mut(target_vtl);
 
         if !non_global {
             // TODO: Track EPT invalidations separately.


### PR DESCRIPTION
Currently the data structures shared between OpenHCL and the kernel are not VTL aware. For now, add some safeguards to make sure we don't attempt to access these structures in a VTL 1 context. Making this data properly VTL aware is tracked by #746.