### PR TITLE
openhcl: Add the license and copyright notes to few files

### DIFF
--- a/openhcl/Set-OpenHCL-HyperV-VM.ps1
+++ b/openhcl/Set-OpenHCL-HyperV-VM.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     Sets OpenHCL for the VM on the current Hyper-V host.

--- a/openhcl/gen_init_ramfs.py
+++ b/openhcl/gen_init_ramfs.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 #
 # There is a similar tool implemented in C inside the Linux kernel source tree.
 # The goal for this one has been to be independent of the kernel source tree,

--- a/openhcl/perftoolsfs.config
+++ b/openhcl/perftoolsfs.config
@@ -1,2 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 file /usr/bin/perf    ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/tools/perf/bin/perf  0755 0 0
 file /usr/bin/trace    ${OPENHCL_KERNEL_PATH}/build/native/bin/${OPENHCL_KERNEL_ARCH}/tools/perf/bin/trace  0755 0 0

--- a/openhcl/rootfs.config
+++ b/openhcl/rootfs.config
@@ -1,4 +1,5 @@
-# Copyright (C) Microsoft Corporation. All rights reserved.
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 # This file describes the Underhill root file system layout.
 

--- a/openhcl/update-rootfs.py
+++ b/openhcl/update-rootfs.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python3
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import os
 import sys
 import io


### PR DESCRIPTION
The tooling didn't flag these files for missing these lines, fixing manually this time.