### PR TITLE
VmBus: use Poll with the MessagePort trait.

### DIFF
--- a/vm/vmcore/src/synic.rs
+++ b/vm/vmcore/src/synic.rs
@@ -8,6 +8,8 @@ use crate::monitor::MonitorId;
 use hvdef::Vtl;
 use inspect::Inspect;
 use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
 use thiserror::Error;
 
 pub trait MessagePort: Send + Sync {
@@ -16,7 +18,7 @@ pub trait MessagePort: Send + Sync {
     /// A message is `trusted` if it was was received from the guest without using host-visible
     /// mechanisms on a hardware-isolated VM. The `trusted` parameter is always `false` if not
     /// running in the paravisor of a hardware-isolated VM.
-    fn handle_message(&self, msg: &[u8], trusted: bool) -> bool;
+    fn poll_handle_message(&self, cx: &mut Context<'_>, msg: &[u8], trusted: bool) -> Poll<bool>;
 }
 
 pub trait EventPort: Send + Sync {

--- a/vmm_core/src/synic.rs
+++ b/vmm_core/src/synic.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use futures::task::noop_waker_ref;
 use hvdef::HvError;
 use hvdef::HvResult;
 use hvdef::Vtl;
@@ -11,6 +12,8 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Weak;
+use std::task::Context;
+use std::task::Poll;
 use virt::Synic;
 use virt::VpIndex;
 use vmcore::monitor::MonitorId;
@@ -51,7 +54,12 @@ impl SynicPorts {
         {
             if vtl < minimum_vtl {
                 Err(HvError::OperationDenied)
-            } else if port.handle_message(message, secure) {
+            } else if port.poll_handle_message(
+                &mut Context::from_waker(noop_waker_ref()),
+                message,
+                secure,
+            ) == Poll::Ready(true)
+            {
                 Ok(())
             } else {
                 // TODO: VMBus sometimes (in Azure?) returns HV_STATUS_TIMEOUT


### PR DESCRIPTION
This change replaces the `MessagePort::handle_message` function with `poll_handle_message`, allowing VmBus to apply back pressure.