### PR TITLE
hcl: fix multiple calls to `flush_deferred_actions` (#739)

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1686,6 +1686,8 @@ mod private {
 impl<T> Drop for ProcessorRunner<'_, T> {
     fn drop(&mut self) {
         self.flush_deferred_actions();
+        let actions = DEFERRED_ACTIONS.with(|actions| actions.take());
+        assert!(actions.is_none_or(|a| a.is_empty()));
         let old_state = std::mem::replace(&mut *self.vp.state.lock(), VpState::NotRunning);
         assert!(matches!(old_state, VpState::Running(thread) if thread == Pthread::current()));
     }
@@ -1697,8 +1699,10 @@ impl<T> ProcessorRunner<'_, T> {
     /// actions will be lost.
     pub fn flush_deferred_actions(&mut self) {
         if self.sidecar.is_none() {
-            let mut deferred_actions = DEFERRED_ACTIONS.with(|state| state.take().unwrap());
-            deferred_actions.run_actions(self.hcl);
+            DEFERRED_ACTIONS.with(|actions| {
+                let mut actions = actions.borrow_mut();
+                actions.as_mut().unwrap().run_actions(self.hcl);
+            })
         }
     }
 }

--- a/openhcl/hcl/src/ioctl/deferred.rs
+++ b/openhcl/hcl/src/ioctl/deferred.rs
@@ -27,6 +27,10 @@ impl DeferredActions {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.actions.is_empty()
+    }
+
     /// Copies the queued actions to the slots in the run page. Issues any
     /// immediately that won't fit in the run page.
     pub fn copy_to_slots(&mut self, slots: &mut DeferredActionSlots, hcl: &Hcl) {


### PR DESCRIPTION
Don't remove the deferred action list from TLS until the
`ProcessorRunner` is actually dropped.

This fixes crashes after a failed servicing operation.

Backport-of: #739
