### PR TITLE
virt_mshv_vtl: Remove the need for private_interfaces

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -245,7 +245,7 @@ struct UhPartitionInner {
 #[derive(Inspect)]
 #[inspect(external_tag)]
 #[doc(hidden)]
-enum BackingShared {
+pub enum BackingShared {
     Hypervisor(#[inspect(flatten)] HypervisorBackedShared),
     #[cfg(guest_arch = "x86_64")]
     Snp(#[inspect(flatten)] SnpBackedShared),

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -171,13 +171,14 @@ impl LapicState {
     }
 }
 
-pub(crate) struct BackingParams<'a, 'b, T: Backing> {
+#[doc(hidden)]
+pub struct BackingParams<'a, 'b, T: Backing> {
     partition: &'a UhPartitionInner,
     vp_info: &'a TargetVpInfo,
     runner: &'a mut ProcessorRunner<'b, T::HclBacking<'b>>,
 }
 
-#[expect(private_interfaces, missing_docs)]
+#[expect(missing_docs)]
 pub trait Backing: 'static + Sized + InspectMut + Sized {
     type HclBacking<'b>: hcl::ioctl::Backing<'b>;
     type EmulationCache;

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -92,7 +92,6 @@ struct ProcessorStatsArm64 {
     synic_deliverable: Counter,
 }
 
-#[expect(private_interfaces)]
 impl Backing for HypervisorBackedArm64 {
     type HclBacking<'mshv> = MshvArm64;
     type EmulationCache = UhCpuStateCache;

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -134,7 +134,6 @@ pub struct MshvEmulationCache {
     rflags: RFlags,
 }
 
-#[expect(private_interfaces)]
 impl Backing for HypervisorBackedX86 {
     type HclBacking<'mshv> = MshvX64<'mshv>;
     type Shared = HypervisorBackedX86Shared;

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -267,7 +267,6 @@ impl SnpBackedShared {
     }
 }
 
-#[expect(private_interfaces)]
 impl Backing for SnpBacked {
     type HclBacking<'snp> = hcl::ioctl::snp::Snp<'snp>;
     type Shared = SnpBackedShared;

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -570,7 +570,6 @@ impl TdxBacked {
     }
 }
 
-#[expect(private_interfaces)]
 impl Backing for TdxBacked {
     type HclBacking<'tdx> = Tdx<'tdx>;
     type Shared = TdxBackedShared;


### PR DESCRIPTION
Turns out we don't need to make all that much pub to make some of the warnings go away. HardwareIsolatedBacking being private and the private_interfaces lints it creates remain.