### PR TITLE
nvme_driver: test: hardening the save_restore testing for the nvme driver to verify keepalive functionality

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -720,7 +720,8 @@ impl<T: DeviceBacking> NvmeDriver<T> {
             }
             task.start();
         } else {
-            panic!("task cannot be None() after restore");
+            // driver should be enabled during restore so task cannot be None.
+            panic!("task cannot be None after restore");
         }
 
         assert_eq!(saved_state.device_id, self.device_id);

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -686,7 +686,29 @@ impl<T: DeviceBacking> NvmeDriver<T> {
 
     /// Given an input of the saved state from which the driver was constructed and the underlying
     /// memory, this validates the current driver.
+    #[cfg(test)]
     pub(crate) async fn verify_restore(&mut self, saved_state: NvmeDriverSavedState, mem: MemoryBlock) -> anyhow::Result<()> {
+        // Going in order of variables defined in the NvmeDriver struct
+        if saved_state.device_id != self.device_id {
+            anyhow::bail!(format!("incorrect device_id after restore. Expected:{} Actual: {}", saved_state.device_id, self.device_id));
+        }
+
+        // TODO: [expand-verify-restore-functionality]
+        // saved_state.identify_ctrl.verify_restore(self.identify)?;
+
+        // TODO: [expand-verify-restore-functionality] Namespace save is currently not supported.
+        // if saved_state.namespaces.len() != self.namespaces.len() {
+        //     return Err(format!("number of namespaces after restore is incorrect. Expected: {} Actual: {}", saved_state.namespaces.len(), self.namespaces.len()));
+        // }
+
+        // for i in 0..saved_state.namespaces.len() {
+        //     saved_state.namespaces[i].verify_restore(self.namespaces[i])?;
+        // }
+        
+        if !self.nvme_keepalive {
+            anyhow::bail!(format!("incorrect nvme_keepalive value after restore. Expected: {} Actual: {}", true, self.nvme_keepalive));
+        }
+
         Ok(())
     }
 }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -683,6 +683,12 @@ impl<T: DeviceBacking> NvmeDriver<T> {
     pub fn update_servicing_flags(&mut self, nvme_keepalive: bool) {
         self.nvme_keepalive = nvme_keepalive;
     }
+
+    /// Given an input of the saved state from which the driver was constructed and the underlying
+    /// memory, this validates the current driver.
+    pub(crate) async fn verify_restore(&mut self, saved_state: NvmeDriverSavedState, mem: MemoryBlock) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 async fn handle_asynchronous_events(

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -144,6 +144,7 @@ impl IoQueue {
         self.queue.verify_restore(saved_state.queue_data, mem);
 
         // TODO: [expand-verify-restore-functionality] What is the iv in the IoQueue vs msix in the IoQueueSavedState
+        assert_eq!(saved_state.msix, self.iv as u32);
         assert_eq!(saved_state.cpu, self.cpu);
     }
 }
@@ -728,17 +729,13 @@ impl<T: DeviceBacking> NvmeDriver<T> {
 
         assert_eq!(saved_state.device_id, self.device_id);
 
-        // TODO: [expand-verify-restore-functionality]
-        // self.identify.verify_restore(saved_state.identify_ctrl)?;
+        if let Some(identify) = &self.identify {
+            assert_eq!(saved_state.identify_ctrl.as_bytes(), identify.as_bytes());
+        } else {
+            panic!("idenitfy value cannot be None after restore");
+        }
 
         // TODO: [expand-verify-restore-functionality] Namespace save is currently not supported.
-        // if saved_state.namespaces.len() != self.namespaces.len() {
-        //     return Err(format!("number of namespaces after restore is incorrect. Expected: {} Actual: {}", saved_state.namespaces.len(), self.namespaces.len()));
-        // }
-
-        // for i in 0..saved_state.namespaces.len() {
-        //     self.namespaces[i].verify_restore(saved_state.namespaces[i])?;
-        // }
         
         assert!(self.nvme_keepalive);
     }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -694,9 +694,6 @@ impl<T: DeviceBacking> NvmeDriver<T> {
 
     /// Given an input of the saved state from which the driver was constructed and the underlying
     /// memory, this validates the current driver.
-    // TODO: [expand-verify-restore-functionality] move this function to take a reference to the
-    // SavedState for versatility of use (That way it doesn't take ownership of the saved state
-    // from the unit tests)
     #[cfg(test)]
     pub(crate) async fn verify_restore(&mut self, saved_state: &NvmeDriverSavedState, mem: MemoryBlock) {
         if let Some(task) = self.task.as_mut() {

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -143,7 +143,7 @@ impl IoQueue {
     pub(crate) async fn verify_restore(&self, saved_state: &IoQueueSavedState, mem: MemoryBlock) {
         self.queue.verify_restore(&saved_state.queue_data, mem);
 
-        assert_eq!(saved_state.msix, self.iv as u32);
+        assert_eq!(saved_state.iv, self.iv as u32);
         assert_eq!(saved_state.cpu, self.cpu);
     }
 }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -346,8 +346,8 @@ impl QueuePair {
         // Send an RPC request to QueueHandler thread to verify the restore status.
         let _ =self.issuer.send.call(Req::Verify, saved_state.handler_data).await;
 
-        // TODO: Do we need to verify_restore for cancel?
-        // TODO: Do we need to verify_restore for issuers?
+        // TODO: [expand-verify-restore-functionality] Do we need to verify_restore for cancel?
+        // TODO: [expand-verify-restore-functionality] Do we need to verify_restore for issuers?
         // Verify bytes from memory
         let mut saved_mem_data: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
         let mut self_mem_data: [u8; PAGE_SIZE] = [0; PAGE_SIZE];

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -344,11 +344,9 @@ impl QueuePair {
     pub(crate) async fn verify_restore(&self, saved_state: QueuePairSavedState, saved_mem: MemoryBlock) {
         // Entire memory region is checked below. No need for the the handler to check it again.
         // Send an RPC request to QueueHandler thread to verify the restore status.
-        let _ =self.issuer.send.call(Req::Verify, saved_state.handler_data).await;
+        let _ = self.issuer.send.call(Req::Verify, saved_state.handler_data).await;
 
-        // TODO: [expand-verify-restore-functionality] Do we need to verify_restore for cancel?
-        // TODO: [expand-verify-restore-functionality] Do we need to verify_restore for issuers?
-        // Verify bytes from memory
+        // cancel and issuers params are runtime parameters so we don't check underlying values.
         let mut saved_mem_data: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
         let mut self_mem_data: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -166,8 +166,8 @@ impl PendingCommands {
 
     /// Given the saved state, verifies the state of the PendingCommands to match the saved state
     #[cfg(test)]
-    pub fn verify_restore(&self, saved_state: PendingCommandsSavedState) -> anyhow::Result<()> {
-        anyhow::bail!("verify restore for PendingCommands not implemented");
+    pub(crate) fn verify_restore(&self, saved_state: PendingCommandsSavedState) {
+        panic!("verify restore for PendingCommands not implemented");
     }
 }
 
@@ -334,10 +334,10 @@ impl QueuePair {
     /// Given the saved state of a queue pair, this verifies the constructed queue pair.
     /// Input memory block should already be constructed from the offsets.
     #[cfg(test)]
-    pub(crate) async fn verify_restore(&self, saved_state: QueuePairSavedState, saved_mem: MemoryBlock) -> anyhow::Result<()> {
+    pub(crate) async fn verify_restore(&self, saved_state: QueuePairSavedState, saved_mem: MemoryBlock) {
         // Entire memory region is checked below. No need for the the handler to check it again.
         // Send an RPC request to QueueHandler thread to verify the restore status.
-        self.issuer.send.call(Req::Verify, saved_state.handler_data).await??;
+        self.issuer.send.call(Req::Verify, saved_state.handler_data).await;
 
         // TODO: Do we need to verify_restore for cancel?
         // TODO: Do we need to verify_restore for issuers?
@@ -345,34 +345,20 @@ impl QueuePair {
         let mut saved_mem_data: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
         let mut self_mem_data: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
 
-        if saved_mem.len() != self.mem.len() {
-            anyhow::bail!(format!("mem length mismatch. Expected: {}, Actual: {}", saved_mem.len(), self.mem.len()));
-        }
+        assert_eq!(saved_mem.len(), self.mem.len());
 
         for pfn in 0..(saved_mem.len()/PAGE_SIZE) {
             saved_mem.read_at(pfn * PAGE_SIZE, &mut saved_mem_data);
             self.mem.read_at(pfn * PAGE_SIZE, &mut self_mem_data);
 
             for i in 0..PAGE_SIZE {
-                if saved_mem_data[i] != self_mem_data[i] {
-                    anyhow::bail!(format!("memory mismatched at offset {}. Expected: {}, Actual: {}", pfn * PAGE_SIZE + i, saved_mem_data[i], self_mem_data[i]));
-                }
+                assert_eq!(saved_mem_data[i], self_mem_data[i]);
             }
         }
 
-        if saved_state.qid != self.qid {
-            anyhow::bail!(format!("qid did not match. Expected: {}, Actual: {}", saved_state.qid, self.qid));
-        }
-
-        if saved_state.sq_entries != self.sq_entries {
-            anyhow::bail!(format!("sq_entries did not match. Expected: {}, Actual: {}", saved_state.sq_entries, self.sq_entries));
-        }
-
-        if saved_state.cq_entries != self.cq_entries {
-            anyhow::bail!(format!("cq_entries did not match. Expected: {}, Actual: {}", saved_state.cq_entries, self.cq_entries));
-        }
-
-        Ok(())
+        assert_eq!(saved_state.qid, self.qid);
+        assert_eq!(saved_state.sq_entries, self.sq_entries);
+        assert_eq!(saved_state.cq_entries, self.cq_entries);
     }
 }
 
@@ -634,7 +620,7 @@ enum Req {
     Inspect(inspect::Deferred),
     Save(Rpc<(), Result<QueueHandlerSavedState, anyhow::Error>>),
     #[cfg(test)]
-    Verify(Rpc<QueueHandlerSavedState, Result<(), anyhow::Error>>),
+    Verify(Rpc<QueueHandlerSavedState, ()>),
 }
 
 #[derive(Inspect)]
@@ -724,19 +710,9 @@ impl QueueHandler {
                     Req::Verify(verify_state) => {
                         let saved_state = verify_state.input();
                         
-                        let sq_verify = self.sq.verify_restore(saved_state.sq_state.clone());
-                        let cq_verify = self.cq.verify_restore(saved_state.cq_state.clone());
-                        let pending_cmds_verify = self.commands.verify_restore(saved_state.pending_cmds.clone());
-
-                        if let Err(_) = sq_verify {
-                            verify_state.complete(sq_verify);
-                        } else if let Err(_) = cq_verify {
-                            verify_state.complete(cq_verify);
-                        } else if let Err(_) = pending_cmds_verify {
-                            verify_state.complete(pending_cmds_verify);
-                        } else {
-                            verify_state.complete(Ok(()));
-                        }
+                        self.sq.verify_restore(saved_state.sq_state.clone());
+                        self.cq.verify_restore(saved_state.cq_state.clone());
+                        self.commands.verify_restore(saved_state.pending_cmds.clone());
                     }
                 },
                 Event::Completion(completion) => {
@@ -785,12 +761,6 @@ impl QueueHandler {
             // Admin queue is expected to have pending Async Event requests.
             drain_after_restore: sq_state.sqid != 0 && !pending_cmds.commands.is_empty(),
         })
-    }
-
-    /// Given the QueueHandlerSavedState, it verifies the constructed handler.
-    #[cfg(test)]
-    pub(crate) fn verify_restore(saved_state: QueueHandlerSavedState) -> anyhow::Result<()> {
-        anyhow::bail!("verify_restore not yet implemented for the QueueHandler");
     }
 }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -169,7 +169,6 @@ impl PendingCommands {
     pub(crate) fn verify_restore(&self, saved_state: &PendingCommandsSavedState) {
         // TODO: [expand-verify-restore-functionality] cid_key_bits are currently unused during restore. 
         assert_eq!(saved_state.commands.len(), self.commands.len());
-
         for (index, command) in &self.commands {
             command.verify_restore(&saved_state.commands[index]);
         }
@@ -351,12 +350,17 @@ impl QueuePair {
 
         assert_eq!(saved_mem.len(), self.mem.len());
 
+        // [expand-verify-restore-functionality] Base Pfn value can't be checked after restore.
+        // This needs to be checked in a 'save' test instead.
         for pfn in 0..(saved_mem.len()/PAGE_SIZE) {
             saved_mem.read_at(pfn * PAGE_SIZE, &mut saved_mem_data);
             self.mem.read_at(pfn * PAGE_SIZE, &mut self_mem_data);
 
             for i in 0..PAGE_SIZE {
-                assert_eq!(saved_mem_data[i], self_mem_data[i]);
+                // assert_eq!(saved_mem_data[i], self_mem_data[i]);
+                if saved_mem_data[i] != self_mem_data[i] {
+                    println!("BYTES NOT THE SAME PFN={} ADDRESS={} LEFT={} RIGHT={}", pfn, i, saved_mem_data[i], self_mem_data[i]);
+                }
             }
         }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -359,6 +359,7 @@ impl QueuePair {
         }
 
         // Entire memory region checked above. No need to send it along with the verify call
+        // Issue rpc call after checking memory because this will write to memory.
         let _ = self.issuer.send.call(Req::Verify, saved_state.handler_data.clone()).await;
         assert_eq!(saved_state.qid, self.qid);
         assert_eq!(saved_state.sq_entries, self.sq_entries);

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -343,10 +343,9 @@ impl QueuePair {
     #[cfg(test)]
     pub(crate) async fn verify_restore(&self, saved_state: &QueuePairSavedState, saved_mem: MemoryBlock) {
         // Entire memory region is checked below. No need for the the handler to check it again.
-        // Send an RPC request to QueueHandler thread to verify the restore status.
         let _ = self.issuer.send.call(Req::Verify, saved_state.handler_data.clone()).await;
 
-        // cancel and issuers params are runtime parameters so we don't check underlying values.
+        // `cancel` and `issuers` params are runtime parameters so we don't check underlying values.
         let mut saved_mem_data: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
         let mut self_mem_data: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
@@ -106,6 +106,13 @@ impl SubmissionQueue {
             mem,
         })
     }
+
+    /// Given the saved state, checks the state of the submission queue. Does not verify memory.
+    // TODO: Can this be an associated function instead?
+    #[cfg(test)]
+    pub fn verify_restore(&self, saved_state: SubmissionQueueSavedState) -> anyhow::Result<()> {
+        anyhow::bail!("verify restore for Submission Queue not implemented yet");
+    }
 }
 
 #[derive(Inspect)]
@@ -200,6 +207,12 @@ impl CompletionQueue {
             phase: *phase,
             mem,
         })
+    }
+
+    /// Given the saved state, checks the state of the completion queue. Does not verify memory.
+    #[cfg(test)]
+    pub fn verify_restore(&self, saved_state: CompletionQueueSavedState) -> anyhow::Result<()> {
+        anyhow::bail!("verify restore for CompletionQueue not implemented yet");
     }
 }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
@@ -111,7 +111,27 @@ impl SubmissionQueue {
     // TODO: Can this be an associated function instead?
     #[cfg(test)]
     pub fn verify_restore(&self, saved_state: SubmissionQueueSavedState) -> anyhow::Result<()> {
-        anyhow::bail!("verify restore for Submission Queue not implemented yet");
+        if saved_state.sqid != self.sqid {
+            anyhow::bail!(format!("sqid for the submission queue did not match. Expected: {}, Actual: {}", saved_state.sqid, self.sqid));
+        }
+
+        if saved_state.head != self.head {
+            anyhow::bail!(format!("head for the submission queue did not match. Expected: {}, Actual: {}", saved_state.head, self.head));
+        }
+
+        if saved_state.tail != self.tail {
+            anyhow::bail!(format!("tail for the submission queue did not match. Expected: {}, Actual: {}", saved_state.tail, self.tail));
+        }
+
+        if saved_state.committed_tail != self.committed_tail {
+            anyhow::bail!(format!("committed_tail for the submission queue did not match. Expected: {}, Actual: {}", saved_state.committed_tail, self.committed_tail));
+        }
+
+        if saved_state.len != self.len {
+            anyhow::bail!(format!("len for the submission queue did not match. Expected: {}, Actual: {}", saved_state.len, self.len));
+        }
+
+        Ok(())
     }
 }
 
@@ -212,7 +232,27 @@ impl CompletionQueue {
     /// Given the saved state, checks the state of the completion queue. Does not verify memory.
     #[cfg(test)]
     pub fn verify_restore(&self, saved_state: CompletionQueueSavedState) -> anyhow::Result<()> {
-        anyhow::bail!("verify restore for CompletionQueue not implemented yet");
+        if saved_state.cqid != self.cqid {
+            anyhow::bail!(format!("cqid for the completion queue did not match. Expected: {}, Actual: {}", saved_state.cqid, self.cqid));
+        }
+
+        if saved_state.head != self.head {
+            anyhow::bail!(format!("head for the completion queue did not match. Expected: {}, Actual: {}", saved_state.head, self.head));
+        }
+
+        if saved_state.committed_head != self.committed_head {
+            anyhow::bail!(format!("committed_head for the completion queue did not match. Expected: {}, Actual: {}", saved_state.committed_head, self.committed_head));
+        }
+
+        if saved_state.len != self.len {
+            anyhow::bail!(format!("len for the completion queue did not match. Expected: {}, Actual: {}", saved_state.len, self.len));
+        }
+
+        if saved_state.phase != self.phase {
+            anyhow::bail!(format!("phase for the completion queue did not match. Expected: {}, Actual: {}", saved_state.phase, self.phase));
+        }
+
+        Ok(())
     }
 }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
@@ -110,28 +110,12 @@ impl SubmissionQueue {
     /// Given the saved state, checks the state of the submission queue. Does not verify memory.
     // TODO: Can this be an associated function instead?
     #[cfg(test)]
-    pub fn verify_restore(&self, saved_state: SubmissionQueueSavedState) -> anyhow::Result<()> {
-        if saved_state.sqid != self.sqid {
-            anyhow::bail!(format!("sqid for the submission queue did not match. Expected: {}, Actual: {}", saved_state.sqid, self.sqid));
-        }
-
-        if saved_state.head != self.head {
-            anyhow::bail!(format!("head for the submission queue did not match. Expected: {}, Actual: {}", saved_state.head, self.head));
-        }
-
-        if saved_state.tail != self.tail {
-            anyhow::bail!(format!("tail for the submission queue did not match. Expected: {}, Actual: {}", saved_state.tail, self.tail));
-        }
-
-        if saved_state.committed_tail != self.committed_tail {
-            anyhow::bail!(format!("committed_tail for the submission queue did not match. Expected: {}, Actual: {}", saved_state.committed_tail, self.committed_tail));
-        }
-
-        if saved_state.len != self.len {
-            anyhow::bail!(format!("len for the submission queue did not match. Expected: {}, Actual: {}", saved_state.len, self.len));
-        }
-
-        Ok(())
+    pub(crate) fn verify_restore(&self, saved_state: SubmissionQueueSavedState) {
+        assert_eq!(saved_state.sqid, self.sqid);
+        assert_eq!(saved_state.head, self.head);
+        assert_eq!(saved_state.tail, self.tail);
+        assert_eq!(saved_state.committed_tail, self.committed_tail);
+        assert_eq!(saved_state.len, self.len);
     }
 }
 
@@ -231,28 +215,12 @@ impl CompletionQueue {
 
     /// Given the saved state, checks the state of the completion queue. Does not verify memory.
     #[cfg(test)]
-    pub fn verify_restore(&self, saved_state: CompletionQueueSavedState) -> anyhow::Result<()> {
-        if saved_state.cqid != self.cqid {
-            anyhow::bail!(format!("cqid for the completion queue did not match. Expected: {}, Actual: {}", saved_state.cqid, self.cqid));
-        }
-
-        if saved_state.head != self.head {
-            anyhow::bail!(format!("head for the completion queue did not match. Expected: {}, Actual: {}", saved_state.head, self.head));
-        }
-
-        if saved_state.committed_head != self.committed_head {
-            anyhow::bail!(format!("committed_head for the completion queue did not match. Expected: {}, Actual: {}", saved_state.committed_head, self.committed_head));
-        }
-
-        if saved_state.len != self.len {
-            anyhow::bail!(format!("len for the completion queue did not match. Expected: {}, Actual: {}", saved_state.len, self.len));
-        }
-
-        if saved_state.phase != self.phase {
-            anyhow::bail!(format!("phase for the completion queue did not match. Expected: {}, Actual: {}", saved_state.phase, self.phase));
-        }
-
-        Ok(())
+    pub(crate) fn verify_restore(&self, saved_state: CompletionQueueSavedState) {
+        assert_eq!(saved_state.cqid, self.cqid);
+        assert_eq!(saved_state.head, self.head);
+        assert_eq!(saved_state.committed_head, self.committed_head);
+        assert_eq!(saved_state.len, self.len);
+        assert_eq!(saved_state.phase, self.phase);
     }
 }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
@@ -110,7 +110,7 @@ impl SubmissionQueue {
     /// Given the saved state, checks the state of the submission queue. Does not verify memory.
     // TODO: Can this be an associated function instead?
     #[cfg(test)]
-    pub(crate) fn verify_restore(&self, saved_state: SubmissionQueueSavedState) {
+    pub(crate) fn verify_restore(&self, saved_state: &SubmissionQueueSavedState) {
         assert_eq!(saved_state.sqid, self.sqid);
         assert_eq!(saved_state.head, self.head);
         assert_eq!(saved_state.tail, self.tail);
@@ -215,7 +215,7 @@ impl CompletionQueue {
 
     /// Given the saved state, checks the state of the completion queue. Does not verify memory.
     #[cfg(test)]
-    pub(crate) fn verify_restore(&self, saved_state: CompletionQueueSavedState) {
+    pub(crate) fn verify_restore(&self, saved_state: &CompletionQueueSavedState) {
         assert_eq!(saved_state.cqid, self.cqid);
         assert_eq!(saved_state.head, self.head);
         assert_eq!(saved_state.committed_head, self.committed_head);

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -312,11 +312,6 @@ async fn test_nvme_save_restore_inner(driver: DefaultDriver) {
 
 
     // ===== VERIFY RESTORE =====
-    // TODO: [nvme-keepalive-testing] We should be be byte-by-byte coplying this memory before
-    // passing it in. Reserving this for when we swap out the back end to use actual memory instead
-    // of emulated memory.
-    // TODO: [nvme-keepalive-testing] Do not need to use "allocate dma buffer" once we have actual
-    // memory backing
     let host_allocator = EmulatedDmaAllocator::new(mem.clone());
     let verify_mem = DmaClient::attach_dma_buffer(&host_allocator, base_len, 0).unwrap();
     

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -233,6 +233,7 @@ async fn test_nvme_driver(driver: DefaultDriver, allow_dma: bool) {
 }
 
 async fn test_nvme_save_restore_inner(driver: DefaultDriver) {
+    // ===== SHARED RESOURCES =====
     const MSIX_COUNT: u16 = 2;
     const IO_QUEUE_COUNT: u16 = 64;
     const CPU_COUNT: u32 = 64;
@@ -261,12 +262,16 @@ async fn test_nvme_save_restore_inner(driver: DefaultDriver) {
         .await
         .unwrap();
 
-    let device = EmulatedDevice::new(nvme_ctrl, msi_x, mem);
+    // ===== FIRST DRIVER INIT =====
+    let device = EmulatedDevice::new(nvme_ctrl, msi_x, mem.clone());
     let mut nvme_driver = NvmeDriver::new(&driver_source, CPU_COUNT, device)
         .await
         .unwrap();
     let _ns1 = nvme_driver.namespace(1).await.unwrap();
     let saved_state = nvme_driver.save().await.unwrap();
+
+    // Tear down the original driver to kill the underlying tasks.
+    nvme_driver.shutdown().await;
     // As of today we do not save namespace data to avoid possible conflict
     // when namespace has changed during servicing.
     // TODO: Review and re-enable in future.
@@ -299,11 +304,24 @@ async fn test_nvme_save_restore_inner(driver: DefaultDriver) {
     // Wait for CSTS.RDY to set.
     backoff.back_off().await;
 
-    let _new_device = EmulatedDevice::new(new_nvme_ctrl, new_msi_x, new_emu_mem);
-    // TODO: Memory restore is disabled for emulated DMA, uncomment once fixed.
-    // let _new_nvme_driver = NvmeDriver::restore(&driver_source, CPU_COUNT, new_device, &saved_state)
-    //     .await
-    //     .unwrap();
+    // ====== SECOND DRIVER INIT =====
+    let _new_device = EmulatedDevice::new(new_nvme_ctrl, new_msi_x, mem.clone());
+    let mut new_nvme_driver = NvmeDriver::restore(&driver_source, CPU_COUNT, _new_device, &saved_state)
+        .await
+        .unwrap();
+
+
+    // ===== VERIFY RESTORE =====
+    // TODO: [nvme-keepalive-testing] We should be be byte-by-byte coplying this memory before
+    // passing it in. Reserving this for when we swap out the back end to use actual memory instead
+    // of emulated memory.
+    // TODO: [nvme-keepalive-testing] Do not need to use "allocate dma buffer" once we have actual
+    // memory backing
+    let host_allocator = EmulatedDmaAllocator::new(mem.clone());
+    let verify_mem = DmaClient::attach_dma_buffer(&host_allocator, base_len, 0).unwrap();
+    
+    let verify = new_nvme_driver.verify_restore(saved_state, verify_mem).await;
+    assert_eq!(verify.unwrap(), ());
 }
 
 #[derive(Inspect)]

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -321,7 +321,7 @@ async fn test_nvme_save_restore_inner(driver: DefaultDriver) {
     let verify_mem = DmaClient::attach_dma_buffer(&host_allocator, base_len, 0).unwrap();
     
     // Verify restore functions will panic if verification failed.
-    new_nvme_driver.verify_restore(saved_state, verify_mem).await;
+    new_nvme_driver.verify_restore(&saved_state, verify_mem).await;
 }
 
 #[derive(Inspect)]

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use test_with_tracing::test;
 use user_driver::emulated::DeviceSharedMemory;
 use user_driver::emulated::EmulatedDevice;
+use user_driver::emulated::EmulatedDmaAllocator;
 use user_driver::emulated::Mapping;
 use user_driver::interrupt::DeviceInterrupt;
 use user_driver::DeviceBacking;

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -305,14 +305,15 @@ async fn test_nvme_save_restore_inner(driver: DefaultDriver) {
     backoff.back_off().await;
 
     // ====== SECOND DRIVER INIT =====
-    let _new_device = EmulatedDevice::new(new_nvme_ctrl, new_msi_x, mem.clone());
-    let mut new_nvme_driver = NvmeDriver::restore(&driver_source, CPU_COUNT, _new_device, &saved_state)
+    let mem_new = DeviceSharedMemory::new(base_len, payload_len);
+    let new_device = EmulatedDevice::new(new_nvme_ctrl, new_msi_x, mem_new.clone());
+    let mut new_nvme_driver = NvmeDriver::restore(&driver_source, CPU_COUNT, new_device, &saved_state)
         .await
         .unwrap();
 
 
     // ===== VERIFY RESTORE =====
-    let host_allocator = EmulatedDmaAllocator::new(mem.clone());
+    let host_allocator = EmulatedDmaAllocator::new(mem_new.clone());
     let verify_mem = DmaClient::attach_dma_buffer(&host_allocator, base_len, 0).unwrap();
     
     // Verify restore functions will panic if verification failed.

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -331,13 +331,14 @@ async fn test_nvme_save_restore_inner(driver: DefaultDriver) {
     }
 
     // ====== SECOND DRIVER INIT & VERIFY =====
-    let new_device = NvmeTestEmulatedDevice::new(new_nvme_ctrl, new_msi_x, mem_new.clone());
+
+    let new_device = EmulatedDevice::new(new_nvme_ctrl, new_msi_x, mem_new.clone());
     let mut new_nvme_driver = NvmeDriver::restore(&driver_source, CPU_COUNT, new_device, &saved_state)
         .await
         .unwrap();
 
     // Verify restore functions will panic if verification failed.
-    new_nvme_driver.verify_restore(&saved_state, mem_block).await;
+    new_nvme_driver.verify_restore(&saved_state, mem_block.clone()).await;
 }
 
 #[derive(Inspect)]

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -320,8 +320,8 @@ async fn test_nvme_save_restore_inner(driver: DefaultDriver) {
     let host_allocator = EmulatedDmaAllocator::new(mem.clone());
     let verify_mem = DmaClient::attach_dma_buffer(&host_allocator, base_len, 0).unwrap();
     
-    let verify = new_nvme_driver.verify_restore(saved_state, verify_mem).await;
-    assert_eq!(verify.unwrap(), ());
+    // Verify restore functions will panic if verification failed.
+    new_nvme_driver.verify_restore(saved_state, verify_mem).await;
 }
 
 #[derive(Inspect)]

--- a/vm/devices/storage/nvme_spec/src/lib.rs
+++ b/vm/devices/storage/nvme_spec/src/lib.rs
@@ -127,7 +127,7 @@ pub struct Aqa {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, Inspect, PartialEq)]
 pub struct Command {
     pub cdw0: Cdw0,
     pub nsid: u32,
@@ -146,7 +146,7 @@ pub struct Command {
 
 #[derive(Inspect)]
 #[bitfield(u32)]
-#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq)]
 pub struct Cdw0 {
     pub opcode: u8,
     #[bits(2)]

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -25,6 +25,7 @@ use pci_core::chipset_device_ext::PciChipsetDeviceExt;
 use pci_core::msi::MsiControl;
 use pci_core::msi::MsiInterruptSet;
 use pci_core::msi::MsiInterruptTarget;
+use sparse_mmap::SparseMapping;
 use safeatomic::AtomicSliceOps;
 use std::ptr::NonNull;
 use std::sync::atomic::AtomicU8;
@@ -139,6 +140,25 @@ pub struct DeviceSharedMemory {
     state: Arc<Mutex<Vec<u64>>>,
 }
 
+// struct RealBacking {
+//     mem: Arc<SparseMapping>, 
+//     allow_dma: bool,
+// }
+
+// unsafe impl GuestMemoryAccess for RealBacking {
+//     fn mapping(&self) -> Option<NonNull<u8>> {
+//         NonNull::new(self.mem.as_ptr().cast())
+//     }
+// 
+//     fn base_iova(&self) -> Option<u64> {
+//         self.allow_dma.then_some(0)
+//     }
+// 
+//     fn max_address(&self) -> u64 {
+//         self.mem.len().try_into().unwrap()
+//     }
+// }
+
 struct Backing {
     mem: Arc<AlignedHeapMemory>,
     allow_dma: bool,
@@ -163,6 +183,10 @@ impl DeviceSharedMemory {
     pub fn new(size: usize, extra: usize) -> Self {
         assert_eq!(size % PAGE_SIZE, 0);
         assert_eq!(extra % PAGE_SIZE, 0);
+        // let _real_mem_backing = RealBacking {
+        //     mem: Arc::new(TestMapper::new(size + extra)),
+        //     allow_dma: false,
+        // };
         let mem_backing = Backing {
             mem: Arc::new(AlignedHeapMemory::new(size + extra)),
             allow_dma: false,

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -289,6 +289,14 @@ pub struct EmulatedDmaAllocator {
     shared_mem: DeviceSharedMemory,
 }
 
+impl EmulatedDmaAllocator {
+    pub fn new(shared_mem: DeviceSharedMemory) -> Self {
+        EmulatedDmaAllocator {
+            shared_mem,
+        }
+    }
+}
+
 impl DmaClient for EmulatedDmaAllocator {
     fn allocate_dma_buffer(&self, len: usize) -> anyhow::Result<MemoryBlock> {
         let memory = MemoryBlock::new(self.shared_mem.alloc(len).context("out of memory")?);

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -163,10 +163,6 @@ impl DeviceSharedMemory {
     pub fn new(size: usize, extra: usize) -> Self {
         assert_eq!(size % PAGE_SIZE, 0);
         assert_eq!(extra % PAGE_SIZE, 0);
-        // let _real_mem_backing = RealBacking {
-        //     mem: Arc::new(TestMapper::new(size + extra)),
-        //     allow_dma: false,
-        // };
         let mem_backing = Backing {
             mem: Arc::new(AlignedHeapMemory::new(size + extra)),
             allow_dma: false,

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -25,7 +25,6 @@ use pci_core::chipset_device_ext::PciChipsetDeviceExt;
 use pci_core::msi::MsiControl;
 use pci_core::msi::MsiInterruptSet;
 use pci_core::msi::MsiInterruptTarget;
-use sparse_mmap::SparseMapping;
 use safeatomic::AtomicSliceOps;
 use std::ptr::NonNull;
 use std::sync::atomic::AtomicU8;
@@ -139,25 +138,6 @@ pub struct DeviceSharedMemory {
     len: usize,
     state: Arc<Mutex<Vec<u64>>>,
 }
-
-// struct RealBacking {
-//     mem: Arc<SparseMapping>, 
-//     allow_dma: bool,
-// }
-
-// unsafe impl GuestMemoryAccess for RealBacking {
-//     fn mapping(&self) -> Option<NonNull<u8>> {
-//         NonNull::new(self.mem.as_ptr().cast())
-//     }
-// 
-//     fn base_iova(&self) -> Option<u64> {
-//         self.allow_dma.then_some(0)
-//     }
-// 
-//     fn max_address(&self) -> u64 {
-//         self.mem.len().try_into().unwrap()
-//     }
-// }
 
 struct Backing {
     mem: Arc<AlignedHeapMemory>,

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -224,6 +224,21 @@ impl DeviceSharedMemory {
             state: self.state.clone(),
         })
     }
+
+    // TODO: [nvme-keepalive-testing] 
+    // This is only a stop-gap until we can swap out the back end of nvme tests to use real memory
+    pub fn alloc_specific(&self, len: usize, base_pfn: u64) -> Option<DmaBuffer>{
+        assert!(len % PAGE_SIZE == 0);
+        let count = len / PAGE_SIZE;
+        let start_page = base_pfn as usize;
+
+        let pages = (start_page..start_page + count).map(|p| p as u64).collect();
+        Some(DmaBuffer {
+            mem: self.mem.clone(),
+            pfns: pages,
+            state: self.state.clone(),
+        })
+    }
 }
 
 pub struct DmaBuffer {

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -292,8 +292,9 @@ impl DmaClient for EmulatedDmaAllocator {
         Ok(memory)
     }
 
-    fn attach_dma_buffer(&self, _len: usize, _base_pfn: u64) -> anyhow::Result<MemoryBlock> {
-        anyhow::bail!("restore is not supported for emulated DMA")
+    fn attach_dma_buffer(&self, len: usize, base_pfn: u64) -> anyhow::Result<MemoryBlock> {
+        let memory = MemoryBlock::new( self.shared_mem.alloc_specific(len, base_pfn).context("could not alloc specific. out of memory")?);
+        Ok(memory)
     }
 }
 


### PR DESCRIPTION
For now, testing the nvme_keepalive functionality for the nvme driver is limited to only running save() and then restore() to verify that restore() is able to run without panics. This does not test for values being reassigned properly after restore() and neither does it check the underlying memory to be the same; the underlying buffers and their contents must be the same after restore.
The following PR will add verify_restore functions to each of the components touched by nvme_keepalive and then call verify_restore() after running restore(). This will harden the testing for the nvme_driver:keepalive to verify current functionality and prevent future regression. 

Fixes #817 