### PR TITLE
Fix incorrect key name in rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,4 +3,4 @@
 
 newline_style="unix"
 use_field_init_shorthand=true
-edition="2021"
+style_edition="2021"


### PR DESCRIPTION
rustfmt.toml's 'edition' key only controls parsing behavior. We should leave this to the default (read from Cargo.toml) so that rustfmt's parsing behavior always matches what our code is targeting. Formatting behavior is controlled by this separate key, 'style_edition', which we can change separately from the actual code edition. This will allow us to take 2024 edition formatting changes separately from code behavior changes, should we so choose.

Part of #288