### PR TITLE
hv1_emulator: Support flushing the TLB when writing to the hypercall page MSR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7269,7 +7269,6 @@ dependencies = [
  "futures",
  "guestmem",
  "hcl",
- "hv1_emulator",
  "hv1_structs",
  "hvdef",
  "inspect",

--- a/openhcl/underhill_mem/Cargo.toml
+++ b/openhcl/underhill_mem/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]
 guestmem.workspace = true
 hcl.workspace = true
-hv1_emulator.workspace = true
 hv1_structs.workspace = true
 hvdef.workspace = true
 memory_range.workspace = true

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -51,7 +51,6 @@ use hcl::ioctl::Hcl;
 use hcl::ioctl::SetVsmPartitionConfigError;
 use hcl::GuestVtl;
 use hv1_emulator::hv::GlobalHv;
-use hv1_emulator::hv::VtlProtectHypercallOverlay;
 use hv1_emulator::message_queues::MessageQueues;
 use hv1_emulator::synic::GlobalSynic;
 use hv1_emulator::synic::SintProxied;
@@ -1323,27 +1322,16 @@ pub trait ProtectIsolatedMemory: Send + Sync {
         tlb_access: &mut dyn TlbFlushLockAccess,
     ) -> Result<(), (HvError, usize)>;
 
-    /// Retrieves a protector for the hypercall code page overlay for a target
-    /// VTL.
-    fn hypercall_overlay_protector(
-        self: Arc<Self>,
-        vtl: GuestVtl,
-    ) -> Box<dyn VtlProtectHypercallOverlay>;
-
     /// Changes the overlay for the hypercall code page for a target VTL.
     fn change_hypercall_overlay(
         &self,
         vtl: GuestVtl,
         gpn: u64,
-        tlb_access: &mut dyn hv1_emulator::hv::TlbFlushAccess,
+        tlb_access: &mut dyn TlbFlushLockAccess,
     );
 
     /// Disables the overlay for the hypercall code page for a target VTL.
-    fn disable_hypercall_overlay(
-        &self,
-        vtl: GuestVtl,
-        tlb_access: &mut dyn hv1_emulator::hv::TlbFlushAccess,
-    );
+    fn disable_hypercall_overlay(&self, vtl: GuestVtl, tlb_access: &mut dyn TlbFlushLockAccess);
 
     /// Alerts the memory protector that vtl 1 is ready to set vtl protections
     /// on lower-vtl memory, and that these protections should be enforced.
@@ -1893,12 +1881,6 @@ impl UhProtoPartition<'_> {
             vendor: caps.vendor,
             tsc_frequency,
             ref_time,
-            hypercall_page_protectors: VtlArray::from_fn(|vtl| {
-                late_params.isolated_memory_protector.as_ref().map(|p| {
-                    p.clone()
-                        .hypercall_overlay_protector(vtl.try_into().expect("no vtl 2"))
-                })
-            }),
         });
 
         Ok(UhCvmPartitionState {

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1335,11 +1335,15 @@ pub trait ProtectIsolatedMemory: Send + Sync {
         &self,
         vtl: GuestVtl,
         gpn: u64,
-        tlb_access: &mut dyn TlbFlushLockAccess,
+        tlb_access: &mut dyn hv1_emulator::hv::TlbFlushAccess,
     );
 
     /// Disables the overlay for the hypercall code page for a target VTL.
-    fn disable_hypercall_overlay(&self, vtl: GuestVtl, tlb_access: &mut dyn TlbFlushLockAccess);
+    fn disable_hypercall_overlay(
+        &self,
+        vtl: GuestVtl,
+        tlb_access: &mut dyn hv1_emulator::hv::TlbFlushAccess,
+    );
 
     /// Alerts the memory protector that vtl 1 is ready to set vtl protections
     /// on lower-vtl memory, and that these protections should be enforced.

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1276,7 +1276,7 @@ where
                 .clone(),
             tlb_access: DelayedTlbFlushAccess { vtl: None },
         };
-        let r = hv.msr_write(msr, value, &mut access);
+        let r = hv.msr_write(msr, value, Some(&mut access));
         if let Some(vtl) = access.tlb_access.vtl {
             self.flush(vtl);
         }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1276,7 +1276,7 @@ where
                 .clone(),
             tlb_access: DelayedTlbFlushAccess { vtl: None },
         };
-        let r = hv.msr_write(msr, value, Some(&mut access));
+        let r = hv.msr_write(msr, value, &mut access);
         if let Some(vtl) = access.tlb_access.vtl {
             self.flush(vtl);
         }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -2013,8 +2013,8 @@ impl UhProcessor<'_, TdxBacked> {
         intercepted_vtl: GuestVtl,
     ) -> Result<(), MsrError> {
         match msr {
-            msr @ hvdef::HV_X64_MSR_GUEST_OS_ID => {
-                self.backing.cvm.hv[intercepted_vtl].msr_write(msr, value)?
+            hvdef::HV_X64_MSR_GUEST_OS_ID => {
+                self.backing.cvm.hv[intercepted_vtl].msr_write_guest_os_id(value)
             }
             _ => {
                 // If we get here we must have an untrusted synic, as otherwise

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -121,9 +121,13 @@ impl GlobalHv {
     }
 
     /// Resets the global (but not per-processor) state.
-    pub fn reset(&self, mut overlay_access: Option<&mut dyn VtlProtectHypercallOverlay>) {
-        for state in self.vtl_mutable_state.iter() {
-            state.lock().reset(&mut overlay_access);
+    pub fn reset(
+        &self,
+        mut overlay_access: VtlArray<Option<&mut dyn VtlProtectHypercallOverlay>, 2>,
+    ) {
+        for (state, overlay_access) in self.vtl_mutable_state.iter().zip(overlay_access.iter_mut())
+        {
+            state.lock().reset(overlay_access);
         }
         // There is no global synic state to reset, since the synic is per-VP.
     }

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -73,9 +73,9 @@ impl MutableHvState {
         }
     }
 
-    fn reset(&mut self) {
+    fn reset(&mut self, tlb_access: &mut dyn TlbFlushAccess) {
         if let Some(p) = self.hypercall_protector.as_mut() {
-            p.disable_overlay(todo!());
+            p.disable_overlay(tlb_access);
         }
         self.hypercall = hvdef::hypercall::MsrHypercallContents::new();
         self.guest_os_id = hvdef::hypercall::HvGuestOsId::new();
@@ -128,9 +128,9 @@ impl GlobalHv {
     }
 
     /// Resets the global (but not per-processor) state.
-    pub fn reset(&self) {
+    pub fn reset(&self, tlb_access: &mut dyn TlbFlushAccess) {
         for state in self.vtl_mutable_state.iter() {
-            state.lock().reset();
+            state.lock().reset(tlb_access);
         }
         // There is no global synic state to reset, since the synic is per-VP.
     }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1434,10 +1434,23 @@ impl VtlPartition {
     }
 }
 
+struct WhpNoVtlProtections;
+impl hv1_emulator::hv::VtlProtectHypercallOverlay for WhpNoVtlProtections {
+    fn change_overlay(&mut self, _gpn: u64) {}
+    fn disable_overlay(&mut self) {}
+}
+
 impl Hv1State {
     fn reset(&self) {
         match self {
-            Hv1State::Emulated(hv) => hv.reset([None, None].into()),
+            Hv1State::Emulated(hv) => hv.reset(
+                [
+                    &mut WhpNoVtlProtections
+                        as &mut dyn hv1_emulator::hv::VtlProtectHypercallOverlay,
+                    &mut WhpNoVtlProtections,
+                ]
+                .into(),
+            ),
             Hv1State::Offloaded => {}
             Hv1State::Disabled => {}
         }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1437,7 +1437,7 @@ impl VtlPartition {
 impl Hv1State {
     fn reset(&self) {
         match self {
-            Hv1State::Emulated(hv) => hv.reset(None),
+            Hv1State::Emulated(hv) => hv.reset([None, None].into()),
             Hv1State::Offloaded => {}
             Hv1State::Disabled => {}
         }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -27,7 +27,6 @@ use guestmem::GuestMemory;
 use hv1_emulator::hv::GlobalHv;
 use hv1_emulator::hv::GlobalHvParams;
 use hv1_emulator::hv::ProcessorVtlHv;
-use hv1_emulator::hv::TlbFlushAccess;
 use hv1_emulator::message_queues::MessageQueues;
 use hv1_structs::VtlSet;
 use hvdef::HvDeliverabilityNotificationsRegister;
@@ -1350,7 +1349,6 @@ impl VtlPartition {
                     vendor,
                     tsc_frequency,
                     ref_time,
-                    hypercall_page_protectors: hv1_structs::VtlArray::from_fn(|_| None),
                 }))
             }
         } else {
@@ -1436,17 +1434,10 @@ impl VtlPartition {
     }
 }
 
-/// WHP is responsible for managing the TLB.
-struct WhpNoOpTlbFlushAccess;
-
-impl TlbFlushAccess for WhpNoOpTlbFlushAccess {
-    fn flush(&mut self, _vtl: Vtl) {}
-}
-
 impl Hv1State {
     fn reset(&self) {
         match self {
-            Hv1State::Emulated(hv) => hv.reset(&mut WhpNoOpTlbFlushAccess),
+            Hv1State::Emulated(hv) => hv.reset(None),
             Hv1State::Offloaded => {}
             Hv1State::Disabled => {}
         }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -27,6 +27,7 @@ use guestmem::GuestMemory;
 use hv1_emulator::hv::GlobalHv;
 use hv1_emulator::hv::GlobalHvParams;
 use hv1_emulator::hv::ProcessorVtlHv;
+use hv1_emulator::hv::TlbFlushAccess;
 use hv1_emulator::message_queues::MessageQueues;
 use hv1_structs::VtlSet;
 use hvdef::HvDeliverabilityNotificationsRegister;
@@ -1435,10 +1436,17 @@ impl VtlPartition {
     }
 }
 
+/// WHP is responsible for managing the TLB.
+struct WhpNoOpTlbFlushAccess;
+
+impl TlbFlushAccess for WhpNoOpTlbFlushAccess {
+    fn flush(&mut self, _vtl: Vtl) {}
+}
+
 impl Hv1State {
     fn reset(&self) {
         match self {
-            Hv1State::Emulated(hv) => hv.reset(),
+            Hv1State::Emulated(hv) => hv.reset(&mut WhpNoOpTlbFlushAccess),
             Hv1State::Offloaded => {}
             Hv1State::Disabled => {}
         }

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -1326,7 +1326,7 @@ mod x86 {
                     }
                     0x40000000..=0x4fffffff => {
                         if let Some(hv) = &mut self.state.vtls[self.state.active_vtl].hv {
-                            hv.msr_write(msr, v, None)
+                            hv.msr_write(msr, v, &mut crate::WhpNoVtlProtections)
                         } else {
                             match msr {
                                 hvdef::HV_X64_MSR_VP_ASSIST_PAGE

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -1326,7 +1326,7 @@ mod x86 {
                     }
                     0x40000000..=0x4fffffff => {
                         if let Some(hv) = &mut self.state.vtls[self.state.active_vtl].hv {
-                            hv.msr_write(msr, v)
+                            hv.msr_write(msr, v, &mut crate::WhpNoOpTlbFlushAccess)
                         } else {
                             match msr {
                                 hvdef::HV_X64_MSR_VP_ASSIST_PAGE

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -1326,7 +1326,7 @@ mod x86 {
                     }
                     0x40000000..=0x4fffffff => {
                         if let Some(hv) = &mut self.state.vtls[self.state.active_vtl].hv {
-                            hv.msr_write(msr, v, &mut crate::WhpNoOpTlbFlushAccess)
+                            hv.msr_write(msr, v, None)
                         } else {
                             match msr {
                                 hvdef::HV_X64_MSR_VP_ASSIST_PAGE


### PR DESCRIPTION
Fixes #849
