### PR TITLE
virt_mshv_vtl: don't lock the cpuid results

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -2160,6 +2160,8 @@ impl UhPartitionInner {
             //
             // If it is only for CVM, then it should be moved to the
             // CVM-specific cpuid fixups.
+            //
+            // TODO TDX GUEST VSM: Consider changing TLB hypercall flag too
             let mut features = hvdef::HvFeatures::from_cpuid(r);
             if self.guest_vsm_revoked.load(Ordering::Acquire) {
                 features.set_privileges(features.privileges().with_access_vsm(false));

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -207,7 +207,9 @@ struct UhPartitionInner {
     enter_modes: Mutex<EnterModes>,
     #[inspect(skip)]
     enter_modes_atomic: AtomicU8,
-    cpuid: Mutex<CpuidLeafSet>,
+    cpuid: CpuidLeafSet,
+    // Only transitions from `false` to `true`.
+    guest_vsm_revoked: AtomicBool,
     lower_vtl_memory_layout: MemoryLayout,
     gm: VtlArray<GuestMemory, 2>,
     shared_memory: Option<GuestMemory>,
@@ -724,40 +726,10 @@ impl UhPartition {
             BackingShared::Snp(SnpBackedShared { cvm, .. })
             | BackingShared::Tdx(TdxBackedShared { cvm, .. }) => {
                 revoke(&mut *cvm.guest_vsm.write())?;
-                let mut cpuid_lock = self.inner.cpuid.lock();
-                let current_result =
-                    cpuid_lock.result(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES, 0, &[0; 4]);
-
-                let mut features = hvdef::HvFeatures::from(u128::from_le_bytes(
-                    current_result
-                        .iter()
-                        .flat_map(|i| i.to_le_bytes())
-                        .collect::<Vec<u8>>()
-                        .try_into()
-                        .unwrap(),
-                ));
-
-                let privileges = hvdef::HvPartitionPrivilege::from(features.privileges());
-                features.set_privileges(privileges.with_access_vsm(false).into());
-
-                let split_u128 = |x: u128| -> [u32; 4] {
-                    let bytes = x.to_le_bytes();
-                    [
-                        u32::from_le_bytes(bytes[0..4].try_into().unwrap()),
-                        u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
-                        u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
-                        u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
-                    ]
-                };
-
-                cpuid_lock.update_result(
-                    hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES,
-                    0,
-                    &split_u128(features.into()),
-                );
             }
         };
 
+        self.inner.guest_vsm_revoked.store(true, Ordering::Release);
         Ok(())
     }
 
@@ -1610,7 +1582,7 @@ impl<'a> UhProtoPartition<'a> {
         #[cfg(guest_arch = "aarch64")]
         let (caps, cpuid) = (
             virt::aarch64::Aarch64PartitionCapabilities {},
-            Mutex::new(CpuidLeafSet::new(Vec::new())),
+            CpuidLeafSet::new(Vec::new()),
         );
 
         #[cfg(guest_arch = "x86_64")]
@@ -1635,9 +1607,6 @@ impl<'a> UhProtoPartition<'a> {
             isolation,
             params.hide_isolation,
         );
-
-        #[cfg(guest_arch = "x86_64")]
-        let cpuid = Mutex::new(cpuid);
 
         let untrusted_synic = if params.handle_synic {
             if matches!(isolation, IsolationType::Tdx) {
@@ -1690,6 +1659,7 @@ impl<'a> UhProtoPartition<'a> {
             gm: late_params.gm,
             shared_memory: late_params.shared_memory,
             cpuid,
+            guest_vsm_revoked: false.into(),
             crash_notification_send: late_params.crash_notification_send,
             monitor_page: MonitorPage::new(),
             software_devices,
@@ -2175,6 +2145,28 @@ impl UhPartitionInner {
             !write || self.monitor_page.gpa() != Some(gpa & !(HV_PAGE_SIZE - 1))
         } else {
             false
+        }
+    }
+
+    /// Gets the CPUID result, applying any necessary runtime modifications.
+    #[cfg(guest_arch = "x86_64")]
+    fn cpuid_result(&self, eax: u32, ecx: u32, default: &[u32; 4]) -> [u32; 4] {
+        let r = self.cpuid.result(eax, ecx, default);
+        if eax == hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES {
+            // Update the VSM access privilege.
+            //
+            // FUTURE: Investigate if this is really necessary for non-CVM--the
+            // hypervisor should already update this correctly.
+            //
+            // If it is only for CVM, then it should be moved to the
+            // CVM-specific cpuid fixups.
+            let mut features = hvdef::HvFeatures::from_cpuid(r);
+            if self.guest_vsm_revoked.load(Ordering::Acquire) {
+                features.set_privileges(features.privileges().with_access_vsm(false));
+            }
+            features.into_cpuid()
+        } else {
+            r
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -761,11 +761,10 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
 
         tracing::trace!(msg = %format_args!("{:x?}", message), "cpuid");
 
-        let [eax, ebx, ecx, edx] = self.vp.partition.cpuid.lock().result(
-            message.rax as u32,
-            message.rcx as u32,
-            &default_result,
-        );
+        let [eax, ebx, ecx, edx] =
+            self.vp
+                .partition
+                .cpuid_result(message.rax as u32, message.rcx as u32, &default_result);
 
         let next_rip = next_rip(&message.header);
         self.vp.runner.cpu_context_mut().gps[protocol::RAX] = eax.into();

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -998,7 +998,7 @@ impl UhProcessor<'_, SnpBacked> {
                     &guest_state,
                 );
 
-                let [eax, ebx, ecx, edx] = self.partition.cpuid.lock().result(
+                let [eax, ebx, ecx, edx] = self.partition.cpuid_result(
                     vmsa.rax() as u32,
                     vmsa.rcx() as u32,
                     &[result.eax, result.ebx, result.ecx, result.edx],

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1680,7 +1680,7 @@ impl UhProcessor<'_, TdxBacked> {
                         .cpuid
                         .guest_result(CpuidFunction(leaf), subleaf, &guest_state);
 
-                let [eax, ebx, ecx, edx] = self.partition.cpuid.lock().result(
+                let [eax, ebx, ecx, edx] = self.partition.cpuid_result(
                     leaf,
                     subleaf,
                     &[result.eax, result.ebx, result.ecx, result.edx],

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -47,7 +47,7 @@ pub fn hv_cpuid_leaves(
             //     .with_fast_hypercall_output(true);
         }
 
-        u64::from(privileges)
+        privileges
     };
 
     let mut hv_cpuid = vec![

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -108,8 +108,10 @@ open_enum! {
 }
 
 #[bitfield(u128)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvFeatures {
-    pub privileges: u64, // HvPartitionPrivilege
+    #[bits(64)]
+    pub privileges: HvPartitionPrivilege,
 
     #[bits(4)]
     pub max_supported_cstate: u32,
@@ -153,6 +155,16 @@ pub struct HvFeatures {
     pub idle_spec_ctrl_available: bool,
     pub translate_gva_flags_available: bool,
     pub apic_eoi_intercept_available: bool,
+}
+
+impl HvFeatures {
+    pub fn from_cpuid(cpuid: [u32; 4]) -> Self {
+        zerocopy::transmute!(cpuid)
+    }
+
+    pub fn into_cpuid(self) -> [u32; 4] {
+        zerocopy::transmute!(self)
+    }
 }
 
 #[bitfield(u128)]

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -188,17 +188,15 @@ impl virt::Hypervisor for Kvm {
             };
 
             use hvdef::*;
-            let privileges = u64::from(
-                HvPartitionPrivilege::new()
-                    .with_access_partition_reference_counter(true)
-                    .with_access_hypercall_msrs(true)
-                    .with_access_vp_index(true)
-                    .with_access_frequency_msrs(true)
-                    .with_access_synic_msrs(true)
-                    .with_access_synthetic_timer_msrs(true)
-                    .with_access_vp_runtime_msr(true)
-                    .with_access_apic_msrs(true),
-            );
+            let privileges = HvPartitionPrivilege::new()
+                .with_access_partition_reference_counter(true)
+                .with_access_hypercall_msrs(true)
+                .with_access_vp_index(true)
+                .with_access_frequency_msrs(true)
+                .with_access_synic_msrs(true)
+                .with_access_synthetic_timer_msrs(true)
+                .with_access_vp_runtime_msr(true)
+                .with_access_apic_msrs(true);
 
             let hv_cpuid = &[
                 CpuidLeaf::new(


### PR DESCRIPTION
Don't update cpuid results in place for VSM support revocation. Just
apply a fixup after the fact, like we do with all the other dynamic
leaves.
