### PR TITLE
vmbus_client: handle host backpressure properly

### DIFF
--- a/support/pal/pal_async/src/timer.rs
+++ b/support/pal/pal_async/src/timer.rs
@@ -127,6 +127,12 @@ impl PolledTimer {
             deadline,
         }
     }
+
+    /// Returns `Pending` until the current time is later than `deadline`. Then
+    /// returns `Ready` with the current time.
+    pub fn poll_until(&mut self, cx: &mut Context<'_>, deadline: Instant) -> Poll<Instant> {
+        self.0.poll_timer(cx, Some(deadline))
+    }
 }
 
 /// [`Future`] implementation for [`PolledTimer::sleep`] and


### PR DESCRIPTION
To avoid deadlocks with the host, queue and retry sending messages
asynchronously rather than blocking the thread.

Also, support restoring pending messages for saved state compatibility
with changes in main, especially #962.

This is a partial backport of #884.
