### PR TITLE
virt_mshv_vtl: Make much of crate non-pub by carefully allowing private-in-pub warnings

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -8,7 +8,6 @@ cfg_if::cfg_if! {
         pub use hvdef::HvX64RegisterName as HvArchRegisterName;
         use chipset_device_resources::BSP_LINT_LINE_SET;
         use virt::irqcon::MsiRequest;
-        use virt_mshv_vtl::HardwareIsolatedBacking;
         use vmm_core::acpi_builder::AcpiTablesBuilder;
     } else if #[cfg(guest_arch = "aarch64")] {
         pub use hvdef::HvArm64RegisterName as HvArchRegisterName;

--- a/openhcl/virt_mshv_vtl/src/devmsr.rs
+++ b/openhcl/virt_mshv_vtl/src/devmsr.rs
@@ -7,7 +7,7 @@
 
 use fs_err::os::unix::fs::FileExt;
 
-pub struct MsrDevice(fs_err::File);
+pub(crate) struct MsrDevice(fs_err::File);
 
 impl MsrDevice {
     /// Open `/dev/msr`.

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -622,7 +622,7 @@ impl<T: CpuIo, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         )
     }
 
-    pub fn hcvm_validate_flush_inputs(
+    pub(crate) fn hcvm_validate_flush_inputs(
         &mut self,
         processor_set: ProcessorSet<'_>,
         flags: HvFlushFlags,
@@ -1278,6 +1278,7 @@ impl hv1_emulator::hv::VtlProtectHypercallOverlay for HypercallOverlayAccess<'_>
     }
 }
 
+#[expect(private_bounds)]
 impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
     pub(crate) fn write_msr_cvm(
         &mut self,
@@ -1408,21 +1409,19 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
         Ok(())
     }
-}
 
-impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
     /// Returns the partition-wide CVM state.
-    pub fn cvm_partition(&self) -> &'_ crate::UhCvmPartitionState {
+    pub(crate) fn cvm_partition(&self) -> &'_ crate::UhCvmPartitionState {
         B::cvm_partition_state(self.shared)
     }
 
     /// Returns the per-vp cvm inner state for this vp
-    pub fn cvm_vp_inner(&self) -> &'_ crate::UhCvmVpInner {
+    pub(crate) fn cvm_vp_inner(&self) -> &'_ crate::UhCvmVpInner {
         self.cvm_partition().vp_inner(self.vp_index().index())
     }
 
     /// Returns the appropriately backed TLB flush and lock access
-    pub fn tlb_flush_lock_access(&self) -> impl TlbFlushLockAccess + use<'_, B> {
+    pub(crate) fn tlb_flush_lock_access(&self) -> impl TlbFlushLockAccess + use<'_, B> {
         B::tlb_flush_lock_access(self.vp_index(), self.partition, self.shared)
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -7,9 +7,9 @@
 
 type VpRegisterName = HvArm64RegisterName;
 
-use super::super::BackingPrivate;
+use super::super::Backing;
+use super::super::BackingParams;
 use super::super::UhRunVpError;
-use super::super::private::BackingParams;
 use super::super::signal_mnf;
 use super::super::vp_state;
 use super::super::vp_state::UhVpStateAccess;
@@ -78,7 +78,7 @@ pub struct HypervisorBackedArm64Shared {
 
 impl HypervisorBackedArm64Shared {
     /// Creates a new partition-shared data structure for hypervisor backed VMs.
-    pub fn new(params: BackingSharedParams) -> Result<Self, Error> {
+    pub(crate) fn new(params: BackingSharedParams) -> Result<Self, Error> {
         Ok(Self {
             guest_vsm: RwLock::new(GuestVsmState::from_availability(params.guest_vsm_available)),
         })
@@ -93,7 +93,8 @@ struct ProcessorStatsArm64 {
     synic_deliverable: Counter,
 }
 
-impl BackingPrivate for HypervisorBackedArm64 {
+#[expect(private_interfaces)]
+impl Backing for HypervisorBackedArm64 {
     type HclBacking<'mshv> = MshvArm64;
     type EmulationCache = UhCpuStateCache;
     type Shared = HypervisorBackedArm64Shared;
@@ -855,15 +856,12 @@ impl UhVpStateAccess<'_, '_, HypervisorBackedArm64> {
     }
 
     /// Get the system VP registers on the current VP.
-    pub fn get_system_registers(&mut self) -> Result<vp::SystemRegisters, vp_state::Error> {
+    fn get_system_registers(&mut self) -> Result<vp::SystemRegisters, vp_state::Error> {
         self.get_register_state()
     }
 
     /// Set the system VP registers on the current VP.
-    pub fn set_system_registers(
-        &mut self,
-        regs: &vp::SystemRegisters,
-    ) -> Result<(), vp_state::Error> {
+    fn set_system_registers(&mut self, regs: &vp::SystemRegisters) -> Result<(), vp_state::Error> {
         self.set_register_state(regs)
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/tlb_lock.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/tlb_lock.rs
@@ -14,7 +14,8 @@ impl UhProcessor<'_, HypervisorBacked> {
     /// Causes the specified VTL on the current VP to wait on all TLB locks.
     /// This is typically used to synchronize VTL permission changes with
     /// concurrent instruction emulation.
-    pub fn set_wait_for_tlb_locks(&mut self, target_vtl: Vtl) {
+    #[expect(dead_code)]
+    pub(crate) fn set_wait_for_tlb_locks(&mut self, target_vtl: Vtl) {
         let reg = [(
             HvAllArchRegisterName::VsmVpWaitForTlbLock,
             u64::from(hvdef::HvRegisterVsmWpWaitForTlbLock::new().with_wait(true)),
@@ -25,7 +26,8 @@ impl UhProcessor<'_, HypervisorBacked> {
     }
 
     /// Lock the TLB of the target VTL on the current VP.
-    pub fn set_tlb_lock(&mut self, requesting_vtl: Vtl, target_vtl: GuestVtl) {
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
+    pub(crate) fn set_tlb_lock(&mut self, requesting_vtl: Vtl, target_vtl: GuestVtl) {
         debug_assert_eq!(requesting_vtl, Vtl::Vtl2);
 
         if self.is_tlb_locked(requesting_vtl, target_vtl) {
@@ -46,7 +48,7 @@ impl UhProcessor<'_, HypervisorBacked> {
     }
 
     /// Check the status of the TLB lock of the target VTL on the current VP.
-    pub fn is_tlb_locked(&mut self, requesting_vtl: Vtl, target_vtl: GuestVtl) -> bool {
+    pub(crate) fn is_tlb_locked(&mut self, requesting_vtl: Vtl, target_vtl: GuestVtl) -> bool {
         debug_assert_eq!(requesting_vtl, Vtl::Vtl2);
         let local_status = self.vtls_tlb_locked.get(requesting_vtl, target_vtl);
         // The hypervisor may lock the TLB without us knowing, but the inverse should never happen.
@@ -71,7 +73,8 @@ impl UhProcessor<'_, HypervisorBacked> {
 
     /// Marks the TLBs of all lower VTLs as unlocked.
     /// The hypervisor does the actual unlocking required upon VTL exit.
-    pub fn unlock_tlb_lock(&mut self, unlocking_vtl: Vtl) {
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
+    pub(crate) fn unlock_tlb_lock(&mut self, unlocking_vtl: Vtl) {
         debug_assert_eq!(unlocking_vtl, Vtl::Vtl2);
         self.vtls_tlb_locked.fill(unlocking_vtl, false);
     }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -7,10 +7,10 @@
 
 type VpRegisterName = HvX64RegisterName;
 
-use super::super::BackingPrivate;
+use super::super::Backing;
+use super::super::BackingParams;
 use super::super::UhEmulationState;
 use super::super::UhRunVpError;
-use super::super::private::BackingParams;
 use super::super::signal_mnf;
 use super::super::vp_state;
 use super::super::vp_state::UhVpStateAccess;
@@ -99,7 +99,7 @@ pub struct HypervisorBackedX86Shared {
 
 impl HypervisorBackedX86Shared {
     /// Creates a new partition-shared data structure for hypervisor backed VMs.
-    pub fn new(params: BackingSharedParams) -> Result<Self, Error> {
+    pub(crate) fn new(params: BackingSharedParams) -> Result<Self, Error> {
         Ok(Self {
             guest_vsm: RwLock::new(GuestVsmState::from_availability(params.guest_vsm_available)),
         })
@@ -135,7 +135,8 @@ pub struct MshvEmulationCache {
     rflags: RFlags,
 }
 
-impl BackingPrivate for HypervisorBackedX86 {
+#[expect(private_interfaces)]
+impl Backing for HypervisorBackedX86 {
     type HclBacking<'mshv> = MshvX64<'mshv>;
     type Shared = HypervisorBackedX86Shared;
     type EmulationCache = MshvEmulationCache;


### PR DESCRIPTION
Not an ideal solution, but it makes things a lot better IMO.