### PR TITLE
deps: use crates.io release of mshv-bindings, mshv-ioctl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4227,7 +4227,8 @@ dependencies = [
 [[package]]
 name = "mshv-bindings"
 version = "0.3.4"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#c7edf4d5a2d73cacadba160b11c63098dc3696fd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c369385758f81ca937414dc2147737c92032e4fb399669f287abf94d89252d"
 dependencies = [
  "libc",
  "num_enum",
@@ -4240,7 +4241,8 @@ dependencies = [
 [[package]]
 name = "mshv-ioctls"
 version = "0.3.4"
-source = "git+https://github.com/rust-vmm/mshv?branch=main#c7edf4d5a2d73cacadba160b11c63098dc3696fd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53efb6110ead2e8788f79f2455b21464cb416ba9154112527b11584cb7fceea6"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,8 +453,8 @@ macaddr = "1.0"
 mbrman = "0.5"
 mimalloc = { version = "0.1.39", default-features = false }
 ms-tpm-20-ref = { version = "0.1", git = "https://github.com/microsoft/ms-tpm-20-ref-rs.git", branch = "main" }
-mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main" }
-mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main" }
+mshv-bindings = "0.3.4"
+mshv-ioctls = "0.3.4"
 nix = { version = "0.27", default-features = false }
 ntapi = "0.4"
 object = { version = "0.36.7", default-features = false }


### PR DESCRIPTION
Instead of using the github branch, use the published releases on crates.io for these two crates. There seems to be a bug with xsync when git dependencies are being used, which this works around. 