### PR TITLE
Adding WHV_ARM64_IC_GIC_V3_PARAMETERS::GicPpiPerformanceMonitorsInterrupt to aarch64 unstable_whp (#356)

### DIFF
--- a/vm/whp/src/abi.rs
+++ b/vm/whp/src/abi.rs
@@ -1030,7 +1030,8 @@ pub struct WHV_ARM64_IC_GIC_V3_PARAMETERS {
     pub Reserved: u32,
     pub GicLpiIntIdBits: u32,
     pub GicPpiOverflowInterruptFromCntv: u32,
-    pub Reserved1: [u32; 7],
+    pub GicPpiPerformanceMonitorsInterrupt: u32,
+    pub Reserved1: [u32; 6],
 }
 
 // Legacy Hyper-V defaults

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1224,7 +1224,8 @@ impl VtlPartition {
                     Reserved: 0,
                     GicLpiIntIdBits: 1,
                     GicPpiOverflowInterruptFromCntv: 0x14,
-                    Reserved1: [0; 7],
+                    GicPpiPerformanceMonitorsInterrupt: 0x17,
+                    Reserved1: [0; 6],
                 },
             };
             whp_config


### PR DESCRIPTION
New builds of WHP on aarch64 require that the VMM configure the PMU interrupt ID. This PR configures it using the same value that Hyper-V uses. 

Backporting #356 to fix ARM OpenVMM tests.