### PR TITLE
[RFC] user_driver: introduce dma map api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4698,6 +4698,7 @@ dependencies = [
  "memory_range",
  "mesh",
  "page_pool_alloc",
+ "tracing",
  "user_driver",
  "virt",
  "vmcore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7473,6 +7473,7 @@ dependencies = [
  "libc",
  "mesh",
  "pal_async",
+ "pal_async_test",
  "pal_event",
  "parking_lot",
  "pci_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4698,6 +4698,8 @@ dependencies = [
  "memory_range",
  "mesh",
  "page_pool_alloc",
+ "pal_async",
+ "pal_async_test",
  "tracing",
  "user_driver",
  "virt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3728,6 +3728,7 @@ name = "lower_vtl_permissions_guard"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "guestmem",
  "hvdef",
  "inspect",
  "user_driver",
@@ -4688,6 +4689,7 @@ name = "openhcl_dma_manager"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "guestmem",
  "hcl",
  "hcl_mapper",
  "hvdef",
@@ -4978,6 +4980,7 @@ name = "page_pool_alloc"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "guestmem",
  "inspect",
  "memory_range",
  "mesh",
@@ -7472,6 +7475,7 @@ dependencies = [
  "pci_core",
  "safeatomic",
  "sparse_mmap",
+ "thiserror 2.0.0",
  "tracing",
  "uevent",
  "vfio-bindings",

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1481,6 +1481,171 @@ impl MshvHvcall {
 
         self.get_vp_register_for_vtl_inner(vtl, name.into())
     }
+
+    fn pin_unpin_gpa_ranges_internal(
+        &self,
+        gpa_ranges: &[HvGpaRange],
+        action: GpaPinUnpinAction,
+    ) -> Result<(), PinUnpinError> {
+        const PIN_REQUEST_HEADER_SIZE: usize =
+            size_of::<hvdef::hypercall::PinUnpinGpaPageRangesHeader>();
+        const MAX_INPUT_ELEMENTS: usize =
+            (HV_PAGE_SIZE as usize - PIN_REQUEST_HEADER_SIZE) / size_of::<u64>();
+
+        let header = hvdef::hypercall::PinUnpinGpaPageRangesHeader { reserved: 0 };
+        let mut ranges_processed = 0;
+
+        for chunk in gpa_ranges.chunks(MAX_INPUT_ELEMENTS) {
+            // SAFETY: This unsafe block is valid because:
+            // 1. The code and header going to match the expected input for the hypercall.
+            //
+            // 2. Hypercall result is checked right after the hypercall is issued.
+            //
+            let output = unsafe {
+                self.hvcall_rep(
+                    match action {
+                        GpaPinUnpinAction::PinGpaRange => HypercallCode::HvCallPinGpaPageRanges,
+                        GpaPinUnpinAction::UnpinGpaRange => HypercallCode::HvCallUnpinGpaPageRanges,
+                    },
+                    &header,
+                    HvcallRepInput::Elements(chunk),
+                    None::<&mut [u8]>,
+                )
+                .expect("submitting pin/unpin hypercall should not fail")
+            };
+
+            ranges_processed += output.elements_processed();
+
+            output.result().map_err(|e| PinUnpinError {
+                ranges_processed,
+                error: e,
+            })?;
+        }
+
+        // At end all the ranges should be processed
+        if ranges_processed == gpa_ranges.len() {
+            Ok(())
+        } else {
+            Err(PinUnpinError {
+                ranges_processed,
+                error: HvError::OperationFailed,
+            })
+        }
+    }
+
+    fn to_hv_gpa_range_array(gpa_memory_ranges: &[MemoryRange]) -> Vec<HvGpaRange> {
+        const PAGES_PER_ENTRY: u64 = 2048;
+        const PAGE_SIZE: u64 = HV_PAGE_SIZE;
+
+        // Estimate the total number of pages across all memory ranges
+        let estimated_size: usize = gpa_memory_ranges
+            .iter()
+            .map(|memory_range| {
+                let total_pages = (memory_range.end() - memory_range.start()).div_ceil(PAGE_SIZE);
+                total_pages.div_ceil(PAGES_PER_ENTRY)
+            })
+            .sum::<u64>() as usize;
+
+        // Create a vector with the estimated size
+        let mut hv_gpa_ranges = Vec::with_capacity(estimated_size);
+
+        for memory_range in gpa_memory_ranges {
+            // Calculate the total number of pages in the memory range
+            let total_pages = (memory_range.end() - memory_range.start()).div_ceil(PAGE_SIZE);
+
+            // Convert start address to page number
+            let start_page = memory_range.start_4k_gpn();
+
+            // Generate the ranges and append them to the vector
+            hv_gpa_ranges.extend(
+                (0..total_pages)
+                    .step_by(PAGES_PER_ENTRY as usize)
+                    .map(|start| {
+                        let end = std::cmp::min(total_pages, start + PAGES_PER_ENTRY);
+                        let pages_in_this_range = end - start;
+                        let gpa_page_number = start_page + start;
+
+                        let extended = HvGpaRangeExtended::new()
+                            .with_additional_pages(pages_in_this_range - 1)
+                            .with_large_page(false) // Assuming not a large page
+                            .with_gpa_page_number(gpa_page_number);
+
+                        HvGpaRange(extended.into_bits())
+                    }),
+            );
+        }
+
+        hv_gpa_ranges // Return the vector at the end
+    }
+
+    // TODO: this function allocates via `to_hv_gpa_range_array`. Remove this
+    // allocation by having a fixed size internal buffer of the max allowable
+    // hypercall rep list size, and chunk/convert on the fly.
+    fn perform_pin_unpin_gpa_ranges(
+        &self,
+        gpa_ranges: &[MemoryRange],
+        action: GpaPinUnpinAction,
+        rollback_action: GpaPinUnpinAction,
+    ) -> Result<(), HvError> {
+        let hv_gpa_ranges: Vec<HvGpaRange> = Self::to_hv_gpa_range_array(gpa_ranges);
+
+        // Attempt to pin/unpin the ranges
+        match self.pin_unpin_gpa_ranges_internal(&hv_gpa_ranges, action) {
+            Ok(_) => Ok(()),
+            Err(PinUnpinError {
+                error,
+                ranges_processed,
+            }) => {
+                // Unpin the ranges that were successfully pinned
+                let pinned_ranges = &hv_gpa_ranges[..ranges_processed];
+                if let Err(rollback_error) =
+                    self.pin_unpin_gpa_ranges_internal(pinned_ranges, rollback_action)
+                {
+                    // Panic if rollback is failing
+                    panic!(
+                        "Failed to perform action {:?} on ranges. Error : {:?}. \
+                        Attempted to rollback {:?} ranges out of {:?}.\n rollback error: {:?}",
+                        action,
+                        error,
+                        ranges_processed,
+                        gpa_ranges.len(),
+                        rollback_error
+                    );
+                }
+                // Surface the original error
+                Err(error)
+            }
+        }
+    }
+
+    /// Pins the specified guest physical address ranges in the hypervisor.
+    /// The memory ranges passed to this function must be VA backed memory.
+    /// If a partial failure occurs (i.e., some but not all the ranges were successfully pinned),
+    /// the function will automatically attempt to unpin any successfully pinned ranges.
+    /// This "rollback" behavior ensures that no partially pinned state remains, which
+    /// could otherwise lead to inconsistencies.
+    ///
+    pub fn pin_gpa_ranges(&self, ranges: &[MemoryRange]) -> Result<(), HvError> {
+        self.perform_pin_unpin_gpa_ranges(
+            ranges,
+            GpaPinUnpinAction::PinGpaRange,
+            GpaPinUnpinAction::UnpinGpaRange,
+        )
+    }
+
+    /// Unpins the specified guest physical address ranges in the hypervisor.
+    /// The memory ranges passed to this function must be VA backed memory.
+    /// If a partial failure occurs (i.e., some but not all the ranges were successfully unpinned),
+    /// the function will automatically attempt to pin any successfully unpinned ranges. This "rollback"
+    /// behavior ensures that no partially unpinned state remains, which could otherwise lead to inconsistencies.
+    ///
+    pub fn unpin_gpa_ranges(&self, ranges: &[MemoryRange]) -> Result<(), HvError> {
+        self.perform_pin_unpin_gpa_ranges(
+            ranges,
+            GpaPinUnpinAction::UnpinGpaRange,
+            GpaPinUnpinAction::PinGpaRange,
+        )
+    }
 }
 
 /// The HCL device and collection of fds.
@@ -2628,171 +2793,6 @@ impl Hcl {
             })),
             x => Ok(Err(aarch64::TranslateErrorAarch64 { code: x })),
         }
-    }
-
-    fn to_hv_gpa_range_array(gpa_memory_ranges: &[MemoryRange]) -> Vec<HvGpaRange> {
-        const PAGES_PER_ENTRY: u64 = 2048;
-        const PAGE_SIZE: u64 = HV_PAGE_SIZE;
-
-        // Estimate the total number of pages across all memory ranges
-        let estimated_size: usize = gpa_memory_ranges
-            .iter()
-            .map(|memory_range| {
-                let total_pages = (memory_range.end() - memory_range.start()).div_ceil(PAGE_SIZE);
-                total_pages.div_ceil(PAGES_PER_ENTRY)
-            })
-            .sum::<u64>() as usize;
-
-        // Create a vector with the estimated size
-        let mut hv_gpa_ranges = Vec::with_capacity(estimated_size);
-
-        for memory_range in gpa_memory_ranges {
-            // Calculate the total number of pages in the memory range
-            let total_pages = (memory_range.end() - memory_range.start()).div_ceil(PAGE_SIZE);
-
-            // Convert start address to page number
-            let start_page = memory_range.start_4k_gpn();
-
-            // Generate the ranges and append them to the vector
-            hv_gpa_ranges.extend(
-                (0..total_pages)
-                    .step_by(PAGES_PER_ENTRY as usize)
-                    .map(|start| {
-                        let end = std::cmp::min(total_pages, start + PAGES_PER_ENTRY);
-                        let pages_in_this_range = end - start;
-                        let gpa_page_number = start_page + start;
-
-                        let extended = HvGpaRangeExtended::new()
-                            .with_additional_pages(pages_in_this_range - 1)
-                            .with_large_page(false) // Assuming not a large page
-                            .with_gpa_page_number(gpa_page_number);
-
-                        HvGpaRange(extended.into_bits())
-                    }),
-            );
-        }
-
-        hv_gpa_ranges // Return the vector at the end
-    }
-
-    fn pin_unpin_gpa_ranges_internal(
-        &self,
-        gpa_ranges: &[HvGpaRange],
-        action: GpaPinUnpinAction,
-    ) -> Result<(), PinUnpinError> {
-        const PIN_REQUEST_HEADER_SIZE: usize =
-            size_of::<hvdef::hypercall::PinUnpinGpaPageRangesHeader>();
-        const MAX_INPUT_ELEMENTS: usize =
-            (HV_PAGE_SIZE as usize - PIN_REQUEST_HEADER_SIZE) / size_of::<u64>();
-
-        let header = hvdef::hypercall::PinUnpinGpaPageRangesHeader { reserved: 0 };
-        let mut ranges_processed = 0;
-
-        for chunk in gpa_ranges.chunks(MAX_INPUT_ELEMENTS) {
-            // SAFETY: This unsafe block is valid because:
-            // 1. The code and header going to match the expected input for the hypercall.
-            //
-            // 2. Hypercall result is checked right after the hypercall is issued.
-            //
-            let output = unsafe {
-                self.mshv_hvcall
-                    .hvcall_rep(
-                        match action {
-                            GpaPinUnpinAction::PinGpaRange => HypercallCode::HvCallPinGpaPageRanges,
-                            GpaPinUnpinAction::UnpinGpaRange => {
-                                HypercallCode::HvCallUnpinGpaPageRanges
-                            }
-                        },
-                        &header,
-                        HvcallRepInput::Elements(chunk),
-                        None::<&mut [u8]>,
-                    )
-                    .expect("submitting pin/unpin hypercall should not fail")
-            };
-
-            ranges_processed += output.elements_processed();
-
-            output.result().map_err(|e| PinUnpinError {
-                ranges_processed,
-                error: e,
-            })?;
-        }
-
-        // At end all the ranges should be processed
-        if ranges_processed == gpa_ranges.len() {
-            Ok(())
-        } else {
-            Err(PinUnpinError {
-                ranges_processed,
-                error: HvError::OperationFailed,
-            })
-        }
-    }
-
-    fn perform_pin_unpin_gpa_ranges(
-        &self,
-        gpa_ranges: &[MemoryRange],
-        action: GpaPinUnpinAction,
-        rollback_action: GpaPinUnpinAction,
-    ) -> Result<(), HvError> {
-        let hv_gpa_ranges: Vec<HvGpaRange> = Self::to_hv_gpa_range_array(gpa_ranges);
-
-        // Attempt to pin/unpin the ranges
-        match self.pin_unpin_gpa_ranges_internal(&hv_gpa_ranges, action) {
-            Ok(_) => Ok(()),
-            Err(PinUnpinError {
-                error,
-                ranges_processed,
-            }) => {
-                // Unpin the ranges that were successfully pinned
-                let pinned_ranges = &hv_gpa_ranges[..ranges_processed];
-                if let Err(rollback_error) =
-                    self.pin_unpin_gpa_ranges_internal(pinned_ranges, rollback_action)
-                {
-                    // Panic if rollback is failing
-                    panic!(
-                        "Failed to perform action {:?} on ranges. Error : {:?}. \
-                        Attempted to rollback {:?} ranges out of {:?}.\n rollback error: {:?}",
-                        action,
-                        error,
-                        ranges_processed,
-                        gpa_ranges.len(),
-                        rollback_error
-                    );
-                }
-                // Surface the original error
-                Err(error)
-            }
-        }
-    }
-
-    /// Pins the specified guest physical address ranges in the hypervisor.
-    /// The memory ranges passed to this function must be VA backed memory.
-    /// If a partial failure occurs (i.e., some but not all the ranges were successfully pinned),
-    /// the function will automatically attempt to unpin any successfully pinned ranges.
-    /// This "rollback" behavior ensures that no partially pinned state remains, which
-    /// could otherwise lead to inconsistencies.
-    ///
-    pub fn pin_gpa_ranges(&self, ranges: &[MemoryRange]) -> Result<(), HvError> {
-        self.perform_pin_unpin_gpa_ranges(
-            ranges,
-            GpaPinUnpinAction::PinGpaRange,
-            GpaPinUnpinAction::UnpinGpaRange,
-        )
-    }
-
-    /// Unpins the specified guest physical address ranges in the hypervisor.
-    /// The memory ranges passed to this function must be VA backed memory.
-    /// If a partial failure occurs (i.e., some but not all the ranges were successfully unpinned),
-    /// the function will automatically attempt to pin any successfully unpinned ranges. This "rollback"
-    /// behavior ensures that no partially unpinned state remains, which could otherwise lead to inconsistencies.
-    ///
-    pub fn unpin_gpa_ranges(&self, ranges: &[MemoryRange]) -> Result<(), HvError> {
-        self.perform_pin_unpin_gpa_ranges(
-            ranges,
-            GpaPinUnpinAction::UnpinGpaRange,
-            GpaPinUnpinAction::PinGpaRange,
-        )
     }
 
     /// Read the vsm capabilities register for VTL2.

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -74,7 +74,6 @@ use std::os::unix::prelude::*;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 use std::sync::Once;
 use thiserror::Error;
 use user_driver::memory::MemoryBlock;
@@ -1728,7 +1727,7 @@ impl HclVp {
         vp: u32,
         map_reg_page: bool,
         isolation_type: IsolationType,
-        private_dma_client: Option<&Arc<dyn DmaClient>>,
+        private_dma_client: Option<&DmaClient>,
     ) -> Result<Self, Error> {
         let fd = &hcl.mshv_vtl.file;
         let run: MappedPage<hcl_run> =
@@ -2392,7 +2391,7 @@ impl Hcl {
     pub fn add_vps(
         &mut self,
         vp_count: u32,
-        private_pool: Option<&Arc<dyn DmaClient>>,
+        private_pool: Option<&DmaClient>,
     ) -> Result<(), Error> {
         self.vps = (0..vp_count)
             .map(|vp| {

--- a/openhcl/lower_vtl_permissions_guard/Cargo.toml
+++ b/openhcl/lower_vtl_permissions_guard/Cargo.toml
@@ -7,10 +7,12 @@ edition.workspace = true
 rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+guestmem.workspace = true
 hvdef.workspace = true
 inspect.workspace = true
 user_driver.workspace = true
 virt.workspace = true
+
 
 anyhow.workspace = true
 

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -113,28 +113,32 @@ impl<T: DmaClient> DmaClient for LowerVtlMemorySpawner<T> {
         anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
     }
 
-    fn unmap_dma_ranges(
-        &self,
-        _transaction: user_driver::DmaTransaction<'_>,
-    ) -> std::result::Result<(), user_driver::MapDmaError> {
-        todo!()
+    fn requires_dma_mapping(&self) -> bool {
+        false
     }
 
     fn map_dma_ranges<'a, 'b: 'a>(
         &'a self,
         _guest_memory: &'a GuestMemory,
-        _ranges: PagedRange<'b>,
+        _range: PagedRange<'b>,
         _options: user_driver::MapDmaOptions,
     ) -> std::pin::Pin<
         Box<
             dyn std::prelude::rust_2024::Future<
                     Output = std::result::Result<
-                        user_driver::DmaTransaction<'a>,
+                        Box<dyn user_driver::MappedDmaTransaction + 'a>,
                         user_driver::MapDmaError,
                     >,
                 > + 'a,
         >,
     > {
+        todo!()
+    }
+
+    fn unmap_dma_ranges(
+        &self,
+        _transaction: Box<dyn user_driver::MappedDmaTransaction + '_>,
+    ) -> std::result::Result<(), user_driver::MapDmaError> {
         todo!()
     }
 }

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -14,6 +14,8 @@ pub use device_dma::LowerVtlDmaBuffer;
 
 use anyhow::Context;
 use anyhow::Result;
+use guestmem::ranges::PagedRange;
+use guestmem::GuestMemory;
 use inspect::Inspect;
 use std::sync::Arc;
 use user_driver::memory::MemoryBlock;
@@ -109,5 +111,28 @@ impl<T: DmaClient> DmaClient for LowerVtlMemorySpawner<T> {
 
     fn attach_dma_buffer(&self, _len: usize, _base_pfn: u64) -> Result<MemoryBlock> {
         anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
+    }
+
+    fn unmap_dma_ranges(
+        &self,
+        transaction: user_driver::DmaTransaction<'_>,
+    ) -> std::result::Result<(), user_driver::MapDmaError> {
+        todo!()
+    }
+
+    fn map_dma_ranges<'a, 'b: 'a>(
+        &'a self,
+        guest_memory: &'a GuestMemory,
+        ranges: PagedRange<'b>,
+        options: user_driver::MapDmaOptions,
+    ) -> Box<
+        dyn std::prelude::rust_2024::Future<
+                Output = std::result::Result<
+                    user_driver::DmaTransaction<'a>,
+                    user_driver::MapDmaError,
+                >,
+            > + 'a,
+    > {
+        todo!()
     }
 }

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -125,13 +125,15 @@ impl<T: DmaClient> DmaClient for LowerVtlMemorySpawner<T> {
         guest_memory: &'a GuestMemory,
         ranges: PagedRange<'b>,
         options: user_driver::MapDmaOptions,
-    ) -> Box<
-        dyn std::prelude::rust_2024::Future<
-                Output = std::result::Result<
-                    user_driver::DmaTransaction<'a>,
-                    user_driver::MapDmaError,
-                >,
-            > + 'a,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::prelude::rust_2024::Future<
+                    Output = std::result::Result<
+                        user_driver::DmaTransaction<'a>,
+                        user_driver::MapDmaError,
+                    >,
+                > + 'a,
+        >,
     > {
         todo!()
     }

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -115,16 +115,16 @@ impl<T: DmaClient> DmaClient for LowerVtlMemorySpawner<T> {
 
     fn unmap_dma_ranges(
         &self,
-        transaction: user_driver::DmaTransaction<'_>,
+        _transaction: user_driver::DmaTransaction<'_>,
     ) -> std::result::Result<(), user_driver::MapDmaError> {
         todo!()
     }
 
     fn map_dma_ranges<'a, 'b: 'a>(
         &'a self,
-        guest_memory: &'a GuestMemory,
-        ranges: PagedRange<'b>,
-        options: user_driver::MapDmaOptions,
+        _guest_memory: &'a GuestMemory,
+        _ranges: PagedRange<'b>,
+        _options: user_driver::MapDmaOptions,
     ) -> std::pin::Pin<
         Box<
             dyn std::prelude::rust_2024::Future<

--- a/openhcl/openhcl_dma_manager/Cargo.toml
+++ b/openhcl/openhcl_dma_manager/Cargo.toml
@@ -11,6 +11,7 @@ hcl.workspace = true
 hcl_mapper.workspace = true
 lower_vtl_permissions_guard.workspace = true
 
+guestmem.workspace = true
 hvdef.workspace = true
 inspect.workspace = true
 memory_range.workspace = true

--- a/openhcl/openhcl_dma_manager/Cargo.toml
+++ b/openhcl/openhcl_dma_manager/Cargo.toml
@@ -24,5 +24,9 @@ vmcore.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+pal_async.workspace = true
+pal_async_test.workspace = true
+
 [lints]
 workspace = true

--- a/openhcl/openhcl_dma_manager/Cargo.toml
+++ b/openhcl/openhcl_dma_manager/Cargo.toml
@@ -22,6 +22,7 @@ virt.workspace = true
 vmcore.workspace = true
 
 anyhow.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/openhcl/openhcl_dma_manager/src/lib.rs
+++ b/openhcl/openhcl_dma_manager/src/lib.rs
@@ -222,18 +222,40 @@ impl PinPages {
 
     /// Check if all the pages are pinned.
     fn is_pinned(&self, pfns: &[u64]) -> bool {
-        true
+        pfns[0] > 100
     }
 
     /// returns true if successful pin, false otherwise
     #[must_use]
     fn pin_pages(&self, pfns: &[u64]) -> bool {
         // TODO: impl
-        true
+
+        tracing::error!(?pfns, "pinning pfns");
+
+        // TODO: What happens if some pages are already physically backed and
+        // some are VA backed? is that valid?
+
+        // TODO: change mshvcall methods to not require memory ranges?
+        // TODO: allocates...
+        let ranges = pfns
+            .iter()
+            .map(|pfn| MemoryRange::from_4k_gpn_range(*pfn..*pfn + 1))
+            .collect::<Vec<_>>();
+        self.mshv_hvcall.pin_gpa_ranges(&ranges).is_ok()
     }
 
     fn unpin_pages(&self, pfns: &[u64]) {
-        // TODO: impl
+        tracing::error!(?pfns, "unpinning pfns");
+
+        // TODO: change mshvcall methods to not require memory ranges?
+        // TODO: allocates...
+        let ranges = pfns
+            .iter()
+            .map(|pfn| MemoryRange::from_4k_gpn_range(*pfn..*pfn + 1))
+            .collect::<Vec<_>>();
+        self.mshv_hvcall
+            .unpin_gpa_ranges(&ranges)
+            .expect("unpin cannot fail");
     }
 }
 

--- a/openhcl/openhcl_dma_manager/src/lib.rs
+++ b/openhcl/openhcl_dma_manager/src/lib.rs
@@ -709,7 +709,9 @@ impl OpenhclDmaClient {
             .ok_or(MapDmaError::NoBounceBufferAvailable)?
             .alloc_pages(range.gpns().len())
             .await
-            .expect("BUGBUG more bouncing required than pages available");
+            .ok_or(MapDmaError::NotEnoughBounceBufferSpace {
+                range_bytes: range.len(),
+            })?;
 
         // copy to bounced pages
         if options.is_tx {

--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -65,7 +65,7 @@ async fn create_mana_device(
     pci_id: &str,
     vp_count: u32,
     max_sub_channels: u16,
-    dma_client: Arc<dyn DmaClient>,
+    dma_client: DmaClient,
 ) -> anyhow::Result<ManaDevice<VfioDevice>> {
     // Disable FLR on vfio attach/detach; this allows faster system
     // startup/shutdown with the caveat that the device needs to be properly
@@ -118,7 +118,7 @@ async fn try_create_mana_device(
     pci_id: &str,
     vp_count: u32,
     max_sub_channels: u16,
-    dma_client: Arc<dyn DmaClient>,
+    dma_client: DmaClient,
 ) -> anyhow::Result<ManaDevice<VfioDevice>> {
     let device = VfioDevice::new(driver_source, pci_id, dma_client)
         .await
@@ -201,8 +201,7 @@ struct HclNetworkVFManagerWorker {
     vtl2_pci_id: String,
     #[inspect(skip)]
     dma_mode: GuestDmaMode,
-    #[inspect(skip)]
-    dma_client: Arc<dyn DmaClient>,
+    dma_client: DmaClient,
 }
 
 impl HclNetworkVFManagerWorker {
@@ -218,7 +217,7 @@ impl HclNetworkVFManagerWorker {
         vp_count: u32,
         max_sub_channels: u16,
         dma_mode: GuestDmaMode,
-        dma_client: Arc<dyn DmaClient>,
+        dma_client: DmaClient,
     ) -> (Self, mesh::Sender<HclNetworkVfManagerMessage>) {
         let (tx_to_worker, worker_rx) = mesh::channel();
         let vtl0_bus_control = if save_state.hidden_vtl0.lock().unwrap_or(false) {
@@ -867,7 +866,7 @@ impl HclNetworkVFManager {
         max_sub_channels: u16,
         netvsp_state: &Option<Vec<SavedState>>,
         dma_mode: GuestDmaMode,
-        dma_client: Arc<dyn DmaClient>,
+        dma_client: DmaClient,
     ) -> anyhow::Result<(
         Self,
         Vec<HclNetworkVFManagerEndpointInfo>,

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -317,6 +317,7 @@ async fn launch_workers(
         hide_isolation: opt.hide_isolation,
         nvme_keep_alive: opt.nvme_keep_alive,
         test_configuration: opt.test_configuration,
+        pin_dma_ranges: opt.pin_dma_ranges,
     };
 
     let (mut remote_console_cfg, framebuffer_access) =

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -305,6 +305,7 @@ impl NvmeManagerWorker {
                             AllocationVisibility::Private
                         },
                         persistent_allocations: self.save_restore_supported,
+                        bounce_buffer_pages: None,
                     })
                     .map_err(InnerError::DmaClient)?;
 
@@ -374,6 +375,7 @@ impl NvmeManagerWorker {
                     AllocationVisibility::Private
                 },
                 persistent_allocations: true,
+                bounce_buffer_pages: None,
             })?;
 
             // This code can wait on each VFIO device until it is arrived.

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -140,6 +140,9 @@ pub struct Options {
     /// Test configurations are designed to replicate specific behaviors and
     /// conditions in order to simulate various test scenarios.
     pub test_configuration: Option<TestScenarioConfig>,
+
+    /// (OPENHCL_PIN_DMA_RANGES=1) Enable pinning of DMA ranges.
+    pub pin_dma_ranges: bool,
 }
 
 impl Options {
@@ -238,6 +241,7 @@ impl Options {
                 })
                 .ok()
         });
+        let pin_dma_ranges = parse_env_bool("OPENHCL_PIN_DMA_RANGES");
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.
@@ -292,6 +296,7 @@ impl Options {
             no_sidecar_hotplug,
             nvme_keep_alive,
             test_configuration,
+            pin_dma_ranges,
         })
     }
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2936,6 +2936,7 @@ async fn new_underhill_vm(
         .validate_restore()
         .context("failed to validate restore for dma manager")?;
 
+    // BUGBUG: remove, only for testing dma mapping
     {
         use guestmem::MemoryRead;
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -127,6 +127,7 @@ use underhill_attestation::AttestationType;
 use underhill_threadpool::AffinitizedThreadpool;
 use underhill_threadpool::ThreadpoolBuilder;
 use user_driver::DmaClient;
+use user_driver::DmaOperation;
 use user_driver::MapDmaOptions;
 use virt::state::HvRegisterState;
 use virt::Partition;
@@ -2981,7 +2982,9 @@ async fn new_underhill_vm(
         buffer[hvdef::HV_PAGE_SIZE_USIZE * 3 - 1] = 42;
 
         // do "dma"
-        transaction.bounced_pages.as_ref().unwrap().write(&buffer);
+        if let DmaOperation::Bounced(bounced, _ranges) = &transaction.operation {
+            bounced.write(&buffer);
+        }
 
         client
             .unmap_dma_ranges(transaction)

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2981,11 +2981,7 @@ async fn new_underhill_vm(
         buffer[hvdef::HV_PAGE_SIZE_USIZE * 3 - 1] = 42;
 
         // do "dma"
-        let dma_ranges = PagedRange::new(0, hvdef::HV_PAGE_SIZE_USIZE * 5, &bounced_pfns).unwrap();
-        dma_ranges
-            .writer(gm.vtl0())
-            .write(&buffer)
-            .context("fake dma")?;
+        transaction.bounced_pages.as_ref().unwrap().write(&buffer);
 
         client
             .unmap_dma_ranges(transaction)

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -227,8 +227,8 @@ struct UhPartitionInner {
     guest_vsm: RwLock<GuestVsmState>,
     #[inspect(skip)]
     isolated_memory_protector: Option<Arc<dyn ProtectIsolatedMemory>>,
-    shared_dma_client: Option<Arc<dyn DmaClient>>,
-    private_dma_client: Option<Arc<dyn DmaClient>>,
+    shared_dma_client: Option<DmaClient>,
+    private_dma_client: Option<DmaClient>,
     #[inspect(with = "inspect::AtomicMut")]
     no_sidecar_hotplug: AtomicBool,
     use_mmio_hypercalls: bool,
@@ -1312,9 +1312,9 @@ pub struct UhLateParams<'a> {
     /// An object to call to change host visibility on guest memory.
     pub isolated_memory_protector: Option<Arc<dyn ProtectIsolatedMemory>>,
     /// Dma client for shared visibility pages.
-    pub shared_dma_client: Option<Arc<dyn DmaClient>>,
+    pub shared_dma_client: Option<DmaClient>,
     /// Allocator for private visibility pages.
-    pub private_dma_client: Option<Arc<dyn DmaClient>>,
+    pub private_dma_client: Option<DmaClient>,
 }
 
 /// Trait for CVM-related protections on guest memory.

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -373,7 +373,7 @@ impl GuestEmulationTransportClient {
     /// TODO: This isn't a VfioDevice, but the VfioDmaBuffer is a convienent
     /// trait to use for wrapping the PFN allocations. Refactor this in the
     /// future once a central DMA API is made.
-    pub fn set_gpa_allocator(&mut self, gpa_allocator: Arc<dyn DmaClient>) {
+    pub fn set_gpa_allocator(&mut self, gpa_allocator: DmaClient) {
         self.control
             .notify(msg::Msg::SetGpaAllocator(gpa_allocator));
     }

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -149,7 +149,6 @@ pub(crate) mod msg {
     use chipset_resources::battery::HostBatteryUpdate;
     use guid::Guid;
     use mesh::rpc::Rpc;
-    use std::sync::Arc;
     use user_driver::DmaClient;
     use vpci::bus_control::VpciBusEvent;
 
@@ -180,7 +179,7 @@ pub(crate) mod msg {
         /// Inspect the state of the process loop.
         Inspect(inspect::Deferred),
         /// Store the gpa allocator to be used for attestation.
-        SetGpaAllocator(Arc<dyn DmaClient>),
+        SetGpaAllocator(DmaClient),
 
         // Late bound receivers for Guest Notifications
         /// Take the late-bound GuestRequest receiver for Generation Id updates.
@@ -482,7 +481,7 @@ pub(crate) struct ProcessLoop<T: RingMem> {
     igvm_attest_requests: VecDeque<Pin<Box<dyn Future<Output = Result<(), FatalError>> + Send>>>,
     #[inspect(skip)]
     igvm_attest_read_send: mesh::Sender<Vec<u8>>,
-    gpa_allocator: Option<Arc<dyn DmaClient>>,
+    gpa_allocator: Option<DmaClient>,
     stats: Stats,
 
     guest_notification_listeners: GuestNotificationListeners,
@@ -1830,7 +1829,7 @@ async fn request_saved_state(
 async fn request_igvm_attest(
     mut access: HostRequestPipeAccess,
     request: msg::IgvmAttestRequestData,
-    gpa_allocator: Option<Arc<dyn DmaClient>>,
+    gpa_allocator: Option<DmaClient>,
 ) -> Result<Result<Vec<u8>, IgvmAttestError>, FatalError> {
     let allocator = gpa_allocator.ok_or(FatalError::GpaAllocatorUnavailable)?;
     let dma_size = request.response_buffer_len;

--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -34,7 +34,7 @@ use user_driver::interrupt::DeviceInterrupt;
 use user_driver::memory::MemoryBlock;
 use user_driver::memory::PAGE_SIZE;
 use user_driver::DeviceBacking;
-use user_driver::DmaClient;
+use user_driver::DmaClientDriver;
 use vmcore::vm_task::VmTaskDriverSource;
 
 enum LinkStatus {
@@ -535,8 +535,8 @@ impl<T: DeviceBacking> Vport<T> {
     }
 
     /// Returns an object that can allocate dma memory to be shared with the device.
-    pub async fn dma_client(&self) -> Arc<dyn DmaClient> {
-        self.inner.gdma.lock().await.device().dma_client()
+    pub async fn dma_client(&self) -> DmaClientDriver {
+        self.inner.gdma.lock().await.device().dma_client().clone()
     }
 }
 

--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -34,7 +34,7 @@ use user_driver::interrupt::DeviceInterrupt;
 use user_driver::memory::MemoryBlock;
 use user_driver::memory::PAGE_SIZE;
 use user_driver::DeviceBacking;
-use user_driver::DmaClientDriver;
+use user_driver::DmaClient;
 use vmcore::vm_task::VmTaskDriverSource;
 
 enum LinkStatus {
@@ -535,7 +535,7 @@ impl<T: DeviceBacking> Vport<T> {
     }
 
     /// Returns an object that can allocate dma memory to be shared with the device.
-    pub async fn dma_client(&self) -> DmaClientDriver {
+    pub async fn dma_client(&self) -> DmaClient {
         self.inner.gdma.lock().await.device().dma_client().clone()
     }
 }

--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -61,7 +61,7 @@ use user_driver::memory::MemoryBlock;
 use user_driver::memory::PAGE_SIZE32;
 use user_driver::memory::PAGE_SIZE64;
 use user_driver::DeviceBacking;
-use user_driver::DmaClientDriver;
+use user_driver::DmaClient;
 use vmcore::slim_event::SlimEvent;
 use zerocopy::FromBytes;
 use zerocopy::FromZeros;
@@ -1221,7 +1221,7 @@ struct ContiguousBufferManager {
 struct OutOfMemory;
 
 impl ContiguousBufferManager {
-    pub fn new(dma_client: DmaClientDriver, page_limit: u32) -> anyhow::Result<Self> {
+    pub fn new(dma_client: DmaClient, page_limit: u32) -> anyhow::Result<Self> {
         let len = PAGE_SIZE32 * page_limit;
         let mem = dma_client.allocate_dma_buffer(len as usize)?;
         Ok(Self {

--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -61,7 +61,7 @@ use user_driver::memory::MemoryBlock;
 use user_driver::memory::PAGE_SIZE32;
 use user_driver::memory::PAGE_SIZE64;
 use user_driver::DeviceBacking;
-use user_driver::DmaClient;
+use user_driver::DmaClientDriver;
 use vmcore::slim_event::SlimEvent;
 use zerocopy::FromBytes;
 use zerocopy::FromZeros;
@@ -1221,7 +1221,7 @@ struct ContiguousBufferManager {
 struct OutOfMemory;
 
 impl ContiguousBufferManager {
-    pub fn new(dma_client: Arc<dyn DmaClient>, page_limit: u32) -> anyhow::Result<Self> {
+    pub fn new(dma_client: DmaClientDriver, page_limit: u32) -> anyhow::Result<Self> {
         let len = PAGE_SIZE32 * page_limit;
         let mem = dma_client.allocate_dma_buffer(len as usize)?;
         Ok(Self {

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_emulated_device.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_emulated_device.rs
@@ -18,7 +18,7 @@ use user_driver::emulated::EmulatedDevice;
 use user_driver::emulated::Mapping;
 use user_driver::interrupt::DeviceInterrupt;
 use user_driver::DeviceBacking;
-use user_driver::DmaClientDriver;
+use user_driver::DmaClient;
 
 /// An EmulatedDevice fuzzer that requires a working EmulatedDevice backend.
 #[derive(Inspect)]
@@ -47,7 +47,7 @@ impl<T: 'static + Send + InspectMut + MmioIntercept> DeviceBacking for FuzzEmula
         self.device.map_bar(n)
     }
 
-    fn dma_client(&self) -> &DmaClientDriver {
+    fn dma_client(&self) -> &DmaClient {
         self.device.dma_client()
     }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_emulated_device.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_emulated_device.rs
@@ -5,7 +5,6 @@
 //! This is the primary fuzzer for the host (a.k.a device) ->
 //! openhcl attack surface. Do not sanitize any arbitrary data
 //! responses in this routine.
-use std::sync::Arc;
 
 use crate::arbitrary_data;
 
@@ -19,7 +18,7 @@ use user_driver::emulated::EmulatedDevice;
 use user_driver::emulated::Mapping;
 use user_driver::interrupt::DeviceInterrupt;
 use user_driver::DeviceBacking;
-use user_driver::DmaClient;
+use user_driver::DmaClientDriver;
 
 /// An EmulatedDevice fuzzer that requires a working EmulatedDevice backend.
 #[derive(Inspect)]
@@ -48,7 +47,7 @@ impl<T: 'static + Send + InspectMut + MmioIntercept> DeviceBacking for FuzzEmula
         self.device.map_bar(n)
     }
 
-    fn dma_client(&self) -> Arc<dyn DmaClient> {
+    fn dma_client(&self) -> &DmaClientDriver {
         self.device.dma_client()
     }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -593,8 +593,6 @@ impl<T: DeviceBacking> NvmeDriver<T> {
             .map_interrupt(0, 0)
             .context("failed to map interrupt 0")?;
 
-        let dma_client = worker.device.dma_client();
-
         // Restore the admin queue pair.
         let admin = saved_state
             .worker_data
@@ -602,7 +600,9 @@ impl<T: DeviceBacking> NvmeDriver<T> {
             .as_ref()
             .map(|a| {
                 // Restore memory block for admin queue pair.
-                let mem_block = dma_client
+                let mem_block = worker
+                    .device
+                    .dma_client()
                     .attach_dma_buffer(a.mem_len, a.base_pfn)
                     .expect("unable to restore mem block");
                 QueuePair::restore(driver.clone(), interrupt0, registers.clone(), mem_block, a)
@@ -645,8 +645,10 @@ impl<T: DeviceBacking> NvmeDriver<T> {
                     .device
                     .map_interrupt(q.iv, q.cpu)
                     .context("failed to map interrupt")?;
-                let mem_block =
-                    dma_client.attach_dma_buffer(q.queue_data.mem_len, q.queue_data.base_pfn)?;
+                let mem_block = worker
+                    .device
+                    .dma_client()
+                    .attach_dma_buffer(q.queue_data.mem_len, q.queue_data.base_pfn)?;
                 let q =
                     IoQueue::restore(driver.clone(), interrupt, registers.clone(), mem_block, q)?;
                 let issuer = IoIssuer {

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -25,6 +25,7 @@ use user_driver::interrupt::DeviceInterrupt;
 use user_driver::DeviceBacking;
 use user_driver::DeviceRegisterIo;
 use user_driver::DmaClient;
+use user_driver::DmaClientDriver;
 use vmcore::vm_task::SingleDriverBackend;
 use vmcore::vm_task::VmTaskDriverSource;
 use zerocopy::IntoBytes;
@@ -357,7 +358,7 @@ impl<T: 'static + Send + InspectMut + MmioIntercept> DeviceBacking for NvmeTestE
         })
     }
 
-    fn dma_client(&self) -> Arc<dyn DmaClient> {
+    fn dma_client(&self) -> &DmaClientDriver {
         self.device.dma_client()
     }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -25,7 +25,6 @@ use user_driver::interrupt::DeviceInterrupt;
 use user_driver::DeviceBacking;
 use user_driver::DeviceRegisterIo;
 use user_driver::DmaClient;
-use user_driver::DmaClientDriver;
 use vmcore::vm_task::SingleDriverBackend;
 use vmcore::vm_task::VmTaskDriverSource;
 use zerocopy::IntoBytes;
@@ -358,7 +357,7 @@ impl<T: 'static + Send + InspectMut + MmioIntercept> DeviceBacking for NvmeTestE
         })
     }
 
-    fn dma_client(&self) -> &DmaClientDriver {
+    fn dma_client(&self) -> &DmaClient {
         self.device.dma_client()
     }
 

--- a/vm/devices/user_driver/Cargo.toml
+++ b/vm/devices/user_driver/Cargo.toml
@@ -26,9 +26,11 @@ vmcore.workspace = true
 
 anyhow.workspace = true
 parking_lot.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 vfio-bindings.workspace = true
 zerocopy.workspace = true
+
 [target.'cfg(target_os = "linux")'.dependencies]
 fs-err.workspace = true
 futures.workspace = true

--- a/vm/devices/user_driver/Cargo.toml
+++ b/vm/devices/user_driver/Cargo.toml
@@ -40,5 +40,8 @@ pal_event.workspace = true
 sparse_mmap = { workspace = true, optional = true }
 vfio_sys = { workspace = true, optional = true }
 
+[dev-dependencies]
+pal_async_test.workspace = true
+
 [lints]
 workspace = true

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -282,6 +282,25 @@ impl DmaClient for EmulatedDmaAllocator {
     fn attach_dma_buffer(&self, _len: usize, _base_pfn: u64) -> anyhow::Result<MemoryBlock> {
         anyhow::bail!("restore is not supported for emulated DMA")
     }
+    fn map_dma_ranges<'a, 'b: 'a>(
+        &'a self,
+        guest_memory: &'a GuestMemory,
+        ranges: guestmem::ranges::PagedRange<'b>,
+        options: crate::MapDmaOptions,
+    ) -> Box<
+        dyn std::prelude::rust_2024::Future<
+                Output = Result<crate::DmaTransaction<'a>, crate::MapDmaError>,
+            > + 'a,
+    > {
+        todo!()
+    }
+
+    fn unmap_dma_ranges(
+        &self,
+        transaction: crate::DmaTransaction<'_>,
+    ) -> Result<(), crate::MapDmaError> {
+        todo!()
+    }
 }
 
 impl<T: 'static + Send + InspectMut + MmioIntercept> DeviceBacking for EmulatedDevice<T> {

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -282,15 +282,18 @@ impl DmaClient for EmulatedDmaAllocator {
     fn attach_dma_buffer(&self, _len: usize, _base_pfn: u64) -> anyhow::Result<MemoryBlock> {
         anyhow::bail!("restore is not supported for emulated DMA")
     }
+
     fn map_dma_ranges<'a, 'b: 'a>(
         &'a self,
         guest_memory: &'a GuestMemory,
         ranges: guestmem::ranges::PagedRange<'b>,
         options: crate::MapDmaOptions,
-    ) -> Box<
-        dyn std::prelude::rust_2024::Future<
-                Output = Result<crate::DmaTransaction<'a>, crate::MapDmaError>,
-            > + 'a,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::prelude::rust_2024::Future<
+                    Output = Result<crate::DmaTransaction<'a>, crate::MapDmaError>,
+                > + 'a,
+        >,
     > {
         todo!()
     }

--- a/vm/devices/user_driver/src/emulated.rs
+++ b/vm/devices/user_driver/src/emulated.rs
@@ -285,9 +285,9 @@ impl DmaClient for EmulatedDmaAllocator {
 
     fn map_dma_ranges<'a, 'b: 'a>(
         &'a self,
-        guest_memory: &'a GuestMemory,
-        ranges: guestmem::ranges::PagedRange<'b>,
-        options: crate::MapDmaOptions,
+        _guest_memory: &'a GuestMemory,
+        _ranges: guestmem::ranges::PagedRange<'b>,
+        _options: crate::MapDmaOptions,
     ) -> std::pin::Pin<
         Box<
             dyn std::prelude::rust_2024::Future<
@@ -300,7 +300,7 @@ impl DmaClient for EmulatedDmaAllocator {
 
     fn unmap_dma_ranges(
         &self,
-        transaction: crate::DmaTransaction<'_>,
+        _transaction: crate::DmaTransaction<'_>,
     ) -> Result<(), crate::MapDmaError> {
         todo!()
     }

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -70,6 +70,11 @@ pub enum MapDmaError {
     Map(#[source] anyhow::Error),
     #[error("no bounce buffers available")]
     NoBounceBufferAvailable,
+    #[error("mapped range {range_bytes} is larger than available total bounce buffer space {bounce_buffer_bytes}")]
+    NotEnoughBounceBufferSpace {
+        range_bytes: usize,
+        bounce_buffer_bytes: usize,
+    },
     // UnmapFailed,
     // PinFailed,
     // BounceBufferFailed,

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -76,7 +76,7 @@ pub enum MapDmaError {
     // BounceBufferFailed,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct MapDmaOptions {
     pub always_bounce: bool,
     pub is_rx: bool,

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -67,7 +67,7 @@ pub trait DeviceRegisterIo: Send + Sync {
 #[derive(Debug, thiserror::Error)]
 pub enum MapDmaError {
     #[error("failed to map ranges")]
-    Map,
+    Map(#[source] anyhow::Error),
     #[error("no bounce buffers available")]
     NoBounceBufferAvailable,
     // UnmapFailed,

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -5,6 +5,7 @@
 
 use crate::memory::MappedDmaTarget;
 use anyhow::Context;
+use guestmem::GuestMemory;
 use inspect::Inspect;
 use std::ffi::c_void;
 use std::fs::File;
@@ -137,5 +138,25 @@ impl crate::DmaClient for LockedMemorySpawner {
         _base_pfn: u64,
     ) -> anyhow::Result<crate::memory::MemoryBlock> {
         anyhow::bail!("restore not supported for lockmem")
+    }
+
+    fn map_dma_ranges<'a, 'b: 'a>(
+        &'a self,
+        guest_memory: &'a GuestMemory,
+        ranges: guestmem::ranges::PagedRange<'b>,
+        options: crate::MapDmaOptions,
+    ) -> Box<
+        dyn std::prelude::rust_2024::Future<
+                Output = Result<crate::DmaTransaction<'a>, crate::MapDmaError>,
+            > + 'a,
+    > {
+        todo!()
+    }
+
+    fn unmap_dma_ranges(
+        &self,
+        transaction: crate::DmaTransaction<'_>,
+    ) -> Result<(), crate::MapDmaError> {
+        todo!()
     }
 }

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -142,9 +142,9 @@ impl crate::DmaClient for LockedMemorySpawner {
 
     fn map_dma_ranges<'a, 'b: 'a>(
         &'a self,
-        guest_memory: &'a GuestMemory,
-        ranges: guestmem::ranges::PagedRange<'b>,
-        options: crate::MapDmaOptions,
+        _guest_memory: &'a GuestMemory,
+        _ranges: guestmem::ranges::PagedRange<'b>,
+        _options: crate::MapDmaOptions,
     ) -> std::pin::Pin<
         Box<
             dyn std::prelude::rust_2024::Future<
@@ -157,7 +157,7 @@ impl crate::DmaClient for LockedMemorySpawner {
 
     fn unmap_dma_ranges(
         &self,
-        transaction: crate::DmaTransaction<'_>,
+        _transaction: crate::DmaTransaction<'_>,
     ) -> Result<(), crate::MapDmaError> {
         todo!()
     }

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -5,7 +5,6 @@
 
 use crate::memory::MappedDmaTarget;
 use anyhow::Context;
-use guestmem::GuestMemory;
 use inspect::Inspect;
 use std::ffi::c_void;
 use std::fs::File;
@@ -127,7 +126,7 @@ unsafe impl MappedDmaTarget for LockedMemory {
 #[derive(Clone, Inspect)]
 pub struct LockedMemorySpawner;
 
-impl crate::DmaClient for LockedMemorySpawner {
+impl crate::DmaAlloc for LockedMemorySpawner {
     fn allocate_dma_buffer(&self, len: usize) -> anyhow::Result<crate::memory::MemoryBlock> {
         Ok(crate::memory::MemoryBlock::new(LockedMemory::new(len)?))
     }
@@ -138,31 +137,5 @@ impl crate::DmaClient for LockedMemorySpawner {
         _base_pfn: u64,
     ) -> anyhow::Result<crate::memory::MemoryBlock> {
         anyhow::bail!("restore not supported for lockmem")
-    }
-
-    fn requires_dma_mapping(&self) -> bool {
-        false
-    }
-
-    fn map_dma_ranges<'a, 'b: 'a>(
-        &'a self,
-        _guest_memory: &'a GuestMemory,
-        _range: guestmem::ranges::PagedRange<'b>,
-        _options: crate::MapDmaOptions,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::prelude::rust_2024::Future<
-                    Output = Result<Box<dyn crate::MappedDmaTransaction + 'a>, crate::MapDmaError>,
-                > + 'a,
-        >,
-    > {
-        todo!()
-    }
-
-    fn unmap_dma_ranges(
-        &self,
-        _transaction: Box<dyn crate::MappedDmaTransaction + '_>,
-    ) -> Result<(), crate::MapDmaError> {
-        todo!()
     }
 }

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -145,10 +145,12 @@ impl crate::DmaClient for LockedMemorySpawner {
         guest_memory: &'a GuestMemory,
         ranges: guestmem::ranges::PagedRange<'b>,
         options: crate::MapDmaOptions,
-    ) -> Box<
-        dyn std::prelude::rust_2024::Future<
-                Output = Result<crate::DmaTransaction<'a>, crate::MapDmaError>,
-            > + 'a,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::prelude::rust_2024::Future<
+                    Output = Result<crate::DmaTransaction<'a>, crate::MapDmaError>,
+                > + 'a,
+        >,
     > {
         todo!()
     }

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -140,15 +140,19 @@ impl crate::DmaClient for LockedMemorySpawner {
         anyhow::bail!("restore not supported for lockmem")
     }
 
+    fn requires_dma_mapping(&self) -> bool {
+        false
+    }
+
     fn map_dma_ranges<'a, 'b: 'a>(
         &'a self,
         _guest_memory: &'a GuestMemory,
-        _ranges: guestmem::ranges::PagedRange<'b>,
+        _range: guestmem::ranges::PagedRange<'b>,
         _options: crate::MapDmaOptions,
     ) -> std::pin::Pin<
         Box<
             dyn std::prelude::rust_2024::Future<
-                    Output = Result<crate::DmaTransaction<'a>, crate::MapDmaError>,
+                    Output = Result<Box<dyn crate::MappedDmaTransaction + 'a>, crate::MapDmaError>,
                 > + 'a,
         >,
     > {
@@ -157,7 +161,7 @@ impl crate::DmaClient for LockedMemorySpawner {
 
     fn unmap_dma_ranges(
         &self,
-        _transaction: crate::DmaTransaction<'_>,
+        _transaction: Box<dyn crate::MappedDmaTransaction + '_>,
     ) -> Result<(), crate::MapDmaError> {
         todo!()
     }

--- a/vm/devices/user_driver/src/page_allocator.rs
+++ b/vm/devices/user_driver/src/page_allocator.rs
@@ -46,6 +46,7 @@ impl PageAllocator {
         }
     }
 
+    // BUGBUG remove the single page restriction - the nvme code should instead allocate the PRP list first, and not have this restriction?
     pub async fn alloc_pages(&self, n: usize) -> Option<ScopedPages<'_>> {
         // A single page must be left over for the PRP list, so one request may
         // not use all pages.

--- a/vm/devices/user_driver/src/page_allocator.rs
+++ b/vm/devices/user_driver/src/page_allocator.rs
@@ -142,6 +142,10 @@ impl ScopedPages<'_> {
         self.pages[index].physical_address / PAGE_SIZE64
     }
 
+    pub fn pfns(&self) -> impl Iterator<Item = u64> + use<'_> {
+        self.pages.iter().map(|p| p.physical_address / PAGE_SIZE64)
+    }
+
     pub fn page_as_slice(&self, index: usize) -> &[AtomicU8] {
         &self.alloc.mem.as_slice()[self.pages[index].page_index * PAGE_SIZE..][..PAGE_SIZE]
     }

--- a/vm/devices/user_driver/src/page_allocator.rs
+++ b/vm/devices/user_driver/src/page_allocator.rs
@@ -115,6 +115,15 @@ pub struct ScopedPages<'a> {
     pages: Vec<ScopedPage>,
 }
 
+impl std::fmt::Debug for ScopedPages<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScopedPages")
+            .field("pages", &self.pages)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
 struct ScopedPage {
     page_index: usize,
     physical_address: u64,
@@ -127,6 +136,10 @@ impl ScopedPages<'_> {
 
     pub fn physical_address(&self, index: usize) -> u64 {
         self.pages[index].physical_address
+    }
+
+    pub fn pfn(&self, index: usize) -> u64 {
+        self.pages[index].physical_address / PAGE_SIZE64
     }
 
     pub fn page_as_slice(&self, index: usize) -> &[AtomicU8] {

--- a/vm/devices/user_driver/src/vfio.rs
+++ b/vm/devices/user_driver/src/vfio.rs
@@ -11,6 +11,7 @@ use crate::interrupt::DeviceInterruptSource;
 use crate::DeviceBacking;
 use crate::DeviceRegisterIo;
 use crate::DmaClient;
+use crate::DmaClientDriver;
 use anyhow::Context;
 use futures::FutureExt;
 use futures_concurrency::future::Race;
@@ -56,7 +57,7 @@ pub struct VfioDevice {
     interrupts: Vec<Option<InterruptState>>,
     #[inspect(skip)]
     config_space: vfio_sys::RegionInfo,
-    dma_client: Arc<dyn DmaClient>,
+    dma_client: DmaClientDriver,
 }
 
 #[derive(Inspect)]
@@ -130,7 +131,7 @@ impl VfioDevice {
             config_space,
             driver_source: driver_source.clone(),
             interrupts: Vec::new(),
-            dma_client,
+            dma_client: DmaClientDriver::new(dma_client),
         };
 
         // Ensure bus master enable and memory space enable are set, and that
@@ -231,8 +232,8 @@ impl DeviceBacking for VfioDevice {
         (*self).map_bar(n)
     }
 
-    fn dma_client(&self) -> Arc<dyn DmaClient> {
-        self.dma_client.clone()
+    fn dma_client(&self) -> &DmaClientDriver {
+        &self.dma_client
     }
 
     fn max_interrupt_count(&self) -> u32 {

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -142,11 +142,7 @@ pub struct SimpleVmbusClientDeviceWrapper<T: SimpleVmbusClientDeviceAsync> {
 
 impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceWrapper<T> {
     /// Create a new instance.
-    pub fn new(
-        driver: impl SpawnDriver + Clone,
-        dma_alloc: Arc<dyn DmaClient>,
-        device: T,
-    ) -> Result<Self> {
+    pub fn new(driver: impl SpawnDriver + Clone, dma_alloc: DmaClient, device: T) -> Result<Self> {
         let spawner = Arc::new(driver.clone());
         Ok(Self {
             instance_id: device.instance_id(),
@@ -225,7 +221,7 @@ struct SimpleVmbusClientDeviceTask<T: SimpleVmbusClientDeviceAsync> {
     device: TaskControl<RelayDeviceTask<T>, T::Runner>,
     saved_state: Option<T::SavedState>,
     spawner: Arc<dyn SpawnDriver>,
-    dma_alloc: Arc<dyn DmaClient>,
+    dma_alloc: DmaClient,
 }
 
 impl<T: SimpleVmbusClientDeviceAsync> AsyncRun<SimpleVmbusClientDeviceTaskState>
@@ -256,7 +252,7 @@ impl<T: SimpleVmbusClientDeviceAsync> InspectTaskMut<SimpleVmbusClientDeviceTask
 }
 
 impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
-    pub fn new(device: T, spawner: Arc<dyn SpawnDriver>, dma_alloc: Arc<dyn DmaClient>) -> Self {
+    pub fn new(device: T, spawner: Arc<dyn SpawnDriver>, dma_alloc: DmaClient) -> Self {
         Self {
             device: TaskControl::new(RelayDeviceTask(device)),
             saved_state: None,

--- a/vm/hv1/hv1_hypercall/src/imp.rs
+++ b/vm/hv1/hv1_hypercall/src/imp.rs
@@ -924,3 +924,47 @@ impl<T: ExtendedQueryCapabilities> HypercallDispatch<HvExtQueryCapabilities> for
         HvExtQueryCapabilities::run(params, |()| self.query_extended_capabilities())
     }
 }
+
+/// Implements the `HvPinGpaPageRanges` hypercall.
+pub trait PinGpaRangePages {
+    /// Pins the specified GPA pages.
+    fn pin_gpa_range_pages(&mut self, gpa_page_ranges: &[defs::HvGpaRange]) -> HvRepResult;
+}
+
+/// Defines the `HvPinGpaPageRanges` hypercall.
+pub type HvPinGpaPageRanges = RepHypercall<
+    defs::PinUnpinGpaPageRangesHeader,
+    defs::HvGpaRange,
+    (),
+    { HypercallCode::HvCallPinGpaPageRanges.0 },
+>;
+
+impl<T: PinGpaRangePages> HypercallDispatch<HvPinGpaPageRanges> for T {
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        HvPinGpaPageRanges::run(params, |_header, input, _output| {
+            self.pin_gpa_range_pages(input)
+        })
+    }
+}
+
+/// Implements the `HvUnpinGpaPageRanges` hypercall.
+pub trait UnpinGpaRangePages {
+    /// Unpins the specified GPA pages.
+    fn unpin_gpa_range_pages(&mut self, gpa_page_ranges: &[defs::HvGpaRange]) -> HvRepResult;
+}
+
+/// Defines the `HvUnpinGpaPageRanges` hypercall.
+pub type HvUnpinGpaPageRanges = RepHypercall<
+    defs::PinUnpinGpaPageRangesHeader,
+    defs::HvGpaRange,
+    (),
+    { HypercallCode::HvCallUnpinGpaPageRanges.0 },
+>;
+
+impl<T: UnpinGpaRangePages> HypercallDispatch<HvUnpinGpaPageRanges> for T {
+    fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
+        HvUnpinGpaPageRanges::run(params, |_header, input, _output| {
+            self.unpin_gpa_range_pages(input)
+        })
+    }
+}

--- a/vm/page_pool_alloc/Cargo.toml
+++ b/vm/page_pool_alloc/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+guestmem.workspace = true
 user_driver.workspace = true
 sparse_mmap.workspace = true
 vmcore.workspace = true

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -860,25 +860,32 @@ impl user_driver::DmaClient for PagePoolAllocator {
         alloc.into_memory_block()
     }
 
-    fn unmap_dma_ranges(
-        &self,
-        _transaction: user_driver::DmaTransaction<'_>,
-    ) -> Result<(), user_driver::MapDmaError> {
-        todo!()
+    fn requires_dma_mapping(&self) -> bool {
+        false
     }
 
     fn map_dma_ranges<'a, 'b: 'a>(
         &'a self,
         _guest_memory: &'a GuestMemory,
-        _ranges: PagedRange<'b>,
+        _range: PagedRange<'b>,
         _options: user_driver::MapDmaOptions,
     ) -> std::pin::Pin<
         Box<
             dyn std::prelude::rust_2024::Future<
-                    Output = Result<user_driver::DmaTransaction<'a>, user_driver::MapDmaError>,
+                    Output = Result<
+                        Box<dyn user_driver::MappedDmaTransaction + 'a>,
+                        user_driver::MapDmaError,
+                    >,
                 > + 'a,
         >,
     > {
+        todo!()
+    }
+
+    fn unmap_dma_ranges(
+        &self,
+        _transaction: Box<dyn user_driver::MappedDmaTransaction + '_>,
+    ) -> Result<(), user_driver::MapDmaError> {
         todo!()
     }
 }

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -11,8 +11,6 @@ mod device_dma;
 pub use device_dma::PagePoolDmaBuffer;
 
 use anyhow::Context;
-use guestmem::ranges::PagedRange;
-use guestmem::GuestMemory;
 use inspect::Inspect;
 use inspect::Response;
 use memory_range::MemoryRange;
@@ -818,7 +816,7 @@ impl Drop for PagePoolAllocator {
     }
 }
 
-impl user_driver::DmaClient for PagePoolAllocator {
+impl user_driver::DmaAlloc for PagePoolAllocator {
     fn allocate_dma_buffer(&self, len: usize) -> anyhow::Result<user_driver::memory::MemoryBlock> {
         if len as u64 % PAGE_SIZE != 0 {
             anyhow::bail!("not a page-size multiple");
@@ -858,35 +856,6 @@ impl user_driver::DmaClient for PagePoolAllocator {
         // Preserve the existing contents of memory and do not zero the restored
         // allocation.
         alloc.into_memory_block()
-    }
-
-    fn requires_dma_mapping(&self) -> bool {
-        false
-    }
-
-    fn map_dma_ranges<'a, 'b: 'a>(
-        &'a self,
-        _guest_memory: &'a GuestMemory,
-        _range: PagedRange<'b>,
-        _options: user_driver::MapDmaOptions,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::prelude::rust_2024::Future<
-                    Output = Result<
-                        Box<dyn user_driver::MappedDmaTransaction + 'a>,
-                        user_driver::MapDmaError,
-                    >,
-                > + 'a,
-        >,
-    > {
-        todo!()
-    }
-
-    fn unmap_dma_ranges(
-        &self,
-        _transaction: Box<dyn user_driver::MappedDmaTransaction + '_>,
-    ) -> Result<(), user_driver::MapDmaError> {
-        todo!()
     }
 }
 

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -11,6 +11,8 @@ mod device_dma;
 pub use device_dma::PagePoolDmaBuffer;
 
 use anyhow::Context;
+use guestmem::ranges::PagedRange;
+use guestmem::GuestMemory;
 use inspect::Inspect;
 use inspect::Response;
 use memory_range::MemoryRange;
@@ -856,6 +858,26 @@ impl user_driver::DmaClient for PagePoolAllocator {
         // Preserve the existing contents of memory and do not zero the restored
         // allocation.
         alloc.into_memory_block()
+    }
+
+    fn unmap_dma_ranges(
+        &self,
+        transaction: user_driver::DmaTransaction<'_>,
+    ) -> Result<(), user_driver::MapDmaError> {
+        todo!()
+    }
+
+    fn map_dma_ranges<'a, 'b: 'a>(
+        &'a self,
+        guest_memory: &'a GuestMemory,
+        ranges: PagedRange<'b>,
+        options: user_driver::MapDmaOptions,
+    ) -> Box<
+        dyn std::prelude::rust_2024::Future<
+                Output = Result<user_driver::DmaTransaction<'a>, user_driver::MapDmaError>,
+            > + 'a,
+    > {
+        todo!()
     }
 }
 

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -872,10 +872,12 @@ impl user_driver::DmaClient for PagePoolAllocator {
         guest_memory: &'a GuestMemory,
         ranges: PagedRange<'b>,
         options: user_driver::MapDmaOptions,
-    ) -> Box<
-        dyn std::prelude::rust_2024::Future<
-                Output = Result<user_driver::DmaTransaction<'a>, user_driver::MapDmaError>,
-            > + 'a,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::prelude::rust_2024::Future<
+                    Output = Result<user_driver::DmaTransaction<'a>, user_driver::MapDmaError>,
+                > + 'a,
+        >,
     > {
         todo!()
     }

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -862,16 +862,16 @@ impl user_driver::DmaClient for PagePoolAllocator {
 
     fn unmap_dma_ranges(
         &self,
-        transaction: user_driver::DmaTransaction<'_>,
+        _transaction: user_driver::DmaTransaction<'_>,
     ) -> Result<(), user_driver::MapDmaError> {
         todo!()
     }
 
     fn map_dma_ranges<'a, 'b: 'a>(
         &'a self,
-        guest_memory: &'a GuestMemory,
-        ranges: PagedRange<'b>,
-        options: user_driver::MapDmaOptions,
+        _guest_memory: &'a GuestMemory,
+        _ranges: PagedRange<'b>,
+        _options: user_driver::MapDmaOptions,
     ) -> std::pin::Pin<
         Box<
             dyn std::prelude::rust_2024::Future<

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -685,9 +685,9 @@ impl<T: CpuIo> hv1_hypercall::ModifySparseGpaPageHostVisibility for WhpHypercall
 
 impl<T: CpuIo> hv1_hypercall::PinGpaRangePages for WhpHypercallExit<'_, '_, T> {
     fn pin_gpa_range_pages(&mut self, gpa_page_ranges: &[HvGpaRange]) -> HvRepResult {
-        tracing::error!(?gpa_page_ranges, "pin ranges");
+        tracing::trace!(?gpa_page_ranges, "pin ranges");
 
-        // DMATEST: Fill each page number with the page it is
+        // BUGBUG DMATEST: Fill each page number with the page it is
         for range in gpa_page_ranges {
             let range = range.as_simple();
             let gpa = range.gpa_page_number() * HV_PAGE_SIZE;
@@ -710,7 +710,7 @@ impl<T: CpuIo> hv1_hypercall::PinGpaRangePages for WhpHypercallExit<'_, '_, T> {
 
 impl<T: CpuIo> hv1_hypercall::UnpinGpaRangePages for WhpHypercallExit<'_, '_, T> {
     fn unpin_gpa_range_pages(&mut self, gpa_page_ranges: &[HvGpaRange]) -> HvRepResult {
-        tracing::error!(?gpa_page_ranges, "unpin ranges");
+        tracing::trace!(?gpa_page_ranges, "unpin ranges");
 
         Ok(())
     }


### PR DESCRIPTION
Introduce an API for drivers to call map and unmap on buffers before DMA is expected to occur. On some platforms in the future, such as VA backed VMs, all drivers that are expecting DMA to occur must make sure to call map and unmap, as the pages may not be legal for external devices to perform DMA into the specified guest pages. An implementation may choose to make those pages valid for DMA access, or bounce the ranges into buffers that are valid to access. 

This also comes with a starter implementation in `openhcl_dma_manager` that implements mapping via pinning pages, or bouncing into configured bounce buffers. This can be enabled with `OPENHCL_PIN_DMA_RANGES=1`. This required some refactoring across the codebase to make this codepath a no-op with no allocations if not enabled, as most scenarios do not require this behavior today. 

There are some additional caveats to this starter implementation, namely: 
1) Pages are assumed to always need pinning, with a hypercall being attempted to pin pages. 
2) A transaction is either all bounced or all pinned. 
3) Save restore is not supported, as additional tracking of live mapped ranges and client association is needed. 
4) There are multiple allocations on the map path in order to not require generic arguments to litter the codebase. While it's not expected to impact performance due to the hypercall and pin operation being very expensive, there are ares for improvement here. 

TODO: self test in code marked with BUGBUG, to be removed before PR is ready to merge. 