### PR TITLE
clippy.toml: Remove outdated configs

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -30,7 +30,3 @@ disallowed-methods = [
 ]
 
 avoid-breaking-exported-api = false
-
-# These will become the default in a future version of Rust.
-accept-comment-above-statement = true
-accept-comment-above-attributes = true


### PR DESCRIPTION
These are now the default (the "future version of rust" was a while ago) so we don't need to restate them.