### PR TITLE
virt_mshv_vtl: Cleanup some vpindexes

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -654,7 +654,8 @@ struct UhVpInner {
     message_queues: VtlArray<MessageQueues, 2>,
     #[inspect(skip)]
     vp_info: TargetVpInfo,
-    /// The Linux kernel's CPU index for this VP.
+    /// The Linux kernel's CPU index for this VP. This should be used instead of VpIndex
+    /// when interacting with non-MSHV kernel interfaces.
     cpu_index: u32,
     #[inspect(with = "|arr| inspect::iter_by_index(arr.iter().map(|v| v.lock().is_some()))")]
     hv_start_enable_vtl_vp: VtlArray<Mutex<Option<Box<VpStartEnableVtl>>>, 2>,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -603,7 +603,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         self.vp.partition.request_proxy_irr_filter_update(
             self.intercepted_vtl,
             vector as u8,
-            self.vp.vp_index().index(),
+            self.vp.vp_index(),
         );
 
         // Update `proxy_irr_blocked` for this VP itself
@@ -1414,8 +1414,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
     /// Returns the per-vp cvm inner state for this vp
     pub fn cvm_vp_inner(&self) -> &'_ crate::UhCvmVpInner {
-        self.cvm_partition()
-            .vp_inner(self.inner.vp_info.base.vp_index.index())
+        self.cvm_partition().vp_inner(self.vp_index().index())
     }
 
     /// Returns the appropriately backed TLB flush and lock access
@@ -1481,7 +1480,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             }
 
             tracing::debug!(
-                vp_index = self.inner.cpu_index,
+                vp_index = self.vp_index().index(),
                 ?vtl,
                 ?start_enable_vtl_state.operation,
                 "setting up vp with initial registers"

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -2000,7 +2000,6 @@ mod save_restore {
                         waker: _,
                         // Topology information
                         vp_info: _,
-                        cpu_index: _,
                         hv_start_enable_vtl_vp: _,
                     },
                 // Saved

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -2000,6 +2000,7 @@ mod save_restore {
                         waker: _,
                         // Topology information
                         vp_info: _,
+                        cpu_index: _,
                         hv_start_enable_vtl_vp: _,
                     },
                 // Saved

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -227,7 +227,7 @@ impl HardwareIsolatedBacking for SnpBacked {
         shared: &'a Self::Shared,
     ) -> impl TlbFlushLockAccess + 'a {
         SnpTlbLockFlushAccess {
-            vp_index: vp_index.index() as usize,
+            vp_index,
             partition,
             shared,
         }
@@ -2352,7 +2352,7 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, SnpBacked> {
 }
 
 struct SnpTlbLockFlushAccess<'a> {
-    vp_index: usize,
+    vp_index: VpIndex,
     partition: &'a UhPartitionInner,
     shared: &'a SnpBackedShared,
 }


### PR DESCRIPTION
Try to use VpIndex everywhere instead of usize and u32. The main place where we aren't today is in the hypercall traits, which are defined elsewhere.

This also removes a TODO about cpu_index potentially being different than vp_index, and the cpu_index field entirely, under the assumption that if it hasn't been an issue up till now it's not going to be. If we do want to keep this field we should probably have some docs and a more careful audit of when we should be using vp_index vs cpu_index.