### PR TITLE
hcl: do not use sidecar when x2apic is not available

### DIFF
--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -105,6 +105,15 @@ pub fn start_sidecar<'a>(
         }
     }
 
+    #[cfg(target_arch = "x86_64")]
+    if safe_intrinsics::cpuid(x86defs::cpuid::CpuidFunction::VersionAndFeatures.0, 0).ecx
+        & (1 << 21) == 0
+    {
+        // Currently, sidecar needs x2apic to communicate with the kernel
+        log!("sidecar: x2apic not available; not using sidecar");
+        return None;
+    }
+
     // Split the CPUs by NUMA node, and then into chunks of no more than
     // MAX_SIDECAR_NODE_SIZE processors.
     let cpus_by_node = || {


### PR DESCRIPTION
sidecar relies on x2apic to communicate with the sidecar kernel components. Do not use sidecar when x2apic is not available.