### PR TITLE
nvme_driver: tests: Reducing payload amount to 4MB instead of 4GB for the unit tests

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -52,7 +52,7 @@ async fn test_nvme_ioqueue_max_mqes(driver: DefaultDriver) {
     const CPU_COUNT: u32 = 64;
 
     let base_len = 64 << 20;
-    let payload_len = 4 << 30;
+    let payload_len = 4 << 20;
     let mem = DeviceSharedMemory::new(base_len, payload_len);
 
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
@@ -86,7 +86,7 @@ async fn test_nvme_ioqueue_invalid_mqes(driver: DefaultDriver) {
     const CPU_COUNT: u32 = 64;
 
     let base_len = 64 << 20;
-    let payload_len = 4 << 30;
+    let payload_len = 4 << 20;
     let mem = DeviceSharedMemory::new(base_len, payload_len);
 
     let driver_source = VmTaskDriverSource::new(SingleDriverBackend::new(driver));
@@ -118,7 +118,7 @@ async fn test_nvme_driver(driver: DefaultDriver, allow_dma: bool) {
     const CPU_COUNT: u32 = 64;
 
     let base_len = 64 << 20;
-    let payload_len = 4 << 30;
+    let payload_len = 4 << 20;
     let mem = DeviceSharedMemory::new(base_len, payload_len);
     let payload_mem = mem
         .guest_memory()


### PR DESCRIPTION
Reported-By: @mattkur
nvme driver unit tests were taking upwards of 2.5s to execute. Upon inspection we found that some of the tests were allocating 4GB (4 << 30) for payload memory. This much memory should not be required since the only use case for this memory is dma buffers used by the NvmeDriver.

After this change all tests should be running in < 0.1s 
![image](https://github.com/user-attachments/assets/0c27f507-3f87-4617-8051-8e33c5292412)
