### PR TITLE
TDX: Only clear TLB flush requests when we know the L2 was entered

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1318,11 +1318,6 @@ impl UhProcessor<'_, TdxBacked> {
         let entered_from_vtl = next_vtl;
         self.runner
             .read_private_regs(&mut self.backing.vtls[entered_from_vtl].private_regs);
-        // TODO: Remove this line once the kernel does it for us
-        self.backing.vtls[entered_from_vtl]
-            .private_regs
-            .vp_entry_flags
-            .set_invd_translations(0);
 
         // Kernel offload may have set or cleared the halt/idle states
         if offload_enabled && kernel_known_state {
@@ -1358,6 +1353,10 @@ impl UhProcessor<'_, TdxBacked> {
         }
 
         // The L2 was entered, so process the exit.
+        self.backing.vtls[entered_from_vtl]
+            .private_regs
+            .vp_entry_flags
+            .set_invd_translations(0);
         let stat = match exit_info.code().tdx_exit() {
             TdCallResultCode::SUCCESS => {
                 &mut self.backing.vtls[entered_from_vtl].enter_stats.success

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1352,7 +1352,7 @@ impl UhProcessor<'_, TdxBacked> {
             return Ok(());
         }
 
-        // The L2 was entered, so clear any TLB flush reqeusts and process the exit.
+        // The L2 was entered, so clear any TLB flush requests and process the exit.
         self.backing.vtls[entered_from_vtl]
             .private_regs
             .vp_entry_flags

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1352,7 +1352,7 @@ impl UhProcessor<'_, TdxBacked> {
             return Ok(());
         }
 
-        // The L2 was entered, so process the exit.
+        // The L2 was entered, so clear any TLB flush reqeusts and process the exit.
         self.backing.vtls[entered_from_vtl]
             .private_regs
             .vp_entry_flags


### PR DESCRIPTION
Part of #699.