### PR TITLE
vmbus_server: support hvsocket with vmbusproxy.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8182,8 +8182,10 @@ dependencies = [
 name = "vmbus_proxy"
 version = "0.0.0"
 dependencies = [
+ "bitfield-struct",
  "futures",
  "guestmem",
+ "guid",
  "mesh",
  "pal",
  "pal_async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8185,7 +8185,6 @@ dependencies = [
  "bitfield-struct",
  "futures",
  "guestmem",
- "guid",
  "mesh",
  "pal",
  "pal_async",

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1681,8 +1681,10 @@ impl InitializedVm {
                     vmbus_server::ProxyIntegration::start(
                         &vmbus_driver,
                         proxy_handle,
-                        vmbus.control(),
-                        vtl2_vmbus.as_ref().map(|server| server.control().clone()),
+                        vmbus_server::ProxyServerInfo::new(vmbus.control(), None),
+                        vtl2_vmbus.as_ref().map(|server| {
+                            vmbus_server::ProxyServerInfo::new(server.control().clone(), None)
+                        }),
                         Some(&gm),
                     )
                     .await

--- a/vm/devices/vmbus/vmbus_client/src/hvsock.rs
+++ b/vm/devices/vmbus/vmbus_client/src/hvsock.rs
@@ -94,6 +94,7 @@ mod tests {
             service_id: Guid::new_random(),
             endpoint_id: Guid::new_random(),
             silo_id: Guid::new_random(),
+            hosted_silo_unaware: false,
         };
 
         tracker.add_request(Rpc::detached(request));
@@ -136,6 +137,7 @@ mod tests {
             service_id: Guid::new_random(),
             endpoint_id: Guid::new_random(),
             silo_id: Guid::new_random(),
+            hosted_silo_unaware: false,
         };
 
         tracker.add_request(Rpc::detached(request));

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -2675,6 +2675,7 @@ mod tests {
             service_id: Guid::new_random(),
             endpoint_id: Guid::new_random(),
             silo_id: Guid::new_random(),
+            hosted_silo_unaware: false,
         };
 
         let resp = client.access().connect_hvsock(request);

--- a/vm/devices/vmbus/vmbus_core/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_core/src/lib.rs
@@ -201,14 +201,16 @@ pub struct HvsockConnectRequest {
     pub service_id: Guid,
     pub endpoint_id: Guid,
     pub silo_id: Guid,
+    pub hosted_silo_unaware: bool,
 }
 
-impl From<protocol::TlConnectRequest2> for HvsockConnectRequest {
-    fn from(value: protocol::TlConnectRequest2) -> Self {
+impl HvsockConnectRequest {
+    pub fn from_message(value: protocol::TlConnectRequest2, hosted_silo_unaware: bool) -> Self {
         Self {
             service_id: value.base.service_id,
             endpoint_id: value.base.endpoint_id,
             silo_id: value.silo_id,
+            hosted_silo_unaware,
         }
     }
 }

--- a/vm/devices/vmbus/vmbus_proxy/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_proxy/Cargo.toml
@@ -10,11 +10,13 @@ rust-version.workspace = true
 guestmem.workspace = true
 vmbus_core.workspace = true
 
+guid.workspace = true
 mesh.workspace = true
 pal.workspace = true
 pal_event.workspace = true
 pal_async.workspace = true
 
+bitfield-struct.workspace = true
 futures.workspace = true
 tracing.workspace = true
 widestring.workspace = true

--- a/vm/devices/vmbus/vmbus_proxy/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_proxy/Cargo.toml
@@ -9,8 +9,6 @@ rust-version.workspace = true
 [target.'cfg(windows)'.dependencies]
 guestmem.workspace = true
 vmbus_core.workspace = true
-
-guid.workspace = true
 mesh.workspace = true
 pal.workspace = true
 pal_event.workspace = true

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -20,6 +20,8 @@ use std::mem::zeroed;
 use std::os::windows::prelude::*;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
+use vmbus_core::HvsockConnectRequest;
+use vmbus_core::HvsockConnectResult;
 use vmbusioctl::VMBUS_CHANNEL_OFFER;
 use vmbusioctl::VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS;
 use widestring::utf16str;
@@ -95,6 +97,10 @@ pub enum ProxyAction {
         id: u64,
     },
     InterruptPolicy {},
+    TlConnectResult {
+        result: HvsockConnectResult,
+        vtl: u8,
+    },
 }
 
 struct StaticIoctlBuffer<T>(T);
@@ -228,6 +234,16 @@ impl VmbusProxy {
                 id: output.ChannelId,
             }),
             proxyioctl::VmbusProxyActionTypeInterruptPolicy => Ok(ProxyAction::InterruptPolicy {}),
+            proxyioctl::VmbusProxyActionTypeTlConnectResult => unsafe {
+                Ok(ProxyAction::TlConnectResult {
+                    result: HvsockConnectResult {
+                        endpoint_id: output.u.TlConnectResult.EndpointId.into(),
+                        service_id: output.u.TlConnectResult.ServiceId.into(),
+                        success: output.u.TlConnectResult.Status.is_ok(),
+                    },
+                    vtl: output.u.TlConnectResult.Vtl,
+                })
+            },
             n => panic!("unexpected action: {}", n),
         }
     }
@@ -307,6 +323,24 @@ impl VmbusProxy {
                 StaticIoctlBuffer(proxyioctl::VMBUS_PROXY_DELETE_GPADL_INPUT {
                     ChannelId: id,
                     GpadlId: gpadl_id,
+                }),
+                (),
+            )
+            .await
+        }
+    }
+
+    pub async fn tl_connect_request(&self, request: &HvsockConnectRequest, vtl: u8) -> Result<()> {
+        unsafe {
+            self.ioctl(
+                proxyioctl::IOCTL_VMBUS_PROXY_TL_CONNECT_REQUEST,
+                StaticIoctlBuffer(proxyioctl::VMBUS_PROXY_TL_CONNECT_REQUEST_INPUT {
+                    EndpoindId: request.endpoint_id.into(),
+                    ServiceId: request.service_id.into(),
+                    SiloId: request.silo_id.into(),
+                    Flags: proxyioctl::VMBUS_PROXY_TL_CONNECT_REQUEST_FLAGS::new()
+                        .with_hosted_silo_unaware(request.hosted_silo_unaware),
+                    Vtl: vtl,
                 }),
                 (),
             )

--- a/vm/devices/vmbus/vmbus_proxy/src/vmbusioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/vmbusioctl.rs
@@ -9,6 +9,7 @@
     clippy::upper_case_acronyms
 )]
 
+use bitfield_struct::bitfield;
 use vmbus_core::protocol::UserDefinedData;
 use windows::core::GUID;
 
@@ -18,7 +19,7 @@ pub struct VMBUS_CHANNEL_OFFER {
     pub InterfaceType: GUID,
     pub InterfaceInstance: GUID,
     pub InterruptLatencyIn100nsUnits: u64,
-    pub ChannelFlags: u16,
+    pub ChannelFlags: VmbusChannelOfferFlags,
     pub MmioMegabytes: u16,         // in bytes * 1024 * 1024
     pub MmioMegabytesOptional: u16, // mmio memory in addition to MmioMegabytes that is optional
     pub SubChannelIndex: u16,
@@ -27,16 +28,21 @@ pub struct VMBUS_CHANNEL_OFFER {
     pub UserDefined: UserDefinedData,
 }
 
-pub const VMBUS_CHANNEL_ENUMERATE_DEVICE_INTERFACE: u16 = 1;
-pub const VMBUS_CHANNEL_NAMED_PIPE_MODE: u16 = 0x10;
-pub const VMBUS_CHANNEL_LOOPBACK_OFFER: u16 = 0x100;
-pub const VMBUS_CHANNEL_REQUEST_MONITORED_NOTIFICATION: u16 = 0x400;
-pub const VMBUS_CHANNEL_FORCE_NEW_CHANNEL: u16 = 0x1000;
-pub const VMBUS_CHANNEL_TLNPI_PROVIDER_OFFER: u16 = 0x2000;
-
-pub const VMBUS_PIPE_TYPE_BYTE: u32 = 0;
-pub const VMBUS_PIPE_TYPE_MESSAGE: u32 = 4;
-pub const VMBUS_PIPE_TYPE_RAW: u32 = 8;
+#[bitfield(u16)]
+pub struct VmbusChannelOfferFlags {
+    pub enumerate_device_interface: bool, // 0x1
+    #[bits(3)]
+    _reserved1: u16,
+    pub named_pipe_mode: bool, // 0x10
+    #[bits(5)]
+    _reserved2: u16,
+    pub request_monitored_notification: bool, // 0x400
+    pub _reserved3: bool,
+    pub force_new_channel: bool, // 0x1000
+    pub tlnpi_provider: bool,    // 0x2000
+    #[bits(2)]
+    _reserved4: u16,
+}
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -3033,7 +3033,19 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
     /// Handles MessageType::TL_CONNECT_REQUEST, which requests for an hvsocket
     /// connection.
     fn handle_tl_connect_request(&mut self, request: protocol::TlConnectRequest2) {
-        self.notifier.notify_hvsock(&request.into());
+        let version = self
+            .inner
+            .state
+            .get_version()
+            .expect("must be connected")
+            .version;
+
+        let hosted_silo_unaware = version < Version::Win10Rs5;
+        self.notifier
+            .notify_hvsock(&HvsockConnectRequest::from_message(
+                request,
+                hosted_silo_unaware,
+            ));
     }
 
     /// Sends a message to the guest if an hvsocket connect request failed.

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -46,6 +46,8 @@ use pal_async::task::Task;
 use pal_event::Event;
 #[cfg(windows)]
 pub use proxyintegration::ProxyIntegration;
+#[cfg(windows)]
+pub use proxyintegration::ProxyServerInfo;
 use ring::PAGE_SIZE;
 use std::collections::HashMap;
 use std::future;

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -13,8 +13,11 @@ use super::OfferRequest;
 use super::ProxyHandle;
 use super::TaggedStream;
 use super::VmbusServerControl;
+use crate::HvsockRelayChannelHalf;
 use anyhow::Context;
+use futures::future::OptionFuture;
 use futures::stream::SelectAll;
+use futures::FutureExt;
 use futures::StreamExt;
 use guestmem::GuestMemory;
 use mesh::rpc::RpcSend;
@@ -35,9 +38,9 @@ use vmbus_channel::bus::OfferParams;
 use vmbus_channel::bus::OpenRequest;
 use vmbus_channel::bus::OpenResult;
 use vmbus_channel::gpadl::GpadlId;
-use vmbus_proxy::vmbusioctl::VMBUS_CHANNEL_ENUMERATE_DEVICE_INTERFACE;
-use vmbus_proxy::vmbusioctl::VMBUS_CHANNEL_NAMED_PIPE_MODE;
-use vmbus_proxy::vmbusioctl::VMBUS_CHANNEL_REQUEST_MONITORED_NOTIFICATION;
+use vmbus_core::protocol;
+use vmbus_core::HvsockConnectRequest;
+use vmbus_core::HvsockConnectResult;
 use vmbus_proxy::vmbusioctl::VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS;
 use vmbus_proxy::ProxyAction;
 use vmbus_proxy::VmbusProxy;
@@ -45,6 +48,23 @@ use vmcore::interrupt::Interrupt;
 use windows::core::HRESULT;
 use windows::Win32::Foundation::ERROR_CANCELLED;
 use zerocopy::IntoBytes;
+
+pub struct ProxyServerInfo {
+    control: Arc<VmbusServerControl>,
+    hvsock_relay: Option<HvsockRelayChannelHalf>,
+}
+
+impl ProxyServerInfo {
+    pub fn new(
+        control: Arc<VmbusServerControl>,
+        hvsock_relay: Option<HvsockRelayChannelHalf>,
+    ) -> Self {
+        Self {
+            control,
+            hvsock_relay,
+        }
+    }
+}
 
 pub struct ProxyIntegration {
     cancel: Cancel,
@@ -66,8 +86,8 @@ impl ProxyIntegration {
     pub async fn start(
         driver: &(impl SpawnDriver + Clone),
         handle: ProxyHandle,
-        server: Arc<VmbusServerControl>,
-        vtl2_server: Option<Arc<VmbusServerControl>>,
+        server: ProxyServerInfo,
+        vtl2_server: Option<ProxyServerInfo>,
         mem: Option<&GuestMemory>,
     ) -> io::Result<Self> {
         let mut proxy = VmbusProxy::new(driver, handle)?;
@@ -100,12 +120,16 @@ struct ProxyTask {
     proxy: Arc<VmbusProxy>,
     server: Arc<VmbusServerControl>,
     vtl2_server: Option<Arc<VmbusServerControl>>,
+    hvsock_response_send: Option<mesh::Sender<HvsockConnectResult>>,
+    vtl2_hvsock_response_send: Option<mesh::Sender<HvsockConnectResult>>,
 }
 
 impl ProxyTask {
     fn new(
         server: Arc<VmbusServerControl>,
         vtl2_server: Option<Arc<VmbusServerControl>>,
+        hvsock_response_send: Option<mesh::Sender<HvsockConnectResult>>,
+        vtl2_hvsock_response_send: Option<mesh::Sender<HvsockConnectResult>>,
         proxy: Arc<VmbusProxy>,
     ) -> Self {
         Self {
@@ -113,6 +137,8 @@ impl ProxyTask {
             gpadls: Arc::new(Mutex::new(HashMap::new())),
             proxy,
             server,
+            hvsock_response_send,
+            vtl2_hvsock_response_send,
             vtl2_server,
         }
     }
@@ -224,7 +250,7 @@ impl ProxyTask {
             0 => self.server.as_ref(),
             2 => {
                 if let Some(server) = self.vtl2_server.as_ref() {
-                    server
+                    server.as_ref()
                 } else {
                     tracing::error!(?offer, "VTL2 offer without VTL2 server");
                     return None;
@@ -236,11 +262,22 @@ impl ProxyTask {
             }
         };
 
-        let channel_type = if offer.ChannelFlags & VMBUS_CHANNEL_ENUMERATE_DEVICE_INTERFACE != 0 {
-            let pipe_mode = u32::from_ne_bytes(offer.UserDefined[..4].try_into().unwrap());
-            let message_mode = match pipe_mode {
-                vmbus_proxy::vmbusioctl::VMBUS_PIPE_TYPE_BYTE => false,
-                vmbus_proxy::vmbusioctl::VMBUS_PIPE_TYPE_MESSAGE => true,
+        let channel_type = if offer.ChannelFlags.tlnpi_provider() {
+            let params = offer.UserDefined.as_hvsock_params();
+            ChannelType::HvSocket {
+                is_connect: params.is_for_guest_accept != 0,
+                is_for_container: params.is_for_guest_container != 0,
+                silo_id: if params.version.get() == protocol::HvsockParametersVersion::PRE_RS5 {
+                    Guid::ZERO
+                } else {
+                    params.silo_id.get()
+                },
+            }
+        } else if offer.ChannelFlags.enumerate_device_interface() {
+            let params = offer.UserDefined.as_pipe_params();
+            let message_mode = match params.pipe_type {
+                protocol::PipeType::BYTE => false,
+                protocol::PipeType::MESSAGE => true,
                 _ => {
                     tracing::error!(?offer, "unsupported offer pipe mode");
                     return None;
@@ -249,7 +286,7 @@ impl ProxyTask {
             ChannelType::Pipe { message_mode }
         } else {
             ChannelType::Device {
-                pipe_packets: offer.ChannelFlags & VMBUS_CHANNEL_NAMED_PIPE_MODE != 0,
+                pipe_packets: offer.ChannelFlags.named_pipe_mode(),
             }
         };
 
@@ -264,7 +301,7 @@ impl ProxyTask {
             mmio_megabytes_optional: offer.MmioMegabytesOptional,
             subchannel_index: offer.SubChannelIndex,
             channel_type,
-            use_mnf: (offer.ChannelFlags & VMBUS_CHANNEL_REQUEST_MONITORED_NOTIFICATION) != 0,
+            use_mnf: offer.ChannelFlags.request_monitored_notification(),
             offer_order: id.try_into().ok(),
             allow_confidential_external_memory: false,
         };
@@ -327,6 +364,16 @@ impl ProxyTask {
         }
     }
 
+    fn handle_tl_connect_result(&self, result: HvsockConnectResult, vtl: u8) {
+        let send = match vtl {
+            0 => self.hvsock_response_send.as_ref().unwrap(),
+            2 => self.vtl2_hvsock_response_send.as_ref().unwrap(),
+            _ => panic!("unsupported VTL {vtl}"),
+        };
+
+        send.send(result);
+    }
+
     async fn run_offers(
         &self,
         send: mesh::Sender<TaggedStream<u64, mesh::Receiver<ChannelRequest>>>,
@@ -348,6 +395,9 @@ impl ProxyTask {
                     self.handle_revoke(id).await;
                 }
                 ProxyAction::InterruptPolicy {} => {}
+                ProxyAction::TlConnectResult { result, vtl } => {
+                    self.handle_tl_connect_result(result, vtl);
+                }
             }
         }
 
@@ -422,12 +472,34 @@ impl ProxyTask {
         }
     }
 
+    fn handle_hvsock_request(&self, spawner: &impl Spawn, request: HvsockConnectRequest, vtl: u8) {
+        let proxy = self.proxy.clone();
+        spawner
+            .spawn("vmbus-proxy-hvsock-req", async move {
+                proxy.tl_connect_request(&request, vtl).await
+            })
+            .detach();
+    }
+
     async fn run_channel_requests(
         self: &Arc<Self>,
         spawner: impl Spawn,
         mut recv: mesh::Receiver<TaggedStream<u64, mesh::Receiver<ChannelRequest>>>,
+        mut hvsock_request_recv: Option<mesh::Receiver<HvsockConnectRequest>>,
+        mut vtl2_hvsock_request_recv: Option<mesh::Receiver<HvsockConnectRequest>>,
     ) {
         let mut channel_requests = SelectAll::new();
+        let mut hvsock_requests = OptionFuture::from(
+            hvsock_request_recv
+                .as_mut()
+                .map(|recv| Box::pin(recv.recv()).fuse()),
+        );
+
+        let mut vtl2_hvsock_requests = OptionFuture::from(
+            vtl2_hvsock_request_recv
+                .as_mut()
+                .map(|recv| Box::pin(recv.recv()).fuse()),
+        );
 
         'outer: loop {
             let (proxy_id, request) = loop {
@@ -436,6 +508,12 @@ impl ProxyTask {
                         channel_requests.push(r);
                     }
                     r = channel_requests.select_next_some() => break r,
+                    r = hvsock_requests => {
+                        self.handle_hvsock_request(&spawner, r.unwrap().unwrap(), 0);
+                    }
+                    r = vtl2_hvsock_requests => {
+                        self.handle_hvsock_request(&spawner, r.unwrap().unwrap(), 2);
+                    }
                     complete => break 'outer,
                 }
             };
@@ -455,15 +533,42 @@ impl ProxyTask {
 async fn proxy_thread(
     spawner: impl Spawn,
     proxy: VmbusProxy,
-    server: Arc<VmbusServerControl>,
-    vtl2_server: Option<Arc<VmbusServerControl>>,
+    server: ProxyServerInfo,
+    vtl2_server: Option<ProxyServerInfo>,
     mut cancel: CancelContext,
 ) {
+    let (hvsock_request_recv, hvsock_response_send) = server
+        .hvsock_relay
+        .map(|relay| (relay.request_receive, relay.response_send))
+        .unzip();
+
+    let (vtl2_control, vtl2_hvsock_request_recv, vtl2_hvsock_response_send) =
+        if let Some(server) = vtl2_server {
+            let (vtl2_hvsock_request_recv, vtl2_hvsock_response_send) = server
+                .hvsock_relay
+                .map(|relay| (relay.request_receive, relay.response_send))
+                .unzip();
+            (
+                Some(server.control),
+                vtl2_hvsock_request_recv,
+                vtl2_hvsock_response_send,
+            )
+        } else {
+            (None, None, None)
+        };
+
     let (send, recv) = mesh::channel();
     let proxy = Arc::new(proxy);
-    let task = Arc::new(ProxyTask::new(server, vtl2_server, Arc::clone(&proxy)));
+    let task = Arc::new(ProxyTask::new(
+        server.control,
+        vtl2_control,
+        hvsock_response_send,
+        vtl2_hvsock_response_send,
+        Arc::clone(&proxy),
+    ));
     let offers = task.run_offers(send);
-    let requests = task.run_channel_requests(spawner, recv);
+    let requests =
+        task.run_channel_requests(spawner, recv, hvsock_request_recv, vtl2_hvsock_request_recv);
     let cancellation = async {
         cancel.cancelled().await;
         tracing::debug!("proxy thread cancelling");

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -489,20 +489,21 @@ impl ProxyTask {
         mut vtl2_hvsock_request_recv: Option<mesh::Receiver<HvsockConnectRequest>>,
     ) {
         let mut channel_requests = SelectAll::new();
-        let mut hvsock_requests = OptionFuture::from(
-            hvsock_request_recv
-                .as_mut()
-                .map(|recv| Box::pin(recv.recv()).fuse()),
-        );
-
-        let mut vtl2_hvsock_requests = OptionFuture::from(
-            vtl2_hvsock_request_recv
-                .as_mut()
-                .map(|recv| Box::pin(recv.recv()).fuse()),
-        );
 
         'outer: loop {
             let (proxy_id, request) = loop {
+                let mut hvsock_requests = OptionFuture::from(
+                    hvsock_request_recv
+                        .as_mut()
+                        .map(|recv| Box::pin(recv.recv()).fuse()),
+                );
+
+                let mut vtl2_hvsock_requests = OptionFuture::from(
+                    vtl2_hvsock_request_recv
+                        .as_mut()
+                        .map(|recv| Box::pin(recv.recv()).fuse()),
+                );
+
                 futures::select! { // merge semantics
                     r = recv.select_next_some() => {
                         channel_requests.push(r);


### PR DESCRIPTION
This change updates vmbusproxy to correctly handle hvsocket channel offers. It also allows it to pass connection requests from the guest (the `TlConnectRequest` message) to the proxy driver, and for the driver to request a response (`TlConnectRequestResult`) be sent to the guest.

This functionality is not enabled for openvmm, as it is mutually exclusive with openvmm's normal hvsocket handling, and requires vmbusproxy.sys driver updates.