### PR TITLE
cvm guest vsm: move vtl1_enabled from UhVpInner to a new UhCvmVpInner

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -365,12 +365,26 @@ pub struct UhCvmPartitionState {
         with = "|arr| inspect::iter_by_index(arr.iter()).map_value(|bb| inspect::iter_by_index(bb.iter().map(|v| *v)))"
     )]
     tlb_locked_vps: VtlArray<BitBox<AtomicU64>, 2>,
-    /// The current status of TLB locks, per-VP.
-    #[inspect(
-        with = "|vec| inspect::iter_by_index(vec.iter().map(|arr| inspect::iter_by_index(arr.iter())))"
-    )]
-    tlb_lock_info: Vec<VtlArray<TlbLockInfo, 2>>,
+    #[inspect(with = "inspect::iter_by_index")]
+    vps: Vec<UhCvmVpInner>,
     shared_memory: GuestMemory,
+}
+
+#[cfg(guest_arch = "x86_64")]
+impl UhCvmPartitionState {
+    fn vp_inner(&self, vp_index: u32) -> &UhCvmVpInner {
+        self.vps.get(vp_index as usize).unwrap()
+    }
+}
+
+#[cfg(guest_arch = "x86_64")]
+#[derive(Inspect)]
+/// Per-vp state for CVMs.
+pub struct UhCvmVpInner {
+    /// The current status of TLB locks
+    tlb_lock_info: VtlArray<TlbLockInfo, 2>,
+    /// Whether VTL 1 has been enabled on the vp
+    vtl1_enabled: Mutex<bool>,
 }
 
 /// Partition-wide state for CVMs.
@@ -603,9 +617,6 @@ struct UhVpInner {
     #[inspect(skip)]
     vp_info: TargetVpInfo,
     cpu_index: u32,
-    /// Only modified for hardware CVMs. On other types of VMs, since VTL 2
-    /// doesn't handle EnableVpVtl, there's no obvious place to set this.
-    hcvm_vtl1_enabled: Mutex<bool>,
     #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
     #[inspect(with = "|arr| inspect::iter_by_index(arr.iter().map(|v| v.lock().is_some()))")]
     hv_start_enable_vtl_vp: VtlArray<Mutex<Option<Box<hvdef::hypercall::InitialVpContextX64>>>, 2>,
@@ -1834,15 +1845,18 @@ impl UhProtoPartition<'_> {
         cpuid: cvm_cpuid::CpuidResults,
     ) -> Result<UhCvmPartitionState, Error> {
         let vp_count = params.topology.vp_count() as usize;
-        let tlb_lock_info = (0..vp_count)
-            .map(|_| VtlArray::from_fn(|_| TlbLockInfo::new(vp_count)))
+        let vps = (0..vp_count)
+            .map(|_vp_index| UhCvmVpInner {
+                tlb_lock_info: VtlArray::from_fn(|_| TlbLockInfo::new(vp_count)),
+                vtl1_enabled: Mutex::new(false),
+            })
             .collect();
         let tlb_locked_vps =
             VtlArray::from_fn(|_| BitVec::repeat(false, vp_count).into_boxed_bitslice());
         Ok(UhCvmPartitionState {
             cpuid,
             tlb_locked_vps,
-            tlb_lock_info,
+            vps,
             shared_memory: late_params
                 .shared_memory
                 .clone()

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -373,7 +373,7 @@ pub struct UhCvmPartitionState {
 #[cfg(guest_arch = "x86_64")]
 impl UhCvmPartitionState {
     fn vp_inner(&self, vp_index: u32) -> &UhCvmVpInner {
-        self.vps.get(vp_index as usize).unwrap()
+        &self.vps[vp_index as usize]
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
@@ -64,7 +64,7 @@ pub(crate) fn poll_apic_core<'b, B: HardwareIsolatedBacking, T: ApicBacking<'b, 
     // Check VTL enablement inside each block to avoid taking a lock on the hot path,
     // INIT and SIPI are quite cold.
     if init {
-        if !*apic_backing.vp().inner.hcvm_vtl1_enabled.lock() {
+        if !*apic_backing.vp().cvm_vp_inner().vtl1_enabled.lock() {
             debug_assert_eq!(vtl, GuestVtl::Vtl0);
             apic_backing.handle_init(vtl)?;
         }
@@ -72,7 +72,7 @@ pub(crate) fn poll_apic_core<'b, B: HardwareIsolatedBacking, T: ApicBacking<'b, 
 
     if let Some(vector) = sipi {
         if apic_backing.vp().backing.cvm_state_mut().lapics[vtl].activity == MpState::WaitForSipi {
-            if !*apic_backing.vp().inner.hcvm_vtl1_enabled.lock() {
+            if !*apic_backing.vp().cvm_vp_inner().vtl1_enabled.lock() {
                 debug_assert_eq!(vtl, GuestVtl::Vtl0);
                 let base = (vector as u64) << 12;
                 let selector = (vector as u16) << 8;

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -229,6 +229,12 @@ impl BackingPrivate for HypervisorBackedArm64 {
     ) -> Result<(), UhRunVpError> {
         unimplemented!()
     }
+
+    fn vtl1_inspectable(_this: &UhProcessor<'_, Self>) -> bool {
+        // TODO: Use the VsmVpStatus register to query the hypervisor for
+        // whether VTL 1 is enabled on the vp (this can be cached).
+        false
+    }
 }
 
 impl UhProcessor<'_, HypervisorBackedArm64> {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -339,6 +339,12 @@ impl BackingPrivate for HypervisorBackedX86 {
     ) -> Result<(), UhRunVpError> {
         unimplemented!()
     }
+
+    fn vtl1_inspectable(_this: &UhProcessor<'_, Self>) -> bool {
+        // TODO: Use the VsmVpStatus register to query the hypervisor for
+        // whether VTL 1 is enabled on the vp (this can be cached).
+        false
+    }
 }
 
 fn parse_sidecar_exit(message: &hvdef::HvMessage) -> SidecarRemoveExit {
@@ -1995,8 +2001,6 @@ mod save_restore {
                         // Topology information
                         vp_info: _,
                         cpu_index: _,
-                        // Only relevant for CVMs
-                        hcvm_vtl1_enabled: _,
                         hv_start_enable_vtl_vp: _,
                     },
                 // Saved

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -460,7 +460,7 @@ impl BackingPrivate for SnpBacked {
 
     fn inspect_extra(this: &mut UhProcessor<'_, Self>, resp: &mut inspect::Response<'_>) {
         let vtl0_vmsa = this.runner.vmsa(GuestVtl::Vtl0);
-        let vtl1_vmsa = if *this.inner.hcvm_vtl1_enabled.lock() {
+        let vtl1_vmsa = if *this.cvm_vp_inner().vtl1_enabled.lock() {
             Some(this.runner.vmsa(GuestVtl::Vtl1))
         } else {
             None
@@ -509,6 +509,10 @@ impl BackingPrivate for SnpBacked {
         vtl: GuestVtl,
     ) -> Result<(), UhRunVpError> {
         this.hcvm_handle_vp_start_enable_vtl(vtl)
+    }
+
+    fn vtl1_inspectable(this: &UhProcessor<'_, Self>) -> bool {
+        this.hcvm_vtl1_inspectable()
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -902,6 +902,10 @@ impl BackingPrivate for TdxBacked {
     ) -> Result<(), UhRunVpError> {
         this.hcvm_handle_vp_start_enable_vtl(vtl)
     }
+
+    fn vtl1_inspectable(this: &UhProcessor<'_, Self>) -> bool {
+        this.hcvm_vtl1_inspectable()
+    }
 }
 
 impl UhProcessor<'_, TdxBacked> {


### PR DESCRIPTION
Moves some CVM-specific state off of UhVpInner into a cvm-specific struct.

Tested by booting a non-isolated VM and an SNP VM.