### PR TITLE
loader: don't skip program headers with zero file length

### DIFF
--- a/vm/loader/src/elf.rs
+++ b/vm/loader/src/elf.rs
@@ -162,7 +162,7 @@ where
 
         // Read in each section pointed to by the program headers.
         for phdr in phdrs {
-            if phdr.p_type.get(LE) != elf::PT_LOAD || phdr.p_filesz.get(LE) == 0 {
+            if phdr.p_type.get(LE) != elf::PT_LOAD {
                 continue;
             }
 
@@ -204,7 +204,7 @@ where
     // During the second pass, read in each section pointed to by the program headers,
     // and import into the guest memory.
     for phdr in phdrs {
-        if phdr.p_type.get(LE) != elf::PT_LOAD || phdr.p_filesz.get(LE) == 0 {
+        if phdr.p_type.get(LE) != elf::PT_LOAD {
             continue;
         }
 


### PR DESCRIPTION
Sections with zero file length still need to be loaded. Our existing
binaries don't have these sections, since BSS and data sections tend to
get combined into a single load directive, but fix this for
compatibility with other binary layouts.
