### PR TITLE
EXPERIMENT & RFC: Set x86-64 builds to target v3 features

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -88,8 +88,7 @@ rustflags = [
 [target.'cfg(target_arch = "x86_64")']
 rustflags = [
   # Target newer cpu features, since all our x86_64 machines have them.
-  # We can't target v3 due to disabling XSAVE in OpenHCL.
-  "-Ctarget-cpu=x86-64-v2",
+  "-Ctarget-cpu=x86-64-v3",
 ]
 
 [target.'cfg(target_env = "musl")']

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -88,7 +88,8 @@ rustflags = [
 [target.'cfg(target_arch = "x86_64")']
 rustflags = [
   # Target newer cpu features, since all our x86_64 machines have them.
-  "-Ctarget-cpu=x86-64-v3",
+  # We can't target v3 due to disabling XSAVE in OpenHCL.
+  "-Ctarget-cpu=x86-64-v2",
 ]
 
 [target.'cfg(target_env = "musl")']

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -85,6 +85,12 @@ rustflags = [
   "-Ctarget-feature=+lse,+neon",
 ]
 
+[target.'cfg(target_arch = "x86_64")']
+rustflags = [
+  # Target newer cpu features, since all our x86_64 machines have them.
+  "-Ctarget-cpu=x86-64-v3",
+]
+
 [target.'cfg(target_env = "musl")']
 rustflags = [
   # Use the musl from the sysroot, not from the Rust distribution.

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -88,8 +88,9 @@ rustflags = [
 [target.'cfg(target_arch = "x86_64")']
 rustflags = [
   # Target newer cpu features, since all our x86_64 machines have them.
-  # We can't target v3 due to disabling XSAVE in OpenHCL.
-  "-Ctarget-cpu=x86-64-v2",
+  "-Ctarget-cpu=x86-64-v3",
+  # We disable XSAVE in OpenHCL though.
+  "-Ctarget-feature=-xsave,-xsavec,-xsaveopt,-xsaves"
 ]
 
 [target.'cfg(target_env = "musl")']


### PR DESCRIPTION
I believe every x86_64 machine we care about will have v3 features supported, so we should let codegen take advantage of them. This will definitely need perf testing, as well as a lot of thinking. But maybe it'll reduce our code size?

For details on what the different versions of x86-64 support mean, see https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels