### PR TITLE
virt: CpuIo doesn't need to be Send+Sync

### DIFF
--- a/vmm_core/virt/src/io.rs
+++ b/vmm_core/virt/src/io.rs
@@ -7,7 +7,7 @@ use vm_topology::processor::VpIndex;
 
 /// This trait provides the operations between the VP dispatch loop and the
 /// platform's devices.
-pub trait CpuIo: Send + Sync {
+pub trait CpuIo {
     /// Check if a given address will be handled by a device.
     fn is_mmio(&self, address: u64) -> bool;
 


### PR DESCRIPTION
Allow it to have per-VP state that's bound to the VP thread.
