### PR TITLE
Petri: Stop and remove Hyper-V VMs on failure and before creation

### DIFF
--- a/petri/src/vm/hyperv/hvc.rs
+++ b/petri/src/vm/hyperv/hvc.rs
@@ -10,9 +10,9 @@ pub fn hvc_start(vm: &str) -> anyhow::Result<()> {
     run_hvc(|cmd| cmd.arg("start").arg(vm))
 }
 
-// pub fn hvc_kill(vm: &str) -> anyhow::Result<()> {
-//     run_hvc(|cmd| cmd.arg("kill").arg(vm))
-// }
+pub fn hvc_kill(vm: &str) -> anyhow::Result<()> {
+    run_hvc(|cmd| cmd.arg("kill").arg(vm))
+}
 
 /// HyperV VM state as reported by hvc
 pub enum VmState {
@@ -59,9 +59,22 @@ pub fn hvc_state(vm: &str) -> VmState {
     )
 }
 
+pub fn hvc_list() -> anyhow::Result<Vec<String>> {
+    let output = hvc_output(|cmd| cmd.arg("list").arg("-q"))?;
+    Ok(output.lines().map(|l| l.to_owned()).collect())
+}
+
 pub fn hvc_wait_for_power_off(vm: &str) -> anyhow::Result<()> {
     while !matches!(hvc_state(vm), VmState::Off) {
         std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+
+    Ok(())
+}
+
+pub fn hvc_ensure_off(vm: &str) -> anyhow::Result<()> {
+    if !matches!(hvc_state(vm), VmState::Off) {
+        hvc_kill(vm)?;
     }
 
     Ok(())

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -43,6 +43,12 @@ impl HyperVVM {
             ps_mod,
         };
 
+        // Delete the VM if it already exists
+        if hvc::hvc_list()?.contains(&vm.name) {
+            hvc::hvc_ensure_off(name)?;
+            powershell::run_remove_vm(name)?;
+        }
+
         powershell::run_new_vm(powershell::HyperVNewVMArgs {
             name,
             generation: Some(generation),
@@ -122,6 +128,7 @@ impl HyperVVM {
 
     fn remove_inner(&mut self) -> anyhow::Result<()> {
         if !self.destroyed {
+            hvc::hvc_ensure_off(&self.name)?;
             powershell::run_remove_vm(&self.name)?;
             self.destroyed = true;
         }


### PR DESCRIPTION
Attempts to mitigate an issue where on non-ephemeral ARM test runners, if the previous job orphaned a running VM, all subsequent jobs would fail. This is accomplished by stopping and then removing the VM both in the destructor and before creation (if one exists).