### PR TITLE
flowey: handle empty action id in binary comparison

### DIFF
--- a/flowey/flowey_lib_common/src/gh_workflow_id.rs
+++ b/flowey/flowey_lib_common/src/gh_workflow_id.rs
@@ -79,10 +79,7 @@ impl SimpleFlowNode for Node {
                 };
 
                 let is_empty = |action_id: &Result<String, anyhow::Error>| {
-                    action_id
-                        .as_ref()
-                        .ok()
-                        .map_or(false, |s| s.trim().is_empty())
+                    action_id.as_ref().ok().is_some_and(|s| s.trim().is_empty())
                 };
 
                 let mut github_commit_hash = github_commit_hash.clone();

--- a/flowey/flowey_lib_common/src/gh_workflow_id.rs
+++ b/flowey/flowey_lib_common/src/gh_workflow_id.rs
@@ -102,7 +102,7 @@ impl SimpleFlowNode for Node {
                     );
 
                     if loop_count > 4 {
-                        anyhow::bail!("Failed to get action id for after 5 attempts: {}", e);
+                        anyhow::bail!("Failed to get action id after 5 attempts: {}", e);
                     }
 
                     github_commit_hash =


### PR DESCRIPTION
From [this run](https://github.com/microsoft/openvmm/actions/runs/13446070583/job/37571567182?pr=885), it looks like it's possible to get an empty string as the action id which isn't currently being checked for in the binary comparison. 

This change adds handling for an empty string by converting it into an error and continuing to traverse commits in that case. I've also added some logging for this case.