### PR TITLE
virt_mshv_vtl: Separate out guest vsm state to backing shared states

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -17,6 +17,7 @@ cfg_if::cfg_if!(
         pub use processor::snp::SnpBacked;
         pub use processor::tdx::TdxBacked;
         pub use crate::processor::mshv::x64::HypervisorBackedX86 as HypervisorBacked;
+        pub use crate::processor::mshv::x64::HypervisorBackedX86Shared as HypervisorBackedShared;
         use bitvec::prelude::BitArray;
         use bitvec::prelude::Lsb0;
         use devmsr::MsrDevice;
@@ -33,6 +34,7 @@ cfg_if::cfg_if!(
         type IrrBitmap = BitArray<[u32; 8], Lsb0>;
     } else if #[cfg(target_arch = "aarch64")] { // xtask-fmt allow-target-arch sys-crate
         pub use crate::processor::mshv::arm64::HypervisorBackedArm64 as HypervisorBacked;
+        pub use crate::processor::mshv::arm64::HypervisorBackedArm64Shared as HypervisorBackedShared;
         use hvdef::HvArm64RegisterName;
     }
 );
@@ -224,7 +226,6 @@ struct UhPartitionInner {
     /// This is only set for TDX VMs. For SNP VMs, this is implemented by the
     /// hypervisor. For non-isolated VMs, this isn't a concept.
     untrusted_synic: Option<GlobalSynic>,
-    guest_vsm: RwLock<GuestVsmState>,
     #[inspect(skip)]
     isolated_memory_protector: Option<Arc<dyn ProtectIsolatedMemory>>,
     shared_dma_client: Option<Arc<dyn DmaClient>>,
@@ -245,7 +246,7 @@ struct UhPartitionInner {
 #[doc(hidden)]
 pub enum BackingShared {
     // No shared state for hypervisor-backed VMs today.
-    Hypervisor,
+    Hypervisor(#[inspect(flatten)] HypervisorBackedShared),
     #[cfg(guest_arch = "x86_64")]
     Snp(#[inspect(flatten)] SnpBackedShared),
     #[cfg(guest_arch = "x86_64")]
@@ -259,14 +260,8 @@ impl BackingShared {
     ) -> Result<BackingShared, Error> {
         Ok(match isolation {
             IsolationType::None | IsolationType::Vbs => {
-                #[allow(irrefutable_let_patterns)]
-                let BackingSharedParams {
-                    cvm_state: None, ..
-                } = backing_shared_params
-                else {
-                    unreachable!()
-                };
-                BackingShared::Hypervisor
+                assert!(backing_shared_params.cvm_state.is_none());
+                BackingShared::Hypervisor(HypervisorBackedShared::new(backing_shared_params)?)
             }
             #[cfg(guest_arch = "x86_64")]
             IsolationType::Snp => BackingShared::Snp(SnpBackedShared::new(backing_shared_params)?),
@@ -279,7 +274,7 @@ impl BackingShared {
 
     fn cvm_state(&self) -> Option<&UhCvmPartitionState> {
         match self {
-            BackingShared::Hypervisor => None,
+            BackingShared::Hypervisor(_) => None,
             #[cfg(guest_arch = "x86_64")]
             BackingShared::Snp(s) => Some(&s.cvm),
             #[cfg(guest_arch = "x86_64")]
@@ -412,6 +407,8 @@ pub struct UhCvmPartitionState {
     lapic: VtlArray<LocalApicSet, 2>,
     /// The emulated hypervisor state.
     hv: GlobalHv,
+    /// Guest VSM state.
+    guest_vsm: RwLock<GuestVsmState<CvmVtl1State>>,
 }
 
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
@@ -436,74 +433,31 @@ pub struct UhCvmVpInner {
 #[derive(Inspect)]
 #[inspect(tag = "guest vsm state")]
 /// Partition-wide state for guest vsm. Only applies to CVMs.
-enum GuestVsmState {
+enum GuestVsmState<T: Inspect> {
     NotPlatformSupported,
     NotGuestEnabled,
-    Enabled { vtl1: GuestVsmVtl1State },
+    Enabled { vtl1: T },
 }
 
-impl GuestVsmState {
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-    fn get_vbs_isolated(&self) -> Option<&VbsIsolatedVtl1State> {
-        match self {
-            GuestVsmState::Enabled {
-                vtl1: GuestVsmVtl1State::VbsIsolated { state },
-            } => Some(state),
-
-            _ => None,
-        }
-    }
-
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-    fn get_vbs_isolated_mut(&mut self) -> Option<&mut VbsIsolatedVtl1State> {
-        match self {
-            GuestVsmState::Enabled {
-                vtl1: GuestVsmVtl1State::VbsIsolated { state },
-            } => Some(state),
-
-            _ => None,
-        }
-    }
-
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-    fn get_hardware_cvm_mut(&mut self) -> Option<&mut HardwareCvmVtl1State> {
-        match self {
-            GuestVsmState::Enabled {
-                vtl1: GuestVsmVtl1State::HardwareCvm { state },
-            } => Some(state),
-
-            _ => None,
-        }
-    }
-
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-    fn get_hardware_cvm(&self) -> Option<&HardwareCvmVtl1State> {
-        match self {
-            GuestVsmState::Enabled {
-                vtl1: GuestVsmVtl1State::HardwareCvm { state },
-            } => Some(state),
-            _ => None,
+impl<T: Inspect> GuestVsmState<T> {
+    pub fn from_availability(guest_vsm_available: bool) -> Self {
+        if guest_vsm_available {
+            GuestVsmState::NotGuestEnabled
+        } else {
+            GuestVsmState::NotPlatformSupported
         }
     }
 }
 
-#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-#[derive(Clone, Copy, Inspect)]
-#[inspect(external_tag)]
-enum GuestVsmVtl1State {
-    HardwareCvm { state: HardwareCvmVtl1State },
-    VbsIsolated { state: VbsIsolatedVtl1State },
-}
-
-#[derive(Clone, Copy, Default, Inspect)]
+#[derive(Default, Inspect)]
 struct VbsIsolatedVtl1State {
     #[inspect(with = "|flags| flags.map(|f| inspect::AsHex(u32::from(f)))")]
     default_vtl_protections: Option<HvMapGpaFlags>,
     enable_vtl_protection: bool,
 }
 
-#[derive(Clone, Copy, Default, Inspect)]
-struct HardwareCvmVtl1State {
+#[derive(Default, Inspect)]
+struct CvmVtl1State {
     /// Whether VTL 1 has been enabled on any vp
     enabled_on_any_vp: bool,
     /// Whether guest memory should be zeroed before it resets.
@@ -737,52 +691,59 @@ impl WakeReason {
 impl UhPartition {
     /// Revokes guest VSM.
     pub fn revoke_guest_vsm(&self) -> Result<(), RevokeGuestVsmError> {
-        let mut vsm_state = self.inner.guest_vsm.write();
-
-        if matches!(*vsm_state, GuestVsmState::Enabled { vtl1: _ }) {
-            return Err(RevokeGuestVsmError::Vtl1AlreadyEnabled);
+        fn revoke<T: Inspect>(gvsm: &mut GuestVsmState<T>) -> Result<(), RevokeGuestVsmError> {
+            if matches!(gvsm, GuestVsmState::Enabled { .. }) {
+                return Err(RevokeGuestVsmError::Vtl1AlreadyEnabled);
+            }
+            *gvsm = GuestVsmState::NotPlatformSupported;
+            Ok(())
         }
 
-        *vsm_state = GuestVsmState::NotPlatformSupported;
+        match &self.inner.backing_shared {
+            BackingShared::Hypervisor(s) => {
+                revoke(&mut *s.guest_vsm.write())?;
+                self.inner
+                    .hcl
+                    .set_guest_vsm_partition_config(false)
+                    .map_err(RevokeGuestVsmError::SetGuestVsmConfig)?;
+            }
+            #[cfg(guest_arch = "x86_64")]
+            BackingShared::Snp(SnpBackedShared { cvm, .. })
+            | BackingShared::Tdx(TdxBackedShared { cvm, .. }) => {
+                revoke(&mut *cvm.guest_vsm.write())?;
+                let mut cpuid_lock = self.inner.cpuid.lock();
+                let current_result =
+                    cpuid_lock.result(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES, 0, &[0; 4]);
 
-        if !self.inner.isolation.is_hardware_isolated() {
-            self.inner
-                .hcl
-                .set_guest_vsm_partition_config(false)
-                .map_err(RevokeGuestVsmError::SetGuestVsmConfig)?;
-        } else {
-            let mut cpuid_lock = self.inner.cpuid.lock();
-            let current_result =
-                cpuid_lock.result(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES, 0, &[0; 4]);
+                let mut features = hvdef::HvFeatures::from(u128::from_le_bytes(
+                    current_result
+                        .iter()
+                        .flat_map(|i| i.to_le_bytes())
+                        .collect::<Vec<u8>>()
+                        .try_into()
+                        .unwrap(),
+                ));
 
-            let mut features = hvdef::HvFeatures::from(u128::from_le_bytes(
-                current_result
-                    .iter()
-                    .flat_map(|i| i.to_le_bytes())
-                    .collect::<Vec<u8>>()
-                    .try_into()
-                    .unwrap(),
-            ));
+                let privileges = hvdef::HvPartitionPrivilege::from(features.privileges());
+                features.set_privileges(privileges.with_access_vsm(false).into());
 
-            let privileges = hvdef::HvPartitionPrivilege::from(features.privileges());
-            features.set_privileges(privileges.with_access_vsm(false).into());
+                let split_u128 = |x: u128| -> [u32; 4] {
+                    let bytes = x.to_le_bytes();
+                    [
+                        u32::from_le_bytes(bytes[0..4].try_into().unwrap()),
+                        u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+                        u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
+                        u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
+                    ]
+                };
 
-            let split_u128 = |x: u128| -> [u32; 4] {
-                let bytes = x.to_le_bytes();
-                [
-                    u32::from_le_bytes(bytes[0..4].try_into().unwrap()),
-                    u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
-                    u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
-                    u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
-                ]
-            };
-
-            cpuid_lock.update_result(
-                hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES,
-                0,
-                &split_u128(features.into()),
-            );
-        }
+                cpuid_lock.update_result(
+                    hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES,
+                    0,
+                    &split_u128(features.into()),
+                );
+            }
+        };
 
         Ok(())
     }
@@ -1634,15 +1595,6 @@ impl<'a> UhProtoPartition<'a> {
             Mutex::new(CpuidLeafSet::new(Vec::new())),
         );
 
-        let vsm_state = if guest_vsm_available {
-            if is_hardware_isolated {
-                tracing::warn!("Advertising guest vsm as being supported to the guest. This feature is in development, so the guest might crash.");
-            }
-            GuestVsmState::NotGuestEnabled
-        } else {
-            GuestVsmState::NotPlatformSupported
-        };
-
         #[cfg(guest_arch = "x86_64")]
         let cpuid = UhPartition::construct_cpuid_results(
             &late_params.cpuid,
@@ -1701,7 +1653,9 @@ impl<'a> UhProtoPartition<'a> {
 
         #[cfg(guest_arch = "x86_64")]
         let cvm_state = cvm_cpuid
-            .map(|cpuid| Self::construct_cvm_state(&params, &late_params, &caps, cpuid))
+            .map(|cpuid| {
+                Self::construct_cvm_state(&params, &late_params, &caps, cpuid, guest_vsm_available)
+            })
             .transpose()?;
         #[cfg(guest_arch = "aarch64")]
         let cvm_state = None;
@@ -1726,7 +1680,6 @@ impl<'a> UhProtoPartition<'a> {
             isolation,
             hide_isolation: params.hide_isolation,
             untrusted_synic,
-            guest_vsm: RwLock::new(vsm_state),
             isolated_memory_protector: late_params.isolated_memory_protector.clone(),
             shared_dma_client: late_params.shared_dma_client,
             private_dma_client: late_params.private_dma_client,
@@ -1737,6 +1690,7 @@ impl<'a> UhProtoPartition<'a> {
                 BackingSharedParams {
                     cvm_state,
                     vp_count: params.topology.vp_count(),
+                    guest_vsm_available,
                 },
             )?,
             #[cfg(guest_arch = "x86_64")]
@@ -1886,6 +1840,7 @@ impl UhProtoPartition<'_> {
         late_params: &UhLateParams<'_>,
         caps: &PartitionCapabilities,
         cpuid: cvm_cpuid::CpuidResults,
+        guest_vsm_available: bool,
     ) -> Result<UhCvmPartitionState, Error> {
         let vp_count = params.topology.vp_count() as usize;
         let vps = (0..vp_count)
@@ -1921,6 +1876,10 @@ impl UhProtoPartition<'_> {
             ref_time,
         });
 
+        if guest_vsm_available {
+            tracing::warn!("Advertising guest vsm as being supported to the guest. This feature is in development, so the guest might crash.");
+        }
+
         Ok(UhCvmPartitionState {
             cpuid,
             tlb_locked_vps,
@@ -1931,6 +1890,7 @@ impl UhProtoPartition<'_> {
                 .ok_or(Error::MissingSharedMemory)?,
             lapic,
             hv,
+            guest_vsm: RwLock::new(GuestVsmState::from_availability(guest_vsm_available)),
         })
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -12,8 +12,8 @@ use super::UhRunVpError;
 use crate::processor::HardwareIsolatedBacking;
 use crate::processor::UhHypercallHandler;
 use crate::validate_vtl_gpa_flags;
+use crate::CvmVtl1State;
 use crate::GuestVsmState;
-use crate::GuestVsmVtl1State;
 use crate::GuestVtl;
 use crate::InitialVpContextOperation;
 use crate::TlbFlushLockAccess;
@@ -70,32 +70,32 @@ where
             return Err(HvError::InvalidParameter);
         }
 
-        let mut gvsm_state = self.vp.partition.guest_vsm.write();
+        {
+            let mut gvsm_state = self.vp.cvm_partition().guest_vsm.write();
 
-        match *gvsm_state {
-            GuestVsmState::NotPlatformSupported => return Err(HvError::AccessDenied),
-            GuestVsmState::NotGuestEnabled => (),
-            GuestVsmState::Enabled { vtl1: _ } => {
-                // VTL 1 cannot be already enabled
-                return Err(HvError::VtlAlreadyEnabled);
+            match *gvsm_state {
+                GuestVsmState::NotPlatformSupported => return Err(HvError::AccessDenied),
+                GuestVsmState::NotGuestEnabled => (),
+                GuestVsmState::Enabled { vtl1: _ } => {
+                    // VTL 1 cannot be already enabled
+                    return Err(HvError::VtlAlreadyEnabled);
+                }
             }
-        }
 
-        self.vp.partition.hcl.enable_partition_vtl(
-            target_vtl,
-            // These flags are managed and enforced internally; CVMs can't rely
-            // on the hypervisor
-            0.into(),
-        )?;
+            self.vp.partition.hcl.enable_partition_vtl(
+                target_vtl,
+                // These flags are managed and enforced internally; CVMs can't rely
+                // on the hypervisor
+                0.into(),
+            )?;
 
-        *gvsm_state = GuestVsmState::Enabled {
-            vtl1: GuestVsmVtl1State::HardwareCvm {
-                state: crate::HardwareCvmVtl1State {
+            *gvsm_state = GuestVsmState::Enabled {
+                vtl1: CvmVtl1State {
                     mbec_enabled: flags.enable_mbec(),
                     ..Default::default()
                 },
-            },
-        };
+            };
+        }
 
         let protector = self
             .vp
@@ -945,15 +945,18 @@ impl<T, B: HardwareIsolatedBacking>
         }
 
         // If lower VTL startup has been suppressed, then the request must be
-        // coming from a secure VTL.
+        // coming from a secure VTL. We know guest VSM has been enabled from the
+        // previous check.
         if self.intercepted_vtl == GuestVtl::Vtl0
-            && self
-                .vp
-                .partition
-                .guest_vsm
-                .read()
-                .get_hardware_cvm()
-                .is_some_and(|state| state.deny_lower_vtl_startup)
+            && matches!(
+                *self.vp.cvm_partition().guest_vsm.read(),
+                GuestVsmState::Enabled {
+                    vtl1: CvmVtl1State {
+                        deny_lower_vtl_startup: true,
+                        ..
+                    }
+                }
+            )
         {
             return Err(HvError::AccessDenied);
         }
@@ -1032,18 +1035,20 @@ where
             return Err((HvError::AccessDenied, 0));
         }
 
-        // VTL 1 mut be enabled already.
-        let mut guest_vsm_lock = self.vp.partition.guest_vsm.write();
-        let guest_vsm = guest_vsm_lock
-            .get_hardware_cvm_mut()
-            .ok_or((HvError::InvalidVtlState, 0))?;
+        {
+            // VTL 1 mut be enabled already.
+            let guest_vsm_lock = self.vp.cvm_partition().guest_vsm.read();
+            let GuestVsmState::Enabled { vtl1, .. } = &*guest_vsm_lock else {
+                return Err((HvError::InvalidVtlState, 0));
+            };
 
-        if !validate_vtl_gpa_flags(
-            map_flags,
-            guest_vsm.mbec_enabled,
-            guest_vsm.shadow_supervisor_stack_enabled,
-        ) {
-            return Err((HvError::InvalidRegisterValue, 0));
+            if !validate_vtl_gpa_flags(
+                map_flags,
+                vtl1.mbec_enabled,
+                vtl1.shadow_supervisor_stack_enabled,
+            ) {
+                return Err((HvError::InvalidRegisterValue, 0));
+            }
         }
 
         // The contract for VSM is that the VTL protections describe what
@@ -1088,12 +1093,17 @@ impl<T, B: HardwareIsolatedBacking>
         // If handling on behalf of VTL 0, then lock to make sure that no other
         // VP makes this call on behalf of VTL 0.
         let gvsm_state = {
-            let mut gvsm_state = self.vp.partition.guest_vsm.write();
+            let guest_vsm_lock = self.vp.cvm_partition().guest_vsm.write();
 
             // Should be enabled on the partition
-            let vtl1_state = gvsm_state
-                .get_hardware_cvm_mut()
-                .ok_or(HvError::InvalidVtlState)?;
+            let vtl1 = parking_lot::RwLockWriteGuard::try_map(guest_vsm_lock, |gvsm| {
+                if let GuestVsmState::Enabled { vtl1, .. } = &mut *gvsm {
+                    Some(vtl1)
+                } else {
+                    None
+                }
+            })
+            .map_err(|_| HvError::InvalidVtlState)?;
 
             let current_vp_index = self.vp.vp_index().index();
 
@@ -1102,16 +1112,16 @@ impl<T, B: HardwareIsolatedBacking>
             // the higher VTL has not been enabled on any other VP because at that
             // point, the higher VTL should be orchestrating its own enablement.
             if self.intercepted_vtl < GuestVtl::Vtl1 {
-                if vtl1_state.enabled_on_any_vp || vp_index != current_vp_index {
+                if vtl1.enabled_on_any_vp || vp_index != current_vp_index {
                     return Err(HvError::AccessDenied);
                 }
 
-                Some(gvsm_state)
+                Some(vtl1)
             } else {
                 // If handling on behalf of VTL 1, then some other VP (i.e. the
                 // bsp) must have already handled EnableVpVtl. No partition-wide
                 // state is changing, so no need to hold the lock
-                assert!(vtl1_state.enabled_on_any_vp);
+                assert!(vtl1.enabled_on_any_vp);
                 None
             }
         };
@@ -1157,11 +1167,11 @@ impl<T, B: HardwareIsolatedBacking>
             .enable_vp_vtl(vp_index, vtl, hv_vp_context)?;
 
         // Cannot fail from here
-        if let Some(mut gvsm) = gvsm_state {
+        if let Some(mut vtl1) = gvsm_state {
             // It's valid to only set this when gvsm_state is Some (when VTL 0
             // was intercepted) only because we assert above that if VTL 1 was
             // intercepted, some vp has already enabled VTL 1 on it.
-            gvsm.get_hardware_cvm_mut().unwrap().enabled_on_any_vp = true;
+            vtl1.enabled_on_any_vp = true;
         }
 
         *vtl1_enabled = true;
@@ -1377,40 +1387,49 @@ where
             return Err(HvError::InvalidRegisterValue);
         }
 
-        // VTL 1 mut be enabled already.
-        let mut guest_vsm_lock = self.partition.guest_vsm.write();
-        let guest_vsm = guest_vsm_lock
-            .get_hardware_cvm_mut()
-            .ok_or(HvError::InvalidVtlState)?;
-
         let protections = HvMapGpaFlags::from(value.default_vtl_protection_mask() as u32);
+        // Protections given to set_vsm_partition_config actually apply to VTLs lower
+        // than the VTL specified as an argument for hardware CVMs.
+        let targeted_vtl = GuestVtl::Vtl0;
+
+        {
+            // VTL 1 mut be enabled already.
+            let mut guest_vsm_lock = self.cvm_partition().guest_vsm.write();
+            let GuestVsmState::Enabled { vtl1, .. } = &mut *guest_vsm_lock else {
+                return Err(HvError::InvalidVtlState);
+            };
+
+            if !validate_vtl_gpa_flags(
+                protections,
+                vtl1.mbec_enabled,
+                vtl1.shadow_supervisor_stack_enabled,
+            ) {
+                return Err(HvError::InvalidRegisterValue);
+            }
+
+            // Default VTL protection mask must include read and write.
+            if !(protections.readable() && protections.writable()) {
+                return Err(HvError::InvalidRegisterValue);
+            }
+
+            // Note: Zero memory on reset will happen regardless of this value,
+            // since reset that involves resetting from UEFI isn't supported, and
+            // the partition will get torn down and reconstructed by the host.
+            // TODO: Is it ok to change these values if the below calls fail?
+            vtl1.zero_memory_on_reset = value.zero_memory_on_reset();
+            vtl1.deny_lower_vtl_startup = value.deny_lower_vtl_startup();
+        }
 
         let protector = self
             .partition
             .isolated_memory_protector
             .as_ref()
             .expect("isolated memory protector must exist for a CVM");
+
         // VTL protection cannot be disabled once enabled.
         if !value.enable_vtl_protection() && protector.vtl1_protections_enabled() {
             return Err(HvError::InvalidRegisterValue);
         }
-
-        if !validate_vtl_gpa_flags(
-            protections,
-            guest_vsm.mbec_enabled,
-            guest_vsm.shadow_supervisor_stack_enabled,
-        ) {
-            return Err(HvError::InvalidRegisterValue);
-        }
-
-        // Default VTL protection mask must include read and write.
-        if !(protections.readable() && protections.writable()) {
-            return Err(HvError::InvalidRegisterValue);
-        }
-
-        // Protections given to set_vsm_partition_config actually apply to VTLs lower
-        // than the VTL specified as an argument for hardware CVMs.
-        let targeted_vtl = GuestVtl::Vtl0;
 
         // Don't allow changing existing protections once vtl protection is enabled
         if protector.vtl1_protections_enabled() {
@@ -1425,12 +1444,6 @@ where
         // TODO GUEST VSM: actually use the enable_vtl_protection value when
         // deciding whether to check vtl access();
         protector.set_vtl1_protections_enabled();
-
-        // Note: Zero memory on reset will happen regardless of this value,
-        // since reset that involves resetting from UEFI isn't supported, and
-        // the partition will get torn down and reconstructed by the host.
-        guest_vsm.zero_memory_on_reset = value.zero_memory_on_reset();
-        guest_vsm.deny_lower_vtl_startup = value.deny_lower_vtl_startup();
 
         Ok(())
     }
@@ -1559,15 +1572,15 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
         let requesting_vtl = requesting_vtl.into();
 
-        let guest_vsm_lock = self.partition.guest_vsm.read();
-        let guest_vsm = guest_vsm_lock
-            .get_hardware_cvm()
-            .ok_or(HvError::InvalidVtlState)?;
+        let guest_vsm_lock = self.cvm_partition().guest_vsm.read();
+        let GuestVsmState::Enabled { vtl1, .. } = &*guest_vsm_lock else {
+            return Err(HvError::InvalidVtlState);
+        };
 
         let tlb_locked = self.vtls_tlb_locked.get(requesting_vtl, target_vtl);
 
         Ok(HvRegisterVsmVpSecureVtlConfig::new()
-            .with_mbec_enabled(guest_vsm.mbec_enabled)
+            .with_mbec_enabled(vtl1.mbec_enabled)
             .with_tlb_locked(tlb_locked))
     }
 
@@ -1592,14 +1605,16 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
         let requesting_vtl = requesting_vtl.into();
 
-        let guest_vsm_lock = self.partition.guest_vsm.read();
-        let guest_vsm = guest_vsm_lock
-            .get_hardware_cvm()
-            .ok_or(HvError::InvalidVtlState)?;
+        {
+            let guest_vsm_lock = self.cvm_partition().guest_vsm.read();
+            let GuestVsmState::Enabled { vtl1, .. } = &*guest_vsm_lock else {
+                return Err(HvError::InvalidVtlState);
+            };
 
-        // MBEC must always be enabled or disabled partition-wide.
-        if config.mbec_enabled() != guest_vsm.mbec_enabled {
-            return Err(HvError::InvalidRegisterValue);
+            // MBEC must always be enabled or disabled partition-wide.
+            if config.mbec_enabled() != vtl1.mbec_enabled {
+                return Err(HvError::InvalidRegisterValue);
+            }
         }
 
         let tlb_locked = self.vtls_tlb_locked.get(requesting_vtl, target_vtl);

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -34,7 +34,6 @@ cfg_if::cfg_if! {
 use super::Error;
 use super::UhPartitionInner;
 use super::UhVpInner;
-use crate::GuestVsmState;
 use crate::GuestVtl;
 use crate::WakeReason;
 use hcl::ioctl;
@@ -264,10 +263,11 @@ mod private {
     }
 }
 
+#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 pub struct BackingSharedParams {
     pub(crate) cvm_state: Option<crate::UhCvmPartitionState>,
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     pub(crate) vp_count: u32,
+    pub(crate) guest_vsm_available: bool,
 }
 
 /// Processor backing.
@@ -1012,13 +1012,6 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
             devices,
         )
         .await
-    }
-
-    fn vtl1_supported(&self) -> bool {
-        !matches!(
-            *self.partition.guest_vsm.read(),
-            GuestVsmState::NotPlatformSupported
-        )
     }
 
     fn deliver_synic_messages(&mut self, vtl: GuestVtl, sints: u16) {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -13,11 +13,14 @@ use super::super::vp_state;
 use super::super::vp_state::UhVpStateAccess;
 use super::super::BackingPrivate;
 use super::super::UhRunVpError;
+use crate::processor::BackingSharedParams;
 use crate::processor::UhEmulationState;
 use crate::processor::UhHypercallHandler;
 use crate::processor::UhProcessor;
 use crate::BackingShared;
 use crate::Error;
+use crate::GuestVsmState;
+use crate::VbsIsolatedVtl1State;
 use aarch64defs::Cpsr64;
 use aarch64emu::AccessCpuState;
 use aarch64emu::InterceptState;
@@ -39,6 +42,7 @@ use hvdef::Vtl;
 use inspect::Inspect;
 use inspect::InspectMut;
 use inspect_counters::Counter;
+use parking_lot::RwLock;
 use virt::aarch64::vp;
 use virt::aarch64::vp::AccessVpState;
 use virt::io::CpuIo;
@@ -66,6 +70,21 @@ pub struct HypervisorBackedArm64 {
     stats: ProcessorStatsArm64,
 }
 
+/// Partition-wide shared data for hypervisor backed VMs.
+#[derive(Inspect)]
+pub struct HypervisorBackedArm64Shared {
+    pub(crate) guest_vsm: RwLock<GuestVsmState<VbsIsolatedVtl1State>>,
+}
+
+impl HypervisorBackedArm64Shared {
+    /// Creates a new partition-shared data structure for hypervisor backed VMs.
+    pub fn new(params: BackingSharedParams) -> Result<Self, Error> {
+        Ok(Self {
+            guest_vsm: RwLock::new(GuestVsmState::from_availability(params.guest_vsm_available)),
+        })
+    }
+}
+
 #[derive(Inspect, Default)]
 struct ProcessorStatsArm64 {
     mmio: Counter,
@@ -77,13 +96,21 @@ struct ProcessorStatsArm64 {
 impl BackingPrivate for HypervisorBackedArm64 {
     type HclBacking<'mshv> = MshvArm64;
     type EmulationCache = UhCpuStateCache;
-    type Shared = ();
+    type Shared = HypervisorBackedArm64Shared;
 
-    fn shared(_shared: &BackingShared) -> &Self::Shared {
-        &()
+    fn shared(shared: &BackingShared) -> &Self::Shared {
+        #[expect(irrefutable_let_patterns)]
+        let BackingShared::Hypervisor(shared) = shared
+        else {
+            unreachable!()
+        };
+        shared
     }
 
-    fn new(params: BackingParams<'_, '_, Self>, _shared: &()) -> Result<Self, Error> {
+    fn new(
+        params: BackingParams<'_, '_, Self>,
+        _shared: &HypervisorBackedArm64Shared,
+    ) -> Result<Self, Error> {
         vp::Registers::at_reset(&params.partition.caps, params.vp_info);
         // TODO: reset the registers in the CPU context.
         let _ = params.runner;
@@ -114,8 +141,6 @@ impl BackingPrivate for HypervisorBackedArm64 {
         dev: &impl CpuIo,
         _stop: &mut virt::StopVp<'_>,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let () = this.shared;
-
         if this.backing.deliverability_notifications
             != this.backing.next_deliverability_notifications
         {
@@ -635,7 +660,10 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedA
         // the HvCheckSparseGpaPageVtlAccess hypercall--which is unimplemented in whp--will never be made.
         if mode == emulate::TranslateMode::Execute
             && self.vtl == GuestVtl::Vtl0
-            && self.vp.vtl1_supported()
+            && !matches!(
+                *self.vp.shared.guest_vsm.read(),
+                GuestVsmState::NotPlatformSupported,
+            )
         {
             // Should always be called after translate gva with the tlb lock flag
             debug_assert!(self.vp.is_tlb_locked(Vtl::Vtl2, self.vtl));

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -14,6 +14,7 @@ use super::super::vp_state::UhVpStateAccess;
 use super::super::BackingPrivate;
 use super::super::UhEmulationState;
 use super::super::UhRunVpError;
+use crate::processor::BackingSharedParams;
 use crate::processor::SidecarExitReason;
 use crate::processor::SidecarRemoveExit;
 use crate::processor::UhHypercallHandler;
@@ -22,8 +23,8 @@ use crate::validate_vtl_gpa_flags;
 use crate::BackingShared;
 use crate::Error;
 use crate::GuestVsmState;
-use crate::GuestVsmVtl1State;
 use crate::GuestVtl;
+use crate::VbsIsolatedVtl1State;
 use hcl::ioctl;
 use hcl::ioctl::x64::MshvX64;
 use hcl::ioctl::ApplyVtlProtectionsError;
@@ -49,6 +50,7 @@ use hvdef::HV_PAGE_SIZE;
 use inspect::Inspect;
 use inspect::InspectMut;
 use inspect_counters::Counter;
+use parking_lot::RwLock;
 use std::sync::atomic::Ordering::Relaxed;
 use virt::io::CpuIo;
 use virt::state::HvRegisterState;
@@ -89,6 +91,21 @@ pub struct HypervisorBackedX86 {
     stats: ProcessorStatsX86,
 }
 
+/// Partition-wide shared data for hypervisor backed VMs.
+#[derive(Inspect)]
+pub struct HypervisorBackedX86Shared {
+    pub(crate) guest_vsm: RwLock<GuestVsmState<VbsIsolatedVtl1State>>,
+}
+
+impl HypervisorBackedX86Shared {
+    /// Creates a new partition-shared data structure for hypervisor backed VMs.
+    pub fn new(params: BackingSharedParams) -> Result<Self, Error> {
+        Ok(Self {
+            guest_vsm: RwLock::new(GuestVsmState::from_availability(params.guest_vsm_available)),
+        })
+    }
+}
+
 #[derive(Inspect, Default)]
 struct ProcessorStatsX86 {
     io_port: Counter,
@@ -120,14 +137,20 @@ pub struct MshvEmulationCache {
 
 impl BackingPrivate for HypervisorBackedX86 {
     type HclBacking<'mshv> = MshvX64<'mshv>;
-    type Shared = ();
+    type Shared = HypervisorBackedX86Shared;
     type EmulationCache = MshvEmulationCache;
 
-    fn shared(_: &BackingShared) -> &Self::Shared {
-        &()
+    fn shared(shared: &BackingShared) -> &Self::Shared {
+        let BackingShared::Hypervisor(shared) = shared else {
+            unreachable!()
+        };
+        shared
     }
 
-    fn new(params: BackingParams<'_, '_, Self>, _shared: &()) -> Result<Self, Error> {
+    fn new(
+        params: BackingParams<'_, '_, Self>,
+        _shared: &HypervisorBackedX86Shared,
+    ) -> Result<Self, Error> {
         // Initialize shared register state to architectural state. The kernel
         // zero initializes this.
         //
@@ -916,7 +939,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
             return Err(HvError::InvalidVtlState);
         }
 
-        let mut guest_vsm_lock = self.partition.guest_vsm.write();
+        let mut guest_vsm_lock = self.shared.guest_vsm.write();
 
         // Initialize partition.guest_vsm state if necessary.
         match *guest_vsm_lock {
@@ -926,15 +949,15 @@ impl UhProcessor<'_, HypervisorBackedX86> {
             GuestVsmState::NotGuestEnabled => {
                 // TODO: check status
                 *guest_vsm_lock = GuestVsmState::Enabled {
-                    vtl1: GuestVsmVtl1State::VbsIsolated {
-                        state: Default::default(),
-                    },
+                    vtl1: Default::default(),
                 };
             }
-            GuestVsmState::Enabled { vtl1: _ } => {}
+            GuestVsmState::Enabled { .. } => {}
         }
 
-        let guest_vsm = guest_vsm_lock.get_vbs_isolated_mut().unwrap();
+        let GuestVsmState::Enabled { vtl1 } = &mut *guest_vsm_lock else {
+            unreachable!()
+        };
         let protections = HvMapGpaFlags::from(value.default_vtl_protection_mask() as u32);
 
         if value.reserved() != 0 {
@@ -947,7 +970,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         // setting the enable_vtl_protection bit when it was previously
         // disabled; other cases are handled directly by the hypervisor.
         if !value.enable_vtl_protection() {
-            if guest_vsm.enable_vtl_protection {
+            if vtl1.enable_vtl_protection {
                 // A malicious guest could change its hypercall parameters in
                 // memory while the intercept is being handled; this case
                 // explicitly handles that situation.
@@ -974,12 +997,12 @@ impl UhProcessor<'_, HypervisorBackedX86> {
         }
 
         // Don't allow changing existing protections once set.
-        if let Some(current_protections) = guest_vsm.default_vtl_protections {
+        if let Some(current_protections) = vtl1.default_vtl_protections {
             if protections != current_protections {
                 return Err(HvError::InvalidRegisterValue);
             }
         }
-        guest_vsm.default_vtl_protections = Some(protections);
+        vtl1.default_vtl_protections = Some(protections);
 
         for ram_range in self.partition.lower_vtl_memory_layout.ram().iter() {
             self.partition
@@ -998,7 +1021,7 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         let hc_regs = [(HvX64RegisterName::VsmPartitionConfig, u64::from(value))];
         self.runner.set_vp_registers_hvcall(vtl.into(), hc_regs)?;
-        guest_vsm.enable_vtl_protection = true;
+        vtl1.enable_vtl_protection = true;
 
         Ok(())
     }
@@ -1238,7 +1261,10 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
         // the HvCheckSparseGpaPageVtlAccess hypercall--which is unimplemented in whp--will never be made.
         if mode == virt_support_x86emu::emulate::TranslateMode::Execute
             && self.vtl == GuestVtl::Vtl0
-            && self.vp.vtl1_supported()
+            && !matches!(
+                *self.vp.shared.guest_vsm.read(),
+                GuestVsmState::NotPlatformSupported,
+            )
         {
             // Should always be called after translate gva with the tlb lock flag
             debug_assert!(self.vp.is_tlb_locked(Vtl::Vtl2, self.vtl));
@@ -1790,18 +1816,18 @@ impl<T> hv1_hypercall::ModifyVtlProtectionMask
         // A VTL cannot change its own VTL permissions until it has enabled VTL protection and
         // configured default permissions. Higher VTLs are not under this restriction (as they may
         // need to apply default permissions before VTL protection is enabled).
-        if target_vtl == self.intercepted_vtl {
-            if !self
-                .vp
-                .partition
-                .guest_vsm
-                .read()
-                .get_vbs_isolated()
-                .ok_or((HvError::AccessDenied, 0))?
-                .enable_vtl_protection
-            {
-                return Err((HvError::AccessDenied, 0));
-            }
+        if target_vtl == self.intercepted_vtl
+            && !matches!(
+                *self.vp.shared.guest_vsm.read(),
+                GuestVsmState::Enabled {
+                    vtl1: VbsIsolatedVtl1State {
+                        enable_vtl_protection: true,
+                        default_vtl_protections: Some(_),
+                    },
+                }
+            )
+        {
+            return Err((HvError::AccessDenied, 0));
         }
 
         // TODO VBS GUEST VSM: verify this logic is correct


### PR DESCRIPTION
This avoids a bunch of unwraps and enum matching by moving the different types of Guest VSM state into their appropriate backing shared state. It also introduces backing shared state for hypervisor backed VMs, as they now have a need for it.