### PR TITLE
tmk: add aarch64 support

### DIFF
--- a/build_support/macos/sign_and_run.sh
+++ b/build_support/macos/sign_and_run.sh
@@ -3,7 +3,7 @@
 set -e
 
 case "$CARGO_PKG_NAME" in
-    "openvmm")
+    "openvmm"|"tmk_vmm")
         # Add entitlements for using hypervisor framework.
         entitlements=$(dirname "$0")/entitlements.xml
         codesign --entitlements "$entitlements" -f -s - "$1" > /dev/null

--- a/openhcl/minimal_rt/aarch64-config.toml
+++ b/openhcl/minimal_rt/aarch64-config.toml
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Config file to use to build minimal_rt binaries for aarch64.
+#
+# This requires setting RUSTC_BOOTSTRAP=1, or an unstable toolchain.
+# Consider using the aarch64-unknown-linux-musl target if you want to
+# avoid this.
+
+[build]
+# Custom target needed to enable static PIE support, which is not
+# supported by aarch64-minimal.
+target = "minimal_rt/aarch64-minimal_rt-none.json"
+
+[unstable]
+build-std = ["core"]
+
+[env]
+MINIMAL_RT_BUILD = "1"

--- a/openhcl/minimal_rt/aarch64-config.toml
+++ b/openhcl/minimal_rt/aarch64-config.toml
@@ -3,9 +3,9 @@
 
 # Config file to use to build minimal_rt binaries for aarch64.
 #
-# This requires setting RUSTC_BOOTSTRAP=1, or an unstable toolchain.
-# Consider using the aarch64-unknown-linux-musl target if you want to
-# avoid this.
+# The dependency on build-std requires setting RUSTC_BOOTSTRAP=1, or an
+# unstable toolchain. Consider using the aarch64-unknown-linux-musl
+# target if you want to avoid this.
 
 [build]
 # Custom target needed to enable static PIE support, which is not

--- a/openhcl/minimal_rt/aarch64-minimal_rt-none.json
+++ b/openhcl/minimal_rt/aarch64-minimal_rt-none.json
@@ -1,0 +1,18 @@
+{
+  "arch": "aarch64",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
+  "disable-redzone": true,
+  "features": "+v8a,+strict-align,+neon,+fp-armv8",
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-target": "aarch64-unknown-none",
+  "max-atomic-width": 128,
+  "panic-strategy": "abort",
+  "position-independent-executables": true,
+  "static-position-independent-executables": true,
+  "stack-probes": {
+    "kind": "inline"
+  },
+  "target-pointer-width": "64"
+}

--- a/openhcl/minimal_rt/x86_64-config.toml
+++ b/openhcl/minimal_rt/x86_64-config.toml
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Config file to use to build minimal_rt binaries for x86_64.
+
+[build]
+target = "x86_64-unknown-none"
+
+[env]
+MINIMAL_RT_BUILD = "1"

--- a/tmk/simple_tmk/src/main.rs
+++ b/tmk/simple_tmk/src/main.rs
@@ -5,7 +5,7 @@
 
 #![cfg_attr(minimal_rt, no_std, no_main)]
 
-#[cfg(all(minimal_rt, target_arch = "x86_64"))]
+#[cfg(minimal_rt)]
 mod tmk;
 
 #[cfg(not(minimal_rt))]

--- a/tmk/simple_tmk/src/tmk.rs
+++ b/tmk/simple_tmk/src/tmk.rs
@@ -4,7 +4,9 @@
 // UNSAFETY: needed to write low-level TMK code.
 #![expect(unsafe_code)]
 
-use core::arch::global_asm;
+mod aarch64;
+mod x86;
+
 use core::marker::PhantomData;
 
 #[repr(C)]
@@ -20,37 +22,6 @@ impl<'a> Str<'a> {
         Self(s.as_ptr(), s.len(), PhantomData)
     }
 }
-
-static HELLO_WORLD: Str<'static> = Str::new("hello world");
-
-global_asm! {
-    ".globl _start",
-    "_start:",
-    "lea rsp, {STACK_SIZE} + {stack}[rip]",
-    "lea rdx, _DYNAMIC[rip]",
-    "lea rdi, __ehdr_start[rip]",
-    "mov rsi, rdi",
-    "call {relocate}",
-    "mov rcx, {TMK_ADDRESS_LOG}",
-    "lea rdx, {hello_world}[rip]",
-    "mov qword ptr [rcx], rdx",
-    "mov rcx, {TMK_ADDRESS_COMPLETE}",
-    "mov byte ptr [rcx], 0",
-    "2: hlt",
-    "jmp 2b",
-    hello_world = sym HELLO_WORLD,
-    relocate = sym minimal_rt::reloc::relocate,
-    stack = sym STACK,
-    STACK_SIZE = const STACK_SIZE - 16,
-    TMK_ADDRESS_LOG = const tmk_protocol::TMK_ADDRESS_LOG,
-    TMK_ADDRESS_COMPLETE = const tmk_protocol::TMK_ADDRESS_COMPLETE,
-}
-
-const STACK_SIZE: usize = 4096;
-#[repr(C, align(16))]
-struct Stack([u8; STACK_SIZE]);
-#[unsafe(no_mangle)]
-static mut STACK: Stack = Stack([0; STACK_SIZE]);
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {

--- a/tmk/simple_tmk/src/tmk/aarch64.rs
+++ b/tmk/simple_tmk/src/tmk/aarch64.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Aarch64 entry point and support.
+
+#![cfg(target_arch = "aarch64")]
+
+use super::Str;
+use core::arch::global_asm;
+
+static HELLO_WORLD: Str<'static> = Str::new("hello world");
+
+global_asm! {
+    ".weak _DYNAMIC",
+    ".hidden _DYNAMIC",
+    ".globl _start",
+    "_start:",
+    "adrp x1, {stack}",
+    "add x1, x1, :lo12:{stack}",
+    "add x1, x1, {STACK_SIZE}",
+    "mov sp, x1",
+
+    // Enable the FPU.
+    "mrs     x0, CPACR_EL1",
+    "orr     x0, x0, #(3 << 20)",
+    "orr     x0, x0, #(3 << 16)",
+    "msr     CPACR_EL1, x0",
+    "isb",
+
+    "adrp x0, __ehdr_start",
+    "add x0, x0, :lo12:__ehdr_start",
+    "mov x1, x0",
+    "adrp x2, _DYNAMIC",
+    "add x2, x2, :lo12:_DYNAMIC",
+    "bl {relocate}",
+
+    "ldr x0, ={TMK_ADDRESS_LOG}",
+    "adrp x1, {hello_world}",
+    "add x1, x1, :lo12:{hello_world}",
+    "str x1, [x0]",
+
+    "ldr x0, ={TMK_ADDRESS_COMPLETE}",
+    "mov x1, 0",
+    "str x1, [x0]",
+    "1: wfi",
+    "b 1b",
+    hello_world = sym HELLO_WORLD,
+    relocate = sym minimal_rt::reloc::relocate,
+    stack = sym STACK,
+    STACK_SIZE = const STACK_SIZE,
+    TMK_ADDRESS_LOG = const tmk_protocol::TMK_ADDRESS_LOG,
+    TMK_ADDRESS_COMPLETE = const tmk_protocol::TMK_ADDRESS_COMPLETE,
+}
+
+const STACK_SIZE: usize = 16384;
+#[repr(C, align(16))]
+struct Stack([u8; STACK_SIZE]);
+#[unsafe(no_mangle)]
+static mut STACK: Stack = Stack([0; STACK_SIZE]);

--- a/tmk/simple_tmk/src/tmk/x86.rs
+++ b/tmk/simple_tmk/src/tmk/x86.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! x86_64 entry point and support.
+
+#![cfg(target_arch = "x86_64")]
+
+use super::Str;
+use core::arch::global_asm;
+
+static HELLO_WORLD: Str<'static> = Str::new("hello world");
+
+global_asm! {
+    ".globl _start",
+    "_start:",
+    "lea rsp, {STACK_SIZE} + {stack}[rip]",
+    "lea rdx, _DYNAMIC[rip]",
+    "lea rdi, __ehdr_start[rip]",
+    "mov rsi, rdi",
+    "call {relocate}",
+    "mov rcx, {TMK_ADDRESS_LOG}",
+    "lea rdx, {hello_world}[rip]",
+    "mov qword ptr [rcx], rdx",
+    "mov rcx, {TMK_ADDRESS_COMPLETE}",
+    "mov byte ptr [rcx], 0",
+    "2: hlt",
+    "jmp 2b",
+    hello_world = sym HELLO_WORLD,
+    relocate = sym minimal_rt::reloc::relocate,
+    stack = sym STACK,
+    STACK_SIZE = const STACK_SIZE,
+    TMK_ADDRESS_LOG = const tmk_protocol::TMK_ADDRESS_LOG,
+    TMK_ADDRESS_COMPLETE = const tmk_protocol::TMK_ADDRESS_COMPLETE,
+}
+
+const STACK_SIZE: usize = 4096;
+#[repr(C, align(16))]
+struct Stack([u8; STACK_SIZE]);
+#[unsafe(no_mangle)]
+static mut STACK: Stack = Stack([0; STACK_SIZE]);

--- a/tmk/tmk_vmm/Cargo.toml
+++ b/tmk/tmk_vmm/Cargo.toml
@@ -28,7 +28,7 @@ clap = { workspace = true, features = ["derive"] }
 fs-err.workspace = true
 futures.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(windows)'.dependencies]
 virt_whp.workspace = true

--- a/tmk/tmk_vmm/src/load.rs
+++ b/tmk/tmk_vmm/src/load.rs
@@ -7,12 +7,15 @@ use anyhow::Context as _;
 use fs_err::File;
 use guestmem::GuestMemory;
 use hvdef::Vtl;
+use loader::importer::GuestArch;
 use loader::importer::ImageLoad;
 use loader::importer::X86Register;
+use std::fmt::Debug;
 use std::sync::Arc;
 use virt::VpIndex;
 use vm_topology::memory::MemoryLayout;
 use vm_topology::processor::ProcessorTopology;
+use vm_topology::processor::aarch64::Aarch64Topology;
 use vm_topology::processor::x86::X86Topology;
 
 /// Loads a TMK, returning the initial registers for the BSP.
@@ -25,16 +28,7 @@ pub fn load_x86(
     tmk: &File,
 ) -> anyhow::Result<Arc<virt::x86::X86InitialRegs>> {
     let mut loader = vm_loader::Loader::new(guest_memory.clone(), memory_layout, Vtl::Vtl0);
-    let load_info = loader::elf::load_static_elf(
-        &mut loader,
-        &mut &*tmk,
-        0,
-        0x200000,
-        false,
-        loader::importer::BootPageAcceptance::Exclusive,
-        "tmk",
-    )
-    .context("failed to load tmk")?;
+    let load_info = load_binary(&mut loader, tmk)?;
 
     let page_table_base = load_info.next_available_address;
     let page_tables = page_table::x64::build_page_tables_64(
@@ -79,4 +73,47 @@ pub fn load_x86(
         &processor_topology.vp_arch(VpIndex::BSP),
     );
     Ok(regs)
+}
+
+#[cfg_attr(not(guest_arch = "aarch64"), expect(dead_code))]
+pub fn load_aarch64(
+    memory_layout: &MemoryLayout,
+    guest_memory: &GuestMemory,
+    processor_topology: &ProcessorTopology<Aarch64Topology>,
+    caps: &virt::aarch64::Aarch64PartitionCapabilities,
+    tmk: &File,
+) -> anyhow::Result<Arc<virt::aarch64::Aarch64InitialRegs>> {
+    let mut loader = vm_loader::Loader::new(guest_memory.clone(), memory_layout, Vtl::Vtl0);
+    let load_info = load_binary(&mut loader, tmk)?;
+
+    let mut import_reg = |reg| {
+        loader
+            .import_vp_register(reg)
+            .context("failed to set register")
+    };
+
+    import_reg(loader::importer::Aarch64Register::Pc(load_info.entrypoint))?;
+    let regs = vm_loader::initial_regs::aarch64_initial_regs(
+        &loader.initial_regs(),
+        caps,
+        &processor_topology.vp_arch(VpIndex::BSP),
+    );
+
+    Ok(regs)
+}
+
+fn load_binary<R: Debug + GuestArch>(
+    loader: &mut vm_loader::Loader<'_, R>,
+    tmk: &File,
+) -> anyhow::Result<loader::elf::LoadInfo> {
+    loader::elf::load_static_elf(
+        loader,
+        &mut &*tmk,
+        0,
+        0x200000,
+        false,
+        loader::importer::BootPageAcceptance::Exclusive,
+        "tmk",
+    )
+    .context("failed to load tmk")
 }

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -17,12 +17,24 @@ use pal_async::DefaultDriver;
 use pal_async::DefaultPool;
 use run::CommonState;
 use std::path::PathBuf;
+use tracing::level_filters::LevelFilter;
 use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .fmt_fields(tracing_helpers::formatter::FieldFormatter)
-        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .fmt_fields(tracing_helpers::formatter::FieldFormatter)
+                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE),
+        )
+        .with(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .with_env_var("TMK_LOG")
+                .from_env_lossy(),
+        )
         .init();
 
     DefaultPool::run_with(do_main)

--- a/tmk/tmk_vmm/src/run.rs
+++ b/tmk/tmk_vmm/src/run.rs
@@ -26,7 +26,7 @@ use vmcore::vmtime::VmTimeKeeper;
 use vmcore::vmtime::VmTimeSource;
 
 pub struct CommonState {
-    #[allow(dead_code)] // Only used in some configurations.
+    #[cfg_attr(not(target_os = "linux"), expect(dead_code))]
     pub driver: DefaultDriver,
     pub vmtime_keeper: VmTimeKeeper,
     pub vmtime_source: VmTimeSource,
@@ -271,7 +271,7 @@ impl RunnerBuilder {
             }
             #[cfg(guest_arch = "aarch64")]
             {
-                let virt::InitialRegs {
+                let virt::aarch64::Aarch64InitialRegs {
                     registers,
                     system_registers,
                 } = self.regs.as_ref();

--- a/tmk/tmk_vmm/src/run.rs
+++ b/tmk/tmk_vmm/src/run.rs
@@ -3,15 +3,6 @@
 
 //! Support for running a VM's VPs.
 
-#![cfg_attr(
-    guest_arch = "aarch64",
-    expect(unreachable_code),
-    expect(dead_code),
-    expect(unused_imports),
-    expect(unused_variables),
-    expect(unused_mut)
-)]
-
 use crate::Options;
 use crate::load;
 use anyhow::Context as _;
@@ -54,9 +45,11 @@ impl CommonState {
             .context("failed to build processor topology")?;
 
         #[cfg(guest_arch = "aarch64")]
-        anyhow::bail!("aarch64 not supported yet");
-        #[cfg(guest_arch = "aarch64")]
-        let processor_topology = TopologyBuilder::new_aarch64(todo!())
+        let processor_topology =
+            TopologyBuilder::new_aarch64(vm_topology::processor::arch::GicInfo {
+                gic_distributor_base: 0xff000000,
+                gic_redistributors_base: 0xff020000,
+            })
             .build(1)
             .context("failed to build processor topology")?;
 
@@ -82,8 +75,8 @@ impl CommonState {
         let (event_send, mut event_recv) = mesh::channel();
 
         // Load the TMK.
+        let tmk = fs_err::File::open(&self.opts.tmk).context("failed to open tmk")?;
         let regs = {
-            let tmk = fs_err::File::open(&self.opts.tmk).context("failed to open tmk")?;
             #[cfg(guest_arch = "x86_64")]
             {
                 load::load_x86(
@@ -96,7 +89,13 @@ impl CommonState {
             }
             #[cfg(guest_arch = "aarch64")]
             {
-                anyhow::bail!("aarch64 not supported yet");
+                load::load_aarch64(
+                    &self.memory_layout,
+                    guest_memory,
+                    &self.processor_topology,
+                    caps,
+                    &tmk,
+                )?
             }
         };
 
@@ -272,7 +271,12 @@ impl RunnerBuilder {
             }
             #[cfg(guest_arch = "aarch64")]
             {
-                todo!()
+                let virt::InitialRegs {
+                    registers,
+                    system_registers,
+                } = self.regs.as_ref();
+                state.set_registers(registers)?;
+                state.set_system_registers(system_registers)?;
             }
             state.commit()?;
         }

--- a/vmm_core/virt_hvf/src/vp_state.rs
+++ b/vmm_core/virt_hvf/src/vp_state.rs
@@ -117,7 +117,7 @@ impl AccessVpState for HvfVpStateAccess<'_, '_> {
     }
 
     fn commit(&mut self) -> Result<(), Self::Error> {
-        todo!()
+        Ok(())
     }
 
     fn registers(&mut self) -> Result<virt::aarch64::vp::Registers, Self::Error> {


### PR DESCRIPTION
Add aarch64 support to `tmk_vmm` and `simple_tmk`.

As part of this, I defined a custom target to use when building `simple_tmk` so that it's relatively straightforward to build this on non-Linux platforms. It looks something like:

```
RUSTC_BOOTSTRAP=1 cargo build -p simple_tmk --config openhcl/minimal_rt/aarch64-config.toml
```

On Linux you can still just build with the `aarch64-unknown-linux-musl` target, like we do for `openhcl_boot`, so `RUSTC_BOOTSTRAP=1` remains optional.