### PR TITLE
vmbus_server: infrastructure for interrupt page support in vmbusproxy

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/event.rs
+++ b/vm/devices/vmbus/vmbus_server/src/event.rs
@@ -8,9 +8,13 @@ use pal_event::Event;
 use std::io;
 use vmcore::interrupt::Interrupt;
 
+/// Represents an object that may or may not be backed by an OS event, and can also be signaled
+/// manually.
 pub trait OsEventBacked {
+    /// Gets the OS event associated with this object, if any.
     fn os_event(&self) -> Option<&Event>;
 
+    /// Signals the object manually.
     fn signal(&self);
 }
 
@@ -24,11 +28,14 @@ impl OsEventBacked for Interrupt {
     }
 }
 
+/// A wrapper around an object that does not natively have an OS event, but needs to be signaled
+/// using one.
 pub struct WrappedEvent {
     _task: Task<()>,
 }
 
 impl WrappedEvent {
+    /// Creates an OS event, and a task that will signal the original object when the event is triggered.
     fn new(
         driver: &impl SpawnDriver,
         original: impl OsEventBacked + Send + 'static,
@@ -49,12 +56,16 @@ impl WrappedEvent {
     }
 }
 
+/// Represents an object that either has an OS event or is wrapped using one.
 pub enum MaybeWrappedEvent<T> {
     Original(T),
     Wrapped { event: Event, wrapper: WrappedEvent },
 }
 
 impl<T: OsEventBacked + Send + 'static> MaybeWrappedEvent<T> {
+    /// Creates a new `MaybeWrappedEvent`. If the original object has an OS event, it is used
+    /// directly. Otherwise, a new OS event is created that can be used to signal the original
+    /// object.
     pub fn new(driver: &impl SpawnDriver, original: T) -> io::Result<Self> {
         if original.os_event().is_some() {
             Ok(Self::Original(original))
@@ -64,6 +75,8 @@ impl<T: OsEventBacked + Send + 'static> MaybeWrappedEvent<T> {
         }
     }
 
+    /// Gets the OS event associated with this object. This can be either the original event or the
+    /// wrapped event.
     pub fn event(&self) -> &Event {
         match self {
             Self::Original(original) => original.os_event().expect("event should be present"),
@@ -71,6 +84,7 @@ impl<T: OsEventBacked + Send + 'static> MaybeWrappedEvent<T> {
         }
     }
 
+    /// Extracts the `WrappedEvent`, if one was created.
     pub fn into_wrapped(self) -> Option<WrappedEvent> {
         match self {
             Self::Original(_) => None,

--- a/vm/devices/vmbus/vmbus_server/src/event.rs
+++ b/vm/devices/vmbus/vmbus_server/src/event.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use pal_async::driver::SpawnDriver;
+use pal_async::task::Task;
+use pal_async::wait::PolledWait;
+use pal_event::Event;
+use std::io;
+use vmcore::interrupt::Interrupt;
+
+pub trait OsEventBacked {
+    fn os_event(&self) -> Option<&Event>;
+
+    fn signal(&self);
+}
+
+impl OsEventBacked for Interrupt {
+    fn os_event(&self) -> Option<&Event> {
+        self.event()
+    }
+
+    fn signal(&self) {
+        self.deliver();
+    }
+}
+
+pub struct WrappedEvent {
+    _task: Task<()>,
+}
+
+impl WrappedEvent {
+    fn new(
+        driver: &impl SpawnDriver,
+        original: impl OsEventBacked + Send + 'static,
+    ) -> io::Result<(Self, Event)> {
+        let event = Event::new();
+        let wait = PolledWait::new(driver, event.clone())?;
+        let task = driver.spawn("vmbus-event-wrapper", async move {
+            Self::run(wait, original).await;
+        });
+        Ok((Self { _task: task }, event))
+    }
+
+    async fn run(mut event: PolledWait<Event>, original: impl OsEventBacked) {
+        loop {
+            event.wait().await.expect("wait should not fail");
+            original.signal();
+        }
+    }
+}
+
+pub enum MaybeWrappedEvent<T> {
+    Original(T),
+    Wrapped { event: Event, wrapper: WrappedEvent },
+}
+
+impl<T: OsEventBacked + Send + 'static> MaybeWrappedEvent<T> {
+    pub fn new(driver: &impl SpawnDriver, original: T) -> io::Result<Self> {
+        if original.os_event().is_some() {
+            Ok(Self::Original(original))
+        } else {
+            let (wrapper, event) = WrappedEvent::new(driver, original)?;
+            Ok(Self::Wrapped { event, wrapper })
+        }
+    }
+
+    pub fn event(&self) -> &Event {
+        match self {
+            Self::Original(original) => original.os_event().expect("event should be present"),
+            Self::Wrapped { event, .. } => event,
+        }
+    }
+
+    pub fn into_wrapped(self) -> Option<WrappedEvent> {
+        match self {
+            Self::Original(_) => None,
+            Self::Wrapped { wrapper, .. } => Some(wrapper),
+        }
+    }
+}

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1668,10 +1668,13 @@ impl ServerTaskInner {
             anyhow::bail!("interrupt page {:#x} is not page aligned", interrupt_page);
         }
 
+        // Use a subrange to access the interrupt page to give GuestMemory's without a full mapping
+        // a chance to create one.
         let interrupt_page = self
             .gm
-            .subrange(interrupt_page, PAGE_SIZE as u64, true)?
+            .lockable_subrange(interrupt_page, PAGE_SIZE as u64)?
             .lock_gpns(false, &[0])?;
+
         let channel_bitmap = Arc::new(ChannelBitmap::new(interrupt_page));
         self.channel_bitmap = Some(channel_bitmap.clone());
 

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1669,7 +1669,8 @@ impl ServerTaskInner {
 
         let interrupt_page = self
             .gm
-            .lock_gpns(false, &[interrupt_page / PAGE_SIZE as u64])?;
+            .subrange(interrupt_page, PAGE_SIZE as u64, true)?
+            .lock_gpns(false, &[0])?;
         let channel_bitmap = Arc::new(ChannelBitmap::new(interrupt_page));
         self.channel_bitmap = Some(channel_bitmap.clone());
 

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod channel_bitmap;
 mod channels;
+pub mod event;
 pub mod hvsock;
 mod monitor;
 mod proxyintegration;

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -25,6 +25,9 @@ use mesh::Cancel;
 use mesh::CancelContext;
 use pal_async::driver::SpawnDriver;
 use pal_async::task::Spawn;
+use pal_async::task::Task;
+use pal_async::wait::PolledWait;
+use pal_async::windows::TpPool;
 use pal_event::Event;
 use parking_lot::Mutex;
 use std::collections::HashMap;
@@ -114,6 +117,7 @@ struct Channel {
     server_request_send: Option<mesh::Sender<ChannelServerRequest>>,
     incoming_event: Event,
     worker_result: Option<mesh::OneshotReceiver<()>>,
+    event_task: Option<Task<()>>,
 }
 
 struct ProxyTask {
@@ -150,10 +154,21 @@ impl ProxyTask {
         proxy_id: u64,
         open_request: &OpenRequest,
     ) -> anyhow::Result<Event> {
-        let event = open_request
-            .interrupt
-            .event()
-            .context("synic guest event ports not backed by events, not supported")?;
+        let mut _event_storage = None;
+        let (event, task) = if let Some(event) = open_request.interrupt.event() {
+            (event, None)
+        } else {
+            let event = Event::new();
+            let driver = TpPool::system();
+            let wait = PolledWait::new(&driver, event.clone())?;
+            let interrupt = open_request.interrupt.clone();
+            let task = TpPool::system().spawn("vmbus-proxy-event", async move {
+                Self::run_event_loop(wait, interrupt).await;
+            });
+
+            _event_storage = Some(event);
+            (_event_storage.as_ref().unwrap(), Some(task))
+        };
 
         self.proxy
             .open(
@@ -184,6 +199,7 @@ impl ProxyTask {
         let mut channels = self.channels.lock();
         let channel = channels.get_mut(&proxy_id).unwrap();
         channel.worker_result = Some(recv);
+        channel.event_task = task;
         Ok(channel.incoming_event.clone())
     }
 
@@ -340,6 +356,7 @@ impl ProxyTask {
                 server_request_send,
                 incoming_event,
                 worker_result: None,
+                event_task: None,
             },
         );
         request_recv
@@ -414,9 +431,18 @@ impl ProxyTask {
                     ChannelRequest::Open(rpc) => {
                         rpc.handle(async |open_request| {
                             let result = self.handle_open(proxy_id, &open_request).await;
-                            result.ok().map(|event| OpenResult {
-                                guest_to_host_interrupt: Interrupt::from_event(event),
-                            })
+                            match result {
+                                Ok(event) => Some(OpenResult {
+                                    guest_to_host_interrupt: Interrupt::from_event(event),
+                                }),
+                                Err(err) => {
+                                    tracing::error!(
+                                        error = err.as_ref() as &dyn std::error::Error,
+                                        "failed to open channel"
+                                    );
+                                    None
+                                }
+                            }
                         })
                         .await
                     }
@@ -531,6 +557,13 @@ impl ProxyTask {
         }
 
         tracing::debug!("proxy channel requests finished");
+    }
+
+    async fn run_event_loop(mut wait: PolledWait<Event>, interrupt: Interrupt) {
+        loop {
+            wait.wait().await.expect("event wait should not fail");
+            interrupt.deliver();
+        }
     }
 }
 

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -425,7 +425,7 @@ impl ProxyTask {
                                 Err(err) => {
                                     tracing::error!(
                                         error = err.as_ref() as &dyn std::error::Error,
-                                        "failed to open channel"
+                                        "failed to open proxy channel"
                                     );
                                     None
                                 }

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1175,10 +1175,10 @@ impl GuestMemory {
         f().map_err(|err| self.wrap_err(gpa_len, op, err))
     }
 
-    // Creates a smaller view into guest memory, constraining accesses within the new boundaries. For smaller ranges,
-    // some memory implementations (e.g. HDV) may choose to lock the pages into memory for faster access. Locking
-    // random guest memory may cause issues, so only opt in to this behavior when the range can be considered "owned"
-    // by the caller.
+    /// Creates a smaller view into guest memory, constraining accesses within the new boundaries. For smaller ranges,
+    /// some memory implementations (e.g. HDV) may choose to lock the pages into memory for faster access. Locking
+    /// random guest memory may cause issues, so only opt in to this behavior when the range can be considered "owned"
+    /// by the caller.
     pub fn subrange(
         &self,
         offset: u64,
@@ -1196,6 +1196,17 @@ impl GuestMemory {
                 create_memory_subrange(self.inner.clone(), offset, len, allow_preemptive_locking)
             }
         })
+    }
+
+    /// Creates a smaller view into guest memory, constraining accesses within the new boundaries, allowing the
+    /// implementation to lock the pages into memory for faster access. Locking random guest memory may cause issues, so only
+    /// opt in to this behavior when the range can be considered "owned" by the caller.
+    pub fn lockable_subrange(
+        &self,
+        offset: u64,
+        len: u64,
+    ) -> Result<GuestMemory, GuestMemoryError> {
+        self.subrange(offset, len, true)
     }
 
     /// Returns the mapping for all of guest memory.


### PR DESCRIPTION
This change makes some changes needed to support the interrupt page (used by older protocols) when using vmbusproxy. It modifies `GuestMemory` usage in the server to allow alternative implementations to map memory when needed, and updates proxyintegration to support interrupts that are not backed by an OS event.

This change also fixes an issue where the max version restriction wasn't applied correctly, and one where the hvsocket relay channel closing during shutdown could case proxyintegration to panic.