### PR TITLE
vmbus_client: clean up gpadl handling

### DIFF
--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -1321,7 +1321,6 @@ impl ClientTask {
                     channel_id = channel_id.0,
                     "gpadl teardown for offered gpadl"
                 );
-                return;
             }
             GpadlState::Created => {
                 *gpadl_state = GpadlState::TearingDown { rpcs: vec![rpc] };

--- a/vm/devices/vmbus/vmbus_client/src/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_client/src/saved_state.rs
@@ -110,7 +110,7 @@ impl super::ClientTask {
             let channel_id = ChannelId(gpadl.channel_id);
             let gpadl_id = GpadlId(gpadl.gpadl_id);
             let gpadl_state = gpadl.state.restore();
-            let tearing_down = matches!(gpadl_state, super::GpadlState::TearingDown);
+            let tearing_down = matches!(gpadl_state, super::GpadlState::TearingDown { .. });
 
             let channel = self
                 .inner
@@ -167,9 +167,9 @@ impl super::ClientTask {
                                 channel_id,
                                 gpadl_id,
                             });
-                            *gpadl_state = crate::GpadlState::TearingDown;
+                            *gpadl_state = crate::GpadlState::TearingDown { rpcs: Vec::new() };
                         }
-                        crate::GpadlState::TearingDown => {}
+                        crate::GpadlState::TearingDown { .. } => {}
                     }
                 }
             }
@@ -316,14 +316,14 @@ impl GpadlState {
         match value {
             super::GpadlState::Offered(..) => unreachable!("Cannot save gpadl in offered state."),
             super::GpadlState::Created => Self::Created,
-            super::GpadlState::TearingDown => Self::TearingDown,
+            super::GpadlState::TearingDown { .. } => Self::TearingDown,
         }
     }
 
     fn restore(self) -> super::GpadlState {
         match self {
             GpadlState::Created => super::GpadlState::Created,
-            GpadlState::TearingDown => super::GpadlState::TearingDown,
+            GpadlState::TearingDown => super::GpadlState::TearingDown { rpcs: Vec::new() },
         }
     }
 }

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 use anyhow::Result;
 use client::ModifyConnectionRequest;
 use futures::future::join_all;
+use futures::future::BoxFuture;
 use futures::future::OptionFuture;
 use futures::FutureExt;
 use futures::StreamExt;
@@ -251,9 +252,10 @@ struct RelayChannel {
     /// State used to relay host-to-guest interrupts.
     #[inspect(with = "Option::is_some")]
     interrupt_relay: Option<InterruptRelay>,
-    /// RPCs for gpadls that are waiting for a torndown message.
-    #[inspect(with = "|x| inspect::iter_by_key(x).map_key(|x| x.0).map_value(|_| ())")]
-    gpadls_tearing_down: HashMap<GpadlId, Rpc<(), ()>>,
+    /// Futures waiting for GPADL teardown to complete before responding to
+    /// `vmbus_server`.
+    #[inspect(skip)]
+    gpadls_tearing_down: FuturesUnordered<BoxFuture<'static, ()>>,
 }
 
 #[derive(InspectMut)]
@@ -330,29 +332,24 @@ impl RelayChannelTask {
         let (gpadl_id, rpc) = rpc.split();
         tracing::trace!(gpadl_id = gpadl_id.0, "Tearing down GPADL");
 
-        let _ = &self
+        let call = self
             .channel
             .request_send
-            .send(client::ChannelRequest::TeardownGpadl(gpadl_id));
+            .call(client::ChannelRequest::TeardownGpadl, gpadl_id);
 
         // We cannot wait for GpadlTorndown here, because the host may not send the GpadlTorndown
         // message immediately, for example if the channel is still open and the host device still
         // has the gpadl mapped. We should not block further requests while waiting for the
         // response.
-        let old_value = self.channel.gpadls_tearing_down.insert(gpadl_id, rpc);
-        assert!(old_value.is_none(), "duplicate gpadl teardown");
-    }
-
-    fn handle_gpadl_torndown(&mut self, gpadl_id: GpadlId) {
-        tracing::trace!(gpadl_id = gpadl_id.0, "Torn down GPADL");
-        let rpc = self
-            .channel
-            .gpadls_tearing_down
-            .remove(&gpadl_id)
-            .expect("gpadl not tearing down.");
-
-        // Notify the vmbus server of completion.
-        rpc.complete(());
+        self.channel.gpadls_tearing_down.push(Box::pin(async move {
+            if let Err(err) = call.await {
+                tracing::warn!(
+                    error = &err as &dyn std::error::Error,
+                    "failed to send gpadl teardown"
+                );
+            }
+            rpc.complete(());
+        }));
     }
 
     async fn handle_modify_channel(&mut self, modify_request: ModifyRequest) -> Result<i32> {
@@ -420,14 +417,8 @@ impl RelayChannelTask {
     }
 
     /// Handle responses.
-    fn handle_response(&mut self, response: &client::ChannelResponse) {
-        match response {
-            client::ChannelResponse::TeardownGpadl(gpadl_id) => {
-                // GpadlTorndown messages aren't always sent immediately in response to a
-                // GpadlTeardown message, so they can arrive at any time and must be handled here.
-                self.handle_gpadl_torndown(*gpadl_id);
-            }
-        }
+    fn handle_response(&mut self, response: client::ChannelResponse) {
+        match response {}
     }
 
     fn handle_relay_request(&mut self, request: RelayChannelRequest) {
@@ -495,13 +486,14 @@ impl RelayChannelTask {
                             drop(relay_event);
 
                             // Handle responses that can arrive at any time.
-                            self.handle_response(&response);
+                            self.handle_response(response);
                         }
                         None => {
                             break;
                         }
                     }
                 }
+                () = self.channel.gpadls_tearing_down.select_next_some() => {}
                 _r = relay_event => {
                     // Needed to avoid conflicting interrupt_relay borrow.
                     drop(relay_event);
@@ -510,16 +502,9 @@ impl RelayChannelTask {
             }
         }
 
-        // The remaining teardown requests are those that never made it to the
-        // client before the channel was revoked, but will have been torndown
-        // anyways as part of the revoke. The RPCs might get dropped here before
-        // the server is notified, so we still need to complete any outstanding
-        // requests back to the server to avoid inconsistent state. The server
-        // will ignore the completions if the channel is already released.
-        self.channel
-            .gpadls_tearing_down
-            .drain()
-            .for_each(|(_, rpc)| rpc.complete(()));
+        // Drain GPADL teardown requests cleanly; these will all complete now
+        // that the channel has been revoked.
+        while let Some(()) = self.channel.gpadls_tearing_down.next().await {}
 
         tracing::debug!(channel_id = %self.channel.channel_id.0, "dropped channel");
     }
@@ -782,7 +767,7 @@ impl RelayTask {
                 server_request_recv: request_recv,
                 use_interrupt_relay: Arc::clone(&self.use_interrupt_relay),
                 interrupt_relay: None,
-                gpadls_tearing_down: HashMap::new(),
+                gpadls_tearing_down: FuturesUnordered::new(),
             },
             // New channels start out running.
             running: true,

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -546,8 +546,7 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
             }
             let revoke = pin!(async {
                 if let Some(offer) = &mut state.offer {
-                    let r = offer.response_recv.next().await;
-                    assert!(r.is_none(), "unexpected channel response");
+                    (&mut offer.revoke_recv).await.ok();
                 } else {
                     pending().await
                 }

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -39,7 +39,6 @@ use vmbus_channel::ChannelClosed;
 use vmbus_channel::RawAsyncChannel;
 use vmbus_channel::SignalVmbusChannel;
 use vmbus_client::ChannelRequest;
-use vmbus_client::ChannelResponse;
 use vmbus_client::OfferInfo;
 use vmbus_client::OpenOutput;
 use vmbus_client::OpenRequest;
@@ -353,16 +352,18 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
         };
 
         if state.vtl_pages.is_some() {
-            offer
+            if let Err(err) = offer
                 .request_send
-                .send(ChannelRequest::TeardownGpadl(GpadlId(
-                    state.vtl_pages.as_ref().unwrap().pfns()[1] as u32,
-                )));
-            match offer.response_recv.next().await {
-                Some(ChannelResponse::TeardownGpadl(_)) => {}
-                None => {
-                    tracing::error!("vmbus channel handle closed waiting for GPADL teardown");
-                }
+                .call(
+                    ChannelRequest::TeardownGpadl,
+                    GpadlId(state.vtl_pages.as_ref().unwrap().pfns()[1] as u32),
+                )
+                .await
+            {
+                tracing::error!(
+                    error = &err as &dyn std::error::Error,
+                    "failed to teardown gpadl"
+                );
             }
 
             state.vtl_pages = None;


### PR DESCRIPTION
Simplify GPADL handling:
* Remove the separate GPADL map and just have the GPADLs be owned by the channels.
* Report GPADL torndown responses via individual oneshot mesh channels instead of a single mesh channel for the whole device.