### PR TITLE
For tx segments exceeding 31, coalesce into bounce buffer

### DIFF
--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -1135,7 +1135,7 @@ impl<T: DeviceBacking> ManaQueue<T> {
                 }
                 &sgl[..segment_count]
             } else {
-                let sgl = &mut sgl[..segment_count.min(hardware_segment_limit)];
+                let sgl = &mut sgl[..hardware_segment_limit];
                 for tail_idx in header_segment_count..segments.len() {
                     let tail = &segments[tail_idx];
                     let cur_seg = &mut sgl[sgl_idx];

--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -1264,7 +1264,7 @@ impl<'a, 'b> ContiguousBuffer<'a, 'b> {
     pub fn reserve(self) -> ContiguousBufferInUse {
         let page = self.offset / PAGE_SIZE32;
         let offset_in_page = self.offset - page * PAGE_SIZE32;
-        let gpa = self.parent.get_page_gpa(page as usize) + offset_in_page as u64;
+        let gpa = self.parent.page_gpa(page as usize) + offset_in_page as u64;
         let len_with_padding = self.len + self.padding_len;
         self.parent.head = self.parent.head.wrapping_add(len_with_padding);
         ContiguousBufferInUse {
@@ -1332,7 +1332,7 @@ impl<'a> ContiguousBufferManagerTransaction<'a> {
         self.parent.as_slice()
     }
 
-    pub fn get_page_gpa(&self, page_idx: usize) -> u64 {
+    pub fn page_gpa(&self, page_idx: usize) -> u64 {
         self.parent.mem.pfns()[page_idx] * PAGE_SIZE64
     }
 }

--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -1120,14 +1120,6 @@ impl<T: DeviceBacking> ManaQueue<T> {
             };
 
             let segment_count = tail_sgl_offset + meta.segment_count - header_segment_count;
-            // Verbose logging for testing. TODO: Remove before checkin
-            tracing::error!(
-                "ERIK segment_count {:?} tail_sgl_offset {:?} meta.segment_count {:?} header_segment_count {:?}",
-                segment_count,
-                tail_sgl_offset,
-                meta.segment_count,
-                header_segment_count
-            );
             let sgl = if segment_count < 31 {
                 let sgl = &mut sgl[..segment_count];
                 for (tail, sge) in segments[header_segment_count..]


### PR DESCRIPTION
net_mana has a hardware limit of on the number of segments (either 31 or 30).

Any packet with fewer than 31 segments, net_mana will send correctly.
When a packet has a number of segments greater than 31, openhcl crashes.

Note: netvsp has a max MDL chain length of 34, so for packets with an MDL chain longer than 34, netvsc will bounce buffer, and net_mana will see only 2 segments. This makes the crash rare / difficult to reproduce.

Fixing the problem by:
* Modifying net_mana code to bounce buffer whenever segment count exceeds the hardware limit.
* Adding functionality to ContiguousBufferManager to create logic for transactions and try_extend to support a single bounce buffer that can include either:
    * Header's bounced segments + beginning segments of payload.
    * The first sequence of the payload that can be coalesced.
* Added a new unit test to net_mana to validate coalescing by sending 34 segments.

There is a limitation on the size of the bounce buffer of 4096. It is possible that coalescing will not succeed at getting the number of segments below the hardware limitation. In those cases, the Packet is dropped and an error is traced "Failed to bounce buffer the packet too many segments".

Test results:
112,200 packets with different combinations of # MDLs and various payload sizes sent.
0 crashes
 
680 (.6%) error "Failed to bounce buffer the packet too many segments"
segments_remaining=0x1 350-ish
segments_remaining=0x2 321-ish
*these numbers are approximate because the error message were rate limited and some were dropped, but it's good enough for napkin math.

