### PR TITLE
flowey: use baseline artifact instead of igvm-extras for binary comparison

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
@@ -68,8 +68,8 @@ impl SimpleFlowNode for Node {
         });
 
         let file_name = match target.common_arch().unwrap() {
-            CommonArch::X86_64 => "x64-openhcl-igvm-extras",
-            CommonArch::Aarch64 => "aarch64-openhcl-igvm-extras",
+            CommonArch::X86_64 => "x64-openhcl-baseline",
+            CommonArch::Aarch64 => "aarch64-openhcl-baseline",
         };
 
         let merge_commit = ctx.reqv(|v| git_merge_commit::Request {
@@ -113,14 +113,7 @@ impl SimpleFlowNode for Node {
                 let new_openhcl = rt.read(new_openhcl);
                 let merge_run = rt.read(merge_run);
 
-                let arch = target.common_arch().unwrap();
-
-                let old_path = match arch {
-                    CommonArch::X86_64 => {
-                        old_openhcl.join("x64-openhcl-igvm-extras/openhcl/openhcl")
-                    }
-                    CommonArch::Aarch64 => old_openhcl.join("openhcl-aarch64/openhcl"),
-                };
+                let old_path = old_openhcl.join("openhcl");
                 let new_path = new_openhcl.bin;
 
                 println!(

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
@@ -113,7 +113,7 @@ impl SimpleFlowNode for Node {
                 let new_openhcl = rt.read(new_openhcl);
                 let merge_run = rt.read(merge_run);
 
-                let old_path = old_openhcl.join("openhcl");
+                let old_path = old_openhcl.join(file_name).join("openhcl");
                 let new_path = new_openhcl.bin;
 
                 println!(


### PR DESCRIPTION
As part of #475, I added a new baseline artifact for binary comparison but didn't use it yet as I wanted to wait for there to be builds to diff against but hadn't followed up yet. #895 renamed the binary in igvm-extras that we were using to diff and broke the comparison.

This change uses the baseline artifact for comparison and keeps the binary size artifacts limited in scope.