### PR TITLE
virt_whp: simplify hypervisor message access

### DIFF
--- a/vm/whp/src/abi/arm64.rs
+++ b/vm/whp/src/abi/arm64.rs
@@ -406,10 +406,11 @@ pub const WHvRunVpExitReasonArm64Reset: WHV_RUN_VP_EXIT_REASON = WHV_RUN_VP_EXIT
 pub const WHvRunVpExitReasonHypercall: WHV_RUN_VP_EXIT_REASON = WHV_RUN_VP_EXIT_REASON(0x80000050);
 pub const WHvRunVpExitReasonCanceled: WHV_RUN_VP_EXIT_REASON = WHV_RUN_VP_EXIT_REASON(0xFFFFFFFF);
 
-#[repr(C, align(8))]
-#[derive(Copy, Clone)]
+#[repr(C, align(16))]
+#[derive(Copy, Clone, Debug)]
 pub struct WHV_RUN_VP_EXIT_CONTEXT_u {
-    pub message: [u8; 256],
+    pub message: [u8; 240],
+    pub extra: [u8; 16],
 }
 
 impl WHV_PROCESSOR_FEATURES {

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -1738,7 +1738,7 @@ impl<'a> ExitReason<'a> {
         match ctx.ExitReason {
             abi::WHvRunVpExitReasonNone => Self::None,
             abi::WHvRunVpExitReasonCanceled => Self::Canceled,
-            reason => Self::Hypervisor(reason.0, &ctx.u.message),
+            reason => Self::Hypervisor(reason.0, &ctx.u),
         }
     }
 }
@@ -1785,7 +1785,7 @@ pub enum ExitReason<'a> {
 #[derive(Copy, Clone, Debug)]
 pub enum ExitReason<'a> {
     None,
-    Hypervisor(u32, &'a [u8; 256]),
+    Hypervisor(u32, &'a abi::WHV_RUN_VP_EXIT_CONTEXT_u),
     Canceled,
 }
 


### PR DESCRIPTION
Use the new `MessagePayload` trait to cast with confidence.

Also, fix the alignment problem with `WHV_RUN_VP_EXIT_CONTEXT`; messages
must be 16-byte aligned.
