### PR TITLE
[aarch64emu] enable ldset fast path for MNF (#863)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7276,6 +7276,7 @@ dependencies = [
  "guestmem",
  "hvdef",
  "thiserror 2.0.0",
+ "tracelimit",
  "tracing",
  "virt",
  "vm_topology",

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -299,6 +299,41 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
             Self::intercepted_vtl(&message.header).map_err(|UnsupportedGuestVtl(vtl)| {
                 VpHaltReason::InvalidVmState(UhRunVpError::InvalidInterceptedVtl(vtl))
             })?;
+
+        // Fast path for monitor page writes.
+        if Some(message.guest_physical_address & !(hvdef::HV_PAGE_SIZE - 1))
+            == self.partition.monitor_page.gpa()
+            && message.header.intercept_access_type == hvdef::HvInterceptAccessType::WRITE
+            && message.instruction_byte_count == 4
+        {
+            let gpa = message.guest_physical_address;
+            let guest_memory = &self.partition.gm[intercepted_vtl];
+            if let Some(mut bitmask) = emulate::emulate_mnf_write_fast_path(
+                u32::from_ne_bytes(message.instruction_bytes),
+                &mut UhEmulationState {
+                    vp: &mut *self,
+                    interruption_pending: intercept_state.interruption_pending,
+                    devices: dev,
+                    vtl: intercepted_vtl,
+                    cache: UhCpuStateCache::default(),
+                },
+                guest_memory,
+                dev,
+            ) {
+                let bit_offset = (gpa & (hvdef::HV_PAGE_SIZE - 1)) as u32 * 8;
+                while bitmask != 0 {
+                    let bit = 63 - bitmask.leading_zeros();
+                    bitmask &= !(1 << bit);
+                    if let Some(connection_id) =
+                        self.partition.monitor_page.write_bit(bit_offset + bit)
+                    {
+                        signal_mnf(dev, connection_id);
+                    }
+                }
+                return Ok(());
+            }
+        }
+
         self.emulate(dev, &intercept_state, intercepted_vtl).await?;
         Ok(())
     }

--- a/vm/aarch64/aarch64emu/src/opcodes.rs
+++ b/vm/aarch64/aarch64emu/src/opcodes.rs
@@ -133,28 +133,28 @@ fn decode_load_store_group<E>(opcode: u32) -> Result<Aarch64DecodeLoadStoreGroup
             Aarch64DecodeLoadStoreGroup::RegisterUnsignedImmediate
         }
         3 | 7 | 11 | 15 if op4 == 0 => {
-            if (op3 & 0x60) != 0 {
+            if (op3 & 0x20) != 0 {
                 Aarch64DecodeLoadStoreGroup::Atomic
             } else {
                 Aarch64DecodeLoadStoreGroup::RegisterUnscaledImmediate
             }
         }
         3 | 7 | 11 | 15 if op4 == 1 => {
-            if (op3 & 0x60) != 0 {
+            if (op3 & 0x20) != 0 {
                 Aarch64DecodeLoadStoreGroup::RegisterPac
             } else {
                 Aarch64DecodeLoadStoreGroup::RegisterImmediatePostIndex
             }
         }
         3 | 7 | 11 | 15 if op4 == 2 => {
-            if (op3 & 0x60) != 0 {
+            if (op3 & 0x20) != 0 {
                 Aarch64DecodeLoadStoreGroup::RegisterOffset
             } else {
                 Aarch64DecodeLoadStoreGroup::RegisterUnprivileged
             }
         }
         3 | 7 | 11 | 15 => {
-            if (op3 & 0x60) != 0 {
+            if (op3 & 0x20) != 0 {
                 Aarch64DecodeLoadStoreGroup::RegisterPac
             } else {
                 Aarch64DecodeLoadStoreGroup::RegisterImmediatePreIndex

--- a/vmm_core/virt_support_aarch64emu/Cargo.toml
+++ b/vmm_core/virt_support_aarch64emu/Cargo.toml
@@ -15,6 +15,7 @@ virt.workspace = true
 aarch64emu.workspace = true
 
 thiserror.workspace = true
+tracelimit.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
 


### PR DESCRIPTION
Add a fast path for MNF writes using the ldset instruction.
#863 