### PR TITLE
flowey: update cargo logic to support custom CARGO_TARGET_DIR

### DIFF
--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -1140,6 +1140,16 @@ impl PipelineJob<'_> {
             job_idx: self.job_idx,
         }
     }
+
+    /// Return the job's platform.
+    pub fn get_platform(&self) -> FlowPlatform {
+        self.pipeline.jobs[self.job_idx].platform
+    }
+
+    /// Return the job's architecture.
+    pub fn get_arch(&self) -> FlowArch {
+        self.pipeline.jobs[self.job_idx].arch
+    }
 }
 
 #[derive(Clone)]

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -313,7 +313,25 @@ fn rename_output(
     cargo_out_dir: &Path,
     dry_run: bool,
 ) -> Result<CargoBuildOutput, anyhow::Error> {
-    let do_rename = |ext: &str, no_dash: bool| {
+    fn rename_or_copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> std::io::Result<()> {
+        let res = fs_err::rename(from.as_ref(), to.as_ref());
+
+        let needs_copy = match res {
+            Ok(_) => false,
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::CrossesDevices => true,
+                _ => return Err(e),
+            },
+        };
+
+        if needs_copy {
+            fs_err::copy(from, to)?;
+        }
+
+        Ok(())
+    }
+
+    let do_rename = |ext: &str, no_dash: bool| -> anyhow::Result<_> {
         let file_name = if !no_dash {
             out_name.into()
         } else {
@@ -324,11 +342,12 @@ fn rename_output(
         let rename_path_base = out_dir.join(&file_name);
 
         if !dry_run {
-            fs_err::rename(
+            rename_or_copy(
                 out_path_base.with_extension(ext),
                 rename_path_base.with_extension(ext),
             )?;
         }
+
         anyhow::Ok(rename_path_base.with_extension(ext))
     };
 
@@ -356,7 +375,7 @@ fn rename_output(
             let so = {
                 let rename_path = out_dir.join(format!("lib{out_name}.so"));
                 if !dry_run {
-                    fs_err::rename(
+                    rename_or_copy(
                         cargo_out_dir.join(format!("lib{out_name}.so")),
                         &rename_path,
                     )?;
@@ -376,7 +395,7 @@ fn rename_output(
             let a = {
                 let rename_path = out_dir.join(format!("lib{out_name}.a"));
                 if !dry_run {
-                    fs_err::rename(cargo_out_dir.join(format!("lib{out_name}.a")), &rename_path)?;
+                    rename_or_copy(cargo_out_dir.join(format!("lib{out_name}.a")), &rename_path)?;
                 }
                 rename_path
             };

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -163,16 +163,14 @@ impl FlowNode for Node {
                         if let Ok(dir) = std::env::var("CARGO_TARGET_DIR") {
                             PathBuf::from(dir)
                         } else {
-                            in_folder.join(
-                                Path::new("target")
-                                    .join(target.to_string())
-                                    .join(match profile {
-                                        CargoBuildProfile::Debug => "debug",
-                                        _ => cargo_profile,
-                                    }),
-                            )
+                            in_folder.join("target")
                         }
-                    };
+                    }
+                    .join(target.to_string())
+                    .join(match profile {
+                        CargoBuildProfile::Debug => "debug",
+                        _ => cargo_profile,
+                    });
 
                     // FIXME: this flow is vestigial from a time when this node
                     // would return `CargoBuildCommand` back to the caller.

--- a/flowey/flowey_lib_common/src/run_cargo_doc.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_doc.rs
@@ -259,13 +259,11 @@ impl FlowNode for Node {
                         if let Ok(dir) = std::env::var("CARGO_TARGET_DIR") {
                             PathBuf::from(dir)
                         } else {
-                            in_folder.join(
-                                Path::new("target")
-                                    .join(target_triple.to_string())
-                                    .join("doc"),
-                            )
+                            in_folder.join("target")
                         }
-                    };
+                    }
+                    .join(target_triple.to_string())
+                    .join("doc");
 
                     let cmd = CargoDocCommands {
                         cmds,

--- a/flowey/flowey_lib_common/src/run_cargo_doc.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_doc.rs
@@ -245,14 +245,32 @@ impl FlowNode for Node {
                         cmds.push(v)
                     }
 
+                    let cargo_out_dir = {
+                        // DEVNOTE: this is a _pragmatic_ implementation of this
+                        // logic, and is written with the undersatnding that
+                        // there are undoubtedly many "edge-cases" that may
+                        // result in the final target directory changing.
+                        //
+                        // One possible way to make this handling more robust
+                        // would be to start using `--message-format=json` when
+                        // invoking `cargo`, and then parsing the machine
+                        // readable output in order to obtain the output
+                        // artifact path _after_ the compilation has succeeded.
+                        if let Ok(dir) = std::env::var("CARGO_TARGET_DIR") {
+                            PathBuf::from(dir)
+                        } else {
+                            in_folder.join(
+                                Path::new("target")
+                                    .join(target_triple.to_string())
+                                    .join("doc"),
+                            )
+                        }
+                    };
+
                     let cmd = CargoDocCommands {
                         cmds,
                         cargo_work_dir: in_folder.clone(),
-                        cargo_out_dir: in_folder.join(
-                            Path::new("target")
-                                .join(target_triple.to_string())
-                                .join("doc"),
-                        ),
+                        cargo_out_dir,
                     };
 
                     rt.write(write_doc_cmd, &cmd);


### PR DESCRIPTION
This PR updates the cargo logic in `run_cargo_build.rs` and `run_cargo_doc.rs` to work correctly when a custom CARGO_TARGET_DIR is set.

The build logic is also updated to work correctly even if the target dir is on a different mount from flowey's working folder, by adding a `fs_err::copy`-based fallback path to `fs_err::rename` operations.

Lastly, this PR adds a few helper methods to `PipelineJob`, which are useful when implementing platform-specific policy via APIs like `inject_all_jobs_with`.