### PR TITLE
virt_mshv_vtl: Convert vtl1_enabled to a RwLock

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -427,7 +427,7 @@ pub struct UhCvmVpInner {
     /// The current status of TLB locks
     tlb_lock_info: VtlArray<TlbLockInfo, 2>,
     /// Whether VTL 1 has been enabled on the vp
-    vtl1_enabled: Mutex<bool>,
+    vtl1_enabled: RwLock<bool>,
     /// Whether the VP has been started via the StartVp hypercall.
     started: AtomicBool,
 }
@@ -1891,7 +1891,7 @@ impl UhProtoPartition<'_> {
         let vps = (0..vp_count)
             .map(|vp_index| UhCvmVpInner {
                 tlb_lock_info: VtlArray::from_fn(|_| TlbLockInfo::new(vp_count)),
-                vtl1_enabled: Mutex::new(false),
+                vtl1_enabled: RwLock::new(false),
                 started: AtomicBool::new(vp_index == 0),
             })
             .collect();

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
@@ -64,7 +64,7 @@ pub(crate) fn poll_apic_core<'b, B: HardwareIsolatedBacking, T: ApicBacking<'b, 
     // Check VTL enablement inside each block to avoid taking a lock on the hot path,
     // INIT and SIPI are quite cold.
     if init {
-        if !*apic_backing.vp().cvm_vp_inner().vtl1_enabled.lock() {
+        if !*apic_backing.vp().cvm_vp_inner().vtl1_enabled.read() {
             debug_assert_eq!(vtl, GuestVtl::Vtl0);
             apic_backing.handle_init(vtl)?;
         }
@@ -72,7 +72,7 @@ pub(crate) fn poll_apic_core<'b, B: HardwareIsolatedBacking, T: ApicBacking<'b, 
 
     if let Some(vector) = sipi {
         if apic_backing.vp().backing.cvm_state_mut().lapics[vtl].activity == MpState::WaitForSipi {
-            if !*apic_backing.vp().cvm_vp_inner().vtl1_enabled.lock() {
+            if !*apic_backing.vp().cvm_vp_inner().vtl1_enabled.read() {
                 debug_assert_eq!(vtl, GuestVtl::Vtl0);
                 let base = (vector as u64) << 12;
                 let selector = (vector as u16) << 8;

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -840,7 +840,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlCall for UhHypercallHandle
                 self.intercepted_vtl
             );
             false
-        } else if !*self.vp.cvm_vp_inner().vtl1_enabled.lock() {
+        } else if !*self.vp.cvm_vp_inner().vtl1_enabled.read() {
             // VTL 1 must be enabled on the vp
             tracelimit::warn_ratelimited!("vtl call not allowed because vtl 1 is not enabled");
             false
@@ -940,7 +940,7 @@ impl<T, B: HardwareIsolatedBacking>
         let target_vp_inner = self.vp.cvm_partition().vp_inner(target_vp);
 
         // The target VTL must have been enabled.
-        if target_vtl == GuestVtl::Vtl1 && !*target_vp_inner.vtl1_enabled.lock() {
+        if target_vtl == GuestVtl::Vtl1 && !*target_vp_inner.vtl1_enabled.read() {
             return Err(HvError::InvalidVpState);
         }
 
@@ -1123,7 +1123,7 @@ impl<T, B: HardwareIsolatedBacking>
             .cvm_partition()
             .vp_inner(vp_index)
             .vtl1_enabled
-            .lock();
+            .write();
 
         if *vtl1_enabled {
             return Err(HvError::VtlAlreadyEnabled);
@@ -1514,7 +1514,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             if let InitialVpContextOperation::StartVp = start_enable_vtl_state.operation {
                 match vtl {
                     GuestVtl::Vtl0 => {
-                        if *self.cvm_vp_inner().vtl1_enabled.lock() {
+                        if *self.cvm_vp_inner().vtl1_enabled.read() {
                             // When starting a VP targeting VTL on a
                             // hardware confidential VM, if VTL 1 has been
                             // enabled, switch to it (the highest enabled
@@ -1545,7 +1545,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
     }
 
     pub(crate) fn hcvm_vtl1_inspectable(&self) -> bool {
-        *self.cvm_vp_inner().vtl1_enabled.lock()
+        *self.cvm_vp_inner().vtl1_enabled.read()
     }
 
     fn get_vsm_vp_secure_config_vtl(

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -440,7 +440,7 @@ impl BackingPrivate for SnpBacked {
 
     fn inspect_extra(this: &mut UhProcessor<'_, Self>, resp: &mut inspect::Response<'_>) {
         let vtl0_vmsa = this.runner.vmsa(GuestVtl::Vtl0);
-        let vtl1_vmsa = if *this.cvm_vp_inner().vtl1_enabled.lock() {
+        let vtl1_vmsa = if *this.cvm_vp_inner().vtl1_enabled.read() {
             Some(this.runner.vmsa(GuestVtl::Vtl1))
         } else {
             None


### PR DESCRIPTION
This value is only written to on one path but is read on many. Convert it to a RwLock to allow simultaneous readers to exist.

N.B. If we wanted to do something silly, we could model this as a Once (not a OnceLock, a pure Once) since the value never goes from true to false. I decided against that for the sake of code clarity, and because the reader paths aren't so hot they'd need that level of optimization.