### PR TITLE
whp: Refactor get/set property to improve safety and fix a UB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8802,7 +8802,6 @@ dependencies = [
  "criterion",
  "win_import_lib",
  "winapi",
- "zerocopy 0.8.14",
 ]
 
 [[package]]

--- a/vm/whp/Cargo.toml
+++ b/vm/whp/Cargo.toml
@@ -9,8 +9,6 @@ rust-version.workspace = true
 [features]
 unstable_whp = []
 
-[target.'cfg(windows)'.dependencies]
-zerocopy.workspace = true
 [target.'cfg(windows)'.dependencies.winapi]
 workspace = true
 features = [

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -1020,14 +1020,14 @@ pub const WHvVirtualProcessorStateTypeXsaveState: WHV_VIRTUAL_PROCESSOR_STATE_TY
     WHV_VIRTUAL_PROCESSOR_STATE_TYPE(0x00001001);
 
 #[repr(u32)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout)]
 pub enum WHV_ARM64_IC_EMULATION_MODE {
     None = 0,
     GicV3 = 1,
 }
 
 #[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout)]
 pub struct WHV_ARM64_IC_GIC_V3_PARAMETERS {
     pub GicdBaseAddress: u64,
     pub GitsTranslatorBaseAddress: u64,
@@ -1044,7 +1044,7 @@ pub const DEFAULT_GIC_LPI_INT_ID_BITS: u32 = 1;
 pub const DEFAULT_GIC_PPI_OVERFLOW_INTERRUPT_FROM_CNTV: u32 = 0x14;
 
 #[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout)]
 pub struct WHV_ARM64_IC_PARAMETERS {
     pub EmulationMode: WHV_ARM64_IC_EMULATION_MODE,
     pub Reserved: u32,

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -75,6 +75,10 @@ macro_rules! bitops {
 }
 
 pub(crate) use bitops;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -309,7 +313,7 @@ pub struct WHV_ADVISE_GPA_RANGE_POPULATE {
     pub AccessType: WHV_MEMORY_ACCESS_TYPE,
 }
 
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, IntoBytes, Immutable, KnownLayout)]
 pub struct WHV_EXTENDED_VM_EXITS(pub u64);
 bitops!(WHV_EXTENDED_VM_EXITS);
 
@@ -765,7 +769,7 @@ pub struct WHV_NOTIFICATION_PORT_PARAMETERS_u_Event {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct WHV_CPUID_OUTPUT {
     pub Eax: u32,
     pub Ebx: u32,
@@ -796,7 +800,7 @@ pub union WHV_VIRTUAL_PROCESSOR_PROPERTY_u {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct WHV_MSR_ACTION_ENTRY {
     pub Index: u32,
     pub ReadAction: u8,  // WHV_MSR_ACTION

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -20,6 +20,10 @@ use std::ffi::c_void;
 use std::fmt::Debug;
 use std::fmt::Display;
 use winapi::shared::ntdef::LUID;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
 
 macro_rules! bitops_base {
     ($t:ty) => {
@@ -75,10 +79,6 @@ macro_rules! bitops {
 }
 
 pub(crate) use bitops;
-use zerocopy::FromBytes;
-use zerocopy::Immutable;
-use zerocopy::IntoBytes;
-use zerocopy::KnownLayout;
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -20,10 +20,6 @@ use std::ffi::c_void;
 use std::fmt::Debug;
 use std::fmt::Display;
 use winapi::shared::ntdef::LUID;
-use zerocopy::FromBytes;
-use zerocopy::Immutable;
-use zerocopy::IntoBytes;
-use zerocopy::KnownLayout;
 
 macro_rules! bitops_base {
     ($t:ty) => {
@@ -258,7 +254,7 @@ pub const WHvPartitionPropertyCodeMsrActionList: WHV_PARTITION_PROPERTY_CODE =
 #[cfg(target_arch = "x86_64")]
 pub const WHvPartitionPropertyCodeUnimplementedMsrAction: WHV_PARTITION_PROPERTY_CODE =
     WHV_PARTITION_PROPERTY_CODE(0x00001010);
-pub const WhvPartitionPropertyCodePhysicalAddressWidth: WHV_PARTITION_PROPERTY_CODE =
+pub const WHvPartitionPropertyCodePhysicalAddressWidth: WHV_PARTITION_PROPERTY_CODE =
     WHV_PARTITION_PROPERTY_CODE(0x00001011);
 pub const WHvPartitionPropertyCodeArm64IcParameters: WHV_PARTITION_PROPERTY_CODE =
     WHV_PARTITION_PROPERTY_CODE(0x00001012);
@@ -313,7 +309,7 @@ pub struct WHV_ADVISE_GPA_RANGE_POPULATE {
     pub AccessType: WHV_MEMORY_ACCESS_TYPE,
 }
 
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, IntoBytes, Immutable, KnownLayout)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 pub struct WHV_EXTENDED_VM_EXITS(pub u64);
 bitops!(WHV_EXTENDED_VM_EXITS);
 
@@ -769,7 +765,7 @@ pub struct WHV_NOTIFICATION_PORT_PARAMETERS_u_Event {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(Debug, Copy, Clone)]
 pub struct WHV_CPUID_OUTPUT {
     pub Eax: u32,
     pub Ebx: u32,
@@ -800,7 +796,7 @@ pub union WHV_VIRTUAL_PROCESSOR_PROPERTY_u {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(Debug, Copy, Clone)]
 pub struct WHV_MSR_ACTION_ENTRY {
     pub Index: u32,
     pub ReadAction: u8,  // WHV_MSR_ACTION
@@ -1020,14 +1016,14 @@ pub const WHvVirtualProcessorStateTypeXsaveState: WHV_VIRTUAL_PROCESSOR_STATE_TY
     WHV_VIRTUAL_PROCESSOR_STATE_TYPE(0x00001001);
 
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout)]
+#[derive(Debug, Copy, Clone)]
 pub enum WHV_ARM64_IC_EMULATION_MODE {
     None = 0,
     GicV3 = 1,
 }
 
 #[repr(C, packed)]
-#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout)]
+#[derive(Debug, Copy, Clone)]
 pub struct WHV_ARM64_IC_GIC_V3_PARAMETERS {
     pub GicdBaseAddress: u64,
     pub GitsTranslatorBaseAddress: u64,
@@ -1044,7 +1040,7 @@ pub const DEFAULT_GIC_LPI_INT_ID_BITS: u32 = 1;
 pub const DEFAULT_GIC_PPI_OVERFLOW_INTERRUPT_FROM_CNTV: u32 = 0x14;
 
 #[repr(C, packed)]
-#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout)]
+#[derive(Debug, Copy, Clone)]
 pub struct WHV_ARM64_IC_PARAMETERS {
     pub EmulationMode: WHV_ARM64_IC_EMULATION_MODE,
     pub Reserved: u32,

--- a/vm/whp/src/abi/x64.rs
+++ b/vm/whp/src/abi/x64.rs
@@ -12,10 +12,6 @@ use super::WHV_PROCESSOR_FEATURES1;
 use super::WHV_REGISTER_NAME;
 use super::WHV_RUN_VP_EXIT_REASON;
 use super::WHV_UINT128;
-use zerocopy::FromBytes;
-use zerocopy::Immutable;
-use zerocopy::IntoBytes;
-use zerocopy::KnownLayout;
 
 pub const WHvX64RegisterRax: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0x00000000);
 pub const WHvX64RegisterRcx: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0x00000001);
@@ -717,7 +713,7 @@ pub struct WHV_HYPERCALL_CONTEXT {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(Debug, Copy, Clone)]
 pub struct WHV_X64_CPUID_RESULT {
     pub Function: u32,
     pub Reserved: [u32; 3],
@@ -739,7 +735,7 @@ pub const WHvX64LocalApicEmulationModeX2Apic: WHV_X64_LOCAL_APIC_EMULATION_MODE 
     WHV_X64_LOCAL_APIC_EMULATION_MODE(2);
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(Debug, Copy, Clone)]
 pub struct WHV_X64_CPUID_RESULT2_FLAGS(pub u32);
 bitops!(WHV_X64_CPUID_RESULT2_FLAGS);
 
@@ -749,7 +745,7 @@ pub const WHvX64CpuidResult2FlagVpSpecific: WHV_X64_CPUID_RESULT2_FLAGS =
     WHV_X64_CPUID_RESULT2_FLAGS(0x00000002);
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(Debug, Copy, Clone)]
 pub struct WHV_X64_CPUID_RESULT2 {
     Function: u32,
     Index: u32,

--- a/vm/whp/src/abi/x64.rs
+++ b/vm/whp/src/abi/x64.rs
@@ -12,6 +12,10 @@ use super::WHV_PROCESSOR_FEATURES1;
 use super::WHV_REGISTER_NAME;
 use super::WHV_RUN_VP_EXIT_REASON;
 use super::WHV_UINT128;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
 
 pub const WHvX64RegisterRax: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0x00000000);
 pub const WHvX64RegisterRcx: WHV_REGISTER_NAME = WHV_REGISTER_NAME(0x00000001);
@@ -713,7 +717,7 @@ pub struct WHV_HYPERCALL_CONTEXT {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct WHV_X64_CPUID_RESULT {
     pub Function: u32,
     pub Reserved: [u32; 3],
@@ -735,7 +739,7 @@ pub const WHvX64LocalApicEmulationModeX2Apic: WHV_X64_LOCAL_APIC_EMULATION_MODE 
     WHV_X64_LOCAL_APIC_EMULATION_MODE(2);
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct WHV_X64_CPUID_RESULT2_FLAGS(pub u32);
 bitops!(WHV_X64_CPUID_RESULT2_FLAGS);
 
@@ -745,7 +749,7 @@ pub const WHvX64CpuidResult2FlagVpSpecific: WHV_X64_CPUID_RESULT2_FLAGS =
     WHV_X64_CPUID_RESULT2_FLAGS(0x00000002);
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct WHV_X64_CPUID_RESULT2 {
     Function: u32,
     Index: u32,

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -261,7 +261,7 @@ pub enum PartitionProperty<'a> {
     // Needed to reference 'a on aarch64.
     #[doc(hidden)]
     #[cfg(target_arch = "aarch64")]
-    _Dummy(std::convert::Infallible, std::marker::PhantomData<&'a ()>),
+    _Dummy(std::convert::Infallible, PhantomData<&'a ()>),
 }
 
 impl PartitionConfig {

--- a/vm/whp/src/partition_prop.rs
+++ b/vm/whp/src/partition_prop.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Module defining associations between partition properties and types.
+
+use crate::abi;
+
+pub trait AssociatedType {
+    type Type: ?Sized;
+    const CODE: abi::WHV_PARTITION_PROPERTY_CODE;
+    fn code(&self) -> abi::WHV_PARTITION_PROPERTY_CODE {
+        Self::CODE
+    }
+}
+
+macro_rules! pp {
+    ($($(#[$attr:meta])* ($internal_name:ident, $code:ident, $ty:ty),)*) => {
+        $(
+            #[allow(dead_code)]
+            $(#[$attr])*
+            pub struct $internal_name;
+
+            $(#[$attr])*
+            impl AssociatedType for $internal_name {
+                type Type = $ty;
+                const CODE: abi::WHV_PARTITION_PROPERTY_CODE = abi::$code;
+            }
+        )*
+    };
+}
+
+pp! {
+    (ExtendedVmExits, WHvPartitionPropertyCodeExtendedVmExits, abi::WHV_EXTENDED_VM_EXITS),
+    #[cfg(target_arch = "x86_64")]
+    (ExceptionExitBitmap, WHvPartitionPropertyCodeExceptionExitBitmap, u64),
+    (SeparateSecurityDomain, WHvPartitionPropertyCodeSeparateSecurityDomain, bool),
+    #[cfg(target_arch = "x86_64")]
+    (X64MsrExitBitmap, WHvPartitionPropertyCodeX64MsrExitBitmap, abi::WHV_X64_MSR_EXIT_BITMAP),
+    (PrimaryNumaNode, WHvPartitionPropertyCodePrimaryNumaNode, u16),
+    (CpuReserve, WHvPartitionPropertyCodeCpuReserve, u32),
+    (CpuCap, WHvPartitionPropertyCodeCpuCap, u32),
+    (CpuWeight, WHvPartitionPropertyCodeCpuWeight, u32),
+    (CpuGroupId, WHvPartitionPropertyCodeCpuGroupId, u64),
+    (ProcessorFrequencyCap, WHvPartitionPropertyCodeProcessorFrequencyCap, u32),
+    (AllowDeviceAssignment, WHvPartitionPropertyCodeAllowDeviceAssignment, bool),
+    (DisableSmt, WHvPartitionPropertyCodeDisableSmt, bool),
+
+    (ProcessorFeatures, WHvPartitionPropertyCodeProcessorFeatures, abi::WHV_PROCESSOR_FEATURES),
+    (ProcessorClFlushSize, WHvPartitionPropertyCodeProcessorClFlushSize, u8),
+    #[cfg(target_arch = "x86_64")]
+    (CpuidExitList, WHvPartitionPropertyCodeCpuidExitList, [u32]),
+    #[cfg(target_arch = "x86_64")]
+    (CpuidResultList, WHvPartitionPropertyCodeCpuidResultList, [abi::WHV_X64_CPUID_RESULT]),
+    #[cfg(target_arch = "x86_64")]
+    (LocalApicEmulationMode, WHvPartitionPropertyCodeLocalApicEmulationMode, abi::WHV_X64_LOCAL_APIC_EMULATION_MODE),
+    #[cfg(target_arch = "x86_64")]
+    (ProcessorXsaveFeatures, WHvPartitionPropertyCodeProcessorXsaveFeatures, abi::WHV_PROCESSOR_XSAVE_FEATURES),
+    (ProcessorClockFrequency, WHvPartitionPropertyCodeProcessorClockFrequency, u64),
+    #[cfg(target_arch = "x86_64")]
+    (InterruptClockFrequency, WHvPartitionPropertyCodeInterruptClockFrequency, u64),
+    #[cfg(target_arch = "x86_64")]
+    (ApicRemoteReadSupport, WHvPartitionPropertyCodeApicRemoteReadSupport, bool),
+    (ProcessorFeaturesBanks, WHvPartitionPropertyCodeProcessorFeaturesBanks, abi::WHV_PROCESSOR_FEATURES_BANKS),
+    (ReferenceTime, WHvPartitionPropertyCodeReferenceTime, u64),
+    (SyntheticProcessorFeaturesBanks, WHvPartitionPropertyCodeSyntheticProcessorFeaturesBanks, abi::WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS),
+    #[cfg(target_arch = "x86_64")]
+    (CpuidResultList2, WHvPartitionPropertyCodeCpuidResultList2, [abi::WHV_X64_CPUID_RESULT2]),
+    #[cfg(target_arch = "x86_64")]
+    (ProcessorPerfmonFeatures, WHvPartitionPropertyCodeProcessorPerfmonFeatures, abi::WHV_PROCESSOR_PERFMON_FEATURES),
+    #[cfg(target_arch = "x86_64")]
+    (MsrActionList, WHvPartitionPropertyCodeMsrActionList, [abi::WHV_MSR_ACTION_ENTRY]),
+    #[cfg(target_arch = "x86_64")]
+    (UnimplementedMsrAction, WHvPartitionPropertyCodeUnimplementedMsrAction, abi::WHV_MSR_ACTION),
+    (PhysicalAddressWidth, WHvPartitionPropertyCodePhysicalAddressWidth, u32),
+    #[cfg(target_arch = "aarch64")]
+    (Arm64IcParameters, WHvPartitionPropertyCodeArm64IcParameters, abi::WHV_ARM64_IC_PARAMETERS),
+    (ProcessorCount, WHvPartitionPropertyCodeProcessorCount, u32),
+}


### PR DESCRIPTION
Fixes an issue in the WHP code that caused the WHV_ARM64_IC_PARAMETERS struct to get trampled on when using a release build. This was caused by the use of an unsafe block to return a reference to a struct that went out of scope. In debug builds, the compiler didn't reuse this memory right away, but in the release build it did. Now the original struct outlives the function that uses it.