### PR TITLE
ci: enable arm openhcl test (#782) and fix related UB (#801)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8421,7 +8421,6 @@ dependencies = [
  "criterion",
  "win_import_lib",
  "winapi",
- "zerocopy",
 ]
 
 [[package]]

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -327,7 +327,12 @@ impl IntoPipeline for CheckinGatesCli {
                         },
                         profile: CommonProfile::from_release(release),
                         // FIXME: this relies on openvmm default features
-                        features: [].into(),
+                        // Our ARM test runners need the latest WHP changes
+                        features: if matches!(arch, CommonArch::Aarch64) {
+                            [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::UnstableWhp].into()
+                        } else {
+                            [].into()
+                        },
                         artifact_dir: ctx.publish_artifact(pub_openvmm),
                         done: ctx.new_done_handle(),
                     }

--- a/flowey/flowey_lib_hvlite/src/build_openvmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeSet;
 pub enum OpenvmmFeature {
     Gdb,
     Tpm,
+    UnstableWhp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -92,6 +93,7 @@ impl FlowNode for Node {
                             done: v,
                         }
                     })),
+                    OpenvmmFeature::UnstableWhp => {}
                 }
             }
 
@@ -106,6 +108,7 @@ impl FlowNode for Node {
                         match f {
                             OpenvmmFeature::Gdb => "gdb",
                             OpenvmmFeature::Tpm => "tpm",
+                            OpenvmmFeature::UnstableWhp => "unstable_whp",
                         }
                         .into()
                     })

--- a/vm/whp/Cargo.toml
+++ b/vm/whp/Cargo.toml
@@ -3,14 +3,11 @@
 
 [package]
 name = "whp"
-edition = "2021"
+edition.workspace = true
 rust-version.workspace = true
 
 [features]
 unstable_whp = []
-
-[target.'cfg(windows)'.dependencies]
-zerocopy.workspace = true
 
 [target.'cfg(windows)'.dependencies.winapi]
 workspace = true

--- a/vm/whp/Cargo.toml
+++ b/vm/whp/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "whp"
-edition.workspace = true
+edition = "2021"
 rust-version.workspace = true
 
 [features]

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -254,7 +254,7 @@ pub const WHvPartitionPropertyCodeMsrActionList: WHV_PARTITION_PROPERTY_CODE =
 #[cfg(target_arch = "x86_64")]
 pub const WHvPartitionPropertyCodeUnimplementedMsrAction: WHV_PARTITION_PROPERTY_CODE =
     WHV_PARTITION_PROPERTY_CODE(0x00001010);
-pub const WhvPartitionPropertyCodePhysicalAddressWidth: WHV_PARTITION_PROPERTY_CODE =
+pub const WHvPartitionPropertyCodePhysicalAddressWidth: WHV_PARTITION_PROPERTY_CODE =
     WHV_PARTITION_PROPERTY_CODE(0x00001011);
 pub const WHvPartitionPropertyCodeArm64IcParameters: WHV_PARTITION_PROPERTY_CODE =
     WHV_PARTITION_PROPERTY_CODE(0x00001012);

--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -1030,7 +1030,8 @@ pub struct WHV_ARM64_IC_GIC_V3_PARAMETERS {
     pub Reserved: u32,
     pub GicLpiIntIdBits: u32,
     pub GicPpiOverflowInterruptFromCntv: u32,
-    pub Reserved1: [u32; 7],
+    pub GicPpiPerformanceMonitorsInterrupt: u32,
+    pub Reserved1: [u32; 6],
 }
 
 // Legacy Hyper-V defaults

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod abi;
 mod api;
 mod arm64;
+mod partition_prop;
 mod x64;
 
 #[cfg(target_arch = "aarch64")]
@@ -20,6 +21,9 @@ use std::alloc::Layout;
 use std::ffi::c_void;
 use std::fmt;
 use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::num::NonZeroI32;
+use std::num::NonZeroU16;
 use std::os::windows::prelude::*;
 use std::ptr::null;
 use std::ptr::null_mut;
@@ -29,7 +33,6 @@ use winapi::shared::ntdef::LUID;
 use winapi::shared::winerror;
 use winapi::um::winnt::DEVICE_POWER_STATE;
 use winerror::ERROR_BAD_PATHNAME;
-use zerocopy::AsBytes;
 
 /// Functions to get the WHP platform's capabilities.
 pub mod capabilities {
@@ -252,7 +255,7 @@ pub enum PartitionProperty<'a> {
     // Needed to reference 'a on aarch64.
     #[doc(hidden)]
     #[cfg(target_arch = "aarch64")]
-    _Dummy(std::convert::Infallible, std::marker::PhantomData<&'a ()>),
+    _Dummy(std::convert::Infallible, PhantomData<&'a ()>),
 }
 
 impl PartitionConfig {
@@ -346,201 +349,146 @@ impl Partition {
     }
 
     pub fn set_property(&self, property: PartitionProperty<'_>) -> Result<()> {
-        union UnionData {
-            u8: u8,
-            u16: u16,
-            u32: u32,
-            u64: u64,
-            win32_bool: u32,
-            banks: [u64; 8],
-        }
-        fn set<T: AsBytes>(t: &mut T, v: T) -> &[u8] {
-            *t = v;
-            t.as_bytes()
+        struct Input<'a>(
+            abi::WHV_PARTITION_PROPERTY_CODE,
+            *const u8,
+            u32,
+            PhantomData<&'a ()>,
+        );
+        fn set<T: partition_prop::AssociatedType>(code: T, val: &T::Type) -> Input<'_> {
+            Input(
+                code.code(),
+                (&raw const *val).cast(),
+                size_of_val(val).try_into().unwrap(),
+                PhantomData,
+            )
         }
 
-        let mut u: UnionData = UnionData { u32: 0 };
-
-        let (code, data) = unsafe {
-            match property {
-                PartitionProperty::ExtendedVmExits(val) => (
-                    abi::WHvPartitionPropertyCodeExtendedVmExits,
-                    set(&mut u.u64, val.0),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::ExceptionExitBitmap(val) => (
-                    abi::WHvPartitionPropertyCodeExceptionExitBitmap,
-                    set(&mut u.u64, val),
-                ),
-                PartitionProperty::SeparateSecurityDomain(val) => (
-                    abi::WHvPartitionPropertyCodeSeparateSecurityDomain,
-                    set(&mut u.win32_bool, val.into()),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::X64MsrExitBitmap(val) => (
-                    abi::WHvPartitionPropertyCodeX64MsrExitBitmap,
-                    set(&mut u.u64, val.0),
-                ),
-                PartitionProperty::PrimaryNumaNode(val) => (
-                    abi::WHvPartitionPropertyCodePrimaryNumaNode,
-                    set(&mut u.u16, val),
-                ),
-                PartitionProperty::CpuReserve(val) => (
-                    abi::WHvPartitionPropertyCodeCpuReserve,
-                    set(&mut u.u32, val),
-                ),
-                PartitionProperty::CpuCap(val) => {
-                    (abi::WHvPartitionPropertyCodeCpuCap, set(&mut u.u32, val))
-                }
-                PartitionProperty::CpuWeight(val) => {
-                    (abi::WHvPartitionPropertyCodeCpuWeight, set(&mut u.u32, val))
-                }
-                PartitionProperty::CpuGroupId(val) => (
-                    abi::WHvPartitionPropertyCodeCpuGroupId,
-                    set(&mut u.u64, val),
-                ),
-                PartitionProperty::ProcessorFrequencyCap(val) => (
-                    abi::WHvPartitionPropertyCodeProcessorFrequencyCap,
-                    set(&mut u.u32, val),
-                ),
-                PartitionProperty::AllowDeviceAssignment(val) => (
-                    abi::WHvPartitionPropertyCodeAllowDeviceAssignment,
-                    set(&mut u.win32_bool, val.into()),
-                ),
-                PartitionProperty::DisableSmt(val) => (
-                    abi::WHvPartitionPropertyCodeDisableSmt,
-                    set(&mut u.win32_bool, val.into()),
-                ),
-                PartitionProperty::ProcessorFeatures(val) => {
-                    let ProcessorFeatures {
-                        bank0: b0,
-                        bank1: b1,
-                    } = val;
-                    if b1.0 == 0 {
-                        // Use the old interface if possible.
-                        (
-                            abi::WHvPartitionPropertyCodeProcessorFeatures,
-                            set(&mut u.u64, b0.0),
-                        )
-                    } else {
-                        u.banks[0] = 2;
-                        u.banks[1] = b0.0;
-                        u.banks[2] = b1.0;
-                        (
-                            abi::WHvPartitionPropertyCodeProcessorFeaturesBanks,
-                            u.banks.as_bytes(),
-                        )
-                    }
-                }
-                PartitionProperty::ProcessorClFlushSize(val) => (
-                    abi::WHvPartitionPropertyCodeProcessorClFlushSize,
-                    set(&mut u.u8, val),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::CpuidExitList(val) => {
-                    (abi::WHvPartitionPropertyCodeCpuidExitList, val.as_bytes())
-                }
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::CpuidResultList(val) => (
-                    abi::WHvPartitionPropertyCodeCpuidResultList,
-                    std::slice::from_raw_parts(val.as_ptr().cast(), size_of_val(val)),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::LocalApicEmulationMode(val) => (
-                    abi::WHvPartitionPropertyCodeLocalApicEmulationMode,
-                    set(&mut u.u32, val.0),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::ProcessorXsaveFeatures(val) => (
-                    abi::WHvPartitionPropertyCodeProcessorXsaveFeatures,
-                    set(&mut u.u64, val.0),
-                ),
-                PartitionProperty::ProcessorClockFrequency(val) => (
-                    abi::WHvPartitionPropertyCodeProcessorClockFrequency,
-                    set(&mut u.u64, val),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::InterruptClockFrequency(val) => (
-                    abi::WHvPartitionPropertyCodeInterruptClockFrequency,
-                    set(&mut u.u64, val),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::ApicRemoteReadSupport(val) => (
-                    abi::WHvPartitionPropertyCodeApicRemoteReadSupport,
-                    set(&mut u.win32_bool, val.into()),
-                ),
-                PartitionProperty::ReferenceTime(val) => {
-                    u.u64 = val;
-                    (abi::WHvPartitionPropertyCodeReferenceTime, u.u64.as_bytes())
-                }
-                PartitionProperty::SyntheticProcessorFeatures(val) => {
-                    let SyntheticProcessorFeatures { bank0: b0 } = val;
-                    u.banks[0] = 1;
-                    u.banks[1] = b0.0;
-                    (
-                        abi::WHvPartitionPropertyCodeSyntheticProcessorFeaturesBanks,
-                        u.banks.as_bytes(),
-                    )
-                }
-                PartitionProperty::ProcessorCount(val) => (
-                    abi::WHvPartitionPropertyCodeProcessorCount,
-                    set(&mut u.u32, val),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::CpuidResultList2(val) => (
-                    abi::WHvPartitionPropertyCodeCpuidResultList2,
-                    std::slice::from_raw_parts(val.as_ptr().cast(), size_of_val(val)),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::PerfmonFeatures(val) => (
-                    abi::WHvPartitionPropertyCodeProcessorPerfmonFeatures,
-                    set(&mut u.u64, val.0),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::MsrActionList(val) => (
-                    abi::WHvPartitionPropertyCodeMsrActionList,
-                    std::slice::from_raw_parts(val.as_ptr().cast(), size_of_val(val)),
-                ),
-                #[cfg(target_arch = "x86_64")]
-                PartitionProperty::UnimplementedMsrAction(val) => (
-                    abi::WHvPartitionPropertyCodeUnimplementedMsrAction,
-                    set(&mut u.u32, val.0),
-                ),
-                PartitionProperty::PhysicalAddressWidth(val) => (
-                    abi::WhvPartitionPropertyCodePhysicalAddressWidth,
-                    set(&mut u.u32, val),
-                ),
-                #[cfg(target_arch = "aarch64")]
-                PartitionProperty::GicParameters(val) => (
-                    abi::WHvPartitionPropertyCodeArm64IcParameters,
-                    std::slice::from_raw_parts(
-                        std::ptr::from_ref(&val).cast::<u8>(),
-                        size_of_val(&val),
-                    ),
-                ),
-                #[cfg(target_arch = "aarch64")]
-                PartitionProperty::_Dummy(_, _) => unreachable!(),
+        let banks;
+        let synth_banks;
+        let data = match &property {
+            PartitionProperty::ExtendedVmExits(val) => set(partition_prop::ExtendedVmExits, val),
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::ExceptionExitBitmap(val) => {
+                set(partition_prop::ExceptionExitBitmap, val)
             }
+            PartitionProperty::SeparateSecurityDomain(val) => {
+                set(partition_prop::SeparateSecurityDomain, val)
+            }
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::X64MsrExitBitmap(val) => set(partition_prop::X64MsrExitBitmap, val),
+            PartitionProperty::PrimaryNumaNode(val) => set(partition_prop::PrimaryNumaNode, val),
+            PartitionProperty::CpuReserve(val) => set(partition_prop::CpuReserve, val),
+            PartitionProperty::CpuCap(val) => set(partition_prop::CpuCap, val),
+            PartitionProperty::CpuWeight(val) => set(partition_prop::CpuWeight, val),
+            PartitionProperty::CpuGroupId(val) => set(partition_prop::CpuGroupId, val),
+            PartitionProperty::ProcessorFrequencyCap(val) => {
+                set(partition_prop::ProcessorFrequencyCap, val)
+            }
+            PartitionProperty::AllowDeviceAssignment(val) => {
+                set(partition_prop::AllowDeviceAssignment, val)
+            }
+            PartitionProperty::DisableSmt(val) => set(partition_prop::DisableSmt, val),
+            PartitionProperty::ProcessorFeatures(val) => {
+                let ProcessorFeatures {
+                    bank0: b0,
+                    bank1: b1,
+                } = val;
+
+                if b1.0 == 0 {
+                    // Use the old interface if possible.
+                    set(partition_prop::ProcessorFeatures, b0)
+                } else {
+                    banks = abi::WHV_PROCESSOR_FEATURES_BANKS {
+                        BanksCount: 2,
+                        Reserved0: 0,
+                        Banks: [b0.0, b1.0],
+                    };
+                    set(partition_prop::ProcessorFeaturesBanks, &banks)
+                }
+            }
+            PartitionProperty::ProcessorClFlushSize(val) => {
+                set(partition_prop::ProcessorClFlushSize, val)
+            }
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::CpuidExitList(val) => set(partition_prop::CpuidExitList, val),
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::CpuidResultList(val) => set(partition_prop::CpuidResultList, val),
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::LocalApicEmulationMode(val) => {
+                set(partition_prop::LocalApicEmulationMode, val)
+            }
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::ProcessorXsaveFeatures(val) => {
+                set(partition_prop::ProcessorXsaveFeatures, val)
+            }
+            PartitionProperty::ProcessorClockFrequency(val) => {
+                set(partition_prop::ProcessorClockFrequency, val)
+            }
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::InterruptClockFrequency(val) => {
+                set(partition_prop::InterruptClockFrequency, val)
+            }
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::ApicRemoteReadSupport(val) => {
+                set(partition_prop::ApicRemoteReadSupport, val)
+            }
+            PartitionProperty::ReferenceTime(val) => set(partition_prop::ReferenceTime, val),
+            PartitionProperty::SyntheticProcessorFeatures(val) => {
+                let SyntheticProcessorFeatures { bank0: b0 } = val;
+                synth_banks = abi::WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS {
+                    BanksCount: 1,
+                    Reserved0: 0,
+                    Banks: [b0.0],
+                };
+                set(
+                    partition_prop::SyntheticProcessorFeaturesBanks,
+                    &synth_banks,
+                )
+            }
+            PartitionProperty::ProcessorCount(val) => set(partition_prop::ProcessorCount, val),
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::CpuidResultList2(val) => set(partition_prop::CpuidResultList2, val),
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::PerfmonFeatures(val) => {
+                set(partition_prop::ProcessorPerfmonFeatures, val)
+            }
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::MsrActionList(val) => set(partition_prop::MsrActionList, val),
+            #[cfg(target_arch = "x86_64")]
+            PartitionProperty::UnimplementedMsrAction(val) => {
+                set(partition_prop::UnimplementedMsrAction, val)
+            }
+            PartitionProperty::PhysicalAddressWidth(val) => {
+                set(partition_prop::PhysicalAddressWidth, val)
+            }
+            #[cfg(target_arch = "aarch64")]
+            PartitionProperty::GicParameters(val) => set(partition_prop::Arm64IcParameters, val),
+            #[cfg(target_arch = "aarch64")]
+            PartitionProperty::_Dummy(_, _) => unreachable!(),
         };
         unsafe {
             check_hresult(api::WHvSetPartitionProperty(
                 self.handle,
-                code,
-                data.as_ptr(),
-                data.len().try_into().unwrap(),
+                data.0,
+                data.1,
+                data.2,
             ))
         }
     }
 
-    fn get_property<T>(&self, code: abi::WHV_PARTITION_PROPERTY_CODE) -> Result<T> {
-        let mut val = std::mem::MaybeUninit::<T>::uninit();
+    fn get_property<T: partition_prop::AssociatedType>(&self, code: T) -> Result<T::Type>
+    where
+        T::Type: Sized,
+    {
+        let mut val = std::mem::MaybeUninit::<T::Type>::uninit();
         unsafe {
             let argn = size_of_val(&val) as u32;
             let argp = std::ptr::from_mut(&mut val).cast::<u8>();
             let mut outn = 0;
             check_hresult(api::WHvGetPartitionProperty(
                 self.handle,
-                code,
+                code.code(),
                 argp,
                 argn,
                 &mut outn,
@@ -727,20 +675,20 @@ impl Partition {
     }
 
     pub fn tsc_frequency(&self) -> Result<u64> {
-        self.get_property(abi::WHvPartitionPropertyCodeProcessorClockFrequency)
+        self.get_property(partition_prop::ProcessorClockFrequency)
     }
 
     #[cfg(target_arch = "x86_64")]
     pub fn apic_frequency(&self) -> Result<u64> {
-        self.get_property(abi::WHvPartitionPropertyCodeInterruptClockFrequency)
+        self.get_property(partition_prop::InterruptClockFrequency)
     }
 
     pub fn reference_time(&self) -> Result<u64> {
-        self.get_property(abi::WHvPartitionPropertyCodeReferenceTime)
+        self.get_property(partition_prop::ReferenceTime)
     }
 
     pub fn physical_address_width(&self) -> Result<u32> {
-        self.get_property(abi::WhvPartitionPropertyCodePhysicalAddressWidth)
+        self.get_property(partition_prop::PhysicalAddressWidth)
     }
 
     #[allow(clippy::missing_safety_doc)]

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -22,8 +22,6 @@ use std::ffi::c_void;
 use std::fmt;
 use std::fmt::Debug;
 use std::marker::PhantomData;
-use std::num::NonZeroI32;
-use std::num::NonZeroU16;
 use std::os::windows::prelude::*;
 use std::ptr::null;
 use std::ptr::null_mut;
@@ -358,6 +356,7 @@ impl Partition {
         fn set<T: partition_prop::AssociatedType>(code: T, val: &T::Type) -> Input<'_> {
             Input(
                 code.code(),
+                #[allow(clippy::borrow_deref_ref)]
                 (&raw const *val).cast(),
                 size_of_val(val).try_into().unwrap(),
                 PhantomData,

--- a/vm/whp/src/partition_prop.rs
+++ b/vm/whp/src/partition_prop.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Module defining associations between partition properties and types.
+
+use crate::abi;
+
+pub trait AssociatedType {
+    type Type: ?Sized;
+    const CODE: abi::WHV_PARTITION_PROPERTY_CODE;
+    fn code(&self) -> abi::WHV_PARTITION_PROPERTY_CODE {
+        Self::CODE
+    }
+}
+
+macro_rules! pp {
+    ($($(#[$attr:meta])* ($internal_name:ident, $code:ident, $ty:ty),)*) => {
+        $(
+            #[allow(dead_code)]
+            $(#[$attr])*
+            pub struct $internal_name;
+
+            $(#[$attr])*
+            impl AssociatedType for $internal_name {
+                type Type = $ty;
+                const CODE: abi::WHV_PARTITION_PROPERTY_CODE = abi::$code;
+            }
+        )*
+    };
+}
+
+pp! {
+    (ExtendedVmExits, WHvPartitionPropertyCodeExtendedVmExits, abi::WHV_EXTENDED_VM_EXITS),
+    #[cfg(target_arch = "x86_64")]
+    (ExceptionExitBitmap, WHvPartitionPropertyCodeExceptionExitBitmap, u64),
+    (SeparateSecurityDomain, WHvPartitionPropertyCodeSeparateSecurityDomain, bool),
+    #[cfg(target_arch = "x86_64")]
+    (X64MsrExitBitmap, WHvPartitionPropertyCodeX64MsrExitBitmap, abi::WHV_X64_MSR_EXIT_BITMAP),
+    (PrimaryNumaNode, WHvPartitionPropertyCodePrimaryNumaNode, u16),
+    (CpuReserve, WHvPartitionPropertyCodeCpuReserve, u32),
+    (CpuCap, WHvPartitionPropertyCodeCpuCap, u32),
+    (CpuWeight, WHvPartitionPropertyCodeCpuWeight, u32),
+    (CpuGroupId, WHvPartitionPropertyCodeCpuGroupId, u64),
+    (ProcessorFrequencyCap, WHvPartitionPropertyCodeProcessorFrequencyCap, u32),
+    (AllowDeviceAssignment, WHvPartitionPropertyCodeAllowDeviceAssignment, bool),
+    (DisableSmt, WHvPartitionPropertyCodeDisableSmt, bool),
+
+    (ProcessorFeatures, WHvPartitionPropertyCodeProcessorFeatures, abi::WHV_PROCESSOR_FEATURES),
+    (ProcessorClFlushSize, WHvPartitionPropertyCodeProcessorClFlushSize, u8),
+    #[cfg(target_arch = "x86_64")]
+    (CpuidExitList, WHvPartitionPropertyCodeCpuidExitList, [u32]),
+    #[cfg(target_arch = "x86_64")]
+    (CpuidResultList, WHvPartitionPropertyCodeCpuidResultList, [abi::WHV_X64_CPUID_RESULT]),
+    #[cfg(target_arch = "x86_64")]
+    (LocalApicEmulationMode, WHvPartitionPropertyCodeLocalApicEmulationMode, abi::WHV_X64_LOCAL_APIC_EMULATION_MODE),
+    #[cfg(target_arch = "x86_64")]
+    (ProcessorXsaveFeatures, WHvPartitionPropertyCodeProcessorXsaveFeatures, abi::WHV_PROCESSOR_XSAVE_FEATURES),
+    (ProcessorClockFrequency, WHvPartitionPropertyCodeProcessorClockFrequency, u64),
+    #[cfg(target_arch = "x86_64")]
+    (InterruptClockFrequency, WHvPartitionPropertyCodeInterruptClockFrequency, u64),
+    #[cfg(target_arch = "x86_64")]
+    (ApicRemoteReadSupport, WHvPartitionPropertyCodeApicRemoteReadSupport, bool),
+    (ProcessorFeaturesBanks, WHvPartitionPropertyCodeProcessorFeaturesBanks, abi::WHV_PROCESSOR_FEATURES_BANKS),
+    (ReferenceTime, WHvPartitionPropertyCodeReferenceTime, u64),
+    (SyntheticProcessorFeaturesBanks, WHvPartitionPropertyCodeSyntheticProcessorFeaturesBanks, abi::WHV_SYNTHETIC_PROCESSOR_FEATURES_BANKS),
+    #[cfg(target_arch = "x86_64")]
+    (CpuidResultList2, WHvPartitionPropertyCodeCpuidResultList2, [abi::WHV_X64_CPUID_RESULT2]),
+    #[cfg(target_arch = "x86_64")]
+    (ProcessorPerfmonFeatures, WHvPartitionPropertyCodeProcessorPerfmonFeatures, abi::WHV_PROCESSOR_PERFMON_FEATURES),
+    #[cfg(target_arch = "x86_64")]
+    (MsrActionList, WHvPartitionPropertyCodeMsrActionList, [abi::WHV_MSR_ACTION_ENTRY]),
+    #[cfg(target_arch = "x86_64")]
+    (UnimplementedMsrAction, WHvPartitionPropertyCodeUnimplementedMsrAction, abi::WHV_MSR_ACTION),
+    (PhysicalAddressWidth, WHvPartitionPropertyCodePhysicalAddressWidth, u32),
+    #[cfg(target_arch = "aarch64")]
+    (Arm64IcParameters, WHvPartitionPropertyCodeArm64IcParameters, abi::WHV_ARM64_IC_PARAMETERS),
+    (ProcessorCount, WHvPartitionPropertyCodeProcessorCount, u32),
+}

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1224,7 +1224,8 @@ impl VtlPartition {
                     Reserved: 0,
                     GicLpiIntIdBits: 1,
                     GicPpiOverflowInterruptFromCntv: 0x14,
-                    Reserved1: [0; 7],
+                    GicPpiPerformanceMonitorsInterrupt: 0x17,
+                    Reserved1: [0; 6],
                 },
             };
             whp_config


### PR DESCRIPTION
Builds OpenVMM with the unstable_whp feature for compatibility with the pre-release OS now installed on the runners so that they can support OpenHCL. Enables the ARM OpenHCL Hyper-V test now that we have a capable test runner. Includes changes to WHP get/set property to fix an issue in the WHP code that caused a struct to get trampled in release builds.