### PR TITLE
Lower the binary size gate's threshold

### DIFF
--- a/xtask/src/tasks/verify_size.rs
+++ b/xtask/src/tasks/verify_size.rs
@@ -93,8 +93,15 @@ impl Xtask for VerifySize {
 
         println!("Total difference: {total_diff} KiB.");
 
-        if total_diff > 50 {
-            anyhow::bail!("{} size verification failed: The total difference ({} KiB) is greater than the allowed difference ({} KiB).", self.new.display(), total_diff, 50);
+        const ALLOWED: u64 = 50;
+        if total_diff > ALLOWED {
+            anyhow::bail!(
+                "{} size verification failed: \
+            The total difference ({} KiB) is greater than the allowed difference ({} KiB).",
+                self.new.display(),
+                total_diff,
+                ALLOWED
+            );
         }
 
         Ok(())

--- a/xtask/src/tasks/verify_size.rs
+++ b/xtask/src/tasks/verify_size.rs
@@ -93,8 +93,8 @@ impl Xtask for VerifySize {
 
         println!("Total difference: {total_diff} KiB.");
 
-        if total_diff > 100 {
-            anyhow::bail!("{} size verification failed: The total difference ({} KiB) is greater than the allowed difference ({} KiB).", self.new.display(), total_diff, 100);
+        if total_diff > 50 {
+            anyhow::bail!("{} size verification failed: The total difference ({} KiB) is greater than the allowed difference ({} KiB).", self.new.display(), total_diff, 50);
         }
 
         Ok(())


### PR DESCRIPTION
Now that it's doing proper baselining we can lower the threshold. Cut it in half for now, from 100kb to 50kb.