### PR TITLE
ci: enable arm openhcl test (#782)

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -327,7 +327,12 @@ impl IntoPipeline for CheckinGatesCli {
                         },
                         profile: CommonProfile::from_release(release),
                         // FIXME: this relies on openvmm default features
-                        features: [].into(),
+                        // Our ARM test runners need the latest WHP changes
+                        features: if matches!(arch, CommonArch::Aarch64) {
+                            [flowey_lib_hvlite::build_openvmm::OpenvmmFeature::UnstableWhp].into()
+                        } else {
+                            [].into()
+                        },
                         artifact_dir: ctx.publish_artifact(pub_openvmm),
                         done: ctx.new_done_handle(),
                     }

--- a/flowey/flowey_lib_hvlite/src/build_openvmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeSet;
 pub enum OpenvmmFeature {
     Gdb,
     Tpm,
+    UnstableWhp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -92,6 +93,7 @@ impl FlowNode for Node {
                             done: v,
                         }
                     })),
+                    OpenvmmFeature::UnstableWhp => {}
                 }
             }
 
@@ -106,6 +108,7 @@ impl FlowNode for Node {
                         match f {
                             OpenvmmFeature::Gdb => "gdb",
                             OpenvmmFeature::Tpm => "tpm",
+                            OpenvmmFeature::UnstableWhp => "unstable_whp",
                         }
                         .into()
                     })


### PR DESCRIPTION
Enables the ARM OpenHCL Hyper-V test now that we have a capable test runner. Builds OpenVMM with the unstable_whp feature for compatibility with the pre-release OS now installed on the runners so that they can support OpenHCL.