### PR TITLE
Fix lints for Rust 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -627,6 +627,9 @@ suboptimal_flops = "warn"
 undocumented_unsafe_blocks = "warn"
 unnecessary_box_returns = "warn"
 
+# TODO: Remove this allow in Rust 1.86. See https://github.com/rust-lang/rust-clippy/pull/14115.
+precedence = "allow"
+
 # Possible future additions:
 #
 # useful, but _very_ tedious to fix

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -398,7 +398,6 @@ impl ProcessorRunner<'_, Tdx> {
         gla_info: TdxGlaListInfo,
     ) -> Result<(), TdCallResult> {
         tdcall_vp_invgla(&mut MshvVtlTdcall(&self.hcl.mshv_vtl), gla_flags, gla_info)
-            .map(Into::into)
     }
 
     /// Gets the FPU state for the VP.

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -311,7 +311,7 @@ impl StorageBuilder {
                 .hypervisor
                 .with_vtl2
                 .as_ref()
-                .map_or(true, |c| c.vtl0_alias_map)
+                .is_none_or(|c| c.vtl0_alias_map)
             {
                 anyhow::bail!("must specify --vtl2 and --no-alias-map to offer disks to VTL2");
             }
@@ -357,7 +357,7 @@ impl StorageBuilder {
                 .hypervisor
                 .with_vtl2
                 .as_ref()
-                .map_or(true, |c| c.vtl0_alias_map)
+                .is_none_or(|c| c.vtl0_alias_map)
             {
                 anyhow::bail!("must specify --vtl2 and --no-alias-map to offer disks to VTL2");
             }

--- a/vm/devices/user_driver/src/interrupt.rs
+++ b/vm/devices/user_driver/src/interrupt.rs
@@ -80,7 +80,7 @@ impl DeviceInterruptSlot {
                 self.signaled.store(false, Release);
                 return Poll::Ready(());
             }
-            if waker.as_ref().map_or(true, |w| !w.will_wake(cx.waker())) {
+            if waker.as_ref().is_none_or(|w| !w.will_wake(cx.waker())) {
                 _old_waker = waker.replace(cx.waker().clone());
             }
             Poll::Pending

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -105,7 +105,7 @@ impl std::fmt::Display for GuestMemoryErrorInner {
         // Include the precise GPA if provided and different from the start of
         // the range.
         if let Some(gpa) = self.gpa {
-            if self.range.as_ref().map_or(true, |range| range.start != gpa) {
+            if self.range.as_ref().is_none_or(|range| range.start != gpa) {
                 write!(f, " at {:#x}", gpa)?;
             }
         }

--- a/vm/vmcore/src/vmtime.rs
+++ b/vm/vmcore/src/vmtime.rs
@@ -241,7 +241,7 @@ impl TimerState {
         }
         if self
             .next
-            .map_or(true, |current_next| next.is_before(current_next))
+            .is_none_or(|current_next| next.is_before(current_next))
         {
             let deadline = self.timestamp(next).unwrap().os_time();
             tracing::trace!(?deadline, "updating deadline");
@@ -257,7 +257,7 @@ impl TimerState {
         for (_, state) in &mut self.waiters {
             if let Some(this_next) = state.next {
                 if this_next.is_after(now.vmtime) {
-                    if next.map_or(true, |next| this_next.is_before(next)) {
+                    if next.is_none_or(|next| this_next.is_before(next)) {
                         next = Some(this_next);
                     }
                 } else if let Some(waker) = state.waker.take() {
@@ -851,7 +851,7 @@ impl VmTimeAccess {
     /// Sets the timeout for [`poll_timeout`](Self::poll_timeout) will return ready,
     /// but only if `time` is earlier than the current timeout.
     pub fn set_timeout_if_before(&mut self, time: VmTime) {
-        if self.timeout.map_or(true, |timeout| time.is_before(timeout)) {
+        if self.timeout.is_none_or(|timeout| time.is_before(timeout)) {
             self.set_timeout(time);
         }
     }

--- a/vmm_core/state_unit/src/lib.rs
+++ b/vmm_core/state_unit/src/lib.rs
@@ -1135,10 +1135,7 @@ mod tests {
         }
 
         async fn restore(&mut self, state: SavedStateBlob) -> Result<(), RestoreError> {
-            assert!(self
-                .dep
-                .as_ref()
-                .map_or(true, |v| v.load(Ordering::Relaxed)));
+            assert!(self.dep.as_ref().is_none_or(|v| v.load(Ordering::Relaxed)));
 
             if self.support_saved_state {
                 let state: SavedState = state.parse()?;

--- a/xtask/src/tasks/fmt/unused_deps.rs
+++ b/xtask/src/tasks/fmt/unused_deps.rs
@@ -450,7 +450,7 @@ fn collect_paths(dir_path: &Path, manifest: &Manifest) -> Vec<PathBuf> {
             if dir_entry
                 .path()
                 .extension()
-                .map_or(true, |ext| ext.to_str() != Some("rs"))
+                .is_none_or(|ext| ext.to_str() != Some("rs"))
             {
                 return None;
             }


### PR DESCRIPTION
Mostly cleaning up some more map_ors, but the one big change of note is temporarily allowing the clippy:precedence lint. Previously this lint only applied to arithmetic operations, however a change in 1.85 causes it to apply to bitwise operations as well. This is overly noisy, and unnecessary. And the clippy maintainers agree, as they've since split out this change into a separate lint, precedence_bits, that is allow-by-default. However that split will not be present until 1.86. See https://github.com/rust-lang/rust-clippy/pull/14115 for details on that.