### PR TITLE
virt_mshv_vtl: Move hv_start_enable_vtl_vp to CvmVpInner

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -55,7 +55,6 @@ use pal_async::driver::Driver;
 use pal_async::driver::PollImpl;
 use pal_async::timer::PollTimer;
 use pal_uring::IdleControl;
-use parking_lot::Mutex;
 use private::BackingPrivate;
 use std::convert::Infallible;
 use std::future::poll_fn;
@@ -354,7 +353,6 @@ impl UhVpInner {
             waker: Default::default(),
             cpu_index,
             vp_info,
-            hv_start_enable_vtl_vp: VtlArray::from_fn(|_| Mutex::new(None)),
             sidecar_exit_reason: Default::default(),
         }
     }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -2004,7 +2004,6 @@ mod save_restore {
                         // Topology information
                         vp_info: _,
                         cpu_index: _,
-                        hv_start_enable_vtl_vp: _,
                     },
                 // Saved
                 crash_reg,


### PR DESCRIPTION
Since we no longer support emulating the APIC on hypervisor backings, this can move to be CVM only.