### PR TITLE
tdcall: Adding check for return status and updating error types.

### DIFF
--- a/vm/x86/tdcall/src/lib.rs
+++ b/vm/x86/tdcall/src/lib.rs
@@ -462,7 +462,7 @@ pub fn accept_pages<T: Tdcall>(
                     TdCallResultCode::OPERAND_BUSY => return Err(AcceptPagesError::Busy(e)),
                     TdCallResultCode::OPERAND_INVALID => return Err(AcceptPagesError::Invalid(e)),
                     TdCallResultCode::PAGE_ALREADY_ACCEPTED => {
-                        assert_eq!(e, TdCallResultCode::SUCCESS, "page already accepted");
+                        panic!("page {} already accepted", range.start_4k_gpn());
                     }
                     TdCallResultCode::PAGE_SIZE_MISMATCH => {
                         #[cfg(feature = "tracing")]
@@ -489,7 +489,7 @@ pub fn accept_pages<T: Tdcall>(
                 TdCallResultCode::OPERAND_BUSY => return Err(AcceptPagesError::Busy(e)),
                 TdCallResultCode::OPERAND_INVALID => return Err(AcceptPagesError::Invalid(e)),
                 TdCallResultCode::PAGE_ALREADY_ACCEPTED => {
-                    assert_eq!(e, TdCallResultCode::SUCCESS, "page already accepted");
+                    panic!("page {} already accepted", range.start_4k_gpn());
                 }
                 _ => return Err(AcceptPagesError::Unknown(e)),
             },


### PR DESCRIPTION
Added error types for AcceptPagesError reflecting the error types mentioned in the spec and updated the tdcall_accept_pages error handling accordingly.
Added a check to validate the return code in rax for tdcall_map_gpa.
Addresses Issue #545 
