### PR TITLE
vmbus: add pause/resume messages, use them in vmbus_client save/restore

### DIFF
--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -62,7 +62,8 @@ const SUPPORTED_FEATURE_FLAGS: FeatureFlags = FeatureFlags::new()
     .with_guest_specified_signal_parameters(true)
     .with_channel_interrupt_redirection(true)
     .with_modify_connection(true)
-    .with_client_id(true);
+    .with_client_id(true)
+    .with_pause_resume(true);
 
 /// The client interface synic events.
 pub trait SynicEventClient: Send + Sync {
@@ -439,7 +440,7 @@ enum ClientState {
 impl ClientState {
     fn get_version(&self) -> Option<VersionInfo> {
         match self {
-            ClientState::Connected { version } => Some(*version),
+            ClientState::Connected { version, .. } => Some(*version),
             ClientState::RequestingOffers { version, sender: _ } => Some(*version),
             ClientState::Disconnecting { version, rpc: _ } => Some(*version),
             ClientState::Disconnected | ClientState::Connecting { .. } => None,
@@ -604,7 +605,7 @@ impl ClientTask {
     }
 
     fn handle_request_offers(&mut self, send: mesh::Sender<OfferInfo>) {
-        if let ClientState::Connected { version } = self.state {
+        if let ClientState::Connected { version, .. } = self.state {
             self.state = ClientState::RequestingOffers {
                 version,
                 sender: send,
@@ -626,7 +627,7 @@ impl ClientTask {
     }
 
     fn handle_modify(&mut self, request: Rpc<ModifyConnectionRequest, ConnectionState>) {
-        if !matches!(self.state, ClientState::Connected { version }
+        if !matches!(self.state, ClientState::Connected { version,.. }
             if version.feature_flags.modify_connection())
         {
             tracing::warn!("ModifyConnection not supported");
@@ -1061,7 +1062,8 @@ impl ClientTask {
         }
     }
 
-    fn handle_synic_message(&mut self, data: &[u8]) {
+    /// Returns false if the message was a pause complete message.
+    fn handle_synic_message(&mut self, data: &[u8]) -> bool {
         let msg = Message::parse(data, self.state.get_version()).unwrap();
         tracing::trace!(?msg, "received client message from synic");
 
@@ -1104,6 +1106,9 @@ impl ClientTask {
             Message::CloseReservedChannelResponse(..) => {
                 todo!("Unsupported message {msg:?}")
             }
+            Message::PauseResponse(..) => {
+                return false;
+            }
             // Messages that should only be received by a vmbus server.
             Message::RequestOffers(..)
             | Message::OpenChannel2(..)
@@ -1121,10 +1126,13 @@ impl ClientTask {
             | Message::TlConnectRequest2(..)
             | Message::TlConnectRequest(..)
             | Message::ModifyChannel(..)
-            | Message::ModifyConnection(..) => {
+            | Message::ModifyConnection(..)
+            | Message::Pause(..)
+            | Message::Resume(..) => {
                 unreachable!("Client received server message {msg:?}");
             }
         }
+        true
     }
 
     fn handle_open_channel(
@@ -1147,13 +1155,13 @@ impl ClientTask {
         let (request, rpc) = rpc.split();
         let open_data = &request.open_data;
 
-        let supports_interrupt_redirection = if let ClientState::Connected { version } = self.state
-        {
-            version.feature_flags.guest_specified_signal_parameters()
-                || version.feature_flags.channel_interrupt_redirection()
-        } else {
-            false
-        };
+        let supports_interrupt_redirection =
+            if let ClientState::Connected { version, .. } = self.state {
+                version.feature_flags.guest_specified_signal_parameters()
+                    || version.feature_flags.channel_interrupt_redirection()
+            } else {
+                false
+            };
 
         if !supports_interrupt_redirection && open_data.event_flag != channel_id.0 as u16 {
             rpc.fail(anyhow::anyhow!(
@@ -1464,19 +1472,40 @@ impl ClientTask {
 
     /// Determines if the client is connected with at least the specified version.
     fn check_version(&self, version: Version) -> bool {
-        matches!(self.state, ClientState::Connected { version: v } if v.version >= version)
+        matches!(self.state, ClientState::Connected { version: v, .. } if v.version >= version)
     }
 
     fn handle_start(&mut self) {
         assert!(!self.running);
-        self.msg_source.resume_message_stream();
+        if !self.can_pause_resume() {
+            self.msg_source.resume_message_stream();
+        }
         self.running = true;
     }
 
     async fn handle_stop(&mut self) {
         assert!(self.running);
+
         loop {
-            self.msg_source.pause_message_stream();
+            if self.can_pause_resume() {
+                // Send a pause and flush any queued messages to ensure the host
+                // sees it.
+                self.inner.messages.send(&protocol::Pause {});
+                self.inner.messages.flush_messages().await;
+                // Push the resume message onto the queue now. This ensures the
+                // resume message is sent before any other messages, that new
+                // messages sent during processing below will be queued rather
+                // than sent immediately, and it means we don't need to save the
+                // paused state in the saved state.
+                self.inner
+                    .messages
+                    .queued
+                    .push_back(OutgoingMessage::new(&protocol::Resume));
+            } else {
+                // Mask the sint to pause the message stream. The host will
+                // retry any queued messages after the sint is unmasked.
+                self.msg_source.pause_message_stream();
+            }
 
             // Process messages until we hit EOF.
             tracing::debug!("draining messages");
@@ -1492,7 +1521,9 @@ impl ClientTask {
                     break;
                 }
 
-                self.handle_synic_message(&buf[..size]);
+                if !self.handle_synic_message(&buf[..size]) {
+                    break;
+                }
             }
 
             // Flush any pending outgoing messages. This needs to be done with
@@ -1502,7 +1533,12 @@ impl ClientTask {
             // FUTURE: We can save these pending messages instead, but older
             // versions of OpenHCL cannot restore them. Remove this code once
             // those older versions are no longer supported (e.g. late 2025).
-            if self.inner.messages.is_empty() {
+            //
+            // When pause/resume is supported, we assume that we can save
+            // pending messages safely, though, since a rollback to a version
+            // that doesn't support pause/resume will not be able to restore the
+            // paused state anyway.
+            if self.inner.messages.is_empty() || self.can_pause_resume() {
                 break;
             }
             tracing::info!("flushing outgoing messages");
@@ -1513,6 +1549,14 @@ impl ClientTask {
         tracing::debug!("messages drained");
         // Because the run loop awaits all async operations, there is no need for rundown.
         self.running = false;
+    }
+
+    fn can_pause_resume(&self) -> bool {
+        if let ClientState::Connected { version, .. } = self.state {
+            version.feature_flags.pause_resume()
+        } else {
+            false
+        }
     }
 
     async fn run(&mut self) {

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -1551,6 +1551,14 @@ impl ClientTask {
         self.running = false;
     }
 
+    /// Returns whether the server supports in-band messages to pause/resume the
+    /// message stream.
+    ///
+    /// For hosts where this is not supported, we mask the sint to pause new
+    /// messages being queued to the sint, then drain the messages. This does
+    /// not work with some host implementations, which cannot support draining
+    /// the message queue while the sint is masked (due to the use of
+    /// HvPostMessageDirect).
     fn can_pause_resume(&self) -> bool {
         if let ClientState::Connected { version } = self.state {
             version.feature_flags.pause_resume()

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -627,7 +627,7 @@ impl ClientTask {
     }
 
     fn handle_modify(&mut self, request: Rpc<ModifyConnectionRequest, ConnectionState>) {
-        if !matches!(self.state, ClientState::Connected { version,.. }
+        if !matches!(self.state, ClientState::Connected { version }
             if version.feature_flags.modify_connection())
         {
             tracing::warn!("ModifyConnection not supported");

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -1477,9 +1477,7 @@ impl ClientTask {
 
     fn handle_start(&mut self) {
         assert!(!self.running);
-        if !self.can_pause_resume() {
-            self.msg_source.resume_message_stream();
-        }
+        self.msg_source.resume_message_stream();
         self.running = true;
     }
 

--- a/vm/devices/vmbus/vmbus_client/src/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_client/src/saved_state.rs
@@ -25,9 +25,9 @@ impl super::ClientTask {
                 super::ClientState::Connecting { .. } => {
                     unreachable!("Cannot save in Connecting state.")
                 }
-                super::ClientState::Connected { version } => ClientState::Connected {
-                    version: version.version as u32,
-                    feature_flags: version.feature_flags.into(),
+                super::ClientState::Connected { version: info } => ClientState::Connected {
+                    version: info.version as u32,
+                    feature_flags: info.feature_flags.into(),
                 },
                 super::ClientState::RequestingOffers { .. } => {
                     unreachable!("Cannot save in RequestingOffers state.")

--- a/vm/devices/vmbus/vmbus_client/src/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_client/src/saved_state.rs
@@ -20,14 +20,14 @@ impl super::ClientTask {
         // It's the responsibility of the caller to ensure the client is in a state where it's
         // possible to save.
         SavedState {
-            client_state: match &self.state {
+            client_state: match self.state {
                 super::ClientState::Disconnected => ClientState::Disconnected,
                 super::ClientState::Connecting { .. } => {
                     unreachable!("Cannot save in Connecting state.")
                 }
-                super::ClientState::Connected { version: info } => ClientState::Connected {
-                    version: info.version as u32,
-                    feature_flags: info.feature_flags.into(),
+                super::ClientState::Connected { version } => ClientState::Connected {
+                    version: version.version as u32,
+                    feature_flags: version.feature_flags.into(),
                 },
                 super::ClientState::RequestingOffers { .. } => {
                     unreachable!("Cannot save in RequestingOffers state.")

--- a/vm/devices/vmbus/vmbus_core/src/protocol.rs
+++ b/vm/devices/vmbus/vmbus_core/src/protocol.rs
@@ -100,6 +100,9 @@ vmbus_messages! {
         24 MODIFY_CHANNEL_RESPONSE { ModifyChannelResponse Iron },
         25 MODIFY_CONNECTION { ModifyConnection Copper features:modify_connection },
         26 MODIFY_CONNECTION_RESPONSE { ModifyConnectionResponse Copper features:modify_connection },
+        27 PAUSE { Pause Copper features:pause_resume },
+        28 PAUSE_RESPONSE { PauseResponse Copper features:pause_resume },
+        29 RESUME { Resume Copper features:pause_resume },
     }
 }
 
@@ -170,7 +173,10 @@ pub struct FeatureFlags {
     /// supported.
     pub confidential_channels: bool,
 
-    #[bits(27)]
+    /// The server supports messages to pause and resume additional control messages.
+    pub pause_resume: bool,
+
+    #[bits(26)]
     _reserved: u32,
 }
 
@@ -783,3 +789,15 @@ pub struct UnloadComplete {}
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, IntoBytes, FromBytes, Immutable, KnownLayout)]
 pub struct AllOffersDelivered {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, IntoBytes, FromBytes, Immutable, KnownLayout)]
+pub struct Pause;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, IntoBytes, FromBytes, Immutable, KnownLayout)]
+pub struct PauseResponse;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, IntoBytes, FromBytes, Immutable, KnownLayout)]
+pub struct Resume;

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -1210,7 +1210,8 @@ const SUPPORTED_FEATURE_FLAGS: FeatureFlags = FeatureFlags::new()
     .with_guest_specified_signal_parameters(true)
     .with_channel_interrupt_redirection(true)
     .with_modify_connection(true)
-    .with_client_id(true);
+    .with_client_id(true)
+    .with_pause_resume(true);
 
 /// Trait for sending requests to devices and the guest.
 pub trait Notifier: Send {

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -85,6 +85,8 @@ pub enum ChannelError {
     ChannelNotReserved,
     #[error("received untrusted message for trusted connection")]
     UntrustedMessage,
+    #[error("received a non-resuming message while paused")]
+    Paused,
 }
 
 #[derive(Debug, Error)]
@@ -203,6 +205,7 @@ struct ConnectionInfo {
     target_message_vp: u32,
     modifying: bool,
     client_id: Guid,
+    paused: bool,
 }
 
 /// The state of the VMBus connection.
@@ -245,6 +248,14 @@ impl ConnectionState {
             ConnectionState::Connected(info) => info.trusted,
             ConnectionState::Connecting { info, .. } => info.trusted,
             _ => false,
+        }
+    }
+
+    fn is_paused(&self) -> bool {
+        if let ConnectionState::Connected(info) = self {
+            info.paused
+        } else {
+            false
         }
     }
 }
@@ -1369,7 +1380,7 @@ impl Server {
 
     /// Check if there are any messages in the pending queue.
     pub fn has_pending_messages(&self) -> bool {
-        !self.pending_messages.0.is_empty()
+        !self.pending_messages.0.is_empty() && !self.state.is_paused()
     }
 
     /// Tries to resend pending messages using the provided `send`` function.
@@ -1377,9 +1388,11 @@ impl Server {
         &mut self,
         mut send: impl FnMut(&OutgoingMessage) -> Poll<()>,
     ) -> Poll<()> {
-        while let Some(message) = self.pending_messages.0.front() {
-            ready!(send(message));
-            self.pending_messages.0.pop_front();
+        if !self.state.is_paused() {
+            while let Some(message) = self.pending_messages.0.front() {
+                ready!(send(message));
+                self.pending_messages.0.pop_front();
+            }
         }
 
         Poll::Ready(())
@@ -1439,7 +1452,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 } => {
                     self.inner
                         .pending_messages
-                        .sender(self.notifier)
+                        .sender(self.notifier, self.inner.state.is_paused())
                         .send_open_result(
                             info.channel_id,
                             &request,
@@ -1543,7 +1556,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                             channel.state = ChannelState::Closed;
                             self.inner
                                 .pending_messages
-                                .sender(self.notifier)
+                                .sender(self.notifier, self.inner.state.is_paused())
                                 .send_offer(channel, info.version);
                         }
                     }
@@ -1553,7 +1566,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                     // the saved state. This indicates the offer is meant to be
                     // fresh, so revoke and reoffer it.
                     let retain = revoke(
-                        self.inner.pending_messages.sender(self.notifier),
+                        self.inner
+                            .pending_messages
+                            .sender(self.notifier, self.inner.state.is_paused()),
                         offer_id,
                         channel,
                         &mut self.inner.gpadls,
@@ -1565,7 +1580,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                     // offer_channel was never called for this, but it was in
                     // the saved state. Revoke it.
                     let retain = revoke(
-                        self.inner.pending_messages.sender(self.notifier),
+                        self.inner
+                            .pending_messages
+                            .sender(self.notifier, self.inner.state.is_paused()),
                         offer_id,
                         channel,
                         &mut self.inner.gpadls,
@@ -1749,7 +1766,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
 
             self.inner
                 .pending_messages
-                .sender(self.notifier)
+                .sender(self.notifier, self.inner.state.is_paused())
                 .send_offer(channel, version);
         }
 
@@ -1761,7 +1778,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
     pub fn revoke_channel(&mut self, offer_id: OfferId) {
         let channel = &mut self.inner.channels[offer_id];
         let retain = revoke(
-            self.inner.pending_messages.sender(self.notifier),
+            self.inner
+                .pending_messages
+                .sender(self.notifier, self.inner.state.is_paused()),
             offer_id,
             channel,
             &mut self.inner.gpadls,
@@ -1793,7 +1812,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
 
                 self.inner
                     .pending_messages
-                    .sender(self.notifier)
+                    .sender(self.notifier, self.inner.state.is_paused())
                     .send_open_result(
                         channel_id,
                         &request,
@@ -1920,7 +1939,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                     // Handle closing reserved channels while disconnected/ing. Since we weren't waiting
                     // on the channel, no need to call check_disconnected, but we do need to release it.
                     if Self::client_release_channel(
-                        self.inner.pending_messages.sender(self.notifier),
+                        self.inner
+                            .pending_messages
+                            .sender(self.notifier, self.inner.state.is_paused()),
                         offer_id,
                         channel,
                         &mut self.inner.gpadls,
@@ -2151,6 +2172,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 modifying: false,
                 offers_sent: false,
                 client_id: request.client_id,
+                paused: false,
             },
             next_action: ConnectionAction::None,
         };
@@ -2325,7 +2347,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             // Release reserved channels only if the VM is resetting
             (!vm_reset && channel.state.is_reserved())
                 || !Self::client_release_channel(
-                    self.inner.pending_messages.sender(self.notifier),
+                    self.inner
+                        .pending_messages
+                        .sender(self.notifier, self.inner.state.is_paused()),
                     offer_id,
                     channel,
                     gpadls,
@@ -2479,7 +2503,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             channel.state = ChannelState::Closed;
             self.inner
                 .pending_messages
-                .sender(self.notifier)
+                .sender(self.notifier, info.paused)
                 .send_offer(channel, info.version);
         }
         self.sender().send_message(&protocol::AllOffersDelivered {});
@@ -2552,7 +2576,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
 
         if done
             && !Self::gpadl_updated(
-                self.inner.pending_messages.sender(self.notifier),
+                self.inner
+                    .pending_messages
+                    .sender(self.notifier, self.inner.state.is_paused()),
                 offer_id,
                 channel,
                 input.gpadl_id,
@@ -2587,7 +2613,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
         if gpadl.append(range)? {
             self.inner.incomplete_gpadls.remove(&input.gpadl_id);
             if !Self::gpadl_updated(
-                self.inner.pending_messages.sender(self.notifier),
+                self.inner
+                    .pending_messages
+                    .sender(self.notifier, self.inner.state.is_paused()),
                 offer_id,
                 channel,
                 input.gpadl_id,
@@ -3005,7 +3033,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | ChannelState::Closing { .. }
             | ChannelState::Reoffered => {
                 if Self::client_release_channel(
-                    self.inner.pending_messages.sender(self.notifier),
+                    self.inner
+                        .pending_messages
+                        .sender(self.notifier, self.inner.state.is_paused()),
                     offer_id,
                     channel,
                     &mut self.inner.gpadls,
@@ -3251,6 +3281,18 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
         }
     }
 
+    fn handle_pause(&mut self) {
+        tracelimit::info_ratelimited!("pausing sending messages");
+        self.sender().send_message(&protocol::PauseResponse {});
+        let ConnectionState::Connected(info) = &mut self.inner.state else {
+            unreachable!(
+                "in unexpected state {:?}, should be prevented by Message::parse()",
+                self.inner.state
+            );
+        };
+        info.paused = true;
+    }
+
     /// Processes an incoming message from the guest.
     pub fn handle_synic_message(&mut self, message: SynicMessage) -> Result<(), ChannelError> {
         assert!(!self.is_resetting());
@@ -3263,8 +3305,27 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
         //
         // TODO: Don't allow trusted messages if an untrusted connection was ever used.
         if self.inner.state.is_trusted() && !message.trusted {
-            tracing::warn!(?msg, "Received untrusted message");
+            tracelimit::warn_ratelimited!(?msg, "Received untrusted message");
             return Err(ChannelError::UntrustedMessage);
+        }
+
+        // Unpause channel responses if they are paused.
+        match &mut self.inner.state {
+            ConnectionState::Connected(info) if info.paused => {
+                if !matches!(
+                    msg,
+                    Message::Resume(..)
+                        | Message::Unload(..)
+                        | Message::InitiateContact { .. }
+                        | Message::InitiateContact2 { .. }
+                ) {
+                    tracelimit::warn_ratelimited!(?msg, "Received message while paused");
+                    return Err(ChannelError::Paused);
+                }
+                tracelimit::info_ratelimited!("resuming sending messages");
+                info.paused = false;
+            }
+            _ => {}
         }
 
         match msg {
@@ -3294,6 +3355,8 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             Message::CloseReservedChannel(input, ..) => {
                 self.handle_close_reserved_channel(&input)?
             }
+            Message::Pause(protocol::Pause, ..) => self.handle_pause(),
+            Message::Resume(protocol::Resume, ..) => {}
             // Messages that should only be received by a vmbus client.
             Message::OfferChannel(..)
             | Message::RescindChannelOffer(..)
@@ -3307,7 +3370,8 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             | Message::CloseReservedChannelResponse(..)
             | Message::TlConnectResult(..)
             | Message::ModifyChannelResponse(..)
-            | Message::ModifyConnectionResponse(..) => {
+            | Message::ModifyConnectionResponse(..)
+            | Message::PauseResponse(..) => {
                 unreachable!("Server received client message {:?}", msg);
             }
         }
@@ -3347,7 +3411,7 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                     .channel_id;
                 self.inner
                     .pending_messages
-                    .sender(self.notifier)
+                    .sender(self.notifier, self.inner.state.is_paused())
                     .send_gpadl_created(channel_id, gpadl_id, status);
                 if status >= 0 {
                     gpadl.state = GpadlState::Accepted;
@@ -3424,7 +3488,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
     /// If you cannot borrow all of `self`, you will need to use the `PendingMessages::sender`
     /// method instead.
     fn sender(&mut self) -> MessageSender<'_, N> {
-        self.inner.pending_messages.sender(self.notifier)
+        self.inner
+            .pending_messages
+            .sender(self.notifier, self.inner.state.is_paused())
     }
 }
 
@@ -3497,10 +3563,15 @@ struct PendingMessages(VecDeque<OutgoingMessage>);
 
 impl PendingMessages {
     /// Creates a sender for the specified notifier.
-    fn sender<'a, N: Notifier>(&'a mut self, notifier: &'a mut N) -> MessageSender<'a, N> {
+    fn sender<'a, N: Notifier>(
+        &'a mut self,
+        notifier: &'a mut N,
+        is_paused: bool,
+    ) -> MessageSender<'a, N> {
         MessageSender {
             notifier,
             pending_messages: self,
+            is_paused,
         }
     }
 }
@@ -3510,6 +3581,7 @@ impl PendingMessages {
 struct MessageSender<'a, N> {
     notifier: &'a mut N,
     pending_messages: &'a mut PendingMessages,
+    is_paused: bool,
 }
 
 impl<N: Notifier> MessageSender<'_, N> {
@@ -3525,6 +3597,7 @@ impl<N: Notifier> MessageSender<'_, N> {
         tracing::trace!(typ = ?T::MESSAGE_TYPE, ?msg, "sending message");
         // Don't try to send the message if there are already pending messages.
         if !self.pending_messages.0.is_empty()
+            || self.is_paused
             || !self.notifier.send_message(&message, MessageTarget::Default)
         {
             tracing::trace!("message queued");
@@ -3544,8 +3617,9 @@ impl<N: Notifier> MessageSender<'_, N> {
         if target == MessageTarget::Default {
             self.send_message(msg);
         } else {
-            // Messages for other targets are not queued.
             tracing::trace!(typ = ?T::MESSAGE_TYPE, ?msg, "sending message");
+            // Messages for other targets are not queued, nor are they affected
+            // by the paused state.
             let message = OutgoingMessage::new(msg);
             if !self.notifier.send_message(&message, target) {
                 tracelimit::warn_ratelimited!(?target, "failed to send message");

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -379,6 +379,8 @@ enum Connection {
         client_id: Option<Guid>,
         #[mesh(8)]
         trusted: bool,
+        #[mesh(9)]
+        paused: bool,
     },
 }
 
@@ -409,6 +411,7 @@ impl Connection {
                 modifying: info.modifying,
                 client_id: Some(info.client_id),
                 trusted: info.trusted,
+                paused: info.paused,
             }),
             super::ConnectionState::Disconnecting {
                 next_action,
@@ -439,6 +442,7 @@ impl Connection {
                     offers_sent: false,
                     modifying: false,
                     client_id: client_id.unwrap_or(Guid::ZERO),
+                    paused: false,
                 },
                 next_action: next_action.restore(),
             },
@@ -451,6 +455,7 @@ impl Connection {
                 modifying,
                 client_id,
                 trusted,
+                paused,
             } => super::ConnectionState::Connected(super::ConnectionInfo {
                 version: version.restore(trusted)?,
                 trusted,
@@ -460,6 +465,7 @@ impl Connection {
                 target_message_vp,
                 modifying,
                 client_id: client_id.unwrap_or(Guid::ZERO),
+                paused,
             }),
             Connection::Disconnecting { next_action } => super::ConnectionState::Disconnecting {
                 next_action: next_action.restore(),

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
@@ -67,9 +67,8 @@ async fn openhcl_servicing_keepalive(
     .await
 }
 
-// Disabled until #954 is fixed.
-//#[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
-async fn _openhcl_servicing_shutdown_ic(
+#[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
+async fn openhcl_servicing_shutdown_ic(
     config: PetriVmConfigOpenVmm,
     (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
 ) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
During VTL2 servicing, the host resets the VTL2 synic state, causing any pending vmbus messages to be lost. To mitigate this, `vmbus_client` masks the synic sint and drains and processes any pending messages before saving its state. This prevents the vmbus server in the Hyper-V host from posting new messages, so that they are not lost; Hyper-V retries them later when the sint is unmasked.

Unfortunately, this mask/unmask behavior is not supported by OpenVMM with `virt_whp`, because `virt_whp`'s synic emulation relies on `HvPostMessageDirect`, which does not allow posting a message to the message slot when the sint is masked. This means that it is impossible for `virt_whp` to support this process for draining the message queue, and so any pending messages are lost across VTL2 servicing.

Perhaps we should fix the hypervisor to support posting a message with `HvPostMessageDirect` even when the sint is masked, and to provide a mechanism to get an exit in `virt_whp` when the sint becomes masked so that we can stop queuing new messages, to match the behavior of Hyper-V precisely.

However, it is arguably cleaner just to support pausing/resuming the vmbus message stream in-band in the vmbus protocol. This works around this issue and it avoids the need for the host to get a "sint unmasked" notification or to otherwise retry on a timer.

So, implement that. Add pause, pause complete, and resume messages to the vmbus protocol, behind a protocol feature flag, to allow the client to tell the server to temporarily stop sending synic messages. Use this feature when available in `vmbus_client`; when not available, fall back to the synic masking approach.

Fixes #954. Reverts #955.