### PR TITLE
Reduce GPA pool from 1024 to 512 pages for VMM tests

### DIFF
--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -161,7 +161,7 @@ mod tests {
             }
         );
         assert_eq!(
-            parse_boot_command_line("OPENHCL_ENABLE_VTL2_GPA_POOL=1024"),
+            parse_boot_command_line("OPENHCL_ENABLE_VTL2_GPA_POOL=512"),
             BootCommandLineOptions {
                 logger: None,
                 confidential_debug: false,

--- a/openhcl/openhcl_boot/src/cmdline.rs
+++ b/openhcl/openhcl_boot/src/cmdline.rs
@@ -165,7 +165,7 @@ mod tests {
             BootCommandLineOptions {
                 logger: None,
                 confidential_debug: false,
-                enable_vtl2_gpa_pool: Some(1024),
+                enable_vtl2_gpa_pool: Some(512),
             }
         );
     }

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
@@ -58,7 +58,7 @@ async fn openhcl_servicing_keepalive(
 ) -> Result<(), anyhow::Error> {
     openhcl_servicing_core(
         config,
-        "OPENHCL_ENABLE_VTL2_GPA_POOL=1024",
+        "OPENHCL_ENABLE_VTL2_GPA_POOL=512",
         igvm_file,
         OpenHclServicingFlags {
             enable_nvme_keepalive: true,

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -83,7 +83,7 @@ async fn nvme_relay_shared_pool(config: PetriVmConfigOpenVmm) -> Result<(), anyh
 #[openvmm_test(openhcl_uefi_x64[nvme](vhd(ubuntu_2204_server_x64)))]
 async fn nvme_relay_private_pool(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     // Number of pages to reserve as a private pool.
-    nvme_relay_test_core(config, "OPENHCL_ENABLE_VTL2_GPA_POOL=1024").await
+    nvme_relay_test_core(config, "OPENHCL_ENABLE_VTL2_GPA_POOL=512").await
 }
 
 /// Servicing test of an OpenHCL uefi VM with a NVME disk assigned to VTL2 that boots
@@ -97,7 +97,7 @@ async fn nvme_keepalive(
 ) -> Result<(), anyhow::Error> {
     nvme_relay_servicing_core(
         config,
-        "OPENHCL_ENABLE_VTL2_GPA_POOL=1024",
+        "OPENHCL_ENABLE_VTL2_GPA_POOL=512",
         igvm_file,
         OpenHclServicingFlags {
             enable_nvme_keepalive: true,


### PR DESCRIPTION
After updating CI gates to use Rust 1.85 we started to see test errors which looks like OOM errors.
Unfortunately, weren't reproducible on DevBox testing (both WSL2 and Windows).
This change will return some reserved memory back to Linux pool in attempt to see if it can help.
The change can stay permanent because 512 pages is enough to pass the tests.