### PR TITLE
hcl: propagate failure to get a register (#707)

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -99,6 +99,15 @@ pub enum Error {
     SetVpRegister(#[source] nix::Error),
     #[error("hcl_get_vp_register")]
     GetVpRegister(#[source] nix::Error),
+    #[error("failed to get VP register {reg:#x?} from hypercall")]
+    GetVpRegisterHypercall {
+        #[cfg(guest_arch = "x86_64")]
+        reg: HvX64RegisterName,
+        #[cfg(guest_arch = "aarch64")]
+        reg: HvArm64RegisterName,
+        #[source]
+        err: HvError,
+    },
     #[error("hcl_request_interrupt")]
     RequestInterrupt(#[source] HvError),
     #[error("hcl_cancel_vp failed")]
@@ -1345,13 +1354,12 @@ impl MshvHvcall {
         Ok(())
     }
 
-    /// Get a single VP register for the given VTL via hypercall. The call will
-    /// panic if the hypercall fails.
+    /// Get a single VP register for the given VTL via hypercall.
     fn get_vp_register_for_vtl_inner(
         &self,
         target_vtl: HvInputVtl,
         name: HvRegisterName,
-    ) -> HvRegisterValue {
+    ) -> Result<HvRegisterValue, Error> {
         let header = hvdef::hypercall::GetSetVpRegisters {
             partition_id: HV_PARTITION_ID_SELF,
             vp_index: HV_VP_INDEX_SELF,
@@ -1373,10 +1381,15 @@ impl MshvHvcall {
         };
 
         // Status must be success with 1 rep completed
-        status.result().unwrap();
+        status
+            .result()
+            .map_err(|err| Error::GetVpRegisterHypercall {
+                reg: name.into(),
+                err,
+            })?;
         assert_eq!(status.elements_processed(), 1);
 
-        output[0]
+        Ok(output[0])
     }
 
     /// Get a single VP register for the given VTL via hypercall. Only a select
@@ -1386,7 +1399,7 @@ impl MshvHvcall {
         &self,
         vtl: HvInputVtl,
         name: HvX64RegisterName,
-    ) -> HvRegisterValue {
+    ) -> Result<HvRegisterValue, Error> {
         match vtl.target_vtl().unwrap() {
             None | Some(Vtl::Vtl2) => {
                 assert!(matches!(
@@ -1428,7 +1441,7 @@ impl MshvHvcall {
         &self,
         vtl: HvInputVtl,
         name: HvArm64RegisterName,
-    ) -> HvRegisterValue {
+    ) -> Result<HvRegisterValue, Error> {
         match vtl.target_vtl().unwrap() {
             None | Some(Vtl::Vtl2) => {
                 assert!(matches!(
@@ -1803,7 +1816,7 @@ impl<'a, T: Backing> ProcessorRunner<'a, T> {
                     reg.value = self
                         .hcl
                         .mshv_hvcall
-                        .get_vp_register_for_vtl(vtl.into(), reg.name.into());
+                        .get_vp_register_for_vtl(vtl.into(), reg.name.into())?;
                 }
             }
         }
@@ -2461,9 +2474,10 @@ impl Hcl {
     }
 
     /// Gets the current hypervisor reference time.
-    pub fn reference_time(&self) -> u64 {
-        self.get_vp_register(HvAllArchRegisterName::TimeRefCount, HvInputVtl::CURRENT_VTL)
-            .as_u64()
+    pub fn reference_time(&self) -> Result<u64, Error> {
+        Ok(self
+            .get_vp_register(HvAllArchRegisterName::TimeRefCount, HvInputVtl::CURRENT_VTL)?
+            .as_u64())
     }
 
     /// Get a single VP register for the given VTL via hypercall. Only a select
@@ -2473,7 +2487,7 @@ impl Hcl {
         &self,
         name: impl Into<HvX64RegisterName>,
         vtl: HvInputVtl,
-    ) -> HvRegisterValue {
+    ) -> Result<HvRegisterValue, Error> {
         self.mshv_hvcall.get_vp_register_for_vtl(vtl, name.into())
     }
 
@@ -2484,7 +2498,7 @@ impl Hcl {
         &self,
         name: impl Into<HvArm64RegisterName>,
         vtl: HvInputVtl,
-    ) -> HvRegisterValue {
+    ) -> Result<HvRegisterValue, Error> {
         self.mshv_hvcall.get_vp_register_for_vtl(vtl, name.into())
     }
 
@@ -2780,16 +2794,16 @@ impl Hcl {
     }
 
     /// Read the vsm capabilities register for VTL2.
-    pub fn get_vsm_capabilities(&self) -> hvdef::HvRegisterVsmCapabilities {
+    pub fn get_vsm_capabilities(&self) -> Result<hvdef::HvRegisterVsmCapabilities, Error> {
         let caps = hvdef::HvRegisterVsmCapabilities::from(
             self.get_vp_register(
                 HvAllArchRegisterName::VsmCapabilities,
                 HvInputVtl::CURRENT_VTL,
-            )
+            )?
             .as_u64(),
         );
 
-        match self.isolation {
+        let caps = match self.isolation {
             IsolationType::None | IsolationType::Vbs => caps,
             // TODO SNP: Return actions may be useful, but with alternate injection many of these need
             // cannot actually be processed by the hypervisor without returning to VTL2.
@@ -2801,7 +2815,8 @@ impl Hcl {
             IsolationType::Tdx => hvdef::HvRegisterVsmCapabilities::new()
                 .with_deny_lower_vtl_startup(caps.deny_lower_vtl_startup())
                 .with_intercept_page_available(caps.intercept_page_available()),
-        }
+        };
+        Ok(caps)
     }
 
     /// Set the [`hvdef::HvRegisterVsmPartitionConfig`] register.
@@ -2821,14 +2836,16 @@ impl Hcl {
     }
 
     /// Get the [`hvdef::HvRegisterGuestVsmPartitionConfig`] register
-    pub fn get_guest_vsm_partition_config(&self) -> hvdef::HvRegisterGuestVsmPartitionConfig {
-        hvdef::HvRegisterGuestVsmPartitionConfig::from(
+    pub fn get_guest_vsm_partition_config(
+        &self,
+    ) -> Result<hvdef::HvRegisterGuestVsmPartitionConfig, Error> {
+        Ok(hvdef::HvRegisterGuestVsmPartitionConfig::from(
             self.get_vp_register(
                 HvAllArchRegisterName::GuestVsmPartitionConfig,
                 HvInputVtl::CURRENT_VTL,
-            )
+            )?
             .as_u64(),
-        )
+        ))
     }
 
     /// Configure guest VSM.

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -790,7 +790,10 @@ impl UhVmNetworkSettings {
                 }
             };
             let p = partition.clone();
-            let get_guest_os_id = move || -> HvGuestOsId { p.vtl0_guest_os_id() };
+            let get_guest_os_id = move || -> HvGuestOsId {
+                p.vtl0_guest_os_id()
+                    .expect("cannot fail to query the guest OS ID")
+            };
 
             let mut nic_builder = netvsp::Nic::builder()
                 .limit_ring_buffer(true)

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/tlb_lock.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/tlb_lock.rs
@@ -63,7 +63,8 @@ impl<'a> UhProcessor<'a, HypervisorBacked> {
         let result = self
             .partition
             .hcl
-            .get_vp_register(name, HvInputVtl::CURRENT_VTL);
+            .get_vp_register(name, HvInputVtl::CURRENT_VTL)
+            .expect("failure is a misconfiguration");
         let config = hvdef::HvRegisterVsmVpSecureVtlConfig::from(result.as_u64());
         config.tlb_locked()
     }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -42,7 +42,6 @@ use hvdef::HvMapGpaFlags;
 use hvdef::HvMessageType;
 use hvdef::HvRegisterValue;
 use hvdef::HvRegisterVsmPartitionConfig;
-use hvdef::HvRegisterVsmPartitionStatus;
 use hvdef::HvX64InterceptMessageHeader;
 use hvdef::HvX64InterruptStateRegister;
 use hvdef::HvX64PendingEvent;
@@ -1193,7 +1192,10 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         assert!(self.partition.isolation.is_isolated());
 
-        let status: HvRegisterVsmPartitionStatus = self.partition.vsm_status();
+        let status = self
+            .partition
+            .vsm_status()
+            .expect("cannot fail to query vsm status");
 
         let vtl1_enabled = VtlSet::from(status.enabled_vtl_set()).is_set(GuestVtl::Vtl1);
         if !vtl1_enabled {


### PR DESCRIPTION
Instead of panicking when failing to get a register, propagate the
failure up the stack.

This fixes OpenHCL running on older hypervisors, which do not support
VTL2 accessing the `InternalActivityState` register. It also improves
diagnosability when there are unexpected failures.

Backport-of: #707
