### PR TITLE
TDX: Fill in get_vsm_capabilities and properly mark DR6 as shared

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -2207,7 +2207,6 @@ impl Hcl {
         // within VTL2. Future vtl return actions may be different, requiring granular handling.
         let supports_vtl_ret_action = supports_vtl_ret_action && !isolation.is_hardware_isolated();
         let supports_register_page = supports_register_page && !isolation.is_hardware_isolated();
-        let dr6_shared = dr6_shared && !isolation.is_hardware_isolated();
         let snp_register_bitmap = [0u8; 64];
 
         Ok(Hcl {
@@ -2815,11 +2814,14 @@ impl Hcl {
             IsolationType::Snp => hvdef::HvRegisterVsmCapabilities::new()
                 .with_deny_lower_vtl_startup(caps.deny_lower_vtl_startup())
                 .with_intercept_page_available(caps.intercept_page_available()),
-            // TODO TDX: Figure out what these values should be.
             IsolationType::Tdx => hvdef::HvRegisterVsmCapabilities::new()
                 .with_deny_lower_vtl_startup(caps.deny_lower_vtl_startup())
-                .with_intercept_page_available(caps.intercept_page_available()),
+                .with_intercept_page_available(caps.intercept_page_available())
+                .with_dr6_shared(true),
         };
+
+        assert_eq!(caps.dr6_shared(), self.dr6_shared());
+
         Ok(caps)
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -305,7 +305,9 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             )
             .into()),
             HvX64RegisterName::VsmCapabilities => Ok(u64::from(
-                hvdef::HvRegisterVsmCapabilities::new().with_deny_lower_vtl_startup(true),
+                hvdef::HvRegisterVsmCapabilities::new()
+                    .with_deny_lower_vtl_startup(true)
+                    .with_dr6_shared(self.vp.partition.hcl.dr6_shared()),
             )
             .into()),
             HvX64RegisterName::VpAssistPage => Ok(self.vp.backing.cvm_state_mut().hv[vtl]


### PR DESCRIPTION
This is a partial cherry-pick of https://github.com/microsoft/openvmm/commit/6e390e91bc33f490f24067c3377544b2feef0df0