### PR TITLE
cvm: Check for deny_lower_vtl_startup when handling INIT and SIPI

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -417,6 +417,18 @@ impl UhCvmPartitionState {
     fn vp_inner(&self, vp_index: u32) -> &UhCvmVpInner {
         &self.vps[vp_index as usize]
     }
+
+    fn is_lower_vtl_startup_denied(&self) -> bool {
+        matches!(
+            *self.guest_vsm.read(),
+            GuestVsmState::Enabled {
+                vtl1: CvmVtl1State {
+                    deny_lower_vtl_startup: true,
+                    ..
+                }
+            }
+        )
+    }
 }
 
 #[derive(Inspect)]

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
@@ -74,7 +74,6 @@ pub(crate) fn poll_apic_core<'b, B: HardwareIsolatedBacking, T: ApicBacking<'b, 
                 }
             }
         ) {
-            assert_eq!(vtl, GuestVtl::Vtl0);
             apic_backing.handle_init(vtl)?;
         }
     }
@@ -90,7 +89,6 @@ pub(crate) fn poll_apic_core<'b, B: HardwareIsolatedBacking, T: ApicBacking<'b, 
                     }
                 }
             ) {
-                assert_eq!(vtl, GuestVtl::Vtl0);
                 let base = (vector as u64) << 12;
                 let selector = (vector as u16) << 8;
                 apic_backing.handle_sipi(

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
@@ -4,6 +4,8 @@
 #![cfg(guest_arch = "x86_64")]
 
 use super::UhRunVpError;
+use crate::CvmVtl1State;
+use crate::GuestVsmState;
 use crate::UhProcessor;
 use crate::processor::HardwareIsolatedBacking;
 use hcl::GuestVtl;
@@ -60,28 +62,47 @@ pub(crate) fn poll_apic_core<'b, B: HardwareIsolatedBacking, T: ApicBacking<'b, 
         .lapic
         .scan(&mut vp.vmtime, scan_irr);
 
-    // An INIT/SIPI targeted at a VP with more than one guest VTL enabled is ignored.
-    if init && !apic_backing.vp().backing.cvm_state().vtl1_enabled {
-        assert_eq!(vtl, GuestVtl::Vtl0);
-        apic_backing.handle_init(vtl)?;
+    // Check VTL permissions inside each block to avoid taking a lock on the hot path,
+    // INIT and SIPI are quite cold.
+    if init {
+        if !matches!(
+            *apic_backing.vp().cvm_partition().guest_vsm.read(),
+            GuestVsmState::Enabled {
+                vtl1: CvmVtl1State {
+                    deny_lower_vtl_startup: true,
+                    ..
+                }
+            }
+        ) {
+            assert_eq!(vtl, GuestVtl::Vtl0);
+            apic_backing.handle_init(vtl)?;
+        }
     }
 
     if let Some(vector) = sipi {
-        if apic_backing.vp().backing.cvm_state_mut().lapics[vtl].activity == MpState::WaitForSipi
-            && !apic_backing.vp().backing.cvm_state().vtl1_enabled
-        {
-            assert_eq!(vtl, GuestVtl::Vtl0);
-            let base = (vector as u64) << 12;
-            let selector = (vector as u16) << 8;
-            apic_backing.handle_sipi(
-                vtl,
-                SegmentRegister {
-                    base,
-                    limit: 0xffff,
-                    selector,
-                    attributes: 0x9b,
-                },
-            )?;
+        if apic_backing.vp().backing.cvm_state_mut().lapics[vtl].activity == MpState::WaitForSipi {
+            if !matches!(
+                *apic_backing.vp().cvm_partition().guest_vsm.read(),
+                GuestVsmState::Enabled {
+                    vtl1: CvmVtl1State {
+                        deny_lower_vtl_startup: true,
+                        ..
+                    }
+                }
+            ) {
+                assert_eq!(vtl, GuestVtl::Vtl0);
+                let base = (vector as u64) << 12;
+                let selector = (vector as u16) << 8;
+                apic_backing.handle_sipi(
+                    vtl,
+                    SegmentRegister {
+                        base,
+                        limit: 0xffff,
+                        selector,
+                        attributes: 0x9b,
+                    },
+                )?;
+            }
         }
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -865,15 +865,7 @@ impl<T, B: HardwareIsolatedBacking>
         // coming from a secure VTL. We know guest VSM has been enabled from the
         // previous check.
         if self.intercepted_vtl == GuestVtl::Vtl0
-            && matches!(
-                *self.vp.cvm_partition().guest_vsm.read(),
-                GuestVsmState::Enabled {
-                    vtl1: CvmVtl1State {
-                        deny_lower_vtl_startup: true,
-                        ..
-                    }
-                }
-            )
+            && self.vp.cvm_partition().is_lower_vtl_startup_denied()
         {
             return Err(HvError::AccessDenied);
         }


### PR DESCRIPTION
The important question here is not whether VTL 1 is enabled or not, but whether during enablement deny_lower_vtl_startup was set. This is also an HCL bug, but we should be correct.