### PR TITLE
Fix a missed lint and feature dependency

### DIFF
--- a/vm/devices/storage/storvsp/Cargo.toml
+++ b/vm/devices/storage/storvsp/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 ioperf = ["dep:disklayer_ram"]
 
 # Enable generating arbitrary values of types useful for fuzzing.
-arbitrary = ["dep:arbitrary"]
+arbitrary = ["dep:arbitrary", "scsi_defs/arbitrary"]
 
 # Expose some implementation details publicly, used for fuzzing.
 fuzz_helpers = []

--- a/vm/devices/storage/storvsp/benches/ioperf.rs
+++ b/vm/devices/storage/storvsp/benches/ioperf.rs
@@ -3,6 +3,8 @@
 
 //! StorVSP IO loop performance testing.
 
+#![expect(missing_docs)]
+
 use criterion::async_executor::AsyncExecutor;
 use criterion::criterion_group;
 use criterion::criterion_main;
@@ -20,7 +22,7 @@ impl AsyncExecutor for &'_ WrappedExecutor {
     }
 }
 
-pub fn criterion_benchmark(c: &mut Criterion) {
+fn criterion_benchmark(c: &mut Criterion) {
     let mut pool = DefaultPool::new();
     let driver = pool.driver();
     let tester = Cell::new(Some(


### PR DESCRIPTION
1. Fix the missing docs lint in the ioperf bench
2. Add a missing feature dependency to storvsp