### PR TITLE
underhill_mem: Don't remove write permissions on the hypercall page

### DIFF
--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -808,7 +808,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             .apply_protections_from_flags(
                 MemoryRange::new(gpn * HV_PAGE_SIZE..(gpn + 1) * HV_PAGE_SIZE),
                 vtl,
-                HV_MAP_GPA_PERMISSIONS_ALL.with_writable(false),
+                HV_MAP_GPA_PERMISSIONS_ALL,
             )
             .expect("applying vtl protections should succeed");
 


### PR DESCRIPTION
This causes a TDX debug assertion failure (as we seem to not fully be able to remove this perm), and TDX release mode runtime failures (invalid hypercall inputs). Fixes #901. This is temporary until we figure out why things are failing, we want to keep this behavior.