### PR TITLE
Implement lazy parsing of hypercall processor sets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,6 +2803,7 @@ name = "hv1_hypercall"
 version = "0.0.0"
 dependencies = [
  "guestmem",
+ "hv1_structs",
  "hvdef",
  "open_enum",
  "sparse_mmap",

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -3154,7 +3154,7 @@ impl Hcl {
         entry: hvdef::hypercall::InterruptEntry,
         vector: u32,
         multicast: bool,
-        target_processors: &ProcessorSet<'_>,
+        target_processors: ProcessorSet<'_>,
     ) -> Result<(), HvError> {
         let header = hvdef::hypercall::RetargetDeviceInterrupt {
             partition_id: HV_PARTITION_ID_SELF,
@@ -3171,7 +3171,7 @@ impl Hcl {
                 mask_or_format: hvdef::hypercall::HV_GENERIC_SET_SPARSE_4K,
             },
         };
-        let target_processors = target_processors.as_generic_set().collect::<Vec<_>>();
+        let processor_set = Vec::from_iter(target_processors.as_generic_set());
 
         // SAFETY: The input header and slice are the correct types for this hypercall.
         //         The hypercall output is validated right after the hypercall is issued.
@@ -3180,7 +3180,7 @@ impl Hcl {
                 .hvcall_var(
                     HypercallCode::HvCallRetargetDeviceInterrupt,
                     &header,
-                    target_processors.as_bytes(),
+                    processor_set.as_bytes(),
                     &mut (),
                 )
                 .expect("submitting hypercall should not fail")

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -719,7 +719,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         data: u32,
         vector: u32,
         multicast: bool,
-        target_processors: &ProcessorSet<'_>,
+        target_processors: ProcessorSet<'_>,
     ) -> HvResult<()> {
         // Before dispatching retarget_device_interrupt, add the device vector
         // to partition global device vector table and issue `proxy_irr_blocked`
@@ -748,7 +748,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
 
     pub fn hcvm_validate_flush_inputs(
         &mut self,
-        processor_set: &ProcessorSet<'_>,
+        processor_set: ProcessorSet<'_>,
         flags: HvFlushFlags,
         allow_extended_ranges: bool,
     ) -> HvResult<()> {
@@ -826,7 +826,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> hv1_hypercall::RetargetDeviceInterrup
             data,
             vector,
             multicast,
-            &target_processors,
+            target_processors,
         );
         let virtual_result = self.retarget_virtual_interrupt(
             device_id,
@@ -834,7 +834,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> hv1_hypercall::RetargetDeviceInterrup
             data,
             vector,
             multicast,
-            &target_processors,
+            target_processors,
         );
         hv_result.or(virtual_result)
     }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -719,7 +719,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         data: u32,
         vector: u32,
         multicast: bool,
-        target_processors: &[u32],
+        target_processors: &ProcessorSet<'_>,
     ) -> HvResult<()> {
         // Before dispatching retarget_device_interrupt, add the device vector
         // to partition global device vector table and issue `proxy_irr_blocked`
@@ -815,7 +815,6 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> hv1_hypercall::RetargetDeviceInterrup
             multicast,
             target_processors,
         } = params;
-        let target_processors = target_processors.into_iter().collect::<Vec<_>>();
         // It is unknown whether the interrupt is physical or virtual, so try both. Note that the
         // actual response from the hypervisor can't really be trusted so:
         // 1. Always invoke the virtual interrupt retargeting.

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -42,6 +42,7 @@ use hcl::ioctl;
 use hcl::ioctl::ProcessorRunner;
 use hv1_emulator::message_queues::MessageQueues;
 use hv1_hypercall::HvRepResult;
+use hv1_structs::ProcessorSet;
 use hv1_structs::VtlArray;
 use hvdef::hypercall::HostVisibilityType;
 use hvdef::HvError;
@@ -1324,12 +1325,13 @@ impl<T: CpuIo, B: Backing> UhHypercallHandler<'_, '_, T, B> {
         data: u32,
         vector: u32,
         multicast: bool,
-        target_processors: &[u32],
+        target_processors: &ProcessorSet<'_>,
     ) -> hvdef::HvResult<()> {
+        let target_processors = target_processors.into_iter().collect::<Vec<_>>();
         let vpci_params = vmcore::vpci_msi::VpciInterruptParameters {
             vector,
             multicast,
-            target_processors,
+            target_processors: &target_processors,
         };
 
         self.vp

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -1325,9 +1325,9 @@ impl<T: CpuIo, B: Backing> UhHypercallHandler<'_, '_, T, B> {
         data: u32,
         vector: u32,
         multicast: bool,
-        target_processors: &ProcessorSet<'_>,
+        target_processors: ProcessorSet<'_>,
     ) -> hvdef::HvResult<()> {
-        let target_processors = target_processors.into_iter().collect::<Vec<_>>();
+        let target_processors = Vec::from_iter(target_processors);
         let vpci_params = vmcore::vpci_msi::VpciInterruptParameters {
             vector,
             multicast,

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -739,7 +739,7 @@ impl<T: CpuIo> hv1_hypercall::RetargetDeviceInterrupt
             data,
             params.vector,
             params.multicast,
-            &params.target_processors,
+            params.target_processors,
         )
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -731,7 +731,7 @@ impl<T: CpuIo> hv1_hypercall::RetargetDeviceInterrupt
         device_id: u64,
         address: u64,
         data: u32,
-        params: &hv1_hypercall::HvInterruptParameters<'_>,
+        params: hv1_hypercall::HvInterruptParameters<'_>,
     ) -> hvdef::HvResult<()> {
         self.retarget_virtual_interrupt(
             device_id,
@@ -739,7 +739,7 @@ impl<T: CpuIo> hv1_hypercall::RetargetDeviceInterrupt
             data,
             params.vector,
             params.multicast,
-            params.target_processors,
+            &params.target_processors,
         )
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1712,15 +1712,16 @@ impl<T: CpuIo> hv1_hypercall::RetargetDeviceInterrupt
         device_id: u64,
         address: u64,
         data: u32,
-        params: &hv1_hypercall::HvInterruptParameters<'_>,
+        params: hv1_hypercall::HvInterruptParameters<'_>,
     ) -> hvdef::HvResult<()> {
+        let target_processors = params.target_processors.into_iter().collect::<Vec<_>>();
         self.retarget_virtual_interrupt(
             device_id,
             address,
             data,
             params.vector,
             params.multicast,
-            params.target_processors,
+            &target_processors,
         )
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1720,7 +1720,7 @@ impl<T: CpuIo> hv1_hypercall::RetargetDeviceInterrupt
             data,
             params.vector,
             params.multicast,
-            &params.target_processors,
+            params.target_processors,
         )
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1714,14 +1714,13 @@ impl<T: CpuIo> hv1_hypercall::RetargetDeviceInterrupt
         data: u32,
         params: hv1_hypercall::HvInterruptParameters<'_>,
     ) -> hvdef::HvResult<()> {
-        let target_processors = params.target_processors.into_iter().collect::<Vec<_>>();
         self.retarget_virtual_interrupt(
             device_id,
             address,
             data,
             params.vector,
             params.multicast,
-            &target_processors,
+            &params.target_processors,
         )
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -2358,8 +2358,9 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, SnpBacked> {
         processor_set: &ProcessorSet<'_>,
         flags: HvFlushFlags,
     ) {
-        let only_self = processor_set.len() == 1
-            && processor_set.into_iter().next() == Some(self.vp.vp_index().index());
+        let only_self = [self.vp.vp_index().index()]
+            .into_iter()
+            .eq(processor_set.iter());
         if only_self && flags.non_global_mappings_only() {
             self.vp.runner.vmsa_mut(self.intercepted_vtl).set_pcpu_id(0);
         } else {

--- a/vm/hv1/hv1_hypercall/Cargo.toml
+++ b/vm/hv1/hv1_hypercall/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+hv1_structs.workspace = true
 hvdef.workspace = true
 guestmem.workspace = true
 tracelimit.workspace = true

--- a/vm/hv1/hv1_structs/src/lib.rs
+++ b/vm/hv1/hv1_structs/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Data structures that may be useful when working with hv1_hypercall.
 
+#![warn(missing_docs)]
+
 mod proc_mask;
 mod vtl_array;
 

--- a/vm/hv1/hv1_structs/src/lib.rs
+++ b/vm/hv1/hv1_structs/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Data structures that may be useful when working with hv1_hypercall.
 
+mod proc_mask;
 mod vtl_array;
 
+pub use proc_mask::*;
 pub use vtl_array::*;

--- a/vm/hv1/hv1_structs/src/proc_mask.rs
+++ b/vm/hv1/hv1_structs/src/proc_mask.rs
@@ -4,13 +4,14 @@
 //! Structures for working with processor masks.
 
 /// A set of processor IDs, stored as a sparse array of 64-bit masks.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct ProcessorSet<'a> {
     valid_masks: u64,
     masks: &'a [u64],
 }
 
 impl<'a> ProcessorSet<'a> {
+    /// Attempts to create a ProcessorSet from a HV_GENERIC_SET_SPARSE_4K format HV_GENERIC_SET.
     pub fn from_generic_set(format: u64, rest: &'a [u64]) -> Option<Self> {
         if format != hvdef::hypercall::HV_GENERIC_SET_SPARSE_4K {
             return None;
@@ -21,6 +22,7 @@ impl<'a> ProcessorSet<'a> {
         Self::from_processor_masks(valid_masks, masks)
     }
 
+    /// Attempts to create a ProcessorSet from a set of processor masks.
     pub fn from_processor_masks(valid_masks: u64, masks: &'a [u64]) -> Option<Self> {
         let mask_count = valid_masks.count_ones();
         if masks.len() != mask_count as usize {
@@ -29,78 +31,69 @@ impl<'a> ProcessorSet<'a> {
         Some(Self { valid_masks, masks })
     }
 
-    /// Returns the set as a raw HV_GENERIC_SET_SPARSE_4K, suitable for use in a hypercall.
-    pub fn as_raw(&self) -> Vec<u64> {
-        let mut raw = Vec::with_capacity(1 + self.masks.len());
-        raw.push(self.valid_masks);
-        raw.extend_from_slice(self.masks);
-        raw
+    /// Returns the set as an iterator of u64s, suitable for collecting and
+    /// using as raw HV_GENERIC_SET_SPARSE_4K in a hypercall.
+    pub fn as_generic_set(&self) -> impl Iterator<Item = u64> + use<'_> {
+        std::iter::once(self.valid_masks).chain(self.masks.iter().copied())
     }
 
+    /// Returns true if the set is empty.
     pub fn is_empty(&self) -> bool {
-        self.valid_masks == 0 || self.masks.iter().all(|x| *x == 0)
+        self.valid_masks == 0 || self.count() == 0
     }
 
-    pub fn len(&self) -> usize {
+    /// Returns the number of processors in the set.
+    pub fn count(&self) -> usize {
         self.masks.iter().map(|x| x.count_ones() as usize).sum()
+    }
+
+    /// Returns an iterator over the processor IDs in the set.
+    pub fn iter(&self) -> ProcessorSetIter<'a> {
+        self.into_iter()
     }
 }
 
-impl<'a> IntoIterator for &'a ProcessorSet<'a> {
+impl<'a> IntoIterator for ProcessorSet<'a> {
     type Item = u32;
     type IntoIter = ProcessorSetIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         ProcessorSetIter {
-            len: self.len(),
-            set: self,
-            valid_mask_bit: 0,
-            mask_idx: 0,
-            mask_bit: 0,
+            bit: 0,
+            mask: 0,
+            remaining_valid: self.valid_masks,
+            masks: self.masks,
         }
     }
 }
 
+/// An iterator over the processor IDs in a ProcessorSet.
 pub struct ProcessorSetIter<'a> {
-    set: &'a ProcessorSet<'a>,
-    valid_mask_bit: usize,
-    mask_idx: usize,
-    mask_bit: usize,
-    len: usize,
+    bit: u32,
+    mask: u64,
+    remaining_valid: u64,
+    masks: &'a [u64],
 }
 
 impl Iterator for ProcessorSetIter<'_> {
     type Item = u32;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        while self.valid_mask_bit < 64 {
-            if self.set.valid_masks & (1 << self.valid_mask_bit) == 0 {
-                self.valid_mask_bit += 1;
-                continue;
-            }
-            let mask = self.set.masks[self.mask_idx];
-            while self.mask_bit < 64 {
-                if mask & (1 << self.mask_bit) == 0 {
-                    self.mask_bit += 1;
-                    continue;
-                }
-                let processor_id = (self.valid_mask_bit * 64 + self.mask_bit) as u32;
-                self.mask_bit += 1;
-                return Some(processor_id);
-            }
-            self.mask_bit = 0;
-            self.mask_idx += 1;
-            self.valid_mask_bit += 1;
+    fn next(&mut self) -> Option<u32> {
+        while self.mask == 0 {
+            self.mask = *self.masks.first()?;
+            self.masks = &self.masks[1..];
+            self.bit = self.remaining_valid.trailing_zeros();
+            self.remaining_valid &= !(1 << self.bit);
         }
-        None
+        let proc = self.mask.trailing_zeros();
+        self.mask &= !(1 << proc);
+        Some(self.bit * 64 + proc)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len, Some(self.len))
+        (self.masks.len(), None)
     }
 }
-
-impl ExactSizeIterator for ProcessorSetIter<'_> {}
 
 impl std::iter::FusedIterator for ProcessorSetIter<'_> {}
 
@@ -112,7 +105,7 @@ mod test {
     // Values taken from the Hypervisor Functional Specification
     fn test_processor_set() {
         let set = ProcessorSet::from_processor_masks(0x5, &[0x21, 0x4]).unwrap();
-        assert_eq!(set.len(), 3);
+        assert_eq!(set.count(), 3);
 
         let mut iter = set.into_iter();
         assert_eq!(iter.next(), Some(0));

--- a/vm/hv1/hv1_structs/src/proc_mask.rs
+++ b/vm/hv1/hv1_structs/src/proc_mask.rs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Structures for working with processor masks.
+
+/// A set of processor IDs, stored as a sparse array of 64-bit masks.
+#[derive(Clone)]
+pub struct ProcessorSet<'a> {
+    valid_masks: u64,
+    masks: &'a [u64],
+}
+
+impl<'a> ProcessorSet<'a> {
+    pub fn from_generic_set(format: u64, rest: &'a [u64]) -> Option<Self> {
+        if format != hvdef::hypercall::HV_GENERIC_SET_SPARSE_4K {
+            return None;
+        }
+        let &[valid_masks, ref masks @ ..] = rest else {
+            return None;
+        };
+        Self::from_processor_masks(valid_masks, masks)
+    }
+
+    pub fn from_processor_masks(valid_masks: u64, masks: &'a [u64]) -> Option<Self> {
+        let mask_count = valid_masks.count_ones();
+        if masks.len() != mask_count as usize {
+            return None;
+        }
+        Some(Self { valid_masks, masks })
+    }
+
+    /// Returns the set as a raw HV_GENERIC_SET_SPARSE_4K, suitable for use in a hypercall.
+    pub fn as_raw(&self) -> Vec<u64> {
+        let mut raw = Vec::with_capacity(1 + self.masks.len());
+        raw.push(self.valid_masks);
+        raw.extend_from_slice(self.masks);
+        raw
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.valid_masks == 0 || self.masks.iter().all(|x| *x == 0)
+    }
+
+    pub fn len(&self) -> usize {
+        self.masks.iter().map(|x| x.count_ones() as usize).sum()
+    }
+}
+
+impl<'a> IntoIterator for &'a ProcessorSet<'a> {
+    type Item = u32;
+    type IntoIter = ProcessorSetIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ProcessorSetIter {
+            len: self.len(),
+            set: self,
+            valid_mask_bit: 0,
+            mask_idx: 0,
+            mask_bit: 0,
+        }
+    }
+}
+
+pub struct ProcessorSetIter<'a> {
+    set: &'a ProcessorSet<'a>,
+    valid_mask_bit: usize,
+    mask_idx: usize,
+    mask_bit: usize,
+    len: usize,
+}
+
+impl Iterator for ProcessorSetIter<'_> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.valid_mask_bit < 64 {
+            if self.set.valid_masks & (1 << self.valid_mask_bit) == 0 {
+                self.valid_mask_bit += 1;
+                continue;
+            }
+            let mask = self.set.masks[self.mask_idx];
+            while self.mask_bit < 64 {
+                if mask & (1 << self.mask_bit) == 0 {
+                    self.mask_bit += 1;
+                    continue;
+                }
+                let processor_id = (self.valid_mask_bit * 64 + self.mask_bit) as u32;
+                self.mask_bit += 1;
+                return Some(processor_id);
+            }
+            self.mask_bit = 0;
+            self.mask_idx += 1;
+            self.valid_mask_bit += 1;
+        }
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+}
+
+impl ExactSizeIterator for ProcessorSetIter<'_> {}
+
+impl std::iter::FusedIterator for ProcessorSetIter<'_> {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    // Values taken from the Hypervisor Functional Specification
+    fn test_processor_set() {
+        let set = ProcessorSet::from_processor_masks(0x5, &[0x21, 0x4]).unwrap();
+        assert_eq!(set.len(), 3);
+
+        let mut iter = set.into_iter();
+        assert_eq!(iter.next(), Some(0));
+        assert_eq!(iter.next(), Some(5));
+        assert_eq!(iter.next(), Some(130));
+        assert_eq!(iter.next(), None);
+    }
+}

--- a/vm/hv1/hv1_structs/src/proc_mask.rs
+++ b/vm/hv1/hv1_structs/src/proc_mask.rs
@@ -89,10 +89,6 @@ impl Iterator for ProcessorSetIter<'_> {
         self.mask &= !(1 << proc);
         Some(self.bit * 64 + proc)
     }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.masks.len(), None)
-    }
 }
 
 impl std::iter::FusedIterator for ProcessorSetIter<'_> {}

--- a/vmm_core/virt_whp/src/device.rs
+++ b/vmm_core/virt_whp/src/device.rs
@@ -81,7 +81,7 @@ impl Device {
         if params.multicast && params.target_processors.len() > 1 {
             flags |= whp::abi::WHvVpciInterruptTargetFlagMulticast;
         }
-        let target_processors = params.target_processors.into_iter().collect::<Vec<_>>();
+        let target_processors = Vec::from_iter(params.target_processors);
         let target = VpciInterruptTarget::new(params.vector, flags, &target_processors);
         self.device()
             .retarget_interrupt(address, data, &target)

--- a/vmm_core/virt_whp/src/device.rs
+++ b/vmm_core/virt_whp/src/device.rs
@@ -78,7 +78,7 @@ impl Device {
 
     pub fn _retarget_interrupt(&self, address: u64, data: u32, params: &HvInterruptParameters<'_>) {
         let mut flags = Default::default();
-        if params.multicast && params.target_processors.len() > 1 {
+        if params.multicast && params.target_processors.count() > 1 {
             flags |= whp::abi::WHvVpciInterruptTargetFlagMulticast;
         }
         let target_processors = Vec::from_iter(params.target_processors);

--- a/vmm_core/virt_whp/src/device.rs
+++ b/vmm_core/virt_whp/src/device.rs
@@ -81,7 +81,8 @@ impl Device {
         if params.multicast && params.target_processors.len() > 1 {
             flags |= whp::abi::WHvVpciInterruptTargetFlagMulticast;
         }
-        let target = VpciInterruptTarget::new(params.vector, flags, params.target_processors);
+        let target_processors = params.target_processors.into_iter().collect::<Vec<_>>();
+        let target = VpciInterruptTarget::new(params.vector, flags, &target_processors);
         self.device()
             .retarget_interrupt(address, data, &target)
             .expect("BUGBUG");

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -906,12 +906,13 @@ mod x86 {
             device_id: u64,
             address: u64,
             data: u32,
-            params: &HvInterruptParameters<'_>,
+            params: HvInterruptParameters<'_>,
         ) -> HvResult<()> {
+            let target_processors = params.target_processors.into_iter().collect::<Vec<_>>();
             let vpci_params = VpciInterruptParameters {
                 vector: params.vector,
                 multicast: params.multicast,
-                target_processors: params.target_processors,
+                target_processors: &target_processors,
             };
 
             match self.vp.current_vtlp().software_devices.retarget_interrupt(

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -908,7 +908,7 @@ mod x86 {
             data: u32,
             params: HvInterruptParameters<'_>,
         ) -> HvResult<()> {
-            let target_processors = params.target_processors.into_iter().collect::<Vec<_>>();
+            let target_processors = Vec::from_iter(params.target_processors);
             let vpci_params = VpciInterruptParameters {
                 vector: params.vector,
                 multicast: params.multicast,


### PR DESCRIPTION
This allows us to avoid some heap allocations in the TLB flush hypercalls.