### PR TITLE
mesh_node: Work around 2024 edition temporary lifetime changes

### DIFF
--- a/support/mesh/mesh_node/src/message.rs
+++ b/support/mesh/mesh_node/src/message.rs
@@ -445,12 +445,14 @@ impl MessageEncode<Message<'_>, Resource> for MessageEncoder {
 /// in place on the stack.
 macro_rules! stack_message {
     ($v:expr) => {
-        // UNSAFETY: required to call unsafe function.
-        #[expect(unsafe_code)]
-        {
+        (|v| {
+            // UNSAFETY: required to call unsafe function.
+            #[expect(unsafe_code)]
             // SAFETY: The value is initialized and never used again.
-            unsafe { $crate::message::Message::new_stack(&mut ::core::mem::MaybeUninit::new($v)) }
-        }
+            unsafe {
+                $crate::message::Message::new_stack(v)
+            }
+        })(&mut ::core::mem::MaybeUninit::new($v))
     };
 }
 pub(crate) use stack_message;


### PR DESCRIPTION
Kind of annoying that this has to be done this way, but at least it can still be done.