### PR TITLE
Fix incorrect quote usage in cross-tool.py

### DIFF
--- a/build_support/windows_cross/cross_tool.py
+++ b/build_support/windows_cross/cross_tool.py
@@ -101,7 +101,7 @@ def find_llvm_tool(name):
 
 
 def find_midlrt(sdk):
-    midlrt = f'{sdk['bin']}/midlrt.exe'
+    midlrt = f"{sdk['bin']}/midlrt.exe"
     return os.path.normpath(midlrt)
 
 


### PR DESCRIPTION
For some people, cross-tool.py was failing to be interpreted because we were using single quotes both to define the string and inside the string for a dict index. This changes the string to use double quotes instead.