### PR TITLE
xtask: Copyright and license lints for more file types

### DIFF
--- a/.github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py
+++ b/.github/scripts/add_unsafe_reviewers/add-unsafe-reviewers.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import click
 from git import Repo
 from github import Github

--- a/.github/scripts/refresh_mirror/refresh-mirror.py
+++ b/.github/scripts/refresh_mirror/refresh-mirror.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import click
 import time
 import sys

--- a/support/clap_dyn_complete/src/templates/complete.ps1
+++ b/support/clap_dyn_complete/src/templates/complete.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 Register-ArgumentCompleter -Native -CommandName '__COMMAND_NAME__' -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)
 

--- a/vmm_tests/vmm_tests/test_data/tpm.py
+++ b/vmm_tests/vmm_tests/test_data/tpm.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+
 #
 # The test script that reads AK CERT from TPM and validate its content
 


### PR DESCRIPTION
Few files turned out to not have the notes, and they were fixed
manually.
Provide a robust solution by updating house rules in xtask.

Additionally this includes an updatex for the automatic fix
mode. I made sure that produces desired results and is
idempotent.

Suggested-by: Daniel Prilik  <daprilik@users.noreply.github.com>
Reported-by: Matt Kurjanowicz <mattkur@microsoft.com>
Fixes: https://github.com/microsoft/openvmm/issues/766