### PR TITLE
vmbus_server: don't send synic messages while paused

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2661,6 +2661,8 @@ async fn new_underhill_vm(
             .delay_max_version(delay_max_version)
             .enable_mnf(enable_mnf)
             .force_confidential_external_memory(env_cfg.vmbus_force_confidential_external_memory)
+            // For saved-state compat with release/2411.
+            .send_messages_while_stopped(true)
             .build()
             .context("failed to create vmbus server")?;
 


### PR DESCRIPTION
The synic may be saved or reset while the vmbus server is paused. Don't send any messages during this time, since this can result in torn or corrupt state.

Skip this for vmbus running inside OpenHCL for now, since this relies on the newer saved state field for messages queued by vmbus, and release/2411 won't process that field.