### PR TITLE
Give a better error message when we hit the instruction emulator's fail-fast condition

### DIFF
--- a/vm/x86/x86emu/fuzz/fuzz_x86emu.rs
+++ b/vm/x86/x86emu/fuzz/fuzz_x86emu.rs
@@ -33,7 +33,7 @@ fn do_fuzz(static_params: StaticParams) -> arbitrary::Result<()> {
             // Not useful results - didn't make it into meaningful code
             Error::DecodeFailure
             | Error::UnsupportedInstruction(_)
-            | Error::UnsupportedInstructionFailFast(_) => Err(arbitrary::Error::IncorrectFormat),
+            | Error::NonMemoryOrPortInstruction(_) => Err(arbitrary::Error::IncorrectFormat),
 
             // Should be impossible as we provide the maximum length up front
             Error::NotEnoughBytes => unreachable!(),

--- a/vm/x86/x86emu/fuzz/fuzz_x86emu.rs
+++ b/vm/x86/x86emu/fuzz/fuzz_x86emu.rs
@@ -30,10 +30,10 @@ fn do_fuzz(static_params: StaticParams) -> arbitrary::Result<()> {
             // Acceptable results
             Error::InstructionException(_, _, _) => Ok(()),
 
-            // Not useful results - didn't make it past iced into our code
-            Error::DecodeFailure | Error::UnsupportedInstruction(_) => {
-                Err(arbitrary::Error::IncorrectFormat)
-            }
+            // Not useful results - didn't make it into meaningful code
+            Error::DecodeFailure
+            | Error::UnsupportedInstruction(_)
+            | Error::UnsupportedInstructionFailFast(_) => Err(arbitrary::Error::IncorrectFormat),
 
             // Should be impossible as we provide the maximum length up front
             Error::NotEnoughBytes => unreachable!(),

--- a/vm/x86/x86emu/src/emulator.rs
+++ b/vm/x86/x86emu/src/emulator.rs
@@ -133,8 +133,8 @@ pub struct Emulator<'a, T> {
 
 #[derive(Debug, Error)]
 pub enum Error<E> {
-    #[error("non-emulateable instruction - this is typically a sign of a bug in the caller")]
-    UnsupportedInstructionFailFast(Vec<u8>),
+    #[error("asked to emulate an instruction that doesn't touch memory or PIO")]
+    NonMemoryOrPortInstruction(Vec<u8>),
     #[error("unsupported instruction")]
     UnsupportedInstruction(Vec<u8>),
     #[error("memory access error - {1:?} @ {0:#x}")]
@@ -770,7 +770,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
         // We should not be emulating instructions that don't touch MMIO or PIO, even though we are capable of doing so.
         // If we are asked to do so it is usually indicative of some other problem, so abort so we can track that down.
         if !instr.op_kinds().any(|x| x == OpKind::Memory) && !instr.is_string_instruction() {
-            Err(Error::UnsupportedInstructionFailFast(
+            Err(Error::NonMemoryOrPortInstruction(
                 self.bytes[..instr.len()].into(),
             ))?;
         }

--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -419,7 +419,7 @@ pub async fn emulate<T: EmulatorSupport>(
                     None,
                 ));
             }
-            err @ x86emu::Error::UnsupportedInstructionFailFast { .. } => {
+            err @ x86emu::Error::NonMemoryOrPortInstruction { .. } => {
                 tracelimit::error_ratelimited!(
                     error = &err as &dyn std::error::Error,
                     ?instruction_bytes,
@@ -427,11 +427,9 @@ pub async fn emulate<T: EmulatorSupport>(
                     "given an instruction that we shouldn't have been asked to emulate - likely a bug in the caller"
                 );
 
-                cpu.support.inject_pending_event(make_exception_event(
-                    Exception::INVALID_OPCODE,
-                    None,
-                    None,
-                ));
+                panic!(
+                    "given an instruction that we shouldn't have been asked to emulate - likely a bug in the caller"
+                )
             }
             x86emu::Error::InstructionException(exception, error_code, cause) => {
                 tracing::trace!(

--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -427,9 +427,13 @@ pub async fn emulate<T: EmulatorSupport>(
                     "given an instruction that we shouldn't have been asked to emulate - likely a bug in the caller"
                 );
 
-                panic!(
-                    "given an instruction that we shouldn't have been asked to emulate - likely a bug in the caller"
-                )
+                return Err(VpHaltReason::EmulationFailure(
+                    EmulationError::Emulator {
+                        bytes: instruction_bytes.to_vec(),
+                        error: err,
+                    }
+                    .into(),
+                ));
             }
             x86emu::Error::InstructionException(exception, error_code, cause) => {
                 tracing::trace!(


### PR DESCRIPTION
This has happened twice now, so let's give a more clear error message. Open to bikeshedding.