### PR TITLE
hvdef: clean up `HvMessage` type and handling

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -2448,7 +2448,8 @@ impl Hcl {
             padding0: [0; 3],
             sint,
             padding1: [0; 3],
-            message: *message,
+            message: zerocopy::Unalign::new(*message),
+            padding2: 0,
         };
 
         // SAFETY: calling the hypercall with correct input buffer.

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -71,7 +71,6 @@ use x86defs::xsave::Fxsave;
 use x86defs::xsave::XFEATURE_SSE;
 use x86defs::xsave::XFEATURE_X87;
 use x86defs::xsave::XsaveHeader;
-use zerocopy::FromBytes;
 use zerocopy::FromZeros;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -374,27 +373,21 @@ impl Backing for HypervisorBackedX86 {
 fn parse_sidecar_exit(message: &hvdef::HvMessage) -> SidecarRemoveExit {
     match message.header.typ {
         HvMessageType::HvMessageTypeX64IoPortIntercept => {
-            let message = hvdef::HvX64IoPortInterceptMessage::ref_from_prefix(message.payload())
-                .unwrap()
-                .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+            let message = message.as_message::<hvdef::HvX64IoPortInterceptMessage>();
             SidecarRemoveExit::Io {
                 port: message.port_number,
                 write: message.header.intercept_access_type == HvInterceptAccessType::WRITE,
             }
         }
         HvMessageType::HvMessageTypeUnmappedGpa | HvMessageType::HvMessageTypeGpaIntercept => {
-            let message = hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(message.payload())
-                .unwrap()
-                .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+            let message = message.as_message::<hvdef::HvX64MemoryInterceptMessage>();
             SidecarRemoveExit::Mmio {
                 gpa: message.guest_physical_address,
                 write: message.header.intercept_access_type == HvInterceptAccessType::WRITE,
             }
         }
         HvMessageType::HvMessageTypeHypercallIntercept => {
-            let message = hvdef::HvX64HypercallInterceptMessage::ref_from_prefix(message.payload())
-                .unwrap()
-                .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+            let message = message.as_message::<hvdef::HvX64HypercallInterceptMessage>();
             let is_64bit = message.header.execution_state.cr0_pe()
                 && message.header.execution_state.efer_lma();
             let control = if is_64bit {
@@ -407,18 +400,14 @@ fn parse_sidecar_exit(message: &hvdef::HvMessage) -> SidecarRemoveExit {
             }
         }
         HvMessageType::HvMessageTypeX64CpuidIntercept => {
-            let message = hvdef::HvX64CpuidInterceptMessage::ref_from_prefix(message.payload())
-                .unwrap()
-                .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+            let message = message.as_message::<hvdef::HvX64CpuidInterceptMessage>();
             SidecarRemoveExit::Cpuid {
                 leaf: message.rax as u32,
                 subleaf: message.rcx as u32,
             }
         }
         HvMessageType::HvMessageTypeMsrIntercept => {
-            let message = hvdef::HvX64MsrInterceptMessage::ref_from_prefix(message.payload())
-                .unwrap()
-                .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+            let message = message.as_message::<hvdef::HvX64MsrInterceptMessage>();
             SidecarRemoveExit::Msr {
                 msr: message.msr_number,
                 value: (message.header.intercept_access_type == HvInterceptAccessType::WRITE)
@@ -455,93 +444,71 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
                 } else {
                     let message_header = match &message_type {
                         &HvMessageType::HvMessageTypeX64IoPortIntercept => {
-                            &hvdef::HvX64IoPortInterceptMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64IoPortInterceptMessage>()
+                                .header
                         }
                         &HvMessageType::HvMessageTypeUnmappedGpa
                         | &HvMessageType::HvMessageTypeGpaIntercept => {
-                            &hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64MemoryInterceptMessage>()
+                                .header
                         }
                         &HvMessageType::HvMessageTypeUnacceptedGpa => {
-                            &hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64MemoryInterceptMessage>()
+                                .header
                         }
                         &HvMessageType::HvMessageTypeHypercallIntercept => {
-                            &hvdef::HvX64HypercallInterceptMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64HypercallInterceptMessage>()
+                                .header
                         }
                         &HvMessageType::HvMessageTypeSynicSintDeliverable => {
-                            &hvdef::HvX64SynicSintDeliverableMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64SynicSintDeliverableMessage>()
+                                .header
                         }
                         &HvMessageType::HvMessageTypeX64InterruptionDeliverable => {
-                            &hvdef::HvX64InterruptionDeliverableMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64InterruptionDeliverableMessage>()
+                                .header
                         }
                         &HvMessageType::HvMessageTypeX64CpuidIntercept => {
-                            &hvdef::HvX64CpuidInterceptMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64CpuidInterceptMessage>()
+                                .header
                         }
                         &HvMessageType::HvMessageTypeMsrIntercept => {
-                            &hvdef::HvX64MsrInterceptMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64MsrInterceptMessage>()
+                                .header
                         }
                         &HvMessageType::HvMessageTypeUnrecoverableException => {
-                            &hvdef::HvX64UnrecoverableExceptionMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64UnrecoverableExceptionMessage>()
+                                .header
                         }
                         &HvMessageType::HvMessageTypeX64Halt => {
-                            &hvdef::HvX64HaltMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64HaltMessage>()
+                                .header
                         }
                         &HvMessageType::HvMessageTypeExceptionIntercept => {
-                            &hvdef::HvX64ExceptionInterceptMessage::ref_from_prefix(
-                                vp.runner.exit_message().payload(),
-                            )
-                            .unwrap()
-                            .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: erro (https://github.com/microsoft/openvmm/issues/759)
-                            .header
+                            &vp.runner
+                                .exit_message()
+                                .as_message::<hvdef::HvX64ExceptionInterceptMessage>()
+                                .header
                         }
                         reason => unreachable!("unknown exit reason: {:#x?}", reason),
                     };
@@ -563,11 +530,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         &mut self,
         bus: &impl CpuIo,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message = hvdef::HvX64InterruptionDeliverableMessage::ref_from_prefix(
-            self.vp.runner.exit_message().payload(),
-        )
-        .unwrap()
-        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+        let message = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64InterruptionDeliverableMessage>();
 
         assert_eq!(
             message.deliverable_type,
@@ -604,11 +571,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
     }
 
     fn handle_synic_deliverable_exit(&mut self) {
-        let message = hvdef::HvX64SynicSintDeliverableMessage::ref_from_prefix(
-            self.vp.runner.exit_message().payload(),
-        )
-        .unwrap()
-        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+        let message = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64SynicSintDeliverableMessage>();
 
         tracing::trace!(
             deliverable_sints = message.deliverable_sints,
@@ -634,11 +601,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         &mut self,
         bus: &impl CpuIo,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message = hvdef::HvX64HypercallInterceptMessage::ref_from_prefix(
-            self.vp.runner.exit_message().payload(),
-        )
-        .unwrap()
-        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+        let message = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64HypercallInterceptMessage>();
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "hypercall");
 
@@ -664,11 +631,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         &mut self,
         dev: &impl CpuIo,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message = hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(
-            self.vp.runner.exit_message().payload(),
-        )
-        .unwrap()
-        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+        let message = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64MemoryInterceptMessage>();
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "mmio");
 
@@ -715,11 +682,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         &mut self,
         dev: &impl CpuIo,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message = hvdef::HvX64IoPortInterceptMessage::ref_from_prefix(
-            self.vp.runner.exit_message().payload(),
-        )
-        .unwrap()
-        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+        let message = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64IoPortInterceptMessage>();
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "io_port");
 
@@ -752,12 +719,12 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         &mut self,
         dev: &impl CpuIo,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let gpa = hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(
-            self.vp.runner.exit_message().payload(),
-        )
-        .unwrap()
-        .0 // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
-        .guest_physical_address;
+        let gpa = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64MemoryInterceptMessage>()
+            .guest_physical_address;
 
         if self.vp.partition.is_gpa_lower_vtl_ram(gpa) {
             // The host may have moved the page to an unaccepted state, so fail
@@ -779,11 +746,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
     }
 
     fn handle_cpuid_intercept(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message = hvdef::HvX64CpuidInterceptMessage::ref_from_prefix(
-            self.vp.runner.exit_message().payload(),
-        )
-        .unwrap()
-        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+        let message = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64CpuidInterceptMessage>();
 
         let default_result = [
             message.default_result_rax as u32,
@@ -810,11 +777,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
     }
 
     fn handle_msr_intercept(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message = hvdef::HvX64MsrInterceptMessage::ref_from_prefix(
-            self.vp.runner.exit_message().payload(),
-        )
-        .unwrap()
-        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+        let message = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64MsrInterceptMessage>();
         let rip = next_rip(&message.header);
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "msr");
@@ -859,10 +826,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
     }
 
     fn handle_eoi(&self, dev: &impl CpuIo) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message =
-            hvdef::HvX64ApicEoiMessage::ref_from_prefix(self.vp.runner.exit_message().payload())
-                .unwrap()
-                .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+        let message = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64ApicEoiMessage>();
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "eoi");
 
@@ -877,11 +845,11 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
     }
 
     fn handle_exception(&mut self) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let message = hvdef::HvX64ExceptionInterceptMessage::ref_from_prefix(
-            self.vp.runner.exit_message().payload(),
-        )
-        .unwrap()
-        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+        let message = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64ExceptionInterceptMessage>();
 
         match x86defs::Exception(message.vector as u8) {
             x86defs::Exception::DEBUG if cfg!(feature = "gdb") => {
@@ -1048,10 +1016,10 @@ impl UhProcessor<'_, HypervisorBackedX86> {
 
         let [rsp, es, ds, fs, gs, ss, cr0, efer] = values;
 
-        let message = self.runner.exit_message();
-        let header = HvX64InterceptMessageHeader::ref_from_prefix(message.payload())
-            .unwrap()
-            .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+        let header = self
+            .runner
+            .exit_message()
+            .as_message::<HvX64InterceptMessageHeader>();
 
         MshvEmulationCache {
             rsp: rsp.as_u64(),
@@ -1137,10 +1105,11 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
     fn segment(&mut self, index: x86emu::Segment) -> SegmentRegister {
         match index {
             x86emu::Segment::CS => {
-                let message = self.vp.runner.exit_message();
-                let header = HvX64InterceptMessageHeader::ref_from_prefix(message.payload())
-                    .unwrap()
-                    .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+                let header = self
+                    .vp
+                    .runner
+                    .exit_message()
+                    .as_message::<HvX64InterceptMessageHeader>();
                 from_seg(header.cs_segment)
             }
             x86emu::Segment::ES => self.cache.es,
@@ -1173,17 +1142,11 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
             HvMessageType::HvMessageTypeGpaIntercept
             | HvMessageType::HvMessageTypeUnmappedGpa
             | HvMessageType::HvMessageTypeUnacceptedGpa => {
-                let message =
-                    hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(message.payload())
-                        .unwrap()
-                        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+                let message = message.as_message::<hvdef::HvX64MemoryInterceptMessage>();
                 &message.instruction_bytes[..message.instruction_byte_count as usize]
             }
             HvMessageType::HvMessageTypeX64IoPortIntercept => {
-                let message =
-                    hvdef::HvX64IoPortInterceptMessage::ref_from_prefix(message.payload())
-                        .unwrap()
-                        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+                let message = message.as_message::<hvdef::HvX64IoPortInterceptMessage>();
                 &message.instruction_bytes[..message.instruction_byte_count as usize]
             }
             _ => unreachable!(),
@@ -1196,10 +1159,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
             HvMessageType::HvMessageTypeGpaIntercept
             | HvMessageType::HvMessageTypeUnmappedGpa
             | HvMessageType::HvMessageTypeUnacceptedGpa => {
-                let message =
-                    hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(message.payload())
-                        .unwrap()
-                        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
+                let message = message.as_message::<hvdef::HvX64MemoryInterceptMessage>();
                 Some(message.guest_physical_address)
             }
             _ => None,
@@ -1215,11 +1175,11 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
             return None;
         }
 
-        let message = hvdef::HvX64MemoryInterceptMessage::ref_from_prefix(
-            self.vp.runner.exit_message().payload(),
-        )
-        .unwrap()
-        .0; // TODO: zerocopy: ref-from-prefix: use-rest-of-range, zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
+        let message = self
+            .vp
+            .runner
+            .exit_message()
+            .as_message::<hvdef::HvX64MemoryInterceptMessage>();
 
         if !message.memory_access_info.gva_gpa_valid() {
             tracing::trace!(?message.guest_virtual_address, ?message.guest_physical_address, "gva gpa not valid {:?}", self.vp.runner.exit_message().payload());
@@ -1421,9 +1381,10 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, HypervisorBackedX86> {
 
 impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, HypervisorBackedX86> {
     fn rip(&mut self) -> u64 {
-        HvX64InterceptMessageHeader::ref_from_prefix(self.vp.runner.exit_message().payload())
-            .unwrap()
-            .0
+        self.vp
+            .runner
+            .exit_message()
+            .as_message::<HvX64InterceptMessageHeader>()
             .rip
     }
 

--- a/vm/hv1/hv1_hypercall/src/imp.rs
+++ b/vm/hv1/hv1_hypercall/src/imp.rs
@@ -90,7 +90,7 @@ pub type HvPostMessageDirect =
 impl<T: PostMessageDirect> HypercallDispatch<HvPostMessageDirect> for T {
     fn dispatch(&mut self, params: HypercallParameters<'_>) -> HypercallOutput {
         HvPostMessageDirect::run(params, |input| {
-            let message = input.message;
+            let message = input.message.get();
             self.post_message_direct(
                 input.partition_id,
                 Vtl::try_from(input.vtl)?,

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -768,7 +768,7 @@ pub const HV_MESSAGE_SIZE: usize = size_of::<HvMessage>();
 const_assert!(HV_MESSAGE_SIZE == 256);
 pub const HV_MESSAGE_PAYLOAD_SIZE: usize = 240;
 
-#[repr(C)]
+#[repr(C, align(16))]
 #[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvMessage {
     pub header: HvMessageHeader,
@@ -806,17 +806,27 @@ impl HvMessage {
         &self.payload_buffer[..self.header.len as usize]
     }
 
-    pub fn from_bytes(b: [u8; HV_MESSAGE_SIZE]) -> Self {
-        let mut msg = Self::default();
-        msg.as_mut_bytes().copy_from_slice(&b);
-        msg
+    pub fn as_message<T: MessagePayload>(&self) -> &T {
+        // Ensure invariants are met.
+        let () = T::CHECK;
+        T::ref_from_prefix(&self.payload_buffer).unwrap().0
     }
 
-    pub fn into_bytes(self) -> [u8; HV_MESSAGE_SIZE] {
-        let mut v = [0; HV_MESSAGE_SIZE];
-        v.copy_from_slice(self.as_bytes());
-        v
+    pub fn as_message_mut<T: MessagePayload>(&mut self) -> &T {
+        // Ensure invariants are met.
+        let () = T::CHECK;
+        T::mut_from_prefix(&mut self.payload_buffer).unwrap().0
     }
+}
+
+pub trait MessagePayload: KnownLayout + Immutable + IntoBytes + FromBytes + Sized {
+    /// Used to ensure this trait is only implemented on messages of the proper
+    /// size and alignment.
+    #[doc(hidden)]
+    const CHECK: () = {
+        assert!(size_of::<Self>() <= HV_MESSAGE_PAYLOAD_SIZE);
+        assert!(align_of::<Self>() <= align_of::<HvMessage>());
+    };
 }
 
 #[repr(C)]
@@ -831,6 +841,7 @@ pub struct TimerMessagePayload {
 pub mod hypercall {
     use super::*;
     use core::ops::RangeInclusive;
+    use zerocopy::Unalign;
 
     /// The hypercall input value.
     #[bitfield(u64)]
@@ -946,8 +957,8 @@ pub mod hypercall {
         pub rsvd: u16,
     }
 
-    #[repr(C, packed)]
-    #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+    #[repr(C)]
+    #[derive(Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
     pub struct PostMessageDirect {
         pub partition_id: u64,
         pub vp_index: u32,
@@ -955,7 +966,8 @@ pub mod hypercall {
         pub padding0: [u8; 3],
         pub sint: u8,
         pub padding1: [u8; 3],
-        pub message: HvMessage,
+        pub message: Unalign<HvMessage>,
+        pub padding2: u32,
     }
 
     #[repr(C)]
@@ -2565,6 +2577,8 @@ pub struct HvX64InterceptMessageHeader {
     pub rflags: u64,
 }
 
+impl MessagePayload for HvX64InterceptMessageHeader {}
+
 impl HvX64InterceptMessageHeader {
     pub fn instruction_len(&self) -> u8 {
         self.instruction_length_and_cr8 & 0xf
@@ -2586,6 +2600,8 @@ pub struct HvArm64InterceptMessageHeader {
     pub cspr: u64,
 }
 const_assert!(size_of::<HvArm64InterceptMessageHeader>() == 0x18);
+
+impl MessagePayload for HvArm64InterceptMessageHeader {}
 
 #[repr(transparent)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -2636,6 +2652,8 @@ pub struct HvX64IoPortInterceptMessage {
     pub rdi: u64,
 }
 
+impl MessagePayload for HvX64IoPortInterceptMessage {}
+
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvX64MemoryAccessInfo {
@@ -2683,6 +2701,8 @@ pub struct HvX64MemoryInterceptMessage {
     pub guest_physical_address: u64,
     pub instruction_bytes: [u8; 16],
 }
+
+impl MessagePayload for HvX64MemoryInterceptMessage {}
 const_assert!(size_of::<HvX64MemoryInterceptMessage>() == 0x50);
 
 #[repr(C)]
@@ -2699,16 +2719,21 @@ pub struct HvArm64MemoryInterceptMessage {
     pub guest_physical_address: u64,
     pub syndrome: u64,
 }
+
+impl MessagePayload for HvArm64MemoryInterceptMessage {}
 const_assert!(size_of::<HvArm64MemoryInterceptMessage>() == 0x40);
 
 #[repr(C)]
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct HvArm64MmioInterceptMessage {
     pub header: HvArm64InterceptMessageHeader,
     pub guest_physical_address: u64,
     pub access_size: u32,
     pub data: [u8; 32],
+    pub padding: u32,
 }
+
+impl MessagePayload for HvArm64MmioInterceptMessage {}
 const_assert!(size_of::<HvArm64MmioInterceptMessage>() == 0x48);
 
 #[repr(C)]
@@ -2721,6 +2746,8 @@ pub struct HvX64MsrInterceptMessage {
     pub rax: u64,
 }
 
+impl MessagePayload for HvX64MsrInterceptMessage {}
+
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvX64SipiInterceptMessage {
@@ -2728,6 +2755,8 @@ pub struct HvX64SipiInterceptMessage {
     pub target_vp_index: u32,
     pub vector: u32,
 }
+
+impl MessagePayload for HvX64SipiInterceptMessage {}
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -2738,6 +2767,8 @@ pub struct HvX64SynicSintDeliverableMessage {
     pub rsvd2: u32,
 }
 
+impl MessagePayload for HvX64SynicSintDeliverableMessage {}
+
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvArm64SynicSintDeliverableMessage {
@@ -2747,6 +2778,8 @@ pub struct HvArm64SynicSintDeliverableMessage {
     pub rsvd2: u32,
 }
 
+impl MessagePayload for HvArm64SynicSintDeliverableMessage {}
+
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvX64InterruptionDeliverableMessage {
@@ -2755,6 +2788,8 @@ pub struct HvX64InterruptionDeliverableMessage {
     pub rsvd: [u8; 3],
     pub rsvd2: u32,
 }
+
+impl MessagePayload for HvX64InterruptionDeliverableMessage {}
 
 open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -2784,6 +2819,8 @@ pub struct HvX64HypercallInterceptMessage {
     pub rsvd2: [u32; 3],
 }
 
+impl MessagePayload for HvX64HypercallInterceptMessage {}
+
 #[repr(C)]
 #[derive(Debug, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvArm64HypercallInterceptMessage {
@@ -2793,6 +2830,8 @@ pub struct HvArm64HypercallInterceptMessage {
     pub flags: HvHypercallInterceptMessageFlags,
     pub x: [u64; 18],
 }
+
+impl MessagePayload for HvArm64HypercallInterceptMessage {}
 
 #[bitfield(u32)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -2815,6 +2854,8 @@ pub struct HvX64CpuidInterceptMessage {
     pub default_result_rdx: u64,
     pub default_result_rbx: u64,
 }
+
+impl MessagePayload for HvX64CpuidInterceptMessage {}
 
 #[bitfield(u8)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -2856,12 +2897,16 @@ pub struct HvX64ExceptionInterceptMessage {
     pub r15: u64,
 }
 
+impl MessagePayload for HvX64ExceptionInterceptMessage {}
+
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvInvalidVpRegisterMessage {
     pub vp_index: u32,
     pub reserved: u32,
 }
+
+impl MessagePayload for HvInvalidVpRegisterMessage {}
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -2870,17 +2915,23 @@ pub struct HvX64ApicEoiMessage {
     pub interrupt_vector: u32,
 }
 
+impl MessagePayload for HvX64ApicEoiMessage {}
+
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvX64UnrecoverableExceptionMessage {
     pub header: HvX64InterceptMessageHeader,
 }
 
+impl MessagePayload for HvX64UnrecoverableExceptionMessage {}
+
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvX64HaltMessage {
     pub header: HvX64InterceptMessageHeader,
 }
+
+impl MessagePayload for HvX64HaltMessage {}
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -2889,6 +2940,8 @@ pub struct HvArm64ResetInterceptMessage {
     pub reset_type: HvArm64ResetType,
     pub padding: u32,
 }
+
+impl MessagePayload for HvArm64ResetInterceptMessage {}
 
 open_enum! {
     #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -3539,6 +3592,8 @@ pub struct HvX64VmgexitInterceptMessage {
     pub flags: HvX64VmgexitInterceptMessageFlags,
     pub ghcb_page: HvX64VmgexitInterceptMessageGhcbPage,
 }
+
+impl MessagePayload for HvX64VmgexitInterceptMessage {}
 
 #[bitfield(u64)]
 pub struct HvRegisterVpAssistPage {


### PR DESCRIPTION
Align `HvMessage` to 16 bytes since it sometimes contains messages from the hypervisor that have 16-byte alignment, and it is always 16-byte aligned in mapped memory interfaces.

Add new `as_message` method for casting the payload to a message type without having to use an explicit zerocopy dance. This method validates that the type being cast to is supposed to be a message type and that it has the proper size and alignment.

Use `as_message` in virt_mshv_vtl.