### PR TITLE
user_driver: remove vfio dma trait

### DIFF
--- a/openhcl/lower_vtl_permissions_guard/Cargo.toml
+++ b/openhcl/lower_vtl_permissions_guard/Cargo.toml
@@ -6,13 +6,10 @@ name = "lower_vtl_permissions_guard"
 edition.workspace = true
 rust-version.workspace = true
 
-[features]
-vfio = ["dep:user_driver"]
-
 [target.'cfg(target_os = "linux")'.dependencies]
 hvdef.workspace = true
 inspect.workspace = true
-user_driver = { workspace = true, optional = true }
+user_driver.workspace = true
 virt.workspace = true
 
 anyhow.workspace = true

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -7,20 +7,17 @@
 //! access to pages that were previously protected.
 
 #![warn(missing_docs)]
-#[cfg(feature = "vfio")]
+
 mod device_dma;
 
-#[cfg(feature = "vfio")]
 pub use device_dma::LowerVtlDmaBuffer;
 
 use anyhow::Context;
 use anyhow::Result;
 use inspect::Inspect;
 use std::sync::Arc;
-#[cfg(all(feature = "vfio", target_os = "linux"))]
 use user_driver::memory::MemoryBlock;
-#[cfg(all(feature = "vfio", target_os = "linux"))]
-use user_driver::vfio::VfioDmaBuffer;
+use user_driver::DmaClient;
 use virt::VtlMemoryProtection;
 
 /// A guard that will restore [`hvdef::HV_MAP_GPA_PERMISSIONS_NONE`] permissions
@@ -79,13 +76,12 @@ impl Drop for PagesAccessibleToLowerVtl {
 /// A [`VfioDmaBuffer`] wrapper that will lower the VTL permissions of the page
 /// on the allocated memory block.
 #[cfg(all(feature = "vfio", target_os = "linux"))]
-pub struct LowerVtlMemorySpawner<T: VfioDmaBuffer> {
+pub struct LowerVtlMemorySpawner<T: DmaClient> {
     spawner: T,
     vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
 }
 
-#[cfg(all(feature = "vfio", target_os = "linux"))]
-impl<T: VfioDmaBuffer> LowerVtlMemorySpawner<T> {
+impl<T: DmaClient> LowerVtlMemorySpawner<T> {
     /// Create a new wrapped [`VfioDmaBuffer`] spawner that will lower the VTL
     /// permissions of the returned [`MemoryBlock`].
     pub fn new(spawner: T, vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>) -> Self {
@@ -96,10 +92,9 @@ impl<T: VfioDmaBuffer> LowerVtlMemorySpawner<T> {
     }
 }
 
-#[cfg(all(feature = "vfio", target_os = "linux"))]
-impl<T: VfioDmaBuffer> VfioDmaBuffer for LowerVtlMemorySpawner<T> {
-    fn create_dma_buffer(&self, len: usize) -> Result<MemoryBlock> {
-        let mem = self.spawner.create_dma_buffer(len)?;
+impl<T: DmaClient> DmaClient for LowerVtlMemorySpawner<T> {
+    fn allocate_dma_buffer(&self, len: usize) -> Result<MemoryBlock> {
+        let mem = self.spawner.allocate_dma_buffer(len)?;
         let vtl_guard =
             PagesAccessibleToLowerVtl::new_from_pages(self.vtl_protect.clone(), mem.pfns())
                 .context("failed to lower VTL permissions on memory block")?;
@@ -110,7 +105,7 @@ impl<T: VfioDmaBuffer> VfioDmaBuffer for LowerVtlMemorySpawner<T> {
         }))
     }
 
-    fn restore_dma_buffer(&self, _len: usize, _base_pfn: u64) -> Result<MemoryBlock> {
+    fn attach_dma_buffer(&self, _len: usize, _base_pfn: u64) -> Result<MemoryBlock> {
         anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
     }
 }

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -73,16 +73,15 @@ impl Drop for PagesAccessibleToLowerVtl {
     }
 }
 
-/// A [`VfioDmaBuffer`] wrapper that will lower the VTL permissions of the page
+/// A [`DmaClient`] wrapper that will lower the VTL permissions of the page
 /// on the allocated memory block.
-#[cfg(all(feature = "vfio", target_os = "linux"))]
 pub struct LowerVtlMemorySpawner<T: DmaClient> {
     spawner: T,
     vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
 }
 
 impl<T: DmaClient> LowerVtlMemorySpawner<T> {
-    /// Create a new wrapped [`VfioDmaBuffer`] spawner that will lower the VTL
+    /// Create a new wrapped [`DmaClient`] spawner that will lower the VTL
     /// permissions of the returned [`MemoryBlock`].
     pub fn new(spawner: T, vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>) -> Self {
         Self {

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -32,7 +32,7 @@ cvm_tracing.workspace = true
 diag_proto.workspace = true
 diag_server.workspace = true
 debug_worker_defs = { workspace = true, optional = true }
-page_pool_alloc =  { workspace = true, features = ["vfio"] }
+page_pool_alloc.workspace = true
 virt.workspace = true
 vmm_core.workspace = true
 vmm_core_defs.workspace = true
@@ -67,7 +67,7 @@ ide.workspace = true
 ide_resources.workspace = true
 input_core.workspace = true
 kmsg_defs.workspace = true
-lower_vtl_permissions_guard = { workspace = true, features = ["vfio"] }
+lower_vtl_permissions_guard.workspace = true
 mana_driver.workspace = true
 mcr_resources.workspace = true
 net_backend.workspace = true

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -125,6 +125,7 @@ use underhill_threadpool::AffinitizedThreadpool;
 use underhill_threadpool::ThreadpoolBuilder;
 use user_driver::lockmem::LockedMemorySpawner;
 use user_driver::vfio::VfioDmaBuffer;
+use user_driver::DmaClient;
 use virt::state::HvRegisterState;
 use virt::Partition;
 use virt::VpIndex;
@@ -1880,7 +1881,7 @@ async fn new_underhill_vm(
     let private_pool_spawner_available = private_pool_spanwer.is_some();
 
     let vfio_dma_buffer_spawner = Box::new(
-        move |device_id: String| -> anyhow::Result<Arc<dyn VfioDmaBuffer>> {
+        move |device_id: String| -> anyhow::Result<Arc<dyn DmaClient>> {
             shared_vis_pool_spawner
                 .as_ref()
                 .map(|spawner| {

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -124,7 +124,6 @@ use underhill_attestation::AttestationType;
 use underhill_threadpool::AffinitizedThreadpool;
 use underhill_threadpool::ThreadpoolBuilder;
 use user_driver::lockmem::LockedMemorySpawner;
-use user_driver::vfio::VfioDmaBuffer;
 use user_driver::DmaClient;
 use virt::state::HvRegisterState;
 use virt::Partition;

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -13,7 +13,7 @@ use inspect::Inspect;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use std::sync::Arc;
-use user_driver::vfio::VfioDmaBuffer;
+use user_driver::DmaClient;
 use vpci::bus_control::VpciBusEvent;
 use zerocopy::IntoBytes;
 
@@ -373,7 +373,7 @@ impl GuestEmulationTransportClient {
     /// TODO: This isn't a VfioDevice, but the VfioDmaBuffer is a convienent
     /// trait to use for wrapping the PFN allocations. Refactor this in the
     /// future once a central DMA API is made.
-    pub fn set_gpa_allocator(&mut self, gpa_allocator: Arc<dyn VfioDmaBuffer>) {
+    pub fn set_gpa_allocator(&mut self, gpa_allocator: Arc<dyn DmaClient>) {
         self.control
             .notify(msg::Msg::SetGpaAllocator(gpa_allocator));
     }

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_emulated_device.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_emulated_device.rs
@@ -16,7 +16,6 @@ use inspect::InspectMut;
 use pci_core::msi::MsiInterruptSet;
 use user_driver::emulated::DeviceSharedMemory;
 use user_driver::emulated::EmulatedDevice;
-use user_driver::emulated::EmulatedDmaAllocator;
 use user_driver::emulated::Mapping;
 use user_driver::interrupt::DeviceInterrupt;
 use user_driver::DeviceBacking;
@@ -40,7 +39,6 @@ impl<T: PciConfigSpace + MmioIntercept + InspectMut> FuzzEmulatedDevice<T> {
 /// Implementation for DeviceBacking trait.
 impl<T: 'static + Send + InspectMut + MmioIntercept> DeviceBacking for FuzzEmulatedDevice<T> {
     type Registers = Mapping<T>;
-    type DmaAllocator = EmulatedDmaAllocator;
 
     fn id(&self) -> &str {
         self.device.id()

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use test_with_tracing::test;
 use user_driver::emulated::DeviceSharedMemory;
 use user_driver::emulated::EmulatedDevice;
-use user_driver::emulated::EmulatedDmaAllocator;
 use user_driver::emulated::Mapping;
 use user_driver::interrupt::DeviceInterrupt;
 use user_driver::DeviceBacking;
@@ -345,7 +344,6 @@ impl<T: PciConfigSpace + MmioIntercept + InspectMut> NvmeTestEmulatedDevice<T> {
 /// Implementation of DeviceBacking trait for NvmeTestEmulatedDevice
 impl<T: 'static + Send + InspectMut + MmioIntercept> DeviceBacking for NvmeTestEmulatedDevice<T> {
     type Registers = NvmeTestMapping<T>;
-    type DmaAllocator = EmulatedDmaAllocator;
 
     fn id(&self) -> &str {
         self.device.id()

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -18,14 +18,10 @@ pub mod lockmem;
 pub mod memory;
 pub mod vfio;
 
-pub type DmaAllocator<T> = <T as DeviceBacking>::DmaAllocator;
-
 /// An interface to access device hardware.
 pub trait DeviceBacking: 'static + Send + Inspect {
     /// An object for accessing device registers.
     type Registers: 'static + DeviceRegisterIo + Inspect;
-    /// An object for allocating host memory to share with the device.
-    type DmaAllocator: 'static + HostDmaAllocator;
 
     /// Returns a device ID for diagnostics.
     fn id(&self) -> &str;
@@ -63,17 +59,11 @@ pub trait DeviceRegisterIo: Send + Sync {
     fn write_u64(&self, offset: usize, data: u64);
 }
 
-pub trait HostDmaAllocator: Send + Sync {
-    /// Allocate a new block using default allocation strategy.
-    fn allocate_dma_buffer(&self, len: usize) -> anyhow::Result<MemoryBlock>;
-    /// Attach to a previously allocated memory block with contiguous PFNs.
-    fn attach_dma_buffer(&self, len: usize, base_pfn: u64) -> anyhow::Result<MemoryBlock>;
-}
-
+/// Device interfaces for DMA.
 pub trait DmaClient: Send + Sync {
-    /// Allocate a new DMA buffer.
+    /// Allocate a new DMA buffer. This buffer must be zero initialized.
     fn allocate_dma_buffer(&self, total_size: usize) -> anyhow::Result<MemoryBlock>;
 
-    /// Attach to a previously allocated memory block
+    /// Attach to a previously allocated memory block.
     fn attach_dma_buffer(&self, len: usize, base_pfn: u64) -> anyhow::Result<MemoryBlock>;
 }

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -125,14 +125,12 @@ unsafe impl MappedDmaTarget for LockedMemory {
 #[derive(Clone)]
 pub struct LockedMemorySpawner;
 
-#[cfg(feature = "vfio")]
-impl crate::vfio::VfioDmaBuffer for LockedMemorySpawner {
-    fn create_dma_buffer(&self, len: usize) -> anyhow::Result<crate::memory::MemoryBlock> {
+impl crate::DmaClient for LockedMemorySpawner {
+    fn allocate_dma_buffer(&self, len: usize) -> anyhow::Result<crate::memory::MemoryBlock> {
         Ok(crate::memory::MemoryBlock::new(LockedMemory::new(len)?))
     }
 
-    /// Restore mapped DMA memory at the same physical location after servicing.
-    fn restore_dma_buffer(
+    fn attach_dma_buffer(
         &self,
         _len: usize,
         _base_pfn: u64,

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -33,7 +33,7 @@ use task_control::StopTask;
 use task_control::TaskControl;
 use tracing::Instrument;
 use user_driver::memory::MemoryBlock;
-use user_driver::vfio::VfioDmaBuffer;
+use user_driver::DmaClient;
 use vmbus_channel::bus::GpadlRequest;
 use vmbus_channel::bus::OpenData;
 use vmbus_channel::ChannelClosed;
@@ -149,7 +149,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceWrapper<T> {
     /// Create a new instance.
     pub fn new(
         driver: impl SpawnDriver + Clone,
-        dma_alloc: Arc<dyn VfioDmaBuffer>,
+        dma_alloc: Arc<dyn DmaClient>,
         synic: Arc<dyn vmbus_client::SynicClient>,
         device: T,
     ) -> Result<Self> {
@@ -235,7 +235,7 @@ struct SimpleVmbusClientDeviceTask<T: SimpleVmbusClientDeviceAsync> {
     synic: Arc<dyn vmbus_client::SynicClient>,
     saved_state: Option<T::SavedState>,
     spawner: Arc<dyn SpawnDriver>,
-    dma_alloc: Arc<dyn VfioDmaBuffer>,
+    dma_alloc: Arc<dyn DmaClient>,
 }
 
 impl<T: SimpleVmbusClientDeviceAsync> AsyncRun<SimpleVmbusClientDeviceTaskState>
@@ -269,7 +269,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
         device: T,
         synic: Arc<dyn vmbus_client::SynicClient>,
         spawner: Arc<dyn SpawnDriver>,
-        dma_alloc: Arc<dyn VfioDmaBuffer>,
+        dma_alloc: Arc<dyn DmaClient>,
     ) -> Self {
         Self {
             device: TaskControl::new(RelayDeviceTask(device)),
@@ -446,7 +446,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
 
         let mem = self
             .dma_alloc
-            .create_dma_buffer(page_count * PAGE_SIZE)
+            .allocate_dma_buffer(page_count * PAGE_SIZE)
             .context("allocating memory for vmbus rings")?;
         state.vtl_pages = Some(mem.clone());
         let buf: Vec<_> = [mem.len() as u64]

--- a/vm/page_pool_alloc/Cargo.toml
+++ b/vm/page_pool_alloc/Cargo.toml
@@ -6,10 +6,6 @@ name = "page_pool_alloc"
 edition.workspace = true
 rust-version.workspace = true
 
-[features]
-# Enable user_driver vfio trait support.
-vfio = ["user_driver/vfio"]
-
 [dependencies]
 user_driver.workspace = true
 hvdef.workspace = true

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -357,7 +357,6 @@ impl PagePoolHandle {
     }
 
     /// Create a memory block from this allocation.
-    #[cfg(all(feature = "vfio", target_os = "linux"))]
     fn into_memory_block(
         mut self,
         zero_block: bool,

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -871,9 +871,8 @@ impl Drop for PagePoolAllocator {
     }
 }
 
-#[cfg(all(feature = "vfio", target_os = "linux"))]
-impl user_driver::vfio::VfioDmaBuffer for PagePoolAllocator {
-    fn create_dma_buffer(&self, len: usize) -> anyhow::Result<user_driver::memory::MemoryBlock> {
+impl user_driver::DmaClient for PagePoolAllocator {
+    fn allocate_dma_buffer(&self, len: usize) -> anyhow::Result<user_driver::memory::MemoryBlock> {
         if len as u64 % HV_PAGE_SIZE != 0 {
             anyhow::bail!("not a page-size multiple");
         }
@@ -892,7 +891,7 @@ impl user_driver::vfio::VfioDmaBuffer for PagePoolAllocator {
 
     /// Restore a dma buffer in the predefined location with the given `len` in
     /// bytes.
-    fn restore_dma_buffer(
+    fn attach_dma_buffer(
         &self,
         len: usize,
         base_pfn: u64,


### PR DESCRIPTION
Remove the vfio dma trait and replace all implementations with `DmaClient`. Cleanup an orphaned trait that did not get removed in a previous PR. 

There is still more cleanup to be done, namely it's not clear to me that `PagePool` should implement `DmaClient` and the logic of choosing which page pool for which device should be implemented as policy in `GlobalDmaManager`, but that change requires further thought. 

#786