### PR TITLE
xtask: fix interplay between fmt-on-save and xsync

### DIFF
--- a/Guide/src/dev_guide/getting_started/suggested_dev_env.md
+++ b/Guide/src/dev_guide/getting_started/suggested_dev_env.md
@@ -153,21 +153,31 @@ adding the following line to `keybindings.json`:
 }
 ```
 
-### Running `cargo xtask fmt house-rules` on-save
+### GitHub Pull Request Integration
 
-The OpenVMM project includes a handful of custom "house rule" lints that are
-external to `rustfmt`. These are things like checking for the presence of
-copyright headers, enforcing single-trailing newlines, etc...
+As the repo is hosted on GitHub, you might find convenient to use the
+[GitHub Pull Request](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github)
+VSCode extension. That allows working through the PR feedback and
+issues without leaving the comfort of VSCode.
 
-These lints are enfoced using `cargo xtask fmt house-rules`, and can be
-automatically fixed by passing the `--fix` flag.
+### (Possibly Useful) Enabling 'house-rules' formatting on-save
 
-We recommend installing the
+Aside from using `rustfmt`, the OpenVMM project also relies on a handful of
+extra formatting "house rules". e.g: enfocing the presence of copyright headers,
+enforcing single-trailing newlines, etc...
+
+CI will fail if files are not formatted with `cargo xtask fmt house-rules`.
+
+In general, there are 3 ways to fix "house rules" related lints:
+
+1. Manually fixing issues in response to automated feedback
+2. Invoking `cargo xtask fmt house-rules --fix` to fix the whole project
+3. Invoking `cargo xtask fmt house-rules --fix [FILE]` to fix a given file
+
+If you would prefer having "house-rules" enfoced whenever you save a file in
+VSCode, you can install the
 [RunOnSave](https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave)
-extension, and configuring it to run these lints as part of your regular
-development flow.
-
-Set the following configuration in your `.vscode/settings.json`
+extension, and add the following configuration to `.vscode/settings.json`:
 
 ```json
 {
@@ -180,19 +190,12 @@ Set the following configuration in your `.vscode/settings.json`
             {
                 "match": ".*",
                 "isAsync": true,
-                "cmd": "$(cat ./target/xtask-path) fmt house-rules --fix ${file}"
+                "cmd": "$(cat ./target/xtask-path) --run-on-save fmt house-rules --fix ${file}"
             }
         ]
     },
 }
 ```
-
-### GitHub Pull Request Integration
-
-As the repo is hosted on GitHub, you might find convenient to use the
-[GitHub Pull Request](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github)
-VSCode extension. That allows working through the PR feedback and
-issues without leaving the comfort of VSCode.
 
 ## Setting up pre-commit and pre-push hooks
 

--- a/xtask/src/tasks/verify_size.rs
+++ b/xtask/src/tasks/verify_size.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Copyright (C) Microsoft Corporation. All rights reserved.
-
 use crate::Xtask;
 use anyhow::Context;
 use object::read::Object;


### PR DESCRIPTION
Fixing the underlying issue from #914

This PR does a few things:

1. The `xtask-path` logic has been fixed to always drop the file under `target/xtask-path`, regardless of whether a `--custom-root` is being used or not.
2. A new `--run-on-save` parameter has been added to `xtask`, which can be used to skip certain expensive checks when running `xtask` in response to a file save event. It is not currently being used by the open-source `xtask`, but plays an important role in the internal repo's `xtask fmt` implementation.
3. Updates the Guide to make it more clear why one may or may not want to opt into this functionality.

**These changes are not particularly interesting in isolation, but make more sense when reviewed alongside the changes being made in the internal repo.**

The fact we have this sort of coupling between the oss xtask and the closed-source xtask is unfortunate, and something we should try and move away from in the future...