### PR TITLE
xsync: speed up cargo-lock regen

### DIFF
--- a/xsync/xsync/src/tasks/cargo_lock.rs
+++ b/xsync/xsync/src/tasks/cargo_lock.rs
@@ -235,6 +235,7 @@ impl Cmd for CargoLock {
                 std::process::Command::new("cargo")
                     .arg("update")
                     .arg("--workspace")
+                    .arg("--offline")
                     .current_dir(&ctx.overlay_workspace)
                     .stdout(std::process::Stdio::null())
                     .stderr(std::process::Stdio::null())


### PR DESCRIPTION
When using `cargo update` to update the generated `Cargo.lock` file, pass `--offline` to avoid connecting to crates.io. Since we pass `--workspace`, there should be no reason to fetch anything from the network in this step.

This saves several seconds when calling `cargo xtask fmt`.