### PR TITLE
TDX: Move vp entry flags into private regs

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -14,6 +14,7 @@ use std::collections::VecDeque;
 use std::num::Wrapping;
 use x86defs::tdx::TdGlaVmAndFlags;
 use x86defs::tdx::TdxGlaListInfo;
+use x86defs::tdx::TdxVmFlags;
 use zerocopy::IntoBytes;
 
 pub(super) const FLUSH_GVA_LIST_SIZE: usize = 32;
@@ -99,7 +100,10 @@ impl UhProcessor<'_, TdxBacked> {
         // flush counters to indicate that a complete flush has been accomplished.
         if flush_entire_required {
             *self_flush_state = partition_flush_state.s.clone();
-            Self::do_flush_entire(true, &mut self.runner);
+            Self::set_flush_entire(
+                true,
+                &mut self.backing.vtls[target_vtl].private_regs.vp_entry_flags,
+            );
         }
         // If no flush entire is required, then check to see whether a full
         // non-global flush is required.
@@ -108,7 +112,10 @@ impl UhProcessor<'_, TdxBacked> {
         {
             self_flush_state.flush_entire_non_global_counter =
                 partition_flush_state.s.flush_entire_non_global_counter;
-            Self::do_flush_entire(false, &mut self.runner);
+            Self::set_flush_entire(
+                false,
+                &mut self.backing.vtls[target_vtl].private_regs.vp_entry_flags,
+            );
         }
     }
 
@@ -167,9 +174,7 @@ impl UhProcessor<'_, TdxBacked> {
         true
     }
 
-    fn do_flush_entire(global: bool, runner: &mut ProcessorRunner<'_, Tdx>) {
-        let vp_flags = runner.tdx_vp_entry_flags_mut();
-
+    fn set_flush_entire(global: bool, vp_flags: &mut TdxVmFlags) {
         if global {
             // TODO: Track EPT invalidations separately.
             vp_flags.set_invd_translations(x86defs::tdx::TDX_VP_ENTER_INVD_INVEPT);


### PR DESCRIPTION
Part of cleaning up our kernel-shared state to be harder to use incorrectly for #746. Alternate take on #784.

Part of #699 too.