### PR TITLE
Use async closures everywhere

### DIFF
--- a/hyperv/tools/hypestv/src/windows/mod.rs
+++ b/hyperv/tools/hypestv/src/windows/mod.rs
@@ -300,7 +300,7 @@ pub async fn main(driver: DefaultDriver) -> anyhow::Result<()> {
             }),
             Request::Inspect(rpc) => {
                 let vm = &mut vm;
-                rpc.handle(|(target, path)| async move {
+                rpc.handle(async |(target, path)| {
                     vm.as_mut()
                         .context("no active VM")?
                         .handle_inspect(target, &path)
@@ -309,7 +309,7 @@ pub async fn main(driver: DefaultDriver) -> anyhow::Result<()> {
                 .await
             }
             Request::Command(rpc) => {
-                rpc.handle(|cmd| async {
+                rpc.handle(async |cmd| {
                     match cmd {
                         InteractiveCommand::Detach => {
                             vm = None;

--- a/openhcl/diag_server/src/diag_service.rs
+++ b/openhcl/diag_server/src/diag_service.rs
@@ -478,7 +478,7 @@ impl DiagServiceHandler {
                 // sockets, but don't block the process exit notification.
                 driver
                     .spawn("socket-wait", async move {
-                        let await_output_relay = |task, raw| async {
+                        let await_output_relay = async |task, raw| {
                             let socket = if let Some(task) = task {
                                 Some(task.await)
                             } else {
@@ -605,7 +605,7 @@ impl DiagServiceHandler {
 
                 match op_data {
                     diag_proto::network_packet_capture_request::OpData::StartData(start_data) => {
-                        let writers = join_all(start_data.conns.iter().map(|c| async move {
+                        let writers = join_all(start_data.conns.iter().map(async |c| {
                             let conn = self.take_connection(*c).await?;
                             Ok(conn.into_inner())
                         }))

--- a/openhcl/ohcldiag-dev/src/main.rs
+++ b/openhcl/ohcldiag-dev/src/main.rs
@@ -421,7 +421,7 @@ pub fn main() -> anyhow::Result<()> {
         .init();
 
     term::enable_vt_and_utf8();
-    DefaultPool::run_with(|driver| async move {
+    DefaultPool::run_with(async |driver| {
         let Options { vm, command } = Options::parse();
 
         match command {
@@ -504,7 +504,7 @@ pub fn main() -> anyhow::Result<()> {
                     } else {
                         Some(Duration::from_secs(timeout))
                     };
-                    let query = || async {
+                    let query = async || {
                         client
                             .inspect(
                                 path.as_deref().unwrap_or(""),

--- a/openhcl/profiler_worker/src/lib.rs
+++ b/openhcl/profiler_worker/src/lib.rs
@@ -73,7 +73,7 @@ impl Worker for ProfilerWorker {
 
     /// Run profiler worker and start a profiling session
     fn run(self, mut recv: mesh::Receiver<WorkerRpc<Self::State>>) -> anyhow::Result<()> {
-        DefaultPool::run_with(|driver| async move {
+        DefaultPool::run_with(async |driver| {
             let mut profiling = pin!(profile(self.profiler_request, &driver).fuse());
             loop {
                 let msg = futures::select! { // merge semantics

--- a/openhcl/underhill_core/src/diag.rs
+++ b/openhcl/underhill_core/src/diag.rs
@@ -55,7 +55,7 @@ impl Worker for DiagWorker {
     }
 
     fn run(self, mut recv: mesh::Receiver<WorkerRpc<Self::State>>) -> anyhow::Result<()> {
-        DefaultPool::run_with(|driver| async move {
+        DefaultPool::run_with(async |driver| {
             let (_cancel_send, cancel) = mesh::oneshot();
             let mut serve = pin!(self.server.serve(&driver, cancel, self.request_send).fuse());
             loop {

--- a/openhcl/underhill_core/src/dispatch/pci_shutdown.rs
+++ b/openhcl/underhill_core/src/dispatch/pci_shutdown.rs
@@ -28,7 +28,7 @@ pub enum ShutdownError {
 /// vfio from them won't help.
 pub async fn shutdown_pci_devices() -> Result<(), ShutdownError> {
     let dir = fs_err::read_dir("/sys/bus/pci/devices").map_err(ShutdownError::SysFs)?;
-    let ops = try_join_all(dir.map(|entry| async {
+    let ops = try_join_all(dir.map(async |entry| {
         let entry = entry.map_err(ShutdownError::SysFs)?;
         let driver_link = entry.path().join("driver");
         match driver_link.fs_err_read_link() {

--- a/openhcl/underhill_core/src/emuplat/i440bx_host_pci_bridge.rs
+++ b/openhcl/underhill_core/src/emuplat/i440bx_host_pci_bridge.rs
@@ -232,7 +232,7 @@ impl AdjustGpaRange for GetBackedAdjustGpaRange {
         // the GET runs on a separate thread from the VP threads and has no
         // dependencies on tasks on the VP threads, and this will never be
         // called from the GET thread.
-        pal_async::local::block_with_io(|_| self.adjust(range, state))
+        pal_async::local::block_on(self.adjust(range, state))
     }
 }
 

--- a/openhcl/underhill_core/src/emuplat/local_clock.rs
+++ b/openhcl/underhill_core/src/emuplat/local_clock.rs
@@ -131,8 +131,7 @@ impl LocalClock for UnderhillLocalClock {
             .unwrap();
 
         // TODO: swap this out for a non-blocking version that guarantees the skew is written out _eventually_
-        let res =
-            pal_async::local::block_with_io(|_| self.store.persist(raw_skew.to_le_bytes().into()));
+        let res = pal_async::local::block_on(self.store.persist(raw_skew.to_le_bytes().into()));
         if let Err(err) = res {
             tracing::error!(
                 err = &err as &dyn std::error::Error,

--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -304,7 +304,7 @@ impl HclNetworkVFManagerWorker {
     async fn send_vf_state_change_notifications(&self) -> anyhow::Result<()> {
         const MAX_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
         let all_results =
-            futures::future::join_all(self.guest_state_notifications.iter().map(|update| async {
+            futures::future::join_all(self.guest_state_notifications.iter().map(async |update| {
                 update
                     .call(HclNetworkVFUpdateNotification::Update, ())
                     .await
@@ -335,7 +335,7 @@ impl HclNetworkVFManagerWorker {
 
             // Force data path to VTL2 on error.
             if let Err(err) =
-                futures::future::join_all(self.endpoint_controls.iter_mut().map(|control| async {
+                futures::future::join_all(self.endpoint_controls.iter_mut().map(async |control| {
                     let endpoint = control
                         .disconnect()
                         .await
@@ -393,7 +393,7 @@ impl HclNetworkVFManagerWorker {
     }
 
     pub async fn shutdown_vtl2_device(&mut self, keep_vf_alive: bool) {
-        futures::future::join_all(self.endpoint_controls.iter_mut().map(|control| async {
+        futures::future::join_all(self.endpoint_controls.iter_mut().map(async |control| {
             match control.disconnect().await {
                 Ok(Some(mut endpoint)) => {
                     tracing::info!("Network endpoint disconnected");
@@ -509,14 +509,14 @@ impl HclNetworkVFManagerWorker {
                 NextWorkItem::ManagerMessage(HclNetworkVfManagerMessage::AddGuestVFManager(
                     rpc,
                 )) => {
-                    rpc.handle(|send_update| async {
+                    rpc.handle(async |send_update| {
                         self.guest_state_notifications.push(send_update);
                         self.guest_state.clone()
                     })
                     .await;
                 }
                 NextWorkItem::ManagerMessage(HclNetworkVfManagerMessage::PacketCapture(rpc)) => {
-                    rpc.handle_failable(|params| self.handle_packet_capture(params))
+                    rpc.handle_failable(async |params| self.handle_packet_capture(params).await)
                         .await
                 }
                 NextWorkItem::ManagerMessage(HclNetworkVfManagerMessage::AddVtl0VF) => {
@@ -556,42 +556,40 @@ impl HclNetworkVFManagerWorker {
                         rpc.complete(());
                         continue;
                     }
-                    rpc.handle(|bus_control| {
+                    rpc.handle(async |bus_control| {
                         let is_present = matches!(
                             self.vtl0_bus_control,
                             Vtl0Bus::Present(_) | Vtl0Bus::HiddenPresent(_)
                         );
                         assert!(is_present != bus_control.is_some());
                         tracing::info!(present = bus_control.is_some(), "VTL0 VF device change");
-                        async {
-                            if matches!(&self.vtl0_bus_control, Vtl0Bus::HiddenNotPresent) {
-                                self.vtl0_bus_control = Vtl0Bus::HiddenPresent(bus_control.unwrap())
-                            } else if matches!(&self.vtl0_bus_control, Vtl0Bus::HiddenPresent(_)) {
-                                self.vtl0_bus_control = Vtl0Bus::HiddenNotPresent;
-                            } else if vtl2_device_present {
-                                let bus_control = bus_control
-                                    .map(Vtl0Bus::Present)
-                                    .unwrap_or(Vtl0Bus::NotPresent);
-                                *self.guest_state.vtl0_vfid.lock().await =
-                                    vtl0_vfid_from_bus_control(&bus_control);
-                                let old_bus_control =
-                                    std::mem::replace(&mut self.vtl0_bus_control, bus_control);
-                                match self.vtl0_bus_control {
-                                    Vtl0Bus::Present(_) => self.notify_vtl0_vf_arrival(),
-                                    Vtl0Bus::NotPresent => {
-                                        self.try_notify_guest_and_revoke_vtl0_vf(&old_bus_control)
-                                            .await
-                                    }
-                                    _ => unreachable!(),
+                        if matches!(&self.vtl0_bus_control, Vtl0Bus::HiddenNotPresent) {
+                            self.vtl0_bus_control = Vtl0Bus::HiddenPresent(bus_control.unwrap())
+                        } else if matches!(&self.vtl0_bus_control, Vtl0Bus::HiddenPresent(_)) {
+                            self.vtl0_bus_control = Vtl0Bus::HiddenNotPresent;
+                        } else if vtl2_device_present {
+                            let bus_control = bus_control
+                                .map(Vtl0Bus::Present)
+                                .unwrap_or(Vtl0Bus::NotPresent);
+                            *self.guest_state.vtl0_vfid.lock().await =
+                                vtl0_vfid_from_bus_control(&bus_control);
+                            let old_bus_control =
+                                std::mem::replace(&mut self.vtl0_bus_control, bus_control);
+                            match self.vtl0_bus_control {
+                                Vtl0Bus::Present(_) => self.notify_vtl0_vf_arrival(),
+                                Vtl0Bus::NotPresent => {
+                                    self.try_notify_guest_and_revoke_vtl0_vf(&old_bus_control)
+                                        .await
                                 }
-                            } else {
-                                // When the VTL2 device is restored, the VTL0 update will be applied.
-                                assert_eq!(*self.guest_state.offered_to_guest.lock().await, false);
-                                assert!(self.guest_state.vtl0_vfid.lock().await.is_none());
-                                self.vtl0_bus_control = bus_control
-                                    .map(Vtl0Bus::Present)
-                                    .unwrap_or(Vtl0Bus::NotPresent);
+                                _ => unreachable!(),
                             }
+                        } else {
+                            // When the VTL2 device is restored, the VTL0 update will be applied.
+                            assert_eq!(*self.guest_state.offered_to_guest.lock().await, false);
+                            assert!(self.guest_state.vtl0_vfid.lock().await.is_none());
+                            self.vtl0_bus_control = bus_control
+                                .map(Vtl0Bus::Present)
+                                .unwrap_or(Vtl0Bus::NotPresent);
                         }
                     })
                     .await;
@@ -601,53 +599,46 @@ impl HclNetworkVFManagerWorker {
                         rpc.complete(());
                         continue;
                     }
-                    rpc.handle(|hide_vtl0| {
+                    rpc.handle(async |hide_vtl0| {
                         tracing::info!(hide_vtl0, "VTL0 VF device is hidden");
                         if hide_vtl0 {
                             *self.save_state.hidden_vtl0.lock() = Some(true);
-                            futures::future::Either::Left(async {
-                                if !matches!(self.vtl0_bus_control, Vtl0Bus::HiddenPresent(_)) {
-                                    let old_bus_control = std::mem::replace(
-                                        &mut self.vtl0_bus_control,
-                                        Vtl0Bus::HiddenNotPresent,
-                                    );
-                                    if matches!(old_bus_control, Vtl0Bus::Present(_)) {
-                                        if vtl2_device_present {
-                                            *self.guest_state.vtl0_vfid.lock().await =
-                                                vtl0_vfid_from_bus_control(&self.vtl0_bus_control);
-                                            self.try_notify_guest_and_revoke_vtl0_vf(
-                                                &old_bus_control,
-                                            )
-                                            .await;
-                                        }
-                                        let Vtl0Bus::Present(bus_control) = old_bus_control else {
-                                            unreachable!();
-                                        };
-                                        self.vtl0_bus_control = Vtl0Bus::HiddenPresent(bus_control);
-                                    }
-                                }
-                            })
-                        } else {
-                            *self.save_state.hidden_vtl0.lock() = Some(false);
-                            futures::future::Either::Right(async {
-                                if matches!(self.vtl0_bus_control, Vtl0Bus::HiddenPresent(_)) {
-                                    let Vtl0Bus::HiddenPresent(bus_control) = std::mem::replace(
-                                        &mut self.vtl0_bus_control,
-                                        Vtl0Bus::NotPresent,
-                                    ) else {
-                                        unreachable!();
-                                    };
-                                    self.vtl0_bus_control = Vtl0Bus::Present(bus_control);
+                            if !matches!(self.vtl0_bus_control, Vtl0Bus::HiddenPresent(_)) {
+                                let old_bus_control = std::mem::replace(
+                                    &mut self.vtl0_bus_control,
+                                    Vtl0Bus::HiddenNotPresent,
+                                );
+                                if matches!(old_bus_control, Vtl0Bus::Present(_)) {
                                     if vtl2_device_present {
                                         *self.guest_state.vtl0_vfid.lock().await =
                                             vtl0_vfid_from_bus_control(&self.vtl0_bus_control);
-                                        self.notify_vtl0_vf_arrival();
+                                        self.try_notify_guest_and_revoke_vtl0_vf(&old_bus_control)
+                                            .await;
                                     }
-                                } else if matches!(self.vtl0_bus_control, Vtl0Bus::HiddenNotPresent)
-                                {
-                                    self.vtl0_bus_control = Vtl0Bus::NotPresent;
+                                    let Vtl0Bus::Present(bus_control) = old_bus_control else {
+                                        unreachable!();
+                                    };
+                                    self.vtl0_bus_control = Vtl0Bus::HiddenPresent(bus_control);
                                 }
-                            })
+                            }
+                        } else {
+                            *self.save_state.hidden_vtl0.lock() = Some(false);
+                            if matches!(self.vtl0_bus_control, Vtl0Bus::HiddenPresent(_)) {
+                                let Vtl0Bus::HiddenPresent(bus_control) = std::mem::replace(
+                                    &mut self.vtl0_bus_control,
+                                    Vtl0Bus::NotPresent,
+                                ) else {
+                                    unreachable!();
+                                };
+                                self.vtl0_bus_control = Vtl0Bus::Present(bus_control);
+                                if vtl2_device_present {
+                                    *self.guest_state.vtl0_vfid.lock().await =
+                                        vtl0_vfid_from_bus_control(&self.vtl0_bus_control);
+                                    self.notify_vtl0_vf_arrival();
+                                }
+                            } else if matches!(self.vtl0_bus_control, Vtl0Bus::HiddenNotPresent) {
+                                self.vtl0_bus_control = Vtl0Bus::NotPresent;
+                            }
                         }
                     })
                     .await;
@@ -663,7 +654,7 @@ impl HclNetworkVFManagerWorker {
                 NextWorkItem::ManagerMessage(HclNetworkVfManagerMessage::ShutdownComplete(rpc)) => {
                     assert!(self.is_shutdown_active);
                     drop(self.messages.take().unwrap());
-                    rpc.handle(|keep_vf_alive| async move {
+                    rpc.handle(async |keep_vf_alive| {
                         self.shutdown_vtl2_device(keep_vf_alive).await;
                     })
                     .await;
@@ -936,7 +927,7 @@ impl HclNetworkVFManager {
         // The proxy endpoints are not yet in use, so run them here to switch to the queued endpoints.
         // N.B Endpoint should not return any other action type other than `RestartRequired`
         //     at this time because the notification task hasn't been started yet.
-        futures::future::join_all(endpoints.iter_mut().map(|endpoint| async {
+        futures::future::join_all(endpoints.iter_mut().map(async |endpoint| {
             let message = endpoint.wait_for_endpoint_action().await;
             assert_eq!(message, net_backend::EndpointAction::RestartRequired);
         }))

--- a/openhcl/underhill_core/src/get_tracing.rs
+++ b/openhcl/underhill_core/src/get_tracing.rs
@@ -94,7 +94,7 @@ pub fn init_tracing_backend(driver: impl 'static + SpawnDriver) -> anyhow::Resul
         driver,
         trace_filter,
         perf_trace_filter,
-        move |requests, flush| async move {
+        async move |requests, flush| {
             if let Some(get_backend) = &mut get_backend {
                 get_backend.run(requests, kmsg, flush).await;
             }

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -240,15 +240,16 @@ impl NvmeManagerWorker {
                     }
                 }
                 Request::GetNamespace(rpc) => {
-                    rpc.handle(|(pci_id, nsid)| {
+                    rpc.handle(async |(pci_id, nsid)| {
                         self.get_namespace(pci_id.clone(), nsid)
                             .map_err(|source| NamespaceError { pci_id, source })
+                            .await
                     })
                     .await
                 }
                 // Request to save worker data for servicing.
                 Request::Save(rpc) => {
-                    rpc.handle(|_| self.save())
+                    rpc.handle(async |_| self.save().await)
                         .instrument(tracing::info_span!("nvme_save_state"))
                         .await
                 }

--- a/openhcl/underhill_core/src/vp.rs
+++ b/openhcl/underhill_core/src/vp.rs
@@ -179,7 +179,7 @@ impl VpSpawner {
                     anyhow::bail!("processor {} not online", vp_index.index());
                 }
 
-                thread.set_idle_task(move |mut control| async move {
+                thread.set_idle_task(async move |mut control| {
                     let state = self
                         .run_vp(saved_state.take(), Some(&mut control), false)
                         .await;

--- a/openhcl/underhill_crash/src/lib.rs
+++ b/openhcl/underhill_crash/src/lib.rs
@@ -299,7 +299,7 @@ pub fn main() -> ! {
 
     // Send the dump file
 
-    if let Err(e) = block_with_io(|driver| async move {
+    if let Err(e) = block_with_io(async |driver| {
         let mut dump_stream = AllowStdIo::new(std::io::stdin());
         let pipe = vmbus_user_channel::message_pipe(
             &driver,

--- a/openhcl/underhill_threadpool/src/lib.rs
+++ b/openhcl/underhill_threadpool/src/lib.rs
@@ -385,10 +385,9 @@ impl Thread {
     /// The idle task is run before waiting on the IO ring. The idle task can
     /// block synchronously by first calling [`IdleControl::pre_block`], and
     /// then by polling on the IO ring while the task blocks.
-    pub fn set_idle_task<F, Fut>(&self, f: F)
+    pub fn set_idle_task<F>(&self, f: F)
     where
-        F: 'static + Send + FnOnce(IdleControl) -> Fut,
-        Fut: std::future::Future<Output = ()>,
+        F: 'static + Send + AsyncFnOnce(IdleControl),
     {
         self.with_once(|_, once| once.client.set_idle_task(f))
     }

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1910,22 +1910,20 @@ impl InitializedVm {
                         })
                         .context("failed to assign device")?;
 
-                    {
-                        let mut builder = chipset_builder.arc_mutex_device(vpci_bus_name);
-                        builder
-                            .try_add_async(async |services| {
-                                VpciBus::new(
-                                    &driver_source,
-                                    instance_id,
-                                    device,
-                                    &mut services.register_mmio(),
-                                    vmbus,
-                                    crate::partition::VpciDevice::interrupt_mapper(hv_device),
-                                )
-                                .await
-                            })
-                            .await?;
-                    }
+                    chipset_builder
+                        .arc_mutex_device(vpci_bus_name)
+                        .try_add_async(async |services| {
+                            VpciBus::new(
+                                &driver_source,
+                                instance_id,
+                                device,
+                                &mut services.register_mmio(),
+                                vmbus,
+                                crate::partition::VpciDevice::interrupt_mapper(hv_device),
+                            )
+                            .await
+                        })
+                        .await?;
                 }
             }
         }

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -331,7 +331,7 @@ impl Worker for VmWorker {
             manifest,
             Some(shared_memory),
         ))?;
-        block_with_io(|_| async {
+        pal_async::local::block_on(async {
             let mut vm = vm.load(Some(saved_state), notify).await?;
 
             LOADED_VM.store(&vm);
@@ -348,7 +348,7 @@ impl Worker for VmWorker {
     }
 
     fn run(self, worker_rpc: mesh::Receiver<WorkerRpc<Self::State>>) -> anyhow::Result<()> {
-        DefaultPool::run_with(|driver| async {
+        DefaultPool::run_with(async |driver| {
             let driver = driver;
             self.vm.run(&driver, self.rpc, worker_rpc).await
         });
@@ -1196,7 +1196,7 @@ impl InitializedVm {
 
         let input_distributor = state_units
             .add("input")
-            .spawn(driver_source.simple(), |mut recv| async move {
+            .spawn(driver_source.simple(), async |mut recv| {
                 input_distributor.run(&mut recv).await;
                 input_distributor
             })
@@ -1745,34 +1745,32 @@ impl InitializedVm {
                     .context("failed to create a virtio pci device")
                 })?;
 
-            {
-                let mut builder = chipset_builder.arc_mutex_device(vpci_device_name);
-                let mut mmio = builder.services().register_mmio();
-                builder
-                    .try_add_async(|_services| async {
-                        let vmbus = vmbus_server.as_ref().context("vmbus not configured")?;
-                        let hv_device = partition
-                            .new_virtual_device(Vtl::Vtl0, device_id)
-                            .context("failed to create virtual device")?;
+            chipset_builder
+                .arc_mutex_device(vpci_device_name)
+                .try_add_async(async |services| {
+                    let mut mmio = services.register_mmio();
+                    let vmbus = vmbus_server.as_ref().context("vmbus not configured")?;
+                    let hv_device = partition
+                        .new_virtual_device(Vtl::Vtl0, device_id)
+                        .context("failed to create virtual device")?;
 
-                        let msi_controller = hv_device.clone().target();
-                        let interrupt_mapper = hv_device.clone().interrupt_mapper();
-                        msi_set.connect(msi_controller.as_ref());
+                    let msi_controller = hv_device.clone().target();
+                    let interrupt_mapper = hv_device.clone().interrupt_mapper();
+                    msi_set.connect(msi_controller.as_ref());
 
-                        let bus = VpciBus::new(
-                            driver_source,
-                            instance_id,
-                            device,
-                            &mut mmio,
-                            vmbus.control().as_ref(),
-                            interrupt_mapper,
-                        )
-                        .await?;
-
-                        anyhow::Ok(bus)
-                    })
+                    let bus = VpciBus::new(
+                        driver_source,
+                        instance_id,
+                        device,
+                        &mut mmio,
+                        vmbus.control().as_ref(),
+                        interrupt_mapper,
+                    )
                     .await?;
-            }
+
+                    anyhow::Ok(bus)
+                })
+                .await?;
 
             Ok(())
         }
@@ -1914,14 +1912,13 @@ impl InitializedVm {
 
                     {
                         let mut builder = chipset_builder.arc_mutex_device(vpci_bus_name);
-                        let mut register_mmio = builder.services().register_mmio();
                         builder
-                            .try_add_async(|_services| async {
+                            .try_add_async(async |services| {
                                 VpciBus::new(
                                     &driver_source,
                                     instance_id,
                                     device,
-                                    &mut register_mmio,
+                                    &mut services.register_mmio(),
                                     vmbus,
                                     crate::partition::VpciDevice::interrupt_mapper(hv_device),
                                 )
@@ -2554,18 +2551,18 @@ impl LoadedVm {
                 },
                 Event::VmRpc(Err(_)) => break,
                 Event::VmRpc(Ok(message)) => match message {
-                    VmRpc::Reset(rpc) => rpc.handle_failable(|()| self.reset(true)).await,
+                    VmRpc::Reset(rpc) => {
+                        rpc.handle_failable(async |()| self.reset(true).await).await
+                    }
                     VmRpc::ClearHalt(rpc) => {
-                        rpc.handle(|()| self.inner.partition_unit.clear_halt())
+                        rpc.handle(async |()| self.inner.partition_unit.clear_halt().await)
                             .await
                     }
-                    VmRpc::Resume(rpc) => rpc.handle(|()| self.resume()).await,
-                    VmRpc::Pause(rpc) => rpc.handle(|()| self.pause()).await,
+                    VmRpc::Resume(rpc) => rpc.handle(async |()| self.resume().await).await,
+                    VmRpc::Pause(rpc) => rpc.handle(async |()| self.pause().await).await,
                     VmRpc::Save(rpc) => {
-                        rpc.handle_failable(|()| async {
-                            self.save().await.map(ProtobufMessage::new)
-                        })
-                        .await
+                        rpc.handle_failable(async |()| self.save().await.map(ProtobufMessage::new))
+                            .await
                     }
                     VmRpc::Nmi(rpc) => rpc.handle_sync(|vpindex| {
                         if vpindex < self.inner.processor_topology.vp_count() {
@@ -2593,27 +2590,24 @@ impl LoadedVm {
                         }
                     }),
                     VmRpc::AddVmbusDevice(rpc) => {
-                        rpc.handle_failable(|(vtl, resource)| {
-                            let this = &mut self;
-                            async move {
-                                let vmbus = match vtl {
-                                    DeviceVtl::Vtl0 => this.inner.vmbus_server.as_ref(),
-                                    DeviceVtl::Vtl1 => None,
-                                    DeviceVtl::Vtl2 => this.inner.vtl2_vmbus_server.as_ref(),
-                                }
-                                .context("no vmbus available")?;
-                                let device = offer_vmbus_device_handle_unit(
-                                    &this.inner.driver_source,
-                                    &this.state_units,
-                                    vmbus,
-                                    &this.inner.resolver,
-                                    resource,
-                                )
-                                .await?;
-                                this.inner.vmbus_devices.push(device);
-                                this.state_units.start_stopped_units().await;
-                                anyhow::Ok(())
+                        rpc.handle_failable(async |(vtl, resource)| {
+                            let vmbus = match vtl {
+                                DeviceVtl::Vtl0 => self.inner.vmbus_server.as_ref(),
+                                DeviceVtl::Vtl1 => None,
+                                DeviceVtl::Vtl2 => self.inner.vtl2_vmbus_server.as_ref(),
                             }
+                            .context("no vmbus available")?;
+                            let device = offer_vmbus_device_handle_unit(
+                                &self.inner.driver_source,
+                                &self.state_units,
+                                vmbus,
+                                &self.inner.resolver,
+                                resource,
+                            )
+                            .await?;
+                            self.inner.vmbus_devices.push(device);
+                            self.state_units.start_stopped_units().await;
+                            anyhow::Ok(())
                         })
                         .await
                     }
@@ -2633,7 +2627,7 @@ impl LoadedVm {
                         }
                     }
                     VmRpc::PulseSaveRestore(rpc) => {
-                        rpc.handle(|()| async {
+                        rpc.handle(async |()| {
                             if !self.inner.partition.supports_reset() {
                                 return Err(PulseSaveRestoreError::ResetNotSupported);
                             }
@@ -2651,8 +2645,10 @@ impl LoadedVm {
                         rpc.handle_failable_sync(|file| self.start_reload_igvm(&file))
                     }
                     VmRpc::CompleteReloadIgvm(rpc) => {
-                        rpc.handle_failable(|complete| self.complete_reload_igvm(complete))
-                            .await
+                        rpc.handle_failable(async |complete| {
+                            self.complete_reload_igvm(complete).await
+                        })
+                        .await
                     }
                     VmRpc::ReadMemory(rpc) => {
                         rpc.handle_failable_sync(|(gpa, size)| {

--- a/openvmm/membacking/src/mapping_manager/manager.rs
+++ b/openvmm/membacking/src/mapping_manager/manager.rs
@@ -238,7 +238,8 @@ impl MappingManagerTask {
                     rpc.handle_sync(|params| self.add_mapping(params))
                 }
                 MappingRequest::RemoveMappings(rpc) => {
-                    rpc.handle(|range| self.remove_mappings(range)).await
+                    rpc.handle(async |range| self.remove_mappings(range).await)
+                        .await
                 }
                 MappingRequest::Inspect(deferred) => deferred.inspect(&mut *self),
             }
@@ -332,7 +333,7 @@ impl MappingManagerTask {
 impl Mappers {
     async fn invalidate(&self, ids: &[MapperId], range: MemoryRange) {
         tracing::debug!(mapper_count = ids.len(), %range, "sending invalidations");
-        join_all(ids.iter().map(|&MapperId(i)| async move {
+        join_all(ids.iter().map(async |&MapperId(i)| {
             if let Err(err) = self.mappers[i]
                 .req_send
                 .call(MapperRequest::Unmap, range)

--- a/openvmm/membacking/src/region_manager.rs
+++ b/openvmm/membacking/src/region_manager.rs
@@ -186,25 +186,29 @@ impl RegionManagerTask {
         while let Some(req) = req_recv.next().await {
             match req {
                 RegionRequest::AddMapping(rpc) => {
-                    rpc.handle(|(id, params)| self.add_mapping(id, params))
+                    rpc.handle(async |(id, params)| self.add_mapping(id, params).await)
                         .await
                 }
                 RegionRequest::RemoveMappings(rpc) => {
-                    rpc.handle(|(id, range)| self.remove_mappings(id, range))
+                    rpc.handle(async |(id, range)| self.remove_mappings(id, range).await)
                         .await
                 }
                 RegionRequest::AddPartition(LocalOnly(rpc)) => {
-                    rpc.handle(|partition| self.add_partition(partition)).await
+                    rpc.handle(async |partition| self.add_partition(partition).await)
+                        .await
                 }
                 RegionRequest::AddRegion(rpc) => rpc.handle_sync(|params| self.add_region(params)),
                 RegionRequest::RemoveRegion(rpc) => {
-                    rpc.handle(|id| self.unmap_region(id, true)).await
+                    rpc.handle(async |id| self.unmap_region(id, true).await)
+                        .await
                 }
                 RegionRequest::MapRegion(rpc) => {
-                    rpc.handle(|(id, params)| self.map_region(id, params)).await
+                    rpc.handle(async |(id, params)| self.map_region(id, params).await)
+                        .await
                 }
                 RegionRequest::UnmapRegion(rpc) => {
-                    rpc.handle(|id| self.unmap_region(id, false)).await
+                    rpc.handle(async |id| self.unmap_region(id, false).await)
+                        .await
                 }
                 RegionRequest::Inspect(deferred) => {
                     deferred.inspect(&mut *self);

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1651,7 +1651,7 @@ fn do_main() -> anyhow::Result<()> {
             Ok(())
         })
     } else {
-        DefaultPool::run_with(|driver| async move {
+        DefaultPool::run_with(async |driver| {
             let mesh = VmmMesh::new(&driver, opt.single_process)?;
             let result = run_control(&driver, &mesh, opt).await;
             mesh.shutdown().await;
@@ -2624,7 +2624,7 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
             }
             InteractiveCommand::RestartVnc => {
                 if let Some(vnc) = &mut vnc_worker {
-                    let action = || async move {
+                    let action = async {
                         let vnc_host = mesh
                             .make_host("vnc", None)
                             .await
@@ -2634,7 +2634,7 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
                         anyhow::Result::<_>::Ok(())
                     };
 
-                    if let Err(error) = (action)().await {
+                    if let Err(error) = action.await {
                         eprintln!("error: {}", error);
                     }
                 } else {
@@ -2643,7 +2643,7 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
             }
             InteractiveCommand::Hvsock { term, port } => {
                 let vm_rpc = &vm_rpc;
-                let action = || async move {
+                let action = async || {
                     let service_id = new_hvsock_service_id(port);
                     let socket = vm_rpc
                         .call_failable(

--- a/openvmm/openvmm_entry/src/meshworker.rs
+++ b/openvmm/openvmm_entry/src/meshworker.rs
@@ -17,7 +17,7 @@ use pal_async::task::Task;
 use std::path::PathBuf;
 
 pub(crate) fn run_vmm_mesh_host() -> anyhow::Result<()> {
-    try_run_mesh_host("openvmm", |params: MeshHostParams| async {
+    try_run_mesh_host("openvmm", async |params: MeshHostParams| {
         params.runner.run(RegisteredWorkers).await;
         Ok(())
     })

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -123,7 +123,7 @@ impl Worker for TtrpcWorker {
     }
 
     fn run(self, recv: mesh::Receiver<WorkerRpc<Self::State>>) -> anyhow::Result<()> {
-        DefaultPool::run_with(|driver| async move {
+        DefaultPool::run_with(async |driver| {
             let mut service = VmService {
                 driver,
                 vm: None,

--- a/petri/pipette/src/main.rs
+++ b/petri/pipette/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> anyhow::Result<()> {
         return winsvc::start_service();
     }
 
-    pal_async::DefaultPool::run_with(|driver| async move {
+    pal_async::DefaultPool::run_with(async |driver| {
         let agent = agent::Agent::new(driver).await?;
         agent.run().await
     })

--- a/petri/pipette/src/winsvc.rs
+++ b/petri/pipette/src/winsvc.rs
@@ -26,7 +26,7 @@ pub fn start_service() -> anyhow::Result<()> {
 }
 
 fn service_main(_args: Vec<OsString>) {
-    DefaultPool::run_with(|driver| async move {
+    DefaultPool::run_with(async |driver| {
         if let Err(e) = service_main_inner(driver).await {
             eprintln!("service_main failed: {:#}", e);
         }

--- a/support/console_relay/src/lib.rs
+++ b/support/console_relay/src/lib.rs
@@ -35,7 +35,7 @@ pub fn relay_console(path: &Path) -> anyhow::Result<()> {
     // But we use sync to read/write to stdio because it's quite challenging to
     // poll for stdio readiness, especially on Windows. So we use a separate
     // thread for input and output.
-    block_with_io(|driver| async move {
+    block_with_io(async |driver| {
         #[cfg(unix)]
         let (read, mut write) = {
             let pipe = pal_async::socket::PolledSocket::connect_unix(&driver, path)

--- a/support/mesh/mesh_channel/benches/channel.rs
+++ b/support/mesh/mesh_channel/benches/channel.rs
@@ -15,7 +15,7 @@ fn bench_channel(c: &mut Criterion) {
     c.bench_function("channel_rt", |b| {
         b.to_async(FuturesExecutor).iter_batched(
             mesh_channel::channel::<u64>,
-            |(send, mut recv)| async move {
+            async |(send, mut recv)| {
                 send.send(20);
                 recv.recv().await.unwrap();
             },
@@ -25,7 +25,7 @@ fn bench_channel(c: &mut Criterion) {
     .bench_function("channel_rt_large", |b| {
         b.to_async(FuturesExecutor).iter_batched(
             mesh_channel::channel::<[u8; 1000]>,
-            |(send, mut recv)| async move {
+            async |(send, mut recv)| {
                 send.send([20; 1000]);
                 recv.recv().await.unwrap();
             },
@@ -35,7 +35,7 @@ fn bench_channel(c: &mut Criterion) {
     .bench_function("channel_rt_large_boxed", |b| {
         b.to_async(FuturesExecutor).iter_batched(
             mesh_channel::channel::<Box<[u8; 1000]>>,
-            |(send, mut recv)| async move {
+            async |(send, mut recv)| {
                 send.send(Box::new([20; 1000]));
                 recv.recv().await.unwrap();
             },
@@ -49,7 +49,7 @@ fn bench_channel(c: &mut Criterion) {
                 let send = Sender::<u64>::from(Port::from(send));
                 (send, recv)
             },
-            |(send, mut recv)| async move {
+            async |(send, mut recv)| {
                 send.send(20);
                 recv.recv().await.unwrap();
             },
@@ -63,7 +63,7 @@ fn bench_channel(c: &mut Criterion) {
                 let send = Sender::<i64>::from(Port::from(send));
                 (send, recv)
             },
-            |(send, mut recv)| async move {
+            async |(send, mut recv)| {
                 send.send(20);
                 recv.recv().await.unwrap();
             },
@@ -71,7 +71,7 @@ fn bench_channel(c: &mut Criterion) {
         );
     })
     .bench_function("channel_and_rt", |b| {
-        b.to_async(FuturesExecutor).iter(|| async move {
+        b.to_async(FuturesExecutor).iter(async || {
             let (send, mut recv) = mesh_channel::channel::<u64>();
             send.send(20);
             recv.recv().await.unwrap();
@@ -80,7 +80,7 @@ fn bench_channel(c: &mut Criterion) {
     c.bench_function("oneshot_rt", |b| {
         b.to_async(FuturesExecutor).iter_batched(
             mesh_channel::oneshot::<u64>,
-            |(send, recv)| async move {
+            async |(send, recv)| {
                 send.send(20);
                 recv.await.unwrap();
             },
@@ -94,7 +94,7 @@ fn bench_channel(c: &mut Criterion) {
                 let send = OneshotSender::<u64>::from(Port::from(send));
                 (send, recv)
             },
-            |(send, recv)| async move {
+            async |(send, recv)| {
                 send.send(20);
                 recv.await.unwrap();
             },
@@ -108,7 +108,7 @@ fn bench_channel(c: &mut Criterion) {
                 let send = OneshotSender::<i64>::from(Port::from(send));
                 (send, recv)
             },
-            |(send, recv)| async move {
+            async |(send, recv)| {
                 send.send(20);
                 recv.await.unwrap();
             },
@@ -118,7 +118,7 @@ fn bench_channel(c: &mut Criterion) {
     .bench_function("oneshot_and_rt", |b| {
         b.to_async(FuturesExecutor).iter_batched(
             || (),
-            |()| async move {
+            async |()| {
                 let (send, recv) = mesh_channel::oneshot::<u64>();
                 send.send(20);
                 recv.await.unwrap();

--- a/support/mesh/mesh_node/src/local_node.rs
+++ b/support/mesh/mesh_node/src/local_node.rs
@@ -2892,7 +2892,7 @@ pub mod tests {
         p4.send(bmsg(b"i"));
         drop(p4);
 
-        let recv_all = |mut p: Channel| async move {
+        let recv_all = async |mut p: Channel| {
             let mut v = Vec::new();
             loop {
                 match p.recv().await {

--- a/support/mesh/mesh_remote/src/point_to_point.rs
+++ b/support/mesh/mesh_remote/src/point_to_point.rs
@@ -60,7 +60,7 @@ impl PointToPointMesh {
     /// # use mesh_channel::channel;
     /// # use unix_socket::UnixStream;
     /// # use pal_async::socket::PolledSocket;
-    /// # pal_async::DefaultPool::run_with(|driver| async move {
+    /// # pal_async::DefaultPool::run_with(async |driver| {
     /// let (left, right) = UnixStream::pair().unwrap();
     /// let (a, ax) = channel::<u32>();
     /// let (bx, mut b) = channel::<u32>();

--- a/support/mesh/mesh_rpc/examples/rust-server.rs
+++ b/support/mesh/mesh_rpc/examples/rust-server.rs
@@ -34,9 +34,7 @@ fn server(path: &str) -> anyhow::Result<()> {
     let (_s, stop_listening) = mesh::oneshot();
     let mut recv = server.add_service();
     let thread = std::thread::spawn(move || {
-        block_with_io(
-            |driver| async move { drop(server.run(&driver, listener, stop_listening).await) },
-        )
+        block_with_io(async |driver| drop(server.run(&driver, listener, stop_listening).await))
     });
     block_on(async {
         while let Some((_, message)) = recv.next().await {

--- a/support/mesh/mesh_rpc/fuzz/fuzz_mesh_ttrpc_server.rs
+++ b/support/mesh/mesh_rpc/fuzz/fuzz_mesh_ttrpc_server.rs
@@ -25,7 +25,7 @@ fn do_fuzz(input: &[u8]) {
 
     let mut recv = server.add_service();
 
-    DefaultPool::run_with(|driver| async move {
+    DefaultPool::run_with(async |driver| {
         let control_listener = tempfile::Builder::new()
             .make(|path| UnixListener::bind(path))
             .unwrap();

--- a/support/mesh/mesh_rpc/src/server.rs
+++ b/support/mesh/mesh_rpc/src/server.rs
@@ -633,11 +633,11 @@ mod tests {
         let mut server = Server::new();
         let mut recv = server.add_service::<items::Example>();
         let server_thread = std::thread::spawn(move || {
-            block_with_io(|driver| async move { server.run_single(&driver, s).await })
+            block_with_io(async |driver| server.run_single(&driver, s).await)
         });
 
         let client_thread = std::thread::spawn(move || {
-            DefaultPool::run_with(|driver| async move {
+            DefaultPool::run_with(async |driver| {
                 let client = Client::new(
                     &driver,
                     ExistingConnection::new(PolledSocket::new(&driver, c).unwrap()),

--- a/support/pal/pal_async/src/io_pool.rs
+++ b/support/pal/pal_async/src/io_pool.rs
@@ -65,14 +65,12 @@ impl<T: IoBackend + Default> IoPool<T> {
 
     /// Creates and runs a task pool, seeding it with an initial future
     /// `f(driver)`, until all tasks have completed.
-    pub fn run_with<F, Fut>(f: F) -> Fut::Output
+    pub fn run_with<F, R>(f: F) -> R
     where
-        F: FnOnce(IoDriver<T>) -> Fut,
-        Fut: Future + Send,
-        Fut::Output: 'static + Send,
+        F: AsyncFnOnce(IoDriver<T>) -> R,
     {
         let mut pool = Self::named(std::thread::current().name().unwrap_or_else(|| T::name()));
-        let fut = f(pool.driver());
+        let fut = f(pool.driver.clone());
         drop(pool.driver.scheduler);
         pool.driver
             .inner

--- a/support/pal/pal_async/src/local.rs
+++ b/support/pal/pal_async/src/local.rs
@@ -24,11 +24,18 @@ use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 
-/// Polls a future that needs to issue IO until it completes.
-pub fn block_with_io<F, Fut, R>(f: F) -> R
+/// Blocks the current thread until the given future completes.
+pub fn block_on<Fut>(fut: Fut) -> Fut::Output
 where
-    F: FnOnce(LocalDriver) -> Fut,
-    Fut: Future<Output = R>,
+    Fut: Future,
+{
+    block_with_io(|_| fut)
+}
+
+/// Polls a future that needs to issue IO until it completes.
+pub fn block_with_io<F, R>(f: F) -> R
+where
+    F: AsyncFnOnce(LocalDriver) -> R,
 {
     let mut executor = LocalExecutor::new();
     let fut = f(executor.driver());

--- a/support/pal/pal_async_test/src/lib.rs
+++ b/support/pal/pal_async_test/src/lib.rs
@@ -70,7 +70,7 @@ fn make_async_test(item: ItemFn) -> syn::Result<proc_macro2::TokenStream> {
         #(#attrs)*
         fn #name() {
             #item
-            ::pal_async::DefaultPool::run_with(|driver| async move {
+            ::pal_async::DefaultPool::run_with(async |driver| {
                 #name(#args).await
             })
             #unwrap

--- a/support/pal/pal_uring/src/threadpool.rs
+++ b/support/pal/pal_uring/src/threadpool.rs
@@ -95,10 +95,9 @@ impl PoolClient {
     /// then by polling on the IO ring while the task blocks.
     //
     // TODO: move this functionality into underhill_threadpool.
-    pub fn set_idle_task<F, Fut>(&self, f: F)
+    pub fn set_idle_task<F>(&self, f: F)
     where
-        F: 'static + Send + FnOnce(IdleControl) -> Fut,
-        Fut: Future<Output = ()>,
+        F: 'static + Send + AsyncFnOnce(IdleControl),
     {
         let f =
             Box::new(|fd| Box::pin(async move { f(fd).await }) as Pin<Box<dyn Future<Output = _>>>)

--- a/support/uevent/src/lib.rs
+++ b/support/uevent/src/lib.rs
@@ -104,16 +104,12 @@ impl UeventListener {
     ///
     /// This is inefficient if there are lots of waiters and lots of incoming
     /// uevents, but this is not an expected use case.
-    pub async fn wait_for_matching_child<T: 'static + Send, F, Fut>(
-        &self,
-        path: &Path,
-        f: F,
-    ) -> io::Result<T>
+    pub async fn wait_for_matching_child<T, F, Fut>(&self, path: &Path, f: F) -> io::Result<T>
     where
         F: Fn(PathBuf, bool) -> Fut,
         Fut: Future<Output = Option<T>>,
     {
-        let scan_for_matching_child = || async {
+        let scan_for_matching_child = async || {
             for entry in path.fs_err_read_dir()? {
                 let entry = entry?;
                 if let Some(r) = f(entry.path(), false).await {

--- a/vm/chipset_arc_mutex_device/src/device.rs
+++ b/vm/chipset_arc_mutex_device/src/device.rs
@@ -11,7 +11,6 @@ use chipset_device::mmio::RegisterMmioIntercept;
 use chipset_device::pio::RegisterPortIoIntercept;
 use chipset_device::ChipsetDevice;
 use closeable_mutex::CloseableMutex;
-use std::future::Future;
 use std::sync::Arc;
 use std::sync::Weak;
 use thiserror::Error;
@@ -73,8 +72,7 @@ pub struct AddDeviceError {
 /// constructed `Arc<CloseableMutex<T: ChipsetDevice>>`.
 ///
 /// This is a separate trait from [`ChipsetServices`] because it is specific to
-/// the ArcMutex infrastructure, and because these trait methods should not be
-/// exposed via [`ArcMutexChipsetDeviceBuilder::services()`].
+/// the ArcMutex infrastructure.
 pub trait ArcMutexChipsetServicesFinalize<T> {
     /// Called to finish wiring up the device after it has been completely
     /// constructed.
@@ -252,8 +250,7 @@ where
     #[instrument(name = "add_device", skip_all, fields(device = self.dev_name.as_ref()))]
     pub async fn add_async<F, Fut>(mut self, f: F) -> Result<Arc<CloseableMutex<T>>, AddDeviceError>
     where
-        F: for<'a> FnOnce(&'a mut S) -> Fut,
-        Fut: Future<Output = T>,
+        F: AsyncFnOnce(&mut S) -> T,
     {
         let dev = (f)(&mut self.services).await;
         self.inner_add(Ok(dev))
@@ -277,13 +274,12 @@ where
 
     /// Just like [`try_add`](Self::try_add), except async.
     #[instrument(name = "add_device", skip_all, fields(device = self.dev_name.as_ref()))]
-    pub async fn try_add_async<F, Fut, E>(
+    pub async fn try_add_async<F, E>(
         mut self,
         f: F,
     ) -> Result<Arc<CloseableMutex<T>>, AddDeviceError>
     where
-        F: for<'a> FnOnce(&'a mut S) -> Fut,
-        Fut: Future<Output = Result<T, E>>,
+        F: AsyncFnOnce(&mut S) -> Result<T, E>,
         E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
     {
         let dev = match (f)(&mut self.services).await {
@@ -293,10 +289,5 @@ where
             }
         };
         self.inner_add(Ok(dev))
-    }
-
-    /// Get a mutable reference to the device's services.
-    pub fn services(&mut self) -> &mut S {
-        &mut self.services
     }
 }

--- a/vm/devices/chipset/fuzz/fuzz_cmos_rtc.rs
+++ b/vm/devices/chipset/fuzz/fuzz_cmos_rtc.rs
@@ -19,7 +19,7 @@ fn do_fuzz(u: &mut Unstructured<'_>) -> arbitrary::Result<()> {
     let initial_cmos = u.arbitrary()?;
 
     // TODO: write a streamlined "fuzz driver" impl instead of using pal_async
-    pal_async::DefaultPool::run_with(|driver| async move {
+    pal_async::DefaultPool::run_with(async |driver| {
         let mut vm_time_keeper = VmTimeKeeper::new(&driver, VmTime::from_100ns(0));
         let vm_time_source = vm_time_keeper.builder().build(&driver).await.unwrap();
 

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -67,7 +67,7 @@ use guestmem::GuestMemory;
 use inspect::Inspect;
 use inspect::InspectMut;
 use local_clock::InspectableLocalClock;
-use pal_async::local::block_with_io;
+use pal_async::local::block_on;
 use platform::logger::UefiLogger;
 use platform::nvram::VsmConfig;
 use std::convert::TryInto;
@@ -222,7 +222,7 @@ impl UefiDevice {
 
     fn write_data(&mut self, addr: u32, data: u32) {
         match UefiCommand(addr) {
-            UefiCommand::NVRAM => block_with_io(|_| self.nvram_handle_command(data.into())),
+            UefiCommand::NVRAM => block_on(self.nvram_handle_command(data.into())),
             UefiCommand::EVENT_LOG_FLUSH => self.event_log_flush(data),
             UefiCommand::WATCHDOG_RESOLUTION
             | UefiCommand::WATCHDOG_CONFIG

--- a/vm/devices/net/gdma/src/resolver.rs
+++ b/vm/devices/net/gdma/src/resolver.rs
@@ -45,7 +45,7 @@ impl AsyncResolveResource<PciDeviceHandleKind, GdmaDeviceHandle> for GdmaDeviceR
         resource: GdmaDeviceHandle,
         input: ResolvePciDeviceHandleParams<'_>,
     ) -> Result<Self::Output, Self::Error> {
-        let vports = try_join_all(resource.vports.into_iter().map(|vport| async move {
+        let vports = try_join_all(resource.vports.into_iter().map(async |vport| {
             let endpoint = resolver
                 .resolve(
                     vport.endpoint,

--- a/vm/devices/net/net_backend/src/lib.rs
+++ b/vm/devices/net/net_backend/src/lib.rs
@@ -576,7 +576,7 @@ impl Endpoint for DisconnectableEndpoint {
             ) => {
                 let old_endpoint = self.endpoint.take();
                 self.endpoint = None;
-                rpc.handle(|_| async { old_endpoint }).await;
+                rpc.handle(async |_| old_endpoint).await;
                 EndpointAction::RestartRequired
             }
             Message::UpdateFromEndpoint(update) => update,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -3780,7 +3780,7 @@ impl Coordinator {
             };
             match message {
                 Message::UpdateFromVf(rpc) => {
-                    rpc.handle(|_| async {
+                    rpc.handle(async |_| {
                         self.update_guest_vf_state(state).await;
                     })
                     .await;

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_main.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_main.rs
@@ -44,7 +44,7 @@ where
 
 /// Uses the provided input to repeatedly create and execute an arbitrary action on the NvmeDriver.
 fn do_fuzz() {
-    DefaultPool::run_with(|driver| async move {
+    DefaultPool::run_with(async |driver| {
         let create_fuzzing_driver = FuzzNvmeDriver::new(driver).await;
         if let Err(_e) = create_fuzzing_driver {
             return;

--- a/vm/devices/storage/disk_striped/src/lib.rs
+++ b/vm/devices/storage/disk_striped/src/lib.rs
@@ -43,7 +43,7 @@ impl AsyncResolveResource<DiskHandleKind, StripedDiskHandle> for StripedDiskReso
         let disks = try_join_all(
             rsrc.devices
                 .into_iter()
-                .map(|device| async { resolver.resolve(device, input).await.map(|r| r.0) }),
+                .map(async |device| resolver.resolve(device, input).await.map(|r| r.0)),
         )
         .await?;
         Ok(ResolvedDisk::new(StripedDisk::new(

--- a/vm/devices/storage/floppy/src/lib.rs
+++ b/vm/devices/storage/floppy/src/lib.rs
@@ -1612,7 +1612,7 @@ impl FloppyDiskController {
         let command_buffer = self.command_buffer.access();
 
         tracing::trace!(lba, size, "starting disk read");
-        self.set_io(|disk| async move {
+        self.set_io(async move |disk| {
             let buffers = command_buffer.buffers(0, size as usize, true);
             disk.read_vectored(&buffers, lba).await
         });
@@ -1714,7 +1714,7 @@ impl FloppyDiskController {
             return false;
         }
 
-        self.set_io(|disk| async move {
+        self.set_io(async move |disk| {
             let buffers = command_buffer.buffers(0, size as usize, false);
             let result = disk.write_vectored(&buffers, lba, false).await;
             if let Err(err) = result {
@@ -1807,7 +1807,7 @@ impl FloppyDiskController {
 
         tracing::trace!(?cylinder, ?head, ?lba, ?buffer_ptr, "Format: ");
 
-        self.set_io(|disk| async move {
+        self.set_io(async move |disk| {
             let buffers = command_buffer.buffers(0, size, false);
             let result = disk.write_vectored(&buffers, lba, false).await;
             if let Err(err) = result {

--- a/vm/devices/storage/ide/src/drive/hard_drive.rs
+++ b/vm/devices/storage/ide/src/drive/hard_drive.rs
@@ -1190,7 +1190,7 @@ impl HardDrive {
                 sector_count = write_sector_count,
                 "starting disk write"
             );
-            self.set_io(|disk| async move {
+            self.set_io(async move |disk| {
                 let buffers = command_buffer.buffers(0, size as usize, false);
                 disk.write_vectored(&buffers, lba, fua).await
             });
@@ -1228,7 +1228,7 @@ impl HardDrive {
 
         let sector_count = command.sectors_before_interrupt;
         tracing::trace!(lba, sector_count, "starting disk read");
-        self.set_io(|disk| async move {
+        self.set_io(async move |disk| {
             let buffers = command_buffer.buffers(
                 0,
                 protocol::HARD_DRIVE_SECTOR_BYTES as usize * sector_count as usize,
@@ -1329,7 +1329,7 @@ impl HardDrive {
     }
 
     fn flush(&mut self) {
-        self.set_io(|disk| async move { disk.sync_cache().await });
+        self.set_io(async |disk| disk.sync_cache().await);
     }
 
     fn flush_complete(&mut self) {

--- a/vm/devices/storage/nvme/src/workers/coordinator.rs
+++ b/vm/devices/storage/nvme/src/workers/coordinator.rs
@@ -276,32 +276,26 @@ impl Coordinator {
                         },
                     ),
                     CoordinatorRequest::AddNamespace(rpc) => {
-                        rpc.handle(|(nsid, disk)| {
-                            let this = &mut self;
-                            async move {
-                                let running = this.admin.stop().await;
-                                let (admin, state) = this.admin.get_mut();
-                                let r = admin.add_namespace(state, nsid, disk).await;
-                                if running {
-                                    this.admin.start();
-                                }
-                                r
+                        rpc.handle(async |(nsid, disk)| {
+                            let running = self.admin.stop().await;
+                            let (admin, state) = self.admin.get_mut();
+                            let r = admin.add_namespace(state, nsid, disk).await;
+                            if running {
+                                self.admin.start();
                             }
+                            r
                         })
                         .await
                     }
                     CoordinatorRequest::RemoveNamespace(rpc) => {
-                        rpc.handle(|nsid| {
-                            let this = &mut self;
-                            async move {
-                                let running = this.admin.stop().await;
-                                let (admin, state) = this.admin.get_mut();
-                                let r = admin.remove_namespace(state, nsid).await;
-                                if running {
-                                    this.admin.start();
-                                }
-                                r
+                        rpc.handle(async |nsid| {
+                            let running = self.admin.stop().await;
+                            let (admin, state) = self.admin.get_mut();
+                            let r = admin.remove_namespace(state, nsid).await;
+                            if running {
+                                self.admin.start();
                             }
+                            r
                         })
                         .await
                     }

--- a/vm/devices/storage/scsidisk/src/resolver.rs
+++ b/vm/devices/storage/scsidisk/src/resolver.rs
@@ -120,7 +120,7 @@ async fn handle_dvd_requests(
     while let Some(req) = requests.next().await {
         match req {
             SimpleScsiDvdRequest::ChangeMedia(rpc) => {
-                rpc.handle_failable(|resource| async {
+                rpc.handle_failable(async |resource| {
                     let media = if let Some(resource) = resource {
                         Some(
                             resolver

--- a/vm/devices/storage/storvsp/benches/ioperf.rs
+++ b/vm/devices/storage/storvsp/benches/ioperf.rs
@@ -32,7 +32,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group
             .throughput(criterion::Throughput::Elements(count))
             .bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
-                b.to_async(&runner).iter(|| async {
+                b.to_async(&runner).iter(async || {
                     let mut x = tester.take().unwrap();
                     x.read(count as usize).await;
                     tester.set(Some(x));

--- a/vm/devices/storage/storvsp/fuzz/fuzz_storvsp.rs
+++ b/vm/devices/storage/storvsp/fuzz/fuzz_storvsp.rs
@@ -202,7 +202,7 @@ async fn do_fuzz_loop(
 }
 
 fn do_fuzz(u: &mut Unstructured<'_>) -> Result<(), anyhow::Error> {
-    DefaultPool::run_with(|driver| async move {
+    DefaultPool::run_with(async |driver| {
         let (host, guest_channel) = connected_async_channels(16 * 1024); // TODO: [use-arbitrary-input]
         let guest_queue = Queue::new(guest_channel).unwrap();
 

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -648,10 +648,10 @@ impl Tpm {
             };
 
             if update_ppi {
-                let res = pal_async::local::block_with_io(|_| {
+                let res = pal_async::local::block_on(
                     (self.rt.ppi_store)
-                        .persist(persist_restore::serialize_ppi_state(self.ppi_state))
-                });
+                        .persist(persist_restore::serialize_ppi_state(self.ppi_state)),
+                );
                 if let Err(e) = res {
                     tracing::warn!(
                         error = &e as &dyn std::error::Error,
@@ -985,7 +985,7 @@ impl ChangeDeviceState for Tpm {
         self.tpm_engine_helper
             .initialize_tpm_engine()
             .expect("failed to send TPM startup commands");
-        pal_async::local::block_with_io(|_| self.flush_pending_nvram())
+        pal_async::local::block_on(self.flush_pending_nvram())
             .expect("failed to flush nvram on reset");
     }
 }
@@ -1216,7 +1216,7 @@ impl MmioIntercept for Tpm {
             _ => return IoResult::Err(IoError::InvalidRegister),
         }
 
-        let res = pal_async::local::block_with_io(|_| self.flush_pending_nvram());
+        let res = pal_async::local::block_on(self.flush_pending_nvram());
         if let Err(e) = res {
             tracing::warn!(
                 error = &e as &dyn std::error::Error,

--- a/vm/devices/user_driver/src/vfio.rs
+++ b/vm/devices/user_driver/src/vfio.rs
@@ -95,8 +95,8 @@ impl VfioDevice {
         let instance_path = Path::new("/sys").join(vmbus_device.strip_prefix("../../..")?);
         let vfio_arrived_path = instance_path.join("vfio-dev");
         let uevent_listener = UeventListener::new(&driver_source.simple())?;
-        let wait_for_vfio_device = uevent_listener
-            .wait_for_matching_child(&vfio_arrived_path, move |_, _| async move { Some(()) });
+        let wait_for_vfio_device =
+            uevent_listener.wait_for_matching_child(&vfio_arrived_path, async |_, _| Some(()));
         let mut ctx = mesh::CancelContext::new().with_timeout(Duration::from_secs(1));
         // Ignore any errors and always attempt to open.
         let _ = ctx.until_cancelled(wait_for_vfio_device).await;

--- a/vm/devices/virtio/virtio/src/common.rs
+++ b/vm/devices/virtio/virtio/src/common.rs
@@ -585,7 +585,7 @@ impl<T: LegacyVirtioDevice> VirtioDevice for LegacyWrapper<T> {
         let mut workers = self.workers.drain(..).collect::<Vec<_>>();
         self.driver
             .spawn("shutdown-legacy-virtio-queues".to_owned(), async move {
-                futures::future::join_all(workers.iter_mut().map(|worker| async {
+                futures::future::join_all(workers.iter_mut().map(async |worker| {
                     worker.stop().await;
                     if let Some(VirtioQueueStateInner::Running { queue, .. }) =
                         worker.state_mut().map(|s| &s.inner)

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -157,7 +157,7 @@ impl VirtioDevice for VirtioFsDevice {
         let mut workers = self.workers.drain(..).collect::<Vec<_>>();
         self.driver
             .spawn("shutdown-virtiofs-queues".to_owned(), async move {
-                futures::future::join_all(workers.iter_mut().map(|worker| async {
+                futures::future::join_all(workers.iter_mut().map(async |worker| {
                     worker.stop().await;
                 }))
                 .await;

--- a/vm/devices/vmbus/vmbus_channel/src/channel.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/channel.rs
@@ -488,7 +488,7 @@ impl Device {
             StateRequest(Result<StateRequest, RecvError>),
         }
 
-        let mut state_req_recv = pin!(futures::stream::unfold(state_req_recv, |mut recv| async {
+        let mut state_req_recv = pin!(futures::stream::unfold(state_req_recv, async |mut recv| {
             Some((recv.recv().await, recv))
         }));
 
@@ -552,13 +552,13 @@ impl Device {
     ) {
         match request {
             ChannelRequest::Open(rpc) => {
-                rpc.handle(|open_request| async {
+                rpc.handle(async |open_request| {
                     self.handle_open(channel, channel_idx, open_request).await
                 })
                 .await
             }
             ChannelRequest::Close(rpc) => {
-                rpc.handle(|()| async {
+                rpc.handle(async |()| {
                     self.handle_close(channel_idx, channel).await;
                 })
                 .await
@@ -571,7 +571,7 @@ impl Device {
                 self.handle_teardown_gpadl(rpc, channel_idx);
             }
             ChannelRequest::Modify(rpc) => {
-                rpc.handle(|req| async {
+                rpc.handle(async |req| {
                     self.handle_modify(channel, channel_idx, req).await;
                     0
                 })
@@ -683,7 +683,7 @@ impl Device {
                 channel.start();
             }
             StateRequest::Stop(rpc) => {
-                rpc.handle(|()| async {
+                rpc.handle(async |()| {
                     channel.stop().await;
                 })
                 .await;
@@ -692,7 +692,7 @@ impl Device {
                 rpc.complete(());
             }
             StateRequest::Save(rpc) => {
-                rpc.handle_failable(|()| async {
+                rpc.handle_failable(async |()| {
                     if let Some(channel) = channel.supports_save_restore() {
                         channel.save().await.map(Some)
                     } else {
@@ -702,7 +702,7 @@ impl Device {
                 .await;
             }
             StateRequest::Restore(rpc) => {
-                rpc.handle_failable(|buffer| async {
+                rpc.handle_failable(async |buffer| {
                     let channel = channel
                         .supports_save_restore()
                         .context("saved state not supported")?;

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -1426,7 +1426,7 @@ impl ClientTask {
             }
             TaskRequest::PostRestore(rpc) => rpc.handle_sync(|()| self.handle_post_restore()),
             TaskRequest::Start => self.handle_start(),
-            TaskRequest::Stop(rpc) => rpc.handle(|()| self.handle_stop()).await,
+            TaskRequest::Stop(rpc) => rpc.handle(async |()| self.handle_stop().await).await,
         }
     }
 

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -443,7 +443,7 @@ impl RelayChannelTask {
             RelayChannelRequest::Stop(rpc) => rpc.handle_sync(|()| self.running = false),
             RelayChannelRequest::Save(rpc) => rpc.handle_sync(|_| self.handle_save()),
             RelayChannelRequest::Restore(rpc) => {
-                rpc.handle_failable(|state| self.handle_restore(state))
+                rpc.handle_failable(async |state| self.handle_restore(state).await)
                     .await
             }
             RelayChannelRequest::Inspect(deferred) => deferred.inspect(self),

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -384,7 +384,7 @@ impl RelayChannelTask {
         tracing::trace!(request = ?request, "received channel request");
         match request {
             ChannelRequest::Open(rpc) => {
-                rpc.handle(|open_request| async move {
+                rpc.handle(async |open_request| {
                     self.handle_open_channel(&open_request)
                         .await
                         .inspect_err(|err| {
@@ -399,7 +399,7 @@ impl RelayChannelTask {
                 .await;
             }
             ChannelRequest::Gpadl(rpc) => {
-                rpc.handle(|gpadl| async move {
+                rpc.handle(async |gpadl| {
                     let id = gpadl.id;
                     self.handle_gpadl(gpadl)
                         .await
@@ -416,17 +416,15 @@ impl RelayChannelTask {
                 .await;
             }
             ChannelRequest::Close(rpc) => {
-                rpc.handle(|()| async move { self.handle_close_channel().await })
+                rpc.handle(async |()| self.handle_close_channel().await)
                     .await;
             }
             ChannelRequest::TeardownGpadl(rpc) => {
                 self.handle_gpadl_teardown(rpc);
             }
             ChannelRequest::Modify(rpc) => {
-                rpc.handle(|request| async move {
-                    self.handle_modify_channel(request).await.unwrap_or(-1)
-                })
-                .await;
+                rpc.handle(async |request| self.handle_modify_channel(request).await.unwrap_or(-1))
+                    .await;
             }
         }
 
@@ -864,14 +862,14 @@ impl RelayTask {
                 r = task_recv.recv().fuse() => {
                     match r.unwrap() {
                         TaskRequest::Inspect(req) => req.inspect(&mut *self),
-                        TaskRequest::Save(rpc) => rpc.handle(|()| {
-                             self.handle_save()
+                        TaskRequest::Save(rpc) => rpc.handle(async |()| {
+                             self.handle_save().await
                         }).await,
-                        TaskRequest::Restore(rpc) => rpc.handle(|state|  {
-                            self.handle_restore(state)
+                        TaskRequest::Restore(rpc) => rpc.handle(async |state|  {
+                            self.handle_restore(state).await
                         }).await,
                         TaskRequest::Start => self.handle_start().await,
-                        TaskRequest::Stop(rpc) => rpc.handle(|()| self.handle_stop()).await,
+                        TaskRequest::Stop(rpc) => rpc.handle(async |()| self.handle_stop().await).await,
                     }
                 }
                 r = self.channel_workers.select_next_some() => {

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -586,7 +586,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
                     self.handle_start(state).await;
                 }
                 Event::Request(InterceptChannelRequest::Stop(rpc)) => {
-                    rpc.handle(|()| self.handle_stop(state)).await;
+                    rpc.handle(async |()| self.handle_stop(state).await).await;
                 }
                 Event::Request(InterceptChannelRequest::Save(rpc)) => {
                     rpc.handle_sync(|()| self.handle_save());

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -412,7 +412,7 @@ impl ProxyTask {
             Some(request) => {
                 match request {
                     ChannelRequest::Open(rpc) => {
-                        rpc.handle(|open_request| async move {
+                        rpc.handle(async |open_request| {
                             let result = self.handle_open(proxy_id, &open_request).await;
                             result.ok().map(|event| OpenResult {
                                 guest_to_host_interrupt: Interrupt::from_event(event),
@@ -421,13 +421,13 @@ impl ProxyTask {
                         .await
                     }
                     ChannelRequest::Close(rpc) => {
-                        rpc.handle(|()| async {
+                        rpc.handle(async |()| {
                             self.handle_close(proxy_id).await;
                         })
                         .await
                     }
                     ChannelRequest::Gpadl(rpc) => {
-                        rpc.handle(|gpadl| async move {
+                        rpc.handle(async |gpadl| {
                             let result = self
                                 .handle_gpadl_create(proxy_id, gpadl.id, gpadl.count, &gpadl.buf)
                                 .await;
@@ -436,7 +436,7 @@ impl ProxyTask {
                         .await
                     }
                     ChannelRequest::TeardownGpadl(rpc) => {
-                        rpc.handle(|id| async move {
+                        rpc.handle(async |id| {
                             self.handle_gpadl_teardown(proxy_id, id).await;
                         })
                         .await

--- a/vm/devices/watchdog/watchdog_core/src/lib.rs
+++ b/vm/devices/watchdog/watchdog_core/src/lib.rs
@@ -222,7 +222,7 @@ impl WatchdogServices {
             tracing::error!(name = self.debug_id, "Encountered a watchdog timeout");
             self.state.config.set_configured(false);
             self.state.config.set_enabled(false);
-            pal_async::local::block_with_io(|_driver| self.platform.on_timeout());
+            pal_async::local::block_with_io(async |_driver| self.platform.on_timeout().await);
         }
     }
 }

--- a/vm/devices/watchdog/watchdog_core/src/lib.rs
+++ b/vm/devices/watchdog/watchdog_core/src/lib.rs
@@ -222,7 +222,7 @@ impl WatchdogServices {
             tracing::error!(name = self.debug_id, "Encountered a watchdog timeout");
             self.state.config.set_configured(false);
             self.state.config.set_enabled(false);
-            pal_async::local::block_with_io(async |_driver| self.platform.on_timeout().await);
+            pal_async::local::block_on(self.platform.on_timeout());
         }
     }
 }

--- a/vm/vmgs/vmgs_broker/src/broker.rs
+++ b/vm/vmgs/vmgs_broker/src/broker.rs
@@ -45,17 +45,16 @@ impl VmgsBrokerTask {
                 rpc.handle_sync(|file_id| self.vmgs.get_file_info(file_id))
             }
             VmgsBrokerRpc::ReadFile(rpc) => {
-                rpc.handle(|file_id| self.vmgs.read_file(file_id)).await
+                rpc.handle(async |file_id| self.vmgs.read_file(file_id).await)
+                    .await
             }
             VmgsBrokerRpc::WriteFile(rpc) => {
-                rpc.handle(
-                    |(file_id, buf)| async move { self.vmgs.write_file(file_id, &buf).await },
-                )
-                .await
+                rpc.handle(async |(file_id, buf)| self.vmgs.write_file(file_id, &buf).await)
+                    .await
             }
             #[cfg(with_encryption)]
             VmgsBrokerRpc::WriteFileEncrypted(rpc) => {
-                rpc.handle(|(file_id, buf)| async move {
+                rpc.handle(async |(file_id, buf)| {
                     self.vmgs.write_file_encrypted(file_id, &buf).await
                 })
                 .await

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -331,7 +331,7 @@ fn parse_legacy_args() -> Vec<String> {
 }
 
 fn main() {
-    DefaultPool::run_with(|_| async move {
+    DefaultPool::run_with(async |_| {
         if let Err(e) = do_main().await {
             let exit_code = match e {
                 Error::NotEncrypted => ExitCode::ErrorNotEncrypted,

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -42,17 +42,16 @@ pub async fn build_vpci_device(
     let mut msi_set = MsiInterruptSet::new();
 
     let device = {
-        let mut builder = chipset_builder.arc_mutex_device(device_name);
-        let mut register_mmio = builder.services().register_mmio();
-        builder
+        chipset_builder
+            .arc_mutex_device(device_name)
             .with_external_pci()
-            .try_add_async(|_services| async {
+            .try_add_async(async |services| {
                 resolver
                     .resolve(
                         resource,
                         pci_resources::ResolvePciDeviceHandleParams {
                             register_msi: &mut msi_set,
-                            register_mmio: &mut register_mmio,
+                            register_mmio: &mut services.register_mmio(),
                             driver_source,
                             guest_memory,
                             doorbell_registration,
@@ -68,10 +67,9 @@ pub async fn build_vpci_device(
     {
         let device_id = (instance_id.data2 as u64) << 16 | (instance_id.data3 as u64 & 0xfff8);
         let vpci_bus_name = format!("vpci:{instance_id}");
-        let mut builder = chipset_builder.arc_mutex_device(vpci_bus_name);
-        let mut register_mmio = builder.services().register_mmio();
-        builder
-            .try_add_async(|_services| async {
+        chipset_builder
+            .arc_mutex_device(vpci_bus_name)
+            .try_add_async(async |services| {
                 let (msi_controller, interrupt_mapper) =
                     new_virtual_device(device_id).context("failed to create virtual device")?;
 
@@ -81,7 +79,7 @@ pub async fn build_vpci_device(
                     driver_source,
                     instance_id,
                     device,
-                    &mut register_mmio,
+                    &mut services.register_mmio(),
                     vmbus,
                     interrupt_mapper,
                 )

--- a/vmm_core/src/partition_unit.rs
+++ b/vmm_core/src/partition_unit.rs
@@ -214,7 +214,7 @@ impl PartitionUnit {
         };
 
         let handle = builder
-            .spawn(spawner, |recv| async move {
+            .spawn(spawner, async |recv| {
                 runner.run(recv).await;
                 runner
             })
@@ -326,11 +326,11 @@ impl PartitionUnitRunner {
                 Event::Request(request) => match request {
                     PartitionRequest::ClearHalt(rpc) => rpc.handle_sync(|()| self.clear_halt()),
                     PartitionRequest::SetInitialRegs(rpc) => {
-                        rpc.handle(|(vtl, state)| self.set_initial_regs(vtl, state))
+                        rpc.handle(async |(vtl, state)| self.set_initial_regs(vtl, state).await)
                             .await
                     }
                     PartitionRequest::SetInitialPageVisibility(rpc) => {
-                        rpc.handle(|vis| self.set_initial_page_visibility(vis))
+                        rpc.handle(async |vis| self.set_initial_page_visibility(vis).await)
                             .await
                     }
                 },

--- a/vmm_core/state_unit/src/lib.rs
+++ b/vmm_core/state_unit/src/lib.rs
@@ -200,12 +200,18 @@ impl StateRequest {
     /// Runs this state request against `unit`.
     pub async fn apply(self, unit: &mut impl StateUnit) {
         match self {
-            StateRequest::Start(rpc) => rpc.handle(|()| async { unit.start().await }).await,
-            StateRequest::Stop(rpc) => rpc.handle(|()| async { unit.stop().await }).await,
-            StateRequest::Reset(rpc) => rpc.handle_failable(|()| unit.reset()).await,
-            StateRequest::Save(rpc) => rpc.handle_failable(|()| unit.save()).await,
-            StateRequest::Restore(rpc) => rpc.handle_failable(|buffer| unit.restore(buffer)).await,
-            StateRequest::PostRestore(rpc) => rpc.handle_failable(|()| unit.post_restore()).await,
+            StateRequest::Start(rpc) => rpc.handle(async |()| unit.start().await).await,
+            StateRequest::Stop(rpc) => rpc.handle(async |()| unit.stop().await).await,
+            StateRequest::Reset(rpc) => rpc.handle_failable(async |()| unit.reset().await).await,
+            StateRequest::Save(rpc) => rpc.handle_failable(async |()| unit.save().await).await,
+            StateRequest::Restore(rpc) => {
+                rpc.handle_failable(async |buffer| unit.restore(buffer).await)
+                    .await
+            }
+            StateRequest::PostRestore(rpc) => {
+                rpc.handle_failable(async |()| unit.post_restore().await)
+                    .await
+            }
             StateRequest::Inspect(req) => req.inspect(unit),
         }
     }

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -624,7 +624,7 @@ impl<'a> BaseChipsetBuilder<'a> {
                         gm: gm.clone(),
                         nvram_storage,
                         logger,
-                        vmtime: &vmtime,
+                        vmtime,
                         watchdog_platform,
                         generation_id_deps: generation_id::GenerationIdRuntimeDeps {
                             generation_id_recv,

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -582,19 +582,17 @@ impl<'a> BaseChipsetBuilder<'a> {
         {
             builder
                 .arc_mutex_device("guest-watchdog")
-                .add_async(|services| {
-                    let vmtime = services.register_vmtime().clone();
+                .add_async(async |services| {
+                    let vmtime = services.register_vmtime();
                     let mut register_pio = services.register_pio();
-                    async move {
-                        guest_watchdog::GuestWatchdogServices::new(
-                            vmtime.access("guest-watchdog-time"),
-                            watchdog_platform,
-                            &mut register_pio,
-                            pio_wdat_port,
-                            foundation.is_restoring,
-                        )
-                        .await
-                    }
+                    guest_watchdog::GuestWatchdogServices::new(
+                        vmtime.access("guest-watchdog-time"),
+                        watchdog_platform,
+                        &mut register_pio,
+                        pio_wdat_port,
+                        foundation.is_restoring,
+                    )
+                    .await
                 })
                 .await?;
         }
@@ -611,7 +609,7 @@ impl<'a> BaseChipsetBuilder<'a> {
         {
             builder
                 .arc_mutex_device("uefi")
-                .try_add_async(|services| {
+                .try_add_async(async |services| {
                     let notify_interrupt = match config.command_set {
                         UefiCommandSet::X64 => {
                             services.new_line(GPE0_LINE_SET, "genid", GPE0_LINE_GENERATION_ID)
@@ -620,31 +618,25 @@ impl<'a> BaseChipsetBuilder<'a> {
                             services.new_line(IRQ_LINE_SET, "genid", GENERATION_ID_IRQ)
                         }
                     };
-                    let vmtime = services.register_vmtime().clone();
+                    let vmtime = services.register_vmtime();
                     let gm = foundation.trusted_vtl0_dma_memory.clone();
-                    async move {
-                        let runtime_deps = firmware_uefi::UefiRuntimeDeps {
-                            gm: gm.clone(),
-                            nvram_storage,
-                            logger,
-                            vmtime: &vmtime,
-                            watchdog_platform,
-                            generation_id_deps: generation_id::GenerationIdRuntimeDeps {
-                                generation_id_recv,
-                                gm,
-                                notify_interrupt,
-                            },
-                            vsm_config,
-                            time_source,
-                        };
+                    let runtime_deps = firmware_uefi::UefiRuntimeDeps {
+                        gm: gm.clone(),
+                        nvram_storage,
+                        logger,
+                        vmtime: &vmtime,
+                        watchdog_platform,
+                        generation_id_deps: generation_id::GenerationIdRuntimeDeps {
+                            generation_id_recv,
+                            gm,
+                            notify_interrupt,
+                        },
+                        vsm_config,
+                        time_source,
+                    };
 
-                        firmware_uefi::UefiDevice::new(
-                            runtime_deps,
-                            config,
-                            foundation.is_restoring,
-                        )
+                    firmware_uefi::UefiDevice::new(runtime_deps, config, foundation.is_restoring)
                         .await
-                    }
                 })
                 .await?;
         }
@@ -744,25 +736,28 @@ impl<'a> BaseChipsetBuilder<'a> {
         );
 
         for device in device_handles {
-            let mut builder = builder.arc_mutex_device(device.name.as_ref());
-            let services = builder.services();
-            let dev = resolver
-                .resolve(
-                    device.resource,
-                    ResolveChipsetDeviceHandleParams {
-                        device_name: device.name.as_ref(),
-                        guest_memory: &foundation.untrusted_dma_memory,
-                        encrypted_guest_memory: &foundation.trusted_vtl0_dma_memory,
-                        vmtime: foundation.vmtime,
-                        is_restoring: foundation.is_restoring,
-                        task_driver_source: driver_source,
-                        register_mmio: &mut services.register_mmio(),
-                        register_pio: &mut services.register_pio(),
-                        configure: services,
-                    },
-                )
-                .await;
-            builder.try_add(|_| dev.map(|d| d.0))?;
+            builder
+                .arc_mutex_device(device.name.as_ref())
+                .try_add_async(async |services| {
+                    resolver
+                        .resolve(
+                            device.resource,
+                            ResolveChipsetDeviceHandleParams {
+                                device_name: device.name.as_ref(),
+                                guest_memory: &foundation.untrusted_dma_memory,
+                                encrypted_guest_memory: &foundation.trusted_vtl0_dma_memory,
+                                vmtime: foundation.vmtime,
+                                is_restoring: foundation.is_restoring,
+                                task_driver_source: driver_source,
+                                register_mmio: &mut services.register_mmio(),
+                                register_pio: &mut services.register_pio(),
+                                configure: services,
+                            },
+                        )
+                        .await
+                        .map(|dev| dev.0)
+                })
+                .await?;
         }
 
         Ok(BaseChipsetBuilderOutput {

--- a/vmm_core/vmotherboard/src/chipset/line_sets.rs
+++ b/vmm_core/vmotherboard/src/chipset/line_sets.rs
@@ -40,7 +40,7 @@ impl LineSets {
                 .add(format!("lines/{}", id.name()))
                 .spawn(driver.simple(), {
                     let set = set.clone();
-                    |mut recv| async move {
+                    async move |mut recv| {
                         while let Ok(req) = recv.recv().await {
                             req.apply(&mut LineSetUnit(&set)).await;
                         }

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -669,7 +669,7 @@ fn make_vmm_test(args: Args, item: ItemFn, specific_vmm: Option<Vmm>) -> syn::Re
                     (#artifacts, extra_deps)
                 },
                 |params, (artifacts, extra_deps)| {
-                    ::pal_async::DefaultPool::run_with(|driver| async move {
+                    ::pal_async::DefaultPool::run_with(async |driver| {
                         let config = #petri_vm_config;
                         #original_name(#original_args).await
                     })

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -50,7 +50,7 @@ fn test_ttrpc_interface(
     let mut b = [0];
     assert_eq!(stdout.read(&mut b)?, 0);
 
-    DefaultPool::run_with(|driver| async {
+    DefaultPool::run_with(async |driver| {
         let driver = driver;
         let _stderr_task = driver.spawn(
             "stderr",

--- a/workers/debug_worker/src/lib.rs
+++ b/workers/debug_worker/src/lib.rs
@@ -98,7 +98,7 @@ where
     }
 
     fn run(self, mut rpc_recv: mesh::Receiver<WorkerRpc<Self::Parameters>>) -> anyhow::Result<()> {
-        block_with_io(|driver| async move {
+        block_with_io(async |driver| {
             tracing::info!(
                 address = %self.listener.local_addr().unwrap(),
                 "gdbstub listening",

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -104,7 +104,7 @@ impl<T: 'static + Listener + MeshField + Send> VncWorker<T> {
         self,
         mut rpc_recv: mesh::Receiver<WorkerRpc<VncParameters<T>>>,
     ) -> anyhow::Result<()> {
-        block_with_io(|driver| async move {
+        block_with_io(async |driver| {
             tracing::info!(
                 address = ?self.listener.local_addr().unwrap(),
                 "VNC server listening",

--- a/workers/vnc_worker/vnc/examples/vncserver.rs
+++ b/workers/vnc_worker/vnc/examples/vncserver.rs
@@ -37,7 +37,7 @@ impl vnc::Input for IgnoreInput {
 }
 
 fn main() -> Result<(), Error> {
-    block_with_io(|driver| async move {
+    block_with_io(async |driver| {
         let light_grey = pixel(127, 127, 127);
         let dark_grey = pixel(63, 63, 63);
         // Checkerboard pattern.


### PR DESCRIPTION
Now that Rust 1.85 is out, switch to using async closures instead of closures returning async blocks. Use `AsyncFn*` instead of `Fn* -> impl Future`.

In some places, this requires a little more verbosity: the brief `|| self.foo()` becomes `async || self.foo().await`. But in return, all the weird lifetime issues go away, so we're able to cut down on `let x = &x` and `async move`s that shouldn't be needed. In the case of the chipset builder, this is a significant improvement--we are able to reference various motherboard services within the async closure for adding a device instead of having to pre-clone them outside the closure.

There are still a few places where we have to use the `FnOnce() -> Fut` pattern since `AsyncFnOnce` doesn't yet have a mechanism for specifying that the resulting future must be `Send`.