### PR TITLE
vmbus_client: don't request confidential channel support.

### DIFF
--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -1846,13 +1846,13 @@ mod tests {
                         padding: 0,
                         selected_version_or_connection_id: 0,
                     },
-                    supported_features: FeatureFlags::all().into(),
+                    supported_features: SUPPORTED_FEATURE_FLAGS.into(),
                 },
             ));
 
             let version = recv.await.unwrap().unwrap();
             assert_eq!(version.version, Version::Copper);
-            assert_eq!(version.feature_flags, FeatureFlags::all());
+            assert_eq!(version.feature_flags, SUPPORTED_FEATURE_FLAGS);
         }
 
         async fn get_channel(&mut self, client: &mut VmbusClient) -> OfferInfo {
@@ -2013,7 +2013,7 @@ mod tests {
                     interrupt_page_or_target_info: TargetInfo::new()
                         .with_sint(2)
                         .with_vtl(0)
-                        .with_feature_flags(FeatureFlags::all().into())
+                        .with_feature_flags(SUPPORTED_FEATURE_FLAGS.into())
                         .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
@@ -2040,7 +2040,7 @@ mod tests {
                     interrupt_page_or_target_info: TargetInfo::new()
                         .with_sint(2)
                         .with_vtl(0)
-                        .with_feature_flags(FeatureFlags::all().into())
+                        .with_feature_flags(SUPPORTED_FEATURE_FLAGS.into())
                         .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
@@ -2058,14 +2058,14 @@ mod tests {
                     padding: 0,
                     selected_version_or_connection_id: 0,
                 },
-                supported_features: FeatureFlags::all().into_bits(),
+                supported_features: SUPPORTED_FEATURE_FLAGS.into_bits(),
             },
         ));
 
         let version = recv.await.unwrap().unwrap();
 
         assert_eq!(version.version, Version::Copper);
-        assert_eq!(version.feature_flags, FeatureFlags::all());
+        assert_eq!(version.feature_flags, SUPPORTED_FEATURE_FLAGS);
     }
 
     #[async_test]
@@ -2085,7 +2085,7 @@ mod tests {
                     interrupt_page_or_target_info: TargetInfo::new()
                         .with_sint(2)
                         .with_vtl(0)
-                        .with_feature_flags(FeatureFlags::all().into())
+                        .with_feature_flags(SUPPORTED_FEATURE_FLAGS.into())
                         .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
@@ -2139,7 +2139,7 @@ mod tests {
                     interrupt_page_or_target_info: TargetInfo::new()
                         .with_sint(2)
                         .with_vtl(0)
-                        .with_feature_flags(FeatureFlags::all().into())
+                        .with_feature_flags(SUPPORTED_FEATURE_FLAGS.into())
                         .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,
@@ -2166,7 +2166,7 @@ mod tests {
                     interrupt_page_or_target_info: TargetInfo::new()
                         .with_sint(2)
                         .with_vtl(0)
-                        .with_feature_flags(FeatureFlags::all().into())
+                        .with_feature_flags(SUPPORTED_FEATURE_FLAGS.into())
                         .into(),
                     parent_to_child_monitor_page_gpa: 0,
                     child_to_parent_monitor_page_gpa: 0,

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -58,7 +58,11 @@ use zerocopy::KnownLayout;
 const SINT: u8 = 2;
 const VTL: u8 = 0;
 const SUPPORTED_VERSIONS: &[Version] = &[Version::Iron, Version::Copper];
-const SUPPORTED_FEATURE_FLAGS: FeatureFlags = FeatureFlags::all();
+const SUPPORTED_FEATURE_FLAGS: FeatureFlags = FeatureFlags::new()
+    .with_guest_specified_signal_parameters(true)
+    .with_channel_interrupt_redirection(true)
+    .with_modify_connection(true)
+    .with_client_id(true);
 
 /// The client interface synic events.
 pub trait SynicEventClient: Send + Sync {

--- a/vm/devices/vmbus/vmbus_client/src/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_client/src/saved_state.rs
@@ -4,6 +4,7 @@
 use crate::OfferInfo;
 use crate::RestoreError;
 use crate::RestoredChannel;
+use crate::SUPPORTED_FEATURE_FLAGS;
 use guid::Guid;
 use mesh::payload::Protobuf;
 use vmbus_channel::bus::OfferKey;
@@ -241,7 +242,7 @@ impl TryFrom<ClientState> for super::ClientState {
                     .ok_or(RestoreError::UnsupportedVersion(version))?;
 
                 let feature_flags = FeatureFlags::from(feature_flags);
-                if feature_flags.contains_unsupported_bits() {
+                if !SUPPORTED_FEATURE_FLAGS.contains(feature_flags) {
                     return Err(RestoreError::UnsupportedFeatureFlags(feature_flags.into()));
                 }
 

--- a/vm/devices/vmbus/vmbus_core/src/protocol.rs
+++ b/vm/devices/vmbus/vmbus_core/src/protocol.rs
@@ -175,17 +175,9 @@ pub struct FeatureFlags {
 }
 
 impl FeatureFlags {
-    pub const fn all() -> Self {
-        Self::new()
-            .with_guest_specified_signal_parameters(true)
-            .with_channel_interrupt_redirection(true)
-            .with_modify_connection(true)
-            .with_client_id(true)
-            .with_confidential_channels(true)
-    }
-
-    pub fn contains_unsupported_bits(&self) -> bool {
-        u32::from(*self) & !u32::from(Self::all()) != 0
+    /// Returns true if `other` contains only flags that are also set in `self`.
+    pub fn contains(&self, other: FeatureFlags) -> bool {
+        self.into_bits() & other.into_bits() == other.into_bits()
     }
 }
 

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -1201,17 +1201,6 @@ const SUPPORTED_FEATURE_FLAGS: FeatureFlags = FeatureFlags::new()
     .with_modify_connection(true)
     .with_client_id(true);
 
-/// An error that occurred while mapping the interrupt page.
-#[derive(Error, Debug)]
-pub enum InterruptPageError {
-    #[error("memory")]
-    MemoryError(#[from] GuestMemoryError),
-    #[error("synic")]
-    SynicError(#[from] vmcore::synic::Error),
-    #[error("gpa {0:#x} is not page aligned")]
-    NotPageAligned(u64),
-}
-
 /// Trait for sending requests to devices and the guest.
 pub trait Notifier: Send {
     /// Requests a channel action.

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -5,6 +5,7 @@ use super::OfferError;
 use super::OfferParamsInternal;
 use super::OfferedInfo;
 use super::RestoreState;
+use super::SUPPORTED_FEATURE_FLAGS;
 use guid::Guid;
 use mesh::payload::Protobuf;
 use std::fmt::Display;
@@ -323,7 +324,7 @@ impl VersionInfo {
             .ok_or(RestoreError::UnsupportedVersion(self.version))?;
 
         let feature_flags = FeatureFlags::from(self.feature_flags);
-        if feature_flags.contains_unsupported_bits() {
+        if !SUPPORTED_FEATURE_FLAGS.contains(feature_flags) {
             return Err(RestoreError::UnsupportedFeatureFlags(feature_flags.into()));
         }
 

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -444,7 +444,7 @@ impl<'a, T: Spawn> VmbusServerBuilder<'a, T> {
                     .map(|_| {
                         ModifyConnectionResponse::Supported(
                             protocol::ConnectionState::SUCCESSFUL,
-                            protocol::FeatureFlags::all(),
+                            protocol::FeatureFlags::from_bits(u32::MAX),
                         )
                     })
                     .boxed()


### PR DESCRIPTION
The vmbus client requested all feature flags, which includes confidential channels, which it doesn't actually support. This was harmless, as the host cannot support confidential channels, but it would cause the host to log a warning that unsupported feature flags were requested.