### PR TITLE
hcl: don't flush deferred actions for the wrong thread

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -11,7 +11,6 @@ pub mod tdx;
 pub mod x64;
 
 use self::deferred::DeferredActionSlots;
-use self::deferred::DeferredActions;
 use self::ioctls::*;
 use crate::GuestVtl;
 use crate::ioctl::deferred::DeferredAction;
@@ -24,6 +23,9 @@ use crate::protocol::HCL_VMSA_PAGE_OFFSET;
 use crate::protocol::MSHV_APIC_PAGE_OFFSET;
 use crate::protocol::hcl_intr_offload_flags;
 use crate::protocol::hcl_run;
+use deferred::RegisteredDeferredActions;
+use deferred::push_deferred_action;
+use deferred::register_deferred_actions;
 use hv1_structs::ProcessorSet;
 use hv1_structs::VtlArray;
 use hvdef::HV_PAGE_SIZE;
@@ -62,7 +64,6 @@ use sidecar_client::NewSidecarClientError;
 use sidecar_client::SidecarClient;
 use sidecar_client::SidecarRun;
 use sidecar_client::SidecarVp;
-use std::cell::RefCell;
 use std::cell::UnsafeCell;
 use std::fmt::Debug;
 use std::fs::File;
@@ -1620,6 +1621,7 @@ pub struct ProcessorRunner<'a, T> {
     hcl: &'a Hcl,
     vp: &'a HclVp,
     sidecar: Option<SidecarVp<'a>>,
+    deferred_actions: Option<RegisteredDeferredActions<'a>>,
     run: &'a UnsafeCell<hcl_run>,
     intercept_message: &'a UnsafeCell<HvMessage>,
     state: T,
@@ -1679,9 +1681,7 @@ mod private {
 
 impl<T> Drop for ProcessorRunner<'_, T> {
     fn drop(&mut self) {
-        self.flush_deferred_actions();
-        let actions = DEFERRED_ACTIONS.with(|actions| actions.take());
-        assert!(actions.is_none_or(|a| a.is_empty()));
+        drop(self.deferred_actions.take());
         let old_state = std::mem::replace(&mut *self.vp.state.lock(), VpState::NotRunning);
         assert!(matches!(old_state, VpState::Running(thread) if thread == Pthread::current()));
     }
@@ -1692,11 +1692,8 @@ impl<T> ProcessorRunner<'_, T> {
     /// partition for save/restore (servicing), since otherwise the deferred
     /// actions will be lost.
     pub fn flush_deferred_actions(&mut self) {
-        if self.sidecar.is_none() {
-            DEFERRED_ACTIONS.with(|actions| {
-                let mut actions = actions.borrow_mut();
-                actions.as_mut().unwrap().run_actions(self.hcl);
-            })
+        if let Some(actions) = &mut self.deferred_actions {
+            actions.flush();
         }
     }
 }
@@ -1899,18 +1896,13 @@ impl<'a, T: Backing<'a>> ProcessorRunner<'a, T> {
     pub fn run(&mut self) -> Result<bool, Error> {
         assert!(self.sidecar.is_none());
         // Apply any deferred actions to the run page.
-        DEFERRED_ACTIONS.with(|actions| {
-            let mut actions = actions.borrow_mut();
-            let actions = actions.as_mut().unwrap();
-            if self.hcl.supports_vtl_ret_action {
-                // SAFETY: there are no concurrent accesses to the deferred action
-                // slots.
-                let mut slots = unsafe { DeferredActionSlots::new(self.run) };
-                actions.copy_to_slots(&mut slots, self.hcl);
-            } else {
-                actions.run_actions(self.hcl);
-            }
-        });
+        if let Some(actions) = &mut self.deferred_actions {
+            debug_assert!(self.hcl.supports_vtl_ret_action);
+            // SAFETY: there are no concurrent accesses to the deferred action
+            // slots.
+            let mut slots = unsafe { DeferredActionSlots::new(self.run) };
+            actions.move_to_slots(&mut slots);
+        };
 
         // N.B. cpu_context and exit_context are mutated by this call.
         //
@@ -2126,10 +2118,6 @@ impl<'a, T: Backing<'a>> ProcessorRunner<'a, T> {
     }
 }
 
-thread_local! {
-    static DEFERRED_ACTIONS: RefCell<Option<DeferredActions>> = const { RefCell::new(None) };
-}
-
 impl Hcl {
     /// Returns a new HCL instance.
     pub fn new(isolation: IsolationType, sidecar: Option<SidecarClient>) -> Result<Hcl, Error> {
@@ -2310,11 +2298,11 @@ impl Hcl {
             panic!("another runner already exists")
         };
 
-        if sidecar.is_none() {
-            DEFERRED_ACTIONS.with(|actions| {
-                assert!(actions.replace(Some(Default::default())).is_none());
-            });
-        }
+        let actions = if sidecar.is_none() && self.supports_vtl_ret_action {
+            Some(register_deferred_actions(self))
+        } else {
+            None
+        };
 
         // SAFETY: The run page is guaranteed to be mapped and valid.
         // While the exit message might not be filled in yet we're only computing its address.
@@ -2328,6 +2316,7 @@ impl Hcl {
         Ok(ProcessorRunner {
             hcl: self,
             vp,
+            deferred_actions: actions,
             run: vp.run.as_ref(),
             intercept_message,
             state,
@@ -2381,24 +2370,7 @@ impl Hcl {
     /// hypervisor is returning to a lower VTL.
     pub fn signal_event_direct(&self, vp: u32, sint: u8, flag: u16) {
         tracing::trace!(vp, sint, flag, "signaling event");
-
-        DEFERRED_ACTIONS.with(|actions| {
-            // Push a deferred action if we are running on a VP thread.
-            if let Some(actions) = actions.borrow_mut().as_mut() {
-                actions.push(self, DeferredAction::SignalEvent { vp, sint, flag });
-            } else {
-                // Signal the event directly.
-                if let Err(err) = self.hvcall_signal_event_direct(vp, sint, flag) {
-                    tracelimit::warn_ratelimited!(
-                        error = &err as &dyn std::error::Error,
-                        vp,
-                        sint,
-                        flag,
-                        "failed to signal event"
-                    );
-                }
-            }
-        })
+        push_deferred_action(self, DeferredAction::SignalEvent { vp, sint, flag });
     }
 
     fn hvcall_signal_event_direct(&self, vp: u32, sint: u8, flag: u16) -> Result<bool, Error> {

--- a/openhcl/hcl/src/ioctl/deferred.rs
+++ b/openhcl/hcl/src/ioctl/deferred.rs
@@ -6,45 +6,110 @@
 use super::Hcl;
 use crate::protocol;
 use crate::protocol::hcl_run;
+use std::cell::Cell;
 use std::cell::UnsafeCell;
+use std::marker::PhantomData;
 use zerocopy::IntoBytes;
 
-#[derive(Debug, Default)]
-pub(crate) struct DeferredActions {
-    actions: Vec<DeferredAction>,
+thread_local! {
+    static DEFERRED_ACTIONS: DeferredActions = const { DeferredActions::new() };
 }
 
-const MAX_ACTIONS: usize = 8;
+struct DeferredActions {
+    actions: [Cell<DeferredAction>; MAX_ACTIONS as usize],
+    used: Cell<u8>,
+}
+
+const MAX_ACTIONS: u8 = 8;
+const DISABLED: u8 = !0;
 
 impl DeferredActions {
-    /// Pushes the actions.
-    pub fn push(&mut self, hcl: &Hcl, action: DeferredAction) {
-        if self.actions.len() < MAX_ACTIONS {
-            self.actions.push(action);
+    const fn new() -> Self {
+        Self {
+            actions: [const { Cell::new(DeferredAction::Noop) }; MAX_ACTIONS as usize],
+            used: Cell::new(DISABLED),
+        }
+    }
+
+    fn drain(&self) -> &[Cell<DeferredAction>] {
+        let used = self.used.replace(0);
+        &self.actions[..used as usize]
+    }
+}
+
+/// Pushes an action to the current thread's list of deferred actions. If the
+/// list is full or there is no list for the current thread, the action will be
+/// run immediately.
+pub fn push_deferred_action(hcl: &Hcl, action: DeferredAction) {
+    DEFERRED_ACTIONS.with(|deferred| {
+        let used = deferred.used.get();
+        if used < MAX_ACTIONS {
+            deferred.actions[used as usize].set(action);
+            deferred.used.set(used + 1);
         } else {
-            action.run(hcl);
+            // The action couldn't be deferred, so run it immediately.
+            action.run(hcl)
         }
-    }
+    });
+}
 
-    pub fn is_empty(&self) -> bool {
-        self.actions.is_empty()
-    }
+/// A token representing that a deferred actions list has been registered for
+/// the current thread.
+///
+/// When dropped, this will flush any deferred actions that were registered. The
+/// owner can also call `flush` to run the actions immediately, if desired, and
+/// `move_to_slots` to copy the actions to the HCL run structure's action slots
+/// before running the VP.
+//
+// DEVNOTE: Use a PhantomData to ensure this isn't `Sync` or `Send`, so that it
+// doesn't move to another thread.
+pub struct RegisteredDeferredActions<'a>(&'a Hcl, PhantomData<*const ()>);
 
-    /// Copies the queued actions to the slots in the run page. Issues any
+/// Registers a deferred actions list for the current thread.
+pub fn register_deferred_actions(hcl: &Hcl) -> RegisteredDeferredActions<'_> {
+    DEFERRED_ACTIONS.with(|deferred| {
+        assert_eq!(deferred.used.replace(0), DISABLED);
+    });
+    RegisteredDeferredActions(hcl, PhantomData)
+}
+
+impl RegisteredDeferredActions<'_> {
+    /// Moves the queued actions to the slots in the run page. Issues any
     /// immediately that won't fit in the run page.
-    pub fn copy_to_slots(&mut self, slots: &mut DeferredActionSlots<'_>, hcl: &Hcl) {
-        for action in self.actions.drain(..) {
-            if !action.post(slots) {
-                action.run(hcl);
+    pub fn move_to_slots(&mut self, slots: &mut DeferredActionSlots<'_>) {
+        self.with(|deferred, hcl| {
+            for action in deferred.drain() {
+                let action = action.get();
+                if !action.post(slots) {
+                    action.run(hcl);
+                }
             }
-        }
+        })
     }
 
     /// Runs actions immediately without deferring them to VTL return.
-    pub fn run_actions(&mut self, hcl: &Hcl) {
-        for action in self.actions.drain(..) {
-            action.run(hcl);
-        }
+    pub fn flush(&mut self) {
+        self.with(|deferred, hcl| {
+            for action in deferred.drain() {
+                action.get().run(hcl);
+            }
+        });
+    }
+
+    fn with(&mut self, f: impl FnOnce(&DeferredActions, &Hcl)) {
+        DEFERRED_ACTIONS.with(|deferred| {
+            debug_assert!(deferred.used.get() <= MAX_ACTIONS);
+            f(deferred, self.0);
+        });
+    }
+}
+
+impl Drop for RegisteredDeferredActions<'_> {
+    fn drop(&mut self) {
+        self.flush();
+        DEFERRED_ACTIONS.with(|deferred| {
+            assert_eq!(deferred.used.replace(DISABLED), 0);
+        })
     }
 }
 
@@ -52,6 +117,7 @@ impl DeferredActions {
 /// VTLs.
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum DeferredAction {
+    Noop,
     SignalEvent { vp: u32, sint: u8, flag: u16 },
 }
 
@@ -59,8 +125,17 @@ impl DeferredAction {
     /// Run the action via a hypercall.
     fn run(&self, hcl: &Hcl) {
         match *self {
+            DeferredAction::Noop => {}
             DeferredAction::SignalEvent { vp, sint, flag } => {
-                let _ = hcl.hvcall_signal_event_direct(vp, sint, flag);
+                if let Err(err) = hcl.hvcall_signal_event_direct(vp, sint, flag) {
+                    tracelimit::warn_ratelimited!(
+                        error = &err as &dyn std::error::Error,
+                        vp,
+                        sint,
+                        flag,
+                        "failed to signal event"
+                    );
+                }
             }
         }
     }
@@ -68,6 +143,7 @@ impl DeferredAction {
     /// Post the action to the HCL.
     fn post(&self, slots: &mut DeferredActionSlots<'_>) -> bool {
         match *self {
+            DeferredAction::Noop => true,
             DeferredAction::SignalEvent { vp, sint, flag } => slots.push(
                 protocol::hv_vp_assist_page_signal_event {
                     action_type: protocol::HV_VP_ASSIST_PAGE_ACTION_TYPE_SIGNAL_EVENT,


### PR DESCRIPTION
When a sidecar VP is being disabled, it can incorrectly flush and disable deferred actions for a different VP, causing a panic later.

Fix this. Refactor the deferred actions to eliminate the classes of bugs that have plagued this code. Remove some allocations and panics, too.