### PR TITLE
initrd: rename /bin/underhill to /bin/openvmm_hcl (#326)

### DIFF
--- a/openhcl/rootfs.config
+++ b/openhcl/rootfs.config
@@ -43,10 +43,10 @@ nod /dev/ttyprintk 0600 0 0 c 5  3
 slink /dev/console /dev/ttyprintk  0600 0 0
 
 # Add Underhill and its various alternate entrypoints.
-file /bin/underhill  ${OPENHCL_OPENVMM_PATH}   0755 0 0
-slink /underhill-init       /bin/underhill 0755 0 0
-slink /bin/underhill-crash  /bin/underhill 0755 0 0
-slink /bin/underhill-dump   /bin/underhill 0755 0 0
+file /bin/openvmm_hcl  ${OPENHCL_OPENVMM_PATH}   0755 0 0
+slink /underhill-init       /bin/openvmm_hcl 0755 0 0
+slink /bin/underhill-crash  /bin/openvmm_hcl 0755 0 0
+slink /bin/underhill-dump   /bin/openvmm_hcl 0755 0 0
 
 # The build information
 file /etc/underhill-build-info.json  ${OPENHCL_BUILD_INFO}   0644 0 0

--- a/openhcl/underhill_init/src/lib.rs
+++ b/openhcl/underhill_init/src/lib.rs
@@ -36,7 +36,7 @@ use std::time::Duration;
 use syslog::SysLog;
 use walkdir::WalkDir;
 
-const UNDERHILL_PATH: &str = "/bin/underhill";
+const UNDERHILL_PATH: &str = "/bin/openvmm_hcl";
 
 struct FilesystemMount<'a> {
     source: &'a CStr,

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -209,7 +209,7 @@ async fn vtl2_pipette(config: PetriVmConfig) -> anyhow::Result<()> {
     let vtl2_agent = vm.wait_for_vtl2_agent().await?;
     let sh = vtl2_agent.unix_shell();
     let output = cmd!(sh, "ps").read().await?;
-    assert!(output.contains("underhill vm"));
+    assert!(output.contains("openvmm_hcl vm"));
 
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);


### PR DESCRIPTION
The underhill binary was renamed to openvmm_hcl, but its name was not
updated in the initrd. As a result, crash dumps reference
/bin/underhill, but the symbols are published as openvmm_hcl.dbg. This
makes it hard for the debugger to find the appropriate symbols.

Rename the binary within the initrd to be consistent.

Backport-of: #326
