### PR TITLE
underhill_mem: cvm: don't register shared memory with the kernel

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1795,7 +1795,10 @@ async fn new_underhill_vm(
 
     // ARM64 always bounces, as the OpenHCL kernel does not
     // have access to VTL0 pages. Necessary until #273 is resolved.
-    let always_bounce = cfg!(guest_arch = "aarch64");
+    //
+    // Currently we always bounce for CVM as well, due to underhill_mem not
+    // supporting registering shared or private memory with the kernel.
+    let always_bounce = cfg!(guest_arch = "aarch64") || isolation.is_hardware_isolated();
     resolver.add_async_resolver::<DiskHandleKind, _, OpenBlockDeviceConfig, _>(
         BlockDeviceResolver::new(
             Arc::new(tp.clone()),

--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -283,11 +283,15 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
         // Create the shared mapping with the complete memory map, to include
         // the shared pool. This memory is not private to VTL2 and is expected
         // that devices will access it via DMA.
+        //
+        // Don't allow kernel access here either--the kernel seems to get
+        // confused about shared memory, and our current use of kernel-mode
+        // guest memory access is limited to low-perf paths where we can use
+        // bounce buffering.
         tracing::debug!("Building shared memory map");
         let shared_mapping = Arc::new({
             let _span = tracing::info_span!("map_shared_memory").entered();
             GuestMemoryMapping::builder(shared_offset)
-                .for_kernel_access(true)
                 .shared(true)
                 .use_bitmap(Some(false))
                 .ignore_registration_failure(!params.boot_init)


### PR DESCRIPTION
We are seeing failures when registering shared memory with the kernel in TDX configurations. Rather than try to debug this right now , just prohibit it--this is only used in low-perf paths in practice, and it introduces extra runtime failure paths that are impossible to recover from.

Backport of #1080