### PR TITLE
TDX: Cleanup two small TDX guest VSM comments

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1850,7 +1850,7 @@ impl UhProtoPartition<'_> {
         match params.isolation {
             IsolationType::None | IsolationType::Vbs => {}
             #[cfg(guest_arch = "x86_64")]
-            IsolationType::Tdx => return Ok(false), // TODO TDX GUEST_VSM
+            IsolationType::Tdx => return Ok(params.env_cvm_guest_vsm),
             #[cfg(guest_arch = "x86_64")]
             IsolationType::Snp => {
                 if !params.env_cvm_guest_vsm {

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1850,7 +1850,11 @@ impl UhProtoPartition<'_> {
         match params.isolation {
             IsolationType::None | IsolationType::Vbs => {}
             #[cfg(guest_arch = "x86_64")]
-            IsolationType::Tdx => return Ok(params.env_cvm_guest_vsm),
+            IsolationType::Tdx => {
+                if !params.env_cvm_guest_vsm {
+                    return Ok(false);
+                }
+            }
             #[cfg(guest_arch = "x86_64")]
             IsolationType::Snp => {
                 if !params.env_cvm_guest_vsm {

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1137,10 +1137,7 @@ impl<T, B: HardwareIsolatedBacking>
 
                 hv_vp_context
             }
-            virt::IsolationType::Tdx => {
-                // TODO TDX GUEST VSM
-                hvdef::hypercall::InitialVpContextX64::new_zeroed()
-            }
+            virt::IsolationType::Tdx => hvdef::hypercall::InitialVpContextX64::new_zeroed(),
         };
 
         self.vp

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1121,7 +1121,6 @@ impl<T, B: HardwareIsolatedBacking>
             return Err(HvError::VtlAlreadyEnabled);
         }
 
-        // Register the VMSA with the hypervisor
         let hv_vp_context = match self.vp.partition.isolation {
             virt::IsolationType::None | virt::IsolationType::Vbs => unreachable!(),
             virt::IsolationType::Snp => {
@@ -1140,6 +1139,7 @@ impl<T, B: HardwareIsolatedBacking>
             virt::IsolationType::Tdx => hvdef::hypercall::InitialVpContextX64::new_zeroed(),
         };
 
+        // Tell the hypervisor to enable VTL 1, and register any needed state
         self.vp
             .partition
             .hcl


### PR DESCRIPTION
1. Advertise TDX Guest VSM support through CPUID when the necessary env var allows it. No additional checks are required. Fixes #557.
2. Remove the todo comment from enable_vp_vtl. No additional work is required. Part of #698.