### PR TITLE
vmbus_proxy: allow using an existing handle and make GuestMemory optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8228,10 +8228,8 @@ dependencies = [
  "vmbus_proxy",
  "vmbus_ring",
  "vmcore",
- "zerocopy 0.8.14",
  "windows",
  "zerocopy 0.8.14",
- "zerocopy_helpers",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8057,13 +8057,13 @@ dependencies = [
  "futures",
  "guestmem",
  "mesh",
- "ntapi",
  "pal",
  "pal_async",
  "pal_event",
  "tracing",
  "vmbus_core",
- "winapi",
+ "widestring",
+ "windows-sys 0.52.0",
  "zerocopy 0.8.14",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "mesh_protobuf",
  "thiserror 2.0.0",
  "winapi",
+ "windows",
  "windows-sys 0.52.0",
  "zerocopy 0.8.14",
 ]
@@ -4914,6 +4915,7 @@ dependencies = [
  "widestring",
  "win_import_lib",
  "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -8063,7 +8065,7 @@ dependencies = [
  "tracing",
  "vmbus_core",
  "widestring",
- "windows-sys 0.52.0",
+ "windows",
  "zerocopy 0.8.14",
 ]
 
@@ -8226,8 +8228,10 @@ dependencies = [
  "vmbus_proxy",
  "vmbus_ring",
  "vmcore",
- "winapi",
  "zerocopy 0.8.14",
+ "windows",
+ "zerocopy 0.8.14",
+ "zerocopy_helpers",
 ]
 
 [[package]]

--- a/support/guid/Cargo.toml
+++ b/support/guid/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 zerocopy.workspace = true
 [target.'cfg(windows)'.dependencies]
 windows-sys.workspace = true
+windows.workspace = true
 
 [target.'cfg(windows)'.dependencies.winapi]
 workspace = true

--- a/support/guid/src/lib.rs
+++ b/support/guid/src/lib.rs
@@ -280,6 +280,28 @@ mod windows {
             }
         }
     }
+
+    impl From<windows::core::GUID> for Guid {
+        fn from(guid: windows::core::GUID) -> Self {
+            Self {
+                data1: guid.data1,
+                data2: guid.data2,
+                data3: guid.data3,
+                data4: guid.data4,
+            }
+        }
+    }
+
+    impl From<Guid> for windows::core::GUID {
+        fn from(guid: Guid) -> Self {
+            Self {
+                data1: guid.data1,
+                data2: guid.data2,
+                data3: guid.data3,
+                data4: guid.data4,
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/support/pal/Cargo.toml
+++ b/support/pal/Cargo.toml
@@ -23,7 +23,7 @@ pal_event.workspace = true
 ntapi = { workspace = true, features = ["impl-default"] }
 socket2 = { workspace = true, features = ["all"] }
 widestring.workspace = true
-windows = { workspace = true, features = ["Win32_Foundation"] }
+windows = { workspace = true, features = ["Wdk_Foundation", "Win32_Foundation"] }
 
 [target.'cfg(windows)'.dependencies.winapi]
 workspace = true

--- a/support/pal/Cargo.toml
+++ b/support/pal/Cargo.toml
@@ -23,7 +23,7 @@ pal_event.workspace = true
 ntapi = { workspace = true, features = ["impl-default"] }
 socket2 = { workspace = true, features = ["all"] }
 widestring.workspace = true
-windows.workspace = true
+windows = { workspace = true, features = ["Win32_Foundation"] }
 
 [target.'cfg(windows)'.dependencies.winapi]
 workspace = true

--- a/support/pal/Cargo.toml
+++ b/support/pal/Cargo.toml
@@ -23,6 +23,7 @@ pal_event.workspace = true
 ntapi = { workspace = true, features = ["impl-default"] }
 socket2 = { workspace = true, features = ["all"] }
 widestring.workspace = true
+windows.workspace = true
 
 [target.'cfg(windows)'.dependencies.winapi]
 workspace = true

--- a/support/pal/src/windows.rs
+++ b/support/pal/src/windows.rs
@@ -791,6 +791,14 @@ impl<'a> ObjectAttributes<'a> {
     }
 }
 
+impl AsRef<windows::Wdk::Foundation::OBJECT_ATTRIBUTES> for ObjectAttributes<'_> {
+    fn as_ref(&self) -> &windows::Wdk::Foundation::OBJECT_ATTRIBUTES {
+        // SAFETY: These are different definitions of the same type, so the memory layout is the
+        // same.
+        unsafe { std::mem::transmute(&self.attributes) }
+    }
+}
+
 pub fn open_object_directory(obj_attr: &ObjectAttributes<'_>, access: u32) -> Result<OwnedHandle> {
     // SAFETY: calling the API according to the NT API
     unsafe {

--- a/vm/devices/net/vmswitch/src/kernel.rs
+++ b/vm/devices/net/vmswitch/src/kernel.rs
@@ -28,7 +28,7 @@ impl KernelVmNic {
         friendly_name: &str,
         mac_address: [u8; 6],
         instance_id: &Guid,
-        vmbus_handle: &OwnedHandle,
+        vmbus_handle: BorrowedHandle<'_>,
     ) -> io::Result<Self> {
         let full_nic_name = format!("{}--{}", vm_id, nic_name);
         let path = format!(r#"\\.\VmSwitch\{}"#, &full_nic_name);

--- a/vm/devices/vmbus/vmbus_proxy/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_proxy/Cargo.toml
@@ -18,7 +18,7 @@ pal_async.workspace = true
 futures.workspace = true
 tracing.workspace = true
 widestring.workspace = true
-windows-sys = { workspace = true, features = [
+windows = { workspace = true, features = [
     "Wdk_Foundation",
     "Wdk_Storage_FileSystem",
     "Win32_Storage_FileSystem",

--- a/vm/devices/vmbus/vmbus_proxy/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_proxy/Cargo.toml
@@ -16,9 +16,15 @@ pal_event.workspace = true
 pal_async.workspace = true
 
 futures.workspace = true
-ntapi.workspace = true
 tracing.workspace = true
-winapi = { workspace = true, features = ["debug", "winioctl"] }
+widestring.workspace = true
+windows-sys = { workspace = true, features = [
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Ioctl"
+] }
 zerocopy.workspace = true
 [lints]
 workspace = true

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -15,7 +15,6 @@ use pal_async::windows::overlapped::IoBuf;
 use pal_async::windows::overlapped::IoBufMut;
 use pal_async::windows::overlapped::OverlappedFile;
 use pal_event::Event;
-use std::ffi::c_void;
 use std::mem::zeroed;
 use std::os::windows::prelude::*;
 use std::ptr::null_mut;
@@ -331,10 +330,7 @@ impl VmbusProxy {
             DeviceIoControl(
                 HANDLE(self.file.get().as_raw_handle() as isize),
                 proxyioctl::IOCTL_VMBUS_PROXY_RUN_CHANNEL,
-                Some(
-                    std::ptr::from_ref::<proxyioctl::VMBUS_PROXY_RUN_CHANNEL_INPUT>(&input)
-                        as *mut c_void,
-                ),
+                Some(std::ptr::from_ref(&input).cast()),
                 size_of_val(&input) as u32,
                 None,
                 0,

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -256,6 +256,12 @@ impl ProxyHandle {
     }
 }
 
+impl From<OwnedHandle> for ProxyHandle {
+    fn from(value: OwnedHandle) -> Self {
+        Self(value.into())
+    }
+}
+
 pub struct VmbusProxy {
     file: OverlappedFile,
     // NOTE: This must come after `file` so that it is not released until `file`

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -32,7 +32,6 @@ use windows::Win32::Foundation::NTSTATUS;
 use windows::Win32::Storage::FileSystem::FILE_ALL_ACCESS;
 use windows::Win32::Storage::FileSystem::SYNCHRONIZE;
 use windows::Win32::System::IO::DeviceIoControl;
-use zerocopy::AsBytes;
 use zerocopy::IntoBytes;
 
 pub mod vmbusioctl;

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -34,9 +34,8 @@ use windows::Win32::Storage::FileSystem::SYNCHRONIZE;
 use windows::Win32::System::IO::DeviceIoControl;
 use zerocopy::IntoBytes;
 
-pub mod vmbusioctl;
-
 mod proxyioctl;
+pub mod vmbusioctl;
 
 pub type Error = windows::core::Error;
 pub type Result<T> = windows::core::Result<T>;
@@ -77,6 +76,7 @@ impl ProxyHandle {
 }
 
 impl From<OwnedHandle> for ProxyHandle {
+    /// Create a `ProxyHandle` from an existing VM handle.
     fn from(value: OwnedHandle) -> Self {
         Self(value.into())
     }

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -9,7 +9,6 @@
 use futures::poll;
 use guestmem::GuestMemory;
 use mesh::MeshPayload;
-use pal::windows::chk_status;
 use pal::windows::UnicodeStringRef;
 use pal_async::driver::Driver;
 use pal_async::windows::overlapped::IoBuf;
@@ -30,6 +29,7 @@ use windows::Wdk::Foundation::OBJECT_ATTRIBUTES;
 use windows::Wdk::Storage::FileSystem::NtOpenFile;
 use windows::Win32::Foundation::ERROR_CANCELLED;
 use windows::Win32::Foundation::HANDLE;
+use windows::Win32::Foundation::NTSTATUS;
 use windows::Win32::Storage::FileSystem::FILE_ALL_ACCESS;
 use windows::Win32::Storage::FileSystem::SYNCHRONIZE;
 use windows::Win32::System::IO::DeviceIoControl;
@@ -261,8 +261,7 @@ impl VmbusProxy {
             .await?
             .0
         };
-        chk_status(output.Status)?;
-        Ok(())
+        NTSTATUS(output.Status).ok()
     }
 
     pub async fn close(&self, id: u64) -> Result<()> {

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #![allow(
     dead_code,
     non_snake_case,

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -12,7 +12,8 @@ use windows::Win32::System::Ioctl::FILE_DEVICE_UNKNOWN;
 use windows::Win32::System::Ioctl::FILE_READ_ACCESS;
 use windows::Win32::System::Ioctl::FILE_WRITE_ACCESS;
 use windows::Win32::System::Ioctl::METHOD_BUFFERED;
-use zerocopy::AsBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
 
 const fn CTL_CODE(DeviceType: u32, Function: u32, Method: u32, Access: u32) -> u32 {
     (DeviceType << 16) | (Access << 14) | (Function << 2) | Method
@@ -108,7 +109,7 @@ pub struct VMBUS_PROXY_CLOSE_CHANNEL_INPUT {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, AsBytes)]
+#[derive(Copy, Clone, IntoBytes, Immutable)]
 pub struct VMBUS_PROXY_CREATE_GPADL_INPUT {
     pub ChannelId: u64,
     pub GpadlId: u32,

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -1,0 +1,137 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    clippy::upper_case_acronyms
+)]
+
+use super::vmbusioctl::VMBUS_CHANNEL_OFFER;
+use super::vmbusioctl::VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS;
+use windows_sys::Win32::System::Ioctl::FILE_DEVICE_UNKNOWN;
+use windows_sys::Win32::System::Ioctl::FILE_READ_ACCESS;
+use windows_sys::Win32::System::Ioctl::FILE_WRITE_ACCESS;
+use windows_sys::Win32::System::Ioctl::METHOD_BUFFERED;
+use zerocopy::AsBytes;
+
+const fn CTL_CODE(DeviceType: u32, Function: u32, Method: u32, Access: u32) -> u32 {
+    (DeviceType << 16) | (Access << 14) | (Function << 2) | Method
+}
+
+const fn VMBUS_PROXY_IOCTL(code: u32) -> u32 {
+    CTL_CODE(
+        FILE_DEVICE_UNKNOWN,
+        code,
+        METHOD_BUFFERED,
+        FILE_READ_ACCESS | FILE_WRITE_ACCESS,
+    )
+}
+
+pub const IOCTL_VMBUS_PROXY_SET_VM_NAME: u32 = VMBUS_PROXY_IOCTL(0x1);
+pub const IOCTL_VMBUS_PROXY_SET_TOPOLOGY: u32 = VMBUS_PROXY_IOCTL(0x2);
+pub const IOCTL_VMBUS_PROXY_SET_MEMORY: u32 = VMBUS_PROXY_IOCTL(0x3);
+pub const IOCTL_VMBUS_PROXY_NEXT_ACTION: u32 = VMBUS_PROXY_IOCTL(0x4);
+pub const IOCTL_VMBUS_PROXY_OPEN_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0x5);
+pub const IOCTL_VMBUS_PROXY_CLOSE_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0x6);
+pub const IOCTL_VMBUS_PROXY_CREATE_GPADL: u32 = VMBUS_PROXY_IOCTL(0x7);
+pub const IOCTL_VMBUS_PROXY_DELETE_GPADL: u32 = VMBUS_PROXY_IOCTL(0x8);
+pub const IOCTL_VMBUS_PROXY_RELEASE_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0x9);
+pub const IOCTL_VMBUS_PROXY_RUN_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0xa);
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_SET_VM_NAME_INPUT {
+    pub VmId: [u8; 16],
+    pub NameLength: u16,
+    pub NameOffset: u16,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_SET_TOPOLOGY_INPUT {
+    pub NodeCount: u32,
+    pub VpCount: u32,
+    pub NodesOffset: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_SET_MEMORY_INPUT {
+    pub BaseAddress: u64,
+    pub Size: u64,
+}
+
+pub const VmbusProxyActionTypeOffer: u32 = 1;
+pub const VmbusProxyActionTypeRevoke: u32 = 2;
+pub const VmbusProxyActionTypeInterruptPolicy: u32 = 3;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_NEXT_ACTION_OUTPUT {
+    pub Type: u32,
+    pub ChannelId: u64,
+    pub u: VMBUS_PROXY_NEXT_ACTION_OUTPUT_union,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union VMBUS_PROXY_NEXT_ACTION_OUTPUT_union {
+    pub Offer: VMBUS_PROXY_NEXT_ACTION_OUTPUT_union_Offer,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_NEXT_ACTION_OUTPUT_union_Offer {
+    pub Offer: VMBUS_CHANNEL_OFFER,
+    pub DeviceIncomingRingEvent: u64, // BUGBUG: HANDLE
+    pub DeviceOutgoingRingEvent: u64, // BUGBUG: HANDLE
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_OPEN_CHANNEL_INPUT {
+    pub ChannelId: u64,
+    pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
+    pub VmmSignalEvent: u64, // BUGBUG: HANDLE
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_OPEN_CHANNEL_OUTPUT {
+    pub Status: i32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_CLOSE_CHANNEL_INPUT {
+    pub ChannelId: u64,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, AsBytes)]
+pub struct VMBUS_PROXY_CREATE_GPADL_INPUT {
+    pub ChannelId: u64,
+    pub GpadlId: u32,
+    pub RangeCount: u32,
+    pub RangeBufferOffset: u32,
+    pub RangeBufferSize: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_DELETE_GPADL_INPUT {
+    pub ChannelId: u64,
+    pub GpadlId: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_RELEASE_CHANNEL_INPUT {
+    pub ChannelId: u64,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_RUN_CHANNEL_INPUT {
+    pub ChannelId: u64,
+}

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -8,10 +8,10 @@
 
 use super::vmbusioctl::VMBUS_CHANNEL_OFFER;
 use super::vmbusioctl::VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS;
-use windows_sys::Win32::System::Ioctl::FILE_DEVICE_UNKNOWN;
-use windows_sys::Win32::System::Ioctl::FILE_READ_ACCESS;
-use windows_sys::Win32::System::Ioctl::FILE_WRITE_ACCESS;
-use windows_sys::Win32::System::Ioctl::METHOD_BUFFERED;
+use windows::Win32::System::Ioctl::FILE_DEVICE_UNKNOWN;
+use windows::Win32::System::Ioctl::FILE_READ_ACCESS;
+use windows::Win32::System::Ioctl::FILE_WRITE_ACCESS;
+use windows::Win32::System::Ioctl::METHOD_BUFFERED;
 use zerocopy::AsBytes;
 
 const fn CTL_CODE(DeviceType: u32, Function: u32, Method: u32, Access: u32) -> u32 {

--- a/vm/devices/vmbus/vmbus_proxy/src/vmbusioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/vmbusioctl.rs
@@ -10,10 +10,10 @@
 )]
 
 use vmbus_core::protocol::UserDefinedData;
-use windows_sys::core::GUID;
+use windows::core::GUID;
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct VMBUS_CHANNEL_OFFER {
     pub InterfaceType: GUID,
     pub InterfaceInstance: GUID,

--- a/vm/devices/vmbus/vmbus_proxy/src/vmbusioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/vmbusioctl.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(
+    dead_code,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    clippy::upper_case_acronyms
+)]
+
+use vmbus_core::protocol::UserDefinedData;
+use windows_sys::core::GUID;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_CHANNEL_OFFER {
+    pub InterfaceType: GUID,
+    pub InterfaceInstance: GUID,
+    pub InterruptLatencyIn100nsUnits: u64,
+    pub ChannelFlags: u16,
+    pub MmioMegabytes: u16,         // in bytes * 1024 * 1024
+    pub MmioMegabytesOptional: u16, // mmio memory in addition to MmioMegabytes that is optional
+    pub SubChannelIndex: u16,
+    pub TargetVtl: u8,
+    pub Reserved: [u8; 7],
+    pub UserDefined: UserDefinedData,
+}
+
+pub const VMBUS_CHANNEL_ENUMERATE_DEVICE_INTERFACE: u16 = 1;
+pub const VMBUS_CHANNEL_NAMED_PIPE_MODE: u16 = 0x10;
+pub const VMBUS_CHANNEL_LOOPBACK_OFFER: u16 = 0x100;
+pub const VMBUS_CHANNEL_REQUEST_MONITORED_NOTIFICATION: u16 = 0x400;
+pub const VMBUS_CHANNEL_FORCE_NEW_CHANNEL: u16 = 0x1000;
+pub const VMBUS_CHANNEL_TLNPI_PROVIDER_OFFER: u16 = 0x2000;
+
+pub const VMBUS_PIPE_TYPE_BYTE: u32 = 0;
+pub const VMBUS_PIPE_TYPE_MESSAGE: u32 = 4;
+pub const VMBUS_PIPE_TYPE_RAW: u32 = 8;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS {
+    pub RingBufferGpadlHandle: u32,
+    pub DownstreamRingBufferPageOffset: u32,
+    pub NodeNumber: u16,
+}

--- a/vm/devices/vmbus/vmbus_server/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_server/Cargo.toml
@@ -37,7 +37,7 @@ unicycle.workspace = true
 zerocopy.workspace = true
 [target.'cfg(windows)'.dependencies]
 vmbus_proxy.workspace = true
-winapi.workspace = true
+windows.workspace = true
 
 [dev-dependencies]
 test_with_tracing.workspace = true

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -569,7 +569,7 @@ impl VmbusServer {
         driver: &(impl pal_async::driver::SpawnDriver + Clone),
         handle: ProxyHandle,
     ) -> std::io::Result<ProxyIntegration> {
-        ProxyIntegration::start(driver, handle, self.control(), &self.control.mem).await
+        ProxyIntegration::start(driver, handle, self.control(), Some(&self.control.mem)).await
     }
 
     /// Returns an object that can be used to offer channels.

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -304,7 +304,6 @@ impl ProxyTask {
         send: mesh::Sender<TaggedStream<u64, mesh::Receiver<ChannelRequest>>>,
     ) {
         while let Ok(action) = self.proxy.next_action().await {
-            tracing::debug!(action = ?action, "action");
             match action {
                 ProxyAction::Offer {
                     id,

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -44,7 +44,6 @@ use vmbus_proxy::VmbusProxy;
 use vmcore::interrupt::Interrupt;
 use windows::core::HRESULT;
 use windows::Win32::Foundation::ERROR_CANCELLED;
-use zerocopy::AsBytes;
 use zerocopy::IntoBytes;
 
 pub struct ProxyIntegration {


### PR DESCRIPTION
This change modifies the `vmbus_proxy` crate to allow `VmbusProxy` to be created from an externally-provided handle, and to allow `ProxyIntegration` to be used without needing to provide a fully-mapped `GuestMemory`.

I also took the opportunity to move `vmbus_proxy` over to using `windows` instead of `winapi`.