### PR TITLE
virt_mshv_vtl: add inspection support for cpuid tables

### DIFF
--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -220,7 +220,7 @@ mod inspect_helpers {
         inspect::iter_by_key(
             table
                 .iter()
-                .map(|(key, value)| (format!("{:?}", key), value)),
+                .map(|(key, value)| (format!("{:?} ({:x})", key, key.0), value)),
         )
     }
 

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -14,6 +14,7 @@ use super::ParsedCpuidEntry;
 use super::TopologyError;
 use super::ZERO_CPUID_RESULT;
 use core::arch::x86_64::CpuidResult;
+use inspect::Inspect;
 use x86defs::cpuid;
 use x86defs::cpuid::CpuidFunction;
 use x86defs::snp::HvPspCpuidPage;
@@ -491,6 +492,12 @@ impl CpuidArchSupport for SnpCpuidSupport {
             }
             _ => (),
         }
+    }
+}
+
+impl Inspect for SnpCpuidSupport {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        req.respond().field("type", "snp-cpuid");
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -13,6 +13,7 @@ use super::CpuidSubtable;
 use super::ParsedCpuidEntry;
 use super::TopologyError;
 use core::arch::x86_64::CpuidResult;
+use inspect::Inspect;
 use x86defs::cpuid;
 use x86defs::cpuid::CpuidFunction;
 use x86defs::xsave;
@@ -250,5 +251,11 @@ impl CpuidArchSupport for TdxCpuidSupport {
         _vps_per_socket: u32,
     ) {
         // Nothing extra to do for TDX
+    }
+}
+
+impl Inspect for TdxCpuidSupport {
+    fn inspect(&self, req: inspect::Request<'_>) {
+        req.respond().field("type", "tdx-cpuid");
     }
 }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -393,7 +393,6 @@ impl UhCvmVpState {
 /// Partition-wide state for CVMs.
 struct UhCvmPartitionState {
     #[cfg(guest_arch = "x86_64")]
-    #[inspect(skip)]
     cpuid: cvm_cpuid::CpuidResults,
     /// VPs that have locked their TLB.
     #[inspect(


### PR DESCRIPTION
These weren't inspectable before. 

I think though, that there's probably some more to do here - the raw value themselves aren't always what the guest will see since there's some runtime state that gets modified with the table. This is at least a starting point though. 