### PR TITLE
virt_mshv_vtl: Refactor Backing and HardwareIsolatedBacking methods

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1145,7 +1145,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         }
     }
 
-    fn hcvm_deliver_synic_messages(&mut self, vtl: GuestVtl, sints: u16) {
+    pub(crate) fn hcvm_deliver_synic_messages(&mut self, vtl: GuestVtl, sints: u16) {
         let proxied_sints = self.backing.cvm_state_mut().hv[vtl].synic.proxied_sints();
         let pending_sints =
             self.inner.message_queues[vtl].post_pending_messages(sints, |sint, message| {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -794,7 +794,7 @@ impl UhProcessor<'_, SnpBacked> {
         self.backing.hv_sint_notifications &= !message.deliverable_sints;
 
         // These messages are always VTL0, as VTL1 does not own any VMBUS channels.
-        self.deliver_synic_messages(GuestVtl::Vtl0, message.deliverable_sints);
+        self.hcvm_deliver_synic_messages(GuestVtl::Vtl0, message.deliverable_sints);
     }
 
     fn handle_vmgexit(


### PR DESCRIPTION
Now that the hypervisor backings will never have apic emulation, we can refactor a lot of code that was made to handle such a case, and move more things into HardwareIsolatedBacking.

Still needs testing, I'll be very surprised if this doesn't break anything.