### PR TITLE
vmm_tests: Add test for NVMe-backed SCSI DVD scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8627,6 +8627,7 @@ dependencies = [
  "petri_artifacts_vmm_test",
  "scsidisk_resources",
  "storvsp_resources",
+ "tempfile",
  "tracing",
  "unix_socket",
  "vm_resource",

--- a/vmm_tests/vmm_tests/Cargo.toml
+++ b/vmm_tests/vmm_tests/Cargo.toml
@@ -40,6 +40,8 @@ hvlite_ttrpc_vmservice.workspace = true
 
 mesh_rpc.workspace = true
 
+tempfile.workspace = true
+
 [build-dependencies]
 build_rs_guest_arch.workspace = true
 

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -435,7 +435,7 @@ async fn openhcl_linux_storvsp_dvd_nvme(config: PetriVmConfigOpenVmm) -> Result<
     let data_chunk = data_chunk.as_slice();
     let mut bytes = vec![0_u8; disk_len as usize];
     bytes.chunks_exact_mut(64).for_each(|v| {
-        v.copy_from_slice(&data_chunk);
+        v.copy_from_slice(data_chunk);
     });
     backing_file.write_all(&bytes)?;
 

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -7,7 +7,9 @@ use std::fs::File;
 use std::io::Write;
 
 use anyhow::Context;
+use disk_backend_resources::FileDiskHandle;
 use disk_backend_resources::LayeredDiskHandle;
+use disk_backend_resources::layer::DiskLayerHandle;
 use disk_backend_resources::layer::RamDiskLayerHandle;
 use guid::Guid;
 use hvlite_defs::config::DeviceVtl;

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -135,7 +135,8 @@ fn new_test_vtl2_nvme_device(
                 disk: layer.into_resource(),
                 read_only: false,
             }],
-        },
+        }
+        .into_resource(),
     }
 }
 


### PR DESCRIPTION
These tests have a ramdisk-backed NVMe block device translated by OpenHCL into a SCSI DVD device.