### PR TITLE
lints: Move dead_code allows to expects

### DIFF
--- a/openhcl/hcl/src/protocol.rs
+++ b/openhcl/hcl/src/protocol.rs
@@ -3,7 +3,6 @@
 
 //! Structures and definitions used between the underhill kernel and HvLite.
 
-#![allow(dead_code)]
 #![allow(
     non_upper_case_globals,
     clippy::upper_case_acronyms,

--- a/openhcl/minimal_rt/src/arch/aarch64/serial.rs
+++ b/openhcl/minimal_rt/src/arch/aarch64/serial.rs
@@ -33,7 +33,7 @@
 //! 0xFF8   UARTPCellID2      RO   0x05         8       UARTPCellID2 Register
 //! 0xFFC   UARTPCellID3      RO   0xB1         8       UARTPCellID3 Register
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use core::hint::spin_loop;
 use core::sync::atomic::AtomicBool;

--- a/openhcl/minimal_rt/src/reloc.rs
+++ b/openhcl/minimal_rt/src/reloc.rs
@@ -18,7 +18,7 @@ macro_rules! panic_no_relocs {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(u64)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum ElfDynTag {
     Null = 0,
     RelA = 7,

--- a/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/snp.rs
@@ -19,7 +19,7 @@ pub enum AcceptGpaStatus {
     Retry,
 }
 
-#[allow(dead_code)] // Printed via Debug in the error case.
+#[expect(dead_code)] // Printed via Debug in the error case.
 #[derive(Debug)]
 pub enum AcceptGpaError {
     MemorySecurityViolation {

--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -53,7 +53,7 @@ mod aarch64 {
 #[derive(Debug)]
 pub enum DtError {
     // Field is stored solely for logging via debug, not actually dead.
-    Fdt(#[allow(dead_code)] fdt::builder::Error),
+    Fdt(#[expect(dead_code)] fdt::builder::Error),
 }
 
 impl From<fdt::builder::Error> for DtError {

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -152,7 +152,6 @@ impl HvCall {
     }
 
     /// Hypercall for setting a register to a value.
-    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
     pub fn set_register(
         &mut self,
         name: hvdef::HvRegisterName,
@@ -218,7 +217,7 @@ impl HvCall {
     }
 
     /// Hypercall to apply vtl protections to the pages from address start to end
-    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
+    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     pub fn apply_vtl2_protections(&mut self, range: MemoryRange) -> Result<(), hvdef::HvError> {
         const HEADER_SIZE: usize = size_of::<hvdef::hypercall::ModifyVtlProtectionMask>();
         const MAX_INPUT_ELEMENTS: usize = (HV_PAGE_SIZE as usize - HEADER_SIZE) / size_of::<u64>();
@@ -290,7 +289,7 @@ impl HvCall {
 
     /// Hypercall to accept vtl2 pages from address start to end with VTL 2
     /// protections and no host visibility
-    #[cfg_attr(target_arch = "aarch64", allow(dead_code))]
+    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     pub fn accept_vtl2_pages(
         &mut self,
         range: MemoryRange,

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -372,7 +372,7 @@ fn reserved_memory_regions(
     flattened
 }
 
-#[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
+#[cfg_attr(not(target_arch = "x86_64"), expect(dead_code))]
 mod x86_boot {
     use crate::PageAlign;
     use crate::ReservedMemoryType;

--- a/openhcl/openhcl_boot/src/rt.rs
+++ b/openhcl/openhcl_boot/src/rt.rs
@@ -33,7 +33,7 @@ pub fn verify_stack_cookie() {
 ///
 /// ARM64: The relative offset for shim parameters are passed in the x1 register.
 /// x2 contains the base address of where the shim was loaded at.
-#[expect(dead_code)]
+#[cfg_attr(not(minimal_rt), expect(dead_code))]
 pub unsafe extern "C" fn start(_: usize, shim_params_offset: isize) -> ! {
     crate::shim_main(shim_params_offset)
 }

--- a/openhcl/openhcl_boot/src/rt.rs
+++ b/openhcl/openhcl_boot/src/rt.rs
@@ -12,7 +12,6 @@ pub struct Stack([u8; STACK_SIZE]);
 
 pub static mut STACK: Stack = Stack([0; STACK_SIZE]);
 
-#[cfg_attr(test, allow(dead_code))]
 /// Validate the stack cookie is still present. Panics if overwritten.
 pub fn verify_stack_cookie() {
     // SAFETY: It's possible we've overrun the stack at this point if any
@@ -34,7 +33,7 @@ pub fn verify_stack_cookie() {
 ///
 /// ARM64: The relative offset for shim parameters are passed in the x1 register.
 /// x2 contains the base address of where the shim was loaded at.
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub unsafe extern "C" fn start(_: usize, shim_params_offset: isize) -> ! {
     crate::shim_main(shim_params_offset)
 }

--- a/openhcl/sidecar/src/arch/x86_64/init.rs
+++ b/openhcl/sidecar/src/arch/x86_64/init.rs
@@ -148,7 +148,7 @@ impl Display for InitVpError {
 
 /// BSP entry point from entry.S. Called with BSS, stack, and page tables
 /// initialized, and relocations applied.
-#[cfg_attr(not(minimal_rt), allow(dead_code))]
+#[cfg_attr(not(minimal_rt), expect(dead_code))]
 pub extern "C" fn start(params: u64, output: u64) -> bool {
     enlightened_panic::enable_enlightened_panic();
 

--- a/openhcl/sidecar/src/arch/x86_64/mod.rs
+++ b/openhcl/sidecar/src/arch/x86_64/mod.rs
@@ -189,7 +189,7 @@ fn log_fmt(args: core::fmt::Arguments<'_>) {
 }
 
 #[cfg_attr(minimal_rt, panic_handler)]
-#[cfg_attr(not(minimal_rt), allow(dead_code))]
+#[cfg_attr(not(minimal_rt), expect(dead_code))]
 fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
     let stack_va_to_pa = |ptr| {
         addr_space::stack()
@@ -298,13 +298,13 @@ fn eoi() {
     }
 }
 
-#[cfg_attr(not(minimal_rt), allow(dead_code))]
+#[cfg_attr(not(minimal_rt), expect(dead_code))]
 extern "C" fn irq_handler() {
     eoi();
     log!("irq");
 }
 
-#[cfg_attr(not(minimal_rt), allow(dead_code))]
+#[cfg_attr(not(minimal_rt), expect(dead_code))]
 extern "C" fn exception_handler(exception: Exception, rsp: u64) -> ! {
     // SAFETY: reading cr2 has no safety requirements.
     let cr2 = unsafe {

--- a/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
+++ b/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
@@ -882,7 +882,7 @@ pub struct UhScsiControllerConfig {
     )>,
 }
 
-#[cfg_attr(not(feature = "vpci"), allow(dead_code))]
+#[cfg_attr(not(feature = "vpci"), expect(dead_code))]
 pub struct UhVpciDeviceConfig {
     pub instance_id: Guid,
     pub resource: Resource<PciDeviceHandleKind>,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1081,7 +1081,7 @@ fn round_up_to_2mb(bytes: u64) -> u64 {
     (bytes + (2 * 1024 * 1024) - 1) & !((2 * 1024 * 1024) - 1)
 }
 
-#[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
+#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 fn new_x86_topology(
     cpus: &[bootloader_fdt_parser::Cpu],
     x2apic: vm_topology::processor::x86::X2ApicState,
@@ -1111,7 +1111,7 @@ fn new_x86_topology(
         .context("failed to construct the processor topology")
 }
 
-#[cfg_attr(guest_arch = "x86_64", allow(dead_code))]
+#[cfg_attr(guest_arch = "x86_64", expect(dead_code))]
 fn new_aarch64_topology(
     gic: GicInfo,
     cpus: &[bootloader_fdt_parser::Cpu],

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -626,7 +626,7 @@ impl UhVpInner {
     }
 }
 
-#[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 #[derive(Debug, Inspect)]
 /// Which operation is setting the initial vp context
 enum InitialVpContextOperation {
@@ -636,7 +636,7 @@ enum InitialVpContextOperation {
     EnableVpVtl,
 }
 
-#[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 #[derive(Debug, Inspect)]
 /// State for handling StartVp/EnableVpVtl hypercalls.
 struct VpStartEnableVtl {
@@ -664,7 +664,7 @@ struct TlbLockInfo {
     sleeping: AtomicBool,
 }
 
-#[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 impl TlbLockInfo {
     fn new(vp_count: usize) -> Self {
         Self {

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -122,7 +122,6 @@ struct VtlsTlbLocked {
     vtl2: VtlArray<bool, 2>,
 }
 
-#[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
 impl VtlsTlbLocked {
     fn get(&self, requesting_vtl: Vtl, target_vtl: GuestVtl) -> bool {
         match requesting_vtl {
@@ -301,7 +300,7 @@ trait HardwareIsolatedBacking: Backing {
     ) -> TranslationRegisters;
 }
 
-#[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
+#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 #[derive(Inspect, Debug)]
 #[inspect(tag = "reason")]
 pub(crate) enum SidecarExitReason {
@@ -312,7 +311,7 @@ pub(crate) enum SidecarExitReason {
     ManualRequest,
 }
 
-#[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
+#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 #[derive(Inspect, Debug)]
 #[inspect(tag = "exit")]
 pub(crate) enum SidecarRemoveExit {
@@ -383,7 +382,6 @@ impl UhVpInner {
         }
     }
 
-    #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
     pub fn set_sidecar_exit_reason(&self, reason: SidecarExitReason) {
         self.sidecar_exit_reason.lock().get_or_insert_with(|| {
             tracing::info!(?reason, "sidecar exit");

--- a/openhcl/virt_mshv_vtl/src/processor/vp_state.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/vp_state.rs
@@ -8,7 +8,6 @@ use thiserror::Error;
 
 pub struct UhVpStateAccess<'a, 'b, T: Backing> {
     pub(crate) vp: &'a mut UhProcessor<'b, T>,
-    #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
     pub(crate) vtl: GuestVtl,
 }
 

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -699,6 +699,7 @@ impl InitializedVm {
         }
     }
 
+    #[allow(dead_code)]
     async fn new_with_hypervisor<P, H>(
         driver_source: VmTaskDriverSource,
         hypervisor: &mut H,

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -517,12 +517,12 @@ struct LoadedVmInner {
     virtio_serial: Option<SerialPipes>,
 
     chipset_cfg: BaseChipsetManifest,
-    #[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+    #[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
     virtio_mmio_count: usize,
-    #[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+    #[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
     virtio_mmio_irq: u32,
     /// ((device, function), interrupt)
-    #[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+    #[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
     pci_legacy_interrupts: Vec<((u8, Option<u8>), u32)>,
     firmware_event_send: Option<mesh::Sender<get_resources::ged::FirmwareEvent>>,
 
@@ -699,7 +699,6 @@ impl InitializedVm {
         }
     }
 
-    #[allow(dead_code)]
     async fn new_with_hypervisor<P, H>(
         driver_source: VmTaskDriverSource,
         hypervisor: &mut H,
@@ -2874,7 +2873,7 @@ impl LoadedVm {
     }
 }
 
-#[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 fn add_devices_to_dsdt(
     mem_layout: &MemoryLayout,
     dsdt: &mut dsdt::Dsdt,

--- a/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/igvm.rs
@@ -571,7 +571,7 @@ pub fn load_igvm(
 ///
 /// TODO: only supports underhill for now, with assumptions that the file always
 /// has VTL2 enabled.
-#[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 fn load_igvm_x86(
     params: LoadIgvmParams<'_, X86Topology>,
 ) -> Result<(Vec<X86Register>, Vec<(MemoryRange, PageVisibility)>), Error> {
@@ -1274,7 +1274,7 @@ fn build_memory_map(
     (memory_map, vnodes)
 }
 
-#[cfg_attr(not(guest_arch = "aarch64"), allow(dead_code))]
+#[cfg_attr(not(guest_arch = "aarch64"), expect(dead_code))]
 fn load_igvm_aarch64(
     _params: LoadIgvmParams<'_, Aarch64Topology>,
 ) -> Result<(Vec<Aarch64Register>, Vec<(MemoryRange, PageVisibility)>), Error> {

--- a/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
@@ -48,7 +48,7 @@ pub struct AcpiTables {
     pub tables: Vec<u8>,
 }
 
-#[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 pub fn load_linux_x86(
     cfg: &KernelConfig<'_>,
     gm: &GuestMemory,
@@ -363,7 +363,7 @@ fn build_dt(
     Ok(buffer)
 }
 
-#[cfg_attr(not(guest_arch = "aarch64"), allow(dead_code))]
+#[cfg_attr(not(guest_arch = "aarch64"), expect(dead_code))]
 pub fn load_linux_arm64(
     cfg: &KernelConfig<'_>,
     gm: &GuestMemory,

--- a/openvmm/hvlite_core/src/worker/vm_loaders/pcat.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/pcat.rs
@@ -17,7 +17,7 @@ pub enum Error {
 ///
 /// Since the BIOS is in ROM, this actually just returns the PCAT initial
 /// registers.
-#[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 pub fn load_pcat(gm: &GuestMemory, mem_layout: &MemoryLayout) -> Result<Vec<X86Register>, Error> {
     let mut loader = Loader::new(gm.clone(), mem_layout, hvdef::Vtl::Vtl0);
     loader::pcat::load(&mut loader, None, mem_layout.max_ram_below_4gb()).map_err(Error::Loader)?;

--- a/openvmm/hvlite_defs/Cargo.toml
+++ b/openvmm/hvlite_defs/Cargo.toml
@@ -27,7 +27,7 @@ vmm_core_defs.workspace = true
 guid.workspace = true
 mesh_worker.workspace = true
 mesh.workspace = true
-unix_socket.workspace = true
+unix_socket = { workspace = true, features = ["mesh"] }
 
 anyhow.workspace = true
 thiserror.workspace = true

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1138,7 +1138,7 @@ impl FromStr for SmtConfigCli {
     }
 }
 
-#[cfg_attr(not(guest_arch = "x86_64"), allow(dead_code))]
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 fn parse_x2apic(s: &str) -> Result<X2ApicConfig, &'static str> {
     let r = match s {
         "auto" => X2ApicConfig::Auto,

--- a/petri/pipette/src/agent.rs
+++ b/petri/pipette/src/agent.rs
@@ -30,7 +30,6 @@ pub struct Agent {
     watch_send: mesh::OneshotSender<()>,
 }
 
-#[allow(dead_code)] // Not used on all platforms yet
 #[derive(Clone)]
 pub struct DiagnosticSender(mesh::Sender<DiagnosticFile>);
 
@@ -129,7 +128,7 @@ async fn connect_client(driver: &DefaultDriver) -> anyhow::Result<PolledSocket<S
 async fn handle_request(
     driver: &DefaultDriver,
     req: PipetteRequest,
-    _diag_file_send: DiagnosticSender, // Not used on all platforms yet
+    _diag_file_send: DiagnosticSender,
 ) {
     match req {
         PipetteRequest::Ping(rpc) => rpc.handle_sync(|()| {
@@ -197,7 +196,7 @@ async fn write_file(mut request: pipette_protocol::WriteFileRequest) -> anyhow::
 }
 
 impl DiagnosticSender {
-    #[allow(dead_code)] // Not used on all platforms yet
+    #[cfg_attr(not(windows), expect(dead_code))]
     pub async fn send(&self, filename: &str) -> anyhow::Result<()> {
         tracing::debug!(filename, "Beginning diagnostic file request");
         let file = fs_err::File::open(filename)?;

--- a/petri/pipette/src/shutdown.rs
+++ b/petri/pipette/src/shutdown.rs
@@ -115,7 +115,7 @@ pub fn handle_shutdown(request: pipette_protocol::ShutdownRequest) -> anyhow::Re
 }
 
 #[cfg(windows)]
-#[allow(dead_code)] // Currently unused, but left as an example
+#[expect(dead_code)] // Currently unused, but left as an example
 pub fn start_shutdown_trace() -> anyhow::Result<()> {
     use anyhow::Context;
 
@@ -142,7 +142,7 @@ pub fn start_shutdown_trace() -> anyhow::Result<()> {
 }
 
 #[cfg(windows)]
-#[allow(dead_code)] // Currently unused, but left as an example
+#[expect(dead_code)] // Currently unused, but left as an example
 pub async fn send_shutdown_trace(
     diag_file_send: crate::agent::DiagnosticSender,
 ) -> anyhow::Result<()> {

--- a/petri/src/openhcl_diag.rs
+++ b/petri/src/openhcl_diag.rs
@@ -11,7 +11,7 @@ pub(crate) struct OpenHclDiagHandler(DiagClient);
 
 /// The result of running a VTL2 command.
 #[derive(Debug)]
-#[allow(dead_code)] // Fields output via Debug for debugging purposes.
+#[expect(dead_code)] // Fields output via Debug for debugging purposes.
 pub(crate) struct Vtl2CommandResult {
     /// The stdout of the command.
     pub stdout: String,

--- a/support/fdt/src/spec.rs
+++ b/support/fdt/src/spec.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
-
 use zerocopy::BigEndian;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -1850,7 +1850,7 @@ where
     any(feature = "defer", feature = "initiate"),
     derive(mesh::MeshPayload)
 )]
-#[cfg_attr(not(feature = "initiate"), expect(dead_code))]
+#[cfg_attr(not(any(feature = "defer", feature = "initiate")), expect(dead_code))]
 enum InternalNode {
     Unevaluated,
     Failed(InternalError),
@@ -1871,7 +1871,7 @@ enum InternalNode {
 )]
 // Without the initiate feature we never read fields of the InternalEntry
 // to produce a user-visible Entry, but we still need those fields.
-#[cfg_attr(not(feature = "initiate"), expect(dead_code))]
+#[cfg_attr(not(any(feature = "defer", feature = "initiate")), expect(dead_code))]
 struct InternalEntry {
     name: String,
     node: InternalNode,

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -1850,7 +1850,7 @@ where
     any(feature = "defer", feature = "initiate"),
     derive(mesh::MeshPayload)
 )]
-#[cfg_attr(not(feature = "initiate"), allow(dead_code))]
+#[cfg_attr(not(feature = "initiate"), expect(dead_code))]
 enum InternalNode {
     Unevaluated,
     Failed(InternalError),
@@ -1871,7 +1871,7 @@ enum InternalNode {
 )]
 // Without the initiate feature we never read fields of the InternalEntry
 // to produce a user-visible Entry, but we still need those fields.
-#[cfg_attr(not(feature = "initiate"), allow(dead_code))]
+#[cfg_attr(not(feature = "initiate"), expect(dead_code))]
 struct InternalEntry {
     name: String,
     node: InternalNode,
@@ -2688,7 +2688,7 @@ mod tests {
         struct Tr2(#[inspect(debug)] ());
 
         #[derive(Inspect)]
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         enum Enum {
             Foo,
             BarBaz,
@@ -2737,16 +2737,16 @@ mod tests {
 
     #[test]
     fn test_derive_enum() {
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         enum EmptyUnitEmum {}
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         #[inspect(untagged)]
         enum EmptyUntaggedEmum {}
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         enum UnitEnum {
             A,
@@ -2756,7 +2756,7 @@ mod tests {
 
         inspect_sync_expect("", None, &UnitEnum::B, expect!([r#""b""#]));
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         #[inspect(tag = "tag")]
         enum TaggedEnum {
@@ -2771,7 +2771,7 @@ mod tests {
             expect!([r#"{tag: "b", y: true}"#]),
         );
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         #[inspect(external_tag)]
         enum ExternallyTaggedEnum {
@@ -2792,7 +2792,7 @@ mod tests {
 
         inspect_sync_expect("", None, &ExternallyTaggedEnum::C(5), expect!("{c: 5}"));
 
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Inspect)]
         #[inspect(untagged)]
         enum UntaggedEnum {

--- a/support/mesh/mesh_build/src/lib.rs
+++ b/support/mesh/mesh_build/src/lib.rs
@@ -83,7 +83,7 @@ impl prost_build::ServiceGenerator for MeshServiceGenerator {
             }
 
             impl #ident {
-                #[allow(dead_code)]
+                #[expect(dead_code)]
                 pub fn fail(self, status: ::mesh_rpc::service::Status) {
                     match self {
                         #(

--- a/support/mesh/mesh_build/src/lib.rs
+++ b/support/mesh/mesh_build/src/lib.rs
@@ -83,7 +83,7 @@ impl prost_build::ServiceGenerator for MeshServiceGenerator {
             }
 
             impl #ident {
-                #[expect(dead_code)]
+                #[allow(dead_code)]
                 pub fn fail(self, status: ::mesh_rpc::service::Status) {
                     match self {
                         #(

--- a/support/mesh/mesh_node/src/local_node.rs
+++ b/support/mesh/mesh_node/src/local_node.rs
@@ -1062,7 +1062,7 @@ enum EventError {
     UnknownPort,
     Truncated,
     // Field is stored solely for logging via debug, not actually dead.
-    UnknownEventType(#[allow(dead_code)] protocol::EventType),
+    UnknownEventType(#[expect(dead_code)] protocol::EventType),
     MissingOsResource,
 }
 

--- a/support/mesh/mesh_protobuf/src/encoding.rs
+++ b/support/mesh/mesh_protobuf/src/encoding.rs
@@ -1701,7 +1701,7 @@ impl<T: DefaultEncoding + Clone> DefaultEncoding for Arc<T> {
 // Derive an encoding for `Result`.
 #[derive(mesh_derive::Protobuf)]
 #[mesh(impl_for = "::core::result::Result")]
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum ResultAsPayload<T, U> {
     #[mesh(transparent)]
     Ok(T),
@@ -1712,7 +1712,7 @@ enum ResultAsPayload<T, U> {
 // Derive an encoding for `Range`.
 #[derive(mesh_derive::Protobuf)]
 #[mesh(impl_for = "::core::ops::Range")]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct RangeAsPayload<T> {
     start: T,
     end: T,

--- a/support/mesh_tracing/src/bounded.rs
+++ b/support/mesh_tracing/src/bounded.rs
@@ -194,7 +194,6 @@ impl<T: 'static + MeshField + Send> BoundedSender<T> {
         })
     }
 
-    #[allow(dead_code)]
     pub async fn send(&mut self, message: T) {
         let mut message = Some(message);
         poll_fn(|cx| self.poll_send(cx, &mut message)).await

--- a/support/open_enum/src/lib.rs
+++ b/support/open_enum/src/lib.rs
@@ -24,7 +24,7 @@
 /// # #[macro_use] extern crate open_enum; fn main() {
 /// use open_enum::open_enum;
 /// open_enum! {
-///     #[allow(dead_code)] // This will apply to the generated struct defn
+///     #[expect(dead_code)] // This will apply to the generated struct defn
 ///     pub enum ExampleEnumName: u32 {
 ///         #![expect(missing_docs)] // This will apply to all subfields of the enum
 ///         THIS_IS_AN_ENUM = 32,
@@ -34,7 +34,7 @@
 /// //
 /// // #[repr(transparent)]
 //  // #[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-/// // #[allow(dead_code)]
+/// // #[expect(dead_code)]
 /// // struct ExampleEnumName(u32);
 /// //
 /// // #[expect(missing_docs)]

--- a/support/openssl_kdf/src/sys/mod.rs
+++ b/support/openssl_kdf/src/sys/mod.rs
@@ -4,7 +4,7 @@
 // See also the LICENSE file in the root of the crate for additional copyright
 // information.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 #![allow(non_camel_case_types)]
 
 pub mod evp;

--- a/support/pal/pal_async/src/waker.rs
+++ b/support/pal/pal_async/src/waker.rs
@@ -18,7 +18,7 @@ impl WakerList {
         }
     }
 
-    #[allow(dead_code)]
+    #[cfg_attr(not(windows), expect(dead_code))]
     pub fn push(&mut self, waker: Waker) {
         self.0.push(waker);
     }

--- a/support/pal/src/windows/afd.rs
+++ b/support/pal/src/windows/afd.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![cfg(windows)]
-#![allow(dead_code)]
 
 //! Code to interact with the Windows AFD (socket) driver.
 

--- a/vm/devices/firmware/firmware_pcat/src/root_cpu_data.rs
+++ b/vm/devices/firmware/firmware_pcat/src/root_cpu_data.rs
@@ -14,8 +14,6 @@
 //! On Underhill, this information is generated host-side, and sent over the
 //! GET, whereas on HvLite, it will need to be fetched from the Host itself.
 
-#![allow(dead_code)] // Translated protocol structs
-
 use super::config::SmbiosProcessorInfoBundle;
 use core::mem::size_of;
 use zerocopy::FromBytes;

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/mod.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/mod.rs
@@ -134,7 +134,7 @@ impl SupportedAttrs {
 }
 
 /// Helper struct to collect various properties of a parsed authenticated var
-#[cfg_attr(not(feature = "auth-var-verify-crypto"), expect(dead_code))]
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub struct ParsedAuthVar<'a> {
     pub name: &'a Ucs2LeSlice,

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/mod.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/mod.rs
@@ -134,7 +134,7 @@ impl SupportedAttrs {
 }
 
 /// Helper struct to collect various properties of a parsed authenticated var
-#[cfg_attr(not(feature = "auth-var-verify-crypto"), allow(dead_code))]
+#[cfg_attr(not(feature = "auth-var-verify-crypto"), expect(dead_code))]
 #[derive(Debug, Clone, Copy)]
 pub struct ParsedAuthVar<'a> {
     pub name: &'a Ucs2LeSlice,

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/nvram_services_ext.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/nvram_services_ext.rs
@@ -19,7 +19,7 @@ use uefi_specs::uefi::common::EfiStatus;
 pub trait NvramServicesExt {
     /// Get a variable identified by `name` (as a Rust string) + `vendor`,
     /// returning the variable's attributes and data.
-    #[cfg_attr(windows, expect(dead_code))]
+    #[allow(dead_code)]
     async fn get_variable(
         &mut self,
         vendor: Guid,

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/nvram_services_ext.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/nvram_services_ext.rs
@@ -19,7 +19,7 @@ use uefi_specs::uefi::common::EfiStatus;
 pub trait NvramServicesExt {
     /// Get a variable identified by `name` (as a Rust string) + `vendor`,
     /// returning the variable's attributes and data.
-    #[allow(dead_code)] // Useful for debugging
+    #[cfg_attr(windows, expect(dead_code))]
     async fn get_variable(
         &mut self,
         vendor: Guid,
@@ -28,7 +28,6 @@ pub trait NvramServicesExt {
 
     /// Get a variable identified by `name` (as a UCS-2 string) + `vendor`,
     /// returning the variable's attributes and data.
-    #[allow(dead_code)] // Useful for debugging
     async fn get_variable_ucs2(
         &mut self,
         vendor: Guid,

--- a/vm/devices/firmware/uefi_specs/src/uefi/nvram.rs
+++ b/vm/devices/firmware/uefi_specs/src/uefi/nvram.rs
@@ -182,7 +182,6 @@ pub fn is_secure_boot_policy_var(vendor: Guid, name: &ucs2::Ucs2LeSlice) -> bool
 /// wide-string literals, and me not wanting to yak-shave a proc macro
 /// implementation that emits valid Utf16LeSlices at compile time, these
 /// "constants" are actually methods that can only be called at runtime.
-#[allow(dead_code)] // no live code - just a bunch of constants
 pub mod vars {
     use guid::Guid;
 

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -316,7 +316,6 @@ pub struct GedChannel<T: RingMem = GpadlRingMem> {
     // TODO: allow unused temporarily as a follow up change will use it to
     // implement AK cert renewal.
     #[inspect(skip)]
-    #[allow(dead_code)]
     gm: GuestMemory,
 }
 

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -333,7 +333,7 @@ pub struct TestGedClient {
     sender: mesh::Sender<GuestEmulationRequest>,
 }
 
-#[allow(dead_code)] // Tasks are spawned and just need to be held.
+#[expect(dead_code)] // Tasks are spawned and just need to be held.
 enum TestTask {
     Test(Task<Result<(), Error>>),
     Prod(TaskControl<GuestEmulationDevice, GedChannel<FlatRingMem>>),

--- a/vm/devices/get/guest_emulation_transport/src/lib.rs
+++ b/vm/devices/get/guest_emulation_transport/src/lib.rs
@@ -64,7 +64,7 @@ pub mod test_utilities {
 
     pub const DEFAULT_SIZE: usize = 4194816; // 4 MB
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg_attr(not(test), expect(dead_code))]
     pub struct TestGet {
         pub client: GuestEmulationTransportClient,
         pub(crate) gen_id: Receiver<[u8; 16]>,

--- a/vm/devices/hyperv_ic_protocol/src/lib.rs
+++ b/vm/devices/hyperv_ic_protocol/src/lib.rs
@@ -3,8 +3,6 @@
 
 //! IC protocol definitions.
 
-#![allow(dead_code)]
-
 use bitfield_struct::bitfield;
 use open_enum::open_enum;
 use std::fmt::Display;

--- a/vm/devices/net/gdma_defs/src/bnic.rs
+++ b/vm/devices/net/gdma_defs/src/bnic.rs
@@ -3,8 +3,6 @@
 
 //! GDMA Basic NIC (BNIC/MANA) definitions
 
-#![allow(dead_code)]
-
 use super::GdmaQueueType;
 use bitfield_struct::bitfield;
 use open_enum::open_enum;

--- a/vm/devices/net/linux_net_bindings/src/lib.rs
+++ b/vm/devices/net/linux_net_bindings/src/lib.rs
@@ -17,7 +17,6 @@ use std::os::raw::c_int;
 //
 // bindgen --no-layout-tests --with-derive-default --wrap-unsafe-ops --no-doc-comments /usr/include/linux/if.h
 #[allow(non_camel_case_types)]
-#[allow(dead_code)]
 #[allow(non_upper_case_globals)]
 #[expect(clippy::missing_safety_doc)]
 #[expect(clippy::undocumented_unsafe_blocks)]
@@ -29,7 +28,6 @@ pub mod gen_if;
 //
 // bindgen --no-layout-tests --with-derive-default --wrap-unsafe-ops --no-doc-comments /usr/include/linux/if_tun.h
 #[allow(non_camel_case_types)]
-#[allow(dead_code)]
 #[allow(non_upper_case_globals)]
 #[expect(clippy::missing_safety_doc)]
 #[expect(clippy::undocumented_unsafe_blocks)]

--- a/vm/devices/net/netvsp/src/protocol.rs
+++ b/vm/devices/net/netvsp/src/protocol.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use crate::rndisprot;
 use bitfield_struct::bitfield;

--- a/vm/devices/net/netvsp/src/rndisprot.rs
+++ b/vm/devices/net/netvsp/src/rndisprot.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use bitfield_struct::bitfield;
 use open_enum::open_enum;

--- a/vm/devices/net/vmswitch/src/kernel.rs
+++ b/vm/devices/net/vmswitch/src/kernel.rs
@@ -116,7 +116,7 @@ impl KernelVmNic {
 
 #[derive(Debug)]
 // Just a newtype to give a better name and ergonomics, field needs to be held to keep handle alive.
-pub struct SwitchPort(#[allow(dead_code)] OwnedHandle);
+pub struct SwitchPort(#[expect(dead_code)] OwnedHandle);
 
 impl SwitchPort {
     pub fn new(id: &SwitchPortId) -> io::Result<Self> {

--- a/vm/devices/pci/vpci/src/protocol.rs
+++ b/vm/devices/pci/vpci/src/protocol.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use bitfield_struct::bitfield;
 use guid::Guid;

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/namespace.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/namespace.rs
@@ -529,7 +529,6 @@ impl Namespace {
     /// during servicing.
     /// TODO: Re-enable namespace save/restore once we confirm
     /// that we can process namespace change AEN.
-    #[allow(dead_code)]
     pub fn save(&self) -> anyhow::Result<SavedNamespaceData> {
         Ok(SavedNamespaceData {
             nsid: self.nsid,

--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -1815,7 +1815,7 @@ mod tests {
         device_head: u8,
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     enum Addressing {
         Chs,
         Lba28Bit,

--- a/vm/devices/storage/nvme/src/tests/test_helpers.rs
+++ b/vm/devices/storage/nvme/src/tests/test_helpers.rs
@@ -30,7 +30,7 @@ struct TestPciInterruptControllerInner {
 
 impl TestPciInterruptController {
     /// Return a new test PCI interrupt controller
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn new() -> Self {
         Self {
             inner: Arc::new(TestPciInterruptControllerInner {
@@ -40,7 +40,7 @@ impl TestPciInterruptController {
     }
 
     /// Fetch the first (addr, data) MSI-X interrupt in the FIFO interrupt queue
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn get_next_interrupt(&self) -> Option<(u64, u32)> {
         self.inner.msi_requests.lock().pop_front()
     }

--- a/vm/devices/storage/scsi_defs/src/lib.rs
+++ b/vm/devices/storage/scsi_defs/src/lib.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
-#![allow(dead_code)]
 
 pub mod srb;
 

--- a/vm/devices/storage/scsidisk/src/getlbastatus.rs
+++ b/vm/devices/storage/scsidisk/src/getlbastatus.rs
@@ -28,7 +28,7 @@ struct DeviceBlockIndexInfo {
     /// The number of blocks.
     block_count: u32,
     /// The size of the last partial block.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     last_partial_block_size: u32,
     /// The number of LBAs per block.
     lba_per_block: u64,
@@ -40,10 +40,10 @@ enum LbaStatus {
     /// The block is mapped.
     Mapped,
     /// The block is deallocated.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     Deallocated,
     /// The block is anchored.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     Anchored,
 }
 

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -13,6 +13,7 @@ pub mod protocol;
 pub mod test_helpers;
 
 #[cfg(not(feature = "fuzz_helpers"))]
+#[expect(dead_code)]
 mod protocol;
 #[cfg(not(feature = "fuzz_helpers"))]
 mod test_helpers;

--- a/vm/devices/storage/storvsp/src/protocol.rs
+++ b/vm/devices/storage/storvsp/src/protocol.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
-
 use guid::Guid;
 use open_enum::open_enum;
 use scsi_defs::ScsiStatus;

--- a/vm/devices/storage/storvsp/src/test_helpers.rs
+++ b/vm/devices/storage/storvsp/src/test_helpers.rs
@@ -6,7 +6,7 @@
 //! These are used both by unit tests and by benchmarks.
 
 // Benchmarks do not use all the code here, but unit tests should.
-#![cfg_attr(not(test), allow(dead_code))]
+#![cfg_attr(not(test), expect(dead_code))]
 
 use super::protocol;
 use crate::InitState;

--- a/vm/devices/support/fs/fuse/src/protocol.rs
+++ b/vm/devices/support/fs/fuse/src/protocol.rs
@@ -9,7 +9,6 @@
 //! For more details, see fuse.h.
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
-#![allow(dead_code)]
 #![allow(unused_parens)]
 
 use zerocopy::FromBytes;

--- a/vm/devices/support/fs/fuse/tests/fuse_hello.rs
+++ b/vm/devices/support/fs/fuse/tests/fuse_hello.rs
@@ -15,7 +15,7 @@ use zerocopy::FromZeros;
 // Implements a file system similar to libfuse's hello_ll sample.
 // This test is excluded from CI because it requires root.
 #[cfg_attr(not(feature = "ci"), test_with_tracing::test)]
-#[cfg_attr(feature = "ci", allow(dead_code))]
+#[cfg_attr(feature = "ci", expect(dead_code))]
 fn fuse_hello() {
     let mount_point = tempfile::tempdir().unwrap();
 

--- a/vm/devices/support/fs/lxutil/src/lib.rs
+++ b/vm/devices/support/fs/lxutil/src/lib.rs
@@ -1034,9 +1034,9 @@ impl Default for LxVolumeOptions {
 #[derive(Default)]
 pub struct LxCreateOptions {
     mode: lx::mode_t,
-    #[allow(dead_code)]
+    #[cfg_attr(not(windows), expect(dead_code))]
     uid: lx::uid_t,
-    #[allow(dead_code)]
+    #[cfg_attr(not(windows), expect(dead_code))]
     gid: lx::gid_t,
 }
 

--- a/vm/devices/support/fs/plan9/src/protocol/macros.rs
+++ b/vm/devices/support/fs/plan9/src/protocol/macros.rs
@@ -84,7 +84,7 @@ macro_rules! p9_message_struct {
 // Generate the Plan9Message enum.
 macro_rules! p9_message_enum {
     ($( $num:literal $name:ident $($field_name:ident [$field_type:tt] )* ;)*) => {
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         #[derive(Debug)]
         pub enum Plan9Message<'a> {
             $($name($name<'a>),)*

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -143,7 +143,7 @@ struct ControlArea {
 }
 
 // TODO: switch this over to open_enum!
-#[allow(dead_code)]
+#[expect(dead_code)]
 impl ControlArea {
     const OFFSET_OF_LOC_STATE: usize = 0x00;
     const OFFSET_OF_LOC_CTRL: usize = 0x08;
@@ -1271,7 +1271,7 @@ mod io_port_interface {
         }
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     #[repr(u32)]
     #[derive(Debug, Copy, Clone)]
     pub enum TcgProtocol {

--- a/vm/devices/tpm/src/tpm20proto.rs
+++ b/vm/devices/tpm/src/tpm20proto.rs
@@ -1950,7 +1950,7 @@ pub mod protocol {
 
     // === Startup === //
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub enum StartupType {
         Clear,
         State,

--- a/vm/devices/uidevices/src/keyboard/protocol.rs
+++ b/vm/devices/uidevices/src/keyboard/protocol.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use guid::Guid;
 use zerocopy::FromBytes;

--- a/vm/devices/uidevices/src/mouse/protocol.rs
+++ b/vm/devices/uidevices/src/mouse/protocol.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 #![allow(unused_macros)]
 
 use guid::Guid;

--- a/vm/devices/uidevices/src/video/protocol.rs
+++ b/vm/devices/uidevices/src/video/protocol.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use zerocopy::FromBytes;
 use zerocopy::Immutable;

--- a/vm/devices/vga/src/spec.rs
+++ b/vm/devices/vga/src/spec.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use inspect::Inspect;
 use open_enum::open_enum;

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -104,7 +104,7 @@ struct NetStatus {
 
 const DEFAULT_MTU: u16 = 1514;
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 const VIRTIO_NET_MAX_QUEUES: u16 = 0x8000;
 
 #[repr(C)]

--- a/vm/devices/virtio/virtiofs/src/lib.rs
+++ b/vm/devices/virtio/virtiofs/src/lib.rs
@@ -452,7 +452,7 @@ impl<T> HandleMap<T> {
     }
 
     /// Retrieves a value from the map.
-    #[allow(dead_code)]
+    #[cfg_attr(not(windows), expect(dead_code))]
     pub fn get_mut(&mut self, handle: u64) -> Option<&mut T> {
         self.values.get_mut(&handle)
     }

--- a/vm/devices/virtio/virtiofs/src/virtio.rs
+++ b/vm/devices/virtio/virtiofs/src/virtio.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use crate::virtio_util::VirtioPayloadReader;
 use crate::virtio_util::VirtioPayloadWriter;

--- a/vm/devices/vmbus/vmbfs/src/protocol.rs
+++ b/vm/devices/vmbus/vmbfs/src/protocol.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)] // Translated protocol structs
-
 use bitfield_struct::bitfield;
 use guid::Guid;
 use open_enum::open_enum;

--- a/vm/devices/vmbus/vmbus_ring/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_ring/src/lib.rs
@@ -70,8 +70,6 @@ mod pipe_protocol {
 }
 
 mod protocol {
-    #![allow(dead_code)]
-
     use crate::CONTROL_WORD_COUNT;
     use inspect::Inspect;
     use std::fmt::Debug;

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -71,7 +71,7 @@ fn to_igvm_vtl(vtl: Vtl) -> igvm::hv_defs::Vtl {
 
 /// Page table relocation information kept for debugging purposes.
 // Allow dead code because clippy doesn't count #[derive(Debug)] as non-dead code usage.
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Debug, Clone)]
 struct PageTableRegion {
     gpa: u64,

--- a/vm/loader/src/importer.rs
+++ b/vm/loader/src/importer.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 //! Common loader image loading traits and types used by all loaders.
-#![allow(dead_code)]
 
 #[cfg(guest_arch = "aarch64")]
 pub use Aarch64Register as Register;

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1910,7 +1910,7 @@ impl Debug for LockedPages {
 
 #[derive(Copy, Clone, Debug)]
 // Field is read via slice transmute and pointer casts, not actually dead.
-struct PagePtr(#[allow(dead_code)] *const AtomicU8);
+struct PagePtr(#[expect(dead_code)] *const AtomicU8);
 
 // SAFETY: PagePtr is just a pointer with no methods and has no inherent safety
 // constraints.

--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -66,7 +66,7 @@ struct ResolvedFileControlBlock {
 
 /// Implementation of the VMGS file format, backed by a generic [`Disk`]
 /// device.
-#[cfg_attr(not(with_encryption), allow(dead_code))]
+#[cfg_attr(not(with_encryption), expect(dead_code))]
 #[cfg_attr(feature = "inspect", derive(Inspect))]
 pub struct Vmgs {
     storage: VmgsStorage,
@@ -1597,7 +1597,7 @@ fn encrypt_metadata_key(
 }
 
 /// Decrypts metadata_key. Returns decrypted_metadata_key.
-#[cfg_attr(not(with_encryption), allow(unused_variables), allow(dead_code))]
+#[cfg_attr(not(with_encryption), allow(unused_variables), expect(dead_code))]
 fn decrypt_metadata_key(
     datastore_key: &[u8],
     nonce: &[u8],

--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -66,7 +66,6 @@ struct ResolvedFileControlBlock {
 
 /// Implementation of the VMGS file format, backed by a generic [`Disk`]
 /// device.
-#[cfg_attr(not(with_encryption), expect(dead_code))]
 #[cfg_attr(feature = "inspect", derive(Inspect))]
 pub struct Vmgs {
     storage: VmgsStorage,
@@ -80,6 +79,7 @@ pub struct Vmgs {
     #[cfg_attr(feature = "inspect", inspect(with = "vmgs_inspect::fcbs"))]
     fcbs: HashMap<FileId, ResolvedFileControlBlock>,
     encryption_algorithm: EncryptionAlgorithm,
+    #[allow(dead_code)]
     datastore_key_count: u8,
     active_datastore_key_index: Option<usize>,
     #[cfg_attr(feature = "inspect", inspect(iter_by_index))]

--- a/vm/whp/src/api.rs
+++ b/vm/whp/src/api.rs
@@ -43,7 +43,7 @@ macro_rules! delayload {
             )*
         }
         pub mod is_supported {
-            #![allow(dead_code, non_snake_case)]
+            #![expect(dead_code, non_snake_case)]
             $(
                 $(#[$a])*
                 pub fn $name() -> bool {

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -686,7 +686,6 @@ impl Drop for Halted<'_> {
 struct Inner {
     #[inspect(flatten)]
     halt: Arc<Halt>,
-    #[cfg_attr(not(feature = "gdb"), expect(dead_code))]
     #[inspect(skip)]
     vtl_guest_memory: [Option<GuestMemory>; NUM_VTLS],
 }

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -686,7 +686,7 @@ impl Drop for Halted<'_> {
 struct Inner {
     #[inspect(flatten)]
     halt: Arc<Halt>,
-    #[cfg_attr(not(feature = "gdb"), allow(dead_code))]
+    #[cfg_attr(not(feature = "gdb"), expect(dead_code))]
     #[inspect(skip)]
     vtl_guest_memory: [Option<GuestMemory>; NUM_VTLS],
 }
@@ -764,7 +764,7 @@ impl VpSet {
     }
 
     /// Initiates a halt to the VPs.
-    #[cfg_attr(not(feature = "gdb"), allow(dead_code))]
+    #[cfg_attr(not(feature = "gdb"), expect(dead_code))]
     pub fn halt(&mut self, reason: HaltReason) {
         self.inner.halt.halt(reason);
     }

--- a/vmm_core/virt_hvf/src/abi.rs
+++ b/vmm_core/virt_hvf/src/abi.rs
@@ -88,7 +88,7 @@ unsafe extern "C" {
     pub fn hv_vcpu_set_reg(vcpu: u64, reg: HvReg, value: u64) -> HvfResult;
     pub fn hv_vcpu_get_sys_reg(vcpu: u64, reg: HvSysReg, value: *mut u64) -> HvfResult;
     pub fn hv_vcpu_set_sys_reg(vcpu: u64, reg: HvSysReg, value: u64) -> HvfResult;
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn hv_vcpu_get_pending_interrupt(
         vcpu: u64,
         ty: HvInterruptType,
@@ -99,7 +99,7 @@ unsafe extern "C" {
         ty: HvInterruptType,
         pending: bool,
     ) -> HvfResult;
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn hv_vcpu_get_vtimer_mask(vcpu: u64, vtimer_is_masked: *mut bool) -> HvfResult;
     pub fn hv_vcpu_set_vtimer_mask(vcpu: u64, vtimer_is_masked: bool) -> HvfResult;
 }

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -7,7 +7,7 @@
 //! is a start providing assurance that HvLite virtualization model is appropriate for
 //! KVM/aarch64.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 #![cfg(all(target_os = "linux", guest_is_native, guest_arch = "aarch64"))]
 
 use crate::KvmError;

--- a/vmm_core/virt_kvm/src/arch/x86_64/regs.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/regs.rs
@@ -5,7 +5,7 @@ use hvdef::HvX64RegisterName;
 
 #[derive(Debug)]
 // Field is stored solely for logging via debug, not actually dead.
-pub struct NoRegisterMapping(#[allow(dead_code)] HvX64RegisterName);
+pub struct NoRegisterMapping(#[expect(dead_code)] HvX64RegisterName);
 
 /// Converts a register name to an msr.
 pub const fn register_to_msr(name: HvX64RegisterName) -> Result<u32, NoRegisterMapping> {

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -101,7 +101,7 @@ pub enum KvmRunVpError {
     ExtintInterrupt(#[source] kvm::Error),
 }
 
-#[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
+#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 pub struct KvmProcessorBinder {
     partition: Arc<KvmPartitionInner>,
     vpindex: VpIndex,

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -159,7 +159,7 @@ struct WhpVp {
     scrub_next: AtomicBool,
     vp_info: TargetVpInfo,
     waker: RwLock<Option<Waker>>,
-    #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     scan_irr: AtomicBool,
 }
 

--- a/vmm_core/virt_whp/src/memory.rs
+++ b/vmm_core/virt_whp/src/memory.rs
@@ -129,7 +129,7 @@ pub(crate) trait MemoryMapper: Inspect + Send + Sync {
     fn add_allowed_range(&self, range: MemoryRange);
 
     /// Returns true if a `gpa` is in a deferred range.
-    #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     fn in_deferred_range(&self, gpa: u64) -> bool;
 
     /// Map all deferred ranges and put the mapper into a mapped state, where
@@ -155,12 +155,12 @@ pub(crate) trait MemoryMapper: Inspect + Send + Sync {
     fn reset_mappings(&self, partition: &dyn SimpleMemoryMap) -> Result<(), virt::Error>;
 
     /// If page acceptance and visibility is supported by this mapper.
-    #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     fn page_acceptance_supported(&self) -> bool;
 
     /// The page visibility for a given page. None means this page is not
     /// accepted. Only supported on mappers that support page acceptance.
-    #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     fn gpa_visibility(&self, gpa: u64) -> Option<PageVisibility>;
 
     /// Accept the given gpa range on behalf of the guest, with the given
@@ -343,7 +343,6 @@ impl MemoryMapper for WhpMemoryMapper {
 
 /// What VTL access to apply to a page.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Inspect)]
-#[allow(dead_code)]
 pub enum VtlAccess {
     /// No access
     NoAccess,

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -203,7 +203,7 @@ impl<'a> WhpProcessor<'a> {
         Ok(())
     }
 
-    #[cfg_attr(guest_arch = "aarch64", allow(dead_code))]
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     pub(crate) fn vtl2_intercept(&mut self, typ: HvMessageType, payload: &[u8]) {
         match self.vtl2_intercept_inner(typ, payload) {
             Ok(()) => {}

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -889,7 +889,6 @@ pub struct ArcMutexIsaDmaChannel {
 }
 
 impl ArcMutexIsaDmaChannel {
-    #[allow(dead_code)] // use is feature dependent
     pub fn new(dma: Arc<CloseableMutex<dma::DmaController>>, channel_num: u8) -> Self {
         Self { dma, channel_num }
     }

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -889,6 +889,7 @@ pub struct ArcMutexIsaDmaChannel {
 }
 
 impl ArcMutexIsaDmaChannel {
+    #[allow(dead_code)] // use is feature dependent
     pub fn new(dma: Arc<CloseableMutex<dma::DmaController>>, channel_num: u8) -> Self {
         Self { dma, channel_num }
     }

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -686,7 +686,7 @@ fn make_vmm_test(args: Args, item: ItemFn, specific_vmm: Option<Vmm>) -> syn::Re
     Ok(quote! {
         ::petri::multitest!(vec![#tests]);
         // Allow dead code for tests that are not run on the current architecture.
-        #[cfg_attr(not(any(#(guest_arch = #guest_archs,)*)), allow(dead_code))]
+        #[cfg_attr(not(any(#(guest_arch = #guest_archs,)*)), expect(dead_code))]
         #item
     })
 }

--- a/workers/debug_worker/src/gdb/arch/x86/reg/mod.rs
+++ b/workers/debug_worker/src/gdb/arch/x86/reg/mod.rs
@@ -6,7 +6,7 @@
 use gdbstub::arch::Registers;
 
 /// `RegId` definitions for x86 architectures.
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub mod id;
 
 mod core32;

--- a/workers/debug_worker/src/gdb/mod.rs
+++ b/workers/debug_worker/src/gdb/mod.rs
@@ -63,7 +63,7 @@ impl VmProxy {
         NonZeroUsize::new(vp as usize + 1).unwrap()
     }
 
-    #[allow(dead_code)] // TODO: add monitor command to inspect physical memory?
+    #[expect(dead_code)] // TODO: add monitor command to inspect physical memory?
     fn read_guest_physical_memory(&mut self, gpa: u64, data: &mut [u8]) -> anyhow::Result<()> {
         let buf = block_on(self.req_chan.call_failable(
             DebugRequest::ReadMemory,

--- a/workers/vnc_worker/vnc/src/rfb.rs
+++ b/workers/vnc_worker/vnc/src/rfb.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use self::packed_nums::*;
 use zerocopy::FromBytes;

--- a/xtask/src/tasks/fuzz/parse_fuzz_crate_toml.rs
+++ b/xtask/src/tasks/fuzz/parse_fuzz_crate_toml.rs
@@ -27,7 +27,7 @@ pub(super) struct FuzzCrateMetadata {
 #[derive(Debug)]
 pub(super) struct RepoFuzzTarget {
     pub fuzz_dir: PathBuf,
-    #[allow(dead_code)] // useful in `dump` debug output
+    #[expect(dead_code)] // useful in `dump` debug output
     pub crate_name: String,
     pub allowlist: Vec<PathBuf>,
     pub target_options: Vec<String>,


### PR DESCRIPTION
This also deletes a bunch of them, and moves a bunch to be cfg_attrd when needed. Progress on #300