### PR TITLE
Use std's noop waker instead of futures'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,6 @@ dependencies = [
  "chipset_arc_mutex_device",
  "chipset_device",
  "closeable_mutex",
- "futures",
  "parking_lot",
  "range_map_vec",
  "tracing",

--- a/clippy.toml
+++ b/clippy.toml
@@ -21,6 +21,9 @@ disallowed-methods = [
     # This is used by futures::select! and futures::join!, so leave it out for now.
     # { path = "futures::future::poll_fn", reason = "use std::future::poll_fn" },
 
+    { path = "futures::task::noop_waker", reason = "use std::task::Waker::noop" },
+    { path = "futures::task::noop_waker_ref", reason = "use std::task::Waker::noop" },
+
     { path = "futures::channel::mpsc::channel", reason = "use mesh or async-channel" },
     { path = "futures::channel::mpsc::unbounded", reason = "use mesh or async-channel" },
     { path = "futures::channel::oneshot::channel", reason = "use mesh or async-channel" },

--- a/support/pal/pal_uring/src/threadpool.rs
+++ b/support/pal/pal_uring/src/threadpool.rs
@@ -16,7 +16,6 @@
 use super::ioring::IoCompletionRing;
 use super::ioring::IoMemory;
 use super::ioring::IoRing;
-use futures::task::noop_waker;
 use futures::FutureExt;
 use inspect::Inspect;
 use io_uring::opcode;
@@ -540,7 +539,7 @@ impl<T: 'static + Send + Sync + Unpin, Init: Borrow<IoInitiator> + Unpin> Io<T, 
         let idx = unsafe {
             self.initiator
                 .borrow()
-                .submit_io(sqe, IoMemory::new(()), noop_waker())
+                .submit_io(sqe, IoMemory::new(()), Waker::noop().clone())
         };
         self.initiator.borrow().drop_io(idx);
     }

--- a/support/pal/pal_uring/src/uring.rs
+++ b/support/pal/pal_uring/src/uring.rs
@@ -5,7 +5,6 @@
 
 use super::threadpool::Io;
 use super::threadpool::IoInitiator;
-use futures::task::noop_waker_ref;
 use futures::FutureExt;
 use io_uring::opcode;
 use io_uring::types::TimeoutFlags;
@@ -27,6 +26,7 @@ use std::os::unix::prelude::*;
 use std::sync::OnceLock;
 use std::task::Context;
 use std::task::Poll;
+use std::task::Waker;
 
 /// An object that can be used to initiate an IO, by returning a reference to an
 /// [`IoInitiator`].
@@ -292,7 +292,7 @@ impl<T: Initiate> PollWait for FdWaitViaRead<T> {
 
 impl<T: Initiate> Drop for FdWaitViaRead<T> {
     fn drop(&mut self) {
-        let _ = self.poll_cancel_wait(&mut Context::from_waker(noop_waker_ref()));
+        let _ = self.poll_cancel_wait(&mut Context::from_waker(Waker::noop()));
     }
 }
 

--- a/vm/chipset_device_fuzz/Cargo.toml
+++ b/vm/chipset_device_fuzz/Cargo.toml
@@ -15,7 +15,6 @@ closeable_mutex.workspace = true
 range_map_vec.workspace = true
 
 arbitrary = { workspace = true, features = ["derive"] }
-futures.workspace = true
 parking_lot.workspace = true
 zerocopy.workspace = true
 tracing.workspace = true

--- a/vm/chipset_device_fuzz/src/lib.rs
+++ b/vm/chipset_device_fuzz/src/lib.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use std::sync::Weak;
 use std::task::Context;
 use std::task::Poll;
+use std::task::Waker;
 use zerocopy::FromBytes;
 
 type InterceptRanges<U> =
@@ -190,7 +191,7 @@ impl FuzzChipset {
             .lock()
             .supports_poll_device()
             .expect("objects supporting polling support polling")
-            .poll_device(&mut Context::from_waker(futures::task::noop_waker_ref()));
+            .poll_device(&mut Context::from_waker(Waker::noop()));
         Some(())
     }
 
@@ -201,7 +202,7 @@ impl FuzzChipset {
         mut t: DeferredToken,
         data: &mut [u8],
     ) {
-        let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+        let mut cx = Context::from_waker(Waker::noop());
         let dev = dev
             .supports_poll_device()
             .expect("objects returning a DeferredToken support polling");
@@ -229,7 +230,7 @@ impl FuzzChipset {
 
     /// Poll a deferred write once, panic if it isn't complete afterwards.
     fn defer_write_now_or_never(&self, dev: &mut dyn ChipsetDevice, mut t: DeferredToken) {
-        let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+        let mut cx = Context::from_waker(Waker::noop());
         let dev = dev
             .supports_poll_device()
             .expect("objects returning a DeferredToken support polling");

--- a/vm/devices/chipset/src/battery/mod.rs
+++ b/vm/devices/chipset/src/battery/mod.rs
@@ -439,7 +439,7 @@ mod tests {
         sender: &mesh::Sender<HostBatteryUpdate>,
     ) {
         sender.send(update);
-        battery.poll_device(&mut Context::from_waker(futures::task::noop_waker_ref()));
+        battery.poll_device(&mut Context::from_waker(std::task::Waker::noop()));
     }
 
     /// Test basic battery mmio behavior

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -10,7 +10,6 @@ pub use self::saved_state::SavedState;
 use anyhow::Result;
 use futures::future::OptionFuture;
 use futures::stream::SelectAll;
-use futures::task::noop_waker_ref;
 use futures::FutureExt;
 use futures::StreamExt;
 use guid::Guid;
@@ -1414,7 +1413,7 @@ impl OutgoingMessages {
         let msg = OutgoingMessage::with_data(msg, data);
         if self.queued.is_empty() {
             let r = self.poster.poll_post_message(
-                &mut Context::from_waker(noop_waker_ref()),
+                &mut Context::from_waker(std::task::Waker::noop()),
                 protocol::VMBUS_MESSAGE_REDIRECT_CONNECTION_ID,
                 1,
                 msg.data(),

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -33,7 +33,6 @@ use futures::channel::mpsc::SendError;
 use futures::future::poll_fn;
 use futures::future::OptionFuture;
 use futures::stream::SelectAll;
-use futures::task::noop_waker_ref;
 use futures::FutureExt;
 use futures::StreamExt;
 use guestmem::GuestMemory;
@@ -1457,7 +1456,7 @@ impl Notifier for ServerTaskInner {
         // main loop will try to send it again later.
         matches!(
             port.poll_post_message(
-                &mut std::task::Context::from_waker(noop_waker_ref()),
+                &mut std::task::Context::from_waker(std::task::Waker::noop()),
                 VMBUS_MESSAGE_TYPE,
                 message.data()
             ),
@@ -1892,7 +1891,6 @@ impl ParentBus for VmbusServerControl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::task::noop_waker_ref;
     use pal_async::async_test;
     use pal_async::driver::SpawnDriver;
     use pal_async::timer::Instant;
@@ -1948,7 +1946,7 @@ mod tests {
                     .as_ref()
                     .unwrap()
                     .poll_handle_message(
-                        &mut std::task::Context::from_waker(noop_waker_ref()),
+                        &mut std::task::Context::from_waker(std::task::Waker::noop()),
                         msg.data(),
                         trusted,
                     ),

--- a/vmm_core/src/synic.rs
+++ b/vmm_core/src/synic.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use futures::task::noop_waker_ref;
 use hvdef::HvError;
 use hvdef::HvResult;
 use hvdef::Vtl;
@@ -55,7 +54,7 @@ impl SynicPorts {
             if vtl < minimum_vtl {
                 Err(HvError::OperationDenied)
             } else if port.poll_handle_message(
-                &mut Context::from_waker(noop_waker_ref()),
+                &mut Context::from_waker(std::task::Waker::noop()),
                 message,
                 secure,
             ) == Poll::Ready(())


### PR DESCRIPTION
Std's is stable now, no reason to use the one from futures anymore.