### PR TITLE
Lower netvsp max mdl chain length

### DIFF
--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -1096,6 +1096,7 @@ impl<T: DeviceBacking> ManaQueue<T> {
                     (self.guest_memory.iova(head.gpa).unwrap(), 0)
                 };
 
+            // 31 comes from a hardware limit. Max WQE size is 512 bytes.
             let mut sgl = [Sge::new_zeroed(); 31];
             sgl[0] = Sge {
                 address: head_iova,
@@ -1119,6 +1120,14 @@ impl<T: DeviceBacking> ManaQueue<T> {
             };
 
             let segment_count = tail_sgl_offset + meta.segment_count - header_segment_count;
+            // Verbose logging for testing. TODO: Remove before checkin
+            tracing::error!(
+                "ERIK segment_count {:?} tail_sgl_offset {:?} meta.segment_count {:?} header_segment_count {:?}",
+                segment_count,
+                tail_sgl_offset,
+                meta.segment_count,
+                header_segment_count
+            );
             let sgl = &mut sgl[..segment_count];
             for (tail, sge) in segments[header_segment_count..]
                 .iter()

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4570,11 +4570,16 @@ impl<T: 'static + RingMem> NetChannel<T> {
                     PacketData::Init(init) => {
                         let requested_version = init.protocol_version;
                         let version = check_version(requested_version);
+                        // Normally the maximum MDL chain length is 34, which comes from the following formula:
+                        //    RNDIS Max Simulataneous Packets (8) * 3 + 10 = 34
+                        // However net_mana has a hardcoded limit of 31 transmit segments, based on a hardware limitation.
+                        // Reducing the maximum chain length forces Netvsc to bounce packets which exceed the hardware limit.
+                        let max_mdl_chain_len = 31;
                         let mut message = self.message(
                             protocol::MESSAGE_TYPE_INIT_COMPLETE,
                             protocol::MessageInitComplete {
                                 deprecated: protocol::INVALID_PROTOCOL_VERSION,
-                                maximum_mdl_chain_length: 34,
+                                maximum_mdl_chain_length: max_mdl_chain_len,
                                 status: protocol::Status::NONE,
                             },
                         );


### PR DESCRIPTION
Net_mana has a hardware limit of 31 segments.
Netvsp has a max MDL chain length of 34.

Lowing netvsp maximum MDL chain length to force netvsc to bounce buffer packets exceeding hardware limit. This prevents a crash in openhcl.

Open Issues:
* There is a possible loss of performance as more packets are bounced buffered instead of fast-pathed. In testing, I found the highest number of segments I was able to send before hitting the new MDL limit is now 27.
* If there is a case where an MDL can contain multiple SGEs, this solution will not fix the bug. There will still be narrow edge cases where a packet with < 31 MDLs can cause a crash with > 31 segments.
