### PR TITLE
page_pool_alloc: clean up mapping handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,11 +2683,9 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "hcl",
- "hvdef",
  "inspect",
  "page_pool_alloc",
  "sparse_mmap",
- "tracing",
 ]
 
 [[package]]
@@ -4905,16 +4903,15 @@ name = "page_pool_alloc"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "hvdef",
  "inspect",
  "memory_range",
  "mesh",
  "parking_lot",
+ "safeatomic",
  "sparse_mmap",
  "thiserror 2.0.0",
  "tracing",
  "user_driver",
- "vm_topology",
  "vmcore",
 ]
 
@@ -7650,6 +7647,7 @@ dependencies = [
  "parking_lot",
  "pci_core",
  "safe_intrinsics",
+ "safeatomic",
  "sidecar_client",
  "thiserror 2.0.0",
  "tracelimit",

--- a/openhcl/hcl_mapper/Cargo.toml
+++ b/openhcl/hcl_mapper/Cargo.toml
@@ -8,15 +8,12 @@ edition.workspace = true
 
 [dependencies]
 hcl.workspace = true
-
-hvdef.workspace = true
 page_pool_alloc.workspace = true
 
 inspect.workspace = true
 sparse_mmap.workspace = true
 
 anyhow.workspace = true
-tracing.workspace = true
 
 [lints]
 workspace = true

--- a/openhcl/hcl_mapper/src/lib.rs
+++ b/openhcl/hcl_mapper/src/lib.rs
@@ -49,12 +49,12 @@ impl PoolSource for HclMapper {
         self.gpa_bias
     }
 
-    fn mapping_file_offset(&self, address: u64) -> usize {
+    fn file_offset(&self, address: u64) -> u64 {
         address.wrapping_add(if self.is_shared {
             MshvVtlLow::SHARED_MEMORY_FLAG
         } else {
             0
-        }) as usize
+        })
     }
 
     fn mappable(&self) -> sparse_mmap::MappableRef<'_> {

--- a/openhcl/hcl_mapper/src/lib.rs
+++ b/openhcl/hcl_mapper/src/lib.rs
@@ -9,62 +9,55 @@
 
 use anyhow::Context;
 use hcl::ioctl::MshvVtlLow;
-use hvdef::HV_PAGE_SIZE;
 use inspect::Inspect;
-use inspect::Response;
-use page_pool_alloc::Mapper;
-use page_pool_alloc::PoolType;
-use sparse_mmap::SparseMapping;
+use page_pool_alloc::PoolSource;
+use std::os::fd::AsFd;
 
 /// A mapper that uses [`MshvVtlLow`] to map pages.
 #[derive(Inspect)]
-#[inspect(extra = "HclMapper::inspect_extra")]
 pub struct HclMapper {
     #[inspect(skip)]
     fd: MshvVtlLow,
+    gpa_bias: u64,
+    is_shared: bool,
 }
 
 impl HclMapper {
-    /// Creates a new [`HclMapper`].
-    pub fn new() -> Result<Self, anyhow::Error> {
-        let fd = MshvVtlLow::new().context("failed to open gpa fd")?;
-        Ok(Self { fd })
+    /// Creates an instance for mapping shared memory, with shared memory
+    /// appearing to the guest starting at `vtom`.
+    pub fn new_shared(vtom: u64) -> anyhow::Result<Self> {
+        Self::new_inner(vtom, true)
     }
 
-    fn inspect_extra(&self, resp: &mut Response<'_>) {
-        resp.field("type", "hcl_mapper");
+    /// Creates an instance for mapping private memory.
+    pub fn new_private() -> anyhow::Result<Self> {
+        Self::new_inner(0, false)
+    }
+
+    fn new_inner(gpa_bias: u64, is_shared: bool) -> anyhow::Result<Self> {
+        let fd = MshvVtlLow::new().context("failed to open gpa fd")?;
+        Ok(Self {
+            fd,
+            gpa_bias,
+            is_shared,
+        })
     }
 }
 
-impl Mapper for HclMapper {
-    fn map(
-        &self,
-        base_pfn: u64,
-        size_pages: u64,
-        pool_type: PoolType,
-    ) -> Result<SparseMapping, anyhow::Error> {
-        let len = (size_pages * HV_PAGE_SIZE) as usize;
-        let mapping = SparseMapping::new(len).context("failed to create mapping")?;
-        let gpa = base_pfn * HV_PAGE_SIZE;
+impl PoolSource for HclMapper {
+    fn address_bias(&self) -> u64 {
+        self.gpa_bias
+    }
 
-        // When the pool references shared memory, on hardware isolated
-        // platforms the file_offset must have the shared bit set as these
-        // are decrypted pages. Setting this bit is okay on non-hardware
-        // isolated platforms, as it does nothing.
-        let file_offset = match pool_type {
-            PoolType::Private => gpa,
-            PoolType::Shared => {
-                tracing::trace!("setting MshvVtlLow::SHARED_MEMORY_FLAG");
-                gpa | MshvVtlLow::SHARED_MEMORY_FLAG
-            }
-        };
+    fn mapping_file_offset(&self, address: u64) -> usize {
+        address.wrapping_add(if self.is_shared {
+            MshvVtlLow::SHARED_MEMORY_FLAG
+        } else {
+            0
+        }) as usize
+    }
 
-        tracing::trace!(gpa, file_offset, len, "mapping allocation");
-
-        mapping
-            .map_file(0, len, self.fd.get(), file_offset, true)
-            .context("unable to map allocation")?;
-
-        Ok(mapping)
+    fn mappable(&self) -> sparse_mmap::MappableRef<'_> {
+        self.fd.get().as_fd()
     }
 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1510,13 +1510,15 @@ async fn new_underhill_vm(
     let mut shared_vis_pages_pool = if shared_pool_size != 0 {
         use vmcore::save_restore::SaveRestore;
 
-        let mut pool = PagePool::new_shared_visibility_pool(
-            &shared_pool,
-            measured_vtl2_info
-                .vtom_offset_bit
-                .map(|bit| 1 << bit)
-                .unwrap_or(0),
-            HclMapper::new().context("failed to create hcl mapper")?,
+        let mut pool = PagePool::new(
+            &shared_pool.iter().map(|r| r.range).collect::<Vec<_>>(),
+            HclMapper::new_shared(
+                measured_vtl2_info
+                    .vtom_offset_bit
+                    .map(|bit| 1 << bit)
+                    .unwrap_or(0),
+            )
+            .context("failed to create hcl mapper")?,
         )
         .context("failed to create shared vis page pool")?;
 
@@ -1543,9 +1545,9 @@ async fn new_underhill_vm(
         use vmcore::save_restore::SaveRestore;
 
         let ranges = runtime_params.private_pool_ranges();
-        let mut pool = PagePool::new_private_pool(
-            ranges,
-            HclMapper::new().context("failed to create hcl mapper")?,
+        let mut pool = PagePool::new(
+            &ranges.iter().map(|r| r.range).collect::<Vec<_>>(),
+            HclMapper::new_private().context("failed to create hcl mapper")?,
         )
         .context("failed to create private pool")?;
 

--- a/openhcl/virt_mshv_vtl/Cargo.toml
+++ b/openhcl/virt_mshv_vtl/Cargo.toml
@@ -37,6 +37,7 @@ mesh.workspace = true
 pal_async.workspace = true
 pal_uring.workspace = true
 pal.workspace = true
+safeatomic.workspace = true
 tracelimit.workspace = true
 
 anyhow.workspace = true

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -696,7 +696,7 @@ impl BackingPrivate for TdxBacked {
             .private_vis_pages_pool
             .as_ref()
             .expect("private pool exists for cvm")
-            .alloc_with_mapping(1.try_into().unwrap(), "tdx_tlb_flush".into())
+            .alloc(1.try_into().unwrap(), "tdx_tlb_flush".into())
             .expect("not out of memory");
 
         let untrusted_synic = params

--- a/vm/page_pool_alloc/Cargo.toml
+++ b/vm/page_pool_alloc/Cargo.toml
@@ -8,14 +8,13 @@ rust-version.workspace = true
 
 [dependencies]
 user_driver.workspace = true
-hvdef.workspace = true
 sparse_mmap.workspace = true
 vmcore.workspace = true
 memory_range = { workspace = true, features = [ "inspect", "mesh" ] }
-vm_topology = { workspace = true, features = [ "inspect", "mesh" ] }
 
 inspect.workspace = true
 mesh.workspace = true
+safeatomic.workspace = true
 
 parking_lot.workspace = true
 thiserror.workspace = true

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -34,6 +34,7 @@ pub mod save_restore {
     use super::Slot;
     use super::SlotState;
     use super::PAGE_SIZE;
+    use crate::ResolvedSlotState;
     use memory_range::MemoryRange;
     use mesh::payload::Protobuf;
     use vmcore::save_restore::SaveRestore;
@@ -91,17 +92,22 @@ pub mod save_restore {
                     .slots
                     .iter()
                     .map(|slot| {
+                        let slot = slot.resolve(&state.device_ids);
                         let inner_state = match &slot.state {
-                            SlotState::Free => InnerSlotState::Free,
-                            SlotState::Allocated { device_id, tag } => InnerSlotState::Allocated {
-                                device_id: state.device_ids[*device_id].name().to_string(),
-                                tag: tag.clone(),
-                            },
-                            SlotState::Leaked { device_id, tag } => InnerSlotState::Leaked {
-                                device_id: device_id.clone(),
-                                tag: tag.clone(),
-                            },
-                            SlotState::AllocatedPendingRestore { .. } => {
+                            ResolvedSlotState::Free => InnerSlotState::Free,
+                            ResolvedSlotState::Allocated { device_id, tag } => {
+                                InnerSlotState::Allocated {
+                                    device_id: device_id.to_string(),
+                                    tag: tag.to_string(),
+                                }
+                            }
+                            ResolvedSlotState::Leaked { device_id, tag } => {
+                                InnerSlotState::Leaked {
+                                    device_id: device_id.to_string(),
+                                    tag: tag.to_string(),
+                                }
+                            }
+                            ResolvedSlotState::AllocatedPendingRestore { .. } => {
                                 panic!("should not save allocated pending restore")
                             }
                         };

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -93,7 +93,7 @@ pub mod save_restore {
                     .iter()
                     .map(|slot| {
                         let slot = slot.resolve(&state.device_ids);
-                        let inner_state = match &slot.state {
+                        let inner_state = match slot.state {
                             ResolvedSlotState::Free => InnerSlotState::Free,
                             ResolvedSlotState::Allocated { device_id, tag } => {
                                 InnerSlotState::Allocated {

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -11,25 +11,29 @@ mod device_dma;
 pub use device_dma::PagePoolDmaBuffer;
 
 use anyhow::Context;
-use hvdef::HV_PAGE_SIZE;
 use inspect::Inspect;
 use inspect::Response;
 use memory_range::MemoryRange;
 use parking_lot::Mutex;
+use safeatomic::AtomicSliceOps;
 use sparse_mmap::alloc_shared_memory;
 use sparse_mmap::Mappable;
+use sparse_mmap::MappableRef;
 use sparse_mmap::SparseMapping;
 use std::fmt::Debug;
 use std::num::NonZeroU64;
+use std::sync::atomic::AtomicU8;
 use std::sync::Arc;
 use thiserror::Error;
-use vm_topology::memory::MemoryRangeWithNode;
+
+const PAGE_SIZE: u64 = 4096;
 
 /// Save restore suport for [`PagePool`].
 pub mod save_restore {
     use super::PagePool;
     use super::Slot;
     use super::SlotState;
+    use super::PAGE_SIZE;
     use memory_range::MemoryRange;
     use mesh::payload::Protobuf;
     use vmcore::save_restore::SaveRestore;
@@ -81,7 +85,7 @@ pub mod save_restore {
         type SavedState = PagePoolState;
 
         fn save(&mut self) -> Result<Self::SavedState, vmcore::save_restore::SaveError> {
-            let state = self.inner.lock();
+            let state = self.inner.state.lock();
             Ok(PagePoolState {
                 state: state
                     .slots
@@ -115,7 +119,7 @@ pub mod save_restore {
 
         fn restore(
             &mut self,
-            state: Self::SavedState,
+            mut state: Self::SavedState,
         ) -> Result<(), vmcore::save_restore::RestoreError> {
             // Verify that the pool describes the same regions of memory as the
             // saved state.
@@ -128,7 +132,7 @@ pub mod save_restore {
                 }
             }
 
-            let mut inner = self.inner.lock();
+            let mut inner = self.inner.state.lock();
 
             // Verify there are no existing allocators present, as we rely on
             // the pool being completely free since we will overwrite the state
@@ -143,6 +147,9 @@ pub mod save_restore {
                 ));
             }
 
+            state.state.sort_by_key(|slot| slot.base_pfn);
+
+            let mut mapping_offset = 0;
             inner.slots = state
                 .state
                 .into_iter()
@@ -157,13 +164,22 @@ pub mod save_restore {
                         }
                     };
 
-                    Slot {
+                    let slot = Slot {
                         base_pfn: slot.base_pfn,
+                        mapping_offset: mapping_offset as usize,
                         size_pages: slot.size_pages,
                         state: inner,
-                    }
+                    };
+                    mapping_offset += slot.size_pages * PAGE_SIZE;
+                    slot
                 })
                 .collect();
+
+            if mapping_offset != self.inner.mapping.len() as u64 {
+                return Err(vmcore::save_restore::RestoreError::InvalidSavedState(
+                    anyhow::anyhow!("missing slots in saved state"),
+                ));
+            }
 
             Ok(())
         }
@@ -197,6 +213,7 @@ pub struct UnrestoredAllocations;
 #[derive(Debug, PartialEq, Eq)]
 struct Slot {
     base_pfn: u64,
+    mapping_offset: usize,
     size_pages: u64,
     state: SlotState,
 }
@@ -223,6 +240,31 @@ enum SlotState {
     },
 }
 
+impl Slot {
+    fn resolve<'a>(&'a self, device_ids: &'a [DeviceId]) -> ResolvedSlot<'a> {
+        ResolvedSlot {
+            base_pfn: self.base_pfn,
+            mapping_offset: self.mapping_offset,
+            size_pages: self.size_pages,
+            state: match self.state {
+                SlotState::Free => ResolvedSlotState::Free,
+                SlotState::Allocated { device_id, ref tag } => ResolvedSlotState::Allocated {
+                    device_id: device_ids[device_id].name(),
+                    tag,
+                },
+                SlotState::AllocatedPendingRestore {
+                    ref device_id,
+                    ref tag,
+                } => ResolvedSlotState::AllocatedPendingRestore { device_id, tag },
+                SlotState::Leaked {
+                    ref device_id,
+                    ref tag,
+                } => ResolvedSlotState::Leaked { device_id, tag },
+            },
+        }
+    }
+}
+
 impl SlotState {
     fn restore_allocated(&mut self, device_id: usize) {
         if !matches!(self, SlotState::AllocatedPendingRestore { .. }) {
@@ -239,25 +281,23 @@ impl SlotState {
             _ => unreachable!(),
         };
     }
-
-    fn name(&self) -> &str {
-        match self {
-            SlotState::Free => "free",
-            SlotState::Allocated { .. } => "allocated",
-            SlotState::AllocatedPendingRestore { .. } => "allocated_pending_restore",
-            SlotState::Leaked { .. } => "leaked",
-        }
-    }
 }
 
-/// What kind of memory this pool is.
-#[derive(Inspect, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PoolType {
-    /// Private memory, that is not visible to the host.
-    Private,
-    /// Shared memory, that is visible to the host. This requires mapping pages
-    /// with the decrypted bit set on mmap calls.
-    Shared,
+#[derive(Inspect)]
+struct ResolvedSlot<'a> {
+    base_pfn: u64,
+    mapping_offset: usize,
+    size_pages: u64,
+    state: ResolvedSlotState<'a>,
+}
+
+#[derive(Inspect)]
+#[inspect(external_tag)]
+enum ResolvedSlotState<'a> {
+    Free,
+    Allocated { device_id: &'a str, tag: &'a str },
+    AllocatedPendingRestore { device_id: &'a str, tag: &'a str },
+    Leaked { device_id: &'a str, tag: &'a str },
 }
 
 #[derive(Inspect, Debug, Clone, PartialEq, Eq)]
@@ -279,65 +319,49 @@ impl DeviceId {
     }
 }
 
+#[derive(Inspect)]
 struct PagePoolInner {
-    /// The internal slots for the pool, representing page state.
-    slots: Vec<Slot>,
+    #[inspect(flatten)]
+    state: Mutex<PagePoolState>,
     /// The pfn_bias for the pool.
     pfn_bias: u64,
+    /// The mapper used to create mappings for allocations.
+    source: Box<dyn PoolSource>,
+    #[inspect(skip)]
+    mapping: SparseMapping,
+}
+
+struct PagePoolState {
+    /// The internal slots for the pool, representing page state.
+    slots: Vec<Slot>,
     /// The list of device ids for outstanding allocators. Each name must be
     /// unique.
     device_ids: Vec<DeviceId>,
-    /// The mapper used to create mappings for allocations.
-    mapper: Box<dyn Mapper>,
 }
 
-// Manually implement inspect so device_ids can be rendered as strings, not
-// their actual usize index.
-impl Inspect for PagePoolInner {
+impl Inspect for PagePoolState {
     fn inspect(&self, req: inspect::Request<'_>) {
-        req.respond()
-            .field("device_ids", inspect::iter_by_index(&self.device_ids))
-            .field("mapper", &self.mapper)
-            .child("slots", |req| {
-                let mut resp = req.respond();
-                for (i, slot) in self.slots.iter().enumerate() {
-                    resp.child(&i.to_string(), |req| {
-                        let mut resp = req.respond();
-                        resp.field("base_pfn", inspect::AsHex(slot.base_pfn))
-                            .field("size_pages", inspect::AsHex(slot.size_pages))
-                            .field("state", slot.state.name());
-
-                        match &slot.state {
-                            SlotState::Free => {}
-                            SlotState::Allocated { device_id, tag } => {
-                                resp.field("device_id", self.device_ids[*device_id].name())
-                                    .field("tag", tag);
-                            }
-                            SlotState::AllocatedPendingRestore { device_id, tag }
-                            | SlotState::Leaked { device_id, tag } => {
-                                resp.field("device_id", device_id.clone()).field("tag", tag);
-                            }
-                        }
-                    });
-                }
-            });
+        let Self { slots, device_ids } = self;
+        req.respond().field(
+            "slots",
+            inspect::iter_by_index(slots).map_value(|s| s.resolve(device_ids)),
+        );
     }
 }
 
 /// A handle for a page pool allocation. When dropped, the allocation is
 /// freed.
 pub struct PagePoolHandle {
-    inner: Arc<Mutex<PagePoolInner>>,
+    inner: Arc<PagePoolInner>,
     base_pfn: u64,
-    pfn_bias: u64,
     size_pages: u64,
-    mapping: Option<SparseMapping>,
+    mapping_offset: usize,
 }
 
 impl PagePoolHandle {
     /// The base pfn (with bias) for this allocation.
     pub fn base_pfn(&self) -> u64 {
-        self.base_pfn + self.pfn_bias
+        self.base_pfn + self.inner.pfn_bias
     }
 
     /// The base pfn without bias for this allocation.
@@ -350,47 +374,26 @@ impl PagePoolHandle {
         self.size_pages
     }
 
-    /// The associated mapping with this allocation. This is only available if
-    /// this was allocated with [`PagePoolAllocator::alloc_with_mapping`].
-    pub fn mapping(&self) -> Option<&SparseMapping> {
-        self.mapping.as_ref()
+    /// The associated mapping with this allocation.
+    pub fn mapping(&self) -> &[AtomicU8] {
+        self.inner
+            .mapping
+            .atomic_slice(self.mapping_offset, (self.size_pages * PAGE_SIZE) as usize)
     }
 
     /// Create a memory block from this allocation.
-    fn into_memory_block(
-        mut self,
-        zero_block: bool,
-    ) -> anyhow::Result<user_driver::memory::MemoryBlock> {
-        // Take ownership of the mapping, as the outer memory block type will
-        // guarantee the mapping is dropped when the allocation is also dropped.
-        let mapping = self
-            .mapping
-            .take()
-            .context("allocation did not have associated mapping")?;
-
-        // Zero memory block if requested.
-        if zero_block {
-            let len = (self.size_pages * HV_PAGE_SIZE) as usize;
-            mapping
-                .fill_at(0, 0, len)
-                .context("failed to zero allocated memory")?;
-        }
-
+    fn into_memory_block(self) -> anyhow::Result<user_driver::memory::MemoryBlock> {
         let pfns: Vec<_> = (self.base_pfn()..self.base_pfn() + self.size_pages).collect();
-        let pfn_bias = self.pfn_bias;
-
         Ok(user_driver::memory::MemoryBlock::new(PagePoolDmaBuffer {
-            mapping,
-            _alloc: self,
+            alloc: self,
             pfns,
-            pfn_bias,
         }))
     }
 }
 
 impl Drop for PagePoolHandle {
     fn drop(&mut self) {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.state.lock();
 
         let slot = inner
             .slots
@@ -404,44 +407,20 @@ impl Drop for PagePoolHandle {
             })
             .expect("must find allocation");
 
+        assert_eq!(slot.mapping_offset, self.mapping_offset);
         slot.state = SlotState::Free;
     }
 }
 
-/// A trait used to map a range of pages into a [`SparseMapping`].
-pub trait Mapper: Inspect + Send + Sync {
-    /// Create a mapping for the given range of pages.
-    ///
-    /// The pages should be mapped such that the `base_pfn` is at offset zero,
-    /// with the `size_pages` being the total size of the mapping.
-    fn map(
-        &self,
-        base_pfn: u64,
-        size_pages: u64,
-        pool_type: PoolType,
-    ) -> Result<SparseMapping, anyhow::Error>;
-}
-
-/// A mapper that does not support mapping and always returns an error.
-#[derive(Inspect)]
-#[inspect(extra = "NoMapper::inspect_extra")]
-pub struct NoMapper;
-
-impl NoMapper {
-    fn inspect_extra(&self, resp: &mut Response<'_>) {
-        resp.field("type", "unsupported");
-    }
-}
-
-impl Mapper for NoMapper {
-    fn map(
-        &self,
-        _base_pfn: u64,
-        _size_pages: u64,
-        _pool_type: PoolType,
-    ) -> Result<SparseMapping, anyhow::Error> {
-        anyhow::bail!("mapping not supported on this pool")
-    }
+/// A source for pool allocations.
+pub trait PoolSource: Inspect + Send + Sync {
+    /// The bias to apply to the physical address of each allocation.
+    fn address_bias(&self) -> u64;
+    /// Translates a physical address into the file offset to use when mapping
+    /// the page.
+    fn mapping_file_offset(&self, address: u64) -> usize;
+    /// Returns the OS object to map pages from.
+    fn mappable(&self) -> MappableRef<'_>;
 }
 
 /// A mapper that uses an internal buffer to map pages. This is meant to be used
@@ -456,7 +435,7 @@ pub struct TestMapper {
 impl TestMapper {
     /// Create a new test mapper that holds an internal buffer of `size_pages`.
     pub fn new(size_pages: u64) -> anyhow::Result<Self> {
-        let len = (size_pages * HV_PAGE_SIZE) as usize;
+        let len = (size_pages * PAGE_SIZE) as usize;
         let fd = alloc_shared_memory(len).context("creating shared mem")?;
 
         Ok(Self { mem: fd })
@@ -467,22 +446,20 @@ impl TestMapper {
     }
 }
 
-impl Mapper for TestMapper {
-    fn map(
-        &self,
-        base_pfn: u64,
-        size_pages: u64,
-        _pool_type: PoolType,
-    ) -> Result<SparseMapping, anyhow::Error> {
-        let len = (size_pages * HV_PAGE_SIZE) as usize;
-        let mapping = SparseMapping::new(len).context("failed to create mapping")?;
-        let gpa = base_pfn * HV_PAGE_SIZE;
+impl PoolSource for TestMapper {
+    fn address_bias(&self) -> u64 {
+        0
+    }
 
-        mapping
-            .map_file(0, len, &self.mem, gpa, true)
-            .context("unable to map allocation")?;
+    fn mapping_file_offset(&self, address: u64) -> usize {
+        address as usize
+    }
 
-        Ok(mapping)
+    fn mappable(&self) -> MappableRef<'_> {
+        #[cfg(windows)]
+        return std::os::windows::io::AsHandle::as_handle(&self.mem);
+        #[cfg(not(windows))]
+        std::os::unix::io::AsFd::as_fd(&self.mem)
     }
 }
 
@@ -499,65 +476,65 @@ impl Mapper for TestMapper {
 #[derive(Inspect)]
 pub struct PagePool {
     #[inspect(flatten)]
-    inner: Arc<Mutex<PagePoolInner>>,
+    inner: Arc<PagePoolInner>,
     #[inspect(iter_by_index)]
     ranges: Vec<MemoryRange>,
-    typ: PoolType,
 }
 
 impl PagePool {
-    /// Create a new private pool allocator, with the specified memory. The
-    /// memory must not be used by any other entity.
-    pub fn new_private_pool<T: Mapper + 'static>(
-        private_pool: &[MemoryRangeWithNode],
-        mapper: T,
-    ) -> anyhow::Result<Self> {
-        Self::new_internal(private_pool, PoolType::Private, 0, mapper)
+    /// Returns a new page pool managing the address ranges in `ranges`,
+    /// using `source` to access the memory.
+    pub fn new<T: PoolSource + 'static>(ranges: &[MemoryRange], source: T) -> anyhow::Result<Self> {
+        Self::new_internal(ranges, source)
     }
 
-    /// Create a shared visibility page pool allocator, with the specified
-    /// memory. The supplied guest physical address ranges must be in the
-    /// correct shared state and usable. The memory must not be used by any
-    /// other entity.
-    ///
-    /// `addr_bias` represents a bias to apply to addresses in `shared_pool`.
-    /// This should be vtom on hardware isolated platforms.
-    pub fn new_shared_visibility_pool<T: Mapper + 'static>(
-        shared_pool: &[MemoryRangeWithNode],
-        addr_bias: u64,
-        mapper: T,
-    ) -> anyhow::Result<Self> {
-        Self::new_internal(shared_pool, PoolType::Shared, addr_bias, mapper)
-    }
-
-    fn new_internal<T: Mapper + 'static>(
-        memory: &[MemoryRangeWithNode],
-        typ: PoolType,
-        addr_bias: u64,
-        mapper: T,
+    fn new_internal<T: PoolSource + 'static>(
+        memory: &[MemoryRange],
+        source: T,
     ) -> anyhow::Result<Self> {
         // TODO: Allow callers to specify the vnode, but today we discard this
         // information. In the future we may keep ranges with vnode in order to
         // allow per-node allocations.
 
+        let mut i = 0;
         let pages = memory
             .iter()
-            .map(|range| Slot {
-                base_pfn: range.range.start() / HV_PAGE_SIZE,
-                size_pages: range.range.len() / HV_PAGE_SIZE,
-                state: SlotState::Free,
+            .map(|range| {
+                let slot = Slot {
+                    base_pfn: range.start() / PAGE_SIZE,
+                    size_pages: range.len() / PAGE_SIZE,
+                    mapping_offset: i,
+                    state: SlotState::Free,
+                };
+                i += range.len() as usize;
+                slot
             })
             .collect();
 
+        // Create a contiguous mapping of the memory ranges.
+        let mapping = SparseMapping::new(i).context("failed to reserve VA")?;
+        let mappable = source.mappable();
+        let mut i = 0;
+        for range in memory {
+            let file_offset = range.start();
+            let len = range.len() as usize;
+            mapping
+                .map_file(i, len, mappable, file_offset, true)
+                .context("failed to map range")?;
+            i += len;
+        }
+
         Ok(Self {
-            inner: Arc::new(Mutex::new(PagePoolInner {
-                slots: pages,
-                pfn_bias: addr_bias / HV_PAGE_SIZE,
-                device_ids: Vec::new(),
-                mapper: Box::new(mapper),
-            })),
-            ranges: memory.iter().map(|r| r.range).collect(),
-            typ,
+            inner: Arc::new(PagePoolInner {
+                state: Mutex::new(PagePoolState {
+                    slots: pages,
+                    device_ids: Vec::new(),
+                }),
+                pfn_bias: source.address_bias() / PAGE_SIZE,
+                source: Box::new(source),
+                mapping,
+            }),
+            ranges: memory.to_vec(),
         })
     }
 
@@ -567,14 +544,13 @@ impl PagePool {
     /// Users should create a new allocator for each device, as the device name
     /// is used to track allocations in the pool.
     pub fn allocator(&self, device_name: String) -> anyhow::Result<PagePoolAllocator> {
-        PagePoolAllocator::new(&self.inner, self.typ, device_name)
+        PagePoolAllocator::new(&self.inner, device_name)
     }
 
     /// Create a spawner that allows creating multiple allocators.
     pub fn allocator_spawner(&self) -> PagePoolAllocatorSpawner {
         PagePoolAllocatorSpawner {
             inner: self.inner.clone(),
-            typ: self.typ,
         }
     }
 
@@ -588,7 +564,7 @@ impl PagePool {
     ///
     /// Unmatched allocations are always logged via a `tracing::warn!` log.
     pub fn validate_restore(&self, leak_unrestored: bool) -> Result<(), UnrestoredAllocations> {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.state.lock();
         let mut unrestored_allocation = false;
 
         // Mark unrestored allocations as leaked.
@@ -630,8 +606,7 @@ impl PagePool {
 /// Useful when you need to create multiple allocators, without having ownership
 /// of the actual [`PagePool`].
 pub struct PagePoolAllocatorSpawner {
-    inner: Arc<Mutex<PagePoolInner>>,
-    typ: PoolType,
+    inner: Arc<PagePoolInner>,
 }
 
 impl PagePoolAllocatorSpawner {
@@ -641,7 +616,7 @@ impl PagePoolAllocatorSpawner {
     /// Users should create a new allocator for each device, as the device name
     /// is used to track allocations in the pool.
     pub fn allocator(&self, device_name: String) -> anyhow::Result<PagePoolAllocator> {
-        PagePoolAllocator::new(&self.inner, self.typ, device_name)
+        PagePoolAllocator::new(&self.inner, device_name)
     }
 }
 
@@ -655,20 +630,15 @@ impl PagePoolAllocatorSpawner {
 /// same name. Exisitng allocations with that same device_name will be
 /// linked to the new allocator.
 pub struct PagePoolAllocator {
-    inner: Arc<Mutex<PagePoolInner>>,
-    typ: PoolType,
+    inner: Arc<PagePoolInner>,
     device_id: usize,
 }
 
 impl PagePoolAllocator {
-    fn new(
-        inner: &Arc<Mutex<PagePoolInner>>,
-        typ: PoolType,
-        device_name: String,
-    ) -> anyhow::Result<Self> {
+    fn new(inner: &Arc<PagePoolInner>, device_name: String) -> anyhow::Result<Self> {
         let device_id;
         {
-            let mut inner = inner.lock();
+            let mut inner = inner.state.lock();
 
             let index = inner
                 .device_ids
@@ -699,18 +669,12 @@ impl PagePoolAllocator {
 
         Ok(Self {
             inner: inner.clone(),
-            typ,
             device_id,
         })
     }
 
-    fn alloc_inner(
-        &self,
-        size_pages: NonZeroU64,
-        tag: String,
-        with_mapping: bool,
-    ) -> Result<PagePoolHandle, Error> {
-        let mut inner = self.inner.lock();
+    fn alloc_inner(&self, size_pages: NonZeroU64, tag: String) -> Result<PagePoolHandle, Error> {
+        let mut inner = self.inner.state.lock();
         let size_pages = size_pages.get();
 
         let index = inner
@@ -727,17 +691,16 @@ impl PagePoolAllocator {
                 tag: tag.clone(),
             })?;
 
-        let pfn_bias = inner.pfn_bias;
-
         // Track which slots we should append if the mapping creation succeeds.
         // If the mapping creation fails, we instead commit the original free
         // slot back to the pool.
-        let (original_slot, allocation_slot, free_slot) = {
+        let (allocation_slot, free_slot) = {
             let slot = inner.slots.swap_remove(index);
             assert!(matches!(slot.state, SlotState::Free));
 
             let allocation_slot = Slot {
                 base_pfn: slot.base_pfn,
+                mapping_offset: slot.mapping_offset,
                 size_pages,
                 state: SlotState::Allocated {
                     device_id: self.device_id,
@@ -748,6 +711,7 @@ impl PagePoolAllocator {
             let free_slot = if slot.size_pages > size_pages {
                 Some(Slot {
                     base_pfn: slot.base_pfn + size_pages,
+                    mapping_offset: slot.mapping_offset + size_pages as usize,
                     size_pages: slot.size_pages - size_pages,
                     state: SlotState::Free,
                 })
@@ -755,26 +719,11 @@ impl PagePoolAllocator {
                 None
             };
 
-            (slot, allocation_slot, free_slot)
+            (allocation_slot, free_slot)
         };
 
         let base_pfn = allocation_slot.base_pfn;
-
-        let mapping = if with_mapping {
-            let mapping = match inner.mapper.map(base_pfn, size_pages, self.typ) {
-                Ok(mapping) => mapping,
-                Err(e) => {
-                    // Commit the original slot back to the pool.
-                    inner.slots.push(original_slot);
-
-                    return Err(Error::Mapping(e));
-                }
-            };
-
-            Some(mapping)
-        } else {
-            None
-        };
+        let mapping_offset = allocation_slot.mapping_offset;
 
         // Commit state to the pool.
         inner.slots.push(allocation_slot);
@@ -785,9 +734,8 @@ impl PagePoolAllocator {
         Ok(PagePoolHandle {
             inner: self.inner.clone(),
             base_pfn,
-            pfn_bias,
             size_pages,
-            mapping,
+            mapping_offset,
         })
     }
 
@@ -795,18 +743,7 @@ impl PagePoolAllocator {
     /// contiguous region of free pages is not available, then an error is
     /// returned.
     pub fn alloc(&self, size_pages: NonZeroU64, tag: String) -> Result<PagePoolHandle, Error> {
-        self.alloc_inner(size_pages, tag, false)
-    }
-
-    /// The same as [`Self::alloc`], but also creates an associated mapping for
-    /// the allocation so the user can use the mapping via
-    /// [`PagePoolHandle::mapping`].
-    pub fn alloc_with_mapping(
-        &self,
-        size_pages: NonZeroU64,
-        tag: String,
-    ) -> Result<PagePoolHandle, Error> {
-        self.alloc_inner(size_pages, tag, true)
+        self.alloc_inner(size_pages, tag)
     }
 
     /// Restore an allocation that was previously allocated in the pool. The
@@ -818,10 +755,9 @@ impl PagePoolAllocator {
         &self,
         base_pfn: u64,
         size_pages: NonZeroU64,
-        with_mapping: bool,
     ) -> Result<PagePoolHandle, Error> {
         let size_pages = size_pages.get();
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.state.lock();
         let index = inner
             .slots
             .iter()
@@ -836,31 +772,20 @@ impl PagePoolAllocator {
             })
             .ok_or(Error::NoMatchingAllocation)?;
 
-        let mapping = if with_mapping {
-            let mapping = inner
-                .mapper
-                .map(base_pfn, size_pages, self.typ)
-                .map_err(Error::Mapping)?;
-            Some(mapping)
-        } else {
-            None
-        };
-
         inner.slots[index].state.restore_allocated(self.device_id);
 
         Ok(PagePoolHandle {
             inner: self.inner.clone(),
             base_pfn,
-            pfn_bias: inner.pfn_bias,
             size_pages,
-            mapping,
+            mapping_offset: inner.slots[index].mapping_offset,
         })
     }
 }
 
 impl Drop for PagePoolAllocator {
     fn drop(&mut self) {
-        let mut inner = self.inner.lock();
+        let mut inner = self.inner.state.lock();
         let device_name = inner.device_ids[self.device_id].name().to_string();
         let prev = std::mem::replace(
             &mut inner.device_ids[self.device_id],
@@ -872,20 +797,21 @@ impl Drop for PagePoolAllocator {
 
 impl user_driver::DmaClient for PagePoolAllocator {
     fn allocate_dma_buffer(&self, len: usize) -> anyhow::Result<user_driver::memory::MemoryBlock> {
-        if len as u64 % HV_PAGE_SIZE != 0 {
+        if len as u64 % PAGE_SIZE != 0 {
             anyhow::bail!("not a page-size multiple");
         }
 
-        let size_pages = NonZeroU64::new(len as u64 / HV_PAGE_SIZE)
+        let size_pages = NonZeroU64::new(len as u64 / PAGE_SIZE)
             .context("allocation of size 0 not supported")?;
 
         let alloc = self
-            .alloc_with_mapping(size_pages, "vfio dma".into())
+            .alloc(size_pages, "vfio dma".into())
             .context("failed to allocate shared mem")?;
 
         // The VfioDmaBuffer trait requires that newly allocated buffers are
         // zeroed.
-        alloc.into_memory_block(true)
+        alloc.mapping().atomic_fill(0);
+        alloc.into_memory_block()
     }
 
     /// Restore a dma buffer in the predefined location with the given `len` in
@@ -895,47 +821,79 @@ impl user_driver::DmaClient for PagePoolAllocator {
         len: usize,
         base_pfn: u64,
     ) -> anyhow::Result<user_driver::memory::MemoryBlock> {
-        if len as u64 % HV_PAGE_SIZE != 0 {
+        if len as u64 % PAGE_SIZE != 0 {
             anyhow::bail!("not a page-size multiple");
         }
 
-        let size_pages = NonZeroU64::new(len as u64 / HV_PAGE_SIZE)
+        let size_pages = NonZeroU64::new(len as u64 / PAGE_SIZE)
             .context("allocation of size 0 not supported")?;
 
         let alloc = self
-            .restore_alloc(base_pfn, size_pages, true)
+            .restore_alloc(base_pfn, size_pages)
             .context("failed to restore allocation")?;
 
         // Preserve the existing contents of memory and do not zero the restored
         // allocation.
-        alloc.into_memory_block(false)
+        alloc.into_memory_block()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use crate::PagePool;
+    use crate::PoolSource;
+    use crate::TestMapper;
+    use crate::PAGE_SIZE;
+    use inspect::Inspect;
     use memory_range::MemoryRange;
+    use safeatomic::AtomicSliceOps;
+    use sparse_mmap::MappableRef;
     use vmcore::save_restore::SaveRestore;
+
+    #[derive(Inspect)]
+    #[inspect(bound = "T: Inspect")]
+    struct BiasedMapper<T> {
+        mapper: T,
+        bias: u64,
+    }
+
+    impl<T: PoolSource> BiasedMapper<T> {
+        fn new(mapper: T, bias: u64) -> Self {
+            Self { mapper, bias }
+        }
+    }
+
+    impl<T: PoolSource> PoolSource for BiasedMapper<T> {
+        fn address_bias(&self) -> u64 {
+            self.bias.wrapping_add(self.mapper.address_bias())
+        }
+
+        fn mapping_file_offset(&self, address: u64) -> usize {
+            self.mapper.mapping_file_offset(address)
+        }
+
+        fn mappable(&self) -> MappableRef<'_> {
+            self.mapper.mappable()
+        }
+    }
+
+    fn big_test_mapper() -> TestMapper {
+        TestMapper::new(1024 * 1024).unwrap()
+    }
 
     #[test]
     fn test_basic_alloc() {
         let pfn_bias = 15;
-        let pool = PagePool::new_shared_visibility_pool(
-            &[MemoryRangeWithNode {
-                range: MemoryRange::from_4k_gpn_range(10..30),
-                vnode: 0,
-            }],
-            pfn_bias * HV_PAGE_SIZE,
-            NoMapper,
+        let pool = PagePool::new(
+            &[MemoryRange::from_4k_gpn_range(10..30)],
+            BiasedMapper::new(big_test_mapper(), pfn_bias * PAGE_SIZE),
         )
         .unwrap();
         let alloc = pool.allocator("test".into()).unwrap();
 
         let a1 = alloc.alloc(5.try_into().unwrap(), "alloc1".into()).unwrap();
         assert_eq!(a1.base_pfn, 10);
-        assert_eq!(a1.pfn_bias, pfn_bias);
-        assert_eq!(a1.base_pfn(), a1.base_pfn + a1.pfn_bias);
+        assert_eq!(a1.base_pfn(), a1.base_pfn + pfn_bias);
         assert_eq!(a1.base_pfn_without_bias(), a1.base_pfn);
         assert_eq!(a1.size_pages, 5);
 
@@ -943,8 +901,7 @@ mod test {
             .alloc(15.try_into().unwrap(), "alloc2".into())
             .unwrap();
         assert_eq!(a2.base_pfn, 15);
-        assert_eq!(a2.pfn_bias, pfn_bias);
-        assert_eq!(a2.base_pfn(), a2.base_pfn + a2.pfn_bias);
+        assert_eq!(a2.base_pfn(), a2.base_pfn + pfn_bias);
         assert_eq!(a2.base_pfn_without_bias(), a2.base_pfn);
         assert_eq!(a2.size_pages, 15);
 
@@ -953,21 +910,14 @@ mod test {
         drop(a1);
         drop(a2);
 
-        let inner = alloc.inner.lock();
+        let inner = alloc.inner.state.lock();
         assert_eq!(inner.slots.len(), 2);
     }
 
     #[test]
     fn test_duplicate_device_name() {
-        let pool = PagePool::new_shared_visibility_pool(
-            &[MemoryRangeWithNode {
-                range: MemoryRange::from_4k_gpn_range(10..30),
-                vnode: 0,
-            }],
-            0,
-            NoMapper,
-        )
-        .unwrap();
+        let pool =
+            PagePool::new(&[MemoryRange::from_4k_gpn_range(10..30)], big_test_mapper()).unwrap();
         let _alloc = pool.allocator("test".into()).unwrap();
 
         assert!(pool.allocator("test".into()).is_err());
@@ -975,15 +925,8 @@ mod test {
 
     #[test]
     fn test_dropping_allocator() {
-        let pool = PagePool::new_shared_visibility_pool(
-            &[MemoryRangeWithNode {
-                range: MemoryRange::from_4k_gpn_range(10..40),
-                vnode: 0,
-            }],
-            0,
-            NoMapper,
-        )
-        .unwrap();
+        let pool =
+            PagePool::new(&[MemoryRange::from_4k_gpn_range(10..40)], big_test_mapper()).unwrap();
         let alloc = pool.allocator("test".into()).unwrap();
         let _alloc2 = pool.allocator("test2".into()).unwrap();
 
@@ -1000,56 +943,38 @@ mod test {
 
     #[test]
     fn test_save_restore() {
-        let mut pool = PagePool::new_shared_visibility_pool(
-            &[MemoryRangeWithNode {
-                range: MemoryRange::from_4k_gpn_range(10..30),
-                vnode: 0,
-            }],
-            0,
-            NoMapper,
-        )
-        .unwrap();
+        let mut pool =
+            PagePool::new(&[MemoryRange::from_4k_gpn_range(10..30)], big_test_mapper()).unwrap();
         let alloc = pool.allocator("test".into()).unwrap();
 
         let a1 = alloc.alloc(5.try_into().unwrap(), "alloc1".into()).unwrap();
         let a1_pfn = a1.base_pfn();
-        let a1_pfn_bias = a1.pfn_bias;
         let a1_size = a1.size_pages;
 
         let a2 = alloc
             .alloc(15.try_into().unwrap(), "alloc2".into())
             .unwrap();
         let a2_pfn = a2.base_pfn();
-        let a2_pfn_bias = a2.pfn_bias;
         let a2_size = a2.size_pages;
 
         let state = pool.save().unwrap();
 
-        let mut pool = PagePool::new_shared_visibility_pool(
-            &[MemoryRangeWithNode {
-                range: MemoryRange::from_4k_gpn_range(10..30),
-                vnode: 0,
-            }],
-            0,
-            NoMapper,
-        )
-        .unwrap();
+        let mut pool =
+            PagePool::new(&[MemoryRange::from_4k_gpn_range(10..30)], big_test_mapper()).unwrap();
         pool.restore(state).unwrap();
         let alloc = pool.allocator("test".into()).unwrap();
 
         let restored_a1 = alloc
-            .restore_alloc(a1_pfn, a1_size.try_into().unwrap(), false)
+            .restore_alloc(a1_pfn, a1_size.try_into().unwrap())
             .unwrap();
         let restored_a2 = alloc
-            .restore_alloc(a2_pfn, a2_size.try_into().unwrap(), false)
+            .restore_alloc(a2_pfn, a2_size.try_into().unwrap())
             .unwrap();
 
         assert_eq!(restored_a1.base_pfn(), a1_pfn);
-        assert_eq!(restored_a1.pfn_bias, a1_pfn_bias);
         assert_eq!(restored_a1.size_pages, a1_size);
 
         assert_eq!(restored_a2.base_pfn(), a2_pfn);
-        assert_eq!(restored_a2.pfn_bias, a2_pfn_bias);
         assert_eq!(restored_a2.size_pages, a2_size);
 
         pool.validate_restore(false).unwrap();
@@ -1057,30 +982,16 @@ mod test {
 
     #[test]
     fn test_save_restore_unmatched_allocations() {
-        let mut pool = PagePool::new_shared_visibility_pool(
-            &[MemoryRangeWithNode {
-                range: MemoryRange::from_4k_gpn_range(10..30),
-                vnode: 0,
-            }],
-            0,
-            NoMapper,
-        )
-        .unwrap();
+        let mut pool =
+            PagePool::new(&[MemoryRange::from_4k_gpn_range(10..30)], big_test_mapper()).unwrap();
 
         let alloc = pool.allocator("test".into()).unwrap();
         let _a1 = alloc.alloc(5.try_into().unwrap(), "alloc1".into()).unwrap();
 
         let state = pool.save().unwrap();
 
-        let mut pool = PagePool::new_shared_visibility_pool(
-            &[MemoryRangeWithNode {
-                range: MemoryRange::from_4k_gpn_range(10..30),
-                vnode: 0,
-            }],
-            0,
-            NoMapper,
-        )
-        .unwrap();
+        let mut pool =
+            PagePool::new(&[MemoryRange::from_4k_gpn_range(10..30)], big_test_mapper()).unwrap();
 
         pool.restore(state).unwrap();
 
@@ -1089,62 +1000,43 @@ mod test {
 
     #[test]
     fn test_restore_other_allocator() {
-        let mut pool = PagePool::new_shared_visibility_pool(
-            &[MemoryRangeWithNode {
-                range: MemoryRange::from_4k_gpn_range(10..30),
-                vnode: 0,
-            }],
-            0,
-            NoMapper,
-        )
-        .unwrap();
+        let mut pool =
+            PagePool::new(&[MemoryRange::from_4k_gpn_range(10..30)], big_test_mapper()).unwrap();
 
         let alloc = pool.allocator("test".into()).unwrap();
         let a1 = alloc.alloc(5.try_into().unwrap(), "alloc1".into()).unwrap();
 
         let state = pool.save().unwrap();
 
-        let mut pool = PagePool::new_shared_visibility_pool(
-            &[MemoryRangeWithNode {
-                range: MemoryRange::from_4k_gpn_range(10..30),
-                vnode: 0,
-            }],
-            0,
-            NoMapper,
-        )
-        .unwrap();
+        let mut pool =
+            PagePool::new(&[MemoryRange::from_4k_gpn_range(10..30)], big_test_mapper()).unwrap();
 
         pool.restore(state).unwrap();
 
         let alloc = pool.allocator("test2".into()).unwrap();
         assert!(alloc
-            .restore_alloc(a1.base_pfn, a1.size_pages.try_into().unwrap(), false)
+            .restore_alloc(a1.base_pfn, a1.size_pages.try_into().unwrap())
             .is_err());
     }
 
     #[test]
     fn test_mapping() {
-        let pool = PagePool::new_private_pool(
-            &[MemoryRangeWithNode {
-                range: MemoryRange::from_4k_gpn_range(0..30),
-                vnode: 0,
-            }],
+        let pool = PagePool::new(
+            &[MemoryRange::from_4k_gpn_range(0..30)],
             TestMapper::new(30).unwrap(),
         )
         .unwrap();
         let alloc = pool.allocator("test".into()).unwrap();
 
-        let a1 = alloc
-            .alloc_with_mapping(5.try_into().unwrap(), "alloc1".into())
-            .unwrap();
-        let a1_mapping = a1.mapping().unwrap();
-        assert_eq!(a1_mapping.len(), 5 * HV_PAGE_SIZE as usize);
-        a1_mapping.write_at(123, &[1, 2, 3, 4]).unwrap();
+        let a1 = alloc.alloc(5.try_into().unwrap(), "alloc1".into()).unwrap();
+        let a1_mapping = a1.mapping();
+        assert_eq!(a1_mapping.len(), 5 * PAGE_SIZE as usize);
+        a1_mapping[123..][..4].atomic_write(&[1, 2, 3, 4]);
         let mut data = [0; 4];
-        a1_mapping.read_at(123, &mut data).unwrap();
+        a1_mapping[123..][..4].atomic_read(&mut data);
         assert_eq!(data, [1, 2, 3, 4]);
         let mut data = [0; 2];
-        a1_mapping.read_at(125, &mut data).unwrap();
+        a1_mapping[125..][..2].atomic_read(&mut data);
         assert_eq!(data, [3, 4]);
     }
 }


### PR DESCRIPTION
Save a bunch of kernel memory and speed things up by creating one mapping per pool instead of one per allocation. Move knowledge about the pool's use out to the backing memory sources. Remove support for unmapped pools (no use case).

We could simplify things further by moving all the mapping code to the individual mappers, but this would complicate computing the mapping address for a given slot, so skip this for now.