### PR TITLE
repo: Clean up some more allows

### DIFF
--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/github_yaml_defs.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/github_yaml_defs.rs
@@ -3,14 +3,10 @@
 
 //! Serde defs for GitHub YAML
 
-#![allow(unused)]
-
-use flowey_core::pipeline::GhRunner;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::Serializer;
 use serde::ser::SerializeMap;
-use serde::ser::SerializeSeq;
 use std::collections::BTreeMap;
 
 /// Valid names may only contain alphanumeric characters and '_' and may not

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -322,7 +322,7 @@ macro_rules! impl_tuple_claim {
         {
             type Claimed = ($($T::Claimed,)*);
 
-            #[allow(non_snake_case)]
+            #[expect(non_snake_case)]
             fn claim(self, ctx: &mut StepCtx<'_>) -> Self::Claimed {
                 let ($($T,)*) = self;
                 ($($T.claim(ctx),)*)
@@ -2374,7 +2374,7 @@ pub trait IntoRequest {
     /// By implementing this method manually, you're indicating that you know what you're
     /// doing,
     #[doc(hidden)]
-    #[allow(nonstandard_style)]
+    #[expect(nonstandard_style)]
     fn do_not_manually_impl_this_trait__use_the_flowey_request_macro_instead(&mut self);
 }
 

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -3,8 +3,6 @@
 
 //! Centralized list of constants enumerating available GitHub build pools.
 
-#![allow(unused)]
-
 use flowey::node::prelude::FlowPlatformLinuxDistro;
 use flowey::pipeline::prelude::*;
 

--- a/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_vhds.rs
@@ -340,7 +340,7 @@ Otherwise, press `ctrl-c` to cancel the run.
     }
 }
 
-#[allow(unused)]
+#[expect(dead_code)]
 enum AzCopyAuthMethod {
     /// Pull credentials from the Azure CLI instance running the command.
     AzureCli,

--- a/flowey/schema_ado_yaml/src/lib.rs
+++ b/flowey/schema_ado_yaml/src/lib.rs
@@ -4,7 +4,6 @@
 //! Serde defs for ADO YAML
 
 #![expect(missing_docs)]
-#![allow(unused)]
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/openhcl/hcl/src/protocol.rs
+++ b/openhcl/hcl/src/protocol.rs
@@ -3,12 +3,7 @@
 
 //! Structures and definitions used between the underhill kernel and HvLite.
 
-#![allow(
-    non_upper_case_globals,
-    clippy::upper_case_acronyms,
-    non_camel_case_types,
-    missing_docs
-)]
+#![expect(non_camel_case_types, missing_docs)]
 
 use bitfield_struct::bitfield;
 use hvdef::HV_MESSAGE_SIZE;

--- a/openhcl/openhcl_boot/src/boot_logger.rs
+++ b/openhcl/openhcl_boot/src/boot_logger.rs
@@ -99,16 +99,16 @@ pub(crate) use log;
 /// linted against to not pass CI. Use for local development when you just need
 /// debug prints.
 //
-// Allow unused macros for the same reason as unused_imports below, as there
+// Expect unused macros for the same reason as unused_imports below, as there
 // should be no usage of this macro normally.
-#[allow(unused_macros)]
+#[expect(unused_macros)]
 macro_rules! debug_log {
     ($($arg:tt)*) => {
         $crate::boot_logger::log!($($arg)*)
     };
 }
 
-// Allow unused imports because there should be no normal usage in code due to
+// Expect unused imports because there should be no normal usage in code due to
 // lints against it in CI.
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 pub(crate) use debug_log;

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -350,7 +350,7 @@ async fn launch_workers(
 
     #[cfg(feature = "gdb")]
     let mut gdbstub_worker = None;
-    #[cfg_attr(not(feature = "gdb"), allow(unused_mut))]
+    #[cfg_attr(not(feature = "gdb"), expect(unused_mut))]
     let mut debugger_rpc = None;
     #[cfg(feature = "gdb")]
     if opt.gdbstub {

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2517,7 +2517,6 @@ async fn new_underhill_vm(
         })) as Arc<CloseableMutex<dyn ChipsetDevice>>
     });
 
-    #[cfg_attr(not(feature = "vpci"), allow(unused_mut))]
     let BaseChipsetBuilderOutput {
         mut chipset_builder,
         device_interfaces: _,

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1634,7 +1634,6 @@ impl<T> hv1_hypercall::X64RegisterState for UhHypercallHandler<'_, '_, T, SnpBac
     }
 }
 
-#[allow(unused)]
 impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
     type Error = vp_state::Error;
 
@@ -1794,7 +1793,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
         Err(vp_state::Error::Unimplemented("xsave"))
     }
 
-    fn set_xsave(&mut self, value: &vp::Xsave) -> Result<(), Self::Error> {
+    fn set_xsave(&mut self, _value: &vp::Xsave) -> Result<(), Self::Error> {
         Err(vp_state::Error::Unimplemented("xsave"))
     }
 
@@ -1929,7 +1928,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
         Err(vp_state::Error::Unimplemented("tsc"))
     }
 
-    fn set_tsc(&mut self, value: &vp::Tsc) -> Result<(), Self::Error> {
+    fn set_tsc(&mut self, _value: &vp::Tsc) -> Result<(), Self::Error> {
         Err(vp_state::Error::Unimplemented("tsc"))
     }
 
@@ -1980,7 +1979,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
         Err(vp_state::Error::Unimplemented("synic_msrs"))
     }
 
-    fn set_synic_msrs(&mut self, value: &vp::SyntheticMsrs) -> Result<(), Self::Error> {
+    fn set_synic_msrs(&mut self, _value: &vp::SyntheticMsrs) -> Result<(), Self::Error> {
         Err(vp_state::Error::Unimplemented("synic_msrs"))
     }
 
@@ -1988,7 +1987,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
         Err(vp_state::Error::Unimplemented("synic_message_page"))
     }
 
-    fn set_synic_message_page(&mut self, value: &vp::SynicMessagePage) -> Result<(), Self::Error> {
+    fn set_synic_message_page(&mut self, _value: &vp::SynicMessagePage) -> Result<(), Self::Error> {
         Err(vp_state::Error::Unimplemented("synic_message_page"))
     }
 
@@ -1998,7 +1997,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
 
     fn set_synic_event_flags_page(
         &mut self,
-        value: &vp::SynicEventFlagsPage,
+        _value: &vp::SynicEventFlagsPage,
     ) -> Result<(), Self::Error> {
         Err(vp_state::Error::Unimplemented("synic_event_flags_page"))
     }
@@ -2009,7 +2008,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
 
     fn set_synic_message_queues(
         &mut self,
-        value: &vp::SynicMessageQueues,
+        _value: &vp::SynicMessageQueues,
     ) -> Result<(), Self::Error> {
         Err(vp_state::Error::Unimplemented("synic_message_queues"))
     }
@@ -2018,7 +2017,7 @@ impl AccessVpState for UhVpStateAccess<'_, '_, SnpBacked> {
         Err(vp_state::Error::Unimplemented("synic_timers"))
     }
 
-    fn set_synic_timers(&mut self, value: &vp::SynicTimers) -> Result<(), Self::Error> {
+    fn set_synic_timers(&mut self, _value: &vp::SynicTimers) -> Result<(), Self::Error> {
         Err(vp_state::Error::Unimplemented("synic_timers"))
     }
 }

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1003,7 +1003,7 @@ impl InitializedVm {
 
         let mapper = memory_manager.device_memory_mapper();
 
-        #[cfg_attr(not(guest_arch = "x86_64"), allow(unused_mut))]
+        #[cfg_attr(not(guest_arch = "x86_64"), expect(unused_mut))]
         let mut deps_hyperv_firmware_pcat = None;
         let mut deps_hyperv_firmware_uefi = None;
         match &cfg.load_mode {
@@ -2278,7 +2278,7 @@ impl LoadedVmInner {
             assert!(matches!(self.load_mode, LoadMode::Igvm { .. }));
         }
 
-        #[cfg_attr(not(guest_arch = "x86_64"), allow(unused_mut))]
+        #[cfg_attr(not(guest_arch = "x86_64"), expect(unused_mut))]
         let (mut regs, initial_page_vis) = match &self.load_mode {
             LoadMode::None => return Ok(()),
             #[cfg(guest_arch = "x86_64")]

--- a/petri/petri_artifacts_core/src/lib.rs
+++ b/petri/petri_artifacts_core/src/lib.rs
@@ -261,15 +261,15 @@ macro_rules! declare_artifacts {
         $(
             $crate::paste::paste! {
                 $(#[$doc])*
-                #[allow(non_camel_case_types)]
+                #[expect(non_camel_case_types)]
                 pub const $name: $crate::ArtifactHandle<$name> = $crate::ArtifactHandle::new();
 
                 #[doc = concat!("Type-tag for [`",  stringify!($name), "`]")]
-                #[allow(non_camel_case_types)]
+                #[expect(non_camel_case_types)]
                 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
                 pub enum $name {}
 
-                #[allow(non_snake_case)]
+                #[expect(non_snake_case)]
                 mod [< $name __ty >] {
                     impl $crate::ArtifactId for super::$name {
                         const GLOBAL_UNIQUE_ID: &'static str = module_path!();

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -1898,7 +1898,7 @@ impl InternalNode {
     any(feature = "defer", feature = "initiate"),
     derive(mesh::MeshPayload)
 )]
-#[allow(unused)] // some invariants are unused in some configurations, but order matters in their mesh derive, so keep them
+#[cfg_attr(not(any(feature = "defer", feature = "initiate")), expect(dead_code))]
 enum InternalError {
     Immutable,
     Update(String),

--- a/support/mesh/mesh_build/src/lib.rs
+++ b/support/mesh/mesh_build/src/lib.rs
@@ -83,7 +83,6 @@ impl prost_build::ServiceGenerator for MeshServiceGenerator {
             }
 
             impl #ident {
-                #[allow(dead_code)]
                 pub fn fail(self, status: ::mesh_rpc::service::Status) {
                     match self {
                         #(

--- a/support/mesh/mesh_build/src/lib.rs
+++ b/support/mesh/mesh_build/src/lib.rs
@@ -83,6 +83,7 @@ impl prost_build::ServiceGenerator for MeshServiceGenerator {
             }
 
             impl #ident {
+                #[allow(dead_code)]
                 pub fn fail(self, status: ::mesh_rpc::service::Status) {
                     match self {
                         #(

--- a/support/mesh/mesh_channel_core/src/sync_unsafe_cell.rs
+++ b/support/mesh/mesh_channel_core/src/sync_unsafe_cell.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 // UNSAFETY: needed to implement `Sync` for `SyncUnsafeCell`.
-#![allow(unsafe_code)]
+#![expect(unsafe_code)]
 
 use std::cell::UnsafeCell;
 use std::fmt::Debug;

--- a/support/mesh/mesh_protobuf/src/inplace.rs
+++ b/support/mesh/mesh_protobuf/src/inplace.rs
@@ -245,7 +245,6 @@ macro_rules! inplace {
 macro_rules! inplace_some {
     ($v:ident) => {
         let mut $v = core::mem::MaybeUninit::new($v);
-        #[allow(unused_mut)]
         // SAFETY: We just initialized the value.
         let mut $v = unsafe { $crate::inplace::InplaceOption::new_init_unchecked(&mut $v) };
     };
@@ -256,12 +255,10 @@ macro_rules! inplace_some {
 macro_rules! inplace_none {
     ($v:ident) => {
         let mut $v = core::mem::MaybeUninit::uninit();
-        #[allow(unused_mut)]
         let mut $v = $crate::inplace::InplaceOption::uninit(&mut $v);
     };
     ($v:ident : $t:ty) => {
         let mut $v = core::mem::MaybeUninit::<$t>::uninit();
-        #[allow(unused_mut)]
         let mut $v = $crate::inplace::InplaceOption::uninit(&mut $v);
     };
 }

--- a/support/openssl_kdf/src/sys/mod.rs
+++ b/support/openssl_kdf/src/sys/mod.rs
@@ -5,7 +5,7 @@
 // information.
 
 #![expect(dead_code)]
-#![allow(non_camel_case_types)]
+#![expect(non_camel_case_types)]
 
 pub mod evp;
 pub mod kdf;

--- a/support/pal/src/windows.rs
+++ b/support/pal/src/windows.rs
@@ -1026,14 +1026,14 @@ macro_rules! delayload {
     };
 
     (@func pub fn $name:ident($($params:ident : $types:ty),* $(,)?) -> $result:ty) => {
-        #[allow(non_snake_case, clippy::too_many_arguments, clippy::diverging_sub_expression)]
+        #[expect(non_snake_case, clippy::too_many_arguments, clippy::diverging_sub_expression)]
         pub unsafe fn $name($($params: $types,)*) -> $result {
             $crate::delayload!(@body $name($($params : $types),*) -> $result)
         }
     };
 
     (@func fn $name:ident($($params:ident : $types:ty),* $(,)?) -> $result:ty) => {
-        #[allow(non_snake_case, clippy::diverging_sub_expression)]
+        #[expect(non_snake_case, clippy::diverging_sub_expression)]
         unsafe fn $name($($params: $types,)*) -> $result {
             $crate::delayload!(@body $name($($params : $types),*) -> $result)
         }

--- a/vm/devices/chipset/src/battery/mod.rs
+++ b/vm/devices/chipset/src/battery/mod.rs
@@ -64,7 +64,6 @@ pub const BATTERY_STATUS_IRQ_NO: u32 = 4;
 // No functionality is lost by not using this constant, but we prefer
 // ACPI_DEVICE_NOTIFY_BIX_CHANGED because it tells the guest to check for both
 // the BST and BIX registers.
-#[allow(unused)]
 pub const ACPI_DEVICE_NOTIFY_BST_CHANGED: u32 = 0x1;
 pub const ACPI_DEVICE_NOTIFY_BIX_CHANGED: u32 = 0x2;
 

--- a/vm/devices/chipset/src/battery/resolver.rs
+++ b/vm/devices/chipset/src/battery/resolver.rs
@@ -33,10 +33,7 @@ declare_static_async_resolver! {
 }
 
 /// Errors that can occur when resolving a battery device.
-/// Currently marked unused to dodge compiler warning despite needing
-/// this for the type Error below.
 #[derive(Debug, Error)]
-#[allow(unused)]
 pub enum ResolveBatteryError {
     #[error("failed to resolve battery")]
     ResolveBattery(#[source] ResolveError),

--- a/vm/devices/get/vtl2_settings_proto/src/lib.rs
+++ b/vm/devices/get/vtl2_settings_proto/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
-#![allow(unused_qualifications)] // pbjson-build doesn't use ::fully::qualified::paths.
+#![expect(unused_qualifications)] // pbjson-build doesn't use ::fully::qualified::paths.
 #![expect(clippy::needless_lifetimes)] // pbjson-build generates needless lifetimes for `impl` blocks.
 
 // These crates are referenced by the generated code. Reference them

--- a/vm/devices/support/fs/fuse/src/protocol.rs
+++ b/vm/devices/support/fs/fuse/src/protocol.rs
@@ -9,7 +9,7 @@
 //! For more details, see fuse.h.
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
-#![allow(unused_parens)]
+#![expect(unused_parens)]
 
 use zerocopy::FromBytes;
 use zerocopy::Immutable;

--- a/vm/devices/support/fs/lxutil/src/windows/api.rs
+++ b/vm/devices/support/fs/lxutil/src/windows/api.rs
@@ -37,7 +37,7 @@ pub const LX_UTIL_XATTR_LIST_CASE_SENSITIVE_DIR: ntdef::ULONG = 0x1;
 // Size of PE header signature.
 pub const LX_UTIL_PE_HEADER_SIZE: ntdef::ULONG = 2;
 
-#[allow(non_camel_case_types, non_snake_case, unused)]
+#[allow(non_camel_case_types, non_snake_case)]
 #[repr(C)]
 pub struct FILE_ID_64_EXTD_DIR_INFORMATION {
     pub NextEntryOffset: u32,
@@ -56,7 +56,7 @@ pub struct FILE_ID_64_EXTD_DIR_INFORMATION {
     pub FileName: [u16; 1],
 }
 
-#[allow(non_camel_case_types, non_snake_case, unused)]
+#[allow(non_camel_case_types, non_snake_case)]
 #[repr(C)]
 pub struct FILE_ID_ALL_EXTD_DIR_INFORMATION {
     pub NextEntryOffset: u32,

--- a/vm/devices/uidevices/src/keyboard/mod.rs
+++ b/vm/devices/uidevices/src/keyboard/mod.rs
@@ -294,7 +294,7 @@ impl<T: RingMem + Unpin> KeyboardChannel<T> {
                                 _ => return Err(Error::UnexpectedPacketOrder),
                             }
                         }
-                        #[allow(unreachable_code)]
+                        #[expect(unreachable_code)]
                         Ok(())
                     });
 

--- a/vm/devices/uidevices/src/mouse/protocol.rs
+++ b/vm/devices/uidevices/src/mouse/protocol.rs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #![expect(dead_code)]
-#![allow(unused_macros)]
 
 use guid::Guid;
 use static_assertions::const_assert_eq;

--- a/vm/vmgs/vmgs/src/encrypt/mod.rs
+++ b/vm/vmgs/vmgs/src/encrypt/mod.rs
@@ -3,7 +3,6 @@
 
 #![cfg(with_encryption)]
 
-#[allow(unused_macros)]
 macro_rules! activate {
     ($plat:ident) => {
         mod $plat;

--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -1081,7 +1081,7 @@ impl Vmgs {
     }
 
     /// Encrypts the plaintext data and writes the encrypted data to the storage.
-    #[cfg_attr(not(with_encryption), allow(unused_variables))]
+    #[cfg_attr(not(with_encryption), expect(unused_variables))]
     async fn write_encrypted_data(
         &mut self,
         block_offset: u32,
@@ -1112,7 +1112,7 @@ impl Vmgs {
     }
 
     /// Decrypts the encrypted data and reads it to the buffer.
-    #[cfg_attr(not(with_encryption), allow(unused_variables))]
+    #[cfg_attr(not(with_encryption), expect(unused_variables))]
     async fn read_decrypted_data(
         &mut self,
         block_offset: u32,
@@ -1572,7 +1572,7 @@ fn is_empty_key(encryption_key: &[u8]) -> bool {
 }
 
 /// Encrypts MetadataKey. Returns encrypted_metadata_key.
-#[cfg_attr(not(with_encryption), allow(unused_variables))]
+#[cfg_attr(not(with_encryption), expect(unused_variables))]
 fn encrypt_metadata_key(
     encryption_key: &[u8],
     nonce: &[u8],
@@ -1597,7 +1597,7 @@ fn encrypt_metadata_key(
 }
 
 /// Decrypts metadata_key. Returns decrypted_metadata_key.
-#[cfg_attr(not(with_encryption), allow(unused_variables), expect(dead_code))]
+#[cfg_attr(not(with_encryption), expect(unused_variables), expect(dead_code))]
 fn decrypt_metadata_key(
     datastore_key: &[u8],
     nonce: &[u8],

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -459,7 +459,7 @@ async fn vmgs_file_update_key(
     vmgs_update_key(&mut vmgs, encryption_alg, new_encryption_key.as_ref()).await
 }
 
-#[cfg_attr(not(with_encryption), allow(unused_variables))]
+#[cfg_attr(not(with_encryption), expect(unused_variables))]
 async fn vmgs_update_key(
     vmgs: &mut Vmgs,
     encryption_alg: EncryptionAlgorithm,
@@ -560,7 +560,7 @@ fn vhdfiledisk_create(
     Disk::new(disk).map_err(Error::InvalidDisk)
 }
 
-#[cfg_attr(not(with_encryption), allow(unused_mut), allow(unused_variables))]
+#[cfg_attr(not(with_encryption), expect(unused_mut), expect(unused_variables))]
 async fn vmgs_create(
     disk: Disk,
     encryption_alg_key: Option<(EncryptionAlgorithm, &[u8])>,
@@ -924,7 +924,7 @@ async fn vmgs_file_open(
     res
 }
 
-#[cfg_attr(not(with_encryption), allow(unused_mut), allow(unused_variables))]
+#[cfg_attr(not(with_encryption), expect(unused_mut), expect(unused_variables))]
 async fn vmgs_open(
     disk: Disk,
     encryption_key: Option<&[u8]>,

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -1885,7 +1885,7 @@ macro_rules! get_registers {
             let mut values = [$($crate::get_registers!(@def $name)),+];
             ($vp).get_registers(&names, &mut values).map(|_| {
                 let mut vs = &values[..];
-                #[allow(unused_assignments, clippy::mixed_read_write_in_expression)]
+                #[allow(unused_assignments)]
                 ($({
                     let n = $name;
                     let v = &vs[0];

--- a/vmm_core/virt/src/aarch64/vm.rs
+++ b/vmm_core/virt/src/aarch64/vm.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(unused_variables)]
-#![allow(unused_mut)]
-
 use super::Aarch64PartitionCapabilities;
 use crate::state::state_trait;
 use vm_topology::processor::aarch64::Aarch64VpInfo;

--- a/vmm_core/virt/src/lib.rs
+++ b/vmm_core/virt/src/lib.rs
@@ -19,7 +19,6 @@ pub use vm_topology::processor::VpInfo;
 mod arch {
     #[cfg(guest_arch = "x86_64")]
     mod x86 {
-        #![cfg_attr(not(guest_arch = "x86_64"), allow(unused_imports))]
         pub use crate::x86::X86InitialRegs as InitialRegs;
         pub use crate::x86::X86PartitionCapabilities as PartitionCapabilities;
         pub use crate::x86::vm;
@@ -27,7 +26,6 @@ mod arch {
     }
     #[cfg(guest_arch = "aarch64")]
     mod aarch64 {
-        #![cfg_attr(not(guest_arch = "aarch64"), allow(unused_imports))]
         pub use crate::aarch64::Aarch64InitialRegs as InitialRegs;
         pub use crate::aarch64::Aarch64PartitionCapabilities as PartitionCapabilities;
         pub use crate::aarch64::vm;

--- a/vmm_core/virt/src/state.rs
+++ b/vmm_core/virt/src/state.rs
@@ -80,6 +80,7 @@ mod macros {
                 )*
 
                 /// Save all state that can be restored by a call to restore.
+                #[allow(unused_mut)]
                 fn save_all(&mut self) -> Result<$save_state, $crate::state::StateError<Self::Error>> {
                     let mut save_state = $save_state::default();
                     $(
@@ -92,6 +93,7 @@ mod macros {
                 }
 
                 /// Restore state elements saved in save state.
+                #[allow(unused_variables)]
                 fn restore_all(&mut self, state: &$save_state) -> Result<(), $crate::state::StateError<Self::Error>> {
                     $(
                         if let Some(value) = state.$get.as_ref() {
@@ -124,6 +126,7 @@ mod macros {
                 }
 
                 /// Validates that all state elements are in their initial state (after machine reset).
+                #[allow(unused_variables)]
                 fn check_reset_all(&mut self, vp_info: &$vp) {
                     $(
                         if <$ty as $crate::state::StateElement<$caps, $vp>>::can_compare(self.caps()) && <$ty as $crate::state::StateElement<$caps, $vp>>::is_present(self.caps()) {
@@ -132,6 +135,7 @@ mod macros {
                     )*
                 }
 
+                #[allow(unused_variables, unused_mut)]
                 fn inspect_all(&mut self, req: ::inspect::Request<'_>) {
                     let mut resp = req.respond();
                     $(

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -1357,8 +1357,6 @@ impl virt::Processor for MshvProcessor<'_> {
         stop: StopVp<'_>,
         dev: &impl CpuIo,
     ) -> Result<Infallible, VpHaltReason<MshvError>> {
-        #![allow(non_upper_case_globals)]
-
         let vpinner = self.inner;
         let _cleaner = MshvVpInnerCleaner { vpinner };
         let vcpufd = &vpinner.vcpufd;

--- a/vmm_core/virt_mshv/src/vp_state.rs
+++ b/vmm_core/virt_mshv/src/vp_state.rs
@@ -83,7 +83,6 @@ fn hvdef_to_mshv_mut(regs: &mut [HvRegisterAssoc]) -> &mut [hv_register_assoc] {
     unsafe { std::mem::transmute(regs) }
 }
 
-#[allow(unused_variables)]
 impl AccessVpState for &'_ mut MshvProcessor<'_> {
     type Error = Error;
 
@@ -115,7 +114,7 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
         todo!()
     }
 
-    fn set_xsave(&mut self, value: &vp::Xsave) -> Result<(), Self::Error> {
+    fn set_xsave(&mut self, _value: &vp::Xsave) -> Result<(), Self::Error> {
         todo!()
     }
 
@@ -123,7 +122,7 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
         todo!()
     }
 
-    fn set_apic(&mut self, value: &vp::Apic) -> Result<(), Self::Error> {
+    fn set_apic(&mut self, _value: &vp::Apic) -> Result<(), Self::Error> {
         todo!()
     }
 
@@ -219,7 +218,7 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
         todo!()
     }
 
-    fn set_synic_timers(&mut self, value: &vp::SynicTimers) -> Result<(), Self::Error> {
+    fn set_synic_timers(&mut self, _value: &vp::SynicTimers) -> Result<(), Self::Error> {
         todo!()
     }
 
@@ -229,7 +228,7 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
 
     fn set_synic_message_queues(
         &mut self,
-        value: &vp::SynicMessageQueues,
+        _value: &vp::SynicMessageQueues,
     ) -> Result<(), Self::Error> {
         todo!()
     }
@@ -238,7 +237,7 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
         todo!()
     }
 
-    fn set_synic_message_page(&mut self, value: &vp::SynicMessagePage) -> Result<(), Self::Error> {
+    fn set_synic_message_page(&mut self, _value: &vp::SynicMessagePage) -> Result<(), Self::Error> {
         todo!()
     }
 
@@ -248,7 +247,7 @@ impl AccessVpState for &'_ mut MshvProcessor<'_> {
 
     fn set_synic_event_flags_page(
         &mut self,
-        value: &vp::SynicEventFlagsPage,
+        _value: &vp::SynicEventFlagsPage,
     ) -> Result<(), Self::Error> {
         todo!()
     }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -606,10 +606,6 @@ impl virt::BindProcessor for WhpProcessorBinder {
     type Processor<'a> = WhpProcessor<'a>;
     type Error = Error;
 
-    #[cfg_attr(
-        not(all(guest_arch = "aarch64", feature = "unstable_whp")),
-        allow(unused_variables)
-    )]
     fn bind(&mut self) -> Result<Self::Processor<'_>, Self::Error> {
         let vp = WhpProcessor {
             vp: WhpVpRef {

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -638,6 +638,13 @@ impl virt::BindProcessor for WhpProcessorBinder {
                 }
             }
 
+            #[cfg(all(guest_arch = "aarch64", not(feature = "unstable_whp")))]
+            {
+                let _ = vp_info;
+                let _ = vtlp;
+                let _ = vtl;
+            }
+
             #[cfg(all(guest_arch = "aarch64", feature = "unstable_whp"))]
             {
                 let _ = vtlp;

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -1078,8 +1078,6 @@ pub mod options {
         use crate::BusIdPci;
         use chipset_resources::battery::HostBatteryUpdate;
         use local_clock::InspectableLocalClock;
-        #[allow(unused)]
-        use vmcore::non_volatile_store::NonVolatileStore;
 
         macro_rules! feature_gated {
             (


### PR DESCRIPTION
The vast majority of the remaining allows are related to naming conventions, which seem to be bugged at the moment (expect will claim they're unfulfilled but removing it will have them appear). Then there's also a few that would require complicated preconditions, or are macro-generated, which likely will remain forever. Though possibly some more of the macro-generated ones can go away, we'll see.

This is cargo-hack clean.