### PR TITLE
TDX: Remove a todo thats already done

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -707,7 +707,6 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         }
 
         // TODO GUEST VSM: interrupt rewinding
-        // TODO TDX GUEST VSM: update execution mode on CR0 and EFER
     }
 }
 


### PR DESCRIPTION
Because this code path is using our access_state mechanism, updating the execution mode for TDX is already handled. Remove the TODO. Fixes #687 