### PR TITLE
xsync: fix cargo-lock regen

### DIFF
--- a/xsync/xsync/src/main.rs
+++ b/xsync/xsync/src/main.rs
@@ -136,14 +136,18 @@ fn do_full_sync(ctx: &CmdCtx, check: bool) -> Result<(), anyhow::Error> {
             "running: `cargo update --workspace` in {}    (ensuring base-repo `Cargo.lock` is up-to-date)",
             ctx.base_workspace.display()
         );
-        std::process::Command::new("cargo")
+        let status = std::process::Command::new("cargo")
             .arg("update")
             .arg("--workspace")
+            .arg("--quiet")
             .current_dir(&ctx.base_workspace)
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()?
-            .wait()?;
+            .status()?;
+        if !status.success() {
+            return Err(anyhow::anyhow!(
+                "cargo update failed with status: {}",
+                status
+            ));
+        }
     }
 
     log::info!("running xsync cmd: `cargo-lock gen-external base`    (regenerating list of base-repo external dependencies)");


### PR DESCRIPTION
After improving xsync performance in #857, xsync's internal `cargo update` command now (silently) fails in CI, causing one of the overlay deps files to be computed incorrectly. This occurs because in CI, the registry index is not always populated at the point of xsync, and `cargo update` cannot download it due to the use of `--offline`.

To preserve most of the performance benefits while fixing the issue, try `cargo update --offline` first and, if that fails, try it again without `--offline`. Probably `cargo update --workspace` should be fixed to not touch the network unless needed.

Also, report the errors from these commands so that this will be caught next time. Like, come on.