### PR TITLE
TDX: Clean up handling of vp entry and TLB flush flags

### DIFF
--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -133,14 +133,9 @@ impl ProcessorRunner<'_, Tdx> {
         &mut self.tdx_vp_context_mut().vp_state
     }
 
-    /// Gets a reference to the TDX VP entry flags.
-    pub fn tdx_vp_entry_flags(&self) -> &TdxVmFlags {
-        &self.tdx_vp_context().entry_rcx
-    }
-
-    /// Gets a mutable reference to the TDX VP entry flags.
-    pub fn tdx_vp_entry_flags_mut(&mut self) -> &mut TdxVmFlags {
-        &mut self.tdx_vp_context_mut().entry_rcx
+    /// Sets the TDX VP entry flags.
+    pub fn set_tdx_vp_entry_flags(&mut self, flags: TdxVmFlags) {
+        self.tdx_vp_context_mut().entry_rcx = flags;
     }
 
     fn vmcs_field_code(field: VmcsField, vtl: GuestVtl) -> TdxExtendedFieldCode {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -97,6 +97,8 @@ impl UhProcessor<'_, TdxBacked> {
             )
         };
 
+        // TODO: Track EPT invalidations separately.
+
         // If a flush entire is required, then return a flag and update the
         // flush counters to indicate that a complete flush has been accomplished.
         if flush_entire_required {


### PR DESCRIPTION
Part of cleaning up our kernel-shared state to be harder to use incorrectly for #746.

Part of #699 too