### PR TITLE
xsync: Add 'inherit' and 'channel_prefix' options to control toolchain syncing

### DIFF
--- a/xsync/xsync/src/tasks/cargo_toml.rs
+++ b/xsync/xsync/src/tasks/cargo_toml.rs
@@ -31,7 +31,7 @@ impl Cmd for CargoToml {
         let overlay_cargo_toml =
             fs_err::read_to_string(ctx.overlay_workspace.join("Cargo.xsync.toml"))?;
         let mut overlay_cargo_toml = cargo_toml::Manifest::<
-            self::custom_meta::CargoOverlayMetadata,
+            super::custom_meta::CargoOverlayMetadata,
         >::from_slice_with_metadata(
             overlay_cargo_toml.as_bytes()
         )?;
@@ -58,10 +58,11 @@ impl Cmd for CargoToml {
         // handle simple inherited Cargo.toml fields
         //
         {
-            let self::custom_meta::Inherit {
+            let super::custom_meta::Inherit {
                 profile,
                 patch,
-                workspace: self::custom_meta::InheritWorkspace { lints, package },
+                workspace: super::custom_meta::InheritWorkspace { lints, package },
+                rust_toolchain: _,
             } = meta.inherit;
 
             if profile {
@@ -86,7 +87,7 @@ impl Cmd for CargoToml {
                     .as_mut()
                     .unwrap())
                 .clone_from(
-                    &base_cargo_toml
+                    base_cargo_toml
                         .workspace
                         .as_ref()
                         .unwrap()
@@ -155,33 +156,5 @@ impl Cmd for CargoToml {
         }
 
         Ok(())
-    }
-}
-
-mod custom_meta {
-    use serde::Deserialize;
-    use serde::Serialize;
-
-    #[derive(Debug, Serialize, Deserialize)]
-    pub struct CargoOverlayMetadata {
-        pub xsync: Xsync,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    pub struct Xsync {
-        pub inherit: Inherit,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    pub struct Inherit {
-        pub profile: bool,
-        pub patch: bool,
-        pub workspace: InheritWorkspace,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    pub struct InheritWorkspace {
-        pub lints: bool,
-        pub package: bool,
     }
 }

--- a/xsync/xsync/src/tasks/mod.rs
+++ b/xsync/xsync/src/tasks/mod.rs
@@ -28,3 +28,38 @@ const GENERATED_HEADER: &str = r#"
 ################################################################################
 
 "#;
+
+mod custom_meta {
+    use serde::Deserialize;
+    use serde::Serialize;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct CargoOverlayMetadata {
+        pub xsync: Xsync,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Xsync {
+        pub inherit: Inherit,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Inherit {
+        pub profile: bool,
+        pub patch: bool,
+        pub workspace: InheritWorkspace,
+        pub rust_toolchain: InheritRustToolchain,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct InheritWorkspace {
+        pub lints: bool,
+        pub package: bool,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct InheritRustToolchain {
+        pub inherit: bool,
+        pub channel_prefix: Option<String>,
+    }
+}

--- a/xsync/xsync/src/tasks/rust_toolchain_toml.rs
+++ b/xsync/xsync/src/tasks/rust_toolchain_toml.rs
@@ -26,19 +26,51 @@ impl Cmd for RustToolchainToml {
     fn run(self, ctx: crate::CmdCtx) -> anyhow::Result<()> {
         let Command::Regen = self.cmd;
 
+        // parse the Cargo.xsync.toml
+        let overlay_cargo_toml =
+            fs_err::read_to_string(ctx.overlay_workspace.join("Cargo.xsync.toml"))?;
+        let mut overlay_cargo_toml = cargo_toml::Manifest::<
+            super::custom_meta::CargoOverlayMetadata,
+        >::from_slice_with_metadata(
+            overlay_cargo_toml.as_bytes()
+        )?;
+
+        // extract the custom metadata
+        let meta = overlay_cargo_toml
+            .workspace
+            .as_mut()
+            .unwrap()
+            .metadata
+            .take()
+            .unwrap()
+            .xsync;
+        let super::custom_meta::InheritRustToolchain {
+            inherit,
+            channel_prefix,
+        } = meta.inherit.rust_toolchain;
+
+        if !inherit {
+            return Ok(());
+        }
+
         let out = std::path::absolute(ctx.overlay_workspace.join("rust-toolchain.toml"))?;
         let base_toolchain_toml =
             fs_err::read_to_string(ctx.base_workspace.join("rust-toolchain.toml"));
 
-        // Ensure that the rust-toolchain.toml in the overlay matches that of the base repo exactly.
+        // Ensure that the rust-toolchain.toml in the overlay matches that of the base repo exactly,
+        // accounting for prefix additions.
         // This is a policy decision, and is open to changing in the future.
         match base_toolchain_toml {
             Ok(base_toolchain_toml) => {
                 log::info!(
                     "base rust-toolchain.toml found, regenerating overlay rust-toolchain.toml",
                 );
-                let base_toolchain_toml: schema::RustToolchainToml =
+                let mut base_toolchain_toml: schema::RustToolchainToml =
                     toml_edit::de::from_str(&base_toolchain_toml)?;
+                if let Some(prefix) = channel_prefix {
+                    base_toolchain_toml.toolchain.channel =
+                        format!("{}{}", prefix, base_toolchain_toml.toolchain.channel);
+                }
                 let generated_toolchain_toml = format!(
                     "{}{}",
                     super::GENERATED_HEADER.trim_start(),


### PR DESCRIPTION
This might break the mirror pipeline until the corresponding addition of these values is merged internally.