### PR TITLE
virt_mshv_vtl: Bring back BackingPrivate

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -244,7 +244,6 @@ struct UhPartitionInner {
 
 #[derive(Inspect)]
 #[inspect(external_tag)]
-#[doc(hidden)]
 enum BackingShared {
     Hypervisor(#[inspect(flatten)] HypervisorBackedShared),
     #[cfg(guest_arch = "x86_64")]

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -34,13 +34,10 @@ cfg_if::cfg_if! {
 use super::Error;
 use super::UhPartitionInner;
 use super::UhVpInner;
-use crate::BackingShared;
 use crate::GuestVtl;
 use crate::WakeReason;
 use hcl::ioctl::ProcessorRunner;
-use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::message_queues::MessageQueues;
-use hv1_emulator::synic::ProcessorSynic;
 use hv1_hypercall::HvRepResult;
 use hv1_structs::ProcessorSet;
 use hv1_structs::VtlArray;
@@ -59,8 +56,8 @@ use pal_async::driver::PollImpl;
 use pal_async::timer::PollTimer;
 use pal_uring::IdleControl;
 use parking_lot::Mutex;
+use private::BackingPrivate;
 use std::convert::Infallible;
-use std::future::Future;
 use std::future::poll_fn;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -171,81 +168,104 @@ impl LapicState {
     }
 }
 
-pub(crate) struct BackingParams<'a, 'b, T: Backing> {
+struct BackingParams<'a, 'b, T: Backing> {
     partition: &'a UhPartitionInner,
     vp_info: &'a TargetVpInfo,
     runner: &'a mut ProcessorRunner<'b, T::HclBacking<'b>>,
 }
 
-#[expect(private_interfaces, missing_docs)]
-pub trait Backing: 'static + Sized + InspectMut + Sized {
-    type HclBacking<'b>: hcl::ioctl::Backing<'b>;
-    type EmulationCache;
-    type Shared;
+mod private {
+    use super::BackingParams;
+    use super::UhRunVpError;
+    use super::vp_state;
+    use crate::BackingShared;
+    use crate::Error;
+    use crate::GuestVtl;
+    use crate::processor::UhProcessor;
+    use hv1_emulator::hv::ProcessorVtlHv;
+    use hv1_emulator::synic::ProcessorSynic;
+    use inspect::InspectMut;
+    use std::future::Future;
+    use virt::StopVp;
+    use virt::VpHaltReason;
+    use virt::io::CpuIo;
+    use virt::vp::AccessVpState;
 
-    fn shared(shared: &BackingShared) -> &Self::Shared;
+    #[expect(private_interfaces)]
+    pub trait BackingPrivate: 'static + Sized + InspectMut + Sized {
+        type HclBacking<'b>: hcl::ioctl::Backing<'b>;
+        type EmulationCache;
+        type Shared;
 
-    fn new(params: BackingParams<'_, '_, Self>, shared: &Self::Shared) -> Result<Self, Error>;
+        fn shared(shared: &BackingShared) -> &Self::Shared;
 
-    type StateAccess<'p, 'a>: AccessVpState<Error = vp_state::Error>
-    where
-        Self: 'a + 'p,
-        'p: 'a;
+        fn new(params: BackingParams<'_, '_, Self>, shared: &Self::Shared) -> Result<Self, Error>;
 
-    fn init(this: &mut UhProcessor<'_, Self>);
+        type StateAccess<'p, 'a>: AccessVpState<Error = vp_state::Error>
+        where
+            Self: 'a + 'p,
+            'p: 'a;
 
-    fn access_vp_state<'a, 'p>(
-        this: &'a mut UhProcessor<'p, Self>,
-        vtl: GuestVtl,
-    ) -> Self::StateAccess<'p, 'a>;
+        fn init(this: &mut UhProcessor<'_, Self>);
 
-    fn run_vp(
-        this: &mut UhProcessor<'_, Self>,
-        dev: &impl CpuIo,
-        stop: &mut StopVp<'_>,
-    ) -> impl Future<Output = Result<(), VpHaltReason<UhRunVpError>>>;
+        fn access_vp_state<'a, 'p>(
+            this: &'a mut UhProcessor<'p, Self>,
+            vtl: GuestVtl,
+        ) -> Self::StateAccess<'p, 'a>;
 
-    /// Process any pending APIC work.
-    fn poll_apic(
-        this: &mut UhProcessor<'_, Self>,
-        vtl: GuestVtl,
-        scan_irr: bool,
-    ) -> Result<(), UhRunVpError>;
+        fn run_vp(
+            this: &mut UhProcessor<'_, Self>,
+            dev: &impl CpuIo,
+            stop: &mut StopVp<'_>,
+        ) -> impl Future<Output = Result<(), VpHaltReason<UhRunVpError>>>;
 
-    /// Requests the VP to exit when an external interrupt is ready to be
-    /// delivered.
-    ///
-    /// Only used when the hypervisor implements the APIC.
-    fn request_extint_readiness(this: &mut UhProcessor<'_, Self>);
+        /// Process any pending APIC work.
+        fn poll_apic(
+            this: &mut UhProcessor<'_, Self>,
+            vtl: GuestVtl,
+            scan_irr: bool,
+        ) -> Result<(), UhRunVpError>;
 
-    /// Requests the VP to exit when any of the specified SINTs have a free
-    /// message slot.
-    ///
-    /// This is used for hypervisor-managed and untrusted SINTs.
-    fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16);
+        /// Requests the VP to exit when an external interrupt is ready to be
+        /// delivered.
+        ///
+        /// Only used when the hypervisor implements the APIC.
+        fn request_extint_readiness(this: &mut UhProcessor<'_, Self>);
 
-    /// Checks interrupt status for all VTLs, and handles cross VTL interrupt preemption and VINA.
-    /// Returns whether interrupt reprocessing is required.
-    fn handle_cross_vtl_interrupts(
-        this: &mut UhProcessor<'_, Self>,
-        dev: &impl CpuIo,
-    ) -> Result<bool, UhRunVpError>;
+        /// Requests the VP to exit when any of the specified SINTs have a free
+        /// message slot.
+        ///
+        /// This is used for hypervisor-managed and untrusted SINTs.
+        fn request_untrusted_sint_readiness(this: &mut UhProcessor<'_, Self>, sints: u16);
 
-    fn handle_vp_start_enable_vtl_wake(
-        _this: &mut UhProcessor<'_, Self>,
-        _vtl: GuestVtl,
-    ) -> Result<(), UhRunVpError>;
+        /// Checks interrupt status for all VTLs, and handles cross VTL interrupt preemption and VINA.
+        /// Returns whether interrupt reprocessing is required.
+        fn handle_cross_vtl_interrupts(
+            this: &mut UhProcessor<'_, Self>,
+            dev: &impl CpuIo,
+        ) -> Result<bool, UhRunVpError>;
 
-    fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}
+        fn handle_vp_start_enable_vtl_wake(
+            _this: &mut UhProcessor<'_, Self>,
+            _vtl: GuestVtl,
+        ) -> Result<(), UhRunVpError>;
 
-    fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv>;
-    fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv>;
+        fn inspect_extra(_this: &mut UhProcessor<'_, Self>, _resp: &mut inspect::Response<'_>) {}
 
-    fn untrusted_synic(&self) -> Option<&ProcessorSynic>;
-    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic>;
+        fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv>;
+        fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv>;
 
-    fn vtl1_inspectable(this: &UhProcessor<'_, Self>) -> bool;
+        fn untrusted_synic(&self) -> Option<&ProcessorSynic>;
+        fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic>;
+
+        fn vtl1_inspectable(this: &UhProcessor<'_, Self>) -> bool;
+    }
 }
+
+/// Processor backing.
+pub trait Backing: BackingPrivate {}
+
+impl<T: BackingPrivate> Backing for T {}
 
 pub(crate) struct BackingSharedParams {
     pub cvm_state: Option<crate::UhCvmPartitionState>,

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -16,13 +16,14 @@ cfg_if::cfg_if! {
 
         use crate::TlbFlushLockAccess;
         use crate::VtlCrash;
+        use bitvec::prelude::BitArray;
+        use bitvec::prelude::Lsb0;
         use hvdef::HvX64RegisterName;
         use virt::vp::MpState;
         use virt::x86::MsrError;
         use virt_support_apic::LocalApic;
         use virt_support_x86emu::translate::TranslationRegisters;
-        use bitvec::prelude::BitArray;
-        use bitvec::prelude::Lsb0;
+        use virt::vp::AccessVpState;
     } else if #[cfg(guest_arch = "aarch64")] {
         use hv1_hypercall::Arm64RegisterState;
         use hvdef::HvArm64RegisterName;
@@ -69,7 +70,6 @@ use virt::StopVp;
 use virt::VpHaltReason;
 use virt::VpIndex;
 use virt::io::CpuIo;
-use virt::vp::AccessVpState;
 use vm_topology::processor::TargetVpInfo;
 use vmcore::vmtime::VmTimeAccess;
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -7,8 +7,8 @@
 
 type VpRegisterName = HvArm64RegisterName;
 
-use super::super::Backing;
 use super::super::BackingParams;
+use super::super::BackingPrivate;
 use super::super::UhRunVpError;
 use super::super::signal_mnf;
 use super::super::vp_state;
@@ -93,7 +93,7 @@ struct ProcessorStatsArm64 {
 }
 
 #[expect(private_interfaces)]
-impl Backing for HypervisorBackedArm64 {
+impl BackingPrivate for HypervisorBackedArm64 {
     type HclBacking<'mshv> = MshvArm64;
     type EmulationCache = UhCpuStateCache;
     type Shared = HypervisorBackedArm64Shared;

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -7,8 +7,8 @@
 
 type VpRegisterName = HvX64RegisterName;
 
-use super::super::Backing;
 use super::super::BackingParams;
+use super::super::BackingPrivate;
 use super::super::UhEmulationState;
 use super::super::UhRunVpError;
 use super::super::signal_mnf;
@@ -135,7 +135,7 @@ pub struct MshvEmulationCache {
 }
 
 #[expect(private_interfaces)]
-impl Backing for HypervisorBackedX86 {
+impl BackingPrivate for HypervisorBackedX86 {
     type HclBacking<'mshv> = MshvX64<'mshv>;
     type Shared = HypervisorBackedX86Shared;
     type EmulationCache = MshvEmulationCache;

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -3,8 +3,8 @@
 
 //! Processor support for SNP partitions.
 
-use super::Backing;
 use super::BackingParams;
+use super::BackingPrivate;
 use super::BackingSharedParams;
 use super::HardwareIsolatedBacking;
 use super::UhEmulationState;
@@ -268,7 +268,7 @@ impl SnpBackedShared {
 }
 
 #[expect(private_interfaces)]
-impl Backing for SnpBacked {
+impl BackingPrivate for SnpBacked {
     type HclBacking<'snp> = hcl::ioctl::snp::Snp<'snp>;
     type Shared = SnpBackedShared;
     type EmulationCache = ();

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -5,7 +5,7 @@
 
 mod tlb_flush;
 
-use super::Backing;
+use super::BackingPrivate;
 use super::BackingSharedParams;
 use super::HardwareIsolatedBacking;
 use super::UhEmulationState;
@@ -571,7 +571,7 @@ impl TdxBacked {
 }
 
 #[expect(private_interfaces)]
-impl Backing for TdxBacked {
+impl BackingPrivate for TdxBacked {
     type HclBacking<'tdx> = Tdx<'tdx>;
     type Shared = TdxBackedShared;
     type EmulationCache = TdxEmulationCache;


### PR DESCRIPTION
As requested. This can't be quite as clean as hcl's BackingPrivate due to leaking out the associated StateAccess type through our impl of virt::Processor requiring BackingPrivate to be fully pub. I played around with the types for a while but couldn't get anything that was better than this. So just leave the expects in.