### PR TITLE
hcl: Remove BackingPrivate, just expect warnings

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1641,8 +1641,9 @@ pub enum NoRunner {
 }
 
 /// An isolation-type-specific backing for a processor runner.
-#[expect(private_interfaces, missing_docs)]
+#[expect(missing_docs)]
 pub trait Backing<'a>: Sized {
+    #[expect(private_interfaces)]
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'a>>, hcl: &Hcl) -> Result<Self, NoRunner>;
 
     fn try_set_reg(

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1535,7 +1535,8 @@ impl Hcl {
 }
 
 #[derive(Debug)]
-struct HclVp {
+#[doc(hidden)]
+pub struct HclVp {
     state: Mutex<VpState>,
     run: MappedPage<hcl_run>,
     backing: BackingState,
@@ -1643,7 +1644,6 @@ pub enum NoRunner {
 /// An isolation-type-specific backing for a processor runner.
 #[expect(missing_docs)]
 pub trait Backing<'a>: Sized {
-    #[expect(private_interfaces)]
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'a>>, hcl: &Hcl) -> Result<Self, NoRunner>;
 
     fn try_set_reg(

--- a/openhcl/hcl/src/ioctl/aarch64.rs
+++ b/openhcl/hcl/src/ioctl/aarch64.rs
@@ -44,7 +44,8 @@ impl ProcessorRunner<'_, MshvArm64> {
     }
 }
 
-impl super::BackingPrivate<'_> for MshvArm64 {
+#[expect(private_interfaces)]
+impl super::Backing<'_> for MshvArm64 {
     fn new(vp: &HclVp, sidecar: Option<&SidecarVp<'_>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
         let super::BackingState::Mshv { reg_page: _ } = &vp.backing else {

--- a/openhcl/hcl/src/ioctl/aarch64.rs
+++ b/openhcl/hcl/src/ioctl/aarch64.rs
@@ -45,7 +45,6 @@ impl ProcessorRunner<'_, MshvArm64> {
 }
 
 impl super::Backing<'_> for MshvArm64 {
-    #[expect(private_interfaces)]
     fn new(vp: &HclVp, sidecar: Option<&SidecarVp<'_>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
         let super::BackingState::Mshv { reg_page: _ } = &vp.backing else {

--- a/openhcl/hcl/src/ioctl/aarch64.rs
+++ b/openhcl/hcl/src/ioctl/aarch64.rs
@@ -44,8 +44,8 @@ impl ProcessorRunner<'_, MshvArm64> {
     }
 }
 
-#[expect(private_interfaces)]
 impl super::Backing<'_> for MshvArm64 {
+    #[expect(private_interfaces)]
     fn new(vp: &HclVp, sidecar: Option<&SidecarVp<'_>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
         let super::BackingState::Mshv { reg_page: _ } = &vp.backing else {

--- a/openhcl/hcl/src/ioctl/deferred.rs
+++ b/openhcl/hcl/src/ioctl/deferred.rs
@@ -10,7 +10,7 @@ use std::cell::UnsafeCell;
 use zerocopy::IntoBytes;
 
 #[derive(Debug, Default)]
-pub struct DeferredActions {
+pub(crate) struct DeferredActions {
     actions: Vec<DeferredAction>,
 }
 
@@ -51,7 +51,7 @@ impl DeferredActions {
 /// A deferred action that can be handled by the hypervisor as part of switching
 /// VTLs.
 #[derive(Debug, Copy, Clone)]
-pub enum DeferredAction {
+pub(crate) enum DeferredAction {
     SignalEvent { vp: u32, sint: u8, flag: u16 },
 }
 
@@ -83,7 +83,7 @@ impl DeferredAction {
 }
 
 /// A reference to the HCL run data structure's deferred action slots.
-pub struct DeferredActionSlots<'a>(&'a UnsafeCell<hcl_run>);
+pub(crate) struct DeferredActionSlots<'a>(&'a UnsafeCell<hcl_run>);
 
 impl<'a> DeferredActionSlots<'a> {
     /// # Safety

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -173,8 +173,8 @@ impl MshvVtl {
     }
 }
 
-#[expect(private_interfaces)]
 impl<'a> super::Backing<'a> for Snp<'a> {
+    #[expect(private_interfaces)]
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'_>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
         let super::BackingState::Snp { vmsa } = &vp.backing else {

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -174,7 +174,6 @@ impl MshvVtl {
 }
 
 impl<'a> super::Backing<'a> for Snp<'a> {
-    #[expect(private_interfaces)]
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'_>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
         let super::BackingState::Snp { vmsa } = &vp.backing else {

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -173,7 +173,8 @@ impl MshvVtl {
     }
 }
 
-impl<'a> super::private::BackingPrivate<'a> for Snp<'a> {
+#[expect(private_interfaces)]
+impl<'a> super::Backing<'a> for Snp<'a> {
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'_>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
         let super::BackingState::Snp { vmsa } = &vp.backing else {

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -412,7 +412,8 @@ fn vmcs_field_code(field: VmcsField, vtl: GuestVtl) -> TdxExtendedFieldCode {
         .with_field_size(field_size)
 }
 
-impl<'a> super::private::BackingPrivate<'a> for Tdx<'a> {
+#[expect(private_interfaces)]
+impl<'a> super::Backing<'a> for Tdx<'a> {
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'_>>, hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
         let super::BackingState::Tdx {

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -412,8 +412,8 @@ fn vmcs_field_code(field: VmcsField, vtl: GuestVtl) -> TdxExtendedFieldCode {
         .with_field_size(field_size)
 }
 
-#[expect(private_interfaces)]
 impl<'a> super::Backing<'a> for Tdx<'a> {
+    #[expect(private_interfaces)]
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'_>>, hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
         let super::BackingState::Tdx {

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -413,7 +413,6 @@ fn vmcs_field_code(field: VmcsField, vtl: GuestVtl) -> TdxExtendedFieldCode {
 }
 
 impl<'a> super::Backing<'a> for Tdx<'a> {
-    #[expect(private_interfaces)]
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'_>>, hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
         let super::BackingState::Tdx {

--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -168,8 +168,8 @@ impl ProcessorRunner<'_, MshvX64<'_>> {
     }
 }
 
-#[expect(private_interfaces)]
 impl<'a> super::Backing<'a> for MshvX64<'a> {
+    #[expect(private_interfaces)]
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'a>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         let BackingState::Mshv { reg_page } = &vp.backing else {
             return Err(NoRunner::MismatchedIsolation);

--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -12,7 +12,6 @@ use super::NoRunner;
 use super::ProcessorRunner;
 use super::TranslateGvaToGpaError;
 use super::TranslateResult;
-use super::private::BackingPrivate;
 use crate::protocol::hcl_cpu_context_x64;
 use hvdef::HV_PARTITION_ID_SELF;
 use hvdef::HV_VP_INDEX_SELF;
@@ -169,7 +168,8 @@ impl ProcessorRunner<'_, MshvX64<'_>> {
     }
 }
 
-impl<'a> BackingPrivate<'a> for MshvX64<'a> {
+#[expect(private_interfaces)]
+impl<'a> super::Backing<'a> for MshvX64<'a> {
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'a>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         let BackingState::Mshv { reg_page } = &vp.backing else {
             return Err(NoRunner::MismatchedIsolation);

--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -169,7 +169,6 @@ impl ProcessorRunner<'_, MshvX64<'_>> {
 }
 
 impl<'a> super::Backing<'a> for MshvX64<'a> {
-    #[expect(private_interfaces)]
     fn new(vp: &'a HclVp, sidecar: Option<&SidecarVp<'a>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         let BackingState::Mshv { reg_page } = &vp.backing else {
             return Err(NoRunner::MismatchedIsolation);

--- a/openhcl/hcl/src/vmsa.rs
+++ b/openhcl/hcl/src/vmsa.rs
@@ -24,7 +24,7 @@ pub struct VmsaWrapper<'a, T> {
 
 impl<'a, T> VmsaWrapper<'a, T> {
     /// Create a VmsaWrapper
-    pub fn new(vmsa: T, bitmap: &'a [u8; 64]) -> Self {
+    pub(crate) fn new(vmsa: T, bitmap: &'a [u8; 64]) -> Self {
         VmsaWrapper { vmsa, bitmap }
     }
 }


### PR DESCRIPTION
This applies a similar transformation as #1018 and #1040, just to the HCL crate. Also makes a few types `pub(crate)` only.