### PR TITLE
openhcl: Fix the direct invocation of `gen_init_ramfs`

### DIFF
--- a/openhcl/gen_init_ramfs.py
+++ b/openhcl/gen_init_ramfs.py
@@ -72,7 +72,7 @@ import stat
 import time
 import warnings
 
-from typing import BinaryIO
+from typing import BinaryIO, List
 
 
 class CpioEntry(object):
@@ -538,12 +538,12 @@ class CfgCondEval:
 
 
 class InitRamFsConfig:
-    def __init__(self, file_names) -> None:
+    def __init__(self, config_files: List[str]) -> None:
         self.cpio_entries = []
         inode = 721
 
-        for file_name in file_names:
-            with open(file_name, 'rt') as f:
+        for config_file in config_files:
+            with open(config_file, 'rt') as f:
                 cfg_cond = False
                 skip_next_line = False
                 for line_idx, line in enumerate(f):
@@ -630,10 +630,10 @@ def __open_output_stream(file_name: str, compression: str):
         raise Exception("Unknown compression algorithm")
 
 
-def create_cpio_from_config(config_file: str, output_file: str, compression: str):
+def create_cpio_from_config(config_files: List[str], output_file: str, compression: str):
     with __open_output_stream(output_file, compression) as ostream:
         with CpioRamFs(ostream) as cpio:
-            config = InitRamFsConfig(config_file)
+            config = InitRamFsConfig(config_files)
             for entry in config.entries():
                 cpio.write(entry)
 
@@ -679,6 +679,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if not os.path.isdir(args.config_file_or_dir):
-        create_cpio_from_config(args.config_file_or_dir, args.output_file, args.compression)
+        create_cpio_from_config([args.config_file_or_dir], args.output_file, args.compression)
     else:
         create_cpio_from_dir(args.config_file_or_dir, args.output_file, args.compression)


### PR DESCRIPTION
When `create_cpio_from_config` was updated to accept a list, the command line usage didn't get updated. I've had a chance to notice that as I use the this in other repo's.

Update the type annotations and fix the command line usage.