### PR TITLE
x64_regs: Flush dirty registry page contents at save

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1613,61 +1613,6 @@ impl HclVp {
             backing,
         })
     }
-
-    /// Fetch dirty registers and disable the register page until the next VTL
-    /// transition.
-    fn scan_register_page_and_disable(&self) -> Vec<(HvX64RegisterName, HvRegisterValue)> {
-        let mut regs: Vec<(HvX64RegisterName, HvRegisterValue)> = Vec::new();
-        // If the registry page is not active or invalid, nothing to do.
-        let BackingState::Mshv { reg_page } = &self.backing else {
-            return regs;
-        };
-        let Some(reg_page) = reg_page else {
-            return regs;
-        };
-        // SAFETY: the register page will not be concurrently accessed by the
-        // hypervisor while this VP is in VTL2.
-        let reg_page = unsafe { &mut *reg_page.as_ptr() };
-        if reg_page.is_valid == 0 {
-            return regs;
-        }
-
-        // Collect any dirty registers.
-        if (reg_page.dirty & (1 << hvdef::HV_X64_REGISTER_CLASS_IP)) != 0 {
-            regs.push((HvX64RegisterName::Rip, reg_page.rip.into()));
-        }
-        if (reg_page.dirty & (1 << hvdef::HV_X64_REGISTER_CLASS_GENERAL)) != 0 {
-            regs.push((
-                HvX64RegisterName::Rsp,
-                reg_page.gp_registers
-                    [(HvX64RegisterName::Rsp.0 - HvX64RegisterName::Rax.0) as usize]
-                    .into(),
-            ));
-        }
-        if (reg_page.dirty & (1 << hvdef::HV_X64_REGISTER_CLASS_FLAGS)) != 0 {
-            regs.push((HvX64RegisterName::Rflags, reg_page.rflags.into()));
-        }
-        if (reg_page.dirty & (1 << hvdef::HV_X64_REGISTER_CLASS_SEGMENT)) != 0 {
-            let segment_regs = reg_page
-                .segment
-                .iter()
-                .copied()
-                .enumerate()
-                .map(|(i, val)| {
-                    (
-                        HvX64RegisterName::from(HvRegisterName(HvX64RegisterName::Es.0 + i as u32)),
-                        HvRegisterValue::from(val),
-                    )
-                })
-                .collect::<Vec<_>>();
-            regs.extend_from_slice(segment_regs.as_slice());
-        }
-
-        // Disable the reg page so future writes do not use it (until the state
-        // is reset at the next VTL transition).
-        reg_page.is_valid = 0;
-        regs
-    }
 }
 
 /// Object used to run and to access state for a specific VP.
@@ -1729,6 +1674,8 @@ mod private {
             vtl: GuestVtl,
             name: HvRegisterName,
         ) -> Result<Option<HvRegisterValue>, Error>;
+
+        fn flush_register_page(runner: &mut ProcessorRunner<'a, Self>);
     }
 }
 
@@ -1746,7 +1693,7 @@ impl<'a, T: Backing<'a>> ProcessorRunner<'a, T> {
     /// Flushes any deferred state. Must be called if preparing the partition
     /// for save/restore (servicing).
     pub fn flush_deferred_state(&mut self) {
-        self.flush_register_page();
+        T::flush_register_page(self);
         self.flush_deferred_actions();
     }
 
@@ -1759,21 +1706,6 @@ impl<'a, T: Backing<'a>> ProcessorRunner<'a, T> {
                 let mut actions = actions.borrow_mut();
                 actions.as_mut().unwrap().run_actions(self.hcl);
             })
-        }
-    }
-
-    /// Flushes any dirty registers from the register page to ensure the values
-    /// persist across a save/restore (servicing) since there is no guarantee
-    /// the page will be consumed without transitioning to another VTL.
-    fn flush_register_page(&mut self) {
-        let regs = self.vp.scan_register_page_and_disable();
-        if !regs.is_empty() {
-            if let Err(err) = self.set_vp_registers(GuestVtl::Vtl0, regs.as_slice()) {
-                tracing::error!(
-                    err = &err as &dyn std::error::Error,
-                    "Failed to flush register page"
-                );
-            }
         }
     }
 }

--- a/openhcl/hcl/src/ioctl/aarch64.rs
+++ b/openhcl/hcl/src/ioctl/aarch64.rs
@@ -44,7 +44,7 @@ impl ProcessorRunner<'_, MshvArm64> {
     }
 }
 
-impl super::BackingPrivate<'_> for MshvArm64 {
+impl<'a> super::BackingPrivate<'a> for MshvArm64 {
     fn new(vp: &HclVp, sidecar: Option<&SidecarVp<'_>>, _hcl: &Hcl) -> Result<Self, NoRunner> {
         assert!(sidecar.is_none());
         let super::BackingState::Mshv { reg_page: _ } = &vp.backing else {
@@ -54,7 +54,7 @@ impl super::BackingPrivate<'_> for MshvArm64 {
     }
 
     fn try_set_reg(
-        runner: &mut ProcessorRunner<'_, Self>,
+        runner: &mut ProcessorRunner<'a, Self>,
         _vtl: GuestVtl,
         name: HvRegisterName,
         value: HvRegisterValue,
@@ -110,12 +110,12 @@ impl super::BackingPrivate<'_> for MshvArm64 {
         Ok(set)
     }
 
-    fn must_flush_regs_on(_runner: &ProcessorRunner<'_, Self>, _name: HvRegisterName) -> bool {
+    fn must_flush_regs_on(_runner: &ProcessorRunner<'a, Self>, _name: HvRegisterName) -> bool {
         false
     }
 
     fn try_get_reg(
-        runner: &ProcessorRunner<'_, Self>,
+        runner: &ProcessorRunner<'a, Self>,
         _vtl: GuestVtl,
         name: HvRegisterName,
     ) -> Result<Option<HvRegisterValue>, super::Error> {

--- a/openhcl/hcl/src/ioctl/aarch64.rs
+++ b/openhcl/hcl/src/ioctl/aarch64.rs
@@ -158,4 +158,6 @@ impl<'a> super::BackingPrivate<'a> for MshvArm64 {
         };
         Ok(value)
     }
+
+    fn flush_register_page(_runner: &mut ProcessorRunner<'a, Self>) {}
 }

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -205,6 +205,8 @@ impl<'a> super::private::BackingPrivate<'a> for Snp<'a> {
     ) -> Result<Option<HvRegisterValue>, super::Error> {
         Ok(None)
     }
+
+    fn flush_register_page(_runner: &mut ProcessorRunner<'a, Self>) {}
 }
 
 impl<'a> ProcessorRunner<'a, Snp<'a>> {

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -186,7 +186,7 @@ impl<'a> super::private::BackingPrivate<'a> for Snp<'a> {
     }
 
     fn try_set_reg(
-        _runner: &mut ProcessorRunner<'_, Self>,
+        _runner: &mut ProcessorRunner<'a, Self>,
         _vtl: GuestVtl,
         _name: HvRegisterName,
         _value: HvRegisterValue,
@@ -194,12 +194,12 @@ impl<'a> super::private::BackingPrivate<'a> for Snp<'a> {
         Ok(false)
     }
 
-    fn must_flush_regs_on(_runner: &ProcessorRunner<'_, Self>, _name: HvRegisterName) -> bool {
+    fn must_flush_regs_on(_runner: &ProcessorRunner<'a, Self>, _name: HvRegisterName) -> bool {
         false
     }
 
     fn try_get_reg(
-        _runner: &ProcessorRunner<'_, Self>,
+        _runner: &ProcessorRunner<'a, Self>,
         _vtl: GuestVtl,
         _name: HvRegisterName,
     ) -> Result<Option<HvRegisterValue>, super::Error> {
@@ -207,7 +207,7 @@ impl<'a> super::private::BackingPrivate<'a> for Snp<'a> {
     }
 }
 
-impl ProcessorRunner<'_, Snp<'_>> {
+impl<'a> ProcessorRunner<'a, Snp<'a>> {
     /// Gets a reference to the VMSA and backing state of a VTL
     pub fn vmsa(&self, vtl: GuestVtl) -> VmsaWrapper<'_, &SevVmsa> {
         // SAFETY: the VMSA will not be concurrently accessed by the processor

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -463,6 +463,8 @@ impl<'a> super::private::BackingPrivate<'a> for Tdx<'a> {
     ) -> Result<Option<HvRegisterValue>, super::Error> {
         Ok(None)
     }
+
+    fn flush_register_page(_runner: &mut ProcessorRunner<'a, Self>) {}
 }
 
 /// Private registers that are copied to/from the kernel's shared run page.

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -444,7 +444,7 @@ impl<'a> super::private::BackingPrivate<'a> for Tdx<'a> {
     }
 
     fn try_set_reg(
-        _runner: &mut ProcessorRunner<'_, Self>,
+        _runner: &mut ProcessorRunner<'a, Self>,
         _vtl: GuestVtl,
         _name: HvRegisterName,
         _value: HvRegisterValue,
@@ -452,12 +452,12 @@ impl<'a> super::private::BackingPrivate<'a> for Tdx<'a> {
         Ok(false)
     }
 
-    fn must_flush_regs_on(_runner: &ProcessorRunner<'_, Self>, _name: HvRegisterName) -> bool {
+    fn must_flush_regs_on(_runner: &ProcessorRunner<'a, Self>, _name: HvRegisterName) -> bool {
         false
     }
 
     fn try_get_reg(
-        _runner: &ProcessorRunner<'_, Self>,
+        _runner: &ProcessorRunner<'a, Self>,
         _vtl: GuestVtl,
         _name: HvRegisterName,
     ) -> Result<Option<HvRegisterValue>, super::Error> {

--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -436,9 +436,8 @@ impl<'a> BackingPrivate<'a> for MshvX64<'a> {
                         HvX64RegisterName::from(HvRegisterName(HvX64RegisterName::Es.0 + i as u32)),
                         HvRegisterValue::from(val),
                     )
-                })
-                .collect::<Vec<_>>();
-            regs.extend_from_slice(segment_regs.as_slice());
+                });
+            regs.extend(segment_regs);
         }
 
         // Disable the reg page so future writes do not use it (until the state
@@ -448,9 +447,9 @@ impl<'a> BackingPrivate<'a> for MshvX64<'a> {
         // Set the registers now that the register page is marked invalid.
         if !regs.is_empty() {
             if let Err(err) = runner.set_vp_registers(GuestVtl::Vtl0, regs.as_slice()) {
-                tracing::error!(
-                    err = &err as &dyn std::error::Error,
-                    "Failed to flush register page"
+                panic!(
+                    "Failed to flush register page: {}",
+                    &err as &dyn std::error::Error
                 );
             }
         }

--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -443,6 +443,7 @@ impl<'a> BackingPrivate<'a> for MshvX64<'a> {
         // Disable the reg page so future writes do not use it (until the state
         // is reset at the next VTL transition).
         reg_page.is_valid = 0;
+        reg_page.dirty = 0;
 
         // Set the registers now that the register page is marked invalid.
         if !regs.is_empty() {

--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -53,42 +53,6 @@ pub struct MshvX64<'a> {
 }
 
 impl<'a> ProcessorRunner<'a, MshvX64<'a>> {
-    /// Flush any modified state.
-    pub fn flush_state(&mut self) {
-        // Flush contents of the register page and disable it, as it will not
-        // persist through servicing. The VTL level is not checked, instead the
-        // dirty bits are used to determine if the contents should be flushed.
-        let (gp_regs, rip) = if let Some(reg_page) = self.reg_page_mut() {
-            let gp_regs = if reg_page.dirty & (1 << hvdef::HV_X64_REGISTER_CLASS_GENERAL) != 0 {
-                Some(reg_page.gp_registers)
-            } else {
-                None
-            };
-            let rip = if (reg_page.dirty & (1 << hvdef::HV_X64_REGISTER_CLASS_IP)) != 0 {
-                Some(reg_page.rip)
-            } else {
-                None
-            };
-            // Disable the reg page so any future writes do not use it.
-            reg_page.is_valid = 0;
-            (gp_regs, rip)
-        } else {
-            (None, None)
-        };
-        if let Some(gp_regs) = gp_regs {
-            self.cpu_context_mut().gps = gp_regs;
-        }
-        if let Some(rip) = rip {
-            if let Err(err) =
-                self.set_vp_register(GuestVtl::Vtl0, HvX64RegisterName::Rip, rip.into())
-            {
-                tracing::error!(err = &err as &dyn std::error::Error, "Failed to flush RIP");
-            }
-        }
-    }
-}
-
-impl ProcessorRunner<'_, MshvX64<'_>> {
     fn reg_page(&self) -> Option<&HvX64RegisterPage> {
         // SAFETY: the register page will not be concurrently accessed by the
         // hypervisor while this VP is in VTL2.
@@ -234,78 +198,16 @@ impl<'a> BackingPrivate<'a> for MshvX64<'a> {
     }
 
     fn try_set_reg(
-        runner: &mut ProcessorRunner<'_, Self>,
+        runner: &mut ProcessorRunner<'a, Self>,
         vtl: GuestVtl,
         name: HvRegisterName,
         value: HvRegisterValue,
     ) -> Result<bool, Error> {
+        // Try to set the register in the CPU context, the fastest path. Only
+        // VTL-shared registers can be set this way: the CPU context only
+        // exposes the last VTL, and if we entered VTL2 on an interrupt,
+        // OpenHCL doesn't know what the last VTL is.
         let name = name.into();
-        // Try the shared registry page first. These values override any others
-        // when the page is in use.
-        if let Some(reg_page) = runner.reg_page_mut() {
-            if reg_page.vtl == vtl as u8 {
-                let set = match name {
-                    HvX64RegisterName::Rax
-                    | HvX64RegisterName::Rcx
-                    | HvX64RegisterName::Rdx
-                    | HvX64RegisterName::Rbx
-                    | HvX64RegisterName::Rsp
-                    | HvX64RegisterName::Rbp
-                    | HvX64RegisterName::Rsi
-                    | HvX64RegisterName::Rdi
-                    | HvX64RegisterName::R8
-                    | HvX64RegisterName::R9
-                    | HvX64RegisterName::R10
-                    | HvX64RegisterName::R11
-                    | HvX64RegisterName::R12
-                    | HvX64RegisterName::R13
-                    | HvX64RegisterName::R14
-                    | HvX64RegisterName::R15 => {
-                        reg_page.gp_registers[(name.0 - HvX64RegisterName::Rax.0) as usize] =
-                            value.as_u64();
-                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_GENERAL;
-                        true
-                    }
-                    HvX64RegisterName::Rip => {
-                        reg_page.rip = value.as_u64();
-                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_IP;
-                        true
-                    }
-                    HvX64RegisterName::Rflags => {
-                        reg_page.rflags = value.as_u64();
-                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_FLAGS;
-                        true
-                    }
-                    HvX64RegisterName::Es
-                    | HvX64RegisterName::Cs
-                    | HvX64RegisterName::Ss
-                    | HvX64RegisterName::Ds
-                    | HvX64RegisterName::Fs
-                    | HvX64RegisterName::Gs => {
-                        reg_page.segment[(name.0 - HvX64RegisterName::Es.0) as usize] =
-                            value.as_u128();
-                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_SEGMENT;
-                        true
-                    }
-
-                    // Skip unnecessary register updates.
-                    HvX64RegisterName::Cr0 => reg_page.cr0 == value.as_u64(),
-                    HvX64RegisterName::Cr3 => reg_page.cr3 == value.as_u64(),
-                    HvX64RegisterName::Cr4 => reg_page.cr4 == value.as_u64(),
-                    HvX64RegisterName::Cr8 => reg_page.cr8 == value.as_u64(),
-                    HvX64RegisterName::Efer => reg_page.efer == value.as_u64(),
-                    HvX64RegisterName::Dr7 => reg_page.dr7 == value.as_u64(),
-                    _ => false,
-                };
-                if set {
-                    return Ok(true);
-                }
-            }
-        }
-
-        // If the register is shared between VTL states, update the
-        // kernel-supplied CPU context value, which will be restored prior to
-        // switching VTLs.
         let set = match name {
             HvX64RegisterName::Rax
             | HvX64RegisterName::Rcx
@@ -351,10 +253,56 @@ impl<'a> BackingPrivate<'a> for MshvX64<'a> {
             return Ok(true);
         }
 
-        Ok(set)
+        if let Some(reg_page) = runner.reg_page_mut() {
+            if reg_page.vtl == vtl as u8 {
+                let set = match name {
+                    HvX64RegisterName::Rsp => {
+                        reg_page.gp_registers[(name.0 - HvX64RegisterName::Rax.0) as usize] =
+                            value.as_u64();
+                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_GENERAL;
+                        true
+                    }
+                    HvX64RegisterName::Rip => {
+                        reg_page.rip = value.as_u64();
+                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_IP;
+                        true
+                    }
+                    HvX64RegisterName::Rflags => {
+                        reg_page.rflags = value.as_u64();
+                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_FLAGS;
+                        true
+                    }
+                    HvX64RegisterName::Es
+                    | HvX64RegisterName::Cs
+                    | HvX64RegisterName::Ss
+                    | HvX64RegisterName::Ds
+                    | HvX64RegisterName::Fs
+                    | HvX64RegisterName::Gs => {
+                        reg_page.segment[(name.0 - HvX64RegisterName::Es.0) as usize] =
+                            value.as_u128();
+                        reg_page.dirty |= 1 << hvdef::HV_X64_REGISTER_CLASS_SEGMENT;
+                        true
+                    }
+
+                    // Skip unnecessary register updates.
+                    HvX64RegisterName::Cr0 => reg_page.cr0 == value.as_u64(),
+                    HvX64RegisterName::Cr3 => reg_page.cr3 == value.as_u64(),
+                    HvX64RegisterName::Cr4 => reg_page.cr4 == value.as_u64(),
+                    HvX64RegisterName::Cr8 => reg_page.cr8 == value.as_u64(),
+                    HvX64RegisterName::Efer => reg_page.efer == value.as_u64(),
+                    HvX64RegisterName::Dr7 => reg_page.dr7 == value.as_u64(),
+                    _ => false,
+                };
+                if set {
+                    return Ok(true);
+                }
+            }
+        }
+
+        Ok(false)
     }
 
-    fn must_flush_regs_on(runner: &ProcessorRunner<'_, Self>, name: HvRegisterName) -> bool {
+    fn must_flush_regs_on(runner: &ProcessorRunner<'a, Self>, name: HvRegisterName) -> bool {
         // Updating rflags must be ordered with other registers in a batch,
         // since it may affect the validity other interrupt-related registers.
         matches!(HvX64RegisterName::from(name), HvX64RegisterName::Rflags)
@@ -362,67 +310,11 @@ impl<'a> BackingPrivate<'a> for MshvX64<'a> {
     }
 
     fn try_get_reg(
-        runner: &ProcessorRunner<'_, Self>,
+        runner: &ProcessorRunner<'a, Self>,
         vtl: GuestVtl,
         name: HvRegisterName,
     ) -> Result<Option<HvRegisterValue>, Error> {
         let name = name.into();
-
-        // Try the shared registry page first. These values override any others
-        // when the page is in use.
-        if let Some(reg_page) = runner.reg_page() {
-            if reg_page.vtl == vtl as u8 {
-                let value = match name {
-                    HvX64RegisterName::Rax
-                    | HvX64RegisterName::Rcx
-                    | HvX64RegisterName::Rdx
-                    | HvX64RegisterName::Rbx
-                    | HvX64RegisterName::Rsp
-                    | HvX64RegisterName::Rbp
-                    | HvX64RegisterName::Rsi
-                    | HvX64RegisterName::Rdi
-                    | HvX64RegisterName::R8
-                    | HvX64RegisterName::R9
-                    | HvX64RegisterName::R10
-                    | HvX64RegisterName::R11
-                    | HvX64RegisterName::R12
-                    | HvX64RegisterName::R13
-                    | HvX64RegisterName::R14
-                    | HvX64RegisterName::R15 => Some(HvRegisterValue(
-                        reg_page.gp_registers[(name.0 - HvX64RegisterName::Rax.0) as usize].into(),
-                    )),
-                    HvX64RegisterName::Rip => Some(HvRegisterValue((reg_page.rip).into())),
-                    HvX64RegisterName::Rflags => Some(HvRegisterValue((reg_page.rflags).into())),
-                    HvX64RegisterName::Es
-                    | HvX64RegisterName::Cs
-                    | HvX64RegisterName::Ss
-                    | HvX64RegisterName::Ds
-                    | HvX64RegisterName::Fs
-                    | HvX64RegisterName::Gs => Some(HvRegisterValue(
-                        reg_page.segment[(name.0 - HvX64RegisterName::Es.0) as usize].into(),
-                    )),
-                    HvX64RegisterName::Cr0 => Some(HvRegisterValue((reg_page.cr0).into())),
-                    HvX64RegisterName::Cr3 => Some(HvRegisterValue((reg_page.cr3).into())),
-                    HvX64RegisterName::Cr4 => Some(HvRegisterValue((reg_page.cr4).into())),
-                    HvX64RegisterName::Cr8 => Some(HvRegisterValue((reg_page.cr8).into())),
-                    HvX64RegisterName::Efer => Some(HvRegisterValue((reg_page.efer).into())),
-                    HvX64RegisterName::Dr7 => Some(HvRegisterValue((reg_page.dr7).into())),
-                    HvX64RegisterName::InstructionEmulationHints => Some(HvRegisterValue(
-                        (u64::from(reg_page.instruction_emulation_hints)).into(),
-                    )),
-                    HvX64RegisterName::PendingInterruption => {
-                        Some(u64::from(reg_page.pending_interruption).into())
-                    }
-                    HvX64RegisterName::InterruptState => {
-                        Some(u64::from(reg_page.interrupt_state).into())
-                    }
-                    _ => None,
-                };
-                if let Some(value) = value {
-                    return Ok(Some(value));
-                }
-            }
-        }
 
         let value = match name {
             HvX64RegisterName::Rax
@@ -466,6 +358,49 @@ impl<'a> BackingPrivate<'a> for MshvX64<'a> {
             ),
             _ => None,
         };
-        Ok(value)
+        if let Some(value) = value {
+            return Ok(Some(value));
+        }
+
+        if let Some(reg_page) = runner.reg_page() {
+            if reg_page.vtl == vtl as u8 {
+                let value = match name {
+                    HvX64RegisterName::Rsp => Some(HvRegisterValue(
+                        reg_page.gp_registers[(name.0 - HvX64RegisterName::Rax.0) as usize].into(),
+                    )),
+                    HvX64RegisterName::Rip => Some(HvRegisterValue((reg_page.rip).into())),
+                    HvX64RegisterName::Rflags => Some(HvRegisterValue((reg_page.rflags).into())),
+                    HvX64RegisterName::Es
+                    | HvX64RegisterName::Cs
+                    | HvX64RegisterName::Ss
+                    | HvX64RegisterName::Ds
+                    | HvX64RegisterName::Fs
+                    | HvX64RegisterName::Gs => Some(HvRegisterValue(
+                        reg_page.segment[(name.0 - HvX64RegisterName::Es.0) as usize].into(),
+                    )),
+                    HvX64RegisterName::Cr0 => Some(HvRegisterValue((reg_page.cr0).into())),
+                    HvX64RegisterName::Cr3 => Some(HvRegisterValue((reg_page.cr3).into())),
+                    HvX64RegisterName::Cr4 => Some(HvRegisterValue((reg_page.cr4).into())),
+                    HvX64RegisterName::Cr8 => Some(HvRegisterValue((reg_page.cr8).into())),
+                    HvX64RegisterName::Efer => Some(HvRegisterValue((reg_page.efer).into())),
+                    HvX64RegisterName::Dr7 => Some(HvRegisterValue((reg_page.dr7).into())),
+                    HvX64RegisterName::InstructionEmulationHints => Some(HvRegisterValue(
+                        (u64::from(reg_page.instruction_emulation_hints)).into(),
+                    )),
+                    HvX64RegisterName::PendingInterruption => {
+                        Some(u64::from(reg_page.pending_interruption).into())
+                    }
+                    HvX64RegisterName::InterruptState => {
+                        Some(u64::from(reg_page.interrupt_state).into())
+                    }
+                    _ => None,
+                };
+                if let Some(value) = value {
+                    return Ok(Some(value));
+                }
+            }
+        }
+
+        Ok(None)
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -753,7 +753,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                 }
             }
         }
-        self.runner.flush_deferred_actions();
+        self.runner.flush_deferred_state();
         Ok(())
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1957,7 +1957,6 @@ mod save_restore {
             let startup_suspend = internal_activity
                 .map(|a| HvInternalActivityRegister::from(a.as_u64()).startup_suspend());
 
-            self.runner.flush_state();
             let [
                 rax,
                 rcx,

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1957,6 +1957,7 @@ mod save_restore {
             let startup_suspend = internal_activity
                 .map(|a| HvInternalActivityRegister::from(a.as_u64()).startup_suspend());
 
+            self.runner.flush_state();
             let [
                 rax,
                 rcx,

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -310,7 +310,7 @@ impl VirtualRegister {
         Ok(())
     }
 
-    fn read(&self, runner: &ProcessorRunner<'_, Tdx<'_>>) -> u64 {
+    fn read<'a>(&self, runner: &ProcessorRunner<'a, Tdx<'a>>) -> u64 {
         let physical_reg = runner.read_vmcs64(self.vtl, self.register.physical_vmcs_field());
 
         // Get the bits owned by the host from the shadow and the bits owned by the

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -122,11 +122,11 @@ impl UhProcessor<'_, TdxBacked> {
 
     /// Performs any TLB flush by list that may be required. Returns true
     /// if successful, false if a flush entire is required instead.
-    fn try_flush_list(
+    fn try_flush_list<'a>(
         target_vtl: GuestVtl,
         partition_flush_state: &TdxPartitionFlushState,
         gva_list_count: &mut Wrapping<usize>,
-        runner: &mut ProcessorRunner<'_, Tdx<'_>>,
+        runner: &mut ProcessorRunner<'a, Tdx<'a>>,
         flush_page: &user_driver::memory::MemoryBlock,
     ) -> bool {
         // Check quickly to see whether any new addresses are in the list.

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -3616,11 +3616,17 @@ pub struct HvRegisterVpAssistPage {
     pub gpa_page_number: u64,
 }
 
-pub const HV_X64_REGISTER_CLASS_GENERAL: u8 = 0;
-pub const HV_X64_REGISTER_CLASS_IP: u8 = 1;
-pub const HV_X64_REGISTER_CLASS_XMM: u8 = 2;
-pub const HV_X64_REGISTER_CLASS_SEGMENT: u8 = 3;
-pub const HV_X64_REGISTER_CLASS_FLAGS: u8 = 4;
+#[bitfield(u32)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct X64RegisterPageDirtyFlags {
+    pub general_purpose: bool,
+    pub instruction_pointer: bool,
+    pub xmm: bool,
+    pub segments: bool,
+    pub flags: bool,
+    #[bits(27)]
+    reserved: u32,
+}
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -3628,7 +3634,7 @@ pub struct HvX64RegisterPage {
     pub version: u16,
     pub is_valid: u8,
     pub vtl: u8,
-    pub dirty: u32,
+    pub dirty: X64RegisterPageDirtyFlags,
     pub gp_registers: [u64; 16],
     pub rip: u64,
     pub rflags: u64,


### PR DESCRIPTION
Save/restore will destroy the registry page contents, so flush them out to other locations on save.