### PR TITLE
Rename hvlite to openvmm in more user-facing strings

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -152,7 +152,7 @@ jobs:
     - name: unpack mdbook-mermaid
       run: flowey e 0 flowey_lib_common::download_mdbook_mermaid 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 0 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -170,7 +170,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -187,7 +187,7 @@ jobs:
     - name: install Rust
       run: flowey e 0 flowey_lib_common::install_rust 0
       shell: bash
-    - name: build HvLite guide (mdbook)
+    - name: build OpenVMM guide (mdbook)
       run: flowey e 0 flowey_lib_hvlite::build_guide 1
       shell: bash
     - name: 🌼 write_into Var
@@ -298,7 +298,7 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-rustdoc"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-rustdoc" | flowey.exe v 1 'artifact_publish_from_x64-windows-rustdoc' --update-from-stdin --is-raw-string
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 1 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -316,7 +316,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -558,7 +558,7 @@ jobs:
     - name: unpack Microsoft.WSL.LxUtil.AARCH64.zip
       run: flowey e 10 flowey_lib_hvlite::download_lxutil 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 10 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -576,7 +576,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -921,7 +921,7 @@ jobs:
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey e 11 flowey_lib_hvlite::download_lxutil 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 11 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -939,7 +939,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar5 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -1337,7 +1337,7 @@ jobs:
     - name: report common cargo flags
       run: flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 12 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -1355,7 +1355,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -1752,7 +1752,7 @@ jobs:
     - name: report common cargo flags
       run: flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 13 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -1770,7 +1770,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -2295,7 +2295,7 @@ jobs:
     - name: report common cargo flags
       run: flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 14 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -2313,7 +2313,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar6 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -2661,7 +2661,7 @@ jobs:
     - name: unpack Microsoft.WSL.LxUtil.AARCH64.zip
       run: flowey e 15 flowey_lib_hvlite::download_lxutil 1
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 15 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -2679,7 +2679,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar6 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -2993,7 +2993,7 @@ jobs:
     - name: report common cargo flags
       run: flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 16 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -3011,7 +3011,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar6 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -3399,7 +3399,7 @@ jobs:
     - name: installing cargo-nextest
       run: flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 17 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -3417,7 +3417,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar6 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -3680,7 +3680,7 @@ jobs:
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 18 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -3698,7 +3698,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar5 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -4042,7 +4042,7 @@ jobs:
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 19 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -4060,7 +4060,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar5 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -4361,7 +4361,7 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc" | flowey v 2 'artifact_publish_from_x64-linux-rustdoc' --update-from-stdin --is-raw-string
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 2 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -4379,7 +4379,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -4623,7 +4623,7 @@ jobs:
     - name: unpack mu_msvm package (x64)
       run: flowey e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 20 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -4641,7 +4641,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar5 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -5039,7 +5039,7 @@ jobs:
     - name: unpack mu_msvm package (aarch64)
       run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 21 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -5057,7 +5057,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar5 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -5356,7 +5356,7 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 22 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -5374,7 +5374,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -5567,7 +5567,7 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 4 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -5585,7 +5585,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -5757,7 +5757,7 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 5 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -5775,7 +5775,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -5977,7 +5977,7 @@ jobs:
     - name: report common cargo flags
       run: flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 6 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -5995,7 +5995,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -6305,7 +6305,7 @@ jobs:
     - name: unpack Microsoft.WSL.LxUtil.AARCH64.zip
       run: flowey.exe e 7 flowey_lib_hvlite::download_lxutil 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 7 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -6323,7 +6323,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -6564,7 +6564,7 @@ jobs:
     - name: report common cargo flags
       run: flowey.exe e 8 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 8 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -6582,7 +6582,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -6895,7 +6895,7 @@ jobs:
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey.exe e 9 flowey_lib_hvlite::download_lxutil 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 9 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -6913,7 +6913,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -160,7 +160,7 @@ jobs:
     - name: unpack mdbook-mermaid
       run: flowey e 0 flowey_lib_common::download_mdbook_mermaid 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 0 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -178,7 +178,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -195,7 +195,7 @@ jobs:
     - name: install Rust
       run: flowey e 0 flowey_lib_common::install_rust 0
       shell: bash
-    - name: build HvLite guide (mdbook)
+    - name: build OpenVMM guide (mdbook)
       run: flowey e 0 flowey_lib_hvlite::build_guide 1
       shell: bash
     - name: 🌼 write_into Var
@@ -306,7 +306,7 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-rustdoc"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-rustdoc" | flowey.exe v 1 'artifact_publish_from_x64-windows-rustdoc' --update-from-stdin --is-raw-string
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 1 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -324,7 +324,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -568,7 +568,7 @@ jobs:
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey e 10 flowey_lib_hvlite::download_lxutil 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 10 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -586,7 +586,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar5 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -984,7 +984,7 @@ jobs:
     - name: report common cargo flags
       run: flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 11 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -1002,7 +1002,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -1399,7 +1399,7 @@ jobs:
     - name: report common cargo flags
       run: flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 12 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -1417,7 +1417,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -1942,7 +1942,7 @@ jobs:
     - name: report common cargo flags
       run: flowey.exe e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 13 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -1960,7 +1960,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar6 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -2308,7 +2308,7 @@ jobs:
     - name: unpack Microsoft.WSL.LxUtil.AARCH64.zip
       run: flowey e 14 flowey_lib_hvlite::download_lxutil 1
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 14 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -2326,7 +2326,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar6 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -2640,7 +2640,7 @@ jobs:
     - name: report common cargo flags
       run: flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 15 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -2658,7 +2658,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar6 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -3046,7 +3046,7 @@ jobs:
     - name: installing cargo-nextest
       run: flowey.exe e 16 flowey_lib_common::download_cargo_nextest 1
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 16 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -3064,7 +3064,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar6 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -3327,7 +3327,7 @@ jobs:
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 17 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 17 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -3345,7 +3345,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar5 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -3689,7 +3689,7 @@ jobs:
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 18 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -3707,7 +3707,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar5 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -4053,7 +4053,7 @@ jobs:
     - name: unpack mu_msvm package (x64)
       run: flowey e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 19 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -4071,7 +4071,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar5 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -4366,7 +4366,7 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc" | flowey v 2 'artifact_publish_from_x64-linux-rustdoc' --update-from-stdin --is-raw-string
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 2 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -4384,7 +4384,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -4678,7 +4678,7 @@ jobs:
     - name: unpack mu_msvm package (aarch64)
       run: flowey.exe e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 20 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -4696,7 +4696,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar5 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -4995,7 +4995,7 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 21 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -5013,7 +5013,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -5184,7 +5184,7 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 3 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -5202,7 +5202,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -5374,7 +5374,7 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 4 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -5392,7 +5392,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -5594,7 +5594,7 @@ jobs:
     - name: report common cargo flags
       run: flowey.exe e 5 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 5 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -5612,7 +5612,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -5922,7 +5922,7 @@ jobs:
     - name: unpack Microsoft.WSL.LxUtil.AARCH64.zip
       run: flowey.exe e 6 flowey_lib_hvlite::download_lxutil 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 6 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -5940,7 +5940,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -6181,7 +6181,7 @@ jobs:
     - name: report common cargo flags
       run: flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 7 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -6199,7 +6199,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -6512,7 +6512,7 @@ jobs:
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey.exe e 8 flowey_lib_hvlite::download_lxutil 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey.exe e 8 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -6530,7 +6530,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar1 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey.exe v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
@@ -6820,7 +6820,7 @@ jobs:
     - name: unpack Microsoft.WSL.LxUtil.AARCH64.zip
       run: flowey e 9 flowey_lib_hvlite::download_lxutil 0
       shell: bash
-    - name: check if hvlite needs to be cloned
+    - name: check if openvmm needs to be cloned
       run: flowey e 9 flowey_lib_common::git_checkout 0
       shell: bash
     - run: |
@@ -6838,7 +6838,7 @@ jobs:
         fetch-depth: '1'
         path: repo0
         persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo hvlite
+      name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - run: ${{ github.workspace }}
       shell: flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_hvlite_reposource.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_hvlite_reposource.rs
@@ -37,7 +37,7 @@ impl SimpleFlowNode for Node {
         }
 
         ctx.req(flowey_lib_common::git_checkout::Request::RegisterRepo {
-            repo_id: "hvlite".into(),
+            repo_id: "openvmm".into(),
             repo_src: hvlite_repo_source,
             allow_persist_credentials: false,
             depth: Some(1),           // shallow fetch
@@ -45,7 +45,7 @@ impl SimpleFlowNode for Node {
         });
 
         ctx.req(crate::git_checkout_openvmm_repo::req::SetRepoId(
-            ReadVar::from_static("hvlite".into()),
+            ReadVar::from_static("openvmm".into()),
         ));
 
         Ok(())

--- a/flowey/flowey_lib_hvlite/src/build_guide.rs
+++ b/flowey/flowey_lib_hvlite/src/build_guide.rs
@@ -38,7 +38,7 @@ impl FlowNode for Node {
         let rust_is_installed = ctx.reqv(flowey_lib_common::install_rust::Request::EnsureInstalled);
 
         for Request { built_guide } in requests {
-            ctx.emit_rust_step("build HvLite guide (mdbook)", |ctx| {
+            ctx.emit_rust_step("build OpenVMM guide (mdbook)", |ctx| {
                 // rust must be installed to build the `mdbook-openvmm-shim`
                 rust_is_installed.clone().claim(ctx);
                 let mdbook_bin = mdbook_bin.clone().claim(ctx);

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -234,7 +234,7 @@ pub struct Manifest {
 }
 
 #[derive(Protobuf, SavedStateRoot)]
-#[mesh(package = "hvlite")]
+#[mesh(package = "openvmm")]
 pub struct SavedState {
     #[mesh(1)]
     pub units: Vec<SavedStateUnit>,

--- a/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
@@ -309,7 +309,7 @@ fn build_dt(
     root_builder = timer.end_node()?;
 
     let mut soc = root_builder
-        .start_node("hvlite")?
+        .start_node("openvmm")?
         .add_str(p_compatible, "simple-bus")?
         .add_u32(p_address_cells, 2)?
         .add_u32(p_size_cells, 2)?

--- a/openvmm/openvmm_entry/src/meshworker.rs
+++ b/openvmm/openvmm_entry/src/meshworker.rs
@@ -17,7 +17,7 @@ use pal_async::task::Task;
 use std::path::PathBuf;
 
 pub(crate) fn run_vmm_mesh_host() -> anyhow::Result<()> {
-    try_run_mesh_host("hvlite", |params: MeshHostParams| async {
+    try_run_mesh_host("openvmm", |params: MeshHostParams| async {
         params.runner.run(RegisteredWorkers).await;
         Ok(())
     })
@@ -38,7 +38,7 @@ impl VmmMesh {
         let mesh = if single_process {
             None
         } else {
-            Some(Mesh::new("hvlite".to_string())?)
+            Some(Mesh::new("openvmm".to_string())?)
         };
         let (local_host, runner) = mesh_worker::worker_host();
         let task = spawn.spawn("worker-host", runner.run(RegisteredWorkers));

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -262,7 +262,7 @@ impl StorageBuilder {
         luns.push(Lun {
             location,
             device_id: Guid::new_random().to_string(),
-            vendor_id: "HvLite".to_string(),
+            vendor_id: "OpenVMM".to_string(),
             product_id: "Disk".to_string(),
             product_revision_level: "1.0".to_string(),
             serial_number: "0".to_string(),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -867,7 +867,7 @@ impl PetriVmConfigSetupCore<'_> {
                         luns: vec![vtl2_settings_proto::Lun {
                             location: BOOT_NVME_LUN,
                             device_id: Guid::new_random().to_string(),
-                            vendor_id: "HvLite".to_string(),
+                            vendor_id: "OpenVMM".to_string(),
                             product_id: "Disk".to_string(),
                             product_revision_level: "1.0".to_string(),
                             serial_number: "0".to_string(),

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -173,7 +173,7 @@ async fn storvsp(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
                         vtl2_settings_proto::Lun {
                             location: vtl0_scsi_lun,
                             device_id: Guid::new_random().to_string(),
-                            vendor_id: "HvLite".to_string(),
+                            vendor_id: "OpenVMM".to_string(),
                             product_id: "Disk".to_string(),
                             product_revision_level: "1.0".to_string(),
                             serial_number: "0".to_string(),
@@ -195,7 +195,7 @@ async fn storvsp(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
                         vtl2_settings_proto::Lun {
                             location: vtl0_nvme_lun,
                             device_id: Guid::new_random().to_string(),
-                            vendor_id: "HvLite".to_string(),
+                            vendor_id: "OpenVMM".to_string(),
                             product_id: "Disk".to_string(),
                             product_revision_level: "1.0".to_string(),
                             serial_number: "0".to_string(),
@@ -297,7 +297,7 @@ async fn openhcl_linux_storvsp_dvd(config: PetriVmConfigOpenVmm) -> Result<(), a
                     luns: vec![vtl2_settings_proto::Lun {
                         location: vtl0_scsi_lun,
                         device_id: Guid::new_random().to_string(),
-                        vendor_id: "HvLite".to_string(),
+                        vendor_id: "OpenVMM".to_string(),
                         product_id: "Disk".to_string(),
                         product_revision_level: "1.0".to_string(),
                         serial_number: "0".to_string(),
@@ -451,7 +451,7 @@ async fn openhcl_linux_stripe_storvsp(config: PetriVmConfigOpenVmm) -> Result<()
                     luns: vec![vtl2_settings_proto::Lun {
                         location: vtl0_nvme_lun,
                         device_id: Guid::new_random().to_string(),
-                        vendor_id: "HvLite".to_string(),
+                        vendor_id: "OpenVMM".to_string(),
                         product_id: "Disk".to_string(),
                         product_revision_level: "1.0".to_string(),
                         serial_number: "0".to_string(),


### PR DESCRIPTION
I noticed "hvlite" was in a few user-facing strings where we it should not be. Fix the places where this is not a breaking change: in openvmm, flowey, and petri.