### PR TITLE
guide: clarify guidance and warnings related to cloning repo

### DIFF
--- a/Guide/src/dev_guide/getting_started/linux.md
+++ b/Guide/src/dev_guide/getting_started/linux.md
@@ -63,10 +63,11 @@ $ sudo apt install \
 ## Cloning the OpenVMM source
 
 **If using WSL2:** Do NOT clone the repo into Windows then try to access said
-clone from Linux. It will result in serious performance issues.
+clone from Linux! It will result in serious performance issues, and may break
+certain functionality (e.g: cross-compiling Windows binaries).
 
 ```bash
-$ cd path/to/where/you/clone/repos
+$ cd ~/src/
 $ git clone https://github.com/microsoft/openvmm.git
 ```
 

--- a/Guide/src/dev_guide/getting_started/suggested_dev_env.md
+++ b/Guide/src/dev_guide/getting_started/suggested_dev_env.md
@@ -22,9 +22,8 @@ If you're using a different development environment, we nonetheless suggest
 reading through this section, so you can enable similar settings in whatever
 editor / IDE you happen to be using.
 
-```admonish tip
+~~~admonish tip
 Just want the recommended editor settings? Put this in `openvmm/.vscode/settings.json`:
-```
 
 ```json
 {
@@ -39,6 +38,7 @@ Just want the recommended editor settings? Put this in `openvmm/.vscode/settings
     },
 }
 ```
+~~~
 
 ### \[WSL2] Connecting to WSL using VSCode
 

--- a/build_support/setup_windows_cross.sh
+++ b/build_support/setup_windows_cross.sh
@@ -29,7 +29,7 @@ function setup_windows_cross {
 
     if [[ -x /bin/wslpath ]] && [[ $(wslpath -aw "$myfulldir") != '\\wsl.localhost\'* ]];
     then
-        fatal_error "\033[0;33mWARNING: This script is being run from a Windows partition. This will not work. Please move your repo clone to the WSL filesystem.\033[0m"
+        fatal_error "\033[0;33mWARNING: This script is being run from a Windows partition. This will not work. Please re-clone the repo within WSL2 itself (e.g: somewhere under /home/).\033[0m"
     fi
 
     local tooldir="$(realpath "$myfulldir/windows_cross")"


### PR DESCRIPTION
Tweaks some language in the `setup_windows_cross.sh` script and the Guide, to clarify the pitfalls associated with cloning the repo on a Windows partition and then using it from WSL2, as well as offering a more specific suggestion on how to resolve the issue.

Also include a minor drive-by chance in `suggested_dev_env.md`, that's been bugging me for a while, ha