### PR TITLE
mana: Handle deregister message in emulator

### DIFF
--- a/vm/devices/net/gdma/src/hwc.rs
+++ b/vm/devices/net/gdma/src/hwc.rs
@@ -439,6 +439,18 @@ impl HwControl {
                     .update_eq_msix(req.queue_index, req.msix)?;
                 0
             }
+            GdmaRequestType::GDMA_DEREGISTER_DEVICE => {
+                if hdr.dev_id != BNIC_DEV_ID {
+                    anyhow::bail!("invalid device id: {:?}", hdr.dev_id);
+                }
+
+                if !self.bnic_enabled {
+                    anyhow::bail!("bnic not enabled");
+                }
+
+                self.bnic_enabled = false;
+                0
+            }
             ty => {
                 anyhow::bail!("unsupported message type: {:x?}", ty);
             }


### PR DESCRIPTION
Currently, testing servicing with MANA results in the following error:
```
47.426762200s  WARN gdma::hwc:  req error msg_type=0x5 dev_id=GdmaDevId { ty: GDMA_DEVICE_MANA, instance: 1 } error=unsupported message type: GDMA_DEREGISTER_DEVICE
...
vtl0 start failed: guest reported VTL0 start error: failed to create mana device: failed to initialize mana device: establish failed: 1
```

This change handles the message and adds a test for servicing with basic validation.