### PR TITLE
release/2411: netvsp: assign any extra receive buffers to the last active queue (#1…

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -333,7 +333,11 @@ impl RxBufferRange {
             false
         } else {
             let i = (id - RX_RESERVED_CONTROL_BUFFERS) / self.remote_ranges.buffers_per_queue;
-            let _ = self.remote_ranges.buffer_id_send[i as usize].unbounded_send(id);
+            // The total number of receive buffers may not evenly divide among
+            // the active queues. Any extra buffers are given to the last
+            // queue, so redirect any larger values there.
+            let i = (i as usize).min(self.remote_ranges.buffer_id_send.len() - 1);
+            let _ = self.remote_ranges.buffer_id_send[i].unbounded_send(id);
             true
         }
     }
@@ -4158,7 +4162,7 @@ impl Coordinator {
                     // buffers.
                     queue_config.push(QueueConfig {
                         pool: Box::new(BufferPool::new(guest_buffers.clone())),
-                        initial_rx: &[RxId(0)],
+                        initial_rx: &[],
                         driver: Box::new(drivers[0].clone()),
                     });
                     rx_buffers.push(RxBufferRange::new(
@@ -4173,13 +4177,15 @@ impl Coordinator {
                     let queue_active = active_queues.is_empty()
                         || active_queues.binary_search(&queue_index).is_ok();
                     let (range_end, end, buffer_id_recv) = if queue_active {
-                        let range_end = range_start
-                            + ranges.buffers_per_queue
-                            + if queue_index == 0 {
-                                RX_RESERVED_CONTROL_BUFFERS
-                            } else {
-                                0
-                            };
+                        let range_end = if rx_buffers.len() as u16 == active_queue_count - 1 {
+                            // The last queue gets all the remaining buffers.
+                            state.buffers.recv_buffer.count
+                        } else if queue_index == 0 {
+                            // Queue zero always includes the reserved buffers.
+                            RX_RESERVED_CONTROL_BUFFERS + ranges.buffers_per_queue
+                        } else {
+                            range_start + ranges.buffers_per_queue
+                        };
                         (
                             range_end,
                             initial_rx.partition_point(|id| id.0 < range_end),

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -12,6 +12,7 @@ use crate::Guid;
 use crate::InspectMut;
 use async_trait::async_trait;
 use buffers::sub_allocation_size_for_mtu;
+use futures::Future;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures::TryFutureExt;
@@ -25,15 +26,20 @@ use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use mesh::RecvError;
 use net_backend::null::NullEndpoint;
+use net_backend::BufferAccess;
 use net_backend::DisconnectableEndpoint;
 use net_backend::Endpoint;
 use net_backend::EndpointAction;
+use net_backend::MultiQueueSupport;
+use net_backend::Queue as NetQueue;
 use net_backend::QueueConfig;
+use net_backend::TxOffloadSupport;
 use pal_async::async_test;
 use pal_async::DefaultDriver;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::sync::atomic::AtomicBool;
+use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
 use test_with_tracing::test;
@@ -73,6 +79,7 @@ use vmcore::vm_task::VmTaskDriverSource;
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
+use zerocopy::KnownLayout;
 
 const VMNIC_CHANNEL_TYPE_GUID: Guid = Guid::from_static_str("f8615163-df3e-46c5-913f-f2d2f965ed0e");
 
@@ -91,7 +98,7 @@ struct MockVmbus {
 }
 
 impl MockVmbus {
-    const MAX_SUPPORTED_CHANNELS: usize = 2;
+    const MAX_SUPPORTED_CHANNELS: usize = 6;
     // The receive buffer will always need to be at least
     // RX_RESERVED_CONTROL_BUFFERS packets big (eight pages). Then each channel
     // needs four pages for the vmbus send/receive rings, plus at least
@@ -129,6 +136,7 @@ struct TestNicEndpointState {
     pub last_use_vf: Option<bool>,
     pub stop_endpoint_counter: usize,
     pub link_status_updater: Option<mesh::Sender<VecDeque<bool>>>,
+    pub queues: Vec<mesh::Sender<Vec<u8>>>,
 }
 
 impl TestNicEndpointState {
@@ -139,6 +147,7 @@ impl TestNicEndpointState {
             last_use_vf: None,
             stop_endpoint_counter: 0,
             link_status_updater: None,
+            queues: Vec::new(),
         }))
     }
 
@@ -151,24 +160,20 @@ impl TestNicEndpointState {
 }
 
 struct TestNicEndpointInner {
-    pub null_endpoint: NullEndpoint,
     pub endpoint_state: Option<Arc<parking_lot::Mutex<TestNicEndpointState>>>,
 }
 
 impl TestNicEndpointInner {
     pub fn new(endpoint_state: Option<Arc<parking_lot::Mutex<TestNicEndpointState>>>) -> Self {
-        Self {
-            null_endpoint: NullEndpoint::new(),
-            endpoint_state,
-        }
+        Self { endpoint_state }
     }
 }
 
 struct TestNicEndpoint {
     inner: Arc<futures::lock::Mutex<TestNicEndpointInner>>,
     is_ordered: bool,
-    tx_offload_support: net_backend::TxOffloadSupport,
-    multiqueue_support: net_backend::MultiQueueSupport,
+    tx_offload_support: TxOffloadSupport,
+    multiqueue_support: MultiQueueSupport,
     link_status_rx: mesh::Receiver<VecDeque<bool>>,
     pending_link_status_updates: VecDeque<bool>,
 }
@@ -181,14 +186,19 @@ impl TestNicEndpoint {
             locked_state.link_status_updater = Some(link_status_tx);
         }
         let inner = TestNicEndpointInner::new(endpoint_state);
-        let is_ordered = <NullEndpoint as net_backend::Endpoint>::is_ordered(&inner.null_endpoint);
-        let tx_offload_support =
-            <NullEndpoint as net_backend::Endpoint>::tx_offload_support(&inner.null_endpoint);
-        let multiqueue_support =
-            <NullEndpoint as net_backend::Endpoint>::multiqueue_support(&inner.null_endpoint);
+        let tx_offload_support = TxOffloadSupport {
+            ipv4_header: true,
+            tcp: true,
+            udp: true,
+            tso: true,
+        };
+        let multiqueue_support = MultiQueueSupport {
+            max_queues: u16::MAX,
+            indirection_table_size: 128,
+        };
         Self {
             inner: Arc::new(futures::lock::Mutex::new(inner)),
-            is_ordered,
+            is_ordered: true,
             tx_offload_support,
             multiqueue_support,
             link_status_rx,
@@ -210,31 +220,44 @@ impl net_backend::Endpoint for TestNicEndpoint {
     async fn get_queues(
         &mut self,
         config: Vec<QueueConfig<'_>>,
-        rss: Option<&net_backend::RssConfig<'_>>,
+        _rss: Option<&net_backend::RssConfig<'_>>,
         queues: &mut Vec<Box<dyn net_backend::Queue>>,
     ) -> anyhow::Result<()> {
-        let mut inner = self.inner.lock().await;
-        inner.null_endpoint.get_queues(config, rss, queues).await
+        queues.clear();
+        let senders = config
+            .into_iter()
+            .map(|config| {
+                let (tx, rx) = mesh::channel();
+                queues.push(Box::new(TestNicQueue::new(config, rx)));
+                tx
+            })
+            .collect::<Vec<_>>();
+
+        let inner = self.inner.lock().await;
+        if let Some(endpoint_state) = &inner.endpoint_state {
+            let mut locked_data = endpoint_state.lock();
+            locked_data.queues = senders;
+        }
+        Ok(())
     }
 
     async fn stop(&mut self) {
-        let mut inner = self.inner.lock().await;
+        let inner = self.inner.lock().await;
         if let Some(endpoint_state) = &inner.endpoint_state {
             let mut locked_data = endpoint_state.lock();
             locked_data.stop_endpoint_counter += 1;
         }
-        <NullEndpoint as net_backend::Endpoint>::stop::<'_, '_>(&mut inner.null_endpoint).await
     }
 
     fn is_ordered(&self) -> bool {
         self.is_ordered
     }
 
-    fn tx_offload_support(&self) -> net_backend::TxOffloadSupport {
+    fn tx_offload_support(&self) -> TxOffloadSupport {
         self.tx_offload_support
     }
 
-    fn multiqueue_support(&self) -> net_backend::MultiQueueSupport {
+    fn multiqueue_support(&self) -> MultiQueueSupport {
         self.multiqueue_support
     }
 
@@ -276,6 +299,91 @@ impl net_backend::Endpoint for TestNicEndpoint {
                 .append(&mut self.link_status_rx.select_next_some().await);
         }
         EndpointAction::LinkStatusNotify(self.pending_link_status_updates.pop_front().unwrap())
+    }
+}
+
+#[derive(InspectMut)]
+struct TestNicQueue {
+    #[inspect(skip)]
+    pool: Box<dyn BufferAccess>,
+    #[inspect(skip)]
+    rx_ids: VecDeque<RxId>,
+    #[inspect(skip)]
+    rx: mesh::Receiver<Vec<u8>>,
+    next_rx_packet: Option<Vec<u8>>,
+}
+
+impl TestNicQueue {
+    pub fn new(config: QueueConfig<'_>, rx: mesh::Receiver<Vec<u8>>) -> Self {
+        let rx_ids = config.initial_rx.iter().copied().collect();
+        Self {
+            pool: config.pool,
+            rx_ids,
+            rx,
+            next_rx_packet: None,
+        }
+    }
+}
+
+impl NetQueue for TestNicQueue {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        if self.rx_ids.is_empty() {
+            return Poll::Pending;
+        }
+        let recv = std::pin::pin!(self.rx.recv());
+        self.next_rx_packet = Some(std::task::ready!(recv.poll(cx)).unwrap());
+        Poll::Ready(())
+    }
+
+    fn rx_avail(&mut self, done: &[RxId]) {
+        for rx_id in done.iter() {
+            self.rx_ids.push_back(*rx_id);
+        }
+    }
+
+    fn rx_poll(&mut self, packets: &mut [RxId]) -> anyhow::Result<usize> {
+        if packets.is_empty() {
+            return Ok(0);
+        }
+
+        if let Some(packet) = self.next_rx_packet.take() {
+            let len = packet.len();
+            assert!(len > 0);
+            let rx_id = self.rx_ids.pop_front().unwrap();
+            tracing::info!(rx_id = rx_id.0, ?packet, "returning packet on receive path");
+            let mut packet = &packet[..];
+            let guest_memory = self.pool.guest_memory().clone();
+            for seg in self.pool.guest_addresses(rx_id).iter() {
+                // N.B. The packet data is written after the implicit header,
+                //      which is 256 bytes long. The header can be written with
+                //      self.pool.write_header(...) if desired.
+                let write_len = packet.len().min(seg.len as usize);
+                tracing::info!(seg.gpa, write_len, "writing packet to guest memory");
+                guest_memory
+                    .write_at(seg.gpa, &packet[..write_len])
+                    .unwrap();
+                packet = &packet[write_len..];
+                if packet.is_empty() {
+                    break;
+                }
+            }
+            packets[0] = rx_id;
+            Ok(1)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn tx_avail(&mut self, packets: &[TxSegment]) -> anyhow::Result<(bool, usize)> {
+        Ok((true, packets.len()))
+    }
+
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+        Ok(0)
+    }
+
+    fn buffer_access(&mut self) -> Option<&mut dyn BufferAccess> {
+        None
     }
 }
 
@@ -660,11 +768,9 @@ impl TestNicDevice {
 }
 
 struct TestNicSubchannel {
-    _queue: Queue<GpadlRingMem>,
+    queue: Queue<GpadlRingMem>,
     _transaction_id: u64,
     _gpadl_map: Arc<GpadlMap>,
-    _recv_buf_id: GpadlId,
-    _send_buf_id: GpadlId,
     _channel_id: GpadlId,
     _host_to_guest_event: Arc<SlimEvent>,
     _guest_done: Arc<AtomicBool>,
@@ -690,11 +796,9 @@ impl TestNicSubchannel {
         );
         let queue = Queue::new(channel).unwrap();
         Self {
-            _queue: queue,
+            queue,
             _transaction_id: 1,
             _gpadl_map: gpadl_map,
-            _recv_buf_id: GpadlId(0),
-            _send_buf_id: GpadlId(0),
             _channel_id: channel_id,
             _host_to_guest_event: host_to_guest_event,
             _guest_done: guest_done,
@@ -765,6 +869,29 @@ impl<'a> TestNicChannel<'a> {
         Ok(f(&packet))
     }
 
+    pub async fn read_subchannel_with_timeout<F, R>(
+        &mut self,
+        idx: u32,
+        timeout: Duration,
+        f: F,
+    ) -> Result<R, ()>
+    where
+        F: FnOnce(&IncomingPacket<'_, GpadlRingMem>) -> R,
+    {
+        if idx == 0 {
+            return self.read_with_timeout(timeout, f).await;
+        }
+
+        let (mut reader, _) = self.subchannels.get_mut(&idx).unwrap().queue.split();
+        let packet = mesh::CancelContext::new()
+            .with_timeout(timeout)
+            .until_cancelled(reader.read())
+            .await
+            .map_err(drop)?
+            .unwrap();
+        Ok(f(&packet))
+    }
+
     pub async fn read_with<F, R>(&mut self, f: F) -> Result<R, ()>
     where
         F: FnOnce(&IncomingPacket<'_, GpadlRingMem>) -> R,
@@ -772,8 +899,16 @@ impl<'a> TestNicChannel<'a> {
         self.read_with_timeout(Duration::from_millis(333), f).await
     }
 
-    pub fn rndis_control_message_parser(&self) -> RndisControlMessageParser {
-        RndisControlMessageParser::new(
+    pub async fn read_subchannel_with<F, R>(&mut self, idx: u32, f: F) -> Result<R, ()>
+    where
+        F: FnOnce(&IncomingPacket<'_, GpadlRingMem>) -> R,
+    {
+        self.read_subchannel_with_timeout(idx, Duration::from_millis(333), f)
+            .await
+    }
+
+    pub fn rndis_message_parser(&self) -> RndisMessageParser {
+        RndisMessageParser::new(
             self.nic.mock_vmbus.memory.clone(),
             self.gpadl_map.clone(),
             self.recv_buf_id,
@@ -788,13 +923,13 @@ impl<'a> TestNicChannel<'a> {
     where
         T: AsBytes + FromBytes,
     {
-        let parser = self.rndis_control_message_parser();
+        let parser = self.rndis_message_parser();
         let mut transaction_id = None;
         let message = self
             .read_with_timeout(timeout, |packet| {
                 match packet {
                     IncomingPacket::Data(data) => {
-                        let (rndis_header, external_ranges) = parser.parse(data);
+                        let (rndis_header, external_ranges) = parser.parse_control_message(data);
                         // Verify message_type matches caller expectations
                         assert_eq!(rndis_header.message_type, message_type);
 
@@ -843,6 +978,15 @@ impl<'a> TestNicChannel<'a> {
 
     pub async fn write(&mut self, packet: OutgoingPacket<'_, '_>) {
         let (_, mut writer) = self.queue.split();
+        writer.write(packet).await.unwrap();
+    }
+
+    pub async fn write_subchannel(&mut self, idx: u32, packet: OutgoingPacket<'_, '_>) {
+        if idx == 0 {
+            return self.write(packet).await;
+        }
+
+        let (_, mut writer) = self.subchannels.get_mut(&idx).unwrap().queue.split();
         writer.write(packet).await.unwrap();
     }
 
@@ -1094,7 +1238,11 @@ impl<'a> TestNicChannel<'a> {
             .await;
         self.read_with(|packet| match packet {
             IncomingPacket::Completion(_) => (),
-            _ => panic!("Unexpected packet"),
+            IncomingPacket::Data(data) => {
+                let mut reader = data.reader();
+                let header: protocol::MessageHeader = reader.read_plain().unwrap();
+                panic!("Unexpected data packet {}", header.message_type);
+            }
         })
         .await
         .expect("completion message");
@@ -1161,12 +1309,12 @@ impl<'a> TestNicChannel<'a> {
     }
 }
 
-struct RndisControlMessageParser {
+struct RndisMessageParser {
     mem: GuestMemory,
     buf: GpadlView,
 }
 
-impl RndisControlMessageParser {
+impl RndisMessageParser {
     pub fn new(mem: GuestMemory, gpadl_map: Arc<GpadlMap>, buf_id: GpadlId) -> Self {
         Self {
             mem,
@@ -1174,9 +1322,10 @@ impl RndisControlMessageParser {
         }
     }
 
-    pub fn parse(
+    pub fn parse_message(
         &self,
         data: &queue::DataPacket<'_, GpadlRingMem>,
+        channel_type: u32,
     ) -> (rndisprot::MessageHeader, MultiPagedRangeBuf<GpnList>) {
         // Check for RNDIS packet
         let mut reader = data.reader();
@@ -1185,9 +1334,8 @@ impl RndisControlMessageParser {
             header.message_type,
             protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET
         );
-        // Verify it is a control channel message
         let rndis_data: protocol::Message1SendRndisPacket = reader.read_plain().unwrap();
-        assert_eq!(rndis_data.channel_type, protocol::CONTROL_CHANNEL_TYPE);
+        assert_eq!(rndis_data.channel_type, channel_type);
 
         // Fetch RNDIS packet from external memory
         let external_ranges = if let Some(id) = data.transfer_buffer_id() {
@@ -1203,12 +1351,42 @@ impl RndisControlMessageParser {
         (rndis_header, external_ranges)
     }
 
+    pub fn parse_data_message(
+        &self,
+        data: &queue::DataPacket<'_, GpadlRingMem>,
+    ) -> (rndisprot::MessageHeader, MultiPagedRangeBuf<GpnList>) {
+        self.parse_message(data, protocol::DATA_CHANNEL_TYPE)
+    }
+
+    pub fn parse_control_message(
+        &self,
+        data: &queue::DataPacket<'_, GpadlRingMem>,
+    ) -> (rndisprot::MessageHeader, MultiPagedRangeBuf<GpnList>) {
+        self.parse_message(data, protocol::CONTROL_CHANNEL_TYPE)
+    }
+
     pub fn get<T>(&self, external_ranges: &MultiPagedRangeBuf<GpnList>) -> T
     where
         T: AsBytes + FromBytes,
     {
         let mut reader = PagedRanges::new(external_ranges.iter()).reader(&self.mem);
         assert!(reader.skip(size_of::<rndisprot::MessageHeader>()).is_ok());
+        tracing::info!(
+            bytes_read = size_of::<T>(),
+            bytes_available = reader.len(),
+            "parsing packet content"
+        );
+        reader.read_plain::<T>().unwrap()
+    }
+
+    pub fn get_data_packet_content<T>(&self, external_ranges: &MultiPagedRangeBuf<GpnList>) -> T
+    where
+        T: AsBytes + FromBytes + KnownLayout,
+    {
+        const RX_HEADER_LEN: usize = 256;
+        let mut reader = PagedRanges::new(external_ranges.iter()).reader(&self.mem);
+        // Skip RNDIS packet header to get to the data.
+        assert!(reader.skip(RX_HEADER_LEN).is_ok());
         reader.read_plain::<T>().unwrap()
     }
 }
@@ -1381,7 +1559,7 @@ impl SignalVmbusChannel for EventWithDone {
         self.remote_interrupt.deliver();
     }
 
-    fn poll_for_signal(&self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), ChannelClosed>> {
+    fn poll_for_signal(&self, cx: &mut Context<'_>) -> Poll<Result<(), ChannelClosed>> {
         if self.done.load(Ordering::Relaxed) {
             return Err(ChannelClosed).into();
         }
@@ -3462,11 +3640,11 @@ async fn set_rss_parameter(driver: DefaultDriver) {
             rss_params.as_bytes(),
         )
         .await;
-    let rndis_parser = channel.rndis_control_message_parser();
+    let rndis_parser = channel.rndis_message_parser();
     let transaction_id = channel
         .read_with(|packet| match packet {
             IncomingPacket::Data(packet) => {
-                let (header, external_ranges) = rndis_parser.parse(packet);
+                let (header, external_ranges) = rndis_parser.parse_control_message(packet);
                 assert_eq!(header.message_type, rndisprot::MESSAGE_TYPE_SET_CMPLT);
                 let set_complete: rndisprot::SetComplete = rndis_parser.get(&external_ranges);
                 assert_eq!(set_complete.status, rndisprot::STATUS_SUCCESS);
@@ -3561,11 +3739,11 @@ async fn set_rss_parameter_no_valid_queues(driver: DefaultDriver) {
             rss_params.as_bytes(),
         )
         .await;
-    let rndis_parser = channel.rndis_control_message_parser();
+    let rndis_parser = channel.rndis_message_parser();
     let transaction_id = channel
         .read_with(|packet| match packet {
             IncomingPacket::Data(packet) => {
-                let (header, external_ranges) = rndis_parser.parse(packet);
+                let (header, external_ranges) = rndis_parser.parse_control_message(packet);
                 assert_eq!(header.message_type, rndisprot::MESSAGE_TYPE_SET_CMPLT);
                 let set_complete: rndisprot::SetComplete = rndis_parser.get(&external_ranges);
                 assert_eq!(set_complete.status, rndisprot::STATUS_SUCCESS);
@@ -3727,11 +3905,11 @@ async fn set_rss_parameter_unused_first_queue(driver: DefaultDriver) {
             rss_params.as_bytes(),
         )
         .await;
-    let rndis_parser = channel.rndis_control_message_parser();
+    let rndis_parser = channel.rndis_message_parser();
     let transaction_id = channel
         .read_with(|packet| match packet {
             IncomingPacket::Data(packet) => {
-                let (header, external_ranges) = rndis_parser.parse(packet);
+                let (header, external_ranges) = rndis_parser.parse_control_message(packet);
                 assert_eq!(header.message_type, rndisprot::MESSAGE_TYPE_SET_CMPLT);
                 let set_complete: rndisprot::SetComplete = rndis_parser.get(&external_ranges);
                 assert_eq!(set_complete.status, rndisprot::STATUS_SUCCESS);
@@ -3789,6 +3967,264 @@ async fn set_rss_parameter_unused_first_queue(driver: DefaultDriver) {
             .payload(),
         })
         .await;
+}
+
+// Start with six queues (primary plus five subchannels) each with one receive
+// buffer. Send an rx packet on each queue. Then reduce active queues to four,
+// such that the total receive buffers (six) does not evenly divide among the
+// remaining queues. Complete the packets on the original queues they were
+// received to ensure that they are redirected appropriately to the new owning
+// queue.
+#[async_test]
+async fn set_rss_parameter_bufs_not_evenly_divisible(driver: DefaultDriver) {
+    const TOTAL_QUEUES: u32 = 6;
+    let endpoint_state = TestNicEndpointState::new();
+    let endpoint = TestNicEndpoint::new(Some(endpoint_state.clone()));
+    let test_vf = Box::new(TestVirtualFunction::new(123));
+    let builder = Nic::builder();
+    let nic = builder.virtual_function(test_vf).build(
+        &VmTaskDriverSource::new(SingleDriverBackend::new(driver.clone())),
+        Guid::new_random(),
+        Box::new(endpoint),
+        [1, 2, 3, 4, 5, 6].into(),
+        0,
+    );
+
+    let mut nic = TestNicDevice::new_with_nic(&driver, nic).await;
+    nic.start_vmbus_channel();
+    let mut channel = nic.connect_vmbus_channel().await;
+    channel
+        .initialize(
+            TOTAL_QUEUES as usize - 1,
+            protocol::NdisConfigCapabilities::new().with_sriov(true),
+        )
+        .await;
+
+    let rndis_parser = channel.rndis_message_parser();
+
+    channel
+        .send_rndis_control_message(
+            rndisprot::MESSAGE_TYPE_INITIALIZE_MSG,
+            rndisprot::InitializeRequest {
+                request_id: 123,
+                major_version: rndisprot::MAJOR_VERSION,
+                minor_version: rndisprot::MINOR_VERSION,
+                max_transfer_size: 0,
+            },
+            &[],
+        )
+        .await;
+
+    let _: rndisprot::InitializeComplete = channel
+        .read_rndis_control_message(rndisprot::MESSAGE_TYPE_INITIALIZE_CMPLT)
+        .await
+        .unwrap();
+
+    channel
+        .read_with(|packet| match packet {
+            IncomingPacket::Data(_) => (),
+            _ => panic!("Unexpected packet"),
+        })
+        .await
+        .expect("association packet");
+
+    let message = NvspMessage {
+        header: protocol::MessageHeader {
+            message_type: protocol::MESSAGE5_TYPE_SUB_CHANNEL,
+        },
+        data: protocol::Message5SubchannelRequest {
+            operation: protocol::SubchannelOperation::ALLOCATE,
+            num_sub_channels: TOTAL_QUEUES - 1,
+        },
+        padding: &[],
+    };
+    channel
+        .write(OutgoingPacket {
+            transaction_id: 123,
+            packet_type: OutgoingPacketType::InBandWithCompletion,
+            payload: &message.payload(),
+        })
+        .await;
+    channel
+        .read_with(|packet| match packet {
+            IncomingPacket::Completion(completion) => {
+                let mut reader = completion.reader();
+                let header: protocol::MessageHeader = reader.read_plain().unwrap();
+                assert_eq!(header.message_type, protocol::MESSAGE5_TYPE_SUB_CHANNEL);
+                let completion_data: protocol::Message5SubchannelComplete =
+                    reader.read_plain().unwrap();
+                assert_eq!(completion_data.status, protocol::Status::SUCCESS);
+                assert_eq!(completion_data.num_sub_channels, TOTAL_QUEUES - 1);
+            }
+            _ => panic!("Unexpected packet"),
+        })
+        .await
+        .expect("completion message");
+
+    for idx in 1..TOTAL_QUEUES {
+        channel.connect_subchannel(idx).await;
+    }
+
+    let transaction_id = channel
+        .read_with(|packet| match packet {
+            IncomingPacket::Data(packet) => {
+                let mut reader = packet.reader();
+                let header: protocol::MessageHeader = reader.read_plain().unwrap();
+                assert_eq!(
+                    header.message_type,
+                    protocol::MESSAGE5_TYPE_SEND_INDIRECTION_TABLE
+                );
+                packet.transaction_id()
+            }
+            _ => panic!("Unexpected packet"),
+        })
+        .await
+        .expect("indirection table message after all channels connected");
+    if let Some(transaction_id) = transaction_id {
+        channel
+            .write(OutgoingPacket {
+                transaction_id,
+                packet_type: OutgoingPacketType::Completion,
+                payload: &NvspMessage {
+                    header: protocol::MessageHeader {
+                        message_type: protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE,
+                    },
+                    data: protocol::Message1SendRndisPacketComplete {
+                        status: protocol::Status::SUCCESS,
+                    },
+                    padding: &[],
+                }
+                .payload(),
+            })
+            .await;
+    }
+
+    // Receive a packet on every queue.
+    {
+        let locked_state = endpoint_state.lock();
+        for (idx, queue) in locked_state.queues.iter().enumerate() {
+            queue.send(vec![idx as u8]);
+        }
+    }
+
+    // Get the transaction IDs for all of the received packets.
+    let mut rx_tx_ids = Vec::new();
+    for idx in 0..TOTAL_QUEUES {
+        rx_tx_ids.push(
+            channel
+                .read_subchannel_with(idx, |packet| match packet {
+                    IncomingPacket::Data(packet) => {
+                        let (_, external_ranges) = rndis_parser.parse_data_message(packet);
+                        let data: u8 = rndis_parser.get_data_packet_content(&external_ranges);
+                        assert_eq!(idx, data as u32);
+                        packet.transaction_id().unwrap()
+                    }
+                    _ => panic!("Unexpected packet"),
+                })
+                .await
+                .expect("Data packet"),
+        );
+    }
+
+    // Reduce to four active queues.
+    #[repr(C)]
+    #[derive(FromBytes, FromZeroes, AsBytes, KnownLayout)]
+    struct RssParams {
+        params: rndisprot::NdisReceiveScaleParameters,
+        hash_secret_key: [u8; 40],
+        indirection_table: [u32; 4],
+    }
+
+    let rss_params = RssParams {
+        params: rndisprot::NdisReceiveScaleParameters {
+            header: rndisprot::NdisObjectHeader {
+                object_type: rndisprot::NdisObjectType::RSS_PARAMETERS,
+                revision: 1,
+                size: size_of::<RssParams>() as u16,
+            },
+            flags: 0,
+            base_cpu_number: 0,
+            hash_information: rndisprot::NDIS_HASH_FUNCTION_TOEPLITZ,
+            indirection_table_size: 4 * size_of::<u32>() as u16,
+            pad0: 0,
+            indirection_table_offset: offset_of!(RssParams, indirection_table) as u32,
+            hash_secret_key_size: 40,
+            pad1: 0,
+            hash_secret_key_offset: offset_of!(RssParams, hash_secret_key) as u32,
+            processor_masks_offset: 0,
+            number_of_processor_masks: 0,
+            processor_masks_entry_size: 0,
+            default_processor_number: 0,
+        },
+        hash_secret_key: [0; 40],
+        indirection_table: [0, 1, 2, 3],
+    };
+    channel
+        .send_rndis_control_message(
+            rndisprot::MESSAGE_TYPE_SET_MSG,
+            rndisprot::SetRequest {
+                request_id: 0,
+                oid: rndisprot::Oid::OID_GEN_RECEIVE_SCALE_PARAMETERS,
+                information_buffer_length: size_of::<RssParams>() as u32,
+                information_buffer_offset: size_of::<rndisprot::SetRequest>() as u32,
+                device_vc_handle: 0,
+            },
+            rss_params.as_bytes(),
+        )
+        .await;
+    let transaction_id = channel
+        .read_with(|packet| match packet {
+            IncomingPacket::Data(packet) => {
+                let (header, external_ranges) = rndis_parser.parse_control_message(packet);
+                assert_eq!(header.message_type, rndisprot::MESSAGE_TYPE_SET_CMPLT);
+                let set_complete: rndisprot::SetComplete = rndis_parser.get(&external_ranges);
+                assert_eq!(set_complete.status, rndisprot::STATUS_SUCCESS);
+                packet.transaction_id().unwrap()
+            }
+            _ => panic!("Unexpected packet"),
+        })
+        .await
+        .expect("RSS completion message");
+    channel
+        .write(OutgoingPacket {
+            transaction_id,
+            packet_type: OutgoingPacketType::Completion,
+            payload: &NvspMessage {
+                header: protocol::MessageHeader {
+                    message_type: protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE,
+                },
+                data: protocol::Message1SendRndisPacketComplete {
+                    status: protocol::Status::SUCCESS,
+                },
+                padding: &[],
+            }
+            .payload(),
+        })
+        .await;
+
+    // Complete the rx packets on the original six queues.
+    for (idx, rx_tx_id) in rx_tx_ids.into_iter().enumerate() {
+        tracing::info!(idx, rx_tx_id, "completing receive packet");
+        channel
+            .write_subchannel(
+                idx as u32,
+                OutgoingPacket {
+                    transaction_id: rx_tx_id,
+                    packet_type: OutgoingPacketType::Completion,
+                    payload: &NvspMessage {
+                        header: protocol::MessageHeader {
+                            message_type: protocol::MESSAGE1_TYPE_SEND_RNDIS_PACKET_COMPLETE,
+                        },
+                        data: protocol::Message1SendRndisPacketComplete {
+                            status: protocol::Status::SUCCESS,
+                        },
+                        padding: &[],
+                    }
+                    .payload(),
+                },
+            )
+            .await;
+    }
 }
 
 // The netvsp task coordinator can be interrupted for various reasons:
@@ -3874,7 +4310,7 @@ async fn race_coordinator_and_worker_stop_events(driver: DefaultDriver) {
         padding: &[],
     };
 
-    let rndis_parser = channel.rndis_control_message_parser();
+    let rndis_parser = channel.rndis_message_parser();
     endpoint_state.lock().poll_iterations_required = 1;
     for i in 0..25 {
         // Trigger a link update 2/3 of the time. This also will queue a timer,
@@ -3935,7 +4371,7 @@ async fn race_coordinator_and_worker_stop_events(driver: DefaultDriver) {
                 .read_with(|packet| match packet {
                     IncomingPacket::Completion(_) => None,
                     IncomingPacket::Data(data) => {
-                        let (rndis_header, _) = rndis_parser.parse(data);
+                        let (rndis_header, _) = rndis_parser.parse_control_message(data);
                         if rndis_header.message_type == rndisprot::MESSAGE_TYPE_KEEPALIVE_CMPLT {
                             tracing::info!("Got keepalive completion");
                             Some(data.transaction_id().expect("should request completion"))


### PR DESCRIPTION
The number of receive buffers may not always divide equally among the active queues. If there are extras, assign them to the last queue. This way all of the receive buffers are always accessible from one of the queues.

Cherry-pick from #1029