### PR TITLE
vmbus_client: make Close an RPC

### DIFF
--- a/vm/devices/vmbus/vmbus_channel/src/bus.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/bus.rs
@@ -80,6 +80,10 @@ pub enum ChannelRequest {
     /// Open the channel.
     Open(Rpc<OpenRequest, Option<OpenResult>>),
     /// Close the channel.
+    ///
+    /// Although there is no response from the host, this is still modeled as an
+    /// RPC so that the caller can know that the vmbus client's state has been
+    /// updated.
     Close(Rpc<(), ()>),
     /// Create a new GPADL.
     Gpadl(Rpc<GpadlRequest, bool>),

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -309,11 +309,12 @@ impl RelayChannelTask {
         })
     }
 
-    fn handle_close_channel(&mut self) {
-        let _ = &self
-            .channel
+    async fn handle_close_channel(&mut self) {
+        self.channel
             .request_send
-            .send(client::ChannelRequest::Close);
+            .call(client::ChannelRequest::Close, ())
+            .await
+            .ok();
 
         self.channel.interrupt_relay = None;
     }
@@ -399,7 +400,7 @@ impl RelayChannelTask {
                 .await;
             }
             ChannelRequest::Close(rpc) => {
-                rpc.handle(|()| async move { self.handle_close_channel() })
+                rpc.handle(|()| async move { self.handle_close_channel().await })
                     .await;
             }
             ChannelRequest::TeardownGpadl(rpc) => {

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -387,7 +387,11 @@ impl<T: SimpleVmbusClientDeviceAsync> SimpleVmbusClientDeviceTask<T> {
         // available everywhere.
         {
             let offer = state.offer.as_ref().expect("device opened");
-            offer.request_send.send(ChannelRequest::Close);
+            offer
+                .request_send
+                .call(ChannelRequest::Close, ())
+                .await
+                .ok();
         }
         // N.B. This will wait for a TeardownGpadl response which can be used
         // as a signal that the channel is closed and the ring buffers are no


### PR DESCRIPTION
The vmbus client and vmbus relay channel states need to stay in sync, since we cannot save/restore in intermediate states (such as in the middle of opening a channel).

Close currently breaks this--the relay can send a close just before pausing saving, and there is no guarantee (that I can see) that the client will process it before it is saved.

Fix this by making `Close` an RPC, so that the relay can wait for the message to be sent to the host, and the client state updated, before it pauses and saves its own state.