### PR TITLE
vmm_tests: add test for using the shutdown IC across servicing

### DIFF
--- a/vm/devices/hyperv_ic_resources/src/shutdown.rs
+++ b/vm/devices/hyperv_ic_resources/src/shutdown.rs
@@ -23,7 +23,7 @@ impl ResourceId<VmbusDeviceHandleKind> for ShutdownIcHandle {
 #[derive(MeshPayload)]
 pub enum ShutdownRpc {
     /// Wait for the shutdown IC to be ready.
-    WaitReady(Rpc<(), ()>),
+    WaitReady(Rpc<(), mesh::OneshotReceiver<()>>),
     /// Send a shutdown request to the guest.
     Shutdown(Rpc<ShutdownParams, ShutdownResult>),
 }

--- a/vm/devices/hyperv_ic_resources/src/shutdown.rs
+++ b/vm/devices/hyperv_ic_resources/src/shutdown.rs
@@ -23,6 +23,12 @@ impl ResourceId<VmbusDeviceHandleKind> for ShutdownIcHandle {
 #[derive(MeshPayload)]
 pub enum ShutdownRpc {
     /// Wait for the shutdown IC to be ready.
+    ///
+    /// Returns a receiver that closes when the IC is no longer ready.
+    ///
+    /// FUTURE: this should instead be a `Sender` that is used to send the
+    /// shutdown request. Do this once `Sender` has a mechanism to wait on the
+    /// receiver to be closed.
     WaitReady(Rpc<(), mesh::OneshotReceiver<()>>),
     /// Send a shutdown request to the guest.
     Shutdown(Rpc<ShutdownParams, ShutdownResult>),


### PR DESCRIPTION
The shutdown IC is handled specially, so ensure it behaves as expected across OpenHCL servicing.