### PR TITLE
vmbus_server: support VTL2 channels for vmbusproxy.

### DIFF
--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -113,7 +113,6 @@ use vm_topology::processor::TopologyBuilder;
 use vmbus_channel::channel::VmbusDevice;
 use vmbus_server::hvsock::HvsockRelay;
 use vmbus_server::HvsockRelayChannel;
-use vmbus_server::ProxyIntegration;
 use vmbus_server::VmbusServer;
 use vmcore::save_restore::SavedStateRoot;
 use vmcore::vm_task::thread::ThreadDriverBackend;
@@ -501,7 +500,7 @@ struct LoadedVmInner {
     vmbus_server: Option<VmbusServerHandle>,
     vtl2_vmbus_server: Option<VmbusServerHandle>,
     #[cfg(windows)]
-    _vmbus_proxy: Option<ProxyIntegration>,
+    _vmbus_proxy: Option<vmbus_server::ProxyIntegration>,
     #[cfg(windows)]
     _kernel_vmnics: Vec<vmswitch::kernel::KernelVmNic>,
     memory_cfg: MemoryConfig,
@@ -1679,7 +1678,7 @@ impl InitializedVm {
             #[cfg(windows)]
             if let Some(proxy_handle) = vmbus_cfg.vmbusproxy_handle {
                 vmbus_proxy = Some(
-                    ProxyIntegration::start(
+                    vmbus_server::ProxyIntegration::start(
                         &vmbus_driver,
                         proxy_handle,
                         vmbus.control(),

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -569,15 +569,6 @@ impl VmbusServer {
         let _ = self.task.await;
     }
 
-    #[cfg(windows)]
-    pub async fn start_kernel_proxy(
-        &self,
-        driver: &(impl pal_async::driver::SpawnDriver + Clone),
-        handle: ProxyHandle,
-    ) -> std::io::Result<ProxyIntegration> {
-        ProxyIntegration::start(driver, handle, self.control(), Some(&self.control.mem)).await
-    }
-
     /// Returns an object that can be used to offer channels.
     pub fn control(&self) -> Arc<VmbusServerControl> {
         self.control.clone()

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -67,6 +67,7 @@ impl ProxyIntegration {
         driver: &(impl SpawnDriver + Clone),
         handle: ProxyHandle,
         server: Arc<VmbusServerControl>,
+        vtl2_server: Option<Arc<VmbusServerControl>>,
         mem: Option<&GuestMemory>,
     ) -> io::Result<Self> {
         let mut proxy = VmbusProxy::new(driver, handle)?;
@@ -79,7 +80,7 @@ impl ProxyIntegration {
         driver
             .spawn(
                 "vmbus_proxy",
-                proxy_thread(driver.clone(), proxy, server, cancel_ctx),
+                proxy_thread(driver.clone(), proxy, server, vtl2_server, cancel_ctx),
             )
             .detach();
 
@@ -98,15 +99,21 @@ struct ProxyTask {
     gpadls: Arc<Mutex<HashMap<u64, HashSet<GpadlId>>>>,
     proxy: Arc<VmbusProxy>,
     server: Arc<VmbusServerControl>,
+    vtl2_server: Option<Arc<VmbusServerControl>>,
 }
 
 impl ProxyTask {
-    fn new(control: Arc<VmbusServerControl>, proxy: Arc<VmbusProxy>) -> Self {
+    fn new(
+        server: Arc<VmbusServerControl>,
+        vtl2_server: Option<Arc<VmbusServerControl>>,
+        proxy: Arc<VmbusProxy>,
+    ) -> Self {
         Self {
             channels: Arc::new(Mutex::new(HashMap::new())),
             gpadls: Arc::new(Mutex::new(HashMap::new())),
             proxy,
-            server: control,
+            server,
+            vtl2_server,
         }
     }
 
@@ -213,6 +220,16 @@ impl ProxyTask {
         offer: vmbus_proxy::vmbusioctl::VMBUS_CHANNEL_OFFER,
         incoming_event: Event,
     ) -> Option<mesh::Receiver<ChannelRequest>> {
+        let server = match offer.TargetVtl {
+            0 => self.server.as_ref(),
+            2 => self
+                .vtl2_server
+                .as_ref()
+                .expect("VTL2 offer without VTL2 server")
+                .as_ref(),
+            _ => panic!("BUGBUG: unsupported VTL {}", offer.TargetVtl),
+        };
+
         let channel_type = if offer.ChannelFlags & VMBUS_CHANNEL_ENUMERATE_DEVICE_INTERFACE != 0 {
             let pipe_mode = u32::from_ne_bytes(offer.UserDefined[..4].try_into().unwrap());
             let message_mode = match pipe_mode {
@@ -244,7 +261,8 @@ impl ProxyTask {
         };
         let (request_send, request_recv) = mesh::channel();
         let (server_request_send, server_request_recv) = mesh::channel();
-        let recv = self.server.send.call_failable(
+
+        let recv = server.send.call_failable(
             OfferRequest::Offer,
             OfferInfo {
                 params: offer.into(),
@@ -429,11 +447,12 @@ async fn proxy_thread(
     spawner: impl Spawn,
     proxy: VmbusProxy,
     server: Arc<VmbusServerControl>,
+    vtl2_server: Option<Arc<VmbusServerControl>>,
     mut cancel: CancelContext,
 ) {
     let (send, recv) = mesh::channel();
     let proxy = Arc::new(proxy);
-    let task = Arc::new(ProxyTask::new(server, Arc::clone(&proxy)));
+    let task = Arc::new(ProxyTask::new(server, vtl2_server, Arc::clone(&proxy)));
     let offers = task.run_offers(send);
     let requests = task.run_channel_requests(spawner, recv);
     let cancellation = async {


### PR DESCRIPTION
This change makes it possible for vmbusproxy to offer channels to VTL2. Previously, vmbusproxy ignored an offer's target VTL and would always offer to VTL0.