### PR TITLE
Update our cargo-toml and toml-edit dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.18.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802b755090e39835a4b0440fb0bbee0df7495a8b337f63db21e616f7821c7e8c"
+checksum = "02260d489095346e5cafd04dea8e8cb54d1d74fcd759022a9b72986ebe9a1257"
 dependencies = [
  "serde",
  "toml",
@@ -6051,9 +6051,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -6735,9 +6735,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -6747,18 +6747,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -9291,9 +9291,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -388,7 +388,7 @@ bitfield-struct = "0.7"
 bitvec = { version = "1.1", default-features = false }
 blocking = "1.2"
 caps = "0.5"
-cargo_toml = "0.18"
+cargo_toml = "0.22"
 cc = "1.0"
 cfg-if = "1"
 clap = "4.2"
@@ -500,7 +500,7 @@ target-lexicon = "0.12.13"
 tempfile = "3.2"
 thiserror = { version = "2", default-features = false }
 time = "0.3"
-toml_edit = "0.21"
+toml_edit = "0.22"
 tracing = "0.1"
 tracing-core = "=0.1.30" # Pin to avoid binary size increase https://github.com/tokio-rs/tracing/issues/3182
 tracing-subscriber = "0.3.16"

--- a/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
@@ -237,7 +237,7 @@ impl FlowNode for Node {
                     // the profile, and if so, where the output if going to be.
                     let junit_path = {
                         let nextest_toml = fs_err::read_to_string(&config_file)?
-                            .parse::<toml_edit::Document>()
+                            .parse::<toml_edit::DocumentMut>()
                             .context("failed to parse nextest.toml")?;
 
                         let path = Some(&nextest_toml)

--- a/xsync/xsync/src/tasks/cargo_toml.rs
+++ b/xsync/xsync/src/tasks/cargo_toml.rs
@@ -115,7 +115,7 @@ impl Cmd for CargoToml {
                     Ok(base_clippy_toml) => {
                         log::info!("base clippy.toml found, regenerating overlay clippy.toml",);
                         let mut base_clippy_toml =
-                            toml_edit::Document::from_str(&base_clippy_toml)?;
+                            toml_edit::DocumentMut::from_str(&base_clippy_toml)?;
                         base_clippy_toml.fmt();
                         let generated_clippy_toml = format!(
                             "{}{}",

--- a/xsync/xsync/src/tasks/rustfmt_toml.rs
+++ b/xsync/xsync/src/tasks/rustfmt_toml.rs
@@ -58,7 +58,7 @@ impl Cmd for RustfmtToml {
         match base_fmt_toml {
             Ok(base_fmt_toml) => {
                 log::info!("base rustfmt.toml found, regenerating overlay rustfmt.toml",);
-                let mut base_fmt_toml = toml_edit::Document::from_str(&base_fmt_toml)?;
+                let mut base_fmt_toml = toml_edit::DocumentMut::from_str(&base_fmt_toml)?;
                 base_fmt_toml.fmt();
                 let generated_fmt_toml = format!(
                     "{}{}",

--- a/xtask/src/tasks/fmt/house_rules/crate_name_nodash.rs
+++ b/xtask/src/tasks/fmt/house_rules/crate_name_nodash.rs
@@ -16,7 +16,7 @@ pub fn check_crate_name_nodash(path: &Path) -> anyhow::Result<()> {
     }
 
     let contents = fs_err::read_to_string(path)?;
-    let parsed = contents.parse::<toml_edit::Document>()?;
+    let parsed = contents.parse::<toml_edit::DocumentMut>()?;
 
     let package_name = match parsed
         .as_table()

--- a/xtask/src/tasks/fmt/house_rules/package_info.rs
+++ b/xtask/src/tasks/fmt/house_rules/package_info.rs
@@ -32,7 +32,7 @@ pub fn check_package_info(f: &Path, fix: bool) -> anyhow::Result<()> {
     }
 
     let contents = fs_err::read_to_string(f)?;
-    let mut parsed = contents.parse::<toml_edit::Document>()?;
+    let mut parsed = contents.parse::<toml_edit::DocumentMut>()?;
 
     let mut excluded_from_workspace = false;
     if let Some(metadata) = parsed

--- a/xtask/src/tasks/fmt/unused_deps.rs
+++ b/xtask/src/tasks/fmt/unused_deps.rs
@@ -179,7 +179,7 @@ impl Xtask for UnusedDeps {
 }
 
 fn remove_dependencies(manifest: &str, analysis_results: &[DepResult]) -> anyhow::Result<String> {
-    let mut manifest = toml_edit::Document::from_str(manifest)?;
+    let mut manifest = toml_edit::DocumentMut::from_str(manifest)?;
 
     let mut unused_deps = Vec::new();
     let mut ignored_and_shouldnt_be = Vec::new();

--- a/xtask/src/tasks/fmt/workspace.rs
+++ b/xtask/src/tasks/fmt/workspace.rs
@@ -34,7 +34,7 @@ impl Xtask for VerifyWorkspace {
         let excluded = {
             // will always be root Cargo.toml, as xtasks run from project root
             let contents = fs_err::read_to_string("Cargo.toml")?;
-            let parsed = contents.parse::<toml_edit::Document>()?;
+            let parsed = contents.parse::<toml_edit::DocumentMut>()?;
 
             if let Some(excluded) = parsed
                 .as_table()
@@ -138,7 +138,7 @@ fn workspace_manifests() -> anyhow::Result<HashSet<PathBuf>> {
 fn verify_dependencies(path: &PathBuf) -> Result<(), anyhow::Error> {
     // TODO: Convert this to a better crate like cargo_toml once it supports inherited dependencies fully.
     let contents = fs_err::read_to_string(path)?;
-    let parsed = contents.parse::<toml_edit::Document>()?;
+    let parsed = contents.parse::<toml_edit::DocumentMut>()?;
 
     let package_name = match parsed
         .as_table()

--- a/xtask/src/tasks/fuzz/init_from_template.rs
+++ b/xtask/src/tasks/fuzz/init_from_template.rs
@@ -79,7 +79,7 @@ pub(super) fn init_from_template(
     let new_workspace_entry = new_fuzz_dir.strip_prefix(&ctx.root)?.display().to_string();
     let root_toml_raw = fs_err::read_to_string(ctx.root.join("Cargo.toml"))?;
     let mut root_toml = root_toml_raw
-        .parse::<toml_edit::Document>()
+        .parse::<toml_edit::DocumentMut>()
         .context("invalid root workspace Cargo.toml")?;
     let members = &mut root_toml["workspace"]["members"].as_array_mut().unwrap();
     // TODO: slot the new fuzz crate into the workspace members array in *sorted order*


### PR DESCRIPTION
This brings Rust 2024 compatibility. Part of #288