### PR TITLE
hv1_hypercall: Remove blanket implementations of AsHandler

### DIFF
--- a/vm/hv1/hv1_hypercall/src/support.rs
+++ b/vm/hv1/hv1_hypercall/src/support.rs
@@ -111,18 +111,6 @@ pub trait AsHandler<H> {
     fn as_handler(&mut self) -> &mut H;
 }
 
-impl<H> AsHandler<H> for H {
-    fn as_handler(&mut self) -> &mut H {
-        self
-    }
-}
-
-impl<H> AsHandler<H> for &mut H {
-    fn as_handler(&mut self) -> &mut H {
-        self
-    }
-}
-
 impl<'a, T: HypercallIo> InnerDispatcher<'a, T> {
     /// Creates a new dispatcher.
     fn new(guest_memory: &'a GuestMemory, mut handler: T) -> Self {

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -895,6 +895,14 @@ impl<T: CpuIo> KvmHypercallExit<'_, T> {
     );
 }
 
+impl<'a, T: CpuIo> hv1_hypercall::AsHandler<KvmHypercallExit<'a, T>>
+    for &mut KvmHypercallExit<'a, T>
+{
+    fn as_handler(&mut self) -> &mut KvmHypercallExit<'a, T> {
+        self
+    }
+}
+
 impl<T> hv1_hypercall::HypercallIo for KvmHypercallExit<'_, T> {
     fn advance_ip(&mut self) {
         // KVM automatically does this.


### PR DESCRIPTION
This stops them from appearing as suggestions in autocomplete on completely unrelated types.