### PR TITLE
virt_mshv_vtl: Refactor TLB flush and lock code to allow for partial borrows

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -191,9 +191,10 @@ pub struct UhPartition {
     interrupt_targets: VtlArray<Arc<UhInterruptTarget>, 2>,
 }
 
+/// Underhill partition.
 #[derive(Inspect)]
 #[inspect(extra = "UhPartitionInner::inspect_extra")]
-struct UhPartitionInner {
+pub struct UhPartitionInner {
     #[inspect(skip)]
     hcl: Hcl,
     #[inspect(skip)] // inspected separately

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -337,8 +337,6 @@ pub struct UhCvmVpState {
     // Allocation handle for direct overlays
     #[inspect(debug)]
     direct_overlay_handle: user_driver::memory::MemoryBlock,
-    /// The VTLs on this VP waiting for TLB locks on other VPs.
-    vtls_tlb_waiting: VtlArray<bool, 2>,
     /// Used in VTL 2 exit code to determine which VTL to exit to.
     exit_vtl: GuestVtl,
     /// Hypervisor enlightenment emulator state.
@@ -386,7 +384,6 @@ impl UhCvmVpState {
 
         Ok(Self {
             direct_overlay_handle,
-            vtls_tlb_waiting: VtlArray::new(false),
             exit_vtl: GuestVtl::Vtl0,
             hv,
             lapics,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1282,7 +1282,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         value: u64,
         vtl: GuestVtl,
     ) -> Result<(), MsrError> {
-        let self_index = self.vp_index().index() as usize;
+        let self_index = self.vp_index();
         let hv = &mut self.backing.cvm_state_mut().hv[vtl];
         // If updated is Synic MSR, then check if its proxy or previous was proxy
         // in either case, we need to update the `proxy_irr_blocked`
@@ -1420,11 +1420,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
     /// Returns the appropriately backed TLB flush and lock access
     pub fn tlb_flush_lock_access(&self) -> impl TlbFlushLockAccess + use<'_, B> {
-        B::tlb_flush_lock_access(
-            self.vp_index().index() as usize,
-            self.partition,
-            self.shared,
-        )
+        B::tlb_flush_lock_access(self.vp_index(), self.partition, self.shared)
     }
 
     /// Handle checking for cross-VTL interrupts, preempting VTL 0, and setting

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/tlb_lock.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/tlb_lock.rs
@@ -4,29 +4,34 @@
 //! TLB lock infrastructure support for hardware-isolated partitions.
 
 use crate::processor::HardwareIsolatedBacking;
+use crate::UhCvmPartitionState;
 use crate::UhProcessor;
 use hcl::GuestVtl;
 use hvdef::Vtl;
 use std::sync::atomic::Ordering;
 
-impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
-    /// Causes the specified VTL on the current VP to wait on all TLB locks.
-    /// This is typically used to synchronize VTL permission changes with
-    /// concurrent instruction emulation.
+pub struct TlbLockAccess<'a> {
+    pub vp_index: usize,
+    pub cvm_partition: &'a UhCvmPartitionState,
+}
+
+impl TlbLockAccess<'_> {
     pub fn set_wait_for_tlb_locks(&mut self, target_vtl: GuestVtl) {
         // Capture the set of VPs that are currently holding the TLB lock. Only
         // those VPs that hold the lock at this point can block progress, because
         // any VP that acquires the lock after this point is guaranteed to see
         // state that this VP has already flushed.
-        let self_index = self.vp_index().index() as usize;
-        let self_lock = &self.cvm_vp_inner().tlb_lock_info[target_vtl];
-        for vp in self.cvm_partition().tlb_locked_vps[target_vtl]
+        let self_lock = &self
+            .cvm_partition
+            .vp_inner(self.vp_index as u32)
+            .tlb_lock_info[target_vtl];
+        for vp in self.cvm_partition.tlb_locked_vps[target_vtl]
             .clone()
             .iter_ones()
         {
             // Never wait on the current VP, since the current VP will always
             // release its locks correctly when returning to the target VTL.
-            if vp == self_index {
+            if vp == self.vp_index {
                 continue;
             }
 
@@ -43,24 +48,34 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             // Because the wait by the current VP on the target VP is known to
             // be new, this bit should not already be set.
             let other_lock_blocked =
-                &self.cvm_partition().vp_inner(vp as u32).tlb_lock_info[target_vtl].blocked_vps;
-            let _was_other_lock_blocked = other_lock_blocked.set_aliased(self_index, true);
+                &self.cvm_partition.vp_inner(vp as u32).tlb_lock_info[target_vtl].blocked_vps;
+            let _was_other_lock_blocked = other_lock_blocked.set_aliased(self.vp_index, true);
             debug_assert!(!_was_other_lock_blocked);
 
             // It is possible that the target VP released the TLB lock before
             // the current VP was added to its blocked set. Check again to
             // see whether the TLB lock is still held, and if not, remove the
             // block.
-            if !self.cvm_partition().tlb_locked_vps[target_vtl][vp] {
-                other_lock_blocked.set_aliased(self_index, false);
+            if !self.cvm_partition.tlb_locked_vps[target_vtl][vp] {
+                other_lock_blocked.set_aliased(self.vp_index, false);
                 if self_lock.blocking_vps.set_aliased(vp, false) {
                     self_lock.blocking_vp_count.fetch_sub(1, Ordering::Relaxed);
                 }
             }
         }
+    }
+}
 
-        // Mark the target VTL as waiting for TLB locks.
-        self.backing.cvm_state_mut().vtls_tlb_waiting[target_vtl] = true;
+impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
+    /// Causes the specified VTL on the current VP to wait on all TLB locks.
+    /// This is typically used to synchronize VTL permission changes with
+    /// concurrent instruction emulation.
+    pub fn set_wait_for_tlb_locks(&mut self, target_vtl: GuestVtl) {
+        TlbLockAccess {
+            vp_index: self.vp_index().index() as usize,
+            cvm_partition: B::cvm_partition_state(self.shared),
+        }
+        .set_wait_for_tlb_locks(target_vtl);
     }
 
     /// Lock the TLB of the target VTL on the current VP.
@@ -154,30 +169,19 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
     /// Returns whether the VP should halt to wait for the TLB lock of the specified VTL.
     pub fn should_halt_for_tlb_unlock(&mut self, target_vtl: GuestVtl) -> bool {
-        // No wait is required if this VP is not blocked on the TLB lock.
-        if self.backing.cvm_state_mut().vtls_tlb_waiting[target_vtl] {
-            // No wait is required unless this VP is blocked on another VP that
-            // holds the TLB flush lock.
-            let self_lock = &self.cvm_vp_inner().tlb_lock_info[target_vtl];
-            if self_lock.blocking_vp_count.load(Ordering::Relaxed) != 0 {
-                self_lock.sleeping.store(true, Ordering::Relaxed);
-                // Now that this VP has been marked as sleeping, check to see
-                // whether it is still blocked. If not, no sleep should be
-                // attempted.
-                if self_lock.blocking_vp_count.load(Ordering::SeqCst) != 0 {
-                    return true;
-                }
-
-                self_lock.sleeping.store(false, Ordering::Relaxed);
+        // No wait is required unless this VP is blocked on another VP that
+        // holds the TLB flush lock.
+        let self_lock = &self.cvm_vp_inner().tlb_lock_info[target_vtl];
+        if self_lock.blocking_vp_count.load(Ordering::Relaxed) != 0 {
+            self_lock.sleeping.store(true, Ordering::Relaxed);
+            // Now that this VP has been marked as sleeping, check to see
+            // whether it is still blocked. If not, no sleep should be
+            // attempted.
+            if self_lock.blocking_vp_count.load(Ordering::SeqCst) != 0 {
+                return true;
             }
-            self.backing.cvm_state_mut().vtls_tlb_waiting[target_vtl] = false;
-        } else {
-            debug_assert_eq!(
-                self.cvm_vp_inner().tlb_lock_info[target_vtl]
-                    .blocking_vp_count
-                    .load(Ordering::Relaxed),
-                0
-            );
+
+            self_lock.sleeping.store(false, Ordering::Relaxed);
         }
 
         false

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -289,7 +289,7 @@ pub trait HardwareIsolatedBacking: Backing {
     /// Gets a struct that can be used to interact with TLB flushing and
     /// locking.
     fn tlb_flush_lock_access<'a>(
-        vp_index: usize,
+        vp_index: VpIndex,
         partition: &'a UhPartitionInner,
         shared: &'a Self::Shared,
     ) -> impl TlbFlushLockAccess + 'a;

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -36,6 +36,7 @@ use super::UhPartitionInner;
 use super::UhVpInner;
 use crate::GuestVsmState;
 use crate::GuestVtl;
+use crate::TlbFlushLockAccess;
 use crate::WakeReason;
 use hcl::ioctl;
 use hcl::ioctl::ProcessorRunner;
@@ -285,6 +286,13 @@ pub trait HardwareIsolatedBacking: Backing {
     fn cvm_state_mut(&mut self) -> &mut crate::UhCvmVpState;
     /// Gets CVM specific partition state.
     fn cvm_partition_state(shared: &Self::Shared) -> &crate::UhCvmPartitionState;
+    /// Gets a struct that can be used to interact with TLB flushing and
+    /// locking.
+    fn tlb_flush_lock_access<'a>(
+        vp_index: usize,
+        partition: &'a UhPartitionInner,
+        shared: &'a Self::Shared,
+    ) -> impl TlbFlushLockAccess + 'a;
     /// Copies shared registers (per VSM TLFS spec) from the source VTL to
     /// the target VTL that will become active, and set the exit vtl
     fn switch_vtl(this: &mut UhProcessor<'_, Self>, source_vtl: GuestVtl, target_vtl: GuestVtl);

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -14,6 +14,7 @@ cfg_if::cfg_if! {
         pub mod snp;
         pub mod tdx;
 
+        use crate::TlbFlushLockAccess;
         use crate::VtlCrash;
         use hvdef::HvX64RegisterName;
         use virt::vp::AccessVpState;
@@ -36,7 +37,6 @@ use super::UhPartitionInner;
 use super::UhVpInner;
 use crate::GuestVsmState;
 use crate::GuestVtl;
-use crate::TlbFlushLockAccess;
 use crate::WakeReason;
 use hcl::ioctl;
 use hcl::ioctl::ProcessorRunner;

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -216,6 +216,18 @@ impl HardwareIsolatedBacking for SnpBacked {
             ),
         }
     }
+
+    fn tlb_flush_lock_access<'a>(
+        vp_index: usize,
+        partition: &'a UhPartitionInner,
+        shared: &'a Self::Shared,
+    ) -> impl TlbFlushLockAccess + 'a {
+        SnpTlbLockFlushAccess {
+            vp_index,
+            partition,
+            shared,
+        }
+    }
 }
 
 /// Partition-wide shared data for SNP VPs.
@@ -2335,7 +2347,13 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, SnpBacked> {
     }
 }
 
-impl TlbFlushLockAccess for UhProcessor<'_, SnpBacked> {
+struct SnpTlbLockFlushAccess<'a> {
+    vp_index: usize,
+    partition: &'a UhPartitionInner,
+    shared: &'a SnpBackedShared,
+}
+
+impl TlbFlushLockAccess for SnpTlbLockFlushAccess<'_> {
     fn flush(&mut self, vtl: GuestVtl) {
         // SNP provides no mechanism to flush a single VTL across multiple VPs
         // Do a flush entire, but only wait on the VTL that was asked for
@@ -2367,7 +2385,11 @@ impl TlbFlushLockAccess for UhProcessor<'_, SnpBacked> {
     }
 
     fn set_wait_for_tlb_locks(&mut self, vtl: GuestVtl) {
-        Self::set_wait_for_tlb_locks(self, vtl);
+        hardware_cvm::tlb_lock::TlbLockAccess {
+            vp_index: self.vp_index,
+            cvm_partition: &self.shared.cvm,
+        }
+        .set_wait_for_tlb_locks(vtl);
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -218,12 +218,12 @@ impl HardwareIsolatedBacking for SnpBacked {
     }
 
     fn tlb_flush_lock_access<'a>(
-        vp_index: usize,
+        vp_index: VpIndex,
         partition: &'a UhPartitionInner,
         shared: &'a Self::Shared,
     ) -> impl TlbFlushLockAccess + 'a {
         SnpTlbLockFlushAccess {
-            vp_index,
+            vp_index: vp_index.index() as usize,
             partition,
             shared,
         }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -526,6 +526,18 @@ impl HardwareIsolatedBacking for TdxBacked {
             ),
         }
     }
+
+    fn tlb_flush_lock_access<'a>(
+        vp_index: usize,
+        partition: &'a UhPartitionInner,
+        shared: &'a Self::Shared,
+    ) -> impl TlbFlushLockAccess + 'a {
+        TdxTlbLockFlushAccess {
+            vp_index,
+            partition,
+            shared,
+        }
+    }
 }
 
 /// Partition-wide shared data for TDX VPs.
@@ -3345,6 +3357,22 @@ impl<T> HypercallIo for TdHypercall<'_, '_, T> {
     }
 }
 
+impl<T> hv1_hypercall::VtlSwitchOps for UhHypercallHandler<'_, '_, T, TdxBacked> {
+    fn advance_ip(&mut self) {
+        let long_mode = self.vp.long_mode(self.intercepted_vtl);
+        let mut io = hv1_hypercall::X64RegisterIo::new(self, long_mode);
+        io.advance_ip();
+    }
+
+    fn inject_invalid_opcode_fault(&mut self) {
+        self.vp.backing.vtls[self.intercepted_vtl].interruption_information =
+            InterruptionInformation::new()
+                .with_valid(true)
+                .with_interruption_type(INTERRUPT_TYPE_HARDWARE_EXCEPTION)
+                .with_vector(x86defs::Exception::INVALID_OPCODE.0);
+    }
+}
+
 impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressList for UhHypercallHandler<'_, '_, T, TdxBacked> {
     fn flush_virtual_address_list(
         &mut self,
@@ -3392,8 +3420,12 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressListEx
         }
 
         // Send flush IPIs to the specified VPs.
-        self.vp
-            .wake_processors_for_tlb_flush(vtl, (!flags.all_processors()).then_some(processor_set));
+        TdxTlbLockFlushAccess {
+            vp_index: self.vp.vp_index().index() as usize,
+            partition: self.vp.partition,
+            shared: self.vp.shared,
+        }
+        .wake_processors_for_tlb_flush(vtl, (!flags.all_processors()).then_some(processor_set));
 
         // Mark that this VP needs to wait for all TLB locks to be released before returning.
         self.vp.set_wait_for_tlb_locks(vtl);
@@ -3441,8 +3473,12 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressSpaceEx
         }
 
         // Send flush IPIs to the specified VPs.
-        self.vp
-            .wake_processors_for_tlb_flush(vtl, (!flags.all_processors()).then_some(processor_set));
+        TdxTlbLockFlushAccess {
+            vp_index: self.vp.vp_index().index() as usize,
+            partition: self.vp.partition,
+            shared: self.vp.shared,
+        }
+        .wake_processors_for_tlb_flush(vtl, (!flags.all_processors()).then_some(processor_set));
 
         // Mark that this VP needs to wait for all TLB locks to be released before returning.
         self.vp.set_wait_for_tlb_locks(vtl);
@@ -3479,7 +3515,7 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
     }
 }
 
-impl UhProcessor<'_, TdxBacked> {
+impl TdxTlbLockFlushAccess<'_> {
     fn wake_processors_for_tlb_flush(
         &mut self,
         target_vtl: GuestVtl,
@@ -3512,7 +3548,7 @@ impl UhProcessor<'_, TdxBacked> {
         // for each VP.
         std::sync::atomic::fence(Ordering::SeqCst);
         for target_vp in processors {
-            if self.vp_index().index() as usize != target_vp
+            if self.vp_index != target_vp
                 && self.shared.active_vtl[target_vp].load(Ordering::Relaxed) == target_vtl as u8
             {
                 self.partition.vps[target_vp].wake_vtl2();
@@ -3523,23 +3559,13 @@ impl UhProcessor<'_, TdxBacked> {
     }
 }
 
-impl<T> hv1_hypercall::VtlSwitchOps for UhHypercallHandler<'_, '_, T, TdxBacked> {
-    fn advance_ip(&mut self) {
-        let long_mode = self.vp.long_mode(self.intercepted_vtl);
-        let mut io = hv1_hypercall::X64RegisterIo::new(self, long_mode);
-        io.advance_ip();
-    }
-
-    fn inject_invalid_opcode_fault(&mut self) {
-        self.vp.backing.vtls[self.intercepted_vtl].interruption_information =
-            InterruptionInformation::new()
-                .with_valid(true)
-                .with_interruption_type(INTERRUPT_TYPE_HARDWARE_EXCEPTION)
-                .with_vector(x86defs::Exception::INVALID_OPCODE.0);
-    }
+struct TdxTlbLockFlushAccess<'a> {
+    vp_index: usize,
+    partition: &'a UhPartitionInner,
+    shared: &'a TdxBackedShared,
 }
 
-impl TlbFlushLockAccess for UhProcessor<'_, TdxBacked> {
+impl TlbFlushLockAccess for TdxTlbLockFlushAccess<'_> {
     fn flush(&mut self, vtl: GuestVtl) {
         {
             self.shared.flush_state[vtl].write().s.flush_entire_counter += 1;
@@ -3559,7 +3585,11 @@ impl TlbFlushLockAccess for UhProcessor<'_, TdxBacked> {
     }
 
     fn set_wait_for_tlb_locks(&mut self, vtl: GuestVtl) {
-        Self::set_wait_for_tlb_locks(self, vtl);
+        hardware_cvm::tlb_lock::TlbLockAccess {
+            vp_index: self.vp_index,
+            cvm_partition: &self.shared.cvm,
+        }
+        .set_wait_for_tlb_locks(vtl);
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -528,12 +528,12 @@ impl HardwareIsolatedBacking for TdxBacked {
     }
 
     fn tlb_flush_lock_access<'a>(
-        vp_index: usize,
+        vp_index: VpIndex,
         partition: &'a UhPartitionInner,
         shared: &'a Self::Shared,
     ) -> impl TlbFlushLockAccess + 'a {
         TdxTlbLockFlushAccess {
-            vp_index,
+            vp_index: vp_index.index() as usize,
             partition,
             shared,
         }


### PR DESCRIPTION
This allows us to remove the annoying 'delay-flush' struct I added as a workaround previously. This is needed so we can perform similar types of activities elsewhere without having to use the same delayed workaround, like in https://github.com/microsoft/openvmm/pull/921. 

This did require the removal of `vtls_tlb_waiting` in order to make all the partial borrowing possible, however this field was only being used as a small performance optimization to avoid a relaxed atomic load. Since this load is relaxed, I think this is ok?