### PR TITLE
vmbus_core: fix TargetInfo alignment (#807)

### DIFF
--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -508,13 +508,16 @@ impl<T: VmbusMessageSource> ClientTask<T> {
             };
 
             tracing::debug!(version = ?version, ?feature_flags, "VmBus client connecting");
-            let target_info = protocol::TargetInfo::new(SINT, VTL, feature_flags);
+            let target_info = protocol::TargetInfo::new()
+                .with_sint(SINT)
+                .with_vtl(VTL)
+                .with_feature_flags(feature_flags.into());
             let monitor_page = request.monitor_page.unwrap_or_default();
             let msg = protocol::InitiateContact2 {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: version as u32,
                     target_message_vp: request.target_message_vp,
-                    interrupt_page_or_target_info: *target_info.as_u64(),
+                    interrupt_page_or_target_info: target_info.into(),
                     parent_to_child_monitor_page_gpa: monitor_page.parent_to_child,
                     child_to_parent_monitor_page_gpa: monitor_page.child_to_parent,
                 },
@@ -1561,8 +1564,11 @@ mod tests {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: Version::Copper as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::all())
-                        .as_u64(),
+                    interrupt_page_or_target_info: TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(FeatureFlags::all().into())
+                        .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -1586,8 +1592,11 @@ mod tests {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: Version::Copper as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::all())
-                        .as_u64(),
+                    interrupt_page_or_target_info: TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(FeatureFlags::all().into())
+                        .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -1629,8 +1638,11 @@ mod tests {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: Version::Copper as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::all())
-                        .as_u64(),
+                    interrupt_page_or_target_info: TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(FeatureFlags::all().into())
+                        .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -1679,8 +1691,11 @@ mod tests {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: Version::Copper as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::all())
-                        .as_u64(),
+                    interrupt_page_or_target_info: TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(FeatureFlags::all().into())
+                        .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -1704,8 +1719,11 @@ mod tests {
                 initiate_contact: protocol::InitiateContact {
                     version_requested: Version::Copper as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::all())
-                        .as_u64(),
+                    interrupt_page_or_target_info: TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(FeatureFlags::all().into())
+                        .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -1728,7 +1746,11 @@ mod tests {
             OutgoingMessage::new(&protocol::InitiateContact {
                 version_requested: Version::Iron as u32,
                 target_message_vp: 0,
-                interrupt_page_or_target_info: *TargetInfo::new(2, 0, FeatureFlags::new()).as_u64(),
+                interrupt_page_or_target_info: TargetInfo::new()
+                    .with_sint(2)
+                    .with_vtl(0)
+                    .with_feature_flags(FeatureFlags::new().into())
+                    .into(),
                 parent_to_child_monitor_page_gpa: 0,
                 child_to_parent_monitor_page_gpa: 0,
             })

--- a/vm/devices/vmbus/vmbus_core/src/protocol.rs
+++ b/vm/devices/vmbus/vmbus_core/src/protocol.rs
@@ -7,7 +7,6 @@ use hvdef::Vtl;
 use inspect::Inspect;
 use mesh::payload::Protobuf;
 use open_enum::open_enum;
-use static_assertions::const_assert_eq;
 use std::mem::size_of;
 use std::ops::BitAnd;
 use std::ops::BitAndAssign;
@@ -284,36 +283,12 @@ impl From<InitiateContact> for InitiateContact2 {
 }
 
 /// Helper struct to interpret the `InitiateContact::interrupt_page_or_target_info` field.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, AsBytes, FromBytes, FromZeroes)]
+#[bitfield(u64)]
 pub struct TargetInfo {
     pub sint: u8,
     pub vtl: u8,
-    pub _padding: [u8; 2],
+    pub _padding: u16,
     pub feature_flags: u32,
-}
-
-const_assert_eq!(size_of::<u64>(), size_of::<TargetInfo>());
-
-impl TargetInfo {
-    pub fn new(sint: u8, vtl: u8, feature_flags: FeatureFlags) -> Self {
-        Self {
-            sint,
-            vtl,
-            _padding: [0; 2],
-            feature_flags: feature_flags.into(),
-        }
-    }
-
-    /// Interprets a 64 bit value as the `TargetInfo` struct.
-    pub fn from_u64(value: &u64) -> &Self {
-        Self::ref_from_prefix(value.as_bytes()).unwrap()
-    }
-
-    /// Represents the `TargetInfo` struct as a 64 bit number.
-    pub fn as_u64(&self) -> &u64 {
-        u64::ref_from_prefix(self.as_bytes()).unwrap()
-    }
 }
 
 pub const fn make_version(major: u16, minor: u16) -> u32 {

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -1868,12 +1868,12 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
         includes_client_id: bool,
     ) -> Result<(), ChannelError> {
         let target_info =
-            protocol::TargetInfo::from_u64(&input.initiate_contact.interrupt_page_or_target_info);
+            protocol::TargetInfo::from(input.initiate_contact.interrupt_page_or_target_info);
 
         let target_sint = if message.multiclient
             && input.initiate_contact.version_requested >= Version::Win10Rs3_1 as u32
         {
-            target_info.sint
+            target_info.sint()
         } else {
             SINT
         };
@@ -1881,13 +1881,13 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
         let target_vtl = if message.multiclient
             && input.initiate_contact.version_requested >= Version::Win10Rs4 as u32
         {
-            target_info.vtl
+            target_info.vtl()
         } else {
             0
         };
 
         let feature_flags = if input.initiate_contact.version_requested >= Version::Copper as u32 {
-            target_info.feature_flags
+            target_info.feature_flags()
         } else {
             0
         };
@@ -3519,7 +3519,10 @@ mod tests {
         let (mut notifier, _recv) = TestNotifier::new();
         let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
 
-        let target_info = TargetInfo::new(3, 0, FeatureFlags::new());
+        let target_info = TargetInfo::new()
+            .with_sint(3)
+            .with_vtl(0)
+            .with_feature_flags(FeatureFlags::new().into());
 
         server
             .with_notifier(&mut notifier)
@@ -3528,7 +3531,7 @@ mod tests {
                 protocol::InitiateContact {
                     version_requested: Version::Win10Rs3_1 as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *target_info.as_u64(),
+                    interrupt_page_or_target_info: target_info.into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -3556,7 +3559,7 @@ mod tests {
             &mut server,
             &mut notifier,
             Version::Win10Rs3_1 as u32,
-            *target_info.as_u64(),
+            target_info.into(),
             true,
             0,
         );
@@ -3567,7 +3570,10 @@ mod tests {
         let (mut notifier, _recv) = TestNotifier::new();
         let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
 
-        let target_info = TargetInfo::new(SINT, 2, FeatureFlags::new());
+        let target_info = TargetInfo::new()
+            .with_sint(SINT)
+            .with_vtl(2)
+            .with_feature_flags(FeatureFlags::new().into());
 
         server
             .with_notifier(&mut notifier)
@@ -3576,7 +3582,7 @@ mod tests {
                 protocol::InitiateContact {
                     version_requested: Version::Win10Rs4 as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *target_info.as_u64(),
+                    interrupt_page_or_target_info: target_info.into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -3597,7 +3603,7 @@ mod tests {
             &mut server,
             &mut notifier,
             Version::Win10Rs4 as u32,
-            *target_info.as_u64(),
+            target_info.into(),
             true,
             0,
         );
@@ -3611,25 +3617,30 @@ mod tests {
         let mut server = Server::new(Vtl::Vtl0, MESSAGE_CONNECTION_ID, 0);
 
         // Test with no feature flags.
-        let mut target_info = TargetInfo::new(SINT, 0, FeatureFlags::new());
+        let mut target_info = TargetInfo::new()
+            .with_sint(SINT)
+            .with_vtl(0)
+            .with_feature_flags(FeatureFlags::new().into());
         test_initiate_contact(
             &mut server,
             &mut notifier,
             Version::Copper as u32,
-            *target_info.as_u64(),
+            target_info.into(),
             true,
             0,
         );
 
         // Request supported feature flags.
-        target_info.feature_flags = FeatureFlags::new()
-            .with_guest_specified_signal_parameters(true)
-            .into();
+        target_info.set_feature_flags(
+            FeatureFlags::new()
+                .with_guest_specified_signal_parameters(true)
+                .into(),
+        );
         test_initiate_contact(
             &mut server,
             &mut notifier,
             Version::Copper as u32,
-            *target_info.as_u64(),
+            target_info.into(),
             true,
             FeatureFlags::new()
                 .with_guest_specified_signal_parameters(true)
@@ -3637,14 +3648,15 @@ mod tests {
         );
 
         // Request unsupported feature flags. This will succeed and report back the supported ones.
-        target_info.feature_flags =
+        target_info.set_feature_flags(
             u32::from(FeatureFlags::new().with_guest_specified_signal_parameters(true))
-                | 0xf0000000;
+                | 0xf0000000,
+        );
         test_initiate_contact(
             &mut server,
             &mut notifier,
             Version::Copper as u32,
-            *target_info.as_u64(),
+            target_info.into(),
             true,
             FeatureFlags::new()
                 .with_guest_specified_signal_parameters(true)
@@ -3652,12 +3664,12 @@ mod tests {
         );
 
         // Verify client ID feature flag.
-        target_info.feature_flags = FeatureFlags::new().with_client_id(true).into();
+        target_info.set_feature_flags(FeatureFlags::new().with_client_id(true).into());
         test_initiate_contact(
             &mut server,
             &mut notifier,
             Version::Copper as u32,
-            *target_info.as_u64(),
+            target_info.into(),
             true,
             FeatureFlags::new().with_client_id(true).into(),
         );
@@ -3973,9 +3985,12 @@ mod tests {
             })
             .unwrap();
 
-        let mut target_info = TargetInfo::new(SINT, 0, FeatureFlags::new());
+        let mut target_info = TargetInfo::new()
+            .with_sint(SINT)
+            .with_vtl(2)
+            .with_feature_flags(FeatureFlags::new().into());
         if version >= Version::Copper {
-            target_info.feature_flags = feature_flags.into();
+            target_info.set_feature_flags(feature_flags.into());
         }
 
         server
@@ -3985,7 +4000,7 @@ mod tests {
                 protocol::InitiateContact {
                     version_requested: version as u32,
                     target_message_vp: 0,
-                    interrupt_page_or_target_info: *target_info.as_u64(),
+                    interrupt_page_or_target_info: target_info.into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
                 },
@@ -4452,8 +4467,11 @@ mod tests {
                 protocol::InitiateContact2 {
                     initiate_contact: protocol::InitiateContact {
                         version_requested: version as u32,
-                        interrupt_page_or_target_info: *TargetInfo::new(SINT, 0, feature_flags)
-                            .as_u64(),
+                        interrupt_page_or_target_info: TargetInfo::new()
+                            .with_sint(SINT)
+                            .with_vtl(0)
+                            .with_feature_flags(feature_flags.into())
+                            .into(),
                         child_to_parent_monitor_page_gpa: 0x123f000,
                         parent_to_child_monitor_page_gpa: 0x321f000,
                         ..FromZeroes::new_zeroed()

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1869,8 +1869,11 @@ mod tests {
                     target_message_vp: 0,
                     child_to_parent_monitor_page_gpa: 0,
                     parent_to_child_monitor_page_gpa: 0,
-                    interrupt_page_or_target_info: *protocol::TargetInfo::new(2, 0, feature_flags)
-                        .as_u64(),
+                    interrupt_page_or_target_info: protocol::TargetInfo::new()
+                        .with_sint(2)
+                        .with_vtl(0)
+                        .with_feature_flags(feature_flags.into())
+                        .into(),
                 }),
                 trusted,
             );


### PR DESCRIPTION
In unit tests, `TargetInfo` can be unaligned, causing a panic when converting from `&[u8]` to `u64` by reference. Since `TargetInfo` contained `u8`s and a `u32`, the only guarantee was 4-byte alignment. `u64` requires 8 byte alignment.

Fix this by converting `TargetInfo` to a `bitfield`, since that is the semantic reason of this struct anyways (a bit-by-bit representation of 64-bit data type).

```
0x00005555556a213f in vmbus_core::protocol::TargetInfo::as_u64 (self=**0x7ffff768408c**) at vm/devices/vmbus/vmbus_core/src/protocol.rs:320
```

Reported-By: @tjones60
Fix Suggested-By: @jstarks