### PR TITLE
guid: define macro for compile-time GUIDs

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1815,7 +1815,7 @@ async fn new_underhill_vm(
     if env_cfg.mcr {
         use crate::dispatch::vtl2_settings_worker::UhVpciDeviceConfig;
         tracing::info!("Instantiating The MCR Device");
-        const MCR_INSTANCE_ID: Guid = Guid::from_static_str("07effd8f-7501-426c-a947-d8345f39113d");
+        const MCR_INSTANCE_ID: Guid = guid::guid!("07effd8f-7501-426c-a947-d8345f39113d");
 
         let res = UhVpciDeviceConfig {
             instance_id: MCR_INSTANCE_ID,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -562,7 +562,7 @@ fn vm_config_from_command_line(
         tracing::info!("Instantiating MCR controller");
 
         // Arbitrary but constant instance ID to be consistent across boots.
-        const MCR_INSTANCE_ID: Guid = Guid::from_static_str("07effd8f-7501-426c-a947-d8345f39113d");
+        const MCR_INSTANCE_ID: Guid = guid::guid!("07effd8f-7501-426c-a947-d8345f39113d");
 
         vpci_devices.push(VpciDeviceConfig {
             vtl: DeviceVtl::Vtl0,
@@ -584,7 +584,7 @@ fn vm_config_from_command_line(
 
         // Pick a fixed instance ID based on the index.
         const BASE_INSTANCE_ID: Guid =
-            Guid::from_static_str("00000000-435d-11ee-9f59-00155d5016fc");
+            guid::guid!("00000000-435d-11ee-9f59-00155d5016fc");
         let instance_id = Guid {
             data1: index as u32,
             ..BASE_INSTANCE_ID
@@ -1408,7 +1408,7 @@ fn parse_endpoint(
     getrandom::getrandom(&mut mac_address[3..]).expect("rng failure");
 
     // Pick a fixed instance ID based on the index.
-    const BASE_INSTANCE_ID: Guid = Guid::from_static_str("00000000-da43-11ed-936a-00155d6db52f");
+    const BASE_INSTANCE_ID: Guid = guid::guid!("00000000-da43-11ed-936a-00155d6db52f");
     let instance_id = Guid {
         data1: *index as u32,
         ..BASE_INSTANCE_ID

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -583,8 +583,7 @@ fn vm_config_from_command_line(
         getrandom::getrandom(&mut mac_address[3..]).expect("rng failure");
 
         // Pick a fixed instance ID based on the index.
-        const BASE_INSTANCE_ID: Guid =
-            guid::guid!("00000000-435d-11ee-9f59-00155d5016fc");
+        const BASE_INSTANCE_ID: Guid = guid::guid!("00000000-435d-11ee-9f59-00155d5016fc");
         let instance_id = Guid {
             data1: index as u32,
             ..BASE_INSTANCE_ID

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -57,14 +57,14 @@ impl From<UnderhillDiskSource> for DiskLocation {
 
 // Arbitrary but constant instance IDs to maintain the same device IDs
 // across reboots.
-const NVME_VTL0_INSTANCE_ID: Guid = Guid::from_static_str("008091f6-9688-497d-9091-af347dc9173c");
-const NVME_VTL2_INSTANCE_ID: Guid = Guid::from_static_str("f9b90f6f-b129-4596-8171-a23481b8f718");
-const SCSI_VTL0_INSTANCE_ID: Guid = Guid::from_static_str("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
-const SCSI_VTL2_INSTANCE_ID: Guid = Guid::from_static_str("73d3aa59-b82b-4fe7-9e15-e2b0b5575cf8");
+const NVME_VTL0_INSTANCE_ID: Guid = guid::guid!("008091f6-9688-497d-9091-af347dc9173c");
+const NVME_VTL2_INSTANCE_ID: Guid = guid::guid!("f9b90f6f-b129-4596-8171-a23481b8f718");
+const SCSI_VTL0_INSTANCE_ID: Guid = guid::guid!("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
+const SCSI_VTL2_INSTANCE_ID: Guid = guid::guid!("73d3aa59-b82b-4fe7-9e15-e2b0b5575cf8");
 const UNDERHILL_VTL0_SCSI_INSTANCE: Guid =
-    Guid::from_static_str("e1c5bd94-d0d6-41d4-a2b0-88095a16ded7");
+    guid::guid!("e1c5bd94-d0d6-41d4-a2b0-88095a16ded7");
 const UNDERHILL_VTL0_NVME_INSTANCE: Guid =
-    Guid::from_static_str("09a59b81-2bf6-4164-81d7-3a0dc977ba65");
+    guid::guid!("09a59b81-2bf6-4164-81d7-3a0dc977ba65");
 
 impl StorageBuilder {
     pub fn new(openhcl_vtl: Option<DeviceVtl>) -> Self {

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -61,10 +61,8 @@ const NVME_VTL0_INSTANCE_ID: Guid = guid::guid!("008091f6-9688-497d-9091-af347dc
 const NVME_VTL2_INSTANCE_ID: Guid = guid::guid!("f9b90f6f-b129-4596-8171-a23481b8f718");
 const SCSI_VTL0_INSTANCE_ID: Guid = guid::guid!("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
 const SCSI_VTL2_INSTANCE_ID: Guid = guid::guid!("73d3aa59-b82b-4fe7-9e15-e2b0b5575cf8");
-const UNDERHILL_VTL0_SCSI_INSTANCE: Guid =
-    guid::guid!("e1c5bd94-d0d6-41d4-a2b0-88095a16ded7");
-const UNDERHILL_VTL0_NVME_INSTANCE: Guid =
-    guid::guid!("09a59b81-2bf6-4164-81d7-3a0dc977ba65");
+const UNDERHILL_VTL0_SCSI_INSTANCE: Guid = guid::guid!("e1c5bd94-d0d6-41d4-a2b0-88095a16ded7");
+const UNDERHILL_VTL0_NVME_INSTANCE: Guid = guid::guid!("09a59b81-2bf6-4164-81d7-3a0dc977ba65");
 
 impl StorageBuilder {
     pub fn new(openhcl_vtl: Option<DeviceVtl>) -> Self {

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -519,7 +519,7 @@ impl VmService {
                 config.vmbus_devices.push((
                     DeviceVtl::Vtl0,
                     ScsiControllerHandle {
-                        instance_id: Guid::from_static_str("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f"),
+                        instance_id: guid::guid!("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f"),
                         max_sub_channel_count: 0,
                         devices,
                         io_queue_depth: None,

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -45,12 +45,10 @@ use unix_socket::UnixListener;
 use vtl2_settings_proto::Vtl2Settings;
 
 /// The instance guid used for all of our SCSI drives.
-pub(crate) const SCSI_INSTANCE: Guid =
-    guid::guid!("27b553e8-8b39-411b-a55f-839971a7884f");
+pub(crate) const SCSI_INSTANCE: Guid = guid::guid!("27b553e8-8b39-411b-a55f-839971a7884f");
 
 /// The instance guid for the NVMe controller automatically added for boot media.
-pub(crate) const BOOT_NVME_INSTANCE: Guid =
-    guid::guid!("92bc8346-718b-449a-8751-edbf3dcd27e4");
+pub(crate) const BOOT_NVME_INSTANCE: Guid = guid::guid!("92bc8346-718b-449a-8751-edbf3dcd27e4");
 
 /// The instance guid for the MANA nic automatically added when specifying `PetriVmConfigOpenVmm::with_nic`
 const MANA_INSTANCE: Guid = guid::guid!("f9641cf4-d915-4743-a7d8-efa75db7b85a");

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -46,14 +46,14 @@ use vtl2_settings_proto::Vtl2Settings;
 
 /// The instance guid used for all of our SCSI drives.
 pub(crate) const SCSI_INSTANCE: Guid =
-    Guid::from_static_str("27b553e8-8b39-411b-a55f-839971a7884f");
+    guid::guid!("27b553e8-8b39-411b-a55f-839971a7884f");
 
 /// The instance guid for the NVMe controller automatically added for boot media.
 pub(crate) const BOOT_NVME_INSTANCE: Guid =
-    Guid::from_static_str("92bc8346-718b-449a-8751-edbf3dcd27e4");
+    guid::guid!("92bc8346-718b-449a-8751-edbf3dcd27e4");
 
 /// The instance guid for the MANA nic automatically added when specifying `PetriVmConfigOpenVmm::with_nic`
-const MANA_INSTANCE: Guid = Guid::from_static_str("f9641cf4-d915-4743-a7d8-efa75db7b85a");
+const MANA_INSTANCE: Guid = guid::guid!("f9641cf4-d915-4743-a7d8-efa75db7b85a");
 
 /// The namespace ID for the NVMe controller automatically added for boot media.
 pub(crate) const BOOT_NVME_NSID: u32 = 37;

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -134,8 +134,7 @@ impl PetriVmConfigOpenVmm {
     /// for it to connect. This is useful for tests where the first boot attempt
     /// is expected to not succeed, but pipette functionality is still desired.
     pub async fn run_with_lazy_pipette(mut self) -> anyhow::Result<PetriVmOpenVmm> {
-        const CIDATA_SCSI_INSTANCE: Guid =
-            guid::guid!("766e96f8-2ceb-437e-afe3-a93169e48a7b");
+        const CIDATA_SCSI_INSTANCE: Guid = guid::guid!("766e96f8-2ceb-437e-afe3-a93169e48a7b");
 
         // Construct the agent disk.
         let agent_disk = self

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -135,7 +135,7 @@ impl PetriVmConfigOpenVmm {
     /// is expected to not succeed, but pipette functionality is still desired.
     pub async fn run_with_lazy_pipette(mut self) -> anyhow::Result<PetriVmOpenVmm> {
         const CIDATA_SCSI_INSTANCE: Guid =
-            Guid::from_static_str("766e96f8-2ceb-437e-afe3-a93169e48a7b");
+            guid::guid!("766e96f8-2ceb-437e-afe3-a93169e48a7b");
 
         // Construct the agent disk.
         let agent_disk = self
@@ -192,7 +192,7 @@ impl PetriVmConfigOpenVmm {
         if self.firmware.is_openhcl() {
             // Add a second pipette disk for VTL 2
             const UH_CIDATA_SCSI_INSTANCE: Guid =
-                Guid::from_static_str("766e96f8-2ceb-437e-afe3-a93169e48a7c");
+                guid::guid!("766e96f8-2ceb-437e-afe3-a93169e48a7c");
 
             let uh_agent_disk = self
                 .resources

--- a/support/guid/src/lib.rs
+++ b/support/guid/src/lib.rs
@@ -70,7 +70,7 @@ macro_rules! result_helper {
 macro_rules! guid {
     ($x:expr) => {
         const { $crate::Guid::from_static_str($x) }
-    }
+    };
 }
 
 impl Guid {
@@ -312,6 +312,7 @@ mod windows {
 
 #[cfg(test)]
 mod tests {
+    use super::guid;
     use super::Guid;
 
     #[test]
@@ -347,10 +348,9 @@ mod tests {
         );
 
         // Test GUID parsing at compile time.
-        const TEST_GUID: Guid = guid::guid!("cf127acc-c960-41e4-9b1e-513e8a89147d");
+        const TEST_GUID: Guid = guid!("cf127acc-c960-41e4-9b1e-513e8a89147d");
         assert_eq!(guid, TEST_GUID);
-        const TEST_BRACED_GUID: Guid =
-            guid::guid!("{cf127acc-c960-41e4-9b1e-513e8a89147d}");
+        const TEST_BRACED_GUID: Guid = guid!("{cf127acc-c960-41e4-9b1e-513e8a89147d}");
         assert_eq!(guid, TEST_BRACED_GUID);
     }
 }

--- a/support/guid/src/lib.rs
+++ b/support/guid/src/lib.rs
@@ -63,6 +63,16 @@ macro_rules! result_helper {
     };
 }
 
+/// Creates a new GUID from a string, parsing the GUID at compile time.
+/// "{00000000-0000-0000-0000-000000000000}" and
+/// "00000000-0000-0000-0000-000000000000".
+#[macro_export]
+macro_rules! guid {
+    ($x:expr) => {
+        const { $crate::Guid::from_static_str($x) }
+    }
+}
+
 impl Guid {
     /// Return a new randomly-generated Version 4 UUID
     pub fn new_random() -> Self {
@@ -76,15 +86,11 @@ impl Guid {
         guid
     }
 
-    /// Creates a new GUID from a string, panicking if the input is invalid. Accepted formats are
-    /// "{00000000-0000-0000-0000-000000000000}" and "00000000-0000-0000-0000-000000000000".
+    /// Used by [`guid`] macro.
     ///
-    /// # Note
-    ///
-    /// This is a const function, intended to initialize GUID constants at compile time.
-    /// While it can be used at runtime, it will panic if the input is invalid. For initializing
-    /// non-constants, `from_str` should be used instead.
-    pub const fn from_static_str(value: &'static str) -> Guid {
+    /// FUTURE: rename once all callers are updated to use the macro.
+    #[doc(hidden)]
+    pub const fn from_static_str(value: &str) -> Guid {
         // Unwrap and expect are not supported in const fn.
         match Self::parse(value.as_bytes()) {
             Ok(guid) => guid,
@@ -136,7 +142,7 @@ impl Guid {
     }
 
     /// The all-zero GUID.
-    pub const ZERO: Self = Self::from_static_str("00000000-0000-0000-0000-000000000000");
+    pub const ZERO: Self = guid!("00000000-0000-0000-0000-000000000000");
 
     /// Returns true if this is the all-zero GUID.
     pub fn is_zero(&self) -> bool {
@@ -341,10 +347,10 @@ mod tests {
         );
 
         // Test GUID parsing at compile time.
-        const TEST_GUID: Guid = Guid::from_static_str("cf127acc-c960-41e4-9b1e-513e8a89147d");
+        const TEST_GUID: Guid = guid::guid!("cf127acc-c960-41e4-9b1e-513e8a89147d");
         assert_eq!(guid, TEST_GUID);
         const TEST_BRACED_GUID: Guid =
-            Guid::from_static_str("{cf127acc-c960-41e4-9b1e-513e8a89147d}");
+            guid::guid!("{cf127acc-c960-41e4-9b1e-513e8a89147d}");
         assert_eq!(guid, TEST_BRACED_GUID);
     }
 }

--- a/support/serde_helpers/src/lib.rs
+++ b/support/serde_helpers/src/lib.rs
@@ -194,7 +194,7 @@ mod test {
         assert_eq!(guid_sample.field1, 123);
         assert_eq!(
             guid_sample.field2.expect("field2 set"),
-            Guid::from_static_str("12345678-9abc-def0-1234-56789abcdef0")
+            guid::guid!("12345678-9abc-def0-1234-56789abcdef0")
         );
 
         let json = r#"

--- a/vm/devices/firmware/firmware_uefi/fuzz/fuzz_firmware_uefi.rs
+++ b/vm/devices/firmware/firmware_uefi/fuzz/fuzz_firmware_uefi.rs
@@ -157,7 +157,7 @@ fn test_signature_lists() -> Vec<u8> {
     buf
 }
 
-const VALID_OWNER: Guid = Guid::from_static_str("77fa9abd-0359-4d32-bd60-28f4e78f784b");
+const VALID_OWNER: Guid = guid::guid!("77fa9abd-0359-4d32-bd60-28f4e78f784b");
 
 fn test_valid_signature_lists() -> Vec<u8> {
     let lists = vec![

--- a/vm/devices/firmware/uefi_specs/src/hyperv/mod.rs
+++ b/vm/devices/firmware/uefi_specs/src/hyperv/mod.rs
@@ -18,8 +18,8 @@ use guid::Guid;
 
 /// MsvmPkg: `gEfiVmbusChannelDevicePathGuid`
 pub const VM_HW_VENDOR_VMBUS_GUID: Guid =
-    Guid::from_static_str("9b17e5a2-0891-42dd-b653-80b5c22809ba");
+    guid::guid!("9b17e5a2-0891-42dd-b653-80b5c22809ba");
 
 /// MsvmPkg: `gSyntheticStorageClassGuid`
 pub const VM_DISK_VMBUS_CHILD_GUID: Guid =
-    Guid::from_static_str("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
+    guid::guid!("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");

--- a/vm/devices/firmware/uefi_specs/src/hyperv/mod.rs
+++ b/vm/devices/firmware/uefi_specs/src/hyperv/mod.rs
@@ -17,9 +17,7 @@ pub mod time;
 use guid::Guid;
 
 /// MsvmPkg: `gEfiVmbusChannelDevicePathGuid`
-pub const VM_HW_VENDOR_VMBUS_GUID: Guid =
-    guid::guid!("9b17e5a2-0891-42dd-b653-80b5c22809ba");
+pub const VM_HW_VENDOR_VMBUS_GUID: Guid = guid::guid!("9b17e5a2-0891-42dd-b653-80b5c22809ba");
 
 /// MsvmPkg: `gSyntheticStorageClassGuid`
-pub const VM_DISK_VMBUS_CHILD_GUID: Guid =
-    guid::guid!("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
+pub const VM_DISK_VMBUS_CHILD_GUID: Guid = guid::guid!("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");

--- a/vm/devices/firmware/uefi_specs/src/hyperv/nvram.rs
+++ b/vm/devices/firmware/uefi_specs/src/hyperv/nvram.rs
@@ -143,14 +143,12 @@ pub struct NvramSignalRuntimeCommand {
 pub mod vars {
     use guid::Guid;
 
-    const SECURE_BOOT_ENABLE_GUID: Guid =
-        guid::guid!("f0a30bc7-af08-4556-99c4-001009c93a44");
+    const SECURE_BOOT_ENABLE_GUID: Guid = guid::guid!("f0a30bc7-af08-4556-99c4-001009c93a44");
 
     pub const MSFT_SECURE_BOOT_PRODUCTION_GUID: Guid =
         guid::guid!("77fa9abd-0359-4d32-bd60-28f4e78f784b");
 
-    const EFI_HYPERV_PRIVATE_GUID: Guid =
-        guid::guid!("610b9e98-c6f6-47f8-8b47-2d2da0d52a91");
+    const EFI_HYPERV_PRIVATE_GUID: Guid = guid::guid!("610b9e98-c6f6-47f8-8b47-2d2da0d52a91");
 
     defn_nvram_var!(SECURE_BOOT_ENABLE = (SECURE_BOOT_ENABLE_GUID, "SecureBootEnable"));
     defn_nvram_var!(CURRENT_POLICY = (MSFT_SECURE_BOOT_PRODUCTION_GUID, "CurrentPolicy"));

--- a/vm/devices/firmware/uefi_specs/src/hyperv/nvram.rs
+++ b/vm/devices/firmware/uefi_specs/src/hyperv/nvram.rs
@@ -144,13 +144,13 @@ pub mod vars {
     use guid::Guid;
 
     const SECURE_BOOT_ENABLE_GUID: Guid =
-        Guid::from_static_str("f0a30bc7-af08-4556-99c4-001009c93a44");
+        guid::guid!("f0a30bc7-af08-4556-99c4-001009c93a44");
 
     pub const MSFT_SECURE_BOOT_PRODUCTION_GUID: Guid =
-        Guid::from_static_str("77fa9abd-0359-4d32-bd60-28f4e78f784b");
+        guid::guid!("77fa9abd-0359-4d32-bd60-28f4e78f784b");
 
     const EFI_HYPERV_PRIVATE_GUID: Guid =
-        Guid::from_static_str("610b9e98-c6f6-47f8-8b47-2d2da0d52a91");
+        guid::guid!("610b9e98-c6f6-47f8-8b47-2d2da0d52a91");
 
     defn_nvram_var!(SECURE_BOOT_ENABLE = (SECURE_BOOT_ENABLE_GUID, "SecureBootEnable"));
     defn_nvram_var!(CURRENT_POLICY = (MSFT_SECURE_BOOT_PRODUCTION_GUID, "CurrentPolicy"));

--- a/vm/devices/firmware/uefi_specs/src/linux/nvram.rs
+++ b/vm/devices/firmware/uefi_specs/src/linux/nvram.rs
@@ -7,7 +7,7 @@ pub mod vars {
     use guid::Guid;
 
     const EFI_IMAGE_SECURITY_MOK_DATABASE_GUID: Guid =
-        Guid::from_static_str("605dab50-e046-4300-abb6-3dd810dd8b23");
+        guid::guid!("605dab50-e046-4300-abb6-3dd810dd8b23");
 
     defn_nvram_var!(MOK_LIST = (EFI_IMAGE_SECURITY_MOK_DATABASE_GUID, "MokList"));
     defn_nvram_var!(MOK_LISTX = (EFI_IMAGE_SECURITY_MOK_DATABASE_GUID, "MokListX"));

--- a/vm/devices/firmware/uefi_specs/src/uefi/nvram.rs
+++ b/vm/devices/firmware/uefi_specs/src/uefi/nvram.rs
@@ -154,11 +154,9 @@ pub mod signature_list {
         // UINT8 SignatureData[…];
     }
 
-    pub const EFI_CERT_SHA256_GUID: Guid =
-        guid::guid!("c1c41626-504c-4092-aca9-41f936934328");
+    pub const EFI_CERT_SHA256_GUID: Guid = guid::guid!("c1c41626-504c-4092-aca9-41f936934328");
 
-    pub const EFI_CERT_X509_GUID: Guid =
-        guid::guid!("a5c059a1-94e4-4aa7-87b5-ab155c2bf072");
+    pub const EFI_CERT_X509_GUID: Guid = guid::guid!("a5c059a1-94e4-4aa7-87b5-ab155c2bf072");
 }
 
 /// Check if the specified variable is a secure boot policy variable, as
@@ -189,8 +187,7 @@ pub mod vars {
     use guid::Guid;
 
     /// UEFI spec 3.3 - Globally Defined Variables
-    pub const EFI_GLOBAL_VARIABLE: Guid =
-        guid::guid!("8BE4DF61-93CA-11D2-AA0D-00E098032B8C");
+    pub const EFI_GLOBAL_VARIABLE: Guid = guid::guid!("8BE4DF61-93CA-11D2-AA0D-00E098032B8C");
 
     /// UEFI spec 32.6.1 - UEFI Image Variable GUID & Variable Name
     pub const IMAGE_SECURITY_DATABASE_GUID: Guid =

--- a/vm/devices/firmware/uefi_specs/src/uefi/nvram.rs
+++ b/vm/devices/firmware/uefi_specs/src/uefi/nvram.rs
@@ -155,10 +155,10 @@ pub mod signature_list {
     }
 
     pub const EFI_CERT_SHA256_GUID: Guid =
-        Guid::from_static_str("c1c41626-504c-4092-aca9-41f936934328");
+        guid::guid!("c1c41626-504c-4092-aca9-41f936934328");
 
     pub const EFI_CERT_X509_GUID: Guid =
-        Guid::from_static_str("a5c059a1-94e4-4aa7-87b5-ab155c2bf072");
+        guid::guid!("a5c059a1-94e4-4aa7-87b5-ab155c2bf072");
 }
 
 /// Check if the specified variable is a secure boot policy variable, as
@@ -190,11 +190,11 @@ pub mod vars {
 
     /// UEFI spec 3.3 - Globally Defined Variables
     pub const EFI_GLOBAL_VARIABLE: Guid =
-        Guid::from_static_str("8BE4DF61-93CA-11D2-AA0D-00E098032B8C");
+        guid::guid!("8BE4DF61-93CA-11D2-AA0D-00E098032B8C");
 
     /// UEFI spec 32.6.1 - UEFI Image Variable GUID & Variable Name
     pub const IMAGE_SECURITY_DATABASE_GUID: Guid =
-        Guid::from_static_str("d719b2cb-3d3a-4596-a3bc-dad00e67656f");
+        guid::guid!("d719b2cb-3d3a-4596-a3bc-dad00e67656f");
 
     defn_nvram_var!(SECURE_BOOT = (EFI_GLOBAL_VARIABLE, "SecureBoot"));
     defn_nvram_var!(SETUP_MODE = (EFI_GLOBAL_VARIABLE, "SetupMode"));

--- a/vm/devices/firmware/uefi_specs/src/uefi/signing.rs
+++ b/vm/devices/firmware/uefi_specs/src/uefi/signing.rs
@@ -46,7 +46,7 @@ pub struct WIN_CERTIFICATE_UEFI_GUID {
 
 /// UEFI spec 32.2.4 - WIN_CERTIFICATE_UEFI_GUID
 pub const EFI_CERT_TYPE_PKCS7_GUID: Guid =
-    Guid::from_static_str("4aafd29d-68df-49ee-8aa9-347d375665a7");
+    guid::guid!("4aafd29d-68df-49ee-8aa9-347d375665a7");
 
 // UEFI spec 32.2.4 - WIN_CERTIFICATE
 

--- a/vm/devices/firmware/uefi_specs/src/uefi/signing.rs
+++ b/vm/devices/firmware/uefi_specs/src/uefi/signing.rs
@@ -45,8 +45,7 @@ pub struct WIN_CERTIFICATE_UEFI_GUID {
 }
 
 /// UEFI spec 32.2.4 - WIN_CERTIFICATE_UEFI_GUID
-pub const EFI_CERT_TYPE_PKCS7_GUID: Guid =
-    guid::guid!("4aafd29d-68df-49ee-8aa9-347d375665a7");
+pub const EFI_CERT_TYPE_PKCS7_GUID: Guid = guid::guid!("4aafd29d-68df-49ee-8aa9-347d375665a7");
 
 // UEFI spec 32.2.4 - WIN_CERTIFICATE
 

--- a/vm/devices/get/get_protocol/src/crash.rs
+++ b/vm/devices/get/get_protocol/src/crash.rs
@@ -11,7 +11,7 @@ use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 use zerocopy::Unaligned;
 
-pub const CRASHDUMP_GUID: Guid = Guid::from_static_str("427b03e7-4ceb-4286-b5fc-486f4a1dd439");
+pub const CRASHDUMP_GUID: Guid = guid::guid!("427b03e7-4ceb-4286-b5fc-486f4a1dd439");
 
 /// Capabilities supported by the host crash dump services
 #[bitfield(u64)]

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -31,15 +31,15 @@ const_assert!(MAX_MESSAGE_SIZE >= MAX_HEADER_SIZE + MAX_PAYLOAD_SIZE);
 
 /// {455C0F1B-D51B-40B1-BEAC-87377FE6E041}
 pub const GUEST_EMULATION_DEVICE_ID: Guid =
-    Guid::from_static_str("455c0f1b-d51b-40b1-beac-87377fe6e041");
+    guid::guid!("455c0f1b-d51b-40b1-beac-87377fe6e041");
 
 /// {8DEDD1AA-9056-49E4-BFD6-1BF90DC38EF0}
 pub const GUEST_EMULATION_INTERFACE_TYPE: Guid =
-    Guid::from_static_str("8dedd1aa-9056-49e4-bfd6-1bf90dc38ef0");
+    guid::guid!("8dedd1aa-9056-49e4-bfd6-1bf90dc38ef0");
 
 /// {D3E4454D-62AF-44EC-B851-3170915E5F56}
 pub const GUEST_EMULATION_INTERFACE_INSTANCE: Guid =
-    Guid::from_static_str("d3e4454d-62af-44ec-b851-3170915e5f56");
+    guid::guid!("d3e4454d-62af-44ec-b851-3170915e5f56");
 
 /// Make protocol version
 const fn make_version(major: u16, minor: u16) -> u32 {
@@ -1541,7 +1541,7 @@ impl ModifyVtl2SettingsCompleteNotification {
 }
 
 pub const GET_LOG_INTERFACE_GUID: Guid =
-    Guid::from_static_str("AA5DE534-D149-487A-9053-05972BA20A7C");
+    guid::guid!("AA5DE534-D149-487A-9053-05972BA20A7C");
 
 open_enum! {
     #[derive(IntoBytes, FromBytes, Immutable, KnownLayout)]

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -30,8 +30,7 @@ pub const MAX_PAYLOAD_SIZE: usize = 8192;
 const_assert!(MAX_MESSAGE_SIZE >= MAX_HEADER_SIZE + MAX_PAYLOAD_SIZE);
 
 /// {455C0F1B-D51B-40B1-BEAC-87377FE6E041}
-pub const GUEST_EMULATION_DEVICE_ID: Guid =
-    guid::guid!("455c0f1b-d51b-40b1-beac-87377fe6e041");
+pub const GUEST_EMULATION_DEVICE_ID: Guid = guid::guid!("455c0f1b-d51b-40b1-beac-87377fe6e041");
 
 /// {8DEDD1AA-9056-49E4-BFD6-1BF90DC38EF0}
 pub const GUEST_EMULATION_INTERFACE_TYPE: Guid =
@@ -1540,8 +1539,7 @@ impl ModifyVtl2SettingsCompleteNotification {
     }
 }
 
-pub const GET_LOG_INTERFACE_GUID: Guid =
-    guid::guid!("AA5DE534-D149-487A-9053-05972BA20A7C");
+pub const GET_LOG_INTERFACE_GUID: Guid = guid::guid!("AA5DE534-D149-487A-9053-05972BA20A7C");
 
 open_enum! {
     #[derive(IntoBytes, FromBytes, Immutable, KnownLayout)]

--- a/vm/devices/hyperv_ic_protocol/src/lib.rs
+++ b/vm/devices/hyperv_ic_protocol/src/lib.rs
@@ -162,9 +162,9 @@ pub mod shutdown {
     use zerocopy::KnownLayout;
 
     /// The unique vmbus interface ID of the shutdown IC.
-    pub const INTERFACE_ID: Guid = Guid::from_static_str("0e0b6031-5213-4934-818b-38d90ced39db");
+    pub const INTERFACE_ID: Guid = guid::guid!("0e0b6031-5213-4934-818b-38d90ced39db");
     /// The unique vmbus instance ID of the shutdown IC.
-    pub const INSTANCE_ID: Guid = Guid::from_static_str("b6650ff7-33bc-4840-8048-e0676786f393");
+    pub const INSTANCE_ID: Guid = guid::guid!("b6650ff7-33bc-4840-8048-e0676786f393");
 
     /// Supported framework versions.
     pub const FRAMEWORK_VERSIONS: &[Version] = &[Version::new(1, 0), Version::new(3, 0)];

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -74,7 +74,7 @@ use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
-const VMNIC_CHANNEL_TYPE_GUID: Guid = Guid::from_static_str("f8615163-df3e-46c5-913f-f2d2f965ed0e");
+const VMNIC_CHANNEL_TYPE_GUID: Guid = guid::guid!("f8615163-df3e-46c5-913f-f2d2f965ed0e");
 
 enum ChannelResponse {
     Open(Option<OpenResult>),

--- a/vm/devices/pci/vpci/src/protocol.rs
+++ b/vm/devices/pci/vpci/src/protocol.rs
@@ -68,8 +68,7 @@ open_enum! {
     }
 }
 
-pub const GUID_VPCI_VSP_CHANNEL_TYPE: Guid =
-    guid::guid!("44C4F61D-4444-4400-9D52-802E27EDE19F");
+pub const GUID_VPCI_VSP_CHANNEL_TYPE: Guid = guid::guid!("44C4F61D-4444-4400-9D52-802E27EDE19F");
 
 open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]

--- a/vm/devices/pci/vpci/src/protocol.rs
+++ b/vm/devices/pci/vpci/src/protocol.rs
@@ -69,7 +69,7 @@ open_enum! {
 }
 
 pub const GUID_VPCI_VSP_CHANNEL_TYPE: Guid =
-    Guid::from_static_str("44C4F61D-4444-4400-9D52-802E27EDE19F");
+    guid::guid!("44C4F61D-4444-4400-9D52-802E27EDE19F");
 
 open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]

--- a/vm/devices/serial/vmbus_serial_protocol/src/lib.rs
+++ b/vm/devices/serial/vmbus_serial_protocol/src/lib.rs
@@ -20,27 +20,27 @@ pub const MAX_MESSAGE_SIZE: usize = 512;
 
 // {8b60ccf6-709f-4c11-90b5-229c959a9e6a}
 /// VMBUS Interface Type GUID
-pub const UART_INTERFACE_TYPE: Guid = Guid::from_static_str("8b60ccf6-709f-4c11-90b5-229c959a9e6a");
+pub const UART_INTERFACE_TYPE: Guid = guid::guid!("8b60ccf6-709f-4c11-90b5-229c959a9e6a");
 
 // {700df40e-b947-4776-b839-d1b0a35af034}
 /// VMBUS Instance GUID for COM1
 pub const UART_INTERFACE_INSTANCE_COM1: Guid =
-    Guid::from_static_str("700df40e-b947-4776-b839-d1b0a35af034");
+    guid::guid!("700df40e-b947-4776-b839-d1b0a35af034");
 
 // {7e55f4b8-af84-4e98-9f1a-8e8d0bde3744}
 /// VMBUS Instance GUID for COM2
 pub const UART_INTERFACE_INSTANCE_COM2: Guid =
-    Guid::from_static_str("7e55f4b8-af84-4e98-9f1a-8e8d0bde3744");
+    guid::guid!("7e55f4b8-af84-4e98-9f1a-8e8d0bde3744");
 
 // {3f158fa1-b0aa-45e9-ba54-9fc73f6c59ec}
 /// VMBUS Instance GUID for COM3
 pub const UART_INTERFACE_INSTANCE_COM3: Guid =
-    Guid::from_static_str("3f158fa1-b0aa-45e9-ba54-9fc73f6c59ec");
+    guid::guid!("3f158fa1-b0aa-45e9-ba54-9fc73f6c59ec");
 
 // {8688a06f-9b53-48ce-b408-7581626228c5}
 /// VMBUS Instance GUID for COM4
 pub const UART_INTERFACE_INSTANCE_COM4: Guid =
-    Guid::from_static_str("8688a06f-9b53-48ce-b408-7581626228c5");
+    guid::guid!("8688a06f-9b53-48ce-b408-7581626228c5");
 
 const fn make_version(major: u16, minor: u16) -> u32 {
     (minor as u32) | ((major as u32) << 16)

--- a/vm/devices/serial/vmbus_serial_protocol/src/lib.rs
+++ b/vm/devices/serial/vmbus_serial_protocol/src/lib.rs
@@ -24,23 +24,19 @@ pub const UART_INTERFACE_TYPE: Guid = guid::guid!("8b60ccf6-709f-4c11-90b5-229c9
 
 // {700df40e-b947-4776-b839-d1b0a35af034}
 /// VMBUS Instance GUID for COM1
-pub const UART_INTERFACE_INSTANCE_COM1: Guid =
-    guid::guid!("700df40e-b947-4776-b839-d1b0a35af034");
+pub const UART_INTERFACE_INSTANCE_COM1: Guid = guid::guid!("700df40e-b947-4776-b839-d1b0a35af034");
 
 // {7e55f4b8-af84-4e98-9f1a-8e8d0bde3744}
 /// VMBUS Instance GUID for COM2
-pub const UART_INTERFACE_INSTANCE_COM2: Guid =
-    guid::guid!("7e55f4b8-af84-4e98-9f1a-8e8d0bde3744");
+pub const UART_INTERFACE_INSTANCE_COM2: Guid = guid::guid!("7e55f4b8-af84-4e98-9f1a-8e8d0bde3744");
 
 // {3f158fa1-b0aa-45e9-ba54-9fc73f6c59ec}
 /// VMBUS Instance GUID for COM3
-pub const UART_INTERFACE_INSTANCE_COM3: Guid =
-    guid::guid!("3f158fa1-b0aa-45e9-ba54-9fc73f6c59ec");
+pub const UART_INTERFACE_INSTANCE_COM3: Guid = guid::guid!("3f158fa1-b0aa-45e9-ba54-9fc73f6c59ec");
 
 // {8688a06f-9b53-48ce-b408-7581626228c5}
 /// VMBUS Instance GUID for COM4
-pub const UART_INTERFACE_INSTANCE_COM4: Guid =
-    guid::guid!("8688a06f-9b53-48ce-b408-7581626228c5");
+pub const UART_INTERFACE_INSTANCE_COM4: Guid = guid::guid!("8688a06f-9b53-48ce-b408-7581626228c5");
 
 const fn make_version(major: u16, minor: u16) -> u32 {
     (minor as u32) | ((major as u32) << 16)

--- a/vm/devices/storage/scsidisk/src/inquiry.rs
+++ b/vm/devices/storage/scsidisk/src/inquiry.rs
@@ -360,7 +360,7 @@ impl SimpleScsiDisk {
         allocation_length: usize,
     ) -> Result<usize, ScsiError> {
         const VPD_MSFT_VIRTUAL_DEVICE_PROPERTIES_PAGE_SIGNATURE: Guid =
-            Guid::from_static_str("89a98f15-c928-4d8b-94cd-ef51faa99d33");
+            guid::guid!("89a98f15-c928-4d8b-94cd-ef51faa99d33");
 
         let page = scsi::VpdMsftVirtualDevicePropertiesPage {
             version: 1, // Version, leave at 1 to maintain back-compatibility with downlevel guest OSes

--- a/vm/devices/storage/storvsp/src/protocol.rs
+++ b/vm/devices/storage/storvsp/src/protocol.rs
@@ -15,8 +15,7 @@ use zerocopy::KnownLayout;
 
 pub const SCSI_INTERFACE_ID: Guid = guid::guid!("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
 
-pub const IDE_ACCELERATOR_INTERFACE_ID: Guid =
-    guid::guid!("32412632-86cb-44a2-9b5c-50d1417354f5");
+pub const IDE_ACCELERATOR_INTERFACE_ID: Guid = guid::guid!("32412632-86cb-44a2-9b5c-50d1417354f5");
 
 /// Sent as part of the channel offer. Old versions of Windows drivers look at
 /// this to determine the IDE device the channel is for. Newer drivers and Linux

--- a/vm/devices/storage/storvsp/src/protocol.rs
+++ b/vm/devices/storage/storvsp/src/protocol.rs
@@ -13,10 +13,10 @@ use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
-pub const SCSI_INTERFACE_ID: Guid = Guid::from_static_str("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
+pub const SCSI_INTERFACE_ID: Guid = guid::guid!("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
 
 pub const IDE_ACCELERATOR_INTERFACE_ID: Guid =
-    Guid::from_static_str("32412632-86cb-44a2-9b5c-50d1417354f5");
+    guid::guid!("32412632-86cb-44a2-9b5c-50d1417354f5");
 
 /// Sent as part of the channel offer. Old versions of Windows drivers look at
 /// this to determine the IDE device the channel is for. Newer drivers and Linux

--- a/vm/devices/uidevices/src/keyboard/protocol.rs
+++ b/vm/devices/uidevices/src/keyboard/protocol.rs
@@ -10,10 +10,10 @@ use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
 // f912ad6d-2b17-48ea-bd65-f927a61c7684
-pub const INTERFACE_GUID: Guid = Guid::from_static_str("f912ad6d-2b17-48ea-bd65-f927a61c7684");
+pub const INTERFACE_GUID: Guid = guid::guid!("f912ad6d-2b17-48ea-bd65-f927a61c7684");
 
 // d34b2567-b9b6-42b9-8778-0a4ec0b955bf
-pub const INSTANCE_GUID: Guid = Guid::from_static_str("d34b2567-b9b6-42b9-8778-0a4ec0b955bf");
+pub const INSTANCE_GUID: Guid = guid::guid!("d34b2567-b9b6-42b9-8778-0a4ec0b955bf");
 
 const fn make_version(major: u16, minor: u16) -> u32 {
     (major as u32) << 16 | minor as u32

--- a/vm/devices/uidevices/src/mouse/protocol.rs
+++ b/vm/devices/uidevices/src/mouse/protocol.rs
@@ -13,10 +13,10 @@ use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
 //cfa8b69e-5b4a-4cc0-b98b-8ba1a1f3f95a
-pub const INTERFACE_GUID: Guid = Guid::from_static_str("cfa8b69e-5b4a-4cc0-b98b-8ba1a1f3f95a");
+pub const INTERFACE_GUID: Guid = guid::guid!("cfa8b69e-5b4a-4cc0-b98b-8ba1a1f3f95a");
 
 //58f75a6d-d949-4320-99e1-a2a2576d581c
-pub const INSTANCE_GUID: Guid = Guid::from_static_str("58f75a6d-d949-4320-99e1-a2a2576d581c");
+pub const INSTANCE_GUID: Guid = guid::guid!("58f75a6d-d949-4320-99e1-a2a2576d581c");
 
 //SynthHID protocol
 const fn make_version(major: u16, minor: u16) -> u32 {

--- a/vm/devices/vmbus/vmbfs/src/protocol.rs
+++ b/vm/devices/vmbus/vmbfs/src/protocol.rs
@@ -12,9 +12,9 @@ use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
-pub const INTERFACE_TYPE: Guid = Guid::from_static_str("c376c1c3-d276-48d2-90a9-c04748072c60");
-pub const IMC_INSTANCE: Guid = Guid::from_static_str("c4e5e7d1-d748-4afc-979d-683167910a55");
-pub const _BOOT_INSTANCE: Guid = Guid::from_static_str("c63c9bdf-5fa5-4208-b03f-6b458b365592");
+pub const INTERFACE_TYPE: Guid = guid::guid!("c376c1c3-d276-48d2-90a9-c04748072c60");
+pub const IMC_INSTANCE: Guid = guid::guid!("c4e5e7d1-d748-4afc-979d-683167910a55");
+pub const _BOOT_INSTANCE: Guid = guid::guid!("c63c9bdf-5fa5-4208-b03f-6b458b365592");
 
 pub const MAX_MESSAGE_SIZE: usize = 12288;
 pub const MAX_READ_SIZE: usize =

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -442,19 +442,19 @@ impl Channel {
         // that has all of these defined, but for now just redefine the most
         // common ones here. Add more as needed.
 
-        const SHUTDOWN_IC: Guid = Guid::from_static_str("0e0b6031-5213-4934-818b-38d90ced39db");
-        const KVP_IC: Guid = Guid::from_static_str("a9a0f4e7-5a45-4d96-b827-8a841e8c03e6");
-        const VSS_IC: Guid = Guid::from_static_str("35fa2e29-ea23-4236-96ae-3a6ebacba440");
-        const TIMESYNC_IC: Guid = Guid::from_static_str("9527e630-d0ae-497b-adce-e80ab0175caf");
-        const HEARTBEAT_IC: Guid = Guid::from_static_str("57164f39-9115-4e78-ab55-382f3bd5422d");
-        const RDV_IC: Guid = Guid::from_static_str("276aacf4-ac15-426c-98dd-7521ad3f01fe");
+        const SHUTDOWN_IC: Guid = guid::guid!("0e0b6031-5213-4934-818b-38d90ced39db");
+        const KVP_IC: Guid = guid::guid!("a9a0f4e7-5a45-4d96-b827-8a841e8c03e6");
+        const VSS_IC: Guid = guid::guid!("35fa2e29-ea23-4236-96ae-3a6ebacba440");
+        const TIMESYNC_IC: Guid = guid::guid!("9527e630-d0ae-497b-adce-e80ab0175caf");
+        const HEARTBEAT_IC: Guid = guid::guid!("57164f39-9115-4e78-ab55-382f3bd5422d");
+        const RDV_IC: Guid = guid::guid!("276aacf4-ac15-426c-98dd-7521ad3f01fe");
 
         const INHERITED_ACTIVATION: Guid =
-            Guid::from_static_str("3375baf4-9e15-4b30-b765-67acb10d607b");
+            guid::guid!("3375baf4-9e15-4b30-b765-67acb10d607b");
 
-        const NET: Guid = Guid::from_static_str("f8615163-df3e-46c5-913f-f2d2f965ed0e");
-        const SCSI: Guid = Guid::from_static_str("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
-        const VPCI: Guid = Guid::from_static_str("44c4f61d-4444-4400-9d52-802e27ede19f");
+        const NET: Guid = guid::guid!("f8615163-df3e-46c5-913f-f2d2f965ed0e");
+        const SCSI: Guid = guid::guid!("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
+        const VPCI: Guid = guid::guid!("44c4f61d-4444-4400-9d52-802e27ede19f");
 
         match self.offer.interface_id {
             SHUTDOWN_IC => "shutdown_ic",
@@ -1417,7 +1417,7 @@ mod tests {
     use zerocopy::KnownLayout;
 
     const VMBUS_TEST_CLIENT_ID: Guid =
-        Guid::from_static_str("e6e6e6e6-e6e6-e6e6-e6e6-e6e6e6e6e6e6");
+        guid::guid!("e6e6e6e6-e6e6-e6e6-e6e6-e6e6e6e6e6e6");
 
     fn in_msg<T: IntoBytes + Immutable + KnownLayout>(message_type: MessageType, t: T) -> Vec<u8> {
         let mut data = Vec::new();

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -449,8 +449,7 @@ impl Channel {
         const HEARTBEAT_IC: Guid = guid::guid!("57164f39-9115-4e78-ab55-382f3bd5422d");
         const RDV_IC: Guid = guid::guid!("276aacf4-ac15-426c-98dd-7521ad3f01fe");
 
-        const INHERITED_ACTIVATION: Guid =
-            guid::guid!("3375baf4-9e15-4b30-b765-67acb10d607b");
+        const INHERITED_ACTIVATION: Guid = guid::guid!("3375baf4-9e15-4b30-b765-67acb10d607b");
 
         const NET: Guid = guid::guid!("f8615163-df3e-46c5-913f-f2d2f965ed0e");
         const SCSI: Guid = guid::guid!("ba6163d9-04a1-4d29-b605-72e2ffb1dc7f");
@@ -1416,8 +1415,7 @@ mod tests {
     use zerocopy::IntoBytes;
     use zerocopy::KnownLayout;
 
-    const VMBUS_TEST_CLIENT_ID: Guid =
-        guid::guid!("e6e6e6e6-e6e6-e6e6-e6e6-e6e6e6e6e6e6");
+    const VMBUS_TEST_CLIENT_ID: Guid = guid::guid!("e6e6e6e6-e6e6-e6e6-e6e6-e6e6e6e6e6e6");
 
     fn in_msg<T: IntoBytes + Immutable + KnownLayout>(message_type: MessageType, t: T) -> Vec<u8> {
         let mut data = Vec::new();

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -74,7 +74,7 @@ const REQUIRED_FEATURE_FLAGS: FeatureFlags = FeatureFlags::new()
     .with_guest_specified_signal_parameters(true)
     .with_modify_connection(true);
 
-const VMBUS_RELAY_CLIENT_ID: Guid = Guid::from_static_str("ceb1cd55-6a3b-41c5-9473-4dd30624c3d8");
+const VMBUS_RELAY_CLIENT_ID: Guid = guid::guid!("ceb1cd55-6a3b-41c5-9473-4dd30624c3d8");
 
 /// Represents a relay between a vmbus server on the host, and the vmbus server running in
 /// Underhill, allowing offers from the host and offers from Underhill to be mixed.

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -3835,7 +3835,7 @@ mod tests {
                         parent_to_child_monitor_page_gpa: 0,
                         child_to_parent_monitor_page_gpa: 0,
                     },
-                    client_id: Guid::from_static_str("e6e6e6e6-e6e6-e6e6-e6e6-e6e6e6e6e6e6"),
+                    client_id: guid::guid!("e6e6e6e6-e6e6-e6e6-e6e6-e6e6e6e6e6e6"),
                 },
             ))
             .unwrap();

--- a/vm/devices/vmbus/vmbus_server/src/hvsock.rs
+++ b/vm/devices/vmbus/vmbus_server/src/hvsock.rs
@@ -311,7 +311,7 @@ impl Drop for PendingConnection {
 
 // This GUID is an embedding of the AF_VSOCK port into an
 // AF_HYPERV service ID.
-static VSOCK_TEMPLATE: Guid = Guid::from_static_str("00000000-facb-11e6-bd58-64006a7986d3");
+static VSOCK_TEMPLATE: Guid = guid::guid!("00000000-facb-11e6-bd58-64006a7986d3");
 
 fn vsock_port(service_id: &Guid) -> Option<u32> {
     let stripped_id = Guid {

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -112,7 +112,7 @@ async fn mana_nic_servicing(
 /// vmbus relay. This should expose a disk to VTL0 via vmbus.
 #[openvmm_test(openhcl_linux_direct_x64)]
 async fn storvsp(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
-    const NVME_INSTANCE: Guid = Guid::from_static_str("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
+    const NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
     let vtl2_lun = 5;
     let vtl0_scsi_lun = 0;
     let vtl0_nvme_lun = 1;
@@ -399,8 +399,8 @@ async fn openhcl_linux_storvsp_dvd(config: PetriVmConfigOpenVmm) -> Result<(), a
 /// Test an OpenHCL Linux Stripe VM with two SCSI disk assigned to VTL2 via NVMe Emulator
 #[openvmm_test(openhcl_linux_direct_x64)]
 async fn openhcl_linux_stripe_storvsp(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
-    const NVME_INSTANCE_1: Guid = Guid::from_static_str("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
-    const NVME_INSTANCE_2: Guid = Guid::from_static_str("06a97a09-d5ad-4689-b638-9419d7346a68");
+    const NVME_INSTANCE_1: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
+    const NVME_INSTANCE_2: Guid = guid::guid!("06a97a09-d5ad-4689-b638-9419d7346a68");
     let vtl0_nvme_lun = 0;
     let vtl2_nsid = 1;
     let nvme_disk_sectors: u64 = 0x10000;

--- a/xtask/src/tasks/guest_test/uefi/gpt_efi_disk.rs
+++ b/xtask/src/tasks/guest_test/uefi/gpt_efi_disk.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use zerocopy::IntoBytes;
 
 const SECTOR_SIZE: usize = 512;
-const EFI_GUID: Guid = Guid::from_static_str("{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}");
+const EFI_GUID: Guid = guid::guid!("{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}");
 
 pub fn create_gpt_efi_disk(out_img: &Path, with_files: &[(&Path, &Path)]) -> Result<()> {
     if out_img.extension().unwrap_or_default() != "img" {


### PR DESCRIPTION
Instead of requiring users to be careful to use `from_static_str` only with trusted inputs and in a const context, offer a macro `guid!` that ensures that the guid is parsed at compile time.

This fixes some unnecessary runtime parsing of GUIDs in a few places, and it gives us flexiblity to fork the compile-time and runtime parsing implementations if we want to.