### PR TITLE
Recap SWIOTLB to the minimum. (#794)

### DIFF
--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -149,8 +149,10 @@ fn build_kernel_command_line(
         "unknown_nmi_panic=1",
         // Even with iommu=off, the SWIOTLB is still allocated on AARCH64
         // (iommu=off ignored entirely), and CVMs (memory encryption forces it on).
-        // Set it to the minimum, saving ~63 MiB.
-        "swiotlb=1",
+        // Set it to the minimum, saving ~63 MiB. The first parameter controls the
+        // area size, the second controls the number of areas (default is # of CPUs).
+        // Set them both to the minimum.
+        "swiotlb=1,1",
         // Use vfio for MANA devices.
         "vfio_pci.ids=1414:00ba",
         // WORKAROUND: Enable no-IOMMU mode. This mode provides no device isolation,


### PR DESCRIPTION
Some time after originally capping the SWIOTLB at 1 MiB, the SWIOTLB was split into per-CPU areas. This increased the memory usage considerably. Clamp the number of areas at 1 to reduce the memory usage again. This impacts ARM64 and TDX. On a 64 VP ARM machine, this change saves ~22MiB, ~18 MiB on TDX.