### PR TITLE
ci: speed up ubuntu 24.04 boot in vmm tests (#316)

### DIFF
--- a/petri/guest-bootstrap/network-config
+++ b/petri/guest-bootstrap/network-config
@@ -1,0 +1,6 @@
+# Specify a non-present device to work around https://github.com/canonical/cloud-init/issues/5511
+version: 1
+config:
+  - type: physical
+    name: disabled
+    optional: true

--- a/petri/src/disk_image.rs
+++ b/petri/src/disk_image.rs
@@ -58,6 +58,12 @@ pub fn build_agent_image(
                         "user-data",
                         PathOrBinary::Binary(include_bytes!("../guest-bootstrap/user-data")),
                     ),
+                    // Specify a non-present NIC to work around https://github.com/canonical/cloud-init/issues/5511
+                    // TODO: support dynamically configuring the network based on vm configuration
+                    (
+                        "network-config",
+                        PathOrBinary::Binary(include_bytes!("../guest-bootstrap/network-config")),
+                    ),
                 ],
             )
         }


### PR DESCRIPTION
speed up ubuntu 24.04 boot in vmm tests by skipping network wait (since there is no network) to workaround
https://github.com/canonical/cloud-init/issues/5511