### PR TITLE
Small cleanups to hv1 and tdx tlb flush code

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -71,6 +71,7 @@ impl UhProcessor<'_, TdxBacked> {
     /// Completes any pending TLB flush activity on the current VP.
     pub(super) fn do_tlb_flush(&mut self, target_vtl: GuestVtl) {
         let partition_flush_state = self.shared.flush_state[target_vtl].read();
+        let self_flush_state = &mut self.backing.vtls[target_vtl].flush_state;
 
         // NOTE: It is theoretically possible that we haven't run in so long
         // that the partition counters have wrapped all the way around u32::MAX
@@ -78,9 +79,7 @@ impl UhProcessor<'_, TdxBacked> {
         // unlikely that we don't bother to worry about it.
 
         // Check first to see whether a full flush is required.
-        let flush_entire_required = if self.backing.vtls[target_vtl]
-            .flush_state
-            .flush_entire_counter
+        let flush_entire_required = if self_flush_state.flush_entire_counter
             != partition_flush_state.s.flush_entire_counter
         {
             true
@@ -90,19 +89,17 @@ impl UhProcessor<'_, TdxBacked> {
             !Self::try_flush_list(
                 target_vtl,
                 &partition_flush_state,
-                &mut self.backing.vtls[target_vtl].flush_state.gva_list_count,
+                &mut self_flush_state.gva_list_count,
                 &mut self.runner,
                 &self.backing.flush_page,
             )
         };
 
-        let self_flush_state = &mut self.backing.vtls[target_vtl].flush_state;
-
         // If a flush entire is required, then complete the flush and update the
         // flush counters to indicate that a complete flush has been accomplished.
         if flush_entire_required {
             *self_flush_state = partition_flush_state.s.clone();
-            Self::do_flush_entire(false, &mut self.runner);
+            Self::do_flush_entire(true, &mut self.runner);
         }
         // If no flush entire is required, then check to see whether a full
         // non-global flush is required.
@@ -111,7 +108,7 @@ impl UhProcessor<'_, TdxBacked> {
         {
             self_flush_state.flush_entire_non_global_counter =
                 partition_flush_state.s.flush_entire_non_global_counter;
-            Self::do_flush_entire(true, &mut self.runner);
+            Self::do_flush_entire(false, &mut self.runner);
         }
     }
 
@@ -179,13 +176,13 @@ impl UhProcessor<'_, TdxBacked> {
         true
     }
 
-    fn do_flush_entire(non_global: bool, runner: &mut ProcessorRunner<'_, Tdx>) {
+    fn do_flush_entire(global: bool, runner: &mut ProcessorRunner<'_, Tdx>) {
         let vp_flags = runner.tdx_vp_entry_flags_mut();
 
-        if !non_global {
+        if global {
             // TODO: Track EPT invalidations separately.
             vp_flags.set_invd_translations(x86defs::tdx::TDX_VP_ENTER_INVD_INVEPT);
-        } else if non_global && vp_flags.invd_translations() == 0 {
+        } else if !global && vp_flags.invd_translations() == 0 {
             vp_flags.set_invd_translations(x86defs::tdx::TDX_VP_ENTER_INVD_INVVPID_NON_GLOBAL);
         }
     }

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -20,15 +20,7 @@ pub fn hv_cpuid_leaves(
     vtom: Option<u64>,
 ) -> Vec<CpuidLeaf> {
     let hardware_isolated = isolation.is_hardware_isolated();
-    let split_u128 = |x: u128| -> [u32; 4] {
-        let bytes = x.to_le_bytes();
-        [
-            u32::from_le_bytes(bytes[0..4].try_into().unwrap()),
-            u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
-            u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
-            u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
-        ]
-    };
+    let split_u128 = |x: u128| -> [u32; 4] { zerocopy::transmute!(x) };
 
     let privileges = {
         let mut privileges = hvdef::HvPartitionPrivilege::new()


### PR DESCRIPTION
Small miscellaneous drive-by cleanups noticed while doing other work. Just trying to make things easier to follow, and using zerocopy in one new spot that should've. Should introduce no functional changes.