### PR TITLE
vm_topology: remove physical address width from MemoryLayout

### DIFF
--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -244,12 +244,6 @@ pub fn write_dt(
         .add_u32(p_address_cells, address_cells)?
         .add_u32(p_size_cells, 0)?;
 
-    if cfg!(target_arch = "aarch64") {
-        let pa_bits = crate::arch::physical_address_bits(partition_info.isolation);
-        let p_pa_bits = cpu_builder.add_string("pa_bits")?;
-        cpu_builder = cpu_builder.add_u32(p_pa_bits, pa_bits.into())?;
-    }
-
     // Add a CPU node for each cpu.
     for (vp_index, cpu_entry) in partition_info.cpus.iter().enumerate() {
         let name = format_fixed!(32, "cpu@{}", vp_index + 1);

--- a/openhcl/underhill_mem/src/registrar.rs
+++ b/openhcl/underhill_mem/src/registrar.rs
@@ -197,7 +197,6 @@ mod tests {
     #[test]
     fn test_registrar() {
         let layout = MemoryLayout::new(
-            42,
             1 << 40,
             &[
                 MemoryRange::new(0x10000..0x20000),

--- a/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
@@ -251,8 +251,7 @@ pub fn vtl2_memory_range(
     let physical_address_size = physical_address_size - 1;
 
     // Create an initial memory layout to determine the highest used address.
-    let dummy_layout = MemoryLayout::new(physical_address_size, mem_size, mmio_gaps, None)
-        .map_err(Error::MemoryConfig)?;
+    let dummy_layout = MemoryLayout::new(mem_size, mmio_gaps, None).map_err(Error::MemoryConfig)?;
 
     // TODO: Underhill kernel panics if loaded at 32TB or higher. Restrict the
     // max address to 32TB until this is fixed.

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -94,7 +94,7 @@ pub enum MemoryBuildError {
 /// A builder for [`GuestMemoryManager`].
 pub struct GuestMemoryBuilder {
     existing_mapping: Option<SharedMemoryBacking>,
-    vtl0_alias_map: bool,
+    vtl0_alias_map: Option<u64>,
     prefetch_ram: bool,
     pin_mappings: bool,
     x86_legacy_support: bool,
@@ -105,7 +105,7 @@ impl GuestMemoryBuilder {
     pub fn new() -> Self {
         Self {
             existing_mapping: None,
-            vtl0_alias_map: false,
+            vtl0_alias_map: None,
             pin_mappings: false,
             prefetch_ram: false,
             x86_legacy_support: false,
@@ -118,11 +118,11 @@ impl GuestMemoryBuilder {
         self
     }
 
-    /// Specifies whether the VTL0 alias map is enabled for VTL2. This is a
-    /// mirror of VTL0 memory into the high half of the VM's physical address
+    /// Specifies the offset of the VTL0 alias map, if enabled for VTL2. This is
+    /// a mirror of VTL0 memory into a high portion of the VM's physical address
     /// space.
-    pub fn vtl0_alias_map(mut self, enable: bool) -> Self {
-        self.vtl0_alias_map = enable;
+    pub fn vtl0_alias_map(mut self, offset: Option<u64>) -> Self {
+        self.vtl0_alias_map = offset;
         self
     }
 
@@ -186,12 +186,11 @@ impl GuestMemoryBuilder {
         let max_addr =
             (mem_layout.end_of_ram_or_mmio()).max(mem_layout.vtl2_range().map_or(0, |r| r.end()));
 
-        let vtl0_alias_map_mask = if self.vtl0_alias_map {
-            let mask = 1 << (mem_layout.physical_address_size() - 1);
-            if max_addr > mask {
+        let vtl0_alias_map_offset = if let Some(offset) = self.vtl0_alias_map {
+            if max_addr > offset {
                 return Err(MemoryBuildError::AliasMapWontFit);
             }
-            Some(mask)
+            Some(offset)
         } else {
             None
         };
@@ -287,7 +286,7 @@ impl GuestMemoryBuilder {
             mapping_manager,
             region_manager,
             va_mapper,
-            vtl0_alias_map_offset: vtl0_alias_map_mask,
+            vtl0_alias_map_offset,
             pin_mappings: self.pin_mappings,
         };
         Ok(gm)

--- a/vm/devices/firmware/firmware_pcat/src/default_cmos_values.rs
+++ b/vm/devices/firmware/firmware_pcat/src/default_cmos_values.rs
@@ -759,7 +759,7 @@ mod tests {
                 vnode: 0,
             },
         ];
-        let layout = MemoryLayout::new_from_ranges(42, ram, mmio).unwrap();
+        let layout = MemoryLayout::new_from_ranges(ram, mmio).unwrap();
 
         const CMOS_DEFAULT: [u8; 256] = [
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/vm/devices/net/net_backend/src/tests.rs
+++ b/vm/devices/net/net_backend/src/tests.rs
@@ -15,7 +15,6 @@ use vm_topology::memory::MemoryLayout;
 
 pub fn test_layout() -> MemoryLayout {
     MemoryLayout::new(
-        36,
         64 * 4096,
         &[
             MemoryRange::new(64 * 4096..65 * 4096),

--- a/vm/loader/src/common.rs
+++ b/vm/loader/src/common.rs
@@ -96,7 +96,10 @@ pub fn import_default_gdt(
 /// gaps, such as booting Linux, UEFI, or PCAT.
 ///
 /// N.B. Currently this panics if there are not exactly two MMIO ranges.
-pub fn compute_variable_mtrrs(memory: &MemoryLayout) -> Vec<X86Register> {
+pub fn compute_variable_mtrrs(
+    memory: &MemoryLayout,
+    physical_address_width: u8,
+) -> Vec<X86Register> {
     const WRITEBACK: u64 = 0x6;
 
     assert_eq!(
@@ -108,8 +111,8 @@ pub fn compute_variable_mtrrs(memory: &MemoryLayout) -> Vec<X86Register> {
     let mmio_gap_low = memory.mmio()[0];
     let mmio_gap_high = memory.mmio()[1];
 
-    // Clamp the GpaSpaceSize to something reasonable
-    let gpa_space_size = memory.physical_address_size().clamp(36, 52);
+    // Clamp the width to something reasonable.
+    let gpa_space_size = physical_address_width.clamp(36, 52);
 
     // The MMIO limits will be the basis of the MTRR calculations
     // as page count doesn't work when there may be gaps between memory blocks.

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -581,7 +581,7 @@ mod test {
     ];
 
     fn new_mem() -> MemoryLayout {
-        MemoryLayout::new(42, TB, &MMIO, None).unwrap()
+        MemoryLayout::new(TB, &MMIO, None).unwrap()
     }
 
     fn new_builder<'a>(

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -145,6 +145,9 @@ pub struct PartitionConfig<'a> {
     pub guest_memory: &'a GuestMemory,
     /// Cpuid leaves to add to the default CPUID results.
     pub cpuid: &'a [CpuidLeaf],
+    /// The offset of the VTL0 alias map. This maps VTL0's view of memory into
+    /// VTL2 at the specified offset (which must be a power of 2).
+    pub vtl0_alias_map: Option<u64>,
 }
 
 /// Trait for a prototype partition, one that is partially created but still
@@ -226,9 +229,6 @@ pub struct LateMapVtl0MemoryConfig {
 /// VTL2 configuration.
 #[derive(Debug)]
 pub struct Vtl2Config {
-    /// Enable the VTL0 alias map. This maps VTL0's view of memory in VTL2 at
-    /// the highest legal physical address bit.
-    pub vtl0_alias_map: bool,
     /// If set, map VTL0 memory late after VTL2 has started. The current
     /// heuristic is to defer mapping VTL0 memory until the first
     /// [`hvdef::HypercallCode::HvCallModifyVtlProtectionMask`] hypercall is

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -164,7 +164,12 @@ pub trait ProtoPartition {
     #[cfg(guest_arch = "x86_64")]
     fn cpuid(&self, eax: u32, ecx: u32) -> [u32; 4];
 
-    /// The number of bits of a physical address.
+    /// The maximum physical address width that processors and devices for this
+    /// partition can access.
+    ///
+    /// This may be smaller than what is reported to the guest via architectural
+    /// interfaces by default, and it may be larger or smaller than what the VMM
+    /// ultimately chooses to report to the guest.
     fn max_physical_address_size(&self) -> u8;
 
     /// Constructs the full partition.

--- a/vmm_core/virt/src/x86/mod.rs
+++ b/vmm_core/virt/src/x86/mod.rs
@@ -75,6 +75,8 @@ pub struct X86PartitionCapabilities {
     /// a power of 2, if present.
     #[inspect(hex)]
     pub vtom: Option<u64>,
+    /// The physical address width of the CPU, as reported by CPUID.
+    pub physical_address_width: u8,
 
     /// The hypervisor can freeze time across state manipulation.
     pub can_freeze_time: bool,
@@ -113,6 +115,7 @@ impl X86PartitionCapabilities {
             sgx: false,
             tsc_aux: false,
             vtom: None,
+            physical_address_width: max_physical_address_size_from_cpuid(&mut *f),
             can_freeze_time: false,
             xsaves_state_bv_broken: false,
             dr6_tsx_broken: false,
@@ -455,7 +458,7 @@ impl TryFrom<usize> for BreakpointSize {
 }
 
 /// Query the max physical address size of the system.
-pub fn max_physical_address_size_from_cpuid(cpuid: &dyn Fn(u32, u32) -> [u32; 4]) -> u8 {
+pub fn max_physical_address_size_from_cpuid(mut cpuid: impl FnMut(u32, u32) -> [u32; 4]) -> u8 {
     const DEFAULT_PHYSICAL_ADDRESS_SIZE: u8 = 32;
 
     let max_extended = {

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -939,13 +939,11 @@ impl WhpPartitionInner {
             .as_ref()
             .and_then(|cfg| cfg.vtl2.as_ref())
         {
-            if vtl2_config.vtl0_alias_map {
-                vtl0_alias_map_offset = Some(1 << (config.mem_layout.physical_address_size() - 1));
-            }
+            vtl0_alias_map_offset = config.vtl0_alias_map;
 
             // TODO: Supporting the alias map with isolation requires additional
             // mapper changes that are not implemented yet.
-            if vtl2_config.vtl0_alias_map && proto_config.isolation.is_isolated() {
+            if vtl0_alias_map_offset.is_some() && proto_config.isolation.is_isolated() {
                 todo!("alias map and isolation requires memory mapper changes")
             }
 


### PR DESCRIPTION
The physical address width is not really a singular thing--there are many different interesting address widths:

* The width the virtual processor can access via CPU instructions.
* The width virtual devices/mapped devices/the IOMMU can access via DMA.
* The width the hypervisor supports for mapping memory (usually this is limited to the min of the previous two)
* The width reported to the guest
    * By cpuid on x86.
    * By a sysreg on arm64 (this will be rounded up to the next multiple of 4).
* The offset of the VTL0 alias map.
* The size of the VA range we allocate for guest memory mappings.

Some of these have ended up getting conflated in our designs since these are often the same/related to each other in useful ways. But in practice, there are subtle differences. And in reality, we don't really need the value in as many places as we seem to think.

So, remove the generic, underspecified physical address width from `MemoryLayout`. Add a value to the x86 partition capabilities for use in places where we need to specifically get the value that's reported to the guest (for computing MTRRs). Remove propagation of the address width from openhcl_boot through device tree.