### PR TITLE
TDX TLB: Don't add extended ranges to the list

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -3512,7 +3512,7 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
         }
 
         for range in gva_ranges {
-            if range.as_extended().large_page() && use_extended_range_format {
+            if use_extended_range_format && range.as_extended().large_page() {
                 // TDX does not provide a way to flush large page ranges,
                 // we have to promote this request to a flush entire.
                 return Err(());

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -3512,11 +3512,9 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
         }
 
         for range in gva_ranges {
-            if range.as_extended().large_page() && !use_extended_range_format {
-                // If we have not been asked to use extended ranges, but this range
-                // claims to be large pages, then what has actually happened is this
-                // range has overflowed its count field. We have no way to disambiguate
-                // this case at flush time, so we have to promote this to a flush entire.
+            if range.as_extended().large_page() && use_extended_range_format {
+                // TDX does not provide a way to flush large page ranges,
+                // we have to promote this request to a flush entire.
                 return Err(());
             }
             if flush_state.gva_list.len() == FLUSH_GVA_LIST_SIZE {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -146,10 +146,6 @@ impl UhProcessor<'_, TdxBacked> {
 
         if count_diff == 1 {
             let gva_range = flush_addrs.next().unwrap();
-            // Any extended entry can't be handled, promote to a flush entire.
-            if gva_range.as_extended().large_page() {
-                return false;
-            }
             runner
                 .invgla(gla_flags, TdxGlaListInfo::from(gva_range.0))
                 .unwrap();
@@ -159,11 +155,6 @@ impl UhProcessor<'_, TdxBacked> {
             let page_mapping = flush_page.mapping().unwrap();
 
             for (i, gva_range) in flush_addrs.enumerate() {
-                // Any extended entry can't be handled, promote to a flush entire.
-                if gva_range.as_extended().large_page() {
-                    return false;
-                }
-
                 page_mapping
                     .write_at(i * size_of::<HvGvaRange>(), gva_range.as_bytes())
                     .unwrap();


### PR DESCRIPTION
TDX supports flushing ranges with the full size of `count` that our HvGvaSimpleRange supports. It does not support flushing large page ranges. These two cases are indistinguishable at flush time, as they have the same binary representation, but we can tell them apart when we add entries to the list, thanks to the flag parameter in the hypercall. 

The original HCL code this was based on was used in multiple locations and so needed to support storing large page ranges. We do not. Invert the check for them to make things simpler.

Note that this is the first time this code is meaningfully differing from the original HCL code.