### PR TITLE
repo: Tweak our lint groups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -584,9 +584,8 @@ pbjson-build = { git = "https://github.com/jstarks/pbjson", branch = "aliases" }
 
 [workspace.lints.rust]
 # Lint groups need a priority lower than individual lints so they get applied first.
-future_incompatible = { level = "deny", priority = -2 }
-nonstandard_style = { level = "deny", priority = -2 }
-rust_2018_idioms = { level = "deny", priority = -2 }
+future_incompatible = { level = "deny", priority = -1 }
+rust_2018_idioms = { level = "warn", priority = -1 }
 
 rust-2024-compatibility = { level = "warn", priority = -1 }
 edition_2024_expr_fragment_specifier = "allow"


### PR DESCRIPTION
All of the nonstandard-style lints are warn-by-default, there's no need for us to override them, and especially not to deny. All of our lint groups have no overlap, so there's no need for priority to be -2.