### PR TITLE
openhcl_boot: Remove few kernel parameters for uio_hv_generic

### DIFF
--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -81,10 +81,7 @@ fn build_kernel_command_line(
         "printk.time=1",
         // Enable facility and level output on console for ohcldiag-dev.
         "console_msg_format=syslog",
-        // Set uio parameters to size and configure vmbus ring buffer behavior.
-        "uio_hv_generic.send_buf_size=0",
-        "uio_hv_generic.recv_buf_size=0",
-        "uio_hv_generic.ring_size=0x11000",
+        // Set uio parameter to configure vmbus ring buffer behavior.
         "uio_hv_generic.no_mask=1",
         // RELIABILITY: Dump anonymous pages and ELF headers only. Skip over
         // huge pages and the shared pages.


### PR DESCRIPTION
Few of the module parameters that were earlier supported in uio_hv_generic driver no longer exist in kernel. Remove the logic which adds these parameters in kernel cmdline from openvmm.