### PR TITLE
nvme: allow PCI ID overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5198,6 +5198,7 @@ dependencies = [
  "mesh",
  "open_enum",
  "parking_lot",
+ "static_assertions",
  "thiserror 2.0.0",
  "tracelimit",
  "tracing",

--- a/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
+++ b/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
@@ -1409,6 +1409,9 @@ async fn make_nvme_controller_config(
             namespaces,
             max_io_queues: 64,
             msix_count: 64,
+            prog_if_override: None,
+            sub_class_override: None,
+            base_class_override: None,
         }
         .into_resource(),
     })

--- a/openvmm/openvmm_entry/src/storage_builder.rs
+++ b/openvmm/openvmm_entry/src/storage_builder.rs
@@ -337,6 +337,9 @@ impl StorageBuilder {
                     namespaces: std::mem::take(&mut self.vtl0_nvme_namespaces),
                     max_io_queues: 64,
                     msix_count: 64,
+                    prog_if_override: None,
+                    sub_class_override: None,
+                    base_class_override: None,
                 }
                 .into_resource(),
             });
@@ -369,6 +372,9 @@ impl StorageBuilder {
                     namespaces: std::mem::take(&mut self.vtl2_nvme_namespaces),
                     max_io_queues: 64,
                     msix_count: 64,
+                    prog_if_override: None,
+                    sub_class_override: None,
+                    base_class_override: None,
                 }
                 .into_resource(),
             });

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -717,6 +717,9 @@ impl PetriVmConfigSetupCore<'_> {
                             .into_resource(),
                             read_only: false,
                         }],
+                        prog_if_override: None,
+                        sub_class_override: None,
+                        base_class_override: None,
                     }
                     .into_resource(),
                 })]);

--- a/vm/devices/pci/pci_core/Cargo.toml
+++ b/vm/devices/pci/pci_core/Cargo.toml
@@ -16,6 +16,7 @@ inspect.workspace = true
 mesh.workspace = true
 open_enum.workspace = true
 parking_lot.workspace = true
+static_assertions.workspace = true
 thiserror.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -409,6 +409,7 @@ impl ConfigSpaceType0Emulator {
             }
             // rest of the range is reserved for extended device capabilities
             _ if (0x40..0x100).contains(&offset) => {
+                tracing::info!(offset, "extended device capabilities");
                 if let Some((cap_index, cap_offset)) =
                     self.get_capability_index_and_offset(offset - 0x40)
                 {
@@ -424,26 +425,37 @@ impl ConfigSpaceType0Emulator {
                     }
                     value
                 } else {
-                    tracelimit::warn_ratelimited!(offset, "unhandled config space read");
+                    //tracelimit::warn_ratelimited!(offset, "unhandled config space read");
+                    tracing::warn!(offset, "unhandled config space read");
                     return IoResult::Err(IoError::InvalidRegister);
                 }
             }
             _ if (0x100..0x1000).contains(&offset) => {
                 // TODO: properly support extended pci express configuration space
                 if offset == 0x100 {
-                    tracelimit::warn_ratelimited!(offset, "unexpected pci express probe");
+                    //tracelimit::warn_ratelimited!(offset, "unexpected pci express probe");
+                    tracing::warn!(offset, "unexpected pci express probe");
                     0x000ffff
                 } else {
-                    tracelimit::warn_ratelimited!(offset, "unhandled extended config space read");
+                    //tracelimit::warn_ratelimited!(offset, "unhandled extended config space read");
+                    tracing::warn!(offset, "unhandled extended config space read");
                     return IoResult::Err(IoError::InvalidRegister);
                 }
             }
             _ => {
-                tracelimit::warn_ratelimited!(offset, "unexpected config space read");
+                //tracelimit::warn_ratelimited!(offset, "unexpected config space read");
+                tracing::warn!(offset, "unexpected config space read");
                 return IoResult::Err(IoError::InvalidRegister);
             }
         };
 
+        tracing::info!(
+            offset,
+            value,
+            "config space read {:x} -> {:x}",
+            offset,
+            value
+        );
         IoResult::Ok
     }
 

--- a/vm/devices/pci/pci_core/src/spec.rs
+++ b/vm/devices/pci/pci_core/src/spec.rs
@@ -38,7 +38,7 @@ pub mod hwid {
     }
 
     open_enum::open_enum! {
-        /// ClassCode identifies the PCI device's type.
+        /// ClassCode identifies the PCI device's type, the "Base Class".
         ///
         /// Values pulled from <https://wiki.osdev.org/PCI#Class_Codes>.
         #[derive(Inspect)]
@@ -116,20 +116,20 @@ pub mod hwid {
 
             NONE = 0x00,
 
-            // Mass Storage Controller (Class code: 0x01)
+            // Mass Storage Controller (Base class code: 0x01)
             MASS_STORAGE_CONTROLLER_NON_VOLATILE_MEMORY = 0x08,
 
-            // Network Controller (Class code: 0x02)
+            // Network Controller (Base class code: 0x02)
             // Other values: 0x01 - 0x08, 0x80
             NETWORK_CONTROLLER_ETHERNET = 0x00,
 
-            // Bridge (Class code: 0x06)
+            // Bridge (Base class code: 0x06)
             // Other values: 0x02 - 0x0A
             BRIDGE_HOST = 0x00,
             BRIDGE_ISA = 0x01,
             BRIDGE_OTHER = 0x80,
 
-            // Base System Peripheral (Class code: 0x08)
+            // Base System Peripheral (Base class code: 0x08)
             // Other values: 0x00 - 0x06
             BASE_SYSTEM_PERIPHERAL_OTHER = 0x80,
         }
@@ -159,11 +159,13 @@ pub mod hwid {
 
             NONE = 0x00,
 
-            // Non-Volatile Memory Controller (Class code:0x01, Subclass: 0x08)
-            // Other values: 0x01
+            // Non-Volatile Memory Subsystem, Vendor Specific Interface (Base class code:0x01, Subclass: 0x08)
+            MASS_STORAGE_CONTROLLER_NON_VOLATILE_MEMORY_VENDOR_SPECIFIC = 0x00,
+
+            // NVM Express (NVMe) I/O controller (Base class code:0x01, Subclass: 0x08)
             MASS_STORAGE_CONTROLLER_NON_VOLATILE_MEMORY_NVME = 0x02,
 
-            // Ethernet Controller (Class code: 0x02, Subclass: 0x00)
+            // Ethernet Controller (Base class code: 0x02, Subclass: 0x00)
             NETWORK_CONTROLLER_ETHERNET_GDMA = 0x01,
         }
     }

--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
@@ -58,6 +58,9 @@ impl FuzzNvmeDriver {
                 msix_count: 2,     // TODO: [use-arbitrary-input]
                 max_io_queues: 64, // TODO: [use-arbitrary-input]
                 subsystem_id: guid,
+                prog_if_override: None,
+                sub_class_override: None,
+                base_class_override: None,
             },
         );
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/tests.rs
@@ -65,6 +65,9 @@ async fn test_nvme_ioqueue_max_mqes(driver: DefaultDriver) {
             msix_count: MSIX_COUNT,
             max_io_queues: IO_QUEUE_COUNT,
             subsystem_id: Guid::new_random(),
+            prog_if_override: None,
+            sub_class_override: None,
+            base_class_override: None,
         },
     );
 
@@ -99,6 +102,9 @@ async fn test_nvme_ioqueue_invalid_mqes(driver: DefaultDriver) {
             msix_count: MSIX_COUNT,
             max_io_queues: IO_QUEUE_COUNT,
             subsystem_id: Guid::new_random(),
+            prog_if_override: None,
+            sub_class_override: None,
+            base_class_override: None,
         },
     );
 
@@ -144,6 +150,9 @@ async fn test_nvme_driver(driver: DefaultDriver, allow_dma: bool) {
             msix_count: MSIX_COUNT,
             max_io_queues: IO_QUEUE_COUNT,
             subsystem_id: Guid::new_random(),
+            prog_if_override: None,
+            sub_class_override: None,
+            base_class_override: None,
         },
     );
     nvme.client()
@@ -251,6 +260,9 @@ async fn test_nvme_save_restore_inner(driver: DefaultDriver) {
             msix_count: MSIX_COUNT,
             max_io_queues: IO_QUEUE_COUNT,
             subsystem_id: Guid::new_random(),
+            prog_if_override: None,
+            sub_class_override: None,
+            base_class_override: None,
         },
     );
 
@@ -284,6 +296,9 @@ async fn test_nvme_save_restore_inner(driver: DefaultDriver) {
             msix_count: MSIX_COUNT,
             max_io_queues: IO_QUEUE_COUNT,
             subsystem_id: Guid::new_random(),
+            prog_if_override: None,
+            sub_class_override: None,
+            base_class_override: None,
         },
     );
 

--- a/vm/devices/storage/nvme/src/lib.rs
+++ b/vm/devices/storage/nvme/src/lib.rs
@@ -24,7 +24,8 @@ pub use workers::NvmeControllerClient;
 use guestmem::ranges::PagedRange;
 use nvme_spec as spec;
 
-// Device configuration shared by PCI and NVMe.
+// Device configuration constants, shared by the PCI implementation and the
+// NVMe protocol implementation.
 const DOORBELL_STRIDE_BITS: u8 = 2;
 const VENDOR_ID: u16 = 0x1414;
 const NVME_VERSION: u32 = 0x00020000;

--- a/vm/devices/storage/nvme/src/resolver.rs
+++ b/vm/devices/storage/nvme/src/resolver.rs
@@ -61,11 +61,9 @@ impl AsyncResolveResource<PciDeviceHandleKind, NvmeControllerHandle> for NvmeCon
                 msix_count: resource.msix_count,
                 max_io_queues: resource.max_io_queues,
                 subsystem_id: resource.subsystem_id,
-                prog_if_override: resource.prog_if_override.map_or(None, |v| Some(v.into())),
-                sub_class_override: resource.sub_class_override.map_or(None, |v| Some(v.into())),
-                base_class_override: resource
-                    .base_class_override
-                    .map_or(None, |v| Some(v.into())),
+                prog_if_override: resource.prog_if_override.map(|v| v.into()),
+                sub_class_override: resource.sub_class_override.map(|v| v.into()),
+                base_class_override: resource.base_class_override.map(|v| v.into()),
             },
         );
         for NamespaceDefinition {

--- a/vm/devices/storage/nvme/src/resolver.rs
+++ b/vm/devices/storage/nvme/src/resolver.rs
@@ -61,6 +61,11 @@ impl AsyncResolveResource<PciDeviceHandleKind, NvmeControllerHandle> for NvmeCon
                 msix_count: resource.msix_count,
                 max_io_queues: resource.max_io_queues,
                 subsystem_id: resource.subsystem_id,
+                prog_if_override: resource.prog_if_override.map_or(None, |v| Some(v.into())),
+                sub_class_override: resource.sub_class_override.map_or(None, |v| Some(v.into())),
+                base_class_override: resource
+                    .base_class_override
+                    .map_or(None, |v| Some(v.into())),
             },
         );
         for NamespaceDefinition {

--- a/vm/devices/storage/nvme/src/workers.rs
+++ b/vm/devices/storage/nvme/src/workers.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! NVMe admin and IO queue workers.
+//! Supporting definitions for the NVMe admin and IO queue workers.
 
 mod admin;
 mod coordinator;

--- a/vm/devices/storage/nvme_resources/src/lib.rs
+++ b/vm/devices/storage/nvme_resources/src/lib.rs
@@ -23,6 +23,12 @@ pub struct NvmeControllerHandle {
     pub max_io_queues: u16,
     /// The initial set of namespaces.
     pub namespaces: Vec<NamespaceDefinition>,
+    /// Override the PCI Code Programming Interface field.
+    pub prog_if_override: Option<u8>,
+    /// Override the PCI Code Subclass field.
+    pub sub_class_override: Option<u8>,
+    /// Override the PCI Code Base Class field.
+    pub base_class_override: Option<u8>,
 }
 
 impl ResourceId<PciDeviceHandleKind> for NvmeControllerHandle {

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -430,6 +430,9 @@ async fn openhcl_linux_stripe_storvsp(config: PetriVmConfigOpenVmm) -> Result<()
                             .into_resource()),
                             read_only: false,
                         }],
+                        prog_if_override: None,
+                        sub_class_override: None,
+                        base_class_override: None,
                     }
                     .into_resource(),
                 },

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -167,6 +167,9 @@ async fn storvsp(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
                         .into_resource()),
                         read_only: false,
                     }],
+                    prog_if_override: None,
+                    sub_class_override: None,
+                    base_class_override: None,
                 }
                 .into_resource(),
             });
@@ -445,6 +448,9 @@ async fn openhcl_linux_stripe_storvsp(config: PetriVmConfigOpenVmm) -> Result<()
                             .into_resource()),
                             read_only: false,
                         }],
+                        prog_if_override: None,
+                        sub_class_override: None,
+                        base_class_override: None,
                     }
                     .into_resource(),
                 },


### PR DESCRIPTION
I have found it useful to ask the nvme device to pretend to be a different PCI device type. This is useful for testing and prototyping.

Validated via unit tests.