### PR TITLE
Fix some areas rustfmt fails on

### DIFF
--- a/flowey/flowey_lib_common/src/install_rust.rs
+++ b/flowey/flowey_lib_common/src/install_rust.rs
@@ -269,10 +269,10 @@ impl FlowNode for Node {
             }
         };
 
+        // The reason we need to check for relaunch on Local but not GH Actions is that GH Actions
+        // spawns a new shell for each step, so the new shell will have the new $PATH. On the local backend,
+        // the same shell is reused and needs to be relaunched to pick up the new $PATH.
         let is_installed =
-            // The reason we need to check for relaunch on Local but not GH Actions is that GH Actions
-            // spawns a new shell for each step, so the new shell will have the new $PATH. On the local backend,
-            // the same shell is reused and needs to be relaunched to pick up the new $PATH.
             if !ensure_installed.is_empty() && matches!(ctx.backend(), FlowBackend::Local) {
                 let (read_bin, write_cargo_bin) = ctx.new_var();
                 ctx.req(crate::check_needs_relaunch::Params {

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -352,18 +352,13 @@ impl NvmeManagerWorker {
             let dma_client = self
                 .dma_client_spawner
                 .create_client(format!("nvme_{}", pci_id))?;
+            // This code can wait on each VFIO device until it is arrived.
+            // A potential optimization would be to delay VFIO operation
+            // until it is ready, but a redesign of VfioDevice is needed.
             let vfio_device =
-                // This code can wait on each VFIO device until it is arrived.
-                // A potential optimization would be to delay VFIO operation
-                // until it is ready, but a redesign of VfioDevice is needed.
-                VfioDevice::restore(
-                    &self.driver_source,
-                    &disk.pci_id.clone(),
-                    true,
-                    dma_client,
-                )
-                .instrument(tracing::info_span!("vfio_device_restore", pci_id))
-                .await?;
+                VfioDevice::restore(&self.driver_source, &disk.pci_id.clone(), true, dma_client)
+                    .instrument(tracing::info_span!("vfio_device_restore", pci_id))
+                    .await?;
 
             let nvme_driver = nvme_driver::NvmeDriver::restore(
                 &self.driver_source,

--- a/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
+++ b/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
@@ -200,10 +200,11 @@ impl<S: StorageBackend> HclCompatNvram<S> {
             // corresponds to a VARIABLE entry
 
             let (var_header, var_name, var_data) = {
+                // TODO: zerocopy: error propagation (https://github.com/microsoft/openvmm/issues/759)
+                // TODO: zerocopy: manual fix - review carefully! (https://github.com/microsoft/openvmm/issues/759)
                 let (var_header, var_length_data) =
-                    // TODO: zerocopy: error propagation (https://github.com/microsoft/openvmm/issues/759)
-                    // TODO: zerocopy: manual fix - review carefully! (https://github.com/microsoft/openvmm/issues/759)
-                    format::NvramVariable::read_from_prefix(entry_buf).map_err(|_| NvramStorageError::Load("variable entry too short".into()))?;
+                    format::NvramVariable::read_from_prefix(entry_buf)
+                        .map_err(|_| NvramStorageError::Load("variable entry too short".into()))?;
 
                 if var_length_data.len()
                     != var_header.name_bytes as usize + var_header.data_bytes as usize

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -159,12 +159,13 @@ impl<T: RingMem + Unpin> TestGedChannel<T> {
                 match response {
                     Event::Response(response) => {
                         use get_protocol::test_utilities::TEST_VMGS_SECTOR_SIZE;
+                        // TODO: zerocopy: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+                        // Check if response needs special handling. Otherwise, send
+                        // response directly back to the guest.
                         let response_header =
                             get_protocol::HeaderRaw::read_from_prefix(&response[..4])
                                 .unwrap()
-                                .0; // TODO: zerocopy: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
-                                    // Check if response needs special handling. Otherwise, send
-                                    // response directly back to the guest.
+                                .0;
                         match response_header.message_type {
                             get_protocol::MessageTypes::HOST_RESPONSE => {
                                 let header: get_protocol::HeaderHostRequest =
@@ -179,7 +180,8 @@ impl<T: RingMem + Unpin> TestGedChannel<T> {
                                             )
                                             .unwrap()
                                             .0;
-                                        let offset = request.sector_offset as usize // TODO: zerocopy: from-prefix (read_from_prefix): use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+                                        // TODO: zerocopy: from-prefix (read_from_prefix): use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+                                        let offset = request.sector_offset as usize
                                             * TEST_VMGS_SECTOR_SIZE as usize;
                                         let length = request.sector_count as usize
                                             * TEST_VMGS_SECTOR_SIZE as usize;
@@ -194,7 +196,8 @@ impl<T: RingMem + Unpin> TestGedChannel<T> {
                                             )
                                             .unwrap()
                                             .0;
-                                        let buf = &message_buf[request_size..]; // TODO: zerocopy: from-prefix (read_from_prefix): use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+                                        // TODO: zerocopy: from-prefix (read_from_prefix): use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+                                        let buf = &message_buf[request_size..];
                                         let offset = request.sector_offset as usize
                                             * TEST_VMGS_SECTOR_SIZE as usize;
                                         let length = request.sector_count as usize

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
@@ -125,9 +125,11 @@ impl FuzzNvmeDriver {
                 let buf_range = OwnedRequestBuffers::linear(0, 16384, true); // TODO: [use-arbitrary-input]
                 self.namespace
                     .read(
-                        target_cpu % self.cpu_count, // TODO: [panic-or-bail-on-fuzz]
+                        // TODO: [panic-or-bail-on-fuzz]
+                        target_cpu % self.cpu_count,
                         lba,
-                        block_count  // TODO: [panic-or-bail-on-fuzz]
+                        // TODO: [panic-or-bail-on-fuzz]
+                        block_count
                             % (u32::try_from(buf_range.len()).unwrap()
                                 >> self.namespace.block_size().trailing_zeros())
                             % self.namespace.max_transfer_block_count(),
@@ -145,9 +147,11 @@ impl FuzzNvmeDriver {
                 let buf_range = OwnedRequestBuffers::linear(0, 16384, true); // TODO: [use-arbitrary-input]
                 self.namespace
                     .write(
-                        target_cpu % self.cpu_count, // TODO: [panic-or-bail-on-fuzz]
+                        // TODO: [panic-or-bail-on-fuzz]
+                        target_cpu % self.cpu_count,
                         lba,
-                        block_count // TODO: [panic-or-bail-on-fuzz]
+                        // TODO: [panic-or-bail-on-fuzz]
+                        block_count
                             % (u32::try_from(buf_range.len()).unwrap()
                                 >> self.namespace.block_size().trailing_zeros())
                             % self.namespace.max_transfer_block_count(),

--- a/vm/devices/support/fs/lxutil/src/windows/mod.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/mod.rs
@@ -126,7 +126,7 @@ impl LxVolume {
             let block_size = api::LxUtilFsGetFileSystemBlockSize(root.as_raw_handle());
             Ok(Self {
                 root,
-                #[allow(clippy::disallowed_methods)] // need actual canonical path here
+                #[allow(clippy::disallowed_methods, reason = "need actual canonical path here")]
                 root_path: root_path.canonicalize()?,
                 state: VolumeState::new(fs_context, options, block_size),
             })


### PR DESCRIPTION
Found with `cargo fmt -- --config unstable_features=true --config error_on_unformatted=true`. Until this is stable we probably don't want to run this in CI, but it's a useful sanity check now and then.