### PR TITLE
More NVMe keepalive VMM test coverage

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
@@ -12,10 +12,14 @@ use vmm_test_macros::openvmm_test;
 
 async fn openhcl_servicing_core(
     config: PetriVmConfigOpenVmm,
+    openhcl_cmdline: &str,
     new_openhcl: ArtifactHandle<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
     flags: OpenHclServicingFlags,
 ) -> anyhow::Result<()> {
-    let (mut vm, agent) = config.run().await?;
+    let (mut vm, agent) = config
+        .with_openhcl_command_line(openhcl_cmdline)
+        .run()
+        .await?;
 
     agent.ping().await?;
 
@@ -40,6 +44,7 @@ async fn openhcl_servicing_core(
 async fn openhcl_servicing(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     openhcl_servicing_core(
         config,
+        "",
         LATEST_LINUX_DIRECT_TEST_X64,
         OpenHclServicingFlags::default(),
     )
@@ -52,6 +57,7 @@ async fn openhcl_servicing(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::E
 async fn openhcl_servicing_keepalive(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     openhcl_servicing_core(
         config,
+        "OPENHCL_ENABLE_VTL2_GPA_POOL=1024",
         LATEST_LINUX_DIRECT_TEST_X64,
         OpenHclServicingFlags {
             enable_nvme_keepalive: true,

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -4,6 +4,9 @@
 //! Integration tests for Generation 2 UEFI x86_64 guests with OpenHCL.
 
 use petri::openvmm::PetriVmConfigOpenVmm;
+use petri::ArtifactHandle;
+use petri::OpenHclServicingFlags;
+use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
 
@@ -19,6 +22,37 @@ async fn nvme_relay_test_core(
         .await?;
 
     vm.wait_for_successful_boot_event().await?;
+    agent.power_off().await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+
+    Ok(())
+}
+
+/// Servicing tests with NVMe devices attached.
+async fn nvme_relay_servicing_core(
+    config: PetriVmConfigOpenVmm,
+    openhcl_cmdline: &str,
+    new_openhcl: ArtifactHandle<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
+    flags: OpenHclServicingFlags,
+) -> Result<(), anyhow::Error> {
+    let (mut vm, agent) = config
+        .with_openhcl_command_line(openhcl_cmdline)
+        .with_vmbus_redirect()
+        .run()
+        .await?;
+
+    agent.ping().await?;
+
+    // Test that inspect serialization works with the old version.
+    vm.test_inspect_openhcl().await?;
+
+    vm.restart_openhcl(new_openhcl, flags).await?;
+
+    agent.ping().await?;
+
+    // Test that inspect serialization works with the new version.
+    vm.test_inspect_openhcl().await?;
+
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
 
@@ -49,6 +83,23 @@ async fn nvme_relay_shared_pool(config: PetriVmConfigOpenVmm) -> Result<(), anyh
 async fn nvme_relay_private_pool(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     // Number of pages to reserve as a private pool.
     nvme_relay_test_core(config, "OPENHCL_ENABLE_VTL2_GPA_POOL=1024").await
+}
+
+/// Servicing test of an OpenHCL uefi VM with a NVME disk assigned to VTL2 that boots
+/// linux, with vmbus relay. This should expose a disk to VTL0 via vmbus.
+/// Use the private pool override to test the private pool dma path.
+/// Pass 'keepalive' servicing flag which impacts NVMe save/restore.
+#[openvmm_test(openhcl_uefi_x64[nvme](vhd(ubuntu_2204_server_x64)))]
+async fn nvme_keepalive(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+    nvme_relay_servicing_core(
+        config,
+        "OPENHCL_ENABLE_VTL2_GPA_POOL=1024",
+        LATEST_STANDARD_X64,
+        OpenHclServicingFlags {
+            enable_nvme_keepalive: true,
+        },
+    )
+    .await
 }
 
 /// Boot the UEFI firmware, with a VTL2 range automatically configured by


### PR DESCRIPTION
Continuing adding NVMe keepalive and private pool testing. The new one adds necessary config to fully test the feature, even NVMe queue memory is preserved after servicing.