### PR TITLE
virt_mshv_vtl: refactor cvm_cpuid

### DIFF
--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -5,7 +5,6 @@
 
 use super::COMMON_REQUIRED_LEAVES;
 use super::CpuidArchInitializer;
-use super::CpuidArchSupport;
 use super::CpuidResultMask;
 use super::CpuidResults;
 use super::CpuidResultsError;
@@ -207,17 +206,12 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
     ) -> Result<super::ExtendedTopologyResult, CpuidResultsError> {
         // TODO TDX: see HvlpInitializeCpuidTopologyIntel
         // TODO TDX: fix returned errors
-        let vps_per_socket;
         if !version_and_features_edx.mt_per_socket() {
             if version_and_features_ebx.lps_per_package() > 1 {
                 return Err(CpuidResultsError::TopologyInconsistent(
                     TopologyError::ThreadsPerUnit,
                 ));
-            } else {
-                vps_per_socket = 1;
             }
-        } else {
-            vps_per_socket = version_and_features_ebx.lps_per_package();
         }
 
         // TODO TDX: validation of leaf 0xB
@@ -225,7 +219,6 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
         Ok(super::ExtendedTopologyResult {
             subleaf0: None,
             subleaf1: None,
-            vps_per_socket: vps_per_socket.into(),
         })
     }
 
@@ -235,20 +228,5 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
 
     fn supports_tsc_aux_virtualization(&self, _results: &CpuidResults) -> bool {
         true
-    }
-}
-
-pub struct TdxCpuidSupport;
-
-impl CpuidArchSupport for TdxCpuidSupport {
-    fn process_guest_result(
-        &self,
-        _leaf: CpuidFunction,
-        _subleaf: u32,
-        _result: &mut CpuidResult,
-        _guest_state: &super::CpuidGuestState,
-        _vps_per_socket: u32,
-    ) {
-        // Nothing extra to do for TDX
     }
 }

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/topology.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/topology.rs
@@ -4,6 +4,7 @@
 //! Tests for the cpu topology-related subleaves.
 use super::super::*;
 use super::*;
+use virt::CpuidLeafSet;
 use zerocopy::FromZeros;
 
 #[test]
@@ -54,8 +55,10 @@ fn real_topology() {
     })
     .unwrap();
 
+    let cpuid = CpuidLeafSet::new(cpuid.to_leaves());
+
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 0),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 0),
         CpuidResult {
             eax: 0x1,
             ebx: 0x2,
@@ -65,7 +68,7 @@ fn real_topology() {
     );
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 1),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 1),
         CpuidResult {
             eax: 0x4,
             ebx: 0x10,
@@ -75,7 +78,7 @@ fn real_topology() {
     );
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 2),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 2),
         ZERO_CPUID_RESULT
     );
 }
@@ -86,7 +89,7 @@ fn initialize_topology(
     nc: u8,
     lps_per_package: u8,
     threads_per_compute_unit: u8,
-) -> Result<CpuidResults, CpuidResultsError> {
+) -> Result<CpuidLeafSet, CpuidResultsError> {
     let mut pages = vec![HvPspCpuidPage::new_zeroed(), HvPspCpuidPage::new_zeroed()];
 
     pages[0].count += 1;
@@ -152,9 +155,10 @@ fn initialize_topology(
 
     fill_required_leaves(&mut pages, None);
 
-    CpuidResults::new(CpuidResultsIsolationType::Snp {
+    CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
-    })
+    }
+    .build()
 }
 
 #[test]
@@ -243,7 +247,7 @@ fn legacy_topology() {
     .unwrap();
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 0),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 0),
         CpuidResult {
             eax: 0x0,
             ebx: 0x1,
@@ -253,7 +257,7 @@ fn legacy_topology() {
     );
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 1),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 1),
         CpuidResult {
             eax: 0x0,
             ebx: 0x1,
@@ -293,7 +297,7 @@ fn legacy_topology() {
     .unwrap();
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 0),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 0),
         CpuidResult {
             eax: 0x0,
             ebx: 0x1,
@@ -303,7 +307,7 @@ fn legacy_topology() {
     );
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 1),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 1),
         CpuidResult {
             eax: 0x3,
             ebx: 0x8,
@@ -384,7 +388,7 @@ fn topology() {
     .unwrap();
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 0),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 0),
         CpuidResult {
             eax: 0x0,
             ebx: 0x1,
@@ -394,7 +398,7 @@ fn topology() {
     );
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 1),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 1),
         CpuidResult {
             eax: 0x6,
             ebx: 0x40,
@@ -419,7 +423,7 @@ fn topology() {
     .unwrap();
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 0),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 0),
         CpuidResult {
             eax: 0x0,
             ebx: 0x1,
@@ -429,7 +433,7 @@ fn topology() {
     );
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 1),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 1),
         CpuidResult {
             eax: 0x8,
             ebx: 0x100,
@@ -453,7 +457,7 @@ fn topology() {
     .unwrap();
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 0),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 0),
         CpuidResult {
             eax: 0x1,
             ebx: 0x2,
@@ -463,7 +467,7 @@ fn topology() {
     );
 
     assert_eq!(
-        cpuid.registered_result(CpuidFunction::ExtendedTopologyEnumeration, 1),
+        cpuid_result(&cpuid, CpuidFunction::ExtendedTopologyEnumeration, 1),
         CpuidResult {
             eax: 0x8,
             ebx: 0x100,

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -85,6 +85,7 @@ use parking_lot::RwLock;
 use processor::BackingSharedParams;
 use processor::SidecarExitReason;
 use sidecar_client::NewSidecarClientError;
+use std::marker::PhantomData;
 use std::ops::RangeInclusive;
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
@@ -97,7 +98,6 @@ use std::sync::atomic::Ordering;
 use std::task::Waker;
 use thiserror::Error;
 use user_driver::DmaClient;
-use virt::CpuidLeafSet;
 use virt::IsolationType;
 use virt::PartitionCapabilities;
 use virt::VpIndex;
@@ -203,7 +203,8 @@ struct UhPartitionInner {
     enter_modes: Mutex<EnterModes>,
     #[inspect(skip)]
     enter_modes_atomic: AtomicU8,
-    cpuid: CpuidLeafSet,
+    #[cfg(guest_arch = "x86_64")]
+    cpuid: virt::CpuidLeafSet,
     lower_vtl_memory_layout: MemoryLayout,
     gm: VtlArray<GuestMemory, 2>,
     #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
@@ -239,7 +240,7 @@ impl BackingShared {
     fn new(
         isolation: IsolationType,
         partition_params: &UhPartitionNewParams<'_>,
-        backing_shared_params: BackingSharedParams,
+        backing_shared_params: BackingSharedParams<'_>,
     ) -> Result<BackingShared, Error> {
         Ok(match isolation {
             IsolationType::None | IsolationType::Vbs => {
@@ -411,8 +412,7 @@ impl UhCvmVpState {
 /// Partition-wide state for CVMs.
 struct UhCvmPartitionState {
     #[cfg(guest_arch = "x86_64")]
-    #[inspect(skip)]
-    cpuid: cvm_cpuid::CpuidResults,
+    vps_per_socket: u32,
     /// VPs that have locked their TLB.
     #[inspect(
         with = "|arr| inspect::iter_by_index(arr.iter()).map_value(|bb| inspect::iter_by_index(bb.iter().map(|v| *v)))"
@@ -1380,9 +1380,9 @@ pub trait TlbFlushLockAccess {
 pub struct UhProtoPartition<'a> {
     params: UhPartitionNewParams<'a>,
     hcl: Hcl,
-    #[cfg(guest_arch = "x86_64")]
-    cvm_cpuid: Option<cvm_cpuid::CpuidResults>,
     guest_vsm_available: bool,
+    #[cfg(guest_arch = "x86_64")]
+    cpuid: virt::CpuidLeafSet,
 }
 
 impl<'a> UhProtoPartition<'a> {
@@ -1443,33 +1443,32 @@ impl<'a> UhProtoPartition<'a> {
         set_vtl2_vsm_partition_config(&hcl)?;
 
         #[cfg(guest_arch = "x86_64")]
-        let cvm_cpuid = match params.isolation {
-            IsolationType::Snp => Some(
-                cvm_cpuid::CpuidResults::new(cvm_cpuid::CpuidResultsIsolationType::Snp {
-                    cpuid_pages: params.cvm_cpuid_info.unwrap(),
-                })
+        let cpuid = match params.isolation {
+            IsolationType::Snp => cvm_cpuid::CpuidResultsIsolationType::Snp {
+                cpuid_pages: params.cvm_cpuid_info.unwrap(),
+            }
+            .build()
+            .map_err(Error::CvmCpuid)?,
+
+            IsolationType::Tdx => cvm_cpuid::CpuidResultsIsolationType::Tdx
+                .build()
                 .map_err(Error::CvmCpuid)?,
-            ),
-            IsolationType::Tdx => Some(
-                cvm_cpuid::CpuidResults::new(cvm_cpuid::CpuidResultsIsolationType::Tdx)
-                    .map_err(Error::CvmCpuid)?,
-            ),
-            IsolationType::Vbs | IsolationType::None => None,
+            IsolationType::Vbs | IsolationType::None => Default::default(),
         };
 
         let guest_vsm_available = Self::check_guest_vsm_support(
             &hcl,
             &params,
             #[cfg(guest_arch = "x86_64")]
-            cvm_cpuid.as_ref(),
+            &cpuid,
         )?;
 
         Ok(UhProtoPartition {
             hcl,
             params,
-            #[cfg(guest_arch = "x86_64")]
-            cvm_cpuid,
             guest_vsm_available,
+            #[cfg(guest_arch = "x86_64")]
+            cpuid,
         })
     }
 
@@ -1486,9 +1485,9 @@ impl<'a> UhProtoPartition<'a> {
         let Self {
             mut hcl,
             params,
-            #[cfg(guest_arch = "x86_64")]
-            cvm_cpuid,
             guest_vsm_available,
+            #[cfg(guest_arch = "x86_64")]
+            cpuid,
         } = self;
         let isolation = params.isolation;
         let is_hardware_isolated = isolation.is_hardware_isolated();
@@ -1619,13 +1618,11 @@ impl<'a> UhProtoPartition<'a> {
         let software_devices = None;
 
         #[cfg(guest_arch = "aarch64")]
-        let (caps, cpuid) = (
-            virt::aarch64::Aarch64PartitionCapabilities {},
-            CpuidLeafSet::new(Vec::new()),
-        );
+        let caps = virt::aarch64::Aarch64PartitionCapabilities {};
 
         #[cfg(guest_arch = "x86_64")]
         let cpuid = UhPartition::construct_cpuid_results(
+            cpuid,
             &late_params.cpuid,
             params.topology,
             // Note: currently, guest_vsm_available can only set to true for
@@ -1642,7 +1639,6 @@ impl<'a> UhProtoPartition<'a> {
         let caps = UhPartition::construct_capabilities(
             params.topology,
             &cpuid,
-            cvm_cpuid.as_ref(),
             isolation,
             params.hide_isolation,
         );
@@ -1669,16 +1665,27 @@ impl<'a> UhProtoPartition<'a> {
                 &params,
                 late_params.cvm_params.unwrap(),
                 &caps,
-                cvm_cpuid.unwrap(),
                 late_params.gm.clone(),
                 guest_vsm_available,
             )?)
         } else {
             None
         };
-
         #[cfg(guest_arch = "aarch64")]
         let cvm_state = None;
+
+        let backing_shared = BackingShared::new(
+            isolation,
+            &params,
+            BackingSharedParams {
+                cvm_state,
+                guest_memory: late_params.gm.clone(),
+                #[cfg(guest_arch = "x86_64")]
+                cpuid: &cpuid,
+                guest_vsm_available,
+                _phantom: PhantomData,
+            },
+        )?;
 
         let enter_modes = EnterModes::default();
 
@@ -1689,16 +1696,8 @@ impl<'a> UhProtoPartition<'a> {
             caps,
             enter_modes: Mutex::new(enter_modes),
             enter_modes_atomic: u8::from(hcl::protocol::EnterModes::from(enter_modes)).into(),
-            backing_shared: BackingShared::new(
-                isolation,
-                &params,
-                BackingSharedParams {
-                    cvm_state,
-                    guest_memory: late_params.gm.clone(),
-                    guest_vsm_available,
-                },
-            )?,
             gm: late_params.gm,
+            #[cfg(guest_arch = "x86_64")]
             cpuid,
             crash_notification_send: late_params.crash_notification_send,
             monitor_page: MonitorPage::new(),
@@ -1708,6 +1707,7 @@ impl<'a> UhProtoPartition<'a> {
             isolation,
             no_sidecar_hotplug: params.no_sidecar_hotplug.into(),
             use_mmio_hypercalls: params.use_mmio_hypercalls,
+            backing_shared,
             #[cfg(guest_arch = "x86_64")]
             device_vector_table: RwLock::new(IrrBitmap::new(Default::default())),
             intercept_debug_exceptions: params.intercept_debug_exceptions,
@@ -1797,7 +1797,7 @@ impl UhProtoPartition<'_> {
     fn check_guest_vsm_support(
         hcl: &Hcl,
         params: &UhPartitionNewParams<'_>,
-        #[cfg(guest_arch = "x86_64")] cvm_cpuid: Option<&cvm_cpuid::CpuidResults>,
+        #[cfg(guest_arch = "x86_64")] cvm_cpuid: &virt::CpuidLeafSet,
     ) -> Result<bool, Error> {
         match params.isolation {
             IsolationType::None | IsolationType::Vbs => {}
@@ -1814,10 +1814,11 @@ impl UhProtoPartition<'_> {
                 }
                 // Require RMP Query
                 let rmp_query = x86defs::cpuid::ExtendedSevFeaturesEax::from(
-                    cvm_cpuid
-                        .unwrap()
-                        .registered_result(x86defs::cpuid::CpuidFunction::ExtendedSevFeatures, 0)
-                        .eax,
+                    cvm_cpuid.result(
+                        x86defs::cpuid::CpuidFunction::ExtendedSevFeatures.0,
+                        0,
+                        &[0; 4],
+                    )[0],
                 )
                 .rmp_query();
 
@@ -1858,7 +1859,6 @@ impl UhProtoPartition<'_> {
         params: &UhPartitionNewParams<'_>,
         late_params: CvmLateParams,
         caps: &PartitionCapabilities,
-        cpuid: cvm_cpuid::CpuidResults,
         guest_memory: VtlArray<GuestMemory, 2>,
         guest_vsm_available: bool,
     ) -> Result<UhCvmPartitionState, Error> {
@@ -1905,7 +1905,7 @@ impl UhProtoPartition<'_> {
         }
 
         Ok(UhCvmPartitionState {
-            cpuid,
+            vps_per_socket: params.topology.reserved_vps_per_socket(),
             tlb_locked_vps,
             vps,
             shared_memory: late_params.shared_gm,
@@ -1924,21 +1924,39 @@ impl UhPartition {
     #[cfg(guest_arch = "x86_64")]
     /// Constructs the set of cpuid results to show to the guest
     fn construct_cpuid_results(
+        cpuid: virt::CpuidLeafSet,
         initial_cpuid: &[CpuidLeaf],
         topology: &ProcessorTopology<vm_topology::processor::x86::X86Topology>,
         access_vsm: bool,
         vtom: Option<u64>,
         isolation: IsolationType,
         hide_isolation: bool,
-    ) -> CpuidLeafSet {
-        let mut cpuid = CpuidLeafSet::new(Vec::new());
-
+    ) -> virt::CpuidLeafSet {
+        let mut cpuid = cpuid.into_leaves();
         if isolation.is_hardware_isolated() {
+            // Update the x2apic leaf based on the topology.
+            {
+                let x2apic = match topology.apic_mode() {
+                    vm_topology::processor::x86::ApicMode::XApic => false,
+                    vm_topology::processor::x86::ApicMode::X2ApicSupported => true,
+                    vm_topology::processor::x86::ApicMode::X2ApicEnabled => true,
+                };
+                let ecx = x86defs::cpuid::VersionAndFeaturesEcx::new().with_x2_apic(x2apic);
+                let ecx_mask = x86defs::cpuid::VersionAndFeaturesEcx::new().with_x2_apic(true);
+                cpuid.push(
+                    CpuidLeaf::new(
+                        x86defs::cpuid::CpuidFunction::VersionAndFeatures.0,
+                        [0, 0, ecx.into(), 0],
+                    )
+                    .masked([0, 0, ecx_mask.into(), 0]),
+                );
+            }
+
             // Get the hypervisor version from the host. This is just for
             // reporting purposes, so it is safe even if the hypervisor is not
             // trusted.
             let hv_version = safe_intrinsics::cpuid(hvdef::HV_CPUID_FUNCTION_MS_HV_VERSION, 0);
-            cpuid.extend(&hv1_emulator::cpuid::hv_cpuid_leaves(
+            cpuid.extend(hv1_emulator::cpuid::hv_cpuid_leaves(
                 topology,
                 if hide_isolation {
                     IsolationType::None
@@ -1956,16 +1974,14 @@ impl UhPartition {
             ));
         }
         cpuid.extend(initial_cpuid);
-
-        cpuid
+        virt::CpuidLeafSet::new(cpuid)
     }
 
     #[cfg(guest_arch = "x86_64")]
     /// Computes the partition capabilities
     fn construct_capabilities(
         topology: &ProcessorTopology,
-        cpuid: &CpuidLeafSet,
-        cvm_cpuid: Option<&cvm_cpuid::CpuidResults>,
+        cpuid: &virt::CpuidLeafSet,
         isolation: IsolationType,
         hide_isolation: bool,
     ) -> virt::x86::X86PartitionCapabilities {
@@ -1974,22 +1990,9 @@ impl UhPartition {
 
         // Determine the method to get cpuid results for the guest when
         // computing partition capabilities.
-        let cpuid_fn: &mut dyn FnMut(u32, u32) -> [u32; 4] = if let Some(cvm_cpuid) = cvm_cpuid {
+        let cpuid_fn: &mut dyn FnMut(u32, u32) -> [u32; 4] = if isolation.is_hardware_isolated() {
             // Use the filtered CPUID to determine capabilities.
-            let bsp = topology.vp_arch(VpIndex::BSP).apic_id;
-            cvm_cpuid_fn = move |leaf, sub_leaf| {
-                let CpuidResult { eax, ebx, ecx, edx } = cvm_cpuid.guest_result(
-                    x86defs::cpuid::CpuidFunction(leaf),
-                    sub_leaf,
-                    &cvm_cpuid::CpuidGuestState {
-                        xfem: 1,
-                        xss: 0,
-                        cr4: 0,
-                        apic_id: bsp,
-                    },
-                );
-                cpuid.result(leaf, sub_leaf, &[eax, ebx, ecx, edx])
-            };
+            cvm_cpuid_fn = move |leaf, sub_leaf| cpuid.result(leaf, sub_leaf, &[0, 0, 0, 0]);
             &mut cvm_cpuid_fn
         } else {
             // Just use the native cpuid.

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -80,7 +80,7 @@ impl HypervisorBackedArm64Shared {
     /// Creates a new partition-shared data structure for hypervisor backed VMs.
     pub(crate) fn new(
         _partition_params: &UhPartitionNewParams<'_>,
-        params: BackingSharedParams,
+        params: BackingSharedParams<'_>,
     ) -> Result<Self, Error> {
         Ok(Self {
             guest_vsm: RwLock::new(GuestVsmState::from_availability(params.guest_vsm_available)),

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -101,7 +101,7 @@ impl HypervisorBackedX86Shared {
     /// Creates a new partition-shared data structure for hypervisor backed VMs.
     pub(crate) fn new(
         _partition_params: &UhPartitionNewParams<'_>,
-        params: BackingSharedParams,
+        params: BackingSharedParams<'_>,
     ) -> Result<Self, Error> {
         Ok(Self {
             guest_vsm: RwLock::new(GuestVsmState::from_availability(params.guest_vsm_available)),

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -89,7 +89,6 @@ use x86defs::X64_EFER_NXE;
 use x86defs::X64_EFER_SVME;
 use x86defs::X86X_MSR_EFER;
 use x86defs::apic::X2APIC_MSR_BASE;
-use x86defs::cpuid::CpuidFunction;
 use x86defs::tdx::TdCallResultCode;
 use x86defs::tdx::TdVmCallR10Result;
 use x86defs::tdx::TdxGp;
@@ -565,6 +564,10 @@ impl HardwareIsolatedBacking for TdxBacked {
         this.backing.vtls[vtl].interruption_information = new_intr;
         this.backing.vtls[vtl].exception_error_code = event.error_code();
     }
+
+    fn cr4_for_cpuid(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> u64 {
+        this.backing.vtls[vtl].cr4.read(&this.runner)
+    }
 }
 
 /// Partition-wide shared data for TDX VPs.
@@ -583,7 +586,7 @@ pub struct TdxBackedShared {
 impl TdxBackedShared {
     pub(crate) fn new(
         partition_params: &UhPartitionNewParams<'_>,
-        params: BackingSharedParams,
+        params: BackingSharedParams<'_>,
     ) -> Result<Self, crate::Error> {
         // Create a second synic to fully manage the untrusted SINTs
         // here. At time of writing, the hypervisor does not support
@@ -1739,40 +1742,15 @@ impl UhProcessor<'_, TdxBacked> {
                 &mut self.backing.vtls[intercepted_vtl].exit_stats.msr_write
             }
             VmxExitBasic::CPUID => {
-                let xss = self.backing.vtls[intercepted_vtl].private_regs.msr_xss;
                 let gps = self.runner.tdx_enter_guest_gps();
                 let leaf = gps[TdxGp::RAX] as u32;
                 let subleaf = gps[TdxGp::RCX] as u32;
-                let xfem = self
-                    .runner
-                    .get_vp_register(intercepted_vtl, HvX64RegisterName::Xfem)
-                    .map_err(|err| VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err)))?
-                    .as_u64();
-                let guest_state = crate::cvm_cpuid::CpuidGuestState {
-                    xfem,
-                    xss,
-                    cr4: self.backing.vtls[intercepted_vtl].cr4.read(&self.runner),
-                    apic_id: self.inner.vp_info.apic_id,
-                };
-
-                let result =
-                    self.shared
-                        .cvm
-                        .cpuid
-                        .guest_result(CpuidFunction(leaf), subleaf, &guest_state);
-
-                let [eax, ebx, ecx, edx] = self.partition.cpuid_result(
-                    leaf,
-                    subleaf,
-                    &[result.eax, result.ebx, result.ecx, result.edx],
-                );
-
+                let [eax, ebx, ecx, edx] = self.cvm_cpuid_result(intercepted_vtl, leaf, subleaf);
                 let gps = self.runner.tdx_enter_guest_gps_mut();
                 gps[TdxGp::RAX] = eax.into();
                 gps[TdxGp::RBX] = ebx.into();
                 gps[TdxGp::RCX] = ecx.into();
                 gps[TdxGp::RDX] = edx.into();
-
                 self.advance_to_next_instruction(intercepted_vtl);
                 &mut self.backing.vtls[intercepted_vtl].exit_stats.cpuid
             }

--- a/vm/vmcore/vm_topology/src/processor/x86.rs
+++ b/vm/vmcore/vm_topology/src/processor/x86.rs
@@ -141,7 +141,7 @@ impl TopologyBuilder<X86Topology> {
                 let ecx = ExtendedAddressSpaceSizesEcx::from(ecx);
 
                 vps_per_socket = if ecx.apic_core_id_size() != 0 {
-                    ecx.apic_core_id_size().into()
+                    1 << ecx.apic_core_id_size()
                 } else {
                     ecx.nc() as u32 + 1
                 };

--- a/vmm_core/virt/src/cpuid.rs
+++ b/vmm_core/virt/src/cpuid.rs
@@ -92,7 +92,7 @@ impl CpuidLeaf {
 }
 
 /// A collection of CPUID results.
-#[derive(Debug, Inspect)]
+#[derive(Debug, Inspect, Default)]
 pub struct CpuidLeafSet {
     #[inspect(
         flatten,
@@ -124,11 +124,9 @@ impl CpuidLeafSet {
         Self { leaves }
     }
 
-    /// Extends this result collection with additional `leaves`, which are
-    /// merged as in [`new`](Self::new).
-    pub fn extend(&mut self, leaves: &[CpuidLeaf]) {
-        self.leaves.extend(leaves);
-        *self = Self::new(std::mem::take(&mut self.leaves));
+    /// Returns the merged leaves.
+    pub fn into_leaves(self) -> Vec<CpuidLeaf> {
+        self.leaves
     }
 
     /// Returns the merged leaves.
@@ -146,16 +144,5 @@ impl CpuidLeafSet {
             x.apply(&mut result);
         }
         result
-    }
-
-    /// Updates an existing result to have the new value
-    /// Returns false if the leaf was not found
-    pub fn update_result(&mut self, eax: u32, ecx: u32, new_values: &[u32; 4]) -> bool {
-        if let Some(x) = self.leaves.iter_mut().find(|x| x.matches(eax, ecx)) {
-            x.result = *new_values;
-            return true;
-        }
-
-        false
     }
 }


### PR DESCRIPTION
Move the cvm_cpuid fixups (e.g., per-VP topology changes and
xfem-dependent xsave fields) out into the CVM partition code, so that
cvm_cpuid is only responsible for static data.

Use data from `X86PartitionCapabilities` to compute the xsave sizes
rather than recompute them from the cpuid data.

Use data from `ProcessorTopology` to compute the AMD topology leaf at
runtime.

Fix AMD processor topology computation.

Incorporate cvm_cpuid static data into the existing `CpuidLeafSet`
structure for looking up cpuid results.

Future changes should further simplify `cvm_cpuid`, but at least it is
no longer a separate thing at runtime.
