### PR TITLE
vm_topology: don't require 2 MMIO gaps

### DIFF
--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -76,6 +76,8 @@ pub enum Error {
     InvalidAcpiTableLength,
     #[error("invalid acpi table: unknown header signature {0:?}")]
     InvalidAcpiTableSignature([u8; 4]),
+    #[error("acpi tables require at least two mmio ranges")]
+    UnsupportedMmio,
 }
 
 pub const PV_CONFIG_BASE_PAGE: u64 = if cfg!(guest_arch = "x86_64") {
@@ -270,6 +272,10 @@ fn load_linux(params: LoadLinuxParams<'_>) -> Result<VpContext, Error> {
         pm_base: crate::worker::PM_BASE,
         acpi_irq: crate::worker::SYSTEM_IRQ_ACPI,
     };
+
+    if mem_layout.mmio().len() < 2 {
+        return Err(Error::UnsupportedMmio);
+    }
 
     let acpi_tables = acpi_builder.build_acpi_tables(ACPI_BASE, |mem_layout, dsdt| {
         dsdt.add_apic();

--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -76,6 +76,7 @@ pub enum Error {
     InvalidAcpiTableLength,
     #[error("invalid acpi table: unknown header signature {0:?}")]
     InvalidAcpiTableSignature([u8; 4]),
+    #[cfg(guest_arch = "x86_64")]
     #[error("acpi tables require at least two mmio ranges")]
     UnsupportedMmio,
 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3270,10 +3270,13 @@ async fn load_firmware(
     #[cfg(guest_arch = "x86_64")]
     let registers = {
         let crate::loader::VpContext::Vbs(mut registers) = vtl0_vp_context;
-        registers.extend(loader::common::compute_variable_mtrrs(
-            mem_layout,
-            partition.caps().physical_address_width,
-        ));
+        registers.extend(
+            loader::common::compute_variable_mtrrs(
+                mem_layout,
+                partition.caps().physical_address_width,
+            )
+            .context("Failed to compute variable mtrrs")?,
+        );
         registers
     };
     #[cfg(guest_arch = "aarch64")]

--- a/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
@@ -94,6 +94,8 @@ pub enum Error {
     LowerVtlContext,
     #[error("missing required memory range {0}")]
     MissingRequiredMemory(MemoryRange),
+    #[error("IGVM file requires at least two mmio ranges")]
+    UnsupportedMmio,
 }
 
 fn from_memory_range(range: &MemoryRange) -> IGVM_VHS_MEMORY_RANGE {
@@ -966,7 +968,9 @@ fn load_igvm_x86(
                 // Convert the hvlite format to the IGVM format
                 // Any gaps above 2 are ignored.
                 let mmio = mem_layout.mmio();
-                assert!(mmio.len() >= 2);
+                if mmio.len() < 2 {
+                    return Err(Error::UnsupportedMmio);
+                }
                 let mmio_ranges = IGVM_VHS_MMIO_RANGES {
                     mmio_ranges: [from_memory_range(&mmio[0]), from_memory_range(&mmio[1])],
                 };

--- a/openvmm/hvlite_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/uefi.rs
@@ -22,6 +22,8 @@ pub enum Error {
     Firmware(#[source] std::io::Error),
     #[error("uefi loader error")]
     Loader(#[source] loader::uefi::Error),
+    #[error("UEFI requires at least two MMIO ranges")]
+    UnsupportedMmio,
 }
 
 pub struct UefiLoadSettings {
@@ -49,7 +51,9 @@ pub fn load_uefi(
     srat: &[u8],
     pptt: Option<&[u8]>,
 ) -> Result<Vec<Register>, Error> {
-    assert!(mem_layout.mmio().len() >= 2, "UEFI expects 2 MMIO gaps");
+    if mem_layout.mmio().len() < 2 {
+        return Err(Error::UnsupportedMmio);
+    }
 
     let mut loaded_image;
     let image = {

--- a/vm/vmcore/vm_topology/src/memory.rs
+++ b/vm/vmcore/vm_topology/src/memory.rs
@@ -119,9 +119,6 @@ impl MemoryLayout {
         if ram_size == 0 || ram_size & (PAGE_SIZE - 1) != 0 {
             return Err(Error::BadSize);
         }
-        if gaps.len() < 2 {
-            return Err(Error::BadMmioGaps);
-        }
 
         validate_ranges(gaps)?;
         let mut ram = Vec::new();


### PR DESCRIPTION
PCAT and UEFI firmware require 2 MMIO gaps, but this isn't a fundamental requirement of a VM topology. Remove this restriction.
