### PR TITLE
tmk: add simple VMM for running TMKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6392,6 +6392,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simple_tmk"
+version = "0.0.0"
+dependencies = [
+ "minimal_rt",
+ "minimal_rt_build",
+ "tmk_protocol",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6774,6 +6783,43 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tmk_protocol"
+version = "0.0.0"
+
+[[package]]
+name = "tmk_vmm"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "build_rs_guest_arch",
+ "clap",
+ "fs-err",
+ "futures",
+ "guestmem",
+ "hvdef",
+ "loader",
+ "mesh",
+ "page_table",
+ "pal_async",
+ "pal_uring",
+ "tmk_protocol",
+ "tracing",
+ "tracing-subscriber",
+ "tracing_helpers",
+ "underhill_mem",
+ "virt",
+ "virt_hvf",
+ "virt_kvm",
+ "virt_mshv",
+ "virt_mshv_vtl",
+ "virt_whp",
+ "vm_loader",
+ "vm_topology",
+ "vmcore",
+ "x86defs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ members = [
   "petri/make_imc_hive",
   "vm/loader/igvmfilegen",
   "vm/vmgs/vmgs_lib",
-  "vm/vmgs/vmgstool", "tmk/tmk_protocol",
+  "vm/vmgs/vmgstool",
 ]
 exclude = [
   "xsync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ members = [
   "openhcl/openvmm_hcl",
   "openhcl/sidecar",
   "openhcl/vmfirmwareigvm_dll",
+  # tmk
+  "tmk/tmk_vmm",
+  "tmk/simple_tmk",
   # VMM tests
   "vmm_tests/vmm_tests",
   # hyper-v tooling
@@ -41,7 +44,7 @@ members = [
   "petri/make_imc_hive",
   "vm/loader/igvmfilegen",
   "vm/vmgs/vmgs_lib",
-  "vm/vmgs/vmgstool",
+  "vm/vmgs/vmgstool", "tmk/tmk_protocol",
 ]
 exclude = [
   "xsync",
@@ -172,6 +175,8 @@ openhcl_attestation_protocol = { path = "openhcl/openhcl_attestation_protocol" }
 openvmm_hcl_resources = { path = "openhcl/openvmm_hcl_resources" }
 underhill_threadpool = { path = "openhcl/underhill_threadpool" }
 virt_mshv_vtl = { path = "openhcl/virt_mshv_vtl" }
+
+tmk_protocol = { path = "tmk/tmk_protocol" }
 
 aarch64defs = { path = "vm/aarch64/aarch64defs" }
 aarch64emu = { path = "vm/aarch64/aarch64emu" }
@@ -574,6 +579,13 @@ panic = 'abort'
 codegen-units = 1
 opt-level = 'z'
 lto = 'fat'
+
+# Optimize minimal_rt even in the dev profile to ensure no relocations creep
+# into the relocate function.
+#
+# FUTURE: rewrite relocator in asm to avoid depending on this.
+[profile.dev.package.minimal_rt]
+opt-level = 1
 
 [patch.crates-io]
 # Pending <https://github.com/ferrilab/bitvec/pull/273>

--- a/openhcl/rootfs.config
+++ b/openhcl/rootfs.config
@@ -49,6 +49,10 @@ slink /underhill-init       /bin/openvmm_hcl 0755 0 0
 slink /bin/underhill-crash  /bin/openvmm_hcl 0755 0 0
 slink /bin/underhill-dump   /bin/openvmm_hcl 0755 0 0
 
+file /bin/tmk_vmm target/x86_64-unknown-linux-musl/debug/tmk_vmm 0755 0 0
+dir /tmk 0755 0 0
+file /tmk/simple_tmk target/x86_64-unknown-none/debug/simple_tmk 0644 0 0
+
 # The build information
 file /etc/underhill-build-info.json  ${OPENHCL_BUILD_INFO}   0644 0 0
 file /etc/kernel-build-info.json     ${OPENHCL_KERNEL_PATH}/build/native/bin/kernel_build_metadata.json   0644 0 0

--- a/openhcl/rootfs.config
+++ b/openhcl/rootfs.config
@@ -49,10 +49,6 @@ slink /underhill-init       /bin/openvmm_hcl 0755 0 0
 slink /bin/underhill-crash  /bin/openvmm_hcl 0755 0 0
 slink /bin/underhill-dump   /bin/openvmm_hcl 0755 0 0
 
-file /bin/tmk_vmm target/x86_64-unknown-linux-musl/debug/tmk_vmm 0755 0 0
-dir /tmk 0755 0 0
-file /tmk/simple_tmk target/x86_64-unknown-none/debug/simple_tmk 0644 0 0
-
 # The build information
 file /etc/underhill-build-info.json  ${OPENHCL_BUILD_INFO}   0644 0 0
 file /etc/kernel-build-info.json     ${OPENHCL_KERNEL_PATH}/build/native/bin/kernel_build_metadata.json   0644 0 0

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1439,22 +1439,23 @@ async fn new_underhill_vm(
         .context("failed to create prototype partition")?;
 
     let gm = underhill_mem::init(&underhill_mem::Init {
-        tp,
         processor_topology: &processor_topology,
         isolation,
         vtl0_alias_map_bit,
         vtom,
         mem_layout: &mem_layout,
         complete_memory_layout: &complete_memory_layout,
-        boot_init,
+        boot_init: boot_init.then_some(underhill_mem::BootInit {
+            tp,
+            vtl2_memory: runtime_params.vtl2_memory_map(),
+            accepted_regions: measured_vtl2_info.accepted_regions(),
+        }),
         shared_pool: &shared_pool,
         maximum_vtl: if proto_partition.guest_vsm_available() {
             Vtl::Vtl1
         } else {
             Vtl::Vtl0
         },
-        vtl2_memory: runtime_params.vtl2_memory_map(),
-        accepted_regions: measured_vtl2_info.accepted_regions(),
     })
     .await
     .context("failed to initialize memory")?;

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -9,6 +9,7 @@ mod init;
 mod mapping;
 mod registrar;
 
+pub use init::BootInit;
 pub use init::Init;
 pub use init::MemoryMappings;
 pub use init::init;

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -92,6 +92,11 @@ pub struct Options {
     #[clap(long, requires("hv"))]
     pub get: bool,
 
+    /// Disable GET and related devices for using the OpenHCL paravisor, even
+    /// when --vtl2 is passed.
+    #[clap(long, conflicts_with("get"))]
+    pub no_get: bool,
+
     /// The disk to use for the GET VMGS.
     ///
     /// If this is not provided, then a 4MB RAM disk will be used.

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -441,7 +441,7 @@ fn vm_config_from_command_line(
         );
     }
 
-    let with_get = opt.get || opt.vtl2;
+    let with_get = opt.get || (opt.vtl2 && !opt.no_get);
 
     let mut storage = storage_builder::StorageBuilder::new(with_get.then_some(openhcl_vtl));
     for &cli_args::DiskCli {

--- a/tmk/simple_tmk/Cargo.toml
+++ b/tmk/simple_tmk/Cargo.toml
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "simple_tmk"
+rust-version.workspace = true
+edition.workspace = true
+
+[dependencies]
+minimal_rt.workspace = true
+tmk_protocol.workspace = true
+
+[build-dependencies]
+minimal_rt_build.workspace = true
+
+[lints]
+workspace = true

--- a/tmk/simple_tmk/build.rs
+++ b/tmk/simple_tmk/build.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Build script for the simple TMK, needed to build with `minimal_rt`.
+
+fn main() {
+    minimal_rt_build::init();
+}

--- a/tmk/simple_tmk/src/main.rs
+++ b/tmk/simple_tmk/src/main.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! A simple test microkernel (TMK) for testing very basic VMM functionality.
+
+#![cfg_attr(minimal_rt, no_std, no_main)]
+
+#[cfg(all(minimal_rt, target_arch = "x86_64"))]
+mod tmk;
+
+#[cfg(not(minimal_rt))]
+fn main() {
+    unimplemented!("build with MINIMAL_RT_BUILD to produce a working binary");
+}

--- a/tmk/simple_tmk/src/tmk.rs
+++ b/tmk/simple_tmk/src/tmk.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// UNSAFETY: needed to write low-level TMK code.
+#![expect(unsafe_code)]
+
+use core::arch::global_asm;
+use core::marker::PhantomData;
+
+#[repr(C)]
+struct Str<'a>(*const u8, usize, PhantomData<&'a str>);
+
+// SAFETY: `Str` is an ABI-safe type for &str, which is Send+Sync.
+unsafe impl Send for Str<'_> {}
+// SAFETY: `Str` is an ABI-safe type for &str, which is Send+Sync.
+unsafe impl Sync for Str<'_> {}
+
+impl<'a> Str<'a> {
+    const fn new(s: &'a str) -> Self {
+        Self(s.as_ptr(), s.len(), PhantomData)
+    }
+}
+
+static HELLO_WORLD: Str<'static> = Str::new("hello world");
+
+global_asm! {
+    ".globl _start",
+    "_start:",
+    "lea rsp, {STACK_SIZE} + {stack}[rip]",
+    "lea rdx, _DYNAMIC[rip]",
+    "lea rdi, __ehdr_start[rip]",
+    "mov rsi, rdi",
+    "call {relocate}",
+    "mov rcx, {TMK_ADDRESS_LOG}",
+    "lea rdx, {hello_world}[rip]",
+    "mov qword ptr [rcx], rdx",
+    "mov rcx, {TMK_ADDRESS_COMPLETE}",
+    "mov byte ptr [rcx], 0",
+    "2: hlt",
+    "jmp 2b",
+    hello_world = sym HELLO_WORLD,
+    relocate = sym minimal_rt::reloc::relocate,
+    stack = sym STACK,
+    STACK_SIZE = const STACK_SIZE - 16,
+    TMK_ADDRESS_LOG = const tmk_protocol::TMK_ADDRESS_LOG,
+    TMK_ADDRESS_COMPLETE = const tmk_protocol::TMK_ADDRESS_COMPLETE,
+}
+
+const STACK_SIZE: usize = 4096;
+#[repr(C, align(16))]
+struct Stack([u8; STACK_SIZE]);
+#[unsafe(no_mangle)]
+static mut STACK: Stack = Stack([0; STACK_SIZE]);
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
+    minimal_rt::arch::fault();
+}

--- a/tmk/tmk_protocol/Cargo.toml
+++ b/tmk/tmk_protocol/Cargo.toml
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "tmk_protocol"
+rust-version.workspace = true
+edition.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/tmk/tmk_protocol/src/lib.rs
+++ b/tmk/tmk_protocol/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Definitions for the protocol between `tmk_vmm` and the test microkernel.
+
+#![no_std]
+
+/// Address for logging. Write `&[gpa, len]: &[u64; 2]` of a UTF-8 string to
+/// log.
+pub const TMK_ADDRESS_LOG: u64 = 0xffff0000;
+/// Address for reporting test completion. Write 0 to signal completion.
+pub const TMK_ADDRESS_COMPLETE: u64 = 0xffff0008;

--- a/tmk/tmk_vmm/Cargo.toml
+++ b/tmk/tmk_vmm/Cargo.toml
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "tmk_vmm"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tmk_protocol.workspace = true
+
+hvdef.workspace = true
+loader.workspace = true
+guestmem.workspace = true
+page_table.workspace = true
+virt.workspace = true
+vm_topology.workspace = true
+vmcore.workspace = true
+vm_loader.workspace = true
+x86defs.workspace = true
+
+pal_async.workspace = true
+mesh.workspace = true
+tracing_helpers.workspace = true
+
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+fs-err.workspace = true
+futures.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+virt_whp.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+pal_uring.workspace = true
+underhill_mem.workspace = true
+virt_kvm.workspace = true
+virt_mshv.workspace = true
+virt_mshv_vtl.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+virt_hvf.workspace = true
+
+[build-dependencies]
+build_rs_guest_arch.workspace = true
+
+[lints]
+workspace = true

--- a/tmk/tmk_vmm/build.rs
+++ b/tmk/tmk_vmm/build.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Build script for the TMK VMM.
+
+fn main() {
+    build_rs_guest_arch::emit_guest_arch()
+}

--- a/tmk/tmk_vmm/src/host_vmm.rs
+++ b/tmk/tmk_vmm/src/host_vmm.rs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Support for running as a host VMM.
+
+use crate::run::CommonState;
+use crate::run::RunnerBuilder;
+use anyhow::Context as _;
+use futures::executor::block_on;
+use guestmem::GuestMemory;
+use hvdef::Vtl;
+use std::future::Future;
+use std::future::poll_fn;
+use std::pin::pin;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Waker;
+use virt::BindProcessor;
+use virt::Hypervisor;
+use virt::Partition;
+use virt::PartitionConfig;
+use virt::PartitionMemoryMapper;
+use virt::ProtoPartition;
+use virt::ProtoPartitionConfig;
+use virt::VpIndex;
+
+impl CommonState {
+    pub async fn run_host_vmm<H: Hypervisor>(&mut self, mut hv: H) -> anyhow::Result<()>
+    where
+        H::Partition: Partition + PartitionMemoryMapper,
+    {
+        let proto = hv
+            .new_partition(ProtoPartitionConfig {
+                processor_topology: &self.processor_topology,
+                hv_config: None,
+                vmtime: &self.vmtime_source,
+                user_mode_apic: false,
+                isolation: virt::IsolationType::None,
+            })
+            .context("failed to create proto partition")?;
+
+        let guest_memory = GuestMemory::allocate(self.memory_layout.end_of_ram() as usize);
+
+        let (partition, vps) = proto
+            .build(PartitionConfig {
+                mem_layout: &self.memory_layout,
+                guest_memory: &guest_memory,
+                cpuid: &[],
+                vtl0_alias_map: None,
+            })
+            .context("failed to build partition")?;
+
+        let partition = Arc::new(partition);
+
+        // Map guest memory.
+        for r in self.memory_layout.ram() {
+            let range = r.range;
+            // SAFETY: the guest memory is left alive as long as the partition
+            // is using it.
+            unsafe {
+                partition
+                    .memory_mapper(Vtl::Vtl0)
+                    .map_range(
+                        guest_memory.inner_buf().unwrap()
+                            [range.start() as usize..range.end() as usize]
+                            .as_ptr()
+                            .cast_mut()
+                            .cast(),
+                        range.len() as usize,
+                        range.start(),
+                        true,
+                        true,
+                    )
+                    .context("failed to map memory")
+            }?;
+        }
+
+        self.run(&guest_memory, partition.caps(), async |_this, runner| {
+            let [vp] = vps.try_into().ok().unwrap();
+            start_vp(partition.clone(), vp, runner).await?;
+            Ok(())
+        })
+        .await
+    }
+}
+
+trait RequestYield: Send + Sync {
+    /// Forces the run_vp call to yield to the scheduler (i.e. return
+    /// Poll::Pending).
+    fn request_yield(&self, vp_index: VpIndex);
+}
+
+impl<T: Partition> RequestYield for T {
+    fn request_yield(&self, vp_index: VpIndex) {
+        self.request_yield(vp_index)
+    }
+}
+
+struct VpWaker {
+    partition: Arc<dyn RequestYield>,
+    vp: VpIndex,
+    inner: Waker,
+}
+
+impl VpWaker {
+    fn new(partition: Arc<dyn RequestYield>, vp: VpIndex, waker: Waker) -> Self {
+        Self {
+            partition,
+            vp,
+            inner: waker,
+        }
+    }
+}
+
+impl std::task::Wake for VpWaker {
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.partition.request_yield(self.vp);
+        self.inner.wake_by_ref();
+    }
+
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref()
+    }
+}
+
+async fn start_vp(
+    partition: Arc<dyn RequestYield>,
+    mut vp: impl 'static + BindProcessor + Send,
+    mut runner: RunnerBuilder,
+) -> anyhow::Result<()> {
+    let (bind_result_send, bind_result_recv) = mesh::oneshot();
+    let _vp_thread = std::thread::spawn(move || {
+        let vp_index = VpIndex::BSP;
+        let r = vp
+            .bind()
+            .context("failed to bind vp")
+            .and_then(|vp| runner.build(vp));
+        let (vp, r) = match r {
+            Ok(vp) => (Some(vp), Ok(())),
+            Err(err) => (None, Err(err)),
+        };
+
+        bind_result_send.send(r);
+        let Some(mut vp) = vp else { return };
+        block_on(async {
+            let mut run = pin!(vp.run_vp());
+            poll_fn(|cx| {
+                let waker = Waker::from(Arc::new(VpWaker::new(
+                    partition.clone(),
+                    vp_index,
+                    cx.waker().clone(),
+                )));
+                run.as_mut().poll(&mut Context::from_waker(&waker))
+            })
+            .await
+        })
+    });
+
+    bind_result_recv.await.unwrap()
+}

--- a/tmk/tmk_vmm/src/host_vmm.rs
+++ b/tmk/tmk_vmm/src/host_vmm.rs
@@ -3,6 +3,9 @@
 
 //! Support for running as a host VMM.
 
+// UNSAFETY: needed to map guest memory.
+#![expect(unsafe_code)]
+
 use crate::run::CommonState;
 use crate::run::RunnerBuilder;
 use anyhow::Context as _;

--- a/tmk/tmk_vmm/src/load.rs
+++ b/tmk/tmk_vmm/src/load.rs
@@ -71,7 +71,6 @@ pub fn load_x86(
             | x86defs::X64_EFER_LMA
             | x86defs::X64_EFER_NXE,
     ))?;
-    import_reg(X86Register::Pat(x86defs::X86X_MSR_DEFAULT_PAT))?;
     import_reg(X86Register::Rip(load_info.entrypoint))?;
 
     let regs = vm_loader::initial_regs::x86_initial_regs(

--- a/tmk/tmk_vmm/src/load.rs
+++ b/tmk/tmk_vmm/src/load.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Support for loading a TMK into VM memory.
+
+use anyhow::Context as _;
+use fs_err::File;
+use guestmem::GuestMemory;
+use hvdef::Vtl;
+use loader::importer::ImageLoad;
+use loader::importer::X86Register;
+use std::sync::Arc;
+use virt::VpIndex;
+use vm_topology::memory::MemoryLayout;
+use vm_topology::processor::ProcessorTopology;
+use vm_topology::processor::x86::X86Topology;
+
+/// Loads a TMK, returning the initial registers for the BSP.
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
+pub fn load_x86(
+    memory_layout: &MemoryLayout,
+    guest_memory: &GuestMemory,
+    processor_topology: &ProcessorTopology<X86Topology>,
+    caps: &virt::x86::X86PartitionCapabilities,
+    tmk: &File,
+) -> anyhow::Result<Arc<virt::x86::X86InitialRegs>> {
+    let mut loader = vm_loader::Loader::new(guest_memory.clone(), memory_layout, Vtl::Vtl0);
+    let load_info = loader::elf::load_static_elf(
+        &mut loader,
+        &mut &*tmk,
+        0,
+        0x200000,
+        false,
+        loader::importer::BootPageAcceptance::Exclusive,
+        "tmk",
+    )
+    .context("failed to load tmk")?;
+
+    let page_table_base = load_info.next_available_address;
+    let page_tables = page_table::x64::build_page_tables_64(
+        page_table_base,
+        0,
+        page_table::IdentityMapSize::Size4Gb,
+        None,
+    );
+    loader
+        .import_pages(
+            page_table_base >> 12,
+            page_tables.len() as u64 >> 12,
+            "page_tables",
+            loader::importer::BootPageAcceptance::Exclusive,
+            &page_tables,
+        )
+        .context("failed to import page tables")?;
+
+    let gdt_base = page_table_base + page_tables.len() as u64;
+    loader::common::import_default_gdt(&mut loader, gdt_base >> 12)
+        .context("failed to import gdt")?;
+
+    let mut import_reg = |reg| {
+        loader
+            .import_vp_register(reg)
+            .context("failed to set register")
+    };
+    import_reg(X86Register::Cr0(x86defs::X64_CR0_PG | x86defs::X64_CR0_PE))?;
+    import_reg(X86Register::Cr3(page_table_base))?;
+    import_reg(X86Register::Cr4(x86defs::X64_CR4_PAE))?;
+    import_reg(X86Register::Efer(
+        x86defs::X64_EFER_SCE
+            | x86defs::X64_EFER_LME
+            | x86defs::X64_EFER_LMA
+            | x86defs::X64_EFER_NXE,
+    ))?;
+    import_reg(X86Register::Pat(x86defs::X86X_MSR_DEFAULT_PAT))?;
+    import_reg(X86Register::Rip(load_info.entrypoint))?;
+
+    let regs = vm_loader::initial_regs::x86_initial_regs(
+        &loader.initial_regs(),
+        caps,
+        &processor_topology.vp_arch(VpIndex::BSP),
+    );
+    Ok(regs)
+}

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! A simple VMM for loading and running test microkernels (TMKs) but does not
+//! support general-purpose VMs.
+//!
+//! This is used to test the underlying VMM infrastructure without the complexity
+//! of the full OpenVMM stack.
+
+// UNSAFETY: needed to map guest memory.
+#![expect(unsafe_code)]
+
+mod host_vmm;
+mod load;
+mod paravisor_vmm;
+mod run;
+
+use clap::Parser;
+use pal_async::DefaultDriver;
+use pal_async::DefaultPool;
+use run::CommonState;
+use std::path::PathBuf;
+
+fn main() -> anyhow::Result<()> {
+    DefaultPool::run_with(do_main)
+}
+
+#[derive(Parser)]
+struct Options {
+    /// The hypervisor to use.
+    #[clap(long)]
+    hv: HypervisorOpt,
+    /// The path to the TMK binary.
+    #[clap(long)]
+    tmk: PathBuf,
+}
+
+#[derive(clap::ValueEnum, Clone)]
+enum HypervisorOpt {
+    #[cfg(target_os = "linux")]
+    Kvm,
+    #[cfg(all(target_os = "linux", guest_arch = "x86_64"))]
+    Mshv,
+    #[cfg(target_os = "linux")]
+    MshvVtl,
+    #[cfg(target_os = "windows")]
+    Whp,
+    #[cfg(target_os = "macos")]
+    Hvf,
+}
+
+async fn do_main(driver: DefaultDriver) -> anyhow::Result<()> {
+    let opts = Options::parse();
+
+    tracing_subscriber::fmt()
+        .fmt_fields(tracing_helpers::formatter::FieldFormatter)
+        .init();
+
+    let mut state = CommonState::new(driver, opts).await?;
+
+    match state.opts.hv {
+        #[cfg(target_os = "linux")]
+        HypervisorOpt::Kvm => state.run_host_vmm(virt_kvm::Kvm).await,
+        #[cfg(all(target_os = "linux", guest_arch = "x86_64"))]
+        HypervisorOpt::Mshv => state.run_host_vmm(virt_mshv::LinuxMshv).await,
+        #[cfg(target_os = "linux")]
+        HypervisorOpt::MshvVtl => state.run_paravisor_vmm(virt::IsolationType::None).await,
+        #[cfg(windows)]
+        HypervisorOpt::Whp => state.run_host_vmm(virt_whp::Whp).await,
+        #[cfg(target_os = "macos")]
+        HypervisorOpt::Hvf => state.run_host_vmm(virt_hvf::HvfHypervisor).await,
+    }
+}

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -7,9 +7,6 @@
 //! This is used to test the underlying VMM infrastructure without the complexity
 //! of the full OpenVMM stack.
 
-// UNSAFETY: needed to map guest memory.
-#![expect(unsafe_code)]
-
 mod host_vmm;
 mod load;
 mod paravisor_vmm;

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -31,9 +31,15 @@ fn main() -> anyhow::Result<()> {
     DefaultPool::run_with(do_main)
 }
 
+/// A simple VMM for loading and running test microkernels (TMKs).
+///
+/// This is used to test the underlying VMM infrastructure without the complexity
+/// of the full OpenVMM stack.
+///
+/// This can run either on a host or inside a paravisor environment.
 #[derive(Parser)]
 struct Options {
-    /// The hypervisor to use.
+    /// The hypervisor interface to use to run the TMK.
     #[clap(long)]
     hv: HypervisorOpt,
     /// The path to the TMK binary.
@@ -43,14 +49,20 @@ struct Options {
 
 #[derive(clap::ValueEnum, Clone)]
 enum HypervisorOpt {
+    /// Use KVM to run the TMK.
     #[cfg(target_os = "linux")]
     Kvm,
+    /// Use mshv to run the TMK.
     #[cfg(all(target_os = "linux", guest_arch = "x86_64"))]
     Mshv,
+    /// Use mshv-vtl to run the TMK; only supported inside a paravisor
+    /// environment.
     #[cfg(target_os = "linux")]
     MshvVtl,
+    /// Use WHP to run the TMK.
     #[cfg(target_os = "windows")]
     Whp,
+    /// Use Hypervisor.Framework to run the TMK.
     #[cfg(target_os = "macos")]
     Hvf,
 }

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -20,8 +20,14 @@ use pal_async::DefaultDriver;
 use pal_async::DefaultPool;
 use run::CommonState;
 use std::path::PathBuf;
+use tracing_subscriber::fmt::format::FmtSpan;
 
 fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .fmt_fields(tracing_helpers::formatter::FieldFormatter)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+        .init();
+
     DefaultPool::run_with(do_main)
 }
 
@@ -51,10 +57,6 @@ enum HypervisorOpt {
 
 async fn do_main(driver: DefaultDriver) -> anyhow::Result<()> {
     let opts = Options::parse();
-
-    tracing_subscriber::fmt()
-        .fmt_fields(tracing_helpers::formatter::FieldFormatter)
-        .init();
 
     let mut state = CommonState::new(driver, opts).await?;
 

--- a/tmk/tmk_vmm/src/paravisor_vmm.rs
+++ b/tmk/tmk_vmm/src/paravisor_vmm.rs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Support for running as a paravisor VMM.
+
+#![cfg(target_os = "linux")]
+
+use crate::run::CommonState;
+use crate::run::RunnerBuilder;
+use guestmem::GuestMemory;
+use std::sync::Arc;
+use virt::Partition;
+use virt_mshv_vtl::UhLateParams;
+use virt_mshv_vtl::UhPartitionNewParams;
+use virt_mshv_vtl::UhProcessorBox;
+
+impl CommonState {
+    pub async fn run_paravisor_vmm(
+        &mut self,
+        isolation: virt::IsolationType,
+    ) -> anyhow::Result<()> {
+        let params = UhPartitionNewParams {
+            isolation,
+            hide_isolation: false,
+            lower_vtl_memory_layout: &self.memory_layout,
+            topology: &self.processor_topology,
+            cvm_cpuid_info: None,
+            snp_secrets: None,
+            env_cvm_guest_vsm: false,
+            vtom: None,
+            handle_synic: true,
+            no_sidecar_hotplug: false,
+            use_mmio_hypercalls: false,
+            intercept_debug_exceptions: false,
+        };
+        let p = virt_mshv_vtl::UhProtoPartition::new(params, |_| self.driver.clone())?;
+
+        let m = underhill_mem::init(&underhill_mem::Init {
+            processor_topology: &self.processor_topology,
+            isolation,
+            vtl0_alias_map_bit: None,
+            vtom: None,
+            mem_layout: &self.memory_layout,
+            complete_memory_layout: &self.memory_layout,
+            boot_init: None,
+            shared_pool: &[],
+            maximum_vtl: hvdef::Vtl::Vtl0,
+        })
+        .await?;
+
+        let (partition, vps) = p
+            .build(UhLateParams {
+                gm: [
+                    m.vtl0().clone(),
+                    m.vtl1().cloned().unwrap_or(GuestMemory::empty()),
+                ]
+                .into(),
+                #[cfg(guest_arch = "x86_64")]
+                cpuid: Vec::new(),
+                crash_notification_send: mesh::channel().0,
+                vmtime: &self.vmtime_source,
+                shared_dma_client: None,
+                private_dma_client: None,
+                cvm_params: None,
+            })
+            .await?;
+
+        let partition = Arc::new(partition);
+
+        self.run(m.vtl0(), partition.caps(), async |_this, runner| {
+            let [vp] = vps.try_into().ok().unwrap();
+            start_vp(vp, runner).await?;
+            Ok(())
+        })
+        .await
+    }
+}
+
+async fn start_vp(mut vp: UhProcessorBox, mut runner: RunnerBuilder) -> anyhow::Result<()> {
+    std::thread::spawn(move || {
+        let pool = pal_uring::IoUringPool::new("vp", 256).unwrap();
+        let driver = pool.client().initiator().clone();
+        pool.client().set_idle_task(async move |mut control| {
+            let vp = vp
+                .bind_processor::<virt_mshv_vtl::HypervisorBacked>(&driver, Some(&mut control))
+                .unwrap();
+
+            runner.build(vp).unwrap().run_vp().await;
+        });
+        pool.run()
+    });
+    Ok(())
+}

--- a/tmk/tmk_vmm/src/run.rs
+++ b/tmk/tmk_vmm/src/run.rs
@@ -1,0 +1,307 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Support for running a VM's VPs.
+
+#![cfg_attr(
+    guest_arch = "aarch64",
+    expect(unreachable_code),
+    expect(dead_code),
+    expect(unused_imports),
+    expect(unused_variables),
+    expect(unused_mut)
+)]
+
+use crate::Options;
+use crate::load;
+use anyhow::Context as _;
+use futures::StreamExt as _;
+use guestmem::GuestMemory;
+use hvdef::HvError;
+use hvdef::Vtl;
+use pal_async::DefaultDriver;
+use std::sync::Arc;
+use virt::PartitionCapabilities;
+use virt::Processor;
+use virt::StopVpSource;
+use virt::VpIndex;
+use virt::io::CpuIo;
+use virt::vp::AccessVpState as _;
+use vm_topology::memory::MemoryLayout;
+use vm_topology::processor::ProcessorTopology;
+use vm_topology::processor::TopologyBuilder;
+use vmcore::vmtime::VmTime;
+use vmcore::vmtime::VmTimeKeeper;
+use vmcore::vmtime::VmTimeSource;
+
+pub struct CommonState {
+    #[allow(dead_code)] // Only used in some configurations.
+    pub driver: DefaultDriver,
+    pub vmtime_keeper: VmTimeKeeper,
+    pub vmtime_source: VmTimeSource,
+    pub opts: Options,
+    pub processor_topology: ProcessorTopology,
+    pub memory_layout: MemoryLayout,
+}
+
+impl CommonState {
+    pub async fn new(driver: DefaultDriver, opts: Options) -> anyhow::Result<Self> {
+        let vmtime_keeper = VmTimeKeeper::new(&driver, VmTime::from_100ns(0));
+        let vmtime_source = vmtime_keeper.builder().build(&driver).await.unwrap();
+        #[cfg(guest_arch = "x86_64")]
+        let processor_topology = TopologyBuilder::new_x86()
+            .build(1)
+            .context("failed to build processor topology")?;
+
+        #[cfg(guest_arch = "aarch64")]
+        anyhow::bail!("aarch64 not supported yet");
+        #[cfg(guest_arch = "aarch64")]
+        let processor_topology = TopologyBuilder::new_aarch64(todo!())
+            .build(1)
+            .context("failed to build processor topology")?;
+
+        let ram_size = 0x400000;
+        let memory_layout = MemoryLayout::new(ram_size, &[], None).context("bad memory layout")?;
+
+        Ok(Self {
+            driver,
+            vmtime_keeper,
+            vmtime_source,
+            opts,
+            processor_topology,
+            memory_layout,
+        })
+    }
+
+    pub async fn run(
+        &mut self,
+        guest_memory: &GuestMemory,
+        caps: &PartitionCapabilities,
+        start_vp: impl AsyncFnOnce(&mut Self, RunnerBuilder) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        let (event_send, mut event_recv) = mesh::channel();
+
+        // Load the TMK.
+        let regs = {
+            let tmk = fs_err::File::open(&self.opts.tmk).context("failed to open tmk")?;
+            #[cfg(guest_arch = "x86_64")]
+            {
+                load::load_x86(
+                    &self.memory_layout,
+                    guest_memory,
+                    &self.processor_topology,
+                    caps,
+                    &tmk,
+                )?
+            }
+            #[cfg(guest_arch = "aarch64")]
+            {
+                anyhow::bail!("aarch64 not supported yet");
+            }
+        };
+
+        self.vmtime_keeper.start().await;
+
+        start_vp(
+            self,
+            RunnerBuilder::new(
+                VpIndex::BSP,
+                Arc::clone(&regs),
+                guest_memory.clone(),
+                event_send.clone(),
+            ),
+        )
+        .await?;
+
+        let event = event_recv.next().await.unwrap();
+        match event {
+            VpEvent::TestComplete => {
+                tracing::info!("test complete");
+                Ok(())
+            }
+            VpEvent::Halt {
+                vp_index,
+                reason,
+                regs,
+            } => {
+                anyhow::bail!(
+                    "vp {} halted: {}\nregisters:\n{:#x?}",
+                    vp_index.index(),
+                    reason,
+                    regs
+                );
+            }
+        }
+    }
+}
+
+enum VpEvent {
+    TestComplete,
+    Halt {
+        vp_index: VpIndex,
+        reason: String,
+        regs: Option<Box<virt::vp::Registers>>,
+    },
+}
+
+struct IoHandler<'a> {
+    guest_memory: &'a GuestMemory,
+    event_send: &'a mesh::Sender<VpEvent>,
+    stop: &'a StopVpSource,
+}
+
+fn widen(d: &[u8]) -> u64 {
+    let mut v = [0; 8];
+    v[..d.len()].copy_from_slice(d);
+    u64::from_ne_bytes(v)
+}
+
+impl CpuIo for IoHandler<'_> {
+    fn is_mmio(&self, _address: u64) -> bool {
+        false
+    }
+
+    fn acknowledge_pic_interrupt(&self) -> Option<u8> {
+        None
+    }
+
+    fn handle_eoi(&self, irq: u32) {
+        tracing::info!(irq, "eoi");
+    }
+
+    fn signal_synic_event(&self, vtl: Vtl, connection_id: u32, flag: u16) -> hvdef::HvResult<()> {
+        let _ = (vtl, connection_id, flag);
+        Err(HvError::InvalidConnectionId)
+    }
+
+    fn post_synic_message(
+        &self,
+        vtl: Vtl,
+        connection_id: u32,
+        secure: bool,
+        message: &[u8],
+    ) -> hvdef::HvResult<()> {
+        let _ = (vtl, connection_id, secure, message);
+        Err(HvError::InvalidConnectionId)
+    }
+
+    async fn read_mmio(&self, vp: VpIndex, address: u64, data: &mut [u8]) {
+        tracing::info!(vp = vp.index(), address, "read mmio");
+        data.fill(!0);
+    }
+
+    async fn write_mmio(&self, vp: VpIndex, address: u64, data: &[u8]) {
+        match address {
+            tmk_protocol::TMK_ADDRESS_LOG => {
+                let p = widen(data);
+                let [gpa, len]: [u64; 2] = self.guest_memory.read_plain(p).expect("BUGBUG");
+                let mut s = vec![0; len as usize];
+                self.guest_memory.read_at(gpa, &mut s).expect("BUGBUG");
+                let s = String::from_utf8(s).expect("BUGBUG");
+                tracing::info!(target: "tmk", message = s);
+            }
+            tmk_protocol::TMK_ADDRESS_COMPLETE => {
+                self.event_send.send(VpEvent::TestComplete);
+                self.stop.stop();
+            }
+            _ => {
+                tracing::info!(vp = vp.index(), address, data = widen(data), "write mmio");
+            }
+        }
+    }
+
+    async fn read_io(&self, vp: VpIndex, port: u16, data: &mut [u8]) {
+        tracing::info!(vp = vp.index(), port, "read io");
+        data.fill(!0);
+    }
+
+    async fn write_io(&self, vp: VpIndex, port: u16, data: &[u8]) {
+        tracing::info!(vp = vp.index(), port, data = widen(data), "write io");
+    }
+}
+
+pub struct RunnerBuilder {
+    vp_index: VpIndex,
+    regs: Arc<virt::InitialRegs>,
+    guest_memory: GuestMemory,
+    event_send: mesh::Sender<VpEvent>,
+}
+
+impl RunnerBuilder {
+    fn new(
+        vp_index: VpIndex,
+        regs: Arc<virt::InitialRegs>,
+        guest_memory: GuestMemory,
+        event_send: mesh::Sender<VpEvent>,
+    ) -> Self {
+        Self {
+            vp_index,
+            regs,
+            guest_memory,
+            event_send,
+        }
+    }
+
+    pub fn build<P: Processor>(&mut self, mut vp: P) -> anyhow::Result<Runner<'_, P>> {
+        {
+            let mut state = vp.access_state(Vtl::Vtl0);
+            #[cfg(guest_arch = "x86_64")]
+            {
+                let virt::x86::X86InitialRegs {
+                    registers,
+                    mtrrs,
+                    pat,
+                } = self.regs.as_ref();
+                state.set_registers(registers)?;
+                state.set_mtrrs(mtrrs)?;
+                state.set_pat(pat)?;
+            }
+            #[cfg(guest_arch = "aarch64")]
+            {
+                todo!()
+            }
+            state.commit()?;
+        }
+        Ok(Runner {
+            vp,
+            vp_index: self.vp_index,
+            guest_memory: &self.guest_memory,
+            event_send: &self.event_send,
+        })
+    }
+}
+
+pub struct Runner<'a, P> {
+    vp: P,
+    vp_index: VpIndex,
+    guest_memory: &'a GuestMemory,
+    event_send: &'a mesh::Sender<VpEvent>,
+}
+
+impl<P: Processor> Runner<'_, P> {
+    pub async fn run_vp(&mut self) {
+        let stop = StopVpSource::new();
+        let Err(err) = self
+            .vp
+            .run_vp(
+                stop.checker(),
+                &IoHandler {
+                    guest_memory: self.guest_memory,
+                    event_send: self.event_send,
+                    stop: &stop,
+                },
+            )
+            .await;
+        let regs = self
+            .vp
+            .access_state(Vtl::Vtl0)
+            .registers()
+            .map(Box::new)
+            .ok();
+        self.event_send.send(VpEvent::Halt {
+            vp_index: self.vp_index,
+            reason: format!("{:?}", err),
+            regs,
+        });
+    }
+}

--- a/vm/loader/src/lib.rs
+++ b/vm/loader/src/lib.rs
@@ -5,7 +5,7 @@
 #[warn(missing_docs)]
 pub mod common;
 pub mod cpuid;
-mod elf;
+pub mod elf;
 pub mod importer;
 pub mod linux;
 pub mod paravisor;

--- a/xtask/src/tasks/fmt/house_rules/cfg_target_arch.rs
+++ b/xtask/src/tasks/fmt/house_rules/cfg_target_arch.rs
@@ -74,7 +74,7 @@ pub fn check_cfg_target_arch(path: &Path, _fix: bool) -> anyhow::Result<()> {
     //
     // openhcl_boot uses target_arch liberally, since it runs in VTL2 entirely
     // in-service to the VTL2 linux kernel, which will always be native-arch.
-    // Similar for the sidecar kernel. And minimal_rt provides the
+    // Similar for the sidecar kernel and TMKs. And minimal_rt provides the
     // (arch-specific) runtime for both of them.
     //
     // safe_intrinsics performs architecture-specific operations that require
@@ -87,6 +87,7 @@ pub fn check_cfg_target_arch(path: &Path, _fix: bool) -> anyhow::Result<()> {
         || path.starts_with("openhcl/minimal_rt")
         || path.starts_with("openhcl/sidecar")
         || path.starts_with("support/safe_intrinsics")
+        || path.starts_with("tmk/simple_tmk")
         || path.starts_with("vm/whp")
         || path.starts_with("vm/kvm")
     {


### PR DESCRIPTION
To make it easier to test core `virt_*` functionality without all the accoutrements of a full-featured VMM (virtual devices, etc.), create a VMM that can just run simple test microkernels (TMKs) and not full guest operating systems.

This VMM can run either on the host or in a paravisor environment.

Current limitations:

* No docs on using this
* No integration with CI test pass
* x86_64 only
* Non-CVM only
* Just define one simple TMK that doesn't test much of anything

Ideally, this will mesh up with the effort to define some rich TMKs for use with full-features VMMs, so that we can run some subset of TMKs in both environments. But even without that, this will be valuable for platform bringup.