### PR TITLE
vmbus_client: clean up tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8046,7 +8046,6 @@ dependencies = [
  "mesh",
  "pal_async",
  "pal_event",
- "parking_lot",
  "thiserror 2.0.0",
  "tracing",
  "vmbus_async",

--- a/vm/devices/vmbus/vmbus_client/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_client/Cargo.toml
@@ -23,7 +23,6 @@ thiserror.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
 [dev-dependencies]
-parking_lot.workspace = true
 pal_async.workspace = true
 
 [lints]


### PR DESCRIPTION
Don't spawn extra threads, and don't use `std::thread::sleep`.