### PR TITLE
TDX: Properly handle memory protections

### DIFF
--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -464,7 +464,7 @@ impl PartitionInfo {
             let isolation_requirements = match params.isolation_type {
                 #[cfg(target_arch = "x86_64")]
                 // Supporting TLB flush hypercalls on TDX requires 1 page per VP
-                // Supproting guest VSM on TDX requires 1 page per VP for VTL 1's APIC
+                // Supporting guest VSM on TDX requires 1 page per VP for VTL 1's APIC
                 IsolationType::Tdx => parsed.cpus.len() as u64 * 2,
                 _ => 0,
             };

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -45,6 +45,7 @@ use virt_mshv_vtl::TlbFlushLockAccess;
 use vm_topology::memory::MemoryLayout;
 use x86defs::snp::SevRmpAdjust;
 use x86defs::tdx::GpaVmAttributes;
+use x86defs::tdx::GpaVmAttributesMask;
 use x86defs::tdx::TdgMemPageAttrWriteR8;
 use x86defs::tdx::TdgMemPageGpaAttr;
 
@@ -156,17 +157,20 @@ impl GpaVtlPermissions {
                     .with_kernel_execute(protections.kernel_executable())
                     .with_user_execute(protections.user_executable());
 
+                // TODO TDX GUEST VSM: We need to track previous permissions to
+                // be able to set the change mask appropriately.
+
                 let (new_attributes, new_mask) = match vtl {
                     GuestVtl::Vtl0 => {
                         let attributes = TdgMemPageGpaAttr::new().with_l2_vm1(vm_attributes);
-                        let mask =
-                            TdgMemPageAttrWriteR8::new().with_l2_vm1(vm_attributes.to_mask());
+                        let mask = TdgMemPageAttrWriteR8::new()
+                            .with_l2_vm1(GpaVmAttributesMask::ALL_CHANGED);
                         (attributes, mask)
                     }
                     GuestVtl::Vtl1 => {
                         let attributes = TdgMemPageGpaAttr::new().with_l2_vm2(vm_attributes);
-                        let mask =
-                            TdgMemPageAttrWriteR8::new().with_l2_vm2(vm_attributes.to_mask());
+                        let mask = TdgMemPageAttrWriteR8::new()
+                            .with_l2_vm2(GpaVmAttributesMask::ALL_CHANGED);
                         (attributes, mask)
                     }
                 };
@@ -227,8 +231,8 @@ impl MemoryAcceptor {
 
             IsolationType::Tdx => {
                 let attributes = TdgMemPageGpaAttr::new().with_l2_vm1(GpaVmAttributes::FULL_ACCESS);
-                let mask = TdgMemPageAttrWriteR8::new()
-                    .with_l2_vm1(GpaVmAttributes::FULL_ACCESS.to_mask());
+                let mask =
+                    TdgMemPageAttrWriteR8::new().with_l2_vm1(GpaVmAttributesMask::ALL_CHANGED);
 
                 self.mshv_vtl
                     .tdx_accept_pages(range, Some((attributes, mask)))

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -157,9 +157,6 @@ impl GpaVtlPermissions {
                     .with_kernel_execute(protections.kernel_executable())
                     .with_user_execute(protections.user_executable());
 
-                // TODO TDX GUEST VSM: We need to track previous permissions to
-                // be able to set the change mask appropriately.
-
                 let (new_attributes, new_mask) = match vtl {
                     GuestVtl::Vtl0 => {
                         let attributes = TdgMemPageGpaAttr::new().with_l2_vm1(vm_attributes);
@@ -228,7 +225,6 @@ impl MemoryAcceptor {
                         range,
                     })
             }
-
             IsolationType::Tdx => {
                 let attributes = TdgMemPageGpaAttr::new().with_l2_vm1(GpaVmAttributes::FULL_ACCESS);
                 let mask =

--- a/vm/x86/tdcall/src/lib.rs
+++ b/vm/x86/tdcall/src/lib.rs
@@ -380,7 +380,11 @@ fn set_page_attr(
                 let result =
                     tdcall_page_attr_rd(call, mapping.gpa_page_number() * HV_PAGE_SIZE).unwrap();
                 assert_eq!(u64::from(mapping), result.mapping.into());
-                assert_eq!(attributes, result.attributes);
+                assert_eq!(attributes.l1(), result.attributes.l1());
+                assert_eq!(
+                    attributes.into_bits() ^ mask.with_reserved(0).into_bits(),
+                    result.attributes.into_bits() ^ mask.with_reserved(0).into_bits()
+                );
             }
 
             Ok(())

--- a/vm/x86/x86defs/src/tdx.rs
+++ b/vm/x86/x86defs/src/tdx.rs
@@ -107,8 +107,7 @@ impl GpaVmAttributesMask {
         .with_read(true)
         .with_write(true)
         .with_kernel_execute(true)
-        .with_user_execute(true)
-        .with_inv_ept(true);
+        .with_user_execute(true);
 }
 
 /// Corresponds to GPA_ATTR, which is used as input to TDG.MEM.PAGE.ATTR.WR and

--- a/vm/x86/x86defs/src/tdx.rs
+++ b/vm/x86/x86defs/src/tdx.rs
@@ -107,7 +107,8 @@ impl GpaVmAttributesMask {
         .with_read(true)
         .with_write(true)
         .with_kernel_execute(true)
-        .with_user_execute(true);
+        .with_user_execute(true)
+        .with_inv_ept(true);
 }
 
 /// Corresponds to GPA_ATTR, which is used as input to TDG.MEM.PAGE.ATTR.WR and

--- a/vm/x86/x86defs/src/tdx.rs
+++ b/vm/x86/x86defs/src/tdx.rs
@@ -62,6 +62,7 @@ impl TdgMemPageLevel {
 
 /// Attributes for a single VM.
 #[bitfield(u16)]
+#[derive(PartialEq, Eq)]
 pub struct GpaVmAttributes {
     pub read: bool,
     pub write: bool,
@@ -85,28 +86,28 @@ impl GpaVmAttributes {
         .with_valid(true);
 }
 
-impl GpaVmAttributes {
-    /// Convert to the corresponding attributes mask. Note that `inv_ept` must
-    /// be set manually after the conversion, if desired.
-    pub fn to_mask(self) -> GpaVmAttributesMask {
-        GpaVmAttributesMask::from(u16::from(self)).with_inv_ept(false)
-    }
-}
-
 /// Attributes mask used to set which bits are updated in TDG.MEM.PAGE.ATTR.WR.
 #[bitfield(u16)]
 pub struct GpaVmAttributesMask {
-    read: bool,
-    write: bool,
-    kernel_execute: bool,
-    user_execute: bool,
+    pub read: bool,
+    pub write: bool,
+    pub kernel_execute: bool,
+    pub user_execute: bool,
     #[bits(3)]
     reserved: u8,
-    suppress_ve: bool,
+    pub suppress_ve: bool,
     #[bits(7)]
     reserved2: u8,
     /// invalidate ept for this vm
-    inv_ept: bool,
+    pub inv_ept: bool,
+}
+
+impl GpaVmAttributesMask {
+    pub const ALL_CHANGED: Self = Self::new()
+        .with_read(true)
+        .with_write(true)
+        .with_kernel_execute(true)
+        .with_user_execute(true);
 }
 
 /// Corresponds to GPA_ATTR, which is used as input to TDG.MEM.PAGE.ATTR.WR and


### PR DESCRIPTION
Our mask was previously being constructed by just using the attributes. This allowed us to add permissions, but never remove them. Fix this by always setting the mask to have all true bits. Also fixup the debug assertions to only check the bits specified by the mask. Fixes #901 .