### PR TITLE
[flowey]: try getting better merge base

### DIFF
--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -2096,8 +2096,11 @@ jobs:
     - name: setup gh cli
       run: flowey e 13 flowey_lib_common::use_gh_cli 0
       shell: bash
+    - run: ${{ toJSON(github.event.pull_request) }}
+      shell: flowey v 13 'flowey_lib_common::git_merge_commit:0:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0}
+      name: 🌼 Read from 'github.event.pull_request'
     - name: get merge commit
-      run: flowey e 13 flowey_lib_common::git_merge_commit 0
+      run: flowey e 13 flowey_lib_common::git_merge_commit 1
       shell: bash
     - name: get action id
       run: flowey e 13 flowey_lib_common::gh_workflow_id 0

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -2096,11 +2096,8 @@ jobs:
     - name: setup gh cli
       run: flowey e 13 flowey_lib_common::use_gh_cli 0
       shell: bash
-    - run: ${{ toJSON(github.event.pull_request) }}
-      shell: flowey v 13 'flowey_lib_common::git_merge_commit:0:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0}
-      name: 🌼 Read from 'github.event.pull_request'
     - name: get merge commit
-      run: flowey e 13 flowey_lib_common::git_merge_commit 1
+      run: flowey e 13 flowey_lib_common::git_merge_commit 0
       shell: bash
     - name: get action id
       run: flowey e 13 flowey_lib_common::gh_workflow_id 0

--- a/flowey/flowey_lib_common/src/git_merge_commit.rs
+++ b/flowey/flowey_lib_common/src/git_merge_commit.rs
@@ -47,6 +47,8 @@ impl SimpleFlowNode for Node {
 
                 sh.change_dir(repo_path);
 
+                let original_branch = xshell::cmd!(sh, "git rev-parse --abbrev-ref HEAD").read()?;
+
                 xshell::cmd!(sh, "git fetch origin {base_branch}").run()?;
                 xshell::cmd!(sh, "git fetch origin pull/{pr_number}/head:{head_ref}").run()?;
                 xshell::cmd!(sh, "git checkout -b {temp_branch} origin/{base_branch}").run()?;
@@ -54,6 +56,9 @@ impl SimpleFlowNode for Node {
                 let commit =
                     xshell::cmd!(sh, "git merge-base {temp_branch} origin/{base_branch}").read()?;
                 rt.write(merge_commit, &commit);
+
+                xshell::cmd!(sh, "git checkout {original_branch}").run()?;
+                xshell::cmd!(sh, "git branch -D {temp_branch}").run()?;
 
                 Ok(())
             }

--- a/flowey/flowey_lib_common/src/git_merge_commit.rs
+++ b/flowey/flowey_lib_common/src/git_merge_commit.rs
@@ -46,6 +46,8 @@ impl SimpleFlowNode for Node {
 
                 sh.change_dir(repo_path);
 
+                xshell::cmd!(sh, "git fetch --unshallow").run()?;
+
                 xshell::cmd!(sh, "git fetch origin {base_branch}").run()?;
                 xshell::cmd!(sh, "git fetch origin pull/{pr_number}/merge:{merge_ref}").run()?;
                 let commit =

--- a/flowey/flowey_lib_common/src/git_merge_commit.rs
+++ b/flowey/flowey_lib_common/src/git_merge_commit.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Gets the merge commit of the result of merging a PR branch into base_branch
+//! Gets the merge commit of HEAD and a base_branch
 
 use flowey::node::prelude::*;
 
@@ -29,36 +29,19 @@ impl SimpleFlowNode for Node {
             base_branch,
         } = request;
 
-        let pr_event = ctx.get_gh_context_var().event().pull_request();
-
         ctx.emit_rust_step("get merge commit", move |ctx| {
             let merge_commit = merge_commit.claim(ctx);
-            let pr_event = pr_event.claim(ctx);
             let repo_path = repo_path.claim(ctx);
 
             move |rt| {
                 let sh = xshell::Shell::new()?;
                 let repo_path = rt.read(repo_path);
-                let pr_event = rt.read(pr_event).expect("PR event not found");
-
-                let head_ref = pr_event.head.head_ref;
-                let pr_number = pr_event.number.to_string();
-                let temp_branch = format!("temp-merge-{}", pr_number);
 
                 sh.change_dir(repo_path);
 
-                let original_branch = xshell::cmd!(sh, "git rev-parse --abbrev-ref HEAD").read()?;
-
                 xshell::cmd!(sh, "git fetch origin {base_branch}").run()?;
-                xshell::cmd!(sh, "git fetch origin pull/{pr_number}/head:{head_ref}").run()?;
-                xshell::cmd!(sh, "git checkout -b {temp_branch} origin/{base_branch}").run()?;
-                xshell::cmd!(sh, "git merge --no-commit --no-ff {head_ref}").run()?;
-                let commit =
-                    xshell::cmd!(sh, "git merge-base {temp_branch} origin/{base_branch}").read()?;
+                let commit = xshell::cmd!(sh, "git merge-base HEAD origin/{base_branch}").read()?;
                 rt.write(merge_commit, &commit);
-
-                xshell::cmd!(sh, "git checkout {original_branch}").run()?;
-                xshell::cmd!(sh, "git branch -D {temp_branch}").run()?;
 
                 Ok(())
             }

--- a/flowey/flowey_lib_common/src/git_merge_commit.rs
+++ b/flowey/flowey_lib_common/src/git_merge_commit.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Gets the merge commit of HEAD and a base_branch
+//! Gets the merge commit of the result of merging a PR branch into base_branch
 
 use flowey::node::prelude::*;
 
@@ -29,19 +29,36 @@ impl SimpleFlowNode for Node {
             base_branch,
         } = request;
 
+        let pr_event = ctx.get_gh_context_var().event().pull_request();
+
         ctx.emit_rust_step("get merge commit", move |ctx| {
             let merge_commit = merge_commit.claim(ctx);
+            let pr_event = pr_event.claim(ctx);
             let repo_path = repo_path.claim(ctx);
 
             move |rt| {
                 let sh = xshell::Shell::new()?;
                 let repo_path = rt.read(repo_path);
+                let pr_event = rt.read(pr_event).expect("PR event not found");
+
+                let head_ref = pr_event.head.head_ref;
+                let pr_number = pr_event.number.to_string();
+                let temp_branch = format!("temp-merge-{}", pr_number);
 
                 sh.change_dir(repo_path);
 
+                let original_branch = xshell::cmd!(sh, "git rev-parse --abbrev-ref HEAD").read()?;
+
                 xshell::cmd!(sh, "git fetch origin {base_branch}").run()?;
-                let commit = xshell::cmd!(sh, "git merge-base HEAD origin/{base_branch}").read()?;
+                xshell::cmd!(sh, "git fetch origin pull/{pr_number}/head:{head_ref}").run()?;
+                xshell::cmd!(sh, "git checkout -b {temp_branch} origin/{base_branch}").run()?;
+                xshell::cmd!(sh, "git merge --no-commit --no-ff {head_ref}").run()?;
+                let commit =
+                    xshell::cmd!(sh, "git merge-base {temp_branch} origin/{base_branch}").read()?;
                 rt.write(merge_commit, &commit);
+
+                xshell::cmd!(sh, "git checkout {original_branch}").run()?;
+                xshell::cmd!(sh, "git branch -D {temp_branch}").run()?;
 
                 Ok(())
             }

--- a/flowey/flowey_lib_common/src/git_merge_commit.rs
+++ b/flowey/flowey_lib_common/src/git_merge_commit.rs
@@ -29,29 +29,20 @@ impl SimpleFlowNode for Node {
             base_branch,
         } = request;
 
-        let pr_event = ctx.get_gh_context_var().event().pull_request();
-
         ctx.emit_rust_step("get merge commit", move |ctx| {
             let merge_commit = merge_commit.claim(ctx);
-            let pr_event = pr_event.claim(ctx);
             let repo_path = repo_path.claim(ctx);
 
             move |rt| {
                 let sh = xshell::Shell::new()?;
                 let repo_path = rt.read(repo_path);
-                let pr_event = rt.read(pr_event).expect("PR event not found");
-
-                let pr_number = pr_event.number.to_string();
-                let merge_ref = format!("temp-pr-{}-merge", pr_number);
 
                 sh.change_dir(repo_path);
 
                 xshell::cmd!(sh, "git fetch --unshallow").run()?;
 
                 xshell::cmd!(sh, "git fetch origin {base_branch}").run()?;
-                xshell::cmd!(sh, "git fetch origin pull/{pr_number}/merge:{merge_ref}").run()?;
-                let commit =
-                    xshell::cmd!(sh, "git merge-base {merge_ref} origin/{base_branch}").read()?;
+                let commit = xshell::cmd!(sh, "git merge-base HEAD origin/{base_branch}").read()?;
                 rt.write(merge_commit, &commit);
 
                 Ok(())


### PR DESCRIPTION
Right now the binary size comparison gets the merge base of a PR branch and main, but what we really want is the merge base of the result of merging the PR branch into main. This change reflects that.