### PR TITLE
vmbus_server: improve MnF support

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -927,10 +927,22 @@ impl virt::Synic for UhPartition {
         );
     }
 
-    fn new_guest_event_port(&self) -> Box<dyn vmcore::synic::GuestEventPort> {
+    fn new_guest_event_port(
+        &self,
+        vtl: Vtl,
+        vp: u32,
+        sint: u8,
+        flag: u16,
+    ) -> Box<dyn vmcore::synic::GuestEventPort> {
+        let vtl = GuestVtl::try_from(vtl).expect("higher vtl not configured");
         Box::new(UhEventPort {
             partition: Arc::downgrade(&self.inner),
-            params: Default::default(),
+            params: Arc::new(Mutex::new(UhEventPortParams {
+                vp: VpIndex::new(vp),
+                sint,
+                flag,
+                vtl,
+            })),
         })
     }
 
@@ -1032,7 +1044,7 @@ impl UhPartitionInner {
 #[derive(Debug)]
 struct UhEventPort {
     partition: Weak<UhPartitionInner>,
-    params: Arc<Mutex<Option<UhEventPortParams>>>,
+    params: Arc<Mutex<UhEventPortParams>>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -1048,15 +1060,12 @@ impl vmcore::synic::GuestEventPort for UhEventPort {
         let partition = self.partition.clone();
         let params = self.params.clone();
         vmcore::interrupt::Interrupt::from_fn(move || {
-            let Some(UhEventPortParams {
+            let UhEventPortParams {
                 vp,
                 sint,
                 flag,
                 vtl,
-            }) = *params.lock()
-            else {
-                return;
-            };
+            } = *params.lock();
             let Some(partition) = partition.upgrade() else {
                 return;
             };
@@ -1096,25 +1105,8 @@ impl vmcore::synic::GuestEventPort for UhEventPort {
         })
     }
 
-    fn clear(&mut self) {
-        *self.params.lock() = None;
-    }
-
-    fn set(
-        &mut self,
-        vtl: Vtl,
-        vp: u32,
-        sint: u8,
-        flag: u16,
-    ) -> Result<(), vmcore::synic::HypervisorError> {
-        let vtl = GuestVtl::try_from(vtl).expect("higher vtl not configured");
-        *self.params.lock() = Some(UhEventPortParams {
-            vp: VpIndex::new(vp),
-            sint,
-            flag,
-            vtl,
-        });
-
+    fn set_target_vp(&mut self, vp: u32) -> Result<(), vmcore::synic::HypervisorError> {
+        self.params.lock().vp = VpIndex::new(vp);
         Ok(())
     }
 }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -951,7 +951,7 @@ impl virt::Synic for UhPartition {
 }
 
 impl virt::SynicMonitor for UhPartition {
-    fn set_monitor_page(&self, gpa: Option<u64>) -> anyhow::Result<()> {
+    fn set_monitor_page(&self, _vtl: Vtl, gpa: Option<u64>) -> anyhow::Result<()> {
         let old_gpa = self.inner.monitor_page.set_gpa(gpa);
         if let Some(old_gpa) = old_gpa {
             self.inner

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -995,7 +995,7 @@ impl virt::SynicMonitor for UhPartition {
         &self,
         monitor_id: vmcore::monitor::MonitorId,
         connection_id: u32,
-    ) -> Box<dyn Send> {
+    ) -> Box<dyn Sync + Send> {
         self.inner
             .monitor_page
             .register_monitor(monitor_id, connection_id)

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -1135,7 +1135,7 @@ impl VmbusDevice for Nic {
                 data4: [0x91, 0x3f, 0xf2, 0xd2, 0xf9, 0x65, 0xed, 0xe],
             },
             subchannel_index: 0,
-            use_mnf: true,
+            mnf_interrupt_latency: Some(Duration::from_micros(100)),
             ..Default::default()
         }
     }

--- a/vm/devices/vmbus/vmbus_channel/src/bus.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/bus.rs
@@ -12,6 +12,7 @@ use mesh::payload::Protobuf;
 use mesh::rpc::FailableRpc;
 use mesh::rpc::Rpc;
 use std::fmt::Display;
+use std::time::Duration;
 use vmbus_core::protocol;
 use vmbus_core::protocol::GpadlId;
 use vmbus_core::protocol::UserDefinedData;
@@ -287,6 +288,8 @@ pub struct OfferParams {
     /// external GPADLs and GPA direct ranges. This is only used when hardware
     /// isolation is in use.
     pub allow_confidential_external_memory: bool,
+    /// The interrupt latency to use for monitored interrupts.
+    pub interrupt_latency: Duration,
 }
 
 impl OfferParams {

--- a/vm/devices/vmbus/vmbus_channel/src/bus.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/bus.rs
@@ -279,8 +279,9 @@ pub struct OfferParams {
     pub channel_type: ChannelType,
     /// The subchannel index. Index 0 indicates a primary (normal channel).
     pub subchannel_index: u16,
-    /// Indicates whether the channel's interrupts should use monitor pages.
-    pub use_mnf: bool,
+    /// Indicates whether the channel's interrupts should use monitor pages,
+    /// and the interrupt latency to use.
+    pub mnf_interrupt_latency: Option<Duration>,
     /// The order in which channels with the same interface will be offered to
     /// the guest (optional).
     pub offer_order: Option<u32>,
@@ -288,8 +289,6 @@ pub struct OfferParams {
     /// external GPADLs and GPA direct ranges. This is only used when hardware
     /// isolation is in use.
     pub allow_confidential_external_memory: bool,
-    /// The interrupt latency to use for monitored interrupts.
-    pub interrupt_latency: Duration,
 }
 
 impl OfferParams {

--- a/vm/devices/vmbus/vmbus_channel/src/bus.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/bus.rs
@@ -280,7 +280,7 @@ pub struct OfferParams {
     /// The subchannel index. Index 0 indicates a primary (normal channel).
     pub subchannel_index: u16,
     /// Indicates whether the channel's interrupts should use monitor pages,
-    /// and the interrupt latency to use.
+    /// and the interrupt latency if it's enabled.
     pub mnf_interrupt_latency: Option<Duration>,
     /// The order in which channels with the same interface will be offered to
     /// the guest (optional).

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -53,6 +53,7 @@ use vmbus_core::protocol::Message;
 use vmbus_core::protocol::OpenChannelFlags;
 use vmbus_core::protocol::Version;
 use vmcore::interrupt::Interrupt;
+use vmcore::synic::MonitorPageGpas;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -41,7 +41,6 @@ use vmbus_channel::bus::ModifyRequest;
 use vmbus_channel::bus::OpenData;
 use vmbus_channel::gpadl::GpadlId;
 use vmbus_core::HvsockConnectRequest;
-use vmbus_core::MonitorPageGpas;
 use vmbus_core::OutgoingMessage;
 use vmbus_core::TaggedStream;
 use vmbus_core::VersionInfo;

--- a/vm/devices/vmbus/vmbus_core/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_core/src/lib.rs
@@ -188,14 +188,6 @@ impl PartialEq for OutgoingMessage {
 #[error("a synic message exceeds the maximum length")]
 pub struct MessageTooLarge;
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Inspect)]
-pub struct MonitorPageGpas {
-    #[inspect(hex)]
-    pub parent_to_child: u64,
-    #[inspect(hex)]
-    pub child_to_parent: u64,
-}
-
 /// A request from the guest to connect to the specified hvsocket endpoint.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Inspect)]
 pub struct HvsockConnectRequest {

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -42,6 +42,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 use unicycle::FuturesUnordered;
 use vmbus_channel::bus::ChannelRequest;
 use vmbus_channel::bus::ChannelServerRequest;
@@ -689,6 +690,8 @@ impl RelayTask {
                 .with_confidential_external_memory(false),
             user_defined: offer.offer.user_defined,
             monitor_id: use_mnf.then_some(offer.offer.monitor_id),
+            // Because MnF is emulated in OpenHCL, latency is not used.
+            interrupt_latency: Duration::ZERO,
         };
 
         let key = params.key();

--- a/vm/devices/vmbus/vmbus_relay/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay/src/lib.rs
@@ -42,7 +42,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
 use unicycle::FuturesUnordered;
 use vmbus_channel::bus::ChannelRequest;
 use vmbus_channel::bus::ChannelServerRequest;
@@ -59,6 +58,7 @@ use vmbus_core::protocol::ChannelId;
 use vmbus_core::protocol::FeatureFlags;
 use vmbus_core::protocol::GpadlId;
 use vmbus_server::HvsockRelayChannelHalf;
+use vmbus_server::MnfUsage;
 use vmbus_server::ModifyConnectionResponse;
 use vmbus_server::OfferInfo;
 use vmbus_server::OfferParamsInternal;
@@ -669,7 +669,16 @@ impl RelayTask {
             tracing::warn!(offer = ?offer.offer, "All offers should be dedicated with Win8+ host")
         }
 
-        let use_mnf = offer.offer.monitor_allocated != 0;
+        // If the vmbus server is handling MnF, instead of relaying it, it will ignore this monitor
+        // ID and allocate its own.
+        let use_mnf = if offer.offer.monitor_allocated != 0 {
+            MnfUsage::Relayed {
+                monitor_id: offer.offer.monitor_id,
+            }
+        } else {
+            MnfUsage::Disabled
+        };
+
         let params = OfferParamsInternal {
             interface_name: "host relay".to_owned(),
             instance_id: offer.offer.instance_id,
@@ -677,7 +686,6 @@ impl RelayTask {
             mmio_megabytes: offer.offer.mmio_megabytes,
             mmio_megabytes_optional: offer.offer.mmio_megabytes_optional,
             subchannel_index: offer.offer.subchannel_index,
-            // The vmbus server will ignore this field if MNF is being relayed to the host.
             use_mnf,
             // Preserve channel enumeration order from the host within the same
             // interface type.
@@ -689,9 +697,6 @@ impl RelayTask {
                 .with_confidential_ring_buffer(false)
                 .with_confidential_external_memory(false),
             user_defined: offer.offer.user_defined,
-            monitor_id: use_mnf.then_some(offer.offer.monitor_id),
-            // Because MnF is emulated in OpenHCL, latency is not used.
-            interrupt_latency: Duration::ZERO,
         };
 
         let key = params.key();

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -1149,6 +1149,7 @@ pub struct OpenParams {
     pub monitor_info: Option<MonitorInfo>,
     pub flags: protocol::OpenChannelFlags,
     pub reserved_target: Option<ConnectionTarget>,
+    pub channel_id: ChannelId,
 }
 
 impl OpenParams {
@@ -1180,6 +1181,7 @@ impl OpenParams {
             monitor_info,
             flags: request.flags.with_unused(0),
             reserved_target,
+            channel_id: info.channel_id,
         }
     }
 }

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -33,7 +33,6 @@ use vmbus_channel::bus::RestoredGpadl;
 use vmbus_core::HvsockConnectRequest;
 use vmbus_core::HvsockConnectResult;
 use vmbus_core::MaxVersionInfo;
-use vmbus_core::MonitorPageGpas;
 use vmbus_core::OutgoingMessage;
 use vmbus_core::VersionInfo;
 use vmbus_core::protocol;

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -780,7 +780,7 @@ impl Channel {
 
     /// Returns the monitor ID and latency only if it's being handled by this server.
     ///
-    /// The monitor ID can be set while use_mnf is false, which is the case if
+    /// The monitor ID can be set while use_mnf is Relayed, which is the case if
     /// the relay host is handling MNF.
     ///
     /// Also returns `None` for reserved channels, since monitored notifications

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -45,6 +45,7 @@ use vmbus_core::protocol::OfferFlags;
 use vmbus_core::protocol::UserDefinedData;
 use vmbus_ring::gparange;
 use vmcore::monitor::MonitorId;
+use vmcore::synic::MonitorPageGpas;
 use zerocopy::FromZeros;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use super::MnfUsage;
 use super::OfferError;
 use super::OfferParamsInternal;
 use super::OfferedInfo;
@@ -79,13 +80,13 @@ impl super::Server {
 
             // The channel's monitor ID can be already set if it was set by the device, which is
             // the case with relay channels. In that case, it must match the saved ID.
-            if channel.offer.monitor_id.is_some()
-                && channel.offer.monitor_id != saved_channel.monitor_id
-            {
-                return Err(RestoreError::MismatchedMonitorId(
-                    channel.offer.monitor_id.unwrap(),
-                    saved_channel.monitor_id,
-                ));
+            if let MnfUsage::Relayed { monitor_id } = channel.offer.use_mnf {
+                if info.monitor_id != Some(MonitorId(monitor_id)) {
+                    return Err(RestoreError::MismatchedMonitorId(
+                        monitor_id,
+                        saved_channel.monitor_id,
+                    ));
+                }
             }
 
             self.assigned_channels

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1572,6 +1572,7 @@ impl ServerTaskInner {
             target_vp,
             target_sint,
             event_flag,
+            open_params.monitor_info,
         )?;
 
         let interrupt = ChannelBitmap::create_interrupt(
@@ -2135,6 +2136,7 @@ mod tests {
             _vp: u32,
             _sint: u8,
             _flag: u16,
+            _monitor_info: Option<MonitorInfo>,
         ) -> Result<Box<(dyn GuestEventPort)>, vmcore::synic::HypervisorError> {
             Ok(Box::new(MockGuestPort {}))
         }

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -77,7 +77,6 @@ use vmbus_channel::gpadl_ring::GpadlRingMem;
 use vmbus_core::HvsockConnectRequest;
 use vmbus_core::HvsockConnectResult;
 use vmbus_core::MaxVersionInfo;
-use vmbus_core::MonitorPageGpas;
 use vmbus_core::OutgoingMessage;
 use vmbus_core::TaggedStream;
 use vmbus_core::VersionInfo;
@@ -93,6 +92,7 @@ use vmcore::synic::EventPort;
 use vmcore::synic::GuestEventPort;
 use vmcore::synic::GuestMessagePort;
 use vmcore::synic::MessagePort;
+use vmcore::synic::MonitorPageGpas;
 use vmcore::synic::SynicPortAccess;
 
 const SINT: u8 = 2;
@@ -1735,9 +1735,7 @@ impl ServerTaskInner {
 
         if self.enable_mnf {
             if let Some(monitor) = self.synic.monitor_support() {
-                if let Err(err) =
-                    monitor.set_monitor_page(monitor_page.map(|mp| mp.child_to_parent))
-                {
+                if let Err(err) = monitor.set_monitor_page(monitor_page) {
                     anyhow::bail!(
                         "setting monitor page failed, err = {err:?}, monitor_page = {monitor_page:?}"
                     );

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1359,23 +1359,10 @@ impl Notifier for ServerTaskInner {
             }
             channels::Action::Modify { target_vp } => {
                 if let ChannelState::Open {
-                    open_params,
-                    guest_event_port,
-                    ..
+                    guest_event_port, ..
                 } = &mut channel.state
                 {
-                    let (target_vtl, target_sint) = if open_params.flags.redirect_interrupt() {
-                        (self.redirect_vtl, self.redirect_sint)
-                    } else {
-                        (self.vtl, SINT)
-                    };
-
-                    if let Err(err) = guest_event_port.set(
-                        target_vtl,
-                        target_vp,
-                        target_sint,
-                        open_params.event_flag,
-                    ) {
+                    if let Err(err) = guest_event_port.set_target_vp(target_vp) {
                         tracelimit::error_ratelimited!(
                             error = &err as &dyn std::error::Error,
                             channel = %channel.key,
@@ -2048,15 +2035,7 @@ mod tests {
             Interrupt::null()
         }
 
-        fn clear(&mut self) {}
-
-        fn set(
-            &mut self,
-            _vtl: Vtl,
-            _vp: u32,
-            _sint: u8,
-            _flag: u16,
-        ) -> Result<(), vmcore::synic::HypervisorError> {
+        fn set_target_vp(&mut self, _vp: u32) -> Result<(), vmcore::synic::HypervisorError> {
             Ok(())
         }
     }

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1522,7 +1522,7 @@ impl Notifier for ServerTaskInner {
 
     fn reset_complete(&mut self) {
         if let Some(monitor) = self.synic.monitor_support() {
-            if let Err(err) = monitor.set_monitor_page(None) {
+            if let Err(err) = monitor.set_monitor_page(self.vtl, None) {
                 tracing::warn!(?err, "resetting monitor page failed")
             }
         }
@@ -1743,7 +1743,7 @@ impl ServerTaskInner {
 
         if self.enable_mnf {
             if let Some(monitor) = self.synic.monitor_support() {
-                if let Err(err) = monitor.set_monitor_page(monitor_page) {
+                if let Err(err) = monitor.set_monitor_page(self.vtl, monitor_page) {
                     anyhow::bail!(
                         "setting monitor page failed, err = {err:?}, monitor_page = {monitor_page:?}"
                     );

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -307,10 +307,12 @@ impl ProxyTask {
             mmio_megabytes_optional: offer.MmioMegabytesOptional,
             subchannel_index: offer.SubChannelIndex,
             channel_type,
-            use_mnf: offer.ChannelFlags.request_monitored_notification(),
+            mnf_interrupt_latency: offer
+                .ChannelFlags
+                .request_monitored_notification()
+                .then(|| Duration::from_nanos(offer.InterruptLatencyIn100nsUnits * 100)),
             offer_order: id.try_into().ok(),
             allow_confidential_external_memory: false,
-            interrupt_latency: Duration::from_nanos(offer.InterruptLatencyIn100nsUnits * 100),
         };
         let (request_send, request_recv) = mesh::channel();
         let (server_request_send, server_request_recv) = mesh::channel();

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -35,6 +35,7 @@ use std::collections::HashSet;
 use std::io;
 use std::os::windows::prelude::*;
 use std::sync::Arc;
+use std::time::Duration;
 use vmbus_channel::bus::ChannelServerRequest;
 use vmbus_channel::bus::ChannelType;
 use vmbus_channel::bus::OfferParams;
@@ -309,6 +310,7 @@ impl ProxyTask {
             use_mnf: offer.ChannelFlags.request_monitored_notification(),
             offer_order: id.try_into().ok(),
             allow_confidential_external_memory: false,
+            interrupt_latency: Duration::from_nanos(offer.InterruptLatencyIn100nsUnits * 100),
         };
         let (request_send, request_recv) = mesh::channel();
         let (server_request_send, server_request_recv) = mesh::channel();

--- a/vm/vmcore/src/monitor.rs
+++ b/vm/vmcore/src/monitor.rs
@@ -116,7 +116,11 @@ impl MonitorPage {
     /// # Panics
     ///
     /// Panics if monitor_id is already in use.
-    pub fn register_monitor(&self, monitor_id: MonitorId, connection_id: u32) -> Box<dyn Send> {
+    pub fn register_monitor(
+        &self,
+        monitor_id: MonitorId,
+        connection_id: u32,
+    ) -> Box<dyn Sync + Send> {
         self.monitors.set(monitor_id, Some(connection_id));
 
         tracing::trace!(monitor_id = monitor_id.0, "registered monitor");

--- a/vm/vmcore/src/synic.rs
+++ b/vm/vmcore/src/synic.rs
@@ -117,11 +117,8 @@ pub trait GuestEventPort: Send + Sync {
     /// Returns an interrupt object used to signal the guest.
     fn interrupt(&self) -> Interrupt;
 
-    /// Clears the event port state so that the interrupt does nothing.
-    fn clear(&mut self);
-
-    /// Updates the parameters for the event port.
-    fn set(&mut self, vtl: Vtl, vp: u32, sint: u8, flag: u16) -> Result<(), HypervisorError>;
+    /// Updates the target VP for the event port.
+    fn set_target_vp(&mut self, vp: u32) -> Result<(), HypervisorError>;
 }
 
 /// A guest message port, created by [`SynicPortAccess::new_guest_message_port`].
@@ -150,26 +147,8 @@ pub struct MonitorPageGpas {
 /// Provides information about monitor usage for a synic event port.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MonitorInfo {
-    monitor_id: MonitorId,
-    latency: Duration,
-}
-
-impl MonitorInfo {
-    /// Creates a new `MonitorInfo` instance.
-    pub fn new(monitor_id: MonitorId, latency: Duration) -> Self {
-        Self {
-            monitor_id,
-            latency,
-        }
-    }
-
-    /// Returns the monitor ID associated with the event port.
-    pub fn monitor_id(&self) -> MonitorId {
-        self.monitor_id
-    }
-
-    /// Returns the interrupt latency for monitored interrupts to this port.
-    pub fn latency(&self) -> Duration {
-        self.latency
-    }
+    // The monitor ID used by the port.
+    pub monitor_id: MonitorId,
+    /// The nterrupt latency.
+    pub latency: Duration,
 }

--- a/vm/vmcore/src/synic.rs
+++ b/vm/vmcore/src/synic.rs
@@ -136,14 +136,18 @@ pub trait GuestMessagePort: Send + Sync + Inspect {
     fn set_target_vp(&mut self, vp: u32) -> Result<(), HypervisorError>;
 }
 
+/// Represents the GPA of the outgoing and incoming monitor pages.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Inspect)]
 pub struct MonitorPageGpas {
+    /// The GPA of the incoming monitor page.
     #[inspect(hex)]
     pub parent_to_child: u64,
+    /// The GPA of the outgoing monitor page.
     #[inspect(hex)]
     pub child_to_parent: u64,
 }
 
+/// Provides information about monitor usage for a synic event port.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MonitorInfo {
     monitor_id: MonitorId,
@@ -151,6 +155,7 @@ pub struct MonitorInfo {
 }
 
 impl MonitorInfo {
+    /// Creates a new `MonitorInfo` instance.
     pub fn new(monitor_id: MonitorId, latency: Duration) -> Self {
         Self {
             monitor_id,
@@ -158,10 +163,12 @@ impl MonitorInfo {
         }
     }
 
+    /// Returns the monitor ID associated with the event port.
     pub fn monitor_id(&self) -> MonitorId {
         self.monitor_id
     }
 
+    /// Returns the interrupt latency for monitored interrupts to this port.
     pub fn latency(&self) -> Duration {
         self.latency
     }

--- a/vm/vmcore/src/synic.rs
+++ b/vm/vmcore/src/synic.rs
@@ -96,7 +96,7 @@ pub trait SynicMonitorAccess: SynicPortAccess {
     fn register_monitor(&self, monitor_id: MonitorId, connection_id: u32) -> Box<dyn Send>;
 
     /// Sets the GPA of the monitor page currently in use.
-    fn set_monitor_page(&self, gpa: Option<u64>) -> anyhow::Result<()>;
+    fn set_monitor_page(&self, gpa: Option<MonitorPageGpas>) -> anyhow::Result<()>;
 }
 
 /// A guest event port, created by [`SynicPortAccess::new_guest_event_port`].
@@ -121,4 +121,12 @@ pub trait GuestMessagePort: Send + Sync + Inspect {
 
     /// Changes the virtual processor to which messages are sent.
     fn set_target_vp(&mut self, vp: u32) -> Result<(), HypervisorError>;
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Inspect)]
+pub struct MonitorPageGpas {
+    #[inspect(hex)]
+    pub parent_to_child: u64,
+    #[inspect(hex)]
+    pub child_to_parent: u64,
 }

--- a/vm/vmcore/src/synic.rs
+++ b/vm/vmcore/src/synic.rs
@@ -78,6 +78,9 @@ pub trait SynicPortAccess: Send + Sync {
     ) -> Result<Box<dyn GuestMessagePort>, HypervisorError>;
 
     /// Creates a [`GuestEventPort`] for signaling VMBus channels in the guest.
+    ///
+    /// The `monitor_info` parameter is ignored if the synic does not support outgoing monitored
+    /// interrupts.
     fn new_guest_event_port(
         &self,
         port_id: u32,
@@ -85,6 +88,7 @@ pub trait SynicPortAccess: Send + Sync {
         vp: u32,
         sint: u8,
         flag: u16,
+        monitor_info: Option<MonitorInfo>,
     ) -> Result<Box<dyn GuestEventPort>, HypervisorError>;
 
     /// Returns whether callers should pass an OS event when creating event

--- a/vm/vmcore/src/synic.rs
+++ b/vm/vmcore/src/synic.rs
@@ -78,7 +78,14 @@ pub trait SynicPortAccess: Send + Sync {
     ) -> Result<Box<dyn GuestMessagePort>, HypervisorError>;
 
     /// Creates a [`GuestEventPort`] for signaling VMBus channels in the guest.
-    fn new_guest_event_port(&self) -> Result<Box<dyn GuestEventPort>, HypervisorError>;
+    fn new_guest_event_port(
+        &self,
+        port_id: u32,
+        vtl: Vtl,
+        vp: u32,
+        sint: u8,
+        flag: u16,
+    ) -> Result<Box<dyn GuestEventPort>, HypervisorError>;
 
     /// Returns whether callers should pass an OS event when creating event
     /// ports, as opposed to passing a function to call.

--- a/vm/vmcore/src/synic.rs
+++ b/vm/vmcore/src/synic.rs
@@ -109,7 +109,7 @@ pub trait SynicPortAccess: Send + Sync {
 /// Provides monitor page functionality for a `SynicPortAccess` implementation.
 pub trait SynicMonitorAccess: SynicPortAccess {
     /// Sets the GPA of the monitor page currently in use.
-    fn set_monitor_page(&self, gpa: Option<MonitorPageGpas>) -> anyhow::Result<()>;
+    fn set_monitor_page(&self, vtl: Vtl, gpa: Option<MonitorPageGpas>) -> anyhow::Result<()>;
 }
 
 /// A guest event port, created by [`SynicPortAccess::new_guest_event_port`].

--- a/vmm_core/src/synic.rs
+++ b/vmm_core/src/synic.rs
@@ -174,8 +174,15 @@ impl SynicPortAccess for SynicPorts {
 
     fn new_guest_event_port(
         &self,
+        _port_id: u32,
+        vtl: Vtl,
+        vp: u32,
+        sint: u8,
+        flag: u16,
     ) -> Result<Box<(dyn GuestEventPort)>, vmcore::synic::HypervisorError> {
-        Ok(self.partition.new_guest_event_port())
+        let mut port = self.partition.new_guest_event_port();
+        port.set(vtl, vp, sint, flag)?;
+        Ok(port)
     }
 
     fn prefer_os_events(&self) -> bool {

--- a/vmm_core/src/synic.rs
+++ b/vmm_core/src/synic.rs
@@ -196,11 +196,11 @@ impl SynicPortAccess for SynicPorts {
 }
 
 impl SynicMonitorAccess for SynicPorts {
-    fn set_monitor_page(&self, gpa: Option<MonitorPageGpas>) -> anyhow::Result<()> {
+    fn set_monitor_page(&self, vtl: Vtl, gpa: Option<MonitorPageGpas>) -> anyhow::Result<()> {
         self.partition
             .monitor_support()
             .unwrap()
-            .set_monitor_page(gpa.map(|mp| mp.child_to_parent))
+            .set_monitor_page(vtl, gpa.map(|mp| mp.child_to_parent))
     }
 }
 

--- a/vmm_core/src/synic.rs
+++ b/vmm_core/src/synic.rs
@@ -147,7 +147,7 @@ impl SynicPortAccess for SynicPorts {
         let monitor = monitor_info.as_ref().and_then(|info| {
             self.partition
                 .monitor_support()
-                .map(|monitor| monitor.register_monitor(info.monitor_id(), connection_id))
+                .map(|monitor| monitor.register_monitor(info.monitor_id, connection_id))
         });
 
         Ok(Box::new(PortHandle {
@@ -181,9 +181,7 @@ impl SynicPortAccess for SynicPorts {
         flag: u16,
         _monitor_info: Option<MonitorInfo>,
     ) -> Result<Box<(dyn GuestEventPort)>, vmcore::synic::HypervisorError> {
-        let mut port = self.partition.new_guest_event_port();
-        port.set(vtl, vp, sint, flag)?;
-        Ok(port)
+        Ok(self.partition.new_guest_event_port(vtl, vp, sint, flag))
     }
 
     fn prefer_os_events(&self) -> bool {

--- a/vmm_core/src/synic.rs
+++ b/vmm_core/src/synic.rs
@@ -20,6 +20,7 @@ use vmcore::synic::EventPort;
 use vmcore::synic::GuestEventPort;
 use vmcore::synic::GuestMessagePort;
 use vmcore::synic::MessagePort;
+use vmcore::synic::MonitorPageGpas;
 use vmcore::synic::SynicMonitorAccess;
 use vmcore::synic::SynicPortAccess;
 
@@ -185,11 +186,11 @@ impl SynicMonitorAccess for SynicPorts {
             .register_monitor(monitor_id, connection_id)
     }
 
-    fn set_monitor_page(&self, gpa: Option<u64>) -> anyhow::Result<()> {
+    fn set_monitor_page(&self, gpa: Option<MonitorPageGpas>) -> anyhow::Result<()> {
         self.partition
             .monitor_support()
             .unwrap()
-            .set_monitor_page(gpa)
+            .set_monitor_page(gpa.map(|mp| mp.child_to_parent))
     }
 }
 

--- a/vmm_core/src/synic.rs
+++ b/vmm_core/src/synic.rs
@@ -179,6 +179,7 @@ impl SynicPortAccess for SynicPorts {
         vp: u32,
         sint: u8,
         flag: u16,
+        _monitor_info: Option<MonitorInfo>,
     ) -> Result<Box<(dyn GuestEventPort)>, vmcore::synic::HypervisorError> {
         let mut port = self.partition.new_guest_event_port();
         port.set(vtl, vp, sint, flag)?;

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -666,5 +666,5 @@ pub trait SynicMonitor: Synic {
     fn register_monitor(&self, monitor_id: MonitorId, connection_id: u32) -> Box<dyn Sync + Send>;
 
     /// Sets the GPA of the monitor page currently in use.
-    fn set_monitor_page(&self, gpa: Option<u64>) -> anyhow::Result<()>;
+    fn set_monitor_page(&self, vtl: Vtl, gpa: Option<u64>) -> anyhow::Result<()>;
 }

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -639,7 +639,13 @@ pub trait Synic: Send + Sync {
     fn post_message(&self, vtl: Vtl, vp: VpIndex, sint: u8, typ: u32, payload: &[u8]);
 
     /// Creates a [`GuestEventPort`] for signaling VMBus channels in the guest.
-    fn new_guest_event_port(&self) -> Box<dyn GuestEventPort>;
+    fn new_guest_event_port(
+        &self,
+        vtl: Vtl,
+        vp: u32,
+        sint: u8,
+        flag: u16,
+    ) -> Box<dyn GuestEventPort>;
 
     /// Returns whether callers should pass an OS event when creating event
     /// ports, as opposed to passing a function to call.

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -663,7 +663,7 @@ pub trait SynicMonitor: Synic {
     /// # Panics
     ///
     /// Panics if monitor_id is already in use.
-    fn register_monitor(&self, monitor_id: MonitorId, connection_id: u32) -> Box<dyn Send>;
+    fn register_monitor(&self, monitor_id: MonitorId, connection_id: u32) -> Box<dyn Sync + Send>;
 
     /// Sets the GPA of the monitor page currently in use.
     fn set_monitor_page(&self, gpa: Option<u64>) -> anyhow::Result<()>;

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -749,10 +749,10 @@ impl virt::Synic for KvmPartition {
 
     fn new_guest_event_port(
         &self,
-        vtl: Vtl,
-        vp: u32,
-        sint: u8,
-        flag: u16,
+        _vtl: Vtl,
+        _vp: u32,
+        _sint: u8,
+        _flag: u16,
     ) -> Box<dyn vmcore::synic::GuestEventPort> {
         unimplemented!()
     }

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -747,7 +747,13 @@ impl virt::Synic for KvmPartition {
         unimplemented!()
     }
 
-    fn new_guest_event_port(&self) -> Box<dyn vmcore::synic::GuestEventPort> {
+    fn new_guest_event_port(
+        &self,
+        vtl: Vtl,
+        vp: u32,
+        sint: u8,
+        flag: u16,
+    ) -> Box<dyn vmcore::synic::GuestEventPort> {
         unimplemented!()
     }
 

--- a/vmm_core/virt_whp/src/synic.rs
+++ b/vmm_core/virt_whp/src/synic.rs
@@ -323,17 +323,14 @@ impl GuestEventPort for EmulatedGuestEventPort {
                 sint,
                 flag,
             } = *this.params.lock();
-            if let Some(partition) = this.partition.upgrade() {
-                let Hv1State::Emulated(hv) = &partition.vtlp(vtl).hvstate else {
-                    unreachable!()
-                };
-                let _ = hv.synic[vtl].signal_event(
-                    vp,
-                    sint,
-                    flag,
-                    &mut partition.synic_interrupt(vp, vtl),
-                );
-            }
+            let Some(partition) = this.partition.upgrade() else {
+                return;
+            };
+            let Hv1State::Emulated(hv) = &partition.hvstate else {
+                unreachable!()
+            };
+            let _ =
+                hv.synic[vtl].signal_event(vp, sint, flag, &mut partition.synic_interrupt(vp, vtl));
         })
     }
 

--- a/vmm_core/virt_whp/src/synic.rs
+++ b/vmm_core/virt_whp/src/synic.rs
@@ -145,7 +145,9 @@ impl SynicMonitor for WhpPartition {
             .register_monitor(monitor_id, connection_id)
     }
 
-    fn set_monitor_page(&self, gpa: Option<u64>) -> anyhow::Result<()> {
+    fn set_monitor_page(&self, vtl: Vtl, gpa: Option<u64>) -> anyhow::Result<()> {
+        // Monitor pages are not supported at all when VTL2 is enabled.
+        assert!(vtl == Vtl::Vtl0);
         let mut overlays = crate::memory::OverlayMapper::new(&self.inner.vtl0);
         let old_gpa = self.inner.monitor_page.set_gpa(gpa);
         if let Some(old_gpa) = old_gpa {

--- a/vmm_core/virt_whp/src/synic.rs
+++ b/vmm_core/virt_whp/src/synic.rs
@@ -139,7 +139,7 @@ impl virt::Synic for WhpPartition {
 }
 
 impl SynicMonitor for WhpPartition {
-    fn register_monitor(&self, monitor_id: MonitorId, connection_id: u32) -> Box<dyn Send> {
+    fn register_monitor(&self, monitor_id: MonitorId, connection_id: u32) -> Box<dyn Sync + Send> {
         self.inner
             .monitor_page
             .register_monitor(monitor_id, connection_id)


### PR DESCRIPTION
This change updates vmbus_server's support for monitored interrupts.

- The `SynicPortAccess` trait is updated to provide information about monitor usage during host and guest event port creation. When creating guest event ports, initial parameters for their creation must be supplied.
- The `MonitorPortAccess` trait is updated to require the VTL that a monitor page is for.
- The VmBus server delays creation of guest event ports until the channel is opened, at which point all the information needed to create it with initial parameters is known.
- Monitored interrupt latency is passed along for vmbusproxy channels, and provided by internal channels using MnF (this is not used by openvmm's implementation of MnF, since it is emulated, but can be used by other implementations).