### PR TITLE
Use mesh::Sender as mpsc sender everywhere

### DIFF
--- a/hyperv/tools/hypestv/src/windows/completions.rs
+++ b/hyperv/tools/hypestv/src/windows/completions.rs
@@ -12,7 +12,7 @@ use rustyline::Validator;
 
 #[derive(Helper, Highlighter, Hinter, Validator)]
 pub(crate) struct OpenvmmRustylineEditor {
-    pub(crate) req: std::sync::Arc<mesh::Sender<super::Request>>,
+    pub(crate) req: mesh::Sender<super::Request>,
 }
 
 impl rustyline::completion::Completer for OpenvmmRustylineEditor {
@@ -69,7 +69,7 @@ impl clap_dyn_complete::CustomCompleterFactory for &OpenvmmRustylineEditor {
 }
 
 pub struct OpenvmmComplete {
-    req: std::sync::Arc<mesh::Sender<super::Request>>,
+    req: mesh::Sender<super::Request>,
 }
 
 impl clap_dyn_complete::CustomCompleter for OpenvmmComplete {

--- a/hyperv/tools/hypestv/src/windows/mod.rs
+++ b/hyperv/tools/hypestv/src/windows/mod.rs
@@ -21,7 +21,6 @@ use pal_async::DefaultDriver;
 use rustyline_printer::Printer;
 use std::fmt::Display;
 use std::path::PathBuf;
-use std::sync::Arc;
 use vm::Vm;
 
 #[derive(Parser)]
@@ -209,7 +208,6 @@ pub async fn main(driver: DefaultDriver) -> anyhow::Result<()> {
     };
 
     let (send, mut recv) = mesh::channel();
-    let send = Arc::new(send);
 
     rl.set_helper(Some(completions::OpenvmmRustylineEditor {
         req: send.clone(),

--- a/openhcl/underhill_core/src/emuplat/framebuffer.rs
+++ b/openhcl/underhill_core/src/emuplat/framebuffer.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 use std::convert::Infallible;
-use std::sync::Arc;
 use video_core::FramebufferControl;
 use video_core::FramebufferFormat;
 use video_core::ResolvedFramebuffer;
@@ -13,7 +12,7 @@ use vm_resource::ResolveResource;
 #[derive(Clone)]
 pub struct FramebufferRemoteControl {
     pub get: guest_emulation_transport::GuestEmulationTransportClient,
-    pub format_send: Arc<mesh::Sender<FramebufferFormat>>,
+    pub format_send: mesh::Sender<FramebufferFormat>,
 }
 
 #[async_trait::async_trait]

--- a/openhcl/underhill_core/src/inspect_internal.rs
+++ b/openhcl/underhill_core/src/inspect_internal.rs
@@ -40,11 +40,10 @@ use inspect::SensitivityLevel;
 use mesh::Sender;
 use pal_async::task::Spawn;
 use pal_async::DefaultDriver;
-use std::sync::Arc;
 
 pub(crate) fn inspect_internal_diagnostics(
     req: Request<'_>,
-    reinspect: Arc<Sender<Deferred>>,
+    reinspect: Sender<Deferred>,
     driver: DefaultDriver,
 ) {
     req.respond()
@@ -54,7 +53,7 @@ pub(crate) fn inspect_internal_diagnostics(
         });
 }
 
-fn net(req: Request<'_>, reinspect: Arc<Sender<Deferred>>, driver: DefaultDriver) {
+fn net(req: Request<'_>, reinspect: Sender<Deferred>, driver: DefaultDriver) {
     let defer = req.defer();
     let driver2 = driver.clone();
     driver
@@ -94,12 +93,7 @@ fn net(req: Request<'_>, reinspect: Arc<Sender<Deferred>>, driver: DefaultDriver
 
 // net/mac_address
 // Format for mac address is no separators, lowercase letters, e.g. 00155d121212.
-fn net_nic(
-    req: Request<'_>,
-    name: String,
-    reinspect: Arc<Sender<Deferred>>,
-    driver: DefaultDriver,
-) {
+fn net_nic(req: Request<'_>, name: String, reinspect: Sender<Deferred>, driver: DefaultDriver) {
     let defer = req.defer();
     driver
         .spawn("inspect-diagnostics-net-nic", async move {

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -72,7 +72,6 @@ use pal_async::DefaultPool;
 use profiler_worker::ProfilerWorker;
 #[cfg(feature = "profiler")]
 use profiler_worker::ProfilerWorkerParameters;
-use std::sync::Arc;
 use std::time::Duration;
 use vmsocket::VmAddress;
 use vmsocket::VmListener;
@@ -107,7 +106,7 @@ fn new_underhill_remote_console_cfg(
                 synth_keyboard: true,
                 synth_mouse: true,
                 synth_video: true,
-                input: mesh::MpscReceiver::new(),
+                input: mesh::Receiver::new(),
                 framebuffer: Some(fb),
             },
             Some(fba),
@@ -118,7 +117,7 @@ fn new_underhill_remote_console_cfg(
                 synth_keyboard: false,
                 synth_mouse: false,
                 synth_video: false,
-                input: mesh::MpscReceiver::new(),
+                input: mesh::Receiver::new(),
                 framebuffer: None,
             },
             None,
@@ -450,7 +449,6 @@ async fn run_control(
     let mut diag = DiagState::new().await?;
 
     let (diag_reinspect_send, mut diag_reinspect_recv) = mesh::channel();
-    let diag_reinspect_send = Arc::new(diag_reinspect_send);
     #[cfg(feature = "profiler")]
     let mut profiler_host = None;
     let mut state;

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -23,7 +23,6 @@ use pal_async::task::Spawn;
 use pal_async::task::Task;
 use std::collections::hash_map;
 use std::collections::HashMap;
-use std::sync::Arc;
 use thiserror::Error;
 use tracing::Instrument;
 use user_driver::vfio::VfioDevice;
@@ -113,9 +112,7 @@ impl NvmeManager {
         });
         Self {
             task,
-            client: NvmeManagerClient {
-                sender: Arc::new(send),
-            },
+            client: NvmeManagerClient { sender: send },
             save_restore_supported,
         }
     }
@@ -177,7 +174,7 @@ enum Request {
 
 #[derive(Debug, Clone)]
 pub struct NvmeManagerClient {
-    sender: Arc<mesh::Sender<Request>>,
+    sender: mesh::Sender<Request>,
 }
 
 impl NvmeManagerClient {

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -315,7 +315,7 @@ pub struct UnderhillRemoteConsoleCfg {
     pub synth_keyboard: bool,
     pub synth_mouse: bool,
     pub synth_video: bool,
-    pub input: mesh::MpscReceiver<InputData>,
+    pub input: mesh::Receiver<InputData>,
     pub framebuffer: Option<framebuffer::Framebuffer>,
 }
 
@@ -427,7 +427,7 @@ impl Worker for UnderhillVmWorker {
                     synth_keyboard: false,
                     synth_mouse: false,
                     synth_video: false,
-                    input: mesh::MpscReceiver::new(),
+                    input: mesh::Receiver::new(),
                     framebuffer: None,
                 },
                 debugger_rpc: None,
@@ -2863,7 +2863,7 @@ async fn new_underhill_vm(
     if let Some(framebuffer) = remote_console_cfg.framebuffer {
         resolver.add_resolver(FramebufferRemoteControl {
             get: get_client.clone(),
-            format_send: Arc::new(framebuffer.format_send()),
+            format_send: framebuffer.format_send(),
         });
 
         vmbus_device_handles.push(

--- a/openvmm/hvlite_core/src/emuplat/firmware.rs
+++ b/openvmm/hvlite_core/src/emuplat/firmware.rs
@@ -9,14 +9,14 @@ use firmware_uefi::platform::logger::UefiEvent;
 use firmware_uefi::platform::logger::UefiLogger;
 use get_resources::ged::FirmwareEvent;
 
-/// Forwards UEFI and PCAT events to via the provided [`mesh::MpscSender`].
+/// Forwards UEFI and PCAT events to via the provided [`mesh::Sender`].
 #[derive(Debug)]
 pub struct MeshLogger {
-    sender: Option<mesh::MpscSender<FirmwareEvent>>,
+    sender: Option<mesh::Sender<FirmwareEvent>>,
 }
 
 impl MeshLogger {
-    pub fn new(sender: Option<mesh::MpscSender<FirmwareEvent>>) -> Self {
+    pub fn new(sender: Option<mesh::Sender<FirmwareEvent>>) -> Self {
         Self { sender }
     }
 

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -211,7 +211,7 @@ pub struct Manifest {
     chipset: BaseChipsetManifest,
     #[cfg(windows)]
     kernel_vmnics: Vec<hvlite_defs::config::KernelVmNicConfig>,
-    input: mesh::MpscReceiver<InputData>,
+    input: mesh::Receiver<InputData>,
     framebuffer: Option<framebuffer::Framebuffer>,
     vga_firmware: Option<RomFileLocation>,
     vtl2_gfx: bool,
@@ -226,7 +226,7 @@ pub struct Manifest {
     vmgs_disk: Option<Resource<DiskHandleKind>>,
     secure_boot_enabled: bool,
     custom_uefi_vars: firmware_uefi_custom_vars::CustomVars,
-    firmware_event_send: Option<mesh::MpscSender<get_resources::ged::FirmwareEvent>>,
+    firmware_event_send: Option<mesh::Sender<get_resources::ged::FirmwareEvent>>,
     debugger_rpc: Option<mesh::Receiver<vmm_core_defs::debug_rpc::DebugRequest>>,
     vmbus_devices: Vec<(DeviceVtl, Resource<VmbusDeviceHandleKind>)>,
     chipset_devices: Vec<ChipsetDeviceHandle>,
@@ -530,7 +530,7 @@ struct LoadedVmInner {
     /// ((device, function), interrupt)
     #[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
     pci_legacy_interrupts: Vec<((u8, Option<u8>), u32)>,
-    firmware_event_send: Option<mesh::MpscSender<get_resources::ged::FirmwareEvent>>,
+    firmware_event_send: Option<mesh::Sender<get_resources::ged::FirmwareEvent>>,
 
     load_mode: LoadMode,
     igvm_file: Option<IgvmFile>,

--- a/openvmm/hvlite_defs/src/config.rs
+++ b/openvmm/hvlite_defs/src/config.rs
@@ -34,7 +34,7 @@ pub struct Config {
     pub vtl2_vmbus: Option<VmbusConfig>,
     #[cfg(windows)]
     pub kernel_vmnics: Vec<KernelVmNicConfig>,
-    pub input: mesh::MpscReceiver<InputData>,
+    pub input: mesh::Receiver<InputData>,
     pub framebuffer: Option<framebuffer::Framebuffer>,
     pub vga_firmware: Option<RomFileLocation>,
     pub vtl2_gfx: bool,
@@ -48,7 +48,7 @@ pub struct Config {
     pub secure_boot_enabled: bool,
     pub custom_uefi_vars: firmware_uefi_custom_vars::CustomVars,
     // TODO: move FirmwareEvent somewhere not GED-specific.
-    pub firmware_event_send: Option<mesh::MpscSender<get_resources::ged::FirmwareEvent>>,
+    pub firmware_event_send: Option<mesh::Sender<get_resources::ged::FirmwareEvent>>,
     pub debugger_rpc: Option<mesh::Receiver<vmm_core_defs::debug_rpc::DebugRequest>>,
     pub vmbus_devices: Vec<(DeviceVtl, Resource<VmbusDeviceHandleKind>)>,
     pub chipset_devices: Vec<ChipsetDeviceHandle>,

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -68,7 +68,7 @@ impl MappingManager {
 /// Provides access to the mapping manager.
 #[derive(Debug, MeshPayload, Clone)]
 pub struct MappingManagerClient {
-    req_send: mesh::MpscSender<MappingRequest>,
+    req_send: mesh::Sender<MappingRequest>,
     id: ObjectId,
     max_addr: u64,
 }
@@ -224,7 +224,7 @@ impl MappingManagerTask {
         }
     }
 
-    async fn run(&mut self, req_recv: &mut mesh::MpscReceiver<MappingRequest>) {
+    async fn run(&mut self, req_recv: &mut mesh::Receiver<MappingRequest>) {
         while let Some(req) = req_recv.next().await {
             match req {
                 MappingRequest::AddMapper(rpc) => rpc.handle_sync(|send| self.add_mapper(send)),

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -60,7 +60,7 @@ impl std::fmt::Debug for VaMapper {
 struct MapperInner {
     mapping: SparseMapping,
     waiters: Mutex<Option<Vec<MapWaiter>>>,
-    req_send: mesh::MpscSender<MappingRequest>,
+    req_send: mesh::Sender<MappingRequest>,
     id: MapperId,
 }
 
@@ -191,7 +191,7 @@ impl MapperInner {
 
 impl VaMapper {
     pub(crate) async fn new(
-        req_send: mesh::MpscSender<MappingRequest>,
+        req_send: mesh::Sender<MappingRequest>,
         len: u64,
         remote_process: Option<RemoteProcess>,
     ) -> Result<Self, VaMapperError> {

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -36,7 +36,7 @@ impl Inspect for RegionManager {
 /// Provides access to the region manager.
 #[derive(Debug, MeshPayload, Clone)]
 pub struct RegionManagerClient {
-    req_send: mesh::MpscSender<RegionRequest>,
+    req_send: mesh::Sender<RegionRequest>,
 }
 
 struct Region {
@@ -182,7 +182,7 @@ impl RegionManagerTask {
         }
     }
 
-    async fn run(&mut self, req_recv: &mut mesh::MpscReceiver<RegionRequest>) {
+    async fn run(&mut self, req_recv: &mut mesh::Receiver<RegionRequest>) {
         while let Some(req) = req_recv.next().await {
             match req {
                 RegionRequest::AddMapping(rpc) => {
@@ -559,7 +559,7 @@ impl RegionManagerClient {
 #[must_use]
 pub struct RegionHandle {
     id: Option<RegionId>,
-    req_send: mesh::MpscSender<RegionRequest>,
+    req_send: mesh::Sender<RegionRequest>,
 }
 
 impl RegionHandle {

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1283,7 +1283,7 @@ fn vm_config_from_command_line(
         },
         #[cfg(windows)]
         kernel_vmnics,
-        input: mesh::MpscReceiver::new(),
+        input: mesh::Receiver::new(),
         framebuffer,
         vga_firmware,
         vtl2_gfx: opt.vtl2_gfx,
@@ -1959,7 +1959,6 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
 
     // spin up the VM
     let (vm_rpc, rpc_recv) = mesh::channel();
-    let vm_rpc = Arc::new(vm_rpc);
     let (notify_send, notify_recv) = mesh::channel();
     let mut vm_worker = {
         let vm_host = mesh.make_host("vm", opt.log_file.clone()).await?;
@@ -2831,7 +2830,7 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
 
 struct DiagDialer {
     driver: DefaultDriver,
-    vm_rpc: Arc<mesh::Sender<VmRpc>>,
+    vm_rpc: mesh::Sender<VmRpc>,
     openhcl_vtl: DeviceVtl,
 }
 

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -486,7 +486,7 @@ impl VmService {
             },
             #[cfg(windows)]
             kernel_vmnics: vec![],
-            input: mesh::MpscReceiver::new(),
+            input: mesh::Receiver::new(),
             framebuffer: None,
             vga_firmware: None,
             vtl2_gfx: false,

--- a/petri/pipette/src/agent.rs
+++ b/petri/pipette/src/agent.rs
@@ -17,7 +17,6 @@ use pipette_protocol::DiagnosticFile;
 use pipette_protocol::PipetteBootstrap;
 use pipette_protocol::PipetteRequest;
 use socket2::Socket;
-use std::sync::Arc;
 use std::time::Duration;
 use unicycle::FuturesUnordered;
 use vmsocket::VmAddress;
@@ -33,7 +32,7 @@ pub struct Agent {
 
 #[allow(dead_code)] // Not used on all platforms yet
 #[derive(Clone)]
-pub struct DiagnosticSender(Arc<mesh::Sender<DiagnosticFile>>);
+pub struct DiagnosticSender(mesh::Sender<DiagnosticFile>);
 
 impl Agent {
     pub async fn new(driver: DefaultDriver) -> anyhow::Result<Self> {
@@ -74,7 +73,7 @@ impl Agent {
             driver,
             mesh,
             request_recv,
-            diag_file_send: DiagnosticSender(Arc::new(diag_file_send)),
+            diag_file_send: DiagnosticSender(diag_file_send),
             watch_send,
         })
     }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -73,7 +73,6 @@ use serial_socket::net::OpenSocketSerialConfig;
 use sparse_mmap::alloc_shared_memory;
 use std::fmt::Write as _;
 use std::path::PathBuf;
-use std::sync::Arc;
 use storvsp_resources::ScsiControllerHandle;
 use storvsp_resources::ScsiDeviceAndPath;
 use storvsp_resources::ScsiPath;
@@ -170,7 +169,6 @@ impl PetriVmConfigOpenVmm {
                     framebuffer.is_some(),
                 )?;
                 let (vtl2_vsock_listener, vtl2_vsock_path) = make_vsock_listener()?;
-                let ged_send = Arc::new(ged_send);
                 (
                     Some(Vtl2Config {
                         vtl0_alias_map: false, // TODO: enable when OpenVMM supports it for DMA
@@ -326,7 +324,7 @@ impl PetriVmConfigOpenVmm {
             // Disabled for VMM tests by default
             #[cfg(windows)]
             kernel_vmnics: vec![],
-            input: mesh::MpscReceiver::new(),
+            input: mesh::Receiver::new(),
             vtl2_gfx: false,
             virtio_console_pci: false,
             virtio_serial: None,
@@ -793,7 +791,7 @@ impl PetriVmConfigSetupCore<'_> {
         &self,
         serial: &mut [Option<Resource<SerialBackendHandle>>],
         devices: &mut impl Extend<Device>,
-        firmware_event_send: &mesh::MpscSender<FirmwareEvent>,
+        firmware_event_send: &mesh::Sender<FirmwareEvent>,
         framebuffer: bool,
     ) -> anyhow::Result<(
         get_resources::ged::GuestEmulationDeviceHandle,

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -29,7 +29,7 @@ use get_resources::ged::FirmwareEvent;
 use guid::Guid;
 use hvlite_defs::config::Config;
 use hyperv_ic_resources::shutdown::ShutdownRpc;
-use mesh::MpscReceiver;
+use mesh::Receiver;
 use mesh::Sender;
 use pal_async::socket::PolledSocket;
 use pal_async::task::Task;
@@ -40,7 +40,6 @@ use petri_artifacts_core::ArtifactResolver;
 use petri_artifacts_core::ResolvedArtifact;
 use pipette_client::PipetteClient;
 use std::path::PathBuf;
-use std::sync::Arc;
 use tempfile::TempPath;
 use unix_socket::UnixListener;
 use vtl2_settings_proto::Vtl2Settings;
@@ -135,10 +134,10 @@ impl PetriVmConfig for PetriVmConfigOpenVmm {
 /// Various channels and resources used to interact with the VM while it is running.
 struct PetriVmResourcesOpenVmm {
     serial_tasks: Vec<Task<anyhow::Result<()>>>,
-    firmware_event_recv: MpscReceiver<FirmwareEvent>,
+    firmware_event_recv: Receiver<FirmwareEvent>,
     shutdown_ic_send: Sender<ShutdownRpc>,
     expected_boot_event: Option<FirmwareEvent>,
-    ged_send: Option<Arc<Sender<get_resources::ged::GuestEmulationRequest>>>,
+    ged_send: Option<Sender<get_resources::ged::GuestEmulationRequest>>,
     pipette_listener: PolledSocket<UnixListener>,
     vtl2_pipette_listener: Option<PolledSocket<UnixListener>>,
     openhcl_diag_handler: Option<OpenHclDiagHandler>,

--- a/support/mesh/mesh_worker/src/worker.rs
+++ b/support/mesh/mesh_worker/src/worker.rs
@@ -106,7 +106,7 @@ enum LaunchType {
 ///
 /// This may be sent across processes via mesh.
 #[derive(Debug, MeshPayload)]
-pub struct WorkerHostRunner(mesh::MpscReceiver<WorkerHostLaunchRequest>);
+pub struct WorkerHostRunner(mesh::Receiver<WorkerHostLaunchRequest>);
 
 impl WorkerHostRunner {
     /// Runs the worker host until all corresponding [`WorkerHost`] instances
@@ -244,7 +244,7 @@ impl WorkerHandle {
 ///
 /// This may be sent across processes via mesh.
 #[derive(Debug, MeshPayload, Clone)]
-pub struct WorkerHost(mesh::MpscSender<WorkerHostLaunchRequest>);
+pub struct WorkerHost(mesh::Sender<WorkerHostLaunchRequest>);
 
 /// Returns a new [`WorkerHost`], [`WorkerHostRunner`] pair.
 ///

--- a/support/mesh/src/lib.rs
+++ b/support/mesh/src/lib.rs
@@ -29,8 +29,6 @@ pub use mesh_channel::pipe;
 pub use mesh_channel::rpc;
 pub use mesh_channel::ChannelError;
 pub use mesh_channel::ChannelErrorKind;
-pub use mesh_channel::MpscReceiver;
-pub use mesh_channel::MpscSender;
 pub use mesh_channel::OneshotReceiver;
 pub use mesh_channel::OneshotSender;
 pub use mesh_channel::Receiver;

--- a/support/uevent/src/lib.rs
+++ b/support/uevent/src/lib.rs
@@ -32,7 +32,7 @@ use thiserror::Error;
 /// A listener for Linux udev events.
 pub struct UeventListener {
     _task: Task<()>,
-    send: mesh::MpscSender<TaskRequest>,
+    send: mesh::Sender<TaskRequest>,
 }
 
 /// An error from [`UeventListener::new`].
@@ -282,7 +282,7 @@ impl Uevent<'_> {
 #[derive(Debug)]
 pub struct CallbackHandle {
     id: u64,
-    send: mesh::MpscSender<TaskRequest>,
+    send: mesh::Sender<TaskRequest>,
 }
 
 impl Drop for CallbackHandle {
@@ -299,7 +299,7 @@ enum TaskRequest {
 struct ListenerTask {
     socket: PolledSocket<Socket>,
     callbacks: Vec<Filter>,
-    recv: mesh::MpscReceiver<TaskRequest>,
+    recv: mesh::Receiver<TaskRequest>,
     next_id: u64,
 }
 

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -80,7 +80,7 @@ pub mod ged {
         /// Access to VTL2 functionality.
         pub guest_request_recv: mesh::Receiver<GuestEmulationRequest>,
         /// Notification of firmware events.
-        pub firmware_event_send: Option<mesh::MpscSender<FirmwareEvent>>,
+        pub firmware_event_send: Option<mesh::Sender<FirmwareEvent>>,
         /// Enable secure boot.
         pub secure_boot_enabled: bool,
         /// The secure boot template type.

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -183,7 +183,7 @@ pub struct GuestEmulationDevice {
     #[inspect(skip)]
     power_client: PowerRequestClient,
     #[inspect(skip)]
-    firmware_event_send: Option<mesh::MpscSender<FirmwareEvent>>,
+    firmware_event_send: Option<mesh::Sender<FirmwareEvent>>,
     #[inspect(skip)]
     framebuffer_control: Option<Box<dyn FramebufferControl>>,
     #[inspect(skip)]
@@ -211,7 +211,7 @@ impl GuestEmulationDevice {
     pub fn new(
         config: GuestConfig,
         power_client: PowerRequestClient,
-        firmware_event_send: Option<mesh::MpscSender<FirmwareEvent>>,
+        firmware_event_send: Option<mesh::Sender<FirmwareEvent>>,
         guest_request_recv: mesh::Receiver<GuestEmulationRequest>,
         framebuffer_control: Option<Box<dyn FramebufferControl>>,
         vmgs_disk: Option<Disk>,

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -549,7 +549,7 @@ mod inspect_helpers {
 struct HostRequestPipeAccess {
     response_message_recv_mutex: Arc<Mutex<Option<mesh::Receiver<Vec<u8>>>>>,
     response_message_recv: Option<mesh::Receiver<Vec<u8>>>,
-    request_message_send: Arc<mesh::Sender<WriteRequest>>,
+    request_message_send: mesh::Sender<WriteRequest>,
 }
 
 impl Drop for HostRequestPipeAccess {
@@ -563,7 +563,7 @@ struct PipeChannels {
     response_message_recv: Arc<Mutex<Option<mesh::Receiver<Vec<u8>>>>>,
     // This is None when a `HostRequestPipeAccess` has ownership for an IgvmAttest request.
     igvm_attest_response_message_recv: Arc<Mutex<Option<mesh::Receiver<Vec<u8>>>>>,
-    message_send: Arc<mesh::Sender<WriteRequest>>,
+    message_send: mesh::Sender<WriteRequest>,
 }
 
 enum WriteRequest {
@@ -574,7 +574,7 @@ enum WriteRequest {
 impl HostRequestPipeAccess {
     fn new(
         response_message_recv_mutex: Arc<Mutex<Option<mesh::Receiver<Vec<u8>>>>>,
-        request_message_send: Arc<mesh::Sender<WriteRequest>>,
+        request_message_send: mesh::Sender<WriteRequest>,
     ) -> Self {
         let response_message_recv = response_message_recv_mutex.lock().take().unwrap();
         Self {
@@ -672,7 +672,7 @@ impl<T: RingMem> ProcessLoop<T> {
                 igvm_attest_response_message_recv: Arc::new(Mutex::new(Some(
                     igvm_attest_read_recv,
                 ))),
-                message_send: Arc::new(write_send),
+                message_send: write_send,
             },
             read_send,
             write_recv,

--- a/vm/devices/net/net_packet_capture/src/lib.rs
+++ b/vm/devices/net/net_packet_capture/src/lib.rs
@@ -136,7 +136,7 @@ enum PacketCaptureEndpointCommand {
 }
 
 pub struct PacketCaptureEndpointControl {
-    control_tx: Arc<mesh::Sender<PacketCaptureEndpointCommand>>,
+    control_tx: mesh::Sender<PacketCaptureEndpointCommand>,
 }
 
 impl PacketCaptureEndpointControl {
@@ -198,7 +198,6 @@ impl InspectMut for PacketCaptureEndpoint {
 impl PacketCaptureEndpoint {
     pub fn new(endpoint: Box<dyn Endpoint>, id: String) -> (Self, PacketCaptureEndpointControl) {
         let (control_tx, control_rx) = mesh::channel();
-        let control_tx = Arc::new(control_tx);
         let control = PacketCaptureEndpointControl {
             control_tx: control_tx.clone(),
         };
@@ -363,11 +362,11 @@ struct Pcap {
     interface_descriptor_written: AtomicBool,
     enabled: AtomicBool,
     snaplen: AtomicUsize,
-    endpoint_control: Arc<mesh::Sender<PacketCaptureEndpointCommand>>,
+    endpoint_control: mesh::Sender<PacketCaptureEndpointCommand>,
 }
 
 impl Pcap {
-    fn new(endpoint_control: Arc<mesh::Sender<PacketCaptureEndpointCommand>>) -> Self {
+    fn new(endpoint_control: mesh::Sender<PacketCaptureEndpointCommand>) -> Self {
         Self {
             enabled: AtomicBool::new(false),
             snaplen: AtomicUsize::new(65535),

--- a/vm/devices/storage/nvme/src/workers/admin.rs
+++ b/vm/devices/storage/nvme/src/workers/admin.rs
@@ -92,7 +92,7 @@ pub struct AdminState {
     #[inspect(with = "|x| inspect::iter_by_index(x).map_key(|x| x + 1)")]
     io_cqs: Vec<Option<IoCq>>,
     #[inspect(skip)]
-    sq_delete_response: mesh::MpscReceiver<u16>,
+    sq_delete_response: mesh::Receiver<u16>,
     #[inspect(with = "Option::is_some")]
     shadow_db_evt_gpa_base: Option<ShadowDoorbell>,
     #[inspect(iter_by_index)]

--- a/vm/devices/storage/nvme/src/workers/coordinator.rs
+++ b/vm/devices/storage/nvme/src/workers/coordinator.rs
@@ -32,7 +32,7 @@ use vmcore::vm_task::VmTaskDriverSource;
 
 pub struct NvmeWorkers {
     _task: Task<()>,
-    send: mesh::MpscSender<CoordinatorRequest>,
+    send: mesh::Sender<CoordinatorRequest>,
     doorbells: Vec<Arc<DoorbellRegister>>,
     state: EnableState,
 }
@@ -184,7 +184,7 @@ impl NvmeWorkers {
 /// Client for modifying the NVMe controller state at runtime.
 #[derive(Debug)]
 pub struct NvmeControllerClient {
-    send: mesh::MpscSender<CoordinatorRequest>,
+    send: mesh::Sender<CoordinatorRequest>,
 }
 
 impl NvmeControllerClient {
@@ -230,7 +230,7 @@ struct EnableAdminParams {
 }
 
 impl Coordinator {
-    async fn run(mut self, mut recv: mesh::MpscReceiver<CoordinatorRequest>) {
+    async fn run(mut self, mut recv: mesh::Receiver<CoordinatorRequest>) {
         loop {
             enum Event {
                 Request(Option<CoordinatorRequest>),

--- a/vm/devices/storage/nvme/src/workers/io.rs
+++ b/vm/devices/storage/nvme/src/workers/io.rs
@@ -35,7 +35,7 @@ pub struct IoHandler {
     mem: GuestMemory,
     sqid: u16,
     #[inspect(skip)]
-    admin_response: mesh::MpscSender<u16>,
+    admin_response: mesh::Sender<u16>,
 }
 
 #[derive(Inspect)]
@@ -133,7 +133,7 @@ enum HandlerError {
 }
 
 impl IoHandler {
-    pub fn new(mem: GuestMemory, sqid: u16, admin_response: mesh::MpscSender<u16>) -> Self {
+    pub fn new(mem: GuestMemory, sqid: u16, admin_response: mesh::Sender<u16>) -> Self {
         Self {
             mem,
             sqid,

--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -649,7 +649,7 @@ mod tests {
     use vmcore::vm_task::VmTaskDriverSource;
 
     async fn must_recv_in_timeout<T: 'static + Send>(
-        recv: &mut mesh::MpscReceiver<T>,
+        recv: &mut mesh::Receiver<T>,
         timeout: Duration,
     ) -> T {
         mesh::CancelContext::new()

--- a/vm/devices/vmbus/vmbus_channel/src/channel.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/channel.rs
@@ -139,7 +139,7 @@ pub struct ChannelResources {
 /// Control object for enabling subchannels.
 #[derive(Debug, Default, Clone)]
 pub struct ChannelControl {
-    send: Option<Arc<mesh::Sender<u16>>>,
+    send: Option<mesh::Sender<u16>>,
     max: u16,
 }
 
@@ -370,7 +370,7 @@ async fn offer_generic(
         gpadl_map: gpadl_map.clone().view(),
         channels: resources,
         channel_control: ChannelControl {
-            send: Some(Arc::new(subchannel_enable_send)),
+            send: Some(subchannel_enable_send),
             max: max_subchannels,
         },
     });

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -89,7 +89,7 @@ pub enum ConnectError {
 
 #[derive(Clone)]
 pub struct VmbusClientAccess {
-    client_request_send: Arc<mesh::Sender<ClientRequest>>,
+    client_request_send: mesh::Sender<ClientRequest>,
 }
 
 impl VmbusClient {
@@ -127,7 +127,7 @@ impl VmbusClient {
 
         Self {
             access: VmbusClientAccess {
-                client_request_send: Arc::new(client_request_send),
+                client_request_send,
             },
             task_send,
             _thread: thread,

--- a/vm/devices/vmbus/vmbus_server/src/hvsock.rs
+++ b/vm/devices/vmbus/vmbus_server/src/hvsock.rs
@@ -39,7 +39,7 @@ use vmbus_core::HvsockConnectResult;
 
 pub struct HvsockRelay {
     inner: Arc<RelayInner>,
-    host_send: Arc<mesh::Sender<RelayRequest>>,
+    host_send: mesh::Sender<RelayRequest>,
     _relay_task: Task<()>,
     _listener_task: Option<Task<()>>,
 }
@@ -69,14 +69,13 @@ impl HvsockRelay {
         });
 
         let worker = HvsockRelayWorker {
-            guest_send: Arc::new(guest.response_send),
+            guest_send: guest.response_send,
             inner: inner.clone(),
             tasks: Default::default(),
             hybrid_vsock_path,
         };
 
         let (host_send, host_recv) = mesh::channel();
-        let host_send = Arc::new(host_send);
 
         let _listener_task = if let Some(listener) = hybrid_vsock_listener {
             let listener = PolledSocket::new(inner.driver.as_ref(), listener)?;
@@ -145,7 +144,7 @@ impl HvsockRelay {
 
 struct ListenerWorker {
     inner: Arc<RelayInner>,
-    host_send: Arc<mesh::Sender<RelayRequest>>,
+    host_send: mesh::Sender<RelayRequest>,
 }
 
 impl ListenerWorker {
@@ -291,7 +290,7 @@ async fn read_hybrid_vsock_connect(
 }
 
 struct PendingConnection {
-    send: Arc<mesh::Sender<HvsockConnectResult>>,
+    send: mesh::Sender<HvsockConnectResult>,
     request: HvsockConnectRequest,
 }
 
@@ -323,7 +322,7 @@ fn vsock_port(service_id: &Guid) -> Option<u32> {
 }
 
 struct HvsockRelayWorker {
-    guest_send: Arc<mesh::Sender<HvsockConnectResult>>,
+    guest_send: mesh::Sender<HvsockConnectResult>,
     tasks: FuturesUnordered<Task<()>>,
     inner: Arc<RelayInner>,
     hybrid_vsock_path: Option<PathBuf>,

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -608,7 +608,7 @@ struct ServerTask {
     running: bool,
     server: channels::Server,
     task_recv: mesh::Receiver<VmbusRequest>,
-    offer_recv: mesh::MpscReceiver<OfferRequest>,
+    offer_recv: mesh::Receiver<OfferRequest>,
     message_recv: mpsc::Receiver<SynicMessage>,
     server_request_recv: SelectAll<TaggedStream<OfferId, mesh::Receiver<ChannelServerRequest>>>,
     inner: ServerTaskInner,
@@ -1721,7 +1721,7 @@ impl ServerTaskInner {
 pub struct VmbusServerControl {
     mem: GuestMemory,
     private_mem: Option<GuestMemory>,
-    send: mesh::MpscSender<OfferRequest>,
+    send: mesh::Sender<OfferRequest>,
     use_event: bool,
     force_confidential_external_memory: bool,
 }

--- a/vm/vmcore/src/vmtime.rs
+++ b/vm/vmcore/src/vmtime.rs
@@ -536,7 +536,7 @@ impl VmTimeKeeper {
 /// in sync with each other.
 #[derive(MeshPayload, Clone, Debug)]
 pub struct VmTimeSourceBuilder {
-    new_send: mesh::MpscSender<NewKeeperRequest>,
+    new_send: mesh::Sender<NewKeeperRequest>,
 }
 
 /// Error returned by [`VmTimeSourceBuilder::build`] when the time keeper has
@@ -590,7 +590,7 @@ struct PrimaryKeeper {
     #[inspect(skip)]
     req_recv: mesh::Receiver<KeeperRequest>,
     #[inspect(skip)]
-    new_recv: mesh::MpscReceiver<NewKeeperRequest>,
+    new_recv: mesh::Receiver<NewKeeperRequest>,
     #[inspect(skip)]
     keepers: Vec<(u64, mesh::Sender<KeeperRequest>)>,
     #[inspect(skip)]

--- a/vm/vmgs/vmgs_broker/src/broker.rs
+++ b/vm/vmgs/vmgs_broker/src/broker.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use mesh_channel::rpc::Rpc;
-use mesh_channel::MpscReceiver;
+use mesh_channel::Receiver;
 use vmgs::Vmgs;
 use vmgs::VmgsFileInfo;
 use vmgs_format::FileId;
@@ -27,7 +27,7 @@ impl VmgsBrokerTask {
         VmgsBrokerTask { vmgs }
     }
 
-    pub async fn run(&mut self, mut recv: MpscReceiver<VmgsBrokerRpc>) {
+    pub async fn run(&mut self, mut recv: Receiver<VmgsBrokerRpc>) {
         loop {
             match recv.recv().await {
                 Ok(message) => self.process_message(message).await,

--- a/vm/vmgs/vmgs_broker/src/client.rs
+++ b/vm/vmgs/vmgs_broker/src/client.rs
@@ -37,7 +37,7 @@ impl From<RpcError<vmgs::Error>> for VmgsClientError {
 /// Client to interact with a backend-agnostic VMGS instance.
 #[derive(Clone)]
 pub struct VmgsClient {
-    pub(crate) control: mesh_channel::MpscSender<VmgsBrokerRpc>,
+    pub(crate) control: mesh_channel::Sender<VmgsBrokerRpc>,
 }
 
 impl Inspect for VmgsClient {

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -745,7 +745,7 @@ impl VpSet {
             recv,
             _done: done_send,
             cancel_recv,
-            cancel_send: Arc::new(cancel_send),
+            cancel_send,
             inner: RunnerInner {
                 vp: vp.as_ref().vp_index,
                 inner: self.inner.clone(),
@@ -1015,14 +1015,14 @@ enum DebugEvent {
 #[must_use]
 pub struct VpRunner {
     recv: mesh::Receiver<VpEvent>,
-    cancel_send: Arc<mesh::Sender<()>>,
+    cancel_send: mesh::Sender<()>,
     cancel_recv: mesh::Receiver<()>,
     _done: mesh::OneshotSender<()>,
     inner: RunnerInner,
 }
 
 /// An object that can cancel a pending call into [`VpRunner::run`].
-pub struct RunnerCanceller(Arc<mesh::Sender<()>>);
+pub struct RunnerCanceller(mesh::Sender<()>);
 
 impl RunnerCanceller {
     /// Requests that the current or next call to [`VpRunner::run`] return as

--- a/vmm_core/state_unit/src/lib.rs
+++ b/vmm_core/state_unit/src/lib.rs
@@ -242,7 +242,7 @@ struct Inner {
 #[derive(Debug)]
 struct Unit {
     name: Arc<str>,
-    send: Arc<Sender<StateRequest>>,
+    send: Sender<StateRequest>,
     dependencies: Vec<u64>,
     dependents: Vec<u64>,
     state: State,
@@ -981,7 +981,7 @@ impl UnitBuilder<'_> {
                 id,
                 Unit {
                     name: self.name.clone(),
-                    send: Arc::new(send),
+                    send,
                     dependencies: self.dependencies,
                     dependents: self.dependents,
                     state: State::Stopped,

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -242,7 +242,7 @@ impl<T: Listener> inspect::Inspect for Server<T> {
 }
 
 struct VncInput {
-    send: mesh::MpscSender<InputData>,
+    send: mesh::Sender<InputData>,
 }
 
 impl vnc::Input for VncInput {

--- a/workers/vnc_worker_defs/src/lib.rs
+++ b/workers/vnc_worker_defs/src/lib.rs
@@ -13,7 +13,7 @@ pub struct VncParameters<T> {
     /// The framebuffer memory.
     pub framebuffer: framebuffer::FramebufferAccess,
     /// A channel to send input to.
-    pub input_send: mesh::MpscSender<input_core::InputData>,
+    pub input_send: mesh::Sender<input_core::InputData>,
 }
 
 pub const VNC_WORKER_TCP: WorkerId<VncParameters<TcpListener>> = WorkerId::new("VncWorkerTcp");


### PR DESCRIPTION
Replace uses of `MpscSender` and `Arc<Sender>` with just `Sender`, since `Sender` now implements `Clone` directly.