### PR TITLE
vmbus_core: fix TargetInfo alignment

### DIFF
--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -512,13 +512,16 @@ impl<T: VmbusMessageSource> ClientTask<T> {
             let request = rpc.input();
 
             tracing::debug!(version = ?version, ?feature_flags, "VmBus client connecting");
-            let target_info = protocol::TargetInfo::new(SINT, VTL, feature_flags);
+            let target_info = protocol::TargetInfo::new()
+                .with_sint(SINT)
+                .with_vtl(VTL)
+                .with_feature_flags(feature_flags.into());
             let monitor_page = request.monitor_page.unwrap_or_default();
             let msg = protocol::InitiateContact2 {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: version as u32,
                     target_message_vp: request.target_message_vp,
-                    interrupt_page_or_target_info: *target_info.as_u64(),
+                    interrupt_page_or_target_info: target_info.into(),
                     parent_to_child_monitor_page_gpa: monitor_page.parent_to_child,
                     child_to_parent_monitor_page_gpa: monitor_page.child_to_parent,
                 },
@@ -1598,8 +1601,11 @@ mod tests {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: Version::Copper as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::all())
-                        .as_u64(),
+                    interrupt_page_or_target_info: TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(FeatureFlags::all().into())
+                        .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -1622,8 +1628,11 @@ mod tests {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: Version::Copper as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::all())
-                        .as_u64(),
+                    interrupt_page_or_target_info: TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(FeatureFlags::all().into())
+                        .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -1664,8 +1673,11 @@ mod tests {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: Version::Copper as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::all())
-                        .as_u64(),
+                    interrupt_page_or_target_info: TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(FeatureFlags::all().into())
+                        .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -1715,8 +1727,11 @@ mod tests {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: Version::Copper as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::all())
-                        .as_u64(),
+                    interrupt_page_or_target_info: TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(FeatureFlags::all().into())
+                        .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -1739,8 +1754,11 @@ mod tests {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: Version::Copper as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::all())
-                        .as_u64(),
+                    interrupt_page_or_target_info: TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(FeatureFlags::all().into())
+                        .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -1763,7 +1781,11 @@ mod tests {
             OutgoingMessage::new(&protocol::InitiateContact {
                 version_requested: Version::Iron as u32,
                 target_message_vp: 0,
-                interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::new()).as_u64(),
+                interrupt_page_or_target_info: TargetInfo::new()
+                    .with_sint(2)
+                    .with_vtl(0)
+                    .with_feature_flags(FeatureFlags::new().into())
+                    .into(),
                 parent_to_child_monitor_page_gpa: 0,
                 child_to_parent_monitor_page_gpa: 0,
             })

--- a/vm/devices/vmbus/vmbus_core/src/protocol.rs
+++ b/vm/devices/vmbus/vmbus_core/src/protocol.rs
@@ -291,8 +291,7 @@ impl From<InitiateContact> for InitiateContact2 {
 pub struct TargetInfo {
     pub sint: u8,
     pub vtl: u8,
-    #[bits(16)]
-    pub _padding: [u8; 2],
+    pub _padding: u16,
     pub feature_flags: u32,
 }
 

--- a/vm/devices/vmbus/vmbus_core/src/protocol.rs
+++ b/vm/devices/vmbus/vmbus_core/src/protocol.rs
@@ -7,7 +7,6 @@ use hvdef::Vtl;
 use inspect::Inspect;
 use mesh::payload::Protobuf;
 use open_enum::open_enum;
-use static_assertions::const_assert_eq;
 use std::mem::size_of;
 use std::ops::BitAnd;
 use std::ops::BitAndAssign;
@@ -288,36 +287,13 @@ impl From<InitiateContact> for InitiateContact2 {
 }
 
 /// Helper struct to interpret the `InitiateContact::interrupt_page_or_target_info` field.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, IntoBytes, FromBytes, Immutable, KnownLayout)]
+#[bitfield(u64)]
 pub struct TargetInfo {
     pub sint: u8,
     pub vtl: u8,
+    #[bits(16)]
     pub _padding: [u8; 2],
     pub feature_flags: u32,
-}
-
-const_assert_eq!(size_of::<u64>(), size_of::<TargetInfo>());
-
-impl TargetInfo {
-    pub fn new(sint: u8, vtl: u8, feature_flags: FeatureFlags) -> Self {
-        Self {
-            sint,
-            vtl,
-            _padding: [0; 2],
-            feature_flags: feature_flags.into(),
-        }
-    }
-
-    /// Interprets a 64 bit value as the `TargetInfo` struct.
-    pub fn from_u64(value: &u64) -> &Self {
-        Self::ref_from_prefix(value.as_bytes()).unwrap().0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
-    }
-
-    /// Represents the `TargetInfo` struct as a 64 bit number.
-    pub fn as_u64(&self) -> &u64 {
-        u64::ref_from_prefix(self.as_bytes()).unwrap().0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
-    }
 }
 
 pub const fn make_version(major: u16, minor: u16) -> u32 {

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -2168,8 +2168,10 @@ mod tests {
                     target_message_vp: 0,
                     child_to_parent_monitor_page_gpa: 0,
                     parent_to_child_monitor_page_gpa: 0,
-                    interrupt_page_or_target_info: *protocol::TargetInfo::new(2, 0, feature_flags)
-                        .as_u64(),
+                    interrupt_page_or_target_info: protocol::TargetInfo::new()
+                    .with_sint(2)
+                    .with_vtl(0)
+                    .with_feature_flags(feature_flags.into()).into(),
                 }),
                 trusted,
             );

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -2169,9 +2169,10 @@ mod tests {
                     child_to_parent_monitor_page_gpa: 0,
                     parent_to_child_monitor_page_gpa: 0,
                     interrupt_page_or_target_info: protocol::TargetInfo::new()
-                    .with_sint(2)
-                    .with_vtl(0)
-                    .with_feature_flags(feature_flags.into()).into(),
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(feature_flags.into())
+                        .into(),
                 }),
                 trusted,
             );


### PR DESCRIPTION
In unit tests, `TargetInfo` can be unaligned, causing a panic when converting from `&[u8]` to `u64` by reference. Since `TargetInfo` contained `u8`s and a `u32`, the only guarantee was 4-byte alignment. `u64` requires 8 byte alignment.

Fix this by converting `TargetInfo` to a `bitfield`, since that is the semantic reason of this struct anyways (a bit-by-bit representation of 64-bit data type).

```
0x00005555556a213f in vmbus_core::protocol::TargetInfo::as_u64 (self=**0x7ffff768408c**) at vm/devices/vmbus/vmbus_core/src/protocol.rs:320
```

Reported-By: @tjones60
Fix Suggested-By: @jstarks 