### PR TITLE
devcontainer: specify explicit rust version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     // meant for local developer use.
     "features": {
         "ghcr.io/devcontainers/features/rust:1": {
-            "version": "latest",
+            "version": "1.84.1",
             "profile": "default",
             "targets": "aarch64-apple-darwin,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,x86_64-unknown-none"
         },


### PR DESCRIPTION
This seemed to break on my local system when I didn't do this. Probably best to pin this anyways to what we're using currently in the repo. 