### PR TITLE
petri: restore vtl2_vsock_path getter

### DIFF
--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -145,8 +145,9 @@ struct PetriVmResourcesOpenVmm {
     output_dir: PathBuf,
     log_source: PetriLogSource,
 
-    // Resources that are only kept so they can be dropped at the end.
-    _vsock_temp_paths: Vec<TempPath>,
+    // TempPaths that cannot be dropped until the end.
+    vtl2_vsock_path: Option<TempPath>,
+    _vmbus_vsock_path: TempPath,
 }
 
 impl PetriVmConfigOpenVmm {

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -102,6 +102,11 @@ impl PetriVmOpenVmm {
         }
     }
 
+    /// Get the path to the VTL 2 vsock socket, if the VM is configured with OpenHCL.
+    pub fn vtl2_vsock_path(&self) -> Option<&Path> {
+        self.inner.resources.vtl2_vsock_path.as_deref()
+    }
+
     /// Wait for the VM to halt, returning the reason for the halt.
     pub async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason> {
         if let Some(already) = self.halt.already_received.take() {

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -103,8 +103,12 @@ impl PetriVmOpenVmm {
     }
 
     /// Get the path to the VTL 2 vsock socket, if the VM is configured with OpenHCL.
-    pub fn vtl2_vsock_path(&self) -> Option<&Path> {
-        self.inner.resources.vtl2_vsock_path.as_deref()
+    pub fn vtl2_vsock_path(&self) -> anyhow::Result<&Path> {
+        self.inner
+            .resources
+            .vtl2_vsock_path
+            .as_deref()
+            .context("VM is not configured with OpenHCL")
     }
 
     /// Wait for the VM to halt, returning the reason for the halt.


### PR DESCRIPTION
Mistakenly removed this function that is used by internal tests. Brought it back in a way that doesn't require storing an extra copy of the path in the uhdiag handler.