### PR TITLE
mana: poll HWC EQE after interrupt wait

### DIFF
--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -89,6 +89,7 @@ const HWC_WARNING_TIME_IN_MS: u32 = 3000;
 const HWC_TIMEOUT_DEFAULT_IN_MS: u32 = 10000;
 const HWC_TIMEOUT_FOR_SHUTDOWN_IN_MS: u32 = 100;
 const HWC_POLL_TIMEOUT_IN_MS: u64 = 10000;
+const HWC_INTERRUPT_POLL_WAIT_IN_MS: u32 = 500;
 
 #[derive(Inspect)]
 struct Bar0<T: Inspect> {
@@ -892,7 +893,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             last_wait_result = Self::wait_for_hwc_interrupt(
                 self.interrupts[0].as_mut().unwrap(),
                 Some(&mut self.hwc_failure),
-                500,
+                HWC_INTERRUPT_POLL_WAIT_IN_MS,
             )
             .await;
             elapsed += before_wait.elapsed().as_millis();
@@ -900,25 +901,14 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                 interrupt_count += 1;
             }
             if elapsed >= self.hwc_timeout_in_ms as u128 {
-                if self.process_all_eqs() {
-                    break (
-                        true,
-                        elapsed,
-                        interrupt_count,
-                        interrupt_wait_count,
-                        eq_arm_count,
-                        last_wait_result,
-                    );
-                } else {
-                    break (
-                        false,
-                        elapsed,
-                        interrupt_count,
-                        interrupt_wait_count,
-                        eq_arm_count,
-                        last_wait_result,
-                    );
-                }
+                break (
+                    self.process_all_eqs(),
+                    elapsed,
+                    interrupt_count,
+                    interrupt_wait_count,
+                    eq_arm_count,
+                    last_wait_result,
+                );
             }
         };
     }
@@ -969,7 +959,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             }
         }
         self.hwc_failure = false;
-        return Ok(());
+        Ok(())
     }
 
     async fn wait_cq(&mut self) -> anyhow::Result<Cqe> {

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -859,7 +859,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         let mut eq_arm_count = 0;
         let mut interrupt_wait_count = 0;
         let mut interrupt_count = 0;
-        return loop {
+        loop {
             if self.process_all_eqs() {
                 break (
                     true,
@@ -897,7 +897,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             )
             .await;
             elapsed += before_wait.elapsed().as_millis();
-            if !last_wait_result.is_err() {
+            if last_wait_result.is_ok() {
                 interrupt_count += 1;
             }
             if elapsed >= self.hwc_timeout_in_ms as u128 {
@@ -910,7 +910,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                     last_wait_result,
                 );
             }
-        };
+        }
     }
 
     async fn process_eqs_or_wait(&mut self) -> anyhow::Result<()> {

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -214,6 +214,15 @@ impl<T: DeviceBacking> Drop for GdmaDriver<T> {
     }
 }
 
+struct EqeWaitResult {
+    eqe_found: bool,
+    elapsed: u128,
+    eq_arm_count: u32,
+    interrupt_wait_count: u32,
+    interrupt_count: u32,
+    last_wait_result: anyhow::Result<()>,
+}
+
 impl<T: DeviceBacking> GdmaDriver<T> {
     pub fn doorbell(&self) -> Arc<dyn Doorbell> {
         self.bar0.clone() as _
@@ -792,10 +801,10 @@ impl<T: DeviceBacking> GdmaDriver<T> {
     }
 
     pub fn process_all_eqs(&mut self) -> bool {
-        let mut eq_found = false;
+        let mut eqe_found = false;
         while let Some(eqe) = self.eq.pop() {
             self.eq_armed = false;
-            eq_found = true;
+            eqe_found = true;
             match eqe.params.event_type() {
                 GDMA_EQE_COMPLETION => self.cq_armed = false,
                 GDMA_EQE_TEST_EVENT => self.test_events += 1,
@@ -831,7 +840,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             self.eq.arm();
             self.eq_armed = true;
         }
-        eq_found
+        eqe_found
     }
 
     async fn wait_for_hwc_interrupt(
@@ -851,88 +860,69 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         Ok(())
     }
 
-    async fn process_eqs_or_wait_with_retry(
-        &mut self,
-    ) -> (bool, u128, u32, u32, u32, anyhow::Result<()>) {
-        let mut last_wait_result: anyhow::Result<()> = Ok(());
-        let mut elapsed: u128 = 0;
-        let mut eq_arm_count = 0;
-        let mut interrupt_wait_count = 0;
-        let mut interrupt_count = 0;
+    async fn process_eqs_or_wait_with_retry(&mut self) -> EqeWaitResult {
+        let mut eqe_wait_result = EqeWaitResult {
+            eqe_found: false,
+            elapsed: 0,
+            eq_arm_count: 0,
+            interrupt_wait_count: 0,
+            interrupt_count: 0,
+            last_wait_result: Ok(()),
+        };
         loop {
             if self.process_all_eqs() {
-                break (
-                    true,
-                    elapsed,
-                    interrupt_count,
-                    interrupt_wait_count,
-                    eq_arm_count,
-                    last_wait_result,
-                );
+                eqe_wait_result.eqe_found = true;
+                break eqe_wait_result;
             }
             if !self.eq_armed {
-                eq_arm_count += 1;
+                eqe_wait_result.eq_arm_count += 1;
                 self.eq.arm();
                 self.eq_armed = true;
                 // Check if the event arrived while arming.
                 if self.process_all_eqs() {
                     // Remove any pending interrupt events.
                     let _ = self.interrupts[0].as_mut().unwrap().wait().now_or_never();
-                    break (
-                        true,
-                        elapsed,
-                        interrupt_count,
-                        interrupt_wait_count,
-                        eq_arm_count,
-                        last_wait_result,
-                    );
+                    eqe_wait_result.eqe_found = true;
+                    break eqe_wait_result;
                 }
             }
-            interrupt_wait_count += 1;
+            eqe_wait_result.interrupt_wait_count += 1;
             let before_wait = std::time::Instant::now();
-            last_wait_result = Self::wait_for_hwc_interrupt(
+            eqe_wait_result.last_wait_result = Self::wait_for_hwc_interrupt(
                 self.interrupts[0].as_mut().unwrap(),
                 Some(&mut self.hwc_failure),
                 HWC_INTERRUPT_POLL_WAIT_IN_MS,
             )
             .await;
-            elapsed += before_wait.elapsed().as_millis();
-            if last_wait_result.is_ok() {
-                interrupt_count += 1;
+            eqe_wait_result.elapsed += before_wait.elapsed().as_millis();
+            if eqe_wait_result.last_wait_result.is_ok() {
+                eqe_wait_result.interrupt_count += 1;
             }
-            if elapsed >= self.hwc_timeout_in_ms as u128 {
-                break (
-                    self.process_all_eqs(),
-                    elapsed,
-                    interrupt_count,
-                    interrupt_wait_count,
-                    eq_arm_count,
-                    last_wait_result,
-                );
+            if eqe_wait_result.elapsed >= self.hwc_timeout_in_ms as u128 {
+                eqe_wait_result.eqe_found = self.process_all_eqs();
+                break eqe_wait_result;
             }
         }
     }
 
     async fn process_eqs_or_wait(&mut self) -> anyhow::Result<()> {
-        let (
-            eqe_found,
-            elapsed,
-            interrupt_count,
-            interrupt_wait_count,
-            eq_arm_count,
-            last_wait_result,
-        ) = self.process_eqs_or_wait_with_retry().await;
-        let wait_failed = !eqe_found;
-        let interrupt_loss = interrupt_wait_count != 0 && interrupt_count == 0 && !wait_failed;
-        if wait_failed || elapsed > self.hwc_warning_time_in_ms as u128 || interrupt_loss {
+        let eqe_wait_result = self.process_eqs_or_wait_with_retry().await;
+        let wait_failed = !eqe_wait_result.eqe_found;
+        let interrupt_loss = eqe_wait_result.interrupt_wait_count != 0
+            && eqe_wait_result.interrupt_count == 0
+            && !wait_failed;
+        if wait_failed
+            || eqe_wait_result.elapsed > self.hwc_warning_time_in_ms as u128
+            || interrupt_loss
+        {
             tracing::warn!(
                 wait_failed,
-                elapsed,
-                interrupt_loss,
-                interrupt_count,
-                interrupt_wait_count,
-                eq_arm_count,
-                self.hwc_warning_time_in_ms,
+                wait_ms = eqe_wait_result.elapsed,
+                int_loss = interrupt_loss,
+                int_count = eqe_wait_result.interrupt_count,
+                int_waits = eqe_wait_result.interrupt_wait_count,
+                arm_count = eqe_wait_result.eq_arm_count,
+                warn_ms = self.hwc_warning_time_in_ms,
                 "hwc {}",
                 match (wait_failed, interrupt_loss) {
                     (true, _) => "timeout waiting for response",
@@ -941,25 +931,25 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                     _ => "response received with delay",
                 }
             );
-            self.report_hwc_timeout(wait_failed, interrupt_loss, elapsed as u32)
+            self.report_hwc_timeout(wait_failed, interrupt_loss, eqe_wait_result.elapsed as u32)
                 .await;
             if !wait_failed {
                 // Increase warning threshold after each warning occurrence
                 self.hwc_warning_time_in_ms += HWC_WARNING_TIME_IN_MS;
             }
-        } else if interrupt_wait_count != 0 || eq_arm_count != 0 {
+        } else if eqe_wait_result.interrupt_wait_count != 0 || eqe_wait_result.eq_arm_count != 0 {
             tracing::trace!(
-                elapsed,
-                interrupt_count,
-                interrupt_wait_count,
-                eq_arm_count,
+                eqe_wait_result.elapsed,
+                eqe_wait_result.interrupt_count,
+                eqe_wait_result.interrupt_wait_count,
+                eqe_wait_result.eq_arm_count,
                 "found HWC response EQE after arm or wait",
             );
         }
         if wait_failed {
             self.hwc_failure = true;
-            if last_wait_result.is_err() {
-                return last_wait_result;
+            if eqe_wait_result.last_wait_result.is_err() {
+                return eqe_wait_result.last_wait_result;
             } else {
                 return Err(anyhow::anyhow!(
                     "MANA request timed out. No EQE found for HWC response."

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -953,10 +953,10 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             }
         } else if eqe_wait_result.interrupt_wait_count != 0 || eqe_wait_result.eq_arm_count != 0 {
             tracing::trace!(
-                eqe_wait_result.elapsed,
-                eqe_wait_result.interrupt_count,
-                eqe_wait_result.interrupt_wait_count,
-                eqe_wait_result.eq_arm_count,
+                wait_ms = eqe_wait_result.elapsed,
+                int_count = eqe_wait_result.interrupt_count,
+                int_waits = eqe_wait_result.interrupt_wait_count,
+                arm_count = eqe_wait_result.eq_arm_count,
                 "found HWC response EQE after arm or wait",
             );
         }

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -947,6 +947,14 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                 // Increase warning threshold after each warning occurrence
                 self.hwc_warning_time_in_ms += HWC_WARNING_TIME_IN_MS;
             }
+        } else if interrupt_wait_count != 0 || eq_arm_count != 0 {
+            tracing::trace!(
+                elapsed,
+                interrupt_count,
+                interrupt_wait_count,
+                eq_arm_count,
+                "found HWC response EQE after arm or wait",
+            );
         }
         if wait_failed {
             self.hwc_failure = true;


### PR DESCRIPTION
- Use wait and poll cycles to allow HWC command to succeed when new EQE is found regardless of interrupt wait success.
- Detect missed interrupt condition and report in logging and in shmem command for soc logging.