### PR TITLE
mesh_node: send and close channels in one operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3953,6 +3953,8 @@ dependencies = [
 name = "mesh_node"
 version = "0.0.0"
 dependencies = [
+ "bitfield-struct",
+ "futures",
  "futures-channel",
  "getrandom",
  "mesh_derive",

--- a/support/mesh/mesh_node/Cargo.toml
+++ b/support/mesh/mesh_node/Cargo.toml
@@ -10,6 +10,8 @@ rust-version.workspace = true
 mesh_derive.workspace = true
 mesh_protobuf.workspace = true
 open_enum.workspace = true
+
+bitfield-struct.workspace = true
 futures-channel.workspace = true
 getrandom.workspace = true
 parking_lot.workspace = true
@@ -20,8 +22,9 @@ zerocopy.workspace = true
 pal.workspace = true
 
 [dev-dependencies]
-pal_async.workspace = true
+futures.workspace = true
 
+pal_async.workspace = true
 test_with_tracing.workspace = true
 
 [lints]

--- a/support/mesh/mesh_node/src/local_node.rs
+++ b/support/mesh/mesh_node/src/local_node.rs
@@ -2517,6 +2517,10 @@ pub mod tests {
 
     impl RemoteLocalNode {
         fn new(driver: &impl Spawn) -> Self {
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "can't use mesh channels from mesh_node"
+            )]
             let (send, recv) = futures_channel::mpsc::unbounded::<RemoteEvent>();
             let node = Arc::new(LocalNode::with_id(NodeId::new(), Box::new(NullConnect)));
             let task = driver.spawn("test", {

--- a/support/mesh/mesh_node/src/local_node.rs
+++ b/support/mesh/mesh_node/src/local_node.rs
@@ -60,7 +60,7 @@ impl Debug for Port {
 
 impl Drop for Port {
     fn drop(&mut self) {
-        self.inner.close();
+        self.inner.close(None);
     }
 }
 
@@ -286,15 +286,13 @@ impl Port {
 
     /// Sends a message to the peer.
     pub fn send(&self, message: Message<'_>) {
-        let peer_seq = {
-            let mut state = self.inner.state.lock();
-            assert!(!state.is_local_closed);
-            state.next_peer_and_seq()
-        };
+        self.inner.send(message);
+    }
 
-        if let Some((peer, seq)) = peer_seq {
-            PendingEvents::send(&peer, seq, PortEvent::Message(message));
-        }
+    /// Sends a message to the peer and closes the port in one operation.
+    pub fn send_and_close(self, message: Message<'_>) {
+        // Avoid double close: don't run the drop impl.
+        self.into_inner().close(Some(message));
     }
 
     /// Send a protobuf-encodable message to the peer.
@@ -310,6 +308,22 @@ impl Port {
         T::Encoding: mesh_protobuf::MessageEncode<T, Resource>,
     {
         self.send(crate::message::stack_message!(value));
+    }
+
+    /// Send a protobuf-encodable message to the peer and close the port in one
+    /// operation.
+    ///
+    /// Prefer [`Port::send_and_close`] if you already have a [`Message`],
+    /// [`OwnedMessage`], or serialized message, or if the recipient is known to
+    /// take advantage of the [`OwnedMessage::try_unwrap`] optimization.
+    ///
+    /// Otherwise, this method is more efficient since it can avoid an extra
+    /// allocation to construct a [`Message`].
+    pub fn send_protobuf_and_close<T: DefaultEncoding>(self, value: T)
+    where
+        T::Encoding: mesh_protobuf::MessageEncode<T, Resource>,
+    {
+        self.send_and_close(crate::message::stack_message!(value));
     }
 
     pub fn is_closed(&self) -> Result<bool, NodeError> {
@@ -344,12 +358,6 @@ impl<T> Debug for PortWithHandler<T> {
         f.debug_struct("PortWithHandler")
             .field("raw", &self.raw)
             .finish()
-    }
-}
-
-impl<T> Drop for PortWithHandler<T> {
-    fn drop(&mut self) {
-        self.raw.inner.clear_queue(false);
     }
 }
 
@@ -408,13 +416,19 @@ impl<T: HandlePortEvent> PortWithHandler<T> {
 
     pub fn remove_handler(self) -> (Port, T) {
         let port = self.into_port_preserve_handler();
-        let handler = port.inner.clear_queue(true);
-        (port, *handler.into_any().downcast().unwrap())
+        let handler = port.inner.drain_queue();
+        (port, *handler.unwrap().into_any().downcast().unwrap())
     }
 
     pub fn with_handler<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
         let mut state = self.raw.inner.state.lock();
-        f(state.handler.as_any().downcast_mut().unwrap())
+        f(state
+            .handler
+            .as_mut()
+            .unwrap()
+            .as_any()
+            .downcast_mut()
+            .unwrap())
     }
 
     pub fn with_port_and_handler<'a, R>(
@@ -432,7 +446,16 @@ impl<T: HandlePortEvent> PortWithHandler<T> {
             peer_and_seq,
             events: &mut pending_events,
         };
-        let r = f(&mut control, state.handler.as_any().downcast_mut().unwrap());
+        let r = f(
+            &mut control,
+            state
+                .handler
+                .as_mut()
+                .unwrap()
+                .as_any()
+                .downcast_mut()
+                .unwrap(),
+        );
         pending_events.process();
         r
     }
@@ -692,8 +715,14 @@ impl<'a, 'm> PortControl<'a, 'm> {
         if let Some((port_ref, seq)) = &mut self.peer_and_seq {
             let this = **seq;
             **seq += Wrapping(1);
-            self.events
-                .push(port_ref.clone(), this, PortEvent::Message(message))
+            self.events.push(
+                port_ref.clone(),
+                this,
+                PortEvent::Message {
+                    message: Some(message),
+                    close: false,
+                },
+            )
         }
     }
 
@@ -843,7 +872,7 @@ struct PortInnerState {
     local_node: Option<Weak<LocalNodeInner>>,
 
     event_queue: EventQueue,
-    handler: Box<dyn HandlePortEventAndAny>,
+    handler: Option<Box<dyn HandlePortEventAndAny>>,
 
     next_local_seq: Seq,
     is_local_closed: bool,
@@ -983,7 +1012,7 @@ impl PortInnerState {
             activity,
             next_local_seq: Wrapping(1),
             event_queue: EventQueue::new(),
-            handler: Box::<QueuingHandler>::default(),
+            handler: None,
             is_local_closed: false,
         }
     }
@@ -1166,20 +1195,23 @@ impl PortInnerState {
                     let mut v = Some((seq, event));
                     while let Some(port_event) = self.event_queue.pop(v.take()) {
                         match port_event {
-                            PortEvent::Message(message) => {
-                                if let Err(err) = self.handler.message(
-                                    &mut PortControl::peered(
-                                        peer,
-                                        &mut self.next_local_seq,
-                                        pending_events,
-                                    ),
-                                    message,
-                                ) {
-                                    break 'error PortError::BadMessage(err.0);
+                            PortEvent::Message { message, close } => {
+                                if let Some(message) = message {
+                                    let handler = self
+                                        .handler
+                                        .get_or_insert_with(|| Box::new(QueuingHandler::default()));
+                                    if let Err(err) = handler.message(
+                                        &mut PortControl::peered(
+                                            peer,
+                                            &mut self.next_local_seq,
+                                            pending_events,
+                                        ),
+                                        message,
+                                    ) {
+                                        break 'error PortError::BadMessage(err.0);
+                                    }
                                 }
-                            }
-                            PortEvent::Event(e) => match e {
-                                NonMessageEvent::ClosePort => {
+                                if close {
                                     if !self.event_queue.is_empty() {
                                         break 'error PortError::EventAfterClose;
                                     }
@@ -1187,11 +1219,16 @@ impl PortInnerState {
                                         pending_events.push(
                                             peer.clone(),
                                             self.next_local_seq,
-                                            NonMessageEvent::ClosePort,
+                                            PortEvent::Message {
+                                                message: None,
+                                                close: true,
+                                            },
                                         );
                                     }
                                     return Ok(PortEventResult::Done);
                                 }
+                            }
+                            PortEvent::Event(e) => match e {
                                 NonMessageEvent::ChangePeer(new_peer, seq_delta) => {
                                     assert!(new_peer.is_compatible_node(&self.local_node));
                                     new_peer.node_status()?;
@@ -1276,9 +1313,18 @@ impl PortInnerState {
         let mut seq = initial_seq;
 
         // Send any messages in the queue.
-        for message in self.handler.drain() {
-            pending_events.push(target.clone(), seq, OwnedPortEvent::Message(message));
-            seq += Wrapping(1);
+        if let Some(handler) = &mut self.handler {
+            for message in handler.drain() {
+                pending_events.push(
+                    target.clone(),
+                    seq,
+                    OwnedPortEvent::Message {
+                        message: Some(message),
+                        close: false,
+                    },
+                );
+                seq += Wrapping(1);
+            }
         }
 
         // Send the event queue.
@@ -1301,18 +1347,50 @@ impl PortInnerState {
 }
 
 impl PortInner {
-    /// Closes the port. After this, no messages may be sent or received.
-    fn close(&self) {
+    /// Sends a message on the port.
+    fn send(&self, message: Message<'_>) {
         let peer_seq = {
             let mut state = self.state.lock();
             assert!(!state.is_local_closed);
+            state.next_peer_and_seq()
+        };
+
+        if let Some((peer, seq)) = peer_seq {
+            PendingEvents::send(
+                &peer,
+                seq,
+                PortEvent::Message {
+                    message: Some(message),
+                    close: false,
+                },
+            );
+        }
+    }
+
+    /// Closes the port, optionally sending a message first. After this, no
+    /// messages may be sent or received.
+    fn close(&self, message: Option<Message<'_>>) {
+        let _old_handler;
+        let peer_seq = {
+            let mut state = self.state.lock();
+            assert!(!state.is_local_closed);
+
+            // Clear the handler now so that it is reliably dropped.
+            _old_handler = std::mem::take(&mut state.handler);
 
             state.is_local_closed = true;
             state.next_peer_and_seq()
         };
 
         if let Some((peer, seq)) = peer_seq {
-            PendingEvents::send(&peer, seq, NonMessageEvent::ClosePort);
+            PendingEvents::send(
+                &peer,
+                seq,
+                PortEvent::Message {
+                    message,
+                    close: true,
+                },
+            );
         }
     }
 
@@ -1330,16 +1408,16 @@ impl PortInner {
             Ok(PortEventResult::None) => {}
             Ok(PortEventResult::Done) => {
                 state.set_activity(PortActivity::Done);
-                state
-                    .handler
-                    .close(&mut PortControl::unpeered(pending_events));
+                if let Some(handler) = &mut state.handler {
+                    handler.close(&mut PortControl::unpeered(pending_events));
+                }
                 disassociate = true;
             }
             Err(err) => {
                 state.fail(pending_events, err.clone());
-                state
-                    .handler
-                    .fail(&mut PortControl::unpeered(pending_events), err);
+                if let Some(handler) = &mut state.handler {
+                    handler.fail(&mut PortControl::unpeered(pending_events), err);
+                }
                 disassociate = true;
             }
         }
@@ -1376,10 +1454,12 @@ impl PortInner {
 
         if let Some(err) = err {
             self.disassociate(&mut state);
-            state.handler.fail(
-                &mut PortControl::unpeered(pending_events),
-                NodeError::new(remote_node_id, err),
-            );
+            if let Some(handler) = &mut state.handler {
+                handler.fail(
+                    &mut PortControl::unpeered(pending_events),
+                    NodeError::new(remote_node_id, err),
+                );
+            }
 
             drop(state);
             // Trace outside the lock to avoid deadlocks.
@@ -1457,7 +1537,6 @@ impl PortInner {
         {
             let mut state = self.state.lock();
             let state = &mut *state;
-            let messages = state.handler.drain();
             let peer_and_seq = match &state.activity {
                 PortActivity::Peered(peer) => Some((peer, &mut state.next_local_seq)),
                 _ => None,
@@ -1466,13 +1545,15 @@ impl PortInner {
                 peer_and_seq,
                 events: &mut pending_events,
             };
-            for message in messages {
-                if let Err(err) = handler.message(&mut control, message.into()) {
-                    state.fail(
-                        &mut pending_events,
-                        NodeError::local(PortError::BadMessage(err.0)),
-                    );
-                    break;
+            if let Some(mut old_handler) = state.handler.take() {
+                for message in old_handler.drain() {
+                    if let Err(err) = handler.message(&mut control, message.into()) {
+                        state.fail(
+                            &mut pending_events,
+                            NodeError::local(PortError::BadMessage(err.0)),
+                        );
+                        break;
+                    }
                 }
             }
             match &state.activity {
@@ -1485,19 +1566,21 @@ impl PortInner {
                 }
                 _ => unreachable!(),
             }
-            state.handler = handler;
+            state.handler = Some(handler);
         }
         pending_events.process();
     }
 
-    fn clear_queue(&self, drain: bool) -> Box<dyn HandlePortEventAndAny> {
+    fn drain_queue(&self) -> Option<Box<dyn HandlePortEventAndAny>> {
         let mut state = self.state.lock();
-        let messages = if drain {
-            state.handler.drain()
-        } else {
-            Vec::new()
-        };
-        std::mem::replace(&mut state.handler, Box::new(QueuingHandler { messages }))
+        let mut handler = state.handler.take();
+        let messages = handler
+            .as_mut()
+            .map_or_else(Vec::new, |handler| handler.drain());
+        if !messages.is_empty() {
+            state.handler = Some(Box::new(QueuingHandler { messages }));
+        }
+        handler
     }
 }
 
@@ -1574,7 +1657,10 @@ struct LocalNodeState {
 /// The deserialized event for processing by a local port.
 #[derive(Debug)]
 enum PortEvent<'a> {
-    Message(Message<'a>),
+    Message {
+        message: Option<Message<'a>>,
+        close: bool,
+    },
     Event(NonMessageEvent),
 }
 
@@ -1587,7 +1673,10 @@ impl From<NonMessageEvent> for PortEvent<'_> {
 impl From<OwnedPortEvent> for PortEvent<'_> {
     fn from(value: OwnedPortEvent) -> Self {
         match value {
-            OwnedPortEvent::Message(m) => PortEvent::Message(m.into()),
+            OwnedPortEvent::Message { message, close } => PortEvent::Message {
+                message: message.map(Into::into),
+                close,
+            },
             OwnedPortEvent::Event(e) => PortEvent::Event(e),
         }
     }
@@ -1596,7 +1685,10 @@ impl From<OwnedPortEvent> for PortEvent<'_> {
 impl PortEvent<'_> {
     fn into_owned(self) -> OwnedPortEvent {
         match self {
-            PortEvent::Message(message) => OwnedPortEvent::Message(message.into_owned()),
+            PortEvent::Message { message, close } => OwnedPortEvent::Message {
+                message: message.map(|m| m.into_owned()),
+                close,
+            },
             PortEvent::Event(event) => OwnedPortEvent::Event(event),
         }
     }
@@ -1605,14 +1697,16 @@ impl PortEvent<'_> {
 /// An owning version of [`PortEvent`].
 #[derive(Debug)]
 enum OwnedPortEvent {
-    Message(OwnedMessage),
+    Message {
+        message: Option<OwnedMessage>,
+        close: bool,
+    },
     Event(NonMessageEvent),
 }
 
 /// A port event exclusive of a message event.
 #[derive(Debug)]
 enum NonMessageEvent {
-    ClosePort,
     ChangePeer(PortRef, Seq),
     AcknowledgeChangePeer,
     AcknowledgePort,
@@ -1629,7 +1723,10 @@ pub struct OutgoingEvent<'a> {
 }
 
 enum EventAndEncoder<'a> {
-    Message(Encoder<Message<'a>, <Message<'a> as DefaultEncoding>::Encoding, Resource>),
+    Message {
+        message: Option<Encoder<Message<'a>, <Message<'a> as DefaultEncoding>::Encoding, Resource>>,
+        close: bool,
+    },
     Other(NonMessageEvent),
 }
 
@@ -1642,11 +1739,14 @@ impl<'a> OutgoingEvent<'a> {
     ) -> Self {
         let mut len = size_of::<protocol::Event>();
         let event = match event {
-            PortEvent::Message(message) => {
-                let message = Encoder::new(message);
-                len += message.resource_count() * size_of::<protocol::ResourceData>();
-                len += message.len();
-                EventAndEncoder::Message(message)
+            PortEvent::Message { message, close } => {
+                let message = message.map(|m| {
+                    let message = Encoder::new(m);
+                    len += message.resource_count() * size_of::<protocol::ResourceData>();
+                    len += message.len();
+                    message
+                });
+                EventAndEncoder::Message { message, close }
             }
             PortEvent::Event(event) => match event {
                 NonMessageEvent::ChangePeer(_, _) => {
@@ -1657,8 +1757,7 @@ impl<'a> OutgoingEvent<'a> {
                     len += size_of::<protocol::FailPortData>();
                     EventAndEncoder::Other(event)
                 }
-                event @ (NonMessageEvent::ClosePort
-                | NonMessageEvent::AcknowledgeChangePeer
+                event @ (NonMessageEvent::AcknowledgeChangePeer
                 | NonMessageEvent::AcknowledgePort) => EventAndEncoder::Other(event),
             },
         };
@@ -1698,7 +1797,6 @@ impl<'a> OutgoingEvent<'a> {
         };
         match self.event {
             EventAndEncoder::Other(event) => match event {
-                NonMessageEvent::ClosePort => header.event_type = protocol::EventType::CLOSE_PORT,
                 NonMessageEvent::ChangePeer(port, seq_delta) => {
                     let (node_id, port_id) = match port {
                         PortRef::LocalPort(port) => {
@@ -1740,27 +1838,31 @@ impl<'a> OutgoingEvent<'a> {
                     );
                 }
             },
-            EventAndEncoder::Message(message) => {
+            EventAndEncoder::Message { message, close } => {
                 let mut resources = Vec::new();
                 header.event_type = protocol::EventType::MESSAGE;
-                header.message_size = message.len() as u32;
-                header.resource_count = message.resource_count() as u32;
-                buf.write_split(
-                    message.resource_count() * size_of::<protocol::ResourceData>(),
-                    |mut resource_buf, mut message_buf| {
-                        message.encode_into(&mut message_buf, &mut resources);
-                        for resource in resources {
-                            let data = match resource {
-                                Resource::Port(port) => port.prepare_to_send(self.remote_node),
-                                Resource::Os(r) => {
-                                    os_resources.extend([r]);
-                                    protocol::ResourceData::new_zeroed()
-                                }
-                            };
-                            resource_buf.append(data.as_bytes());
-                        }
-                    },
-                );
+                header.flags.set_close(close);
+                if let Some(message) = message {
+                    header.flags.set_message(true);
+                    header.message_size = message.len() as u32;
+                    header.resource_count = message.resource_count() as u32;
+                    buf.write_split(
+                        message.resource_count() * size_of::<protocol::ResourceData>(),
+                        |mut resource_buf, mut message_buf| {
+                            message.encode_into(&mut message_buf, &mut resources);
+                            for resource in resources {
+                                let data = match resource {
+                                    Resource::Port(port) => port.prepare_to_send(self.remote_node),
+                                    Resource::Os(r) => {
+                                        os_resources.extend([r]);
+                                        protocol::ResourceData::new_zeroed()
+                                    }
+                                };
+                                resource_buf.append(data.as_bytes());
+                            }
+                        },
+                    );
+                }
             }
         }
 
@@ -1954,21 +2056,27 @@ impl LocalNode {
 
         let port_event = match header.event_type {
             protocol::EventType::MESSAGE => {
-                // Consume all the ports.
-                let mut resources = Vec::with_capacity(resource_data.len());
-                for data in resource_data {
-                    let data = data.get();
-                    let r = if data.id.is_zero() {
-                        Resource::Os(os_resources.next().ok_or(EventError::MissingOsResource)?)
-                    } else {
-                        Resource::Port(self.receive_port(remote_node_id, data))
-                    };
-                    resources.push(r);
+                let message = if header.flags.message() {
+                    // Consume all the ports.
+                    let mut resources = Vec::with_capacity(resource_data.len());
+                    for data in resource_data {
+                        let data = data.get();
+                        let r = if data.id.is_zero() {
+                            Resource::Os(os_resources.next().ok_or(EventError::MissingOsResource)?)
+                        } else {
+                            Resource::Port(self.receive_port(remote_node_id, data))
+                        };
+                        resources.push(r);
+                    }
+                    Some(Message::serialized(message, resources))
+                } else {
+                    None
+                };
+                PortEvent::Message {
+                    message,
+                    close: header.flags.close(),
                 }
-                let m = Message::serialized(message, resources);
-                PortEvent::Message(m)
             }
-            protocol::EventType::CLOSE_PORT => NonMessageEvent::ClosePort.into(),
             protocol::EventType::CHANGE_PEER => {
                 let data = protocol::ChangePeerData::read_from_prefix(message)
                     .map_err(|_| EventError::Truncated)?
@@ -2132,7 +2240,9 @@ impl LocalNodeInner {
         let mut control = PortControl::unpeered(&mut pending_events);
         for (_, port) in ports {
             let mut state = port.state.lock();
-            state.handler.fail(&mut control, err.clone());
+            if let Some(handler) = &mut state.handler {
+                handler.fail(&mut control, err.clone());
+            }
             state.local_node = None;
             state.set_activity(PortActivity::Failed(err.clone()));
         }
@@ -2187,9 +2297,9 @@ impl LocalNodeInner {
             };
             if fail {
                 state.fail(&mut pending_events, err.clone());
-                state
-                    .handler
-                    .fail(&mut PortControl::unpeered(&mut pending_events), err.clone());
+                if let Some(handler) = &mut state.handler {
+                    handler.fail(&mut PortControl::unpeered(&mut pending_events), err.clone());
+                }
                 port.disassociate(&mut state);
                 drop(state);
 
@@ -2215,13 +2325,40 @@ pub mod tests {
     use super::*;
     use crate::message::MeshField;
     use crate::resource::SerializedMessage;
+    use futures::stream::Stream;
     use pal_async::async_test;
     use pal_async::task::Spawn;
+    use pal_async::task::Task;
+    use pal_async::DefaultDriver;
     use std::future::poll_fn;
+    use std::future::Future;
     use std::marker::PhantomData;
+    use std::pin::pin;
+    use std::pin::Pin;
     use std::task::Context;
     use std::task::Poll;
     use test_with_tracing::test;
+
+    fn yield_once() -> YieldOnce {
+        YieldOnce { yielded: false }
+    }
+
+    struct YieldOnce {
+        yielded: bool,
+    }
+
+    impl Future for YieldOnce {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if !self.yielded {
+                self.yielded = true;
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            ().into()
+        }
+    }
 
     #[derive(Debug)]
     pub enum TryRecvError {
@@ -2360,7 +2497,15 @@ pub mod tests {
     }
 
     struct RemoteLocalNode {
-        node: LocalNode,
+        _task: Task<()>,
+        node: Arc<LocalNode>,
+        send: futures_channel::mpsc::UnboundedSender<RemoteEvent>,
+    }
+
+    struct RemoteEvent {
+        node_id: NodeId,
+        data: Vec<u8>,
+        resources: Vec<OsResource>,
     }
 
     #[derive(Debug)]
@@ -2371,9 +2516,22 @@ pub mod tests {
     }
 
     impl RemoteLocalNode {
-        fn new() -> Self {
+        fn new(driver: &impl Spawn) -> Self {
+            let (send, recv) = futures_channel::mpsc::unbounded::<RemoteEvent>();
+            let node = Arc::new(LocalNode::with_id(NodeId::new(), Box::new(NullConnect)));
+            let task = driver.spawn("test", {
+                let node = node.clone();
+                async move {
+                    let mut recv = pin!(recv);
+                    while let Some(mut event) = poll_fn(|cx| recv.as_mut().poll_next(cx)).await {
+                        node.event(&event.node_id, &event.data, &mut event.resources);
+                    }
+                }
+            });
             Self {
-                node: LocalNode::with_id(NodeId::new(), Box::new(NullConnect)),
+                _task: task,
+                node,
+                send,
             }
         }
 
@@ -2381,7 +2539,7 @@ pub mod tests {
             let handle = self.node.add_remote(other.node.id());
             handle.connect(EventsFrom {
                 node_id: self.node.id(),
-                node: other.clone(),
+                send: other.send.clone(),
             });
             handle
         }
@@ -2389,7 +2547,7 @@ pub mod tests {
 
     struct EventsFrom {
         node_id: NodeId,
-        node: Arc<RemoteLocalNode>,
+        send: futures_channel::mpsc::UnboundedSender<RemoteEvent>,
     }
 
     impl SendEvent for EventsFrom {
@@ -2397,9 +2555,13 @@ pub mod tests {
             let mut buffer = Vec::with_capacity(event.len());
             let mut os_resources = Vec::new();
             event.write_to(&mut buffer, &mut os_resources);
-            self.node
-                .node
-                .event(&self.node_id, &buffer, &mut os_resources);
+            self.send
+                .unbounded_send(RemoteEvent {
+                    node_id: self.node_id,
+                    data: buffer,
+                    resources: os_resources,
+                })
+                .ok();
         }
     }
 
@@ -2414,13 +2576,15 @@ pub mod tests {
         assert!(matches!(right.try_recv().unwrap_err(), TryRecvError::Empty));
     }
 
-    fn new_two_node_mesh() -> (
+    fn new_two_node_mesh(
+        driver: &DefaultDriver,
+    ) -> (
         Arc<RemoteLocalNode>,
         Arc<RemoteLocalNode>,
         Vec<RemoteNodeHandle>,
     ) {
-        let node = Arc::new(RemoteLocalNode::new());
-        let node2 = Arc::new(RemoteLocalNode::new());
+        let node = Arc::new(RemoteLocalNode::new(driver));
+        let node2 = Arc::new(RemoteLocalNode::new(driver));
         let mut v = Vec::new();
         let handle = node.connect(&node2);
         v.push(handle);
@@ -2429,15 +2593,17 @@ pub mod tests {
         (node, node2, v)
     }
 
-    fn new_three_node_mesh() -> (
+    fn new_three_node_mesh(
+        driver: &DefaultDriver,
+    ) -> (
         Arc<RemoteLocalNode>,
         Arc<RemoteLocalNode>,
         Arc<RemoteLocalNode>,
         Vec<RemoteNodeHandle>,
     ) {
-        let node = Arc::new(RemoteLocalNode::new());
-        let node2 = Arc::new(RemoteLocalNode::new());
-        let node3 = Arc::new(RemoteLocalNode::new());
+        let node = Arc::new(RemoteLocalNode::new(driver));
+        let node2 = Arc::new(RemoteLocalNode::new(driver));
+        let node3 = Arc::new(RemoteLocalNode::new(driver));
         let mut v = Vec::new();
         for i in [&node, &node2, &node3][..].iter().copied() {
             for j in [&node, &node2, &node3][..].iter().copied() {
@@ -2450,23 +2616,20 @@ pub mod tests {
         (node, node2, node3, v)
     }
 
-    fn new_remote_port_pair(
-        node1: &Arc<RemoteLocalNode>,
-        node2: &Arc<RemoteLocalNode>,
-    ) -> (Channel, Channel) {
+    fn new_remote_port_pair(node1: &LocalNode, node2: &LocalNode) -> (Channel, Channel) {
         let left_id = PortId::new();
         let right_id = PortId::new();
-        let left = node1.node.add_port(
+        let left = node1.add_port(
             left_id,
             Address {
-                node: node2.node.id(),
+                node: node2.id(),
                 port: right_id,
             },
         );
-        let right = node2.node.add_port(
+        let right = node2.add_port(
             right_id,
             Address {
-                node: node1.node.id(),
+                node: node1.id(),
                 port: left_id,
             },
         );
@@ -2480,26 +2643,27 @@ pub mod tests {
         }
     }
 
-    #[test]
-    fn test_remote() {
-        let (node, node2, _h) = new_two_node_mesh();
+    #[async_test]
+    async fn test_remote(driver: DefaultDriver) {
+        let (node, node2, _h) = new_two_node_mesh(&driver);
         {
-            let (left, mut right) = new_remote_port_pair(&node, &node2);
+            let (left, mut right) = new_remote_port_pair(&node.node, &node2.node);
             left.send(SerializedMessage {
                 data: b"abc".to_vec(),
                 ..Default::default()
             });
-            assert_eq!(right.try_recv().unwrap().data, b"abc");
+            assert_eq!(right.recv().await.unwrap().data, b"abc");
         }
+        yield_once().await;
         assert!(node.node.is_empty());
         assert!(node2.node.is_empty());
     }
 
-    #[test]
-    fn test_send_port() {
-        let (node, node2, _h) = new_two_node_mesh();
+    #[async_test]
+    async fn test_send_port(driver: DefaultDriver) {
+        let (node, node2, _h) = new_two_node_mesh(&driver);
         {
-            let (left, mut right) = new_remote_port_pair(&node, &node2);
+            let (left, mut right) = new_remote_port_pair(&node.node, &node2.node);
             let (left2, right2) = <Channel>::new_pair();
             left2.send(SerializedMessage {
                 data: b"abc".to_vec(),
@@ -2509,26 +2673,27 @@ pub mod tests {
                 resources: vec![Resource::Port(right2.into())],
                 ..Default::default()
             });
-            let r = right.try_recv().unwrap();
+            let r = right.recv().await.unwrap();
             let mut right2 =
                 <Channel>::from(Port::try_from(r.resources.into_iter().next().unwrap()).unwrap());
             left2.send(SerializedMessage {
                 data: b"def".to_vec(),
                 ..Default::default()
             });
-            assert_eq!(right2.try_recv().unwrap().data, b"abc");
-            assert_eq!(right2.try_recv().unwrap().data, b"def");
+            assert_eq!(right2.recv().await.unwrap().data, b"abc");
+            assert_eq!(right2.recv().await.unwrap().data, b"def");
         }
+        yield_once().await;
         assert!(node.node.is_empty());
         assert!(node2.node.is_empty());
     }
 
-    #[test]
-    fn test_send_port_with_three_nodes() {
-        let (node, node2, node3, _h) = new_three_node_mesh();
+    #[async_test]
+    async fn test_send_port_with_three_nodes(driver: DefaultDriver) {
+        let (node, node2, node3, _h) = new_three_node_mesh(&driver);
         {
-            let (left, mut right) = new_remote_port_pair(&node, &node2);
-            let (left2, right2) = new_remote_port_pair(&node3, &node);
+            let (left, mut right) = new_remote_port_pair(&node.node, &node2.node);
+            let (left2, right2) = new_remote_port_pair(&node3.node, &node.node);
             left2.send(SerializedMessage {
                 data: b"abc".to_vec(),
                 ..Default::default()
@@ -2537,33 +2702,34 @@ pub mod tests {
                 resources: vec![Resource::Port(right2.into())],
                 ..Default::default()
             });
-            let r = right.try_recv().unwrap();
+            let r = right.recv().await.unwrap();
             let mut right2 =
                 <Channel>::from(Port::try_from(r.resources.into_iter().next().unwrap()).unwrap());
             left2.send(SerializedMessage {
                 data: b"def".to_vec(),
                 ..Default::default()
             });
-            assert_eq!(right2.try_recv().unwrap().data, b"abc");
-            assert_eq!(right2.try_recv().unwrap().data, b"def");
+            assert_eq!(right2.recv().await.unwrap().data, b"abc");
+            assert_eq!(right2.recv().await.unwrap().data, b"def");
         }
+        yield_once().await;
         assert!(node.node.is_empty());
         assert!(node2.node.is_empty());
         assert!(node3.node.is_empty());
     }
 
-    #[test]
-    fn test_send_closed_port() {
-        let (node, node2, _h) = new_two_node_mesh();
+    #[async_test]
+    async fn test_send_closed_port(driver: DefaultDriver) {
+        let (node, node2, _h) = new_two_node_mesh(&driver);
         {
-            let (left, mut right) = new_remote_port_pair(&node, &node2);
+            let (left, mut right) = new_remote_port_pair(&node.node, &node2.node);
             let (left2, right2) = <Channel>::new_pair();
             drop(left2);
             left.send(SerializedMessage {
                 resources: vec![Resource::Port(right2.into())],
                 ..Default::default()
             });
-            let r = right.try_recv().unwrap();
+            let r = right.recv().await.unwrap();
             let mut right2 =
                 <Channel>::from(Port::try_from(r.resources.into_iter().next().unwrap()).unwrap());
             assert!(matches!(
@@ -2571,6 +2737,7 @@ pub mod tests {
                 TryRecvError::Closed
             ));
         }
+        yield_once().await;
         assert!(node.node.is_empty());
         assert!(node2.node.is_empty());
     }
@@ -2590,30 +2757,31 @@ pub mod tests {
         ));
     }
 
-    #[test]
-    fn test_remote_close() {
-        let (node, node2, _h) = new_two_node_mesh();
+    #[async_test]
+    async fn test_remote_close(driver: DefaultDriver) {
+        let (node, node2, _h) = new_two_node_mesh(&driver);
         {
-            let (left, mut right) = new_remote_port_pair(&node, &node2);
+            let (left, mut right) = new_remote_port_pair(&node.node, &node2.node);
             left.send(SerializedMessage {
                 data: b"abc".to_vec(),
                 ..Default::default()
             });
             drop(left);
-            assert_eq!(right.try_recv().unwrap().data, b"abc");
+            assert_eq!(right.recv().await.unwrap().data, b"abc");
             assert!(matches!(
                 right.try_recv().unwrap_err(),
                 TryRecvError::Closed
             ));
         }
+        yield_once().await;
         assert!(node.node.is_empty());
         assert!(node2.node.is_empty());
     }
 
-    #[test]
-    fn test_node_fail() {
-        let (node, node2, mut handles) = new_two_node_mesh();
-        let (_left, mut right) = new_remote_port_pair(&node, &node2);
+    #[async_test]
+    async fn test_node_fail(driver: DefaultDriver) {
+        let (node, node2, mut handles) = new_two_node_mesh(&driver);
+        let (_left, mut right) = new_remote_port_pair(&node.node, &node2.node);
         handles.remove(1);
         assert!(matches!(
             right.try_recv().unwrap_err(),
@@ -2621,17 +2789,17 @@ pub mod tests {
         ));
     }
 
-    #[test]
-    fn test_send_failed_port() {
-        let (node, node2, node3, mut handles) = new_three_node_mesh();
-        let (_left, right) = new_remote_port_pair(&node, &node2);
-        let (left2, mut right2) = new_remote_port_pair(&node2, &node3);
+    #[async_test]
+    async fn test_send_failed_port(driver: DefaultDriver) {
+        let (node, node2, node3, mut handles) = new_three_node_mesh(&driver);
+        let (_left, right) = new_remote_port_pair(&node.node, &node2.node);
+        let (left2, mut right2) = new_remote_port_pair(&node2.node, &node3.node);
         handles.remove(2);
         left2.send(SerializedMessage {
             resources: vec![Resource::Port(right.into())],
             ..Default::default()
         });
-        let r = right2.try_recv().unwrap();
+        let r = right2.recv().await.unwrap();
         let mut right =
             <Channel>::from(Port::try_from(r.resources.into_iter().next().unwrap()).unwrap());
         assert!(matches!(
@@ -2641,11 +2809,11 @@ pub mod tests {
     }
 
     #[async_test]
-    async fn test_async(spawn: impl Spawn) {
-        let (node, node2, _h) = new_two_node_mesh();
-        let (left, mut right) = new_remote_port_pair(&node, &node2);
+    async fn test_async(driver: DefaultDriver) {
+        let (node, node2, _h) = new_two_node_mesh(&driver);
+        let (left, mut right) = new_remote_port_pair(&node.node, &node2.node);
         let left = Arc::new(left);
-        spawn
+        driver
             .spawn("test", {
                 let left = left.clone();
                 async move {
@@ -2661,10 +2829,10 @@ pub mod tests {
     }
 
     #[async_test]
-    async fn test_async_close(spawn: impl Spawn) {
-        let (node, node2, _h) = new_two_node_mesh();
-        let (left, mut right) = new_remote_port_pair(&node, &node2);
-        spawn
+    async fn test_async_close(driver: DefaultDriver) {
+        let (node, node2, _h) = new_two_node_mesh(&driver);
+        let (left, mut right) = new_remote_port_pair(&node.node, &node2.node);
+        driver
             .spawn("test", async move {
                 drop(left);
             })
@@ -2680,10 +2848,10 @@ pub mod tests {
     }
 
     #[async_test]
-    async fn test_bridge_remote(_: impl Send) {
-        let (node, node2, node3, _h) = new_three_node_mesh();
-        let (p1, p2) = new_remote_port_pair(&node, &node2);
-        let (p3, p4) = new_remote_port_pair(&node2, &node3);
+    async fn test_bridge_remote(driver: DefaultDriver) {
+        let (node, node2, node3, _h) = new_three_node_mesh(&driver);
+        let (p1, p2) = new_remote_port_pair(&node.node, &node2.node);
+        let (p3, p4) = new_remote_port_pair(&node2.node, &node3.node);
         test_bridge(p1, p2, p3, p4).await;
         node.node.wait_for_ports(true).await;
         node2.node.wait_for_ports(true).await;
@@ -2712,8 +2880,8 @@ pub mod tests {
         p4.send(bmsg(b"g"));
         p4.send(bmsg(b"h"));
 
-        p3.try_recv().unwrap();
-        p3.try_recv().unwrap();
+        p3.recv().await.unwrap();
+        p3.recv().await.unwrap();
 
         p2.bridge(p3);
 
@@ -2743,9 +2911,9 @@ pub mod tests {
     }
 
     #[async_test]
-    async fn test_fail_sent_port_to_failed_node() {
-        let (n1, n2, mut h) = new_two_node_mesh();
-        let (p1, _p2) = new_remote_port_pair(&n1, &n2);
+    async fn test_fail_sent_port_to_failed_node(driver: DefaultDriver) {
+        let (n1, n2, mut h) = new_two_node_mesh(&driver);
+        let (p1, _p2) = new_remote_port_pair(&n1.node, &n2.node);
         let (mut p3, p4) = <Channel>::new_pair();
         p1.send(SerializedMessage {
             resources: vec![Resource::Port(p4.into())],
@@ -2814,13 +2982,13 @@ pub mod tests {
     }
 
     #[async_test]
-    async fn test_fail_port() {
+    async fn test_fail_port(driver: DefaultDriver) {
         #[derive(Debug, Error)]
         #[error("test failure")]
         struct ExplicitFailure;
 
-        let (node, node2, _h) = new_two_node_mesh();
-        let (p1, mut p2) = new_remote_port_pair(&node, &node2);
+        let (node, node2, _h) = new_two_node_mesh(&driver);
+        let (p1, mut p2) = new_remote_port_pair(&node.node, &node2.node);
         let p1 = Port::from(p1);
         p1.fail(NodeError::local(ExplicitFailure));
         let err = p2.recv().await.unwrap_err();

--- a/support/mesh/mesh_node/src/local_node/protocol.rs
+++ b/support/mesh/mesh_node/src/local_node/protocol.rs
@@ -3,6 +3,7 @@
 
 //! Protocol definitions for sending events to remote nodes.
 
+use bitfield_struct::bitfield;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -37,7 +38,8 @@ impl From<Uuid> for crate::common::Uuid {
 pub struct Event {
     pub port_id: Uuid,
     pub event_type: EventType,
-    pub reserved: [u8; 7],
+    pub flags: EventFlags,
+    pub reserved: [u8; 6],
     pub seq: u64,
     pub resource_count: u32,
     pub message_size: u32,
@@ -47,12 +49,22 @@ open_enum::open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
     pub enum EventType: u8 {
         MESSAGE = 1,
-        CLOSE_PORT = 2,
         CHANGE_PEER = 3,
         ACKNOWLEDGE_CHANGE_PEER = 4,
         ACKNOWLEDGE_PORT = 5,
         FAIL_PORT = 6,
     }
+}
+
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct EventFlags {
+    /// The event contains a port message.
+    pub message: bool,
+    /// The port is closing.
+    pub close: bool,
+    #[bits(6)]
+    _reserved: u8,
 }
 
 #[repr(C)]


### PR DESCRIPTION
Send the message and the close notification in a single event packet. This improves oneshot performance.