### PR TITLE
Add a .git-blame-ignore-revs for the 2024 formatting commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# 2024 style edition formatting
+0865f61b3eb74104e2713faf95a0d4fd8b4c4ee0


### PR DESCRIPTION
Since this commit was large but didn't actually change anything meaningful, we can exclude it from git blames to provide better history.