### PR TITLE
snp: reset nmi pending when nmi is delivered

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -774,6 +774,7 @@ impl<'b> hardware_cvm::apic::ApicBacking<'b, SnpBacked> for UhProcessor<'b, SnpB
                 .with_vector(2)
                 .with_valid(true),
         );
+        self.backing.cvm.lapics[vtl].nmi_pending = false;
         self.backing.cvm.lapics[vtl].activity = MpState::Running;
         Ok(())
     }


### PR DESCRIPTION
Fixes a bug introduced by a refactor that causes a multi-vp SNP VM to get stuck when a kernel debugger is attached to the guest.

Tested:
SNP with kernel debugging boots