### PR TITLE
flowey: merge minor rust steps in generated YAML

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -112,30 +112,22 @@ jobs:
       run: flowey e 0 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 0 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 0 flowey_lib_common::cache 0
         flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 0 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 0 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 0 flowey_lib_common::cache 2
+        flowey e 0 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 0 flowey_lib_common::install_dist_pkg 0
@@ -153,17 +145,11 @@ jobs:
       run: flowey e 0 flowey_lib_common::download_mdbook_mermaid 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 0 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 0 flowey_lib_common::git_checkout 0
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -172,26 +158,20 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 0 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 0 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 0 flowey_lib_hvlite::build_guide 0
+      run: |-
+        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 0 flowey_lib_common::git_checkout 3
+        flowey e 0 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 0 flowey_lib_hvlite::build_guide 0
       shell: bash
     - name: install Rust
       run: flowey e 0 flowey_lib_common::install_rust 0
       shell: bash
     - name: build OpenVMM guide (mdbook)
-      run: flowey e 0 flowey_lib_hvlite::build_guide 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 0 flowey_lib_hvlite::artifact_guide::publish 0
+      run: |-
+        flowey e 0 flowey_lib_hvlite::build_guide 1
+        flowey e 0 flowey_lib_hvlite::artifact_guide::publish 0
       shell: bash
     - name: copying guide to artifact dir
       run: flowey e 0 flowey_lib_common::copy_to_artifact_dir 0
@@ -299,17 +279,11 @@ jobs:
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-rustdoc" | flowey.exe v 1 'artifact_publish_from_x64-windows-rustdoc' --update-from-stdin --is-raw-string
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 1 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 1 flowey_lib_common::git_checkout 0
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -318,14 +292,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 1 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 1 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 1 flowey_lib_common::git_checkout 3
+        flowey.exe e 1 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 1 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -334,36 +305,27 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 1 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 1 flowey_lib_common::cache 0
         flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 1 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 1 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 1 flowey_lib_common::cache 2
+        flowey.exe e 1 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 1 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 1 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 1 flowey_lib_common::download_protoc 0
+        flowey.exe e 1 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: flowey.exe e 1 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
@@ -378,10 +340,9 @@ jobs:
       run: flowey.exe e 1 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 1 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 1 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 1 flowey_lib_common::install_rust 1
+        flowey.exe e 1 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: construct cargo doc command
       run: flowey.exe e 1 flowey_lib_common::run_cargo_doc 0
@@ -390,10 +351,9 @@ jobs:
       run: flowey.exe e 1 flowey_lib_hvlite::build_rustdoc 0
       shell: bash
     - name: archive rustdoc dir
-      run: flowey.exe e 1 flowey_lib_hvlite::artifact_rustdoc::publish 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 1 flowey_lib_hvlite::artifact_rustdoc::publish 1
+      run: |-
+        flowey.exe e 1 flowey_lib_hvlite::artifact_rustdoc::publish 0
+        flowey.exe e 1 flowey_lib_hvlite::artifact_rustdoc::publish 1
       shell: bash
     - name: copying rustdoc to artifact dir
       run: flowey.exe e 1 flowey_lib_common::copy_to_artifact_dir 0
@@ -515,10 +475,9 @@ jobs:
       run: flowey e 10 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 10 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 10 flowey_lib_common::install_rust 1
+        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 10 flowey_lib_common::install_dist_pkg 0
@@ -530,46 +489,32 @@ jobs:
       run: flowey e 10 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 10 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
         flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 10 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 10 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.AARCH64.zip
       run: flowey e 10 flowey_lib_hvlite::download_lxutil 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 10 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 10 flowey_lib_common::git_checkout 0
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -578,17 +523,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 10 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 10 flowey_lib_common::git_checkout 3
+        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move lxutil.dll into its magic folder
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
@@ -600,136 +540,110 @@ jobs:
       run: flowey e 10 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm
-      run: flowey e 10 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 5
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
       shell: bash
     - name: split debug symbols
       run: flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
       shell: bash
     - name: reporting split debug info
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: report built openvmm
-      run: flowey e 10 flowey_lib_hvlite::build_openvmm 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::build_openvmm 0
       shell: bash
     - name: copying openvmm to publish dir
-      run: flowey e 10 flowey_lib_hvlite::artifact_openvmm::publish 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 10 flowey_lib_hvlite::artifact_openvmm::publish 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgstool
-      run: flowey e 10 flowey_lib_common::run_cargo_build 5
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 5
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
       shell: bash
     - name: reporting split debug info
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: report built vmgstool
-      run: flowey e 10 flowey_lib_hvlite::build_vmgstool 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_vmgstool::publish 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 10 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 10 flowey_lib_hvlite::artifact_vmgstool::publish 0
       shell: bash
     - name: copying vmgstool to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 4
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 4
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build vmgs_lib
-      run: flowey e 10 flowey_lib_common::run_cargo_build 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: check built vmgs_lib
-      run: flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: report built vmgs_lib
-      run: flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 10 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
       shell: bash
     - name: copying vmgs_lib to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 3
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey e 10 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 1
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
       shell: bash
     - name: reporting split debug info
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
       shell: bash
     - name: copying igvmfilegen to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build ohcldiag-dev
-      run: flowey e 10 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: split debug symbols
       run: flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: report built ohcldiag_dev
-      run: flowey e 10 flowey_lib_hvlite::build_ohcldiag_dev 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 10 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 10 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
       shell: bash
     - name: copying ohcldiag-dev to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 2
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 5
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 2
+        flowey e 10 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build guest_test_uefi
-      run: flowey e 10 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: build guest_test_uefi.img
-      run: flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_guest_test_uefi::publish 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 10 flowey_lib_hvlite::artifact_guest_test_uefi::publish 0
       shell: bash
     - name: copying guest_test_uefi to artifact dir
       run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
@@ -878,10 +792,9 @@ jobs:
       run: flowey e 11 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 11 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 11 flowey_lib_common::install_rust 1
+        flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 11 flowey_lib_common::install_dist_pkg 0
@@ -893,46 +806,32 @@ jobs:
       run: flowey e 11 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 11 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 11 flowey_lib_common::cache 4
         flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
         flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar3 }}
         path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 11 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 11 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey e 11 flowey_lib_common::cache 6
+        flowey e 11 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey e 11 flowey_lib_hvlite::download_lxutil 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 11 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 11 flowey_lib_common::git_checkout 0
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -941,17 +840,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 11 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 11 flowey_lib_common::git_checkout 3
+        flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move lxutil.dll into its magic folder
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
@@ -963,139 +857,113 @@ jobs:
       run: flowey e 11 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm
-      run: flowey e 11 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 5
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 5
       shell: bash
     - name: split debug symbols
       run: flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
       shell: bash
     - name: reporting split debug info
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: report built openvmm
-      run: flowey e 11 flowey_lib_hvlite::build_openvmm 0
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::build_openvmm 0
       shell: bash
     - name: copying openvmm to publish dir
-      run: flowey e 11 flowey_lib_hvlite::artifact_openvmm::publish 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey e 11 flowey_lib_hvlite::artifact_openvmm::publish 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
-      run: flowey e 11 flowey_lib_common::run_cargo_build 5
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 5
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
       shell: bash
     - name: reporting split debug info
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: report built vmgstool
-      run: flowey e 11 flowey_lib_hvlite::build_vmgstool 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::artifact_vmgstool::publish 0
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 11 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 11 flowey_lib_hvlite::artifact_vmgstool::publish 0
       shell: bash
     - name: copying vmgstool to artifact dir
-      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 4
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 4
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
-      run: flowey e 11 flowey_lib_common::run_cargo_build 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: check built vmgs_lib
       run: flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
-      run: flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      shell: bash
-    - name: report built vmgs_lib
-      run: flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey e 11 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
       shell: bash
     - name: copying vmgs_lib to artifact dir
-      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 3
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 5
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey e 11 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 1
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
       shell: bash
     - name: reporting split debug info
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
       shell: bash
     - name: copying igvmfilegen to artifact dir
-      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build ohcldiag-dev
-      run: flowey e 11 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: split debug symbols
       run: flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: report built ohcldiag_dev
-      run: flowey e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 11 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
       shell: bash
     - name: copying ohcldiag-dev to artifact dir
-      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 2
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 6
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 2
+        flowey e 11 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build guest_test_uefi
-      run: flowey e 11 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: build guest_test_uefi.img
-      run: flowey e 11 flowey_lib_hvlite::build_guest_test_uefi 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::artifact_guest_test_uefi::publish 0
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 11 flowey_lib_hvlite::artifact_guest_test_uefi::publish 0
       shell: bash
     - name: copying guest_test_uefi to artifact dir
       run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
@@ -1104,48 +972,34 @@ jobs:
       run: flowey e 11 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 11 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 11 flowey_lib_common::cache 0
         flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 11 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey e 11 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 11 flowey_lib_common::install_rust 2
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 11 flowey_lib_common::cache 2
+        flowey e 11 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 11 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey e 11 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 11 flowey_lib_common::download_cargo_nextest 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: build + archive 'vmm_tests' nextests
-      run: flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
-      shell: bash
-    - name: report built vmm_tests
-      run: flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 11 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
       shell: bash
     - name: copying vmm_tests to artifact dir
       run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 5
@@ -1302,30 +1156,22 @@ jobs:
       run: flowey e 12 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 12 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 12 flowey_lib_common::cache 0
         flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 12 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 12 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 12 flowey_lib_common::cache 2
+        flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (aarch64)
       run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -1334,23 +1180,16 @@ jobs:
       run: flowey e 12 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 12 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 1
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 12 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -1359,35 +1198,26 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 12 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 12 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey e 12 flowey_lib_common::download_protoc 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 12 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 12 flowey_lib_hvlite::download_openvmm_deps 0
@@ -1396,220 +1226,151 @@ jobs:
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: cargo build openhcl_boot
-      run: flowey e 12 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 4
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
       shell: bash
     - name: reporting split debug info
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: report built openhcl_boot
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: unpack kernel package
-      run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: inject cross env
-      run: flowey e 12 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
-      run: flowey e 12 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: report built openvmm_hcl
-      run: flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
       shell: bash
     - name: split debug symbols
-      run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      shell: bash
-    - name: inject cross env
-      run: flowey e 12 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey e 12 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
       shell: bash
     - name: reporting split debug info
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
-      run: flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
       shell: bash
     - name: split debug symbols
-      run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
     - name: unpack kernel package
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
-      run: flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: describe OpenHCL igvm artifact
-      run: flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
-      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: describe OpenHCL igvm extras artifact
-      run: flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
       run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
       shell: bash
     - name: extract X64 sysroot.tar.gz
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 12 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 1
+        flowey e 12 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build openvmm_hcl
-      run: flowey e 12 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
       shell: bash
     - name: reporting split debug info
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: report built openvmm_hcl
-      run: flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 1
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 1
       shell: bash
     - name: copying openhcl build to publish dir
-      run: flowey e 12 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 12 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey e 12 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build pipette
-      run: flowey e 12 flowey_lib_common::run_cargo_build 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 9
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 4
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
       shell: bash
     - name: reporting split debug info
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: report built pipette
-      run: flowey e 12 flowey_lib_hvlite::build_pipette 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::artifact_pipette::publish 0
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 12 flowey_lib_hvlite::build_pipette 0
+        flowey e 12 flowey_lib_hvlite::artifact_pipette::publish 0
       shell: bash
     - name: copying pipette to artifact dir
       run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 2
@@ -1748,30 +1509,22 @@ jobs:
       run: flowey e 13 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 13 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 13 flowey_lib_common::cache 0
         flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 13 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 13 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 13 flowey_lib_common::cache 2
+        flowey e 13 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey e 13 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -1780,23 +1533,16 @@ jobs:
       run: flowey e 13 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 13 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 13 flowey_lib_common::install_rust 1
+        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 13 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 13 flowey_lib_common::git_checkout 0
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -1805,419 +1551,271 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 13 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 13 flowey_lib_common::git_checkout 3
+        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 13 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey e 13 flowey_lib_common::download_protoc 0
+        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 13 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 4
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
-      run: flowey e 13 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 4
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 5
       shell: bash
     - name: reporting split debug info
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: report built openhcl_boot
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_boot 0
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 13 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: unpack kernel package
-      run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      run: |-
+        flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 13 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: extract X64 sysroot.tar.gz
-      run: flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 13 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm_hcl
-      run: flowey e 13 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: report built openvmm_hcl
-      run: flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
       shell: bash
     - name: split debug symbols
-      run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 2
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      shell: bash
-    - name: inject cross env
-      run: flowey e 13 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey e 13 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 8
       shell: bash
     - name: reporting split debug info
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey e 13 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
-      run: flowey e 13 flowey_lib_hvlite::run_igvmfilegen 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
       shell: bash
     - name: split debug symbols
-      run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 3
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       shell: bash
     - name: unpack kernel package
       run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
       shell: bash
     - name: building igvm file
-      run: flowey e 13 flowey_lib_hvlite::run_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
       shell: bash
     - name: split debug symbols
-      run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
       shell: bash
     - name: building igvm file
-      run: flowey e 13 flowey_lib_hvlite::run_igvmfilegen 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 12
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
       shell: bash
     - name: split debug symbols
-      run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 4
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
-      run: flowey e 13 flowey_lib_hvlite::run_igvmfilegen 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
       shell: bash
     - name: unpack kernel package
-      run: flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      run: |-
+        flowey e 13 flowey_lib_hvlite::download_openhcl_kernel_package 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
       shell: bash
     - name: split debug symbols
-      run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      run: |-
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
-      run: flowey e 13 flowey_lib_hvlite::run_igvmfilegen 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: describe OpenHCL igvm artifact
-      run: flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 16
+        flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
-      run: flowey e 13 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 11
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 14
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 15
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 19
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: describe OpenHCL igvm extras artifact
-      run: flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      run: |-
+        flowey e 13 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 10
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 11
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 13
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 14
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 15
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 17
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 18
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 19
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 13 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 13 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 13 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 13 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 13 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 13 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
-      run: flowey e 13 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 6
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 2
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 6
       shell: bash
     - name: reporting split debug info
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: report built openvmm_hcl
-      run: flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
       shell: bash
     - name: copying openhcl build to publish dir
-      run: flowey e 13 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 13 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 13 flowey_lib_hvlite::artifact_openvmm_hcl_sizecheck::publish 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build pipette
-      run: flowey e 13 flowey_lib_common::run_cargo_build 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 9
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 4
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 9
       shell: bash
     - name: split debug symbols
       run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 7
       shell: bash
     - name: reporting split debug info
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 10
-      shell: bash
-    - name: report built pipette
-      run: flowey e 13 flowey_lib_hvlite::build_pipette 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::artifact_pipette::publish 0
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 13 flowey_lib_hvlite::build_pipette 0
+        flowey e 13 flowey_lib_hvlite::artifact_pipette::publish 0
       shell: bash
     - name: copying pipette to artifact dir
       run: flowey e 13 flowey_lib_common::copy_to_artifact_dir 2
@@ -2349,23 +1947,16 @@ jobs:
       run: flowey.exe e 14 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 14 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 14 flowey_lib_common::install_rust 1
+        flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 14 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 14 flowey_lib_common::git_checkout 0
+        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -2374,14 +1965,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 14 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 14 flowey_lib_common::git_checkout 3
+        flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -2390,54 +1978,39 @@ jobs:
       run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 14 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 14 flowey_lib_common::cache 4
         flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 14 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 14 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 14 flowey_lib_common::cache 6
+        flowey.exe e 14 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 14 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 14 flowey_lib_common::download_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built xtask
-      run: flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
       run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 1
@@ -2452,22 +2025,16 @@ jobs:
       run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build xtask
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built xtask
-      run: flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine clippy exclusions
       run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 0
@@ -2479,85 +2046,54 @@ jobs:
       run: flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 14 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 14 flowey_lib_common::cache 0
         flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 14 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey.exe e 14 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 14 flowey_lib_common::install_rust 2
+      run: |-
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 14 flowey_lib_common::cache 2
+        flowey.exe e 14 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 14 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 5
+      run: |-
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build xtask
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: report built xtask
-      run: flowey.exe e 14 flowey_lib_hvlite::build_xtask 2
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 2
       shell: bash
     - name: determine unit test exclusions
-      run: flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_common::publish_test_results 0
+        flowey.exe e 14 flowey_lib_common::publish_test_results 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -2674,10 +2210,9 @@ jobs:
       run: flowey e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 15 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 15 flowey_lib_common::install_rust 1
+        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 15 flowey_lib_common::install_dist_pkg 0
@@ -2689,30 +2224,22 @@ jobs:
       run: flowey e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 15 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 15 flowey_lib_common::cache 4
         flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 15 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 15 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey e 15 flowey_lib_common::cache 6
+        flowey e 15 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey e 15 flowey_lib_hvlite::download_lxutil 0
@@ -2721,17 +2248,11 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::download_lxutil 1
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 15 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 15 flowey_lib_common::git_checkout 0
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -2740,17 +2261,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 15 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 15 flowey_lib_common::git_checkout 3
+        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move lxutil.dll into its magic folder
       run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
@@ -2762,79 +2278,66 @@ jobs:
       run: flowey e 15 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 6
+      run: |-
+        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey e 15 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build xtask
-      run: flowey e 15 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 2
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: report built xtask
-      run: flowey e 15 flowey_lib_hvlite::build_xtask 1
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine clippy exclusions
       run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 5
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_clippy 1
+        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build xtask
-      run: flowey e 15 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 2
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 15 flowey_lib_hvlite::run_split_debug_info 3
       shell: bash
     - name: reporting split debug info
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built xtask
-      run: flowey e 15 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
       run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_clippy 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
-      run: flowey e 15 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 4
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
       shell: bash
     - name: reporting split debug info
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: report built xtask
-      run: flowey e 15 flowey_lib_hvlite::build_xtask 2
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 15 flowey_lib_hvlite::build_xtask 2
       shell: bash
     - name: determine clippy exclusions
       run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
@@ -2846,91 +2349,61 @@ jobs:
       run: flowey e 15 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 15 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 15 flowey_lib_common::cache 0
         flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 15 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey e 15 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 15 flowey_lib_common::install_rust 2
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 15 flowey_lib_common::cache 2
+        flowey e 15 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 15 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey e 15 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey e 15 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build xtask
-      run: flowey e 15 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 6
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: flowey e 15 flowey_lib_hvlite::run_split_debug_info 2
       shell: bash
     - name: reporting split debug info
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: report built xtask
-      run: flowey e 15 flowey_lib_hvlite::build_xtask 3
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 15 flowey_lib_hvlite::build_xtask 3
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 15 flowey_lib_common::publish_test_results 0
+        flowey e 15 flowey_lib_common::publish_test_results 1
+        flowey e 15 flowey_lib_common::publish_test_results 2
+        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -3047,23 +2520,16 @@ jobs:
       run: flowey e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 16 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 16 flowey_lib_common::install_rust 1
+        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 16 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 16 flowey_lib_common::git_checkout 0
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -3072,17 +2538,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 16 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 16 flowey_lib_common::git_checkout 3
+        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 16 flowey_lib_common::install_dist_pkg 0
@@ -3094,30 +2555,22 @@ jobs:
       run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 16 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 16 flowey_lib_common::cache 4
         flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 16 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 16 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey e 16 flowey_lib_common::cache 6
+        flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 16 flowey_lib_hvlite::download_openvmm_deps 0
@@ -3141,28 +2594,23 @@ jobs:
       run: flowey e 16 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 4
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
-      run: flowey e 16 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 16 flowey_lib_hvlite::run_split_debug_info 2
       shell: bash
     - name: reporting split debug info
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built xtask
-      run: flowey e 16 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
       run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 1
@@ -3177,31 +2625,27 @@ jobs:
       run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_clippy 4
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
-      run: flowey e 16 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 2
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_build 2
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: report built xtask
-      run: flowey e 16 flowey_lib_hvlite::build_xtask 1
+      run: |-
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine clippy exclusions
       run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
@@ -3216,91 +2660,61 @@ jobs:
       run: flowey e 16 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 16 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 16 flowey_lib_common::cache 0
         flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 16 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey e 16 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 16 flowey_lib_common::install_rust 2
+      run: |-
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 16 flowey_lib_common::cache 2
+        flowey e 16 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 16 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey e 16 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
-      run: flowey e 16 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 4
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_build 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
       shell: bash
     - name: reporting split debug info
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: report built xtask
-      run: flowey e 16 flowey_lib_hvlite::build_xtask 2
+      run: |-
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 16 flowey_lib_hvlite::build_xtask 2
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 5
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 16 flowey_lib_common::publish_test_results 0
+        flowey e 16 flowey_lib_common::publish_test_results 1
+        flowey e 16 flowey_lib_common::publish_test_results 2
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -3414,40 +2828,29 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
     - name: create cargo-nextest cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
+      run: |-
+        flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 17 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 17 flowey_lib_common::cache 0
         flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 17 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey.exe e 17 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: install Rust
-      run: flowey.exe e 17 flowey_lib_common::install_rust 0
+      run: |-
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 17 flowey_lib_common::cache 2
+        flowey.exe e 17 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
       run: flowey.exe e 17 flowey_lib_common::install_rust 1
@@ -3459,17 +2862,11 @@ jobs:
       run: flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 17 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 17 flowey_lib_common::git_checkout 0
+        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -3478,14 +2875,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 17 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 17 flowey_lib_common::git_checkout 3
+        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -3494,51 +2888,38 @@ jobs:
       run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 17 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 17 flowey_lib_common::cache 4
         flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 17 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 17 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 17 flowey_lib_common::cache 6
+        flowey.exe e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 17 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 17 flowey_lib_common::download_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built xtask
-      run: flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine unit test exclusions
       run: flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
@@ -3547,41 +2928,24 @@ jobs:
       run: flowey.exe e 17 flowey_lib_hvlite::download_lxutil 0
       shell: bash
     - name: move lxutil.dll into its magic folder
-      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 17 flowey_lib_common::publish_test_results 0
+        flowey.exe e 17 flowey_lib_common::publish_test_results 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -3682,75 +3046,53 @@ jobs:
       run: flowey.exe e 18 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 18 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 4
         flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - run: |
         flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 18 flowey_lib_common::cache 6
-      shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 18 flowey_lib_common::cache 6
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 18 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 8
         flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
         flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar9 }}
         path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 18 flowey_lib_common::cache 10
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 18 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 18 flowey_lib_common::cache 10
+        flowey.exe e 18 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 18 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 18 flowey_lib_common::git_checkout 0
+        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -3759,26 +3101,20 @@ jobs:
         persist-credentials: ${{ env.floweyvar4 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 18 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 18 flowey_lib_common::git_checkout 3
+        flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
       run: flowey.exe e 18 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
       shell: bash
     - name: init hyperv tests
-      run: flowey.exe e 18 flowey_lib_hvlite::init_hyperv_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::init_hyperv_tests 0
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3802,30 +3138,22 @@ jobs:
       run: flowey.exe e 18 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 18 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 0
         flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - run: |
         flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar5 }}
         path: ${{ env.floweyvar6 }}
       name: 'Restore cache: azcopy'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 18 flowey_lib_common::cache 2
-      shell: bash
     - name: installing azcopy
-      run: flowey.exe e 18 flowey_lib_common::download_azcopy 1
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 18 flowey_lib_common::cache 2
+        flowey.exe e 18 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
       run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
@@ -3840,38 +3168,26 @@ jobs:
       run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
-      run: flowey.exe e 18 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 5
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 18 flowey_lib_common::publish_test_results 4
+        flowey.exe e 18 flowey_lib_common::publish_test_results 5
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
       with:
@@ -3879,21 +3195,13 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: crash-dumps (x64-windows-intel-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 8
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 18 flowey_lib_common::publish_test_results 7
+        flowey.exe e 18 flowey_lib_common::publish_test_results 8
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
       with:
@@ -3901,27 +3209,15 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: logs (x64-windows-intel-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 18 flowey_lib_common::publish_test_results 0
+        flowey.exe e 18 flowey_lib_common::publish_test_results 1
+        flowey.exe e 18 flowey_lib_common::publish_test_results 2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -4022,75 +3318,53 @@ jobs:
       run: flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 19 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 4
         flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - run: |
         flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 19 flowey_lib_common::cache 6
-      shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 19 flowey_lib_common::cache 6
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 19 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 8
         flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
         flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar9 }}
         path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 19 flowey_lib_common::cache 10
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 19 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 19 flowey_lib_common::cache 10
+        flowey.exe e 19 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 19 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 19 flowey_lib_common::git_checkout 0
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -4099,26 +3373,20 @@ jobs:
         persist-credentials: ${{ env.floweyvar4 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 19 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 19 flowey_lib_common::git_checkout 3
+        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
       run: flowey.exe e 19 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
       shell: bash
     - name: init hyperv tests
-      run: flowey.exe e 19 flowey_lib_hvlite::init_hyperv_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::init_hyperv_tests 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4142,30 +3410,22 @@ jobs:
       run: flowey.exe e 19 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 19 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 0
         flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - run: |
         flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar5 }}
         path: ${{ env.floweyvar6 }}
       name: 'Restore cache: azcopy'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 19 flowey_lib_common::cache 2
-      shell: bash
     - name: installing azcopy
-      run: flowey.exe e 19 flowey_lib_common::download_azcopy 1
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 19 flowey_lib_common::cache 2
+        flowey.exe e 19 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
       run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
@@ -4180,38 +3440,26 @@ jobs:
       run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
-      run: flowey.exe e 19 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 5
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 4
+        flowey.exe e 19 flowey_lib_common::publish_test_results 5
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
       with:
@@ -4219,21 +3467,13 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: crash-dumps (x64-windows-amd-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 8
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 19 flowey_lib_common::publish_test_results 7
+        flowey.exe e 19 flowey_lib_common::publish_test_results 8
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 19 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
       with:
@@ -4241,27 +3481,15 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: logs (x64-windows-amd-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 0
+        flowey.exe e 19 flowey_lib_common::publish_test_results 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -4377,17 +3605,11 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc" | flowey v 2 'artifact_publish_from_x64-linux-rustdoc' --update-from-stdin --is-raw-string
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 2 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 2 flowey_lib_common::git_checkout 0
+        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -4396,14 +3618,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 2 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 2 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 2 flowey_lib_common::git_checkout 3
+        flowey e 2 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 2 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -4412,30 +3631,22 @@ jobs:
       run: flowey e 2 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 2 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 2 flowey_lib_common::cache 0
         flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 2 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 2 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 2 flowey_lib_common::cache 2
+        flowey e 2 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 2 flowey_lib_common::install_dist_pkg 0
@@ -4444,10 +3655,9 @@ jobs:
       run: flowey e 2 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: flowey e 2 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 2 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey e 2 flowey_lib_common::download_protoc 0
+        flowey e 2 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: flowey e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
@@ -4462,10 +3672,9 @@ jobs:
       run: flowey e 2 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 2 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 2 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 2 flowey_lib_common::install_rust 1
+        flowey e 2 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: construct cargo doc command
       run: flowey e 2 flowey_lib_common::run_cargo_doc 0
@@ -4474,10 +3683,9 @@ jobs:
       run: flowey e 2 flowey_lib_hvlite::build_rustdoc 0
       shell: bash
     - name: archive rustdoc dir
-      run: flowey e 2 flowey_lib_hvlite::artifact_rustdoc::publish 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 2 flowey_lib_hvlite::artifact_rustdoc::publish 1
+      run: |-
+        flowey e 2 flowey_lib_hvlite::artifact_rustdoc::publish 0
+        flowey e 2 flowey_lib_hvlite::artifact_rustdoc::publish 1
       shell: bash
     - name: copying rustdoc to artifact dir
       run: flowey e 2 flowey_lib_common::copy_to_artifact_dir 0
@@ -4575,30 +3783,22 @@ jobs:
       run: flowey e 20 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 20 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 20 flowey_lib_common::cache 4
         flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - run: |
         flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 20 flowey_lib_common::cache 6
-      shell: bash
     - name: installing cargo-nextest
-      run: flowey e 20 flowey_lib_common::download_cargo_nextest 1
+      run: |-
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey e 20 flowey_lib_common::cache 6
+        flowey e 20 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 20 flowey_lib_common::install_dist_pkg 0
@@ -4610,46 +3810,32 @@ jobs:
       run: flowey e 20 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 20 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 20 flowey_lib_common::cache 8
         flowey v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
         flowey v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar9 }}
         path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 20 flowey_lib_common::cache 10
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 20 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey e 20 flowey_lib_common::cache 10
+        flowey e 20 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 20 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 20 flowey_lib_common::git_checkout 0
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -4658,23 +3844,17 @@ jobs:
         persist-credentials: ${{ env.floweyvar4 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 20 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 20 flowey_lib_common::git_checkout 3
+        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
-      run: flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4695,30 +3875,22 @@ jobs:
       run: flowey e 20 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 20 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 20 flowey_lib_common::cache 0
         flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - run: |
         flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar5 }}
         path: ${{ env.floweyvar6 }}
       name: 'Restore cache: azcopy'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 20 flowey_lib_common::cache 2
-      shell: bash
     - name: installing azcopy
-      run: flowey e 20 flowey_lib_common::download_azcopy 1
+      run: |-
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 20 flowey_lib_common::cache 2
+        flowey e 20 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
       run: flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
@@ -4733,38 +3905,26 @@ jobs:
       run: flowey e 20 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
+      run: |-
+        flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
-      run: flowey e 20 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: |-
+        flowey e 20 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 5
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 20 flowey_lib_common::publish_test_results 4
+        flowey e 20 flowey_lib_common::publish_test_results 5
+        flowey v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
       with:
@@ -4772,21 +3932,13 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: crash-dumps (x64-linux-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 8
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 20 flowey_lib_common::publish_test_results 7
+        flowey e 20 flowey_lib_common::publish_test_results 8
+        flowey v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey v 20 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
       with:
@@ -4794,27 +3946,15 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: logs (x64-linux-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 20 flowey_lib_common::publish_test_results 0
+        flowey e 20 flowey_lib_common::publish_test_results 1
+        flowey e 20 flowey_lib_common::publish_test_results 2
+        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -4975,75 +4115,53 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 21 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 4
         flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - run: |
         flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 21 flowey_lib_common::cache 6
-      shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 21 flowey_lib_common::cache 6
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 21 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 8
         flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
         flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar9 }}
         path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 21 flowey_lib_common::cache 10
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 21 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 21 flowey_lib_common::cache 10
+        flowey.exe e 21 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (aarch64)
       run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 21 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 21 flowey_lib_common::git_checkout 0
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -5052,26 +4170,20 @@ jobs:
         persist-credentials: ${{ env.floweyvar4 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 21 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 21 flowey_lib_common::git_checkout 3
+        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
       run: flowey.exe e 21 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
       shell: bash
     - name: init hyperv tests
-      run: flowey.exe e 21 flowey_lib_hvlite::init_hyperv_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::init_hyperv_tests 0
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -5095,30 +4207,22 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 21 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 0
         flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - run: |
         flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar5 }}
         path: ${{ env.floweyvar6 }}
       name: 'Restore cache: azcopy'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 21 flowey_lib_common::cache 2
-      shell: bash
     - name: installing azcopy
-      run: flowey.exe e 21 flowey_lib_common::download_azcopy 1
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 21 flowey_lib_common::cache 2
+        flowey.exe e 21 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
       run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
@@ -5133,38 +4237,26 @@ jobs:
       run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 5
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_lib_common::publish_test_results 4
+        flowey.exe e 21 flowey_lib_common::publish_test_results 5
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
       with:
@@ -5172,21 +4264,13 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: crash-dumps (aarch64-windows-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 8
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 21 flowey_lib_common::publish_test_results 7
+        flowey.exe e 21 flowey_lib_common::publish_test_results 8
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 21 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
       with:
@@ -5194,27 +4278,15 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: logs (aarch64-windows-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 21 flowey_lib_common::publish_test_results 0
+        flowey.exe e 21 flowey_lib_common::publish_test_results 1
+        flowey.exe e 21 flowey_lib_common::publish_test_results 2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -5328,17 +4400,11 @@ jobs:
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 22 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 22 flowey_lib_common::git_checkout 0
+        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -5347,21 +4413,17 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 22 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 22 flowey_lib_common::git_checkout 3
+        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: install Rust
-      run: flowey e 22 flowey_lib_common::install_rust 0
+      run: |-
+        flowey e 22 flowey_lib_common::install_rust 0
+        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-file ${{ github.token }} --is-raw-string
       shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
       run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
@@ -5429,15 +4491,11 @@ jobs:
       run: flowey e 3 flowey_lib_hvlite::artifact_rustdoc::resolve 0
       shell: bash
     - name: generate consolidated gh pages html
-      run: flowey e 3 flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 3 flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages 1
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 3 flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages 0
+        flowey e 3 flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages 1
         flowey v 3 'flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages:4:flowey_lib_hvlite/src/_jobs/consolidate_and_publish_gh_pages.rs:107:39' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar1'
     - id: flowey_lib_hvlite___jobs__consolidate_and_publish_gh_pages__2
       uses: actions/upload-pages-artifact@v3
       with:
@@ -5539,17 +4597,11 @@ jobs:
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 4 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 4 flowey_lib_common::git_checkout 0
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -5558,23 +4610,19 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 4 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 4 flowey_lib_common::git_checkout 3
+        flowey.exe e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: install Rust
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 4 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 4 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 4 flowey_lib_common::install_rust 1
+        flowey.exe e 4 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 4 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -5583,51 +4631,38 @@ jobs:
       run: flowey.exe e 4 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 4 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 4 flowey_lib_common::cache 0
         flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 4 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 4 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 4 flowey_lib_common::cache 2
+        flowey.exe e 4 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 4 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 4 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 4 flowey_lib_common::download_protoc 0
+        flowey.exe e 4 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey.exe e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 4 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
-      run: flowey.exe e 4 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built xtask
-      run: flowey.exe e 4 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey.exe e 4 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 4 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 4 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: run xtask fmt
       run: flowey.exe e 4 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
@@ -5729,17 +4764,11 @@ jobs:
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 5 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 5 flowey_lib_common::git_checkout 0
+        flowey v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -5748,23 +4777,19 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 5 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 5 flowey_lib_common::git_checkout 3
+        flowey e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: install Rust
       run: flowey e 5 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 5 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 5 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 5 flowey_lib_common::install_rust 1
+        flowey e 5 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 5 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -5773,30 +4798,22 @@ jobs:
       run: flowey e 5 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 5 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 5 flowey_lib_common::cache 0
         flowey v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 5 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 5 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 5 flowey_lib_common::cache 2
+        flowey e 5 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 5 flowey_lib_common::install_dist_pkg 0
@@ -5805,31 +4822,27 @@ jobs:
       run: flowey e 5 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: flowey e 5 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 5 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey e 5 flowey_lib_common::download_protoc 0
+        flowey e 5 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 5 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 5 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
-      run: flowey e 5 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 5 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 5 flowey_lib_common::run_cargo_build 0
+        flowey e 5 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 5 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 5 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built xtask
-      run: flowey e 5 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey e 5 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 5 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: run xtask fmt
       run: flowey e 5 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
@@ -5943,23 +4956,16 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 6 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::install_rust 1
+        flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 6 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 6 flowey_lib_common::git_checkout 0
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -5968,14 +4974,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 6 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 6 flowey_lib_common::git_checkout 3
+        flowey.exe e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 6 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -5984,129 +4987,91 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 6 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 6 flowey_lib_common::cache 0
         flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 6 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 6 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 6 flowey_lib_common::cache 2
+        flowey.exe e 6 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 6 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::download_protoc 0
+        flowey.exe e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 6 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey.exe e 6 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey.exe e 6 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 6 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 6 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
       shell: bash
     - name: copying igvmfilegen to artifact dir
-      run: flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 6 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 1
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build ohcldiag-dev
-      run: flowey.exe e 6 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: report built ohcldiag_dev
-      run: flowey.exe e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey.exe e 6 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
       shell: bash
     - name: copying ohcldiag-dev to artifact dir
-      run: flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 2
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 6 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 2
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build vmgstool
-      run: flowey.exe e 6 flowey_lib_common::run_cargo_build 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: report built vmgstool
-      run: flowey.exe e 6 flowey_lib_hvlite::build_vmgstool 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::artifact_vmgstool::publish 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 6 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 6 flowey_lib_hvlite::artifact_vmgstool::publish 0
       shell: bash
     - name: copying vmgstool to artifact dir
-      run: flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 4
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 6 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 4
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build hypestv
-      run: flowey.exe e 6 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built hypestv
-      run: flowey.exe e 6 flowey_lib_hvlite::build_hypestv 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::artifact_hypestv::publish 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 6 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 6 flowey_lib_hvlite::artifact_hypestv::publish 0
       shell: bash
     - name: copying hypestv to artifact dir
-      run: flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build vmgs_lib
-      run: flowey.exe e 6 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: check built vmgs_lib
-      run: flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: report built vmgs_lib
-      run: flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
+      run: |-
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 6 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
       shell: bash
     - name: copying vmgs_lib to artifact dir
       run: flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 3
@@ -6239,55 +5204,40 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 7 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::install_rust 1
+        flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 7 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 7 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 7 flowey_lib_common::cache 4
         flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 7 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 7 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 7 flowey_lib_common::cache 6
+        flowey.exe e 7 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.AARCH64.zip
       run: flowey.exe e 7 flowey_lib_hvlite::download_lxutil 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 7 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 7 flowey_lib_common::git_checkout 0
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -6296,17 +5246,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 7 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 7 flowey_lib_common::git_checkout 3
+        flowey.exe e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move lxutil.dll into its magic folder
       run: flowey.exe e 7 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
@@ -6318,37 +5263,27 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 7 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey.exe e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm
-      run: flowey.exe e 7 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built openvmm
-      run: flowey.exe e 7 flowey_lib_hvlite::build_openvmm 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 7 flowey_lib_hvlite::build_openvmm 0
       shell: bash
     - name: copying openvmm to publish dir
-      run: flowey.exe e 7 flowey_lib_hvlite::artifact_openvmm::publish 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 7 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey.exe e 7 flowey_lib_hvlite::artifact_openvmm::publish 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build pipette
-      run: flowey.exe e 7 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built pipette
-      run: flowey.exe e 7 flowey_lib_hvlite::build_pipette 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::artifact_pipette::publish 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 7 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 7 flowey_lib_hvlite::artifact_pipette::publish 0
       shell: bash
     - name: copying pipette to artifact dir
       run: flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 0
@@ -6357,48 +5292,34 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 7 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 7 flowey_lib_common::cache 0
         flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 7 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey.exe e 7 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 7 flowey_lib_common::install_rust 2
+      run: |-
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 7 flowey_lib_common::cache 2
+        flowey.exe e 7 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 7 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 7 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 7 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: build + archive 'vmm_tests' nextests
-      run: flowey.exe e 7 flowey_lib_common::run_cargo_nextest_archive 0
-      shell: bash
-    - name: report built vmm_tests
-      run: flowey.exe e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 7 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 7 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
       shell: bash
     - name: copying vmm_tests to artifact dir
       run: flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 1
@@ -6530,23 +5451,16 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 8 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 8 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::install_rust 1
+        flowey.exe e 8 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 8 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 8 flowey_lib_common::git_checkout 0
+        flowey.exe v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -6555,14 +5469,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 8 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 8 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 8 flowey_lib_common::git_checkout 3
+        flowey.exe e 8 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 8 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -6571,132 +5482,94 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 8 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 8 flowey_lib_common::cache 0
         flowey.exe v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey.exe v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 8 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 8 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 8 flowey_lib_common::cache 2
+        flowey.exe e 8 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 8 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 8 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::download_protoc 0
+        flowey.exe e 8 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 8 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey.exe e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build vmgstool
-      run: flowey.exe e 8 flowey_lib_common::run_cargo_build 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: report built vmgstool
-      run: flowey.exe e 8 flowey_lib_hvlite::build_vmgstool 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::artifact_vmgstool::publish 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 8 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 8 flowey_lib_hvlite::artifact_vmgstool::publish 0
       shell: bash
     - name: copying vmgstool to artifact dir
-      run: flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 4
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 8 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 4
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build hypestv
-      run: flowey.exe e 8 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built hypestv
-      run: flowey.exe e 8 flowey_lib_hvlite::build_hypestv 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::artifact_hypestv::publish 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 8 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 8 flowey_lib_hvlite::artifact_hypestv::publish 0
       shell: bash
     - name: copying hypestv to artifact dir
-      run: flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 8 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 0
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build vmgs_lib
-      run: flowey.exe e 8 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey.exe e 8 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: check built vmgs_lib
       run: flowey.exe e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
-      run: flowey.exe e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      shell: bash
-    - name: report built vmgs_lib
-      run: flowey.exe e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
+      run: |-
+        flowey.exe e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey.exe e 8 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
       shell: bash
     - name: copying vmgs_lib to artifact dir
-      run: flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 3
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 8 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 3
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey.exe e 8 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey.exe e 8 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 8 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 8 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
       shell: bash
     - name: copying igvmfilegen to artifact dir
-      run: flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 8 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 1
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build ohcldiag-dev
-      run: flowey.exe e 8 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: report built ohcldiag_dev
-      run: flowey.exe e 8 flowey_lib_hvlite::build_ohcldiag_dev 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 8 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey.exe e 8 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
       shell: bash
     - name: copying ohcldiag-dev to artifact dir
       run: flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 2
@@ -6829,55 +5702,40 @@ jobs:
       run: flowey.exe e 9 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 9 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 9 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 9 flowey_lib_common::install_rust 1
+        flowey.exe e 9 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 9 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 9 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 9 flowey_lib_common::cache 4
         flowey.exe v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey.exe v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 9 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 9 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 9 flowey_lib_common::cache 6
+        flowey.exe e 9 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey.exe e 9 flowey_lib_hvlite::download_lxutil 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 9 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 9 flowey_lib_common::git_checkout 0
+        flowey.exe v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -6886,17 +5744,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 9 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 9 flowey_lib_common::git_checkout 3
+        flowey.exe e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move lxutil.dll into its magic folder
       run: flowey.exe e 9 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
@@ -6908,37 +5761,27 @@ jobs:
       run: flowey.exe e 9 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 9 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey.exe e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm
-      run: flowey.exe e 9 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 9 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built openvmm
-      run: flowey.exe e 9 flowey_lib_hvlite::build_openvmm 0
+      run: |-
+        flowey.exe e 9 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 9 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 9 flowey_lib_hvlite::build_openvmm 0
       shell: bash
     - name: copying openvmm to publish dir
-      run: flowey.exe e 9 flowey_lib_hvlite::artifact_openvmm::publish 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 9 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey.exe e 9 flowey_lib_hvlite::artifact_openvmm::publish 0
+        flowey.exe e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build pipette
-      run: flowey.exe e 9 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 9 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built pipette
-      run: flowey.exe e 9 flowey_lib_hvlite::build_pipette 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 9 flowey_lib_hvlite::artifact_pipette::publish 0
+      run: |-
+        flowey.exe e 9 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 9 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 9 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 9 flowey_lib_hvlite::artifact_pipette::publish 0
       shell: bash
     - name: copying pipette to artifact dir
       run: flowey.exe e 9 flowey_lib_common::copy_to_artifact_dir 0
@@ -6947,48 +5790,34 @@ jobs:
       run: flowey.exe e 9 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 9 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 9 flowey_lib_common::cache 0
         flowey.exe v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey.exe v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 9 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey.exe e 9 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 9 flowey_lib_common::install_rust 2
+      run: |-
+        flowey.exe v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 9 flowey_lib_common::cache 2
+        flowey.exe e 9 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 9 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 9 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 9 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey.exe e 9 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 9 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: build + archive 'vmm_tests' nextests
-      run: flowey.exe e 9 flowey_lib_common::run_cargo_nextest_archive 0
-      shell: bash
-    - name: report built vmm_tests
-      run: flowey.exe e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 9 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
+      run: |-
+        flowey.exe e 9 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 9 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 9 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
       shell: bash
     - name: copying vmm_tests to artifact dir
       run: flowey.exe e 9 flowey_lib_common::copy_to_artifact_dir 1

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -125,7 +125,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 0 flowey_lib_common::cache 2
         flowey e 0 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -160,7 +162,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 0 flowey_lib_common::git_checkout 3
         flowey e 0 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 0 flowey_lib_hvlite::build_guide 0
@@ -294,7 +298,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 1 flowey_lib_common::git_checkout 3
         flowey.exe e 1 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -318,7 +324,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 1 flowey_lib_common::cache 2
         flowey.exe e 1 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -502,7 +510,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 10 flowey_lib_common::cache 2
         flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -525,7 +535,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 10 flowey_lib_common::git_checkout 3
         flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -819,7 +831,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey e 11 flowey_lib_common::cache 6
         flowey e 11 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -842,7 +856,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 11 flowey_lib_common::git_checkout 3
         flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -985,7 +1001,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 11 flowey_lib_common::cache 2
         flowey e 11 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey e 11 flowey_lib_common::install_rust 2
@@ -1169,7 +1187,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -1200,7 +1220,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 12 flowey_lib_common::git_checkout 3
         flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -1522,7 +1544,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 13 flowey_lib_common::cache 2
         flowey e 13 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -1553,7 +1577,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 13 flowey_lib_common::git_checkout 3
         flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -1967,7 +1993,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 14 flowey_lib_common::git_checkout 3
         flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -1991,7 +2019,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 14 flowey_lib_common::cache 6
         flowey.exe e 14 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -2059,7 +2089,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 14 flowey_lib_common::cache 2
         flowey.exe e 14 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 14 flowey_lib_common::install_rust 2
@@ -2237,7 +2269,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey e 15 flowey_lib_common::cache 6
         flowey e 15 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -2263,7 +2297,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 15 flowey_lib_common::git_checkout 3
         flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -2362,7 +2398,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 15 flowey_lib_common::cache 2
         flowey e 15 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey e 15 flowey_lib_common::install_rust 2
@@ -2540,7 +2578,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 16 flowey_lib_common::git_checkout 3
         flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -2568,7 +2608,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey e 16 flowey_lib_common::cache 6
         flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -2673,7 +2715,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 16 flowey_lib_common::cache 2
         flowey e 16 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey e 16 flowey_lib_common::install_rust 2
@@ -2847,7 +2891,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: install Rust
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 17 flowey_lib_common::cache 2
         flowey.exe e 17 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 17 flowey_lib_common::install_rust 0
@@ -2877,7 +2923,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 17 flowey_lib_common::git_checkout 3
         flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -2901,7 +2949,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 17 flowey_lib_common::cache 6
         flowey.exe e 17 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -3059,7 +3109,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: installing cargo-nextest
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 18 flowey_lib_common::cache 6
         flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
       shell: bash
@@ -3080,7 +3132,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
         flowey.exe e 18 flowey_lib_common::cache 10
         flowey.exe e 18 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -3103,7 +3157,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 18 flowey_lib_common::git_checkout 3
         flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -3151,7 +3207,9 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 18 flowey_lib_common::cache 2
         flowey.exe e 18 flowey_lib_common::download_azcopy 1
       shell: bash
@@ -3331,7 +3389,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: installing cargo-nextest
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 19 flowey_lib_common::cache 6
         flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
       shell: bash
@@ -3352,7 +3412,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
         flowey.exe e 19 flowey_lib_common::cache 10
         flowey.exe e 19 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -3375,7 +3437,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -3423,7 +3487,9 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 19 flowey_lib_common::cache 2
         flowey.exe e 19 flowey_lib_common::download_azcopy 1
       shell: bash
@@ -3620,7 +3686,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 2 flowey_lib_common::git_checkout 3
         flowey e 2 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -3644,7 +3712,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 2 flowey_lib_common::cache 2
         flowey e 2 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -3796,7 +3866,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: installing cargo-nextest
       run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey e 20 flowey_lib_common::cache 6
         flowey e 20 flowey_lib_common::download_cargo_nextest 1
       shell: bash
@@ -3823,7 +3895,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
         flowey e 20 flowey_lib_common::cache 10
         flowey e 20 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -3846,7 +3920,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 20 flowey_lib_common::git_checkout 3
         flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -3888,7 +3964,9 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 20 flowey_lib_common::cache 2
         flowey e 20 flowey_lib_common::download_azcopy 1
       shell: bash
@@ -4128,7 +4206,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: installing cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 21 flowey_lib_common::cache 6
         flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
       shell: bash
@@ -4149,7 +4229,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
         flowey.exe e 21 flowey_lib_common::cache 10
         flowey.exe e 21 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -4172,7 +4254,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -4220,7 +4304,9 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 21 flowey_lib_common::cache 2
         flowey.exe e 21 flowey_lib_common::download_azcopy 1
       shell: bash
@@ -4415,14 +4501,18 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: install Rust
       run: |-
         flowey e 22 flowey_lib_common::install_rust 0
-        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-file ${{ github.token }} --is-raw-string
+        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
+        ${{ github.token }}
+        EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
       run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
@@ -4612,7 +4702,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 4 flowey_lib_common::git_checkout 3
         flowey.exe e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -4644,7 +4736,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 4 flowey_lib_common::cache 2
         flowey.exe e 4 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -4779,7 +4873,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 5 flowey_lib_common::git_checkout 3
         flowey e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -4811,7 +4907,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 5 flowey_lib_common::cache 2
         flowey e 5 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -4976,7 +5074,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 6 flowey_lib_common::git_checkout 3
         flowey.exe e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -5000,7 +5100,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 6 flowey_lib_common::cache 2
         flowey.exe e 6 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -5225,7 +5327,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 7 flowey_lib_common::cache 6
         flowey.exe e 7 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -5248,7 +5352,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 7 flowey_lib_common::git_checkout 3
         flowey.exe e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -5305,7 +5411,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 7 flowey_lib_common::cache 2
         flowey.exe e 7 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 7 flowey_lib_common::install_rust 2
@@ -5471,7 +5579,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 8 flowey_lib_common::git_checkout 3
         flowey.exe e 8 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -5495,7 +5605,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 8 flowey_lib_common::cache 2
         flowey.exe e 8 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -5723,7 +5835,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 9 flowey_lib_common::cache 6
         flowey.exe e 9 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -5746,7 +5860,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 9 flowey_lib_common::git_checkout 3
         flowey.exe e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -5803,7 +5919,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 9 flowey_lib_common::cache 2
         flowey.exe e 9 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 9 flowey_lib_common::install_rust 2

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -120,30 +120,22 @@ jobs:
       run: flowey e 0 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 0 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 0 flowey_lib_common::cache 0
         flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 0 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 0 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 0 flowey_lib_common::cache 2
+        flowey e 0 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 0 flowey_lib_common::install_dist_pkg 0
@@ -161,17 +153,11 @@ jobs:
       run: flowey e 0 flowey_lib_common::download_mdbook_mermaid 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 0 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 0 flowey_lib_common::git_checkout 0
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -180,26 +166,20 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 0 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 0 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 0 flowey_lib_hvlite::build_guide 0
+      run: |-
+        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 0 flowey_lib_common::git_checkout 3
+        flowey e 0 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 0 flowey_lib_hvlite::build_guide 0
       shell: bash
     - name: install Rust
       run: flowey e 0 flowey_lib_common::install_rust 0
       shell: bash
     - name: build OpenVMM guide (mdbook)
-      run: flowey e 0 flowey_lib_hvlite::build_guide 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 0 flowey_lib_hvlite::artifact_guide::publish 0
+      run: |-
+        flowey e 0 flowey_lib_hvlite::build_guide 1
+        flowey e 0 flowey_lib_hvlite::artifact_guide::publish 0
       shell: bash
     - name: copying guide to artifact dir
       run: flowey e 0 flowey_lib_common::copy_to_artifact_dir 0
@@ -307,17 +287,11 @@ jobs:
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-rustdoc" | flowey.exe v 1 'artifact_publish_from_x64-windows-rustdoc' --update-from-stdin --is-raw-string
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 1 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 1 flowey_lib_common::git_checkout 0
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -326,14 +300,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 1 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 1 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 1 flowey_lib_common::git_checkout 3
+        flowey.exe e 1 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 1 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -342,36 +313,27 @@ jobs:
       run: flowey.exe e 1 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 1 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 1 flowey_lib_common::cache 0
         flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 1 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 1 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 1 flowey_lib_common::cache 2
+        flowey.exe e 1 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 1 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 1 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 1 flowey_lib_common::download_protoc 0
+        flowey.exe e 1 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: flowey.exe e 1 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
@@ -386,10 +348,9 @@ jobs:
       run: flowey.exe e 1 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 1 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 1 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 1 flowey_lib_common::install_rust 1
+        flowey.exe e 1 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: construct cargo doc command
       run: flowey.exe e 1 flowey_lib_common::run_cargo_doc 0
@@ -398,10 +359,9 @@ jobs:
       run: flowey.exe e 1 flowey_lib_hvlite::build_rustdoc 0
       shell: bash
     - name: archive rustdoc dir
-      run: flowey.exe e 1 flowey_lib_hvlite::artifact_rustdoc::publish 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 1 flowey_lib_hvlite::artifact_rustdoc::publish 1
+      run: |-
+        flowey.exe e 1 flowey_lib_hvlite::artifact_rustdoc::publish 0
+        flowey.exe e 1 flowey_lib_hvlite::artifact_rustdoc::publish 1
       shell: bash
     - name: copying rustdoc to artifact dir
       run: flowey.exe e 1 flowey_lib_common::copy_to_artifact_dir 0
@@ -525,10 +485,9 @@ jobs:
       run: flowey e 10 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 10 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 10 flowey_lib_common::install_rust 1
+        flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 10 flowey_lib_common::install_dist_pkg 0
@@ -540,46 +499,32 @@ jobs:
       run: flowey e 10 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 10 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 10 flowey_lib_common::cache 4
         flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-    - run: |
         flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar4'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar3 }}
         path: ${{ env.floweyvar4 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 10 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 10 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey e 10 flowey_lib_common::cache 6
+        flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey e 10 flowey_lib_hvlite::download_lxutil 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 10 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 10 flowey_lib_common::git_checkout 0
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -588,17 +533,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar5 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 10 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 10 flowey_lib_common::git_checkout 3
+        flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move lxutil.dll into its magic folder
       run: flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
@@ -610,139 +550,113 @@ jobs:
       run: flowey e 10 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm
-      run: flowey e 10 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 5
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 5
       shell: bash
     - name: split debug symbols
       run: flowey e 10 flowey_lib_hvlite::run_split_debug_info 1
       shell: bash
     - name: reporting split debug info
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: report built openvmm
-      run: flowey e 10 flowey_lib_hvlite::build_openvmm 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::build_openvmm 0
       shell: bash
     - name: copying openvmm to publish dir
-      run: flowey e 10 flowey_lib_hvlite::artifact_openvmm::publish 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey e 10 flowey_lib_hvlite::artifact_openvmm::publish 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
-      run: flowey e 10 flowey_lib_common::run_cargo_build 5
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 5
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
       shell: bash
     - name: reporting split debug info
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: report built vmgstool
-      run: flowey e 10 flowey_lib_hvlite::build_vmgstool 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_vmgstool::publish 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 10 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 10 flowey_lib_hvlite::artifact_vmgstool::publish 0
       shell: bash
     - name: copying vmgstool to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 4
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 4
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
-      run: flowey e 10 flowey_lib_common::run_cargo_build 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: check built vmgs_lib
       run: flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
-      run: flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      shell: bash
-    - name: report built vmgs_lib
-      run: flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey e 10 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
       shell: bash
     - name: copying vmgs_lib to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 3
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 5
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey e 10 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 1
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 1
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
       shell: bash
     - name: reporting split debug info
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 10 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
       shell: bash
     - name: copying igvmfilegen to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build ohcldiag-dev
-      run: flowey e 10 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: split debug symbols
       run: flowey e 10 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: report built ohcldiag_dev
-      run: flowey e 10 flowey_lib_hvlite::build_ohcldiag_dev 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 10 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 10 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
       shell: bash
     - name: copying ohcldiag-dev to artifact dir
-      run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 2
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 6
+      run: |-
+        flowey e 10 flowey_lib_common::copy_to_artifact_dir 2
+        flowey e 10 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build guest_test_uefi
-      run: flowey e 10 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: build guest_test_uefi.img
-      run: flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_guest_test_uefi::publish 0
+      run: |-
+        flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 10 flowey_lib_hvlite::artifact_guest_test_uefi::publish 0
       shell: bash
     - name: copying guest_test_uefi to artifact dir
       run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 0
@@ -751,48 +665,34 @@ jobs:
       run: flowey e 10 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 10 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 10 flowey_lib_common::cache 0
         flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 10 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey e 10 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 10 flowey_lib_common::install_rust 2
+      run: |-
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 10 flowey_lib_common::cache 2
+        flowey e 10 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 10 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey e 10 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 10 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 10 flowey_lib_common::download_cargo_nextest 1
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: build + archive 'vmm_tests' nextests
-      run: flowey e 10 flowey_lib_common::run_cargo_nextest_archive 0
-      shell: bash
-    - name: report built vmm_tests
-      run: flowey e 10 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 10 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey e 10 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey e 10 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
       shell: bash
     - name: copying vmm_tests to artifact dir
       run: flowey e 10 flowey_lib_common::copy_to_artifact_dir 5
@@ -947,30 +847,22 @@ jobs:
       run: flowey e 11 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 11 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 11 flowey_lib_common::cache 0
         flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 11 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 11 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 11 flowey_lib_common::cache 2
+        flowey e 11 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (aarch64)
       run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -979,23 +871,16 @@ jobs:
       run: flowey e 11 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 11 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 11 flowey_lib_common::install_rust 1
+        flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 11 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 11 flowey_lib_common::git_checkout 0
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -1004,35 +889,26 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 11 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 11 flowey_lib_common::git_checkout 3
+        flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 11 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey e 11 flowey_lib_common::download_protoc 0
+        flowey e 11 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 11 flowey_lib_hvlite::download_openvmm_deps 0
@@ -1041,196 +917,130 @@ jobs:
       run: flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
       shell: bash
     - name: cargo build openhcl_boot
-      run: flowey e 11 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 4
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
       shell: bash
     - name: reporting split debug info
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: report built openhcl_boot
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: unpack kernel package
-      run: flowey e 11 flowey_lib_hvlite::download_openhcl_kernel_package 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 11 flowey_lib_hvlite::download_openhcl_kernel_package 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
-      run: flowey e 11 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: report built openvmm_hcl
-      run: flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
       shell: bash
     - name: split debug symbols
-      run: flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey e 11 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
       shell: bash
     - name: reporting split debug info
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
-      run: flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
       shell: bash
     - name: split debug symbols
-      run: flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
     - name: unpack kernel package
       run: flowey e 11 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      run: |-
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
-      run: flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: describe OpenHCL igvm artifact
-      run: flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
-      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: describe OpenHCL igvm extras artifact
-      run: flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 11 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 11 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 11 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey e 11 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build pipette
-      run: flowey e 11 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
       shell: bash
     - name: reporting split debug info
-      run: flowey e 11 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: report built pipette
-      run: flowey e 11 flowey_lib_hvlite::build_pipette 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 11 flowey_lib_hvlite::artifact_pipette::publish 0
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 11 flowey_lib_hvlite::build_pipette 0
+        flowey e 11 flowey_lib_hvlite::artifact_pipette::publish 0
       shell: bash
     - name: copying pipette to artifact dir
       run: flowey e 11 flowey_lib_common::copy_to_artifact_dir 2
@@ -1362,30 +1172,22 @@ jobs:
       run: flowey e 12 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 12 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 12 flowey_lib_common::cache 0
         flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 12 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 12 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 12 flowey_lib_common::cache 2
+        flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
@@ -1394,23 +1196,16 @@ jobs:
       run: flowey e 12 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 12 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 12 flowey_lib_common::install_rust 1
+        flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 12 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 12 flowey_lib_common::git_checkout 0
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -1419,398 +1214,253 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 12 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 12 flowey_lib_common::git_checkout 3
+        flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 12 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: unpack protoc
-      run: flowey e 12 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey e 12 flowey_lib_common::download_protoc 0
+        flowey e 12 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 12 flowey_lib_hvlite::init_cross_build 3
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: cargo build openhcl_boot
-      run: flowey e 12 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 4
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
       shell: bash
     - name: reporting split debug info
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: report built openhcl_boot
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_boot 0
       shell: bash
     - name: unpack kernel package
-      run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
+      run: |-
+        flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 12 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: extract X64 sysroot.tar.gz
-      run: flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 12 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
-      run: flowey e 12 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: report built openvmm_hcl
-      run: flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 2
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 23
       shell: bash
     - name: split debug symbols
-      run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 24
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 25
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 29
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
-      shell: bash
-    - name: inject cross env
-      run: flowey e 12 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 30
+        flowey e 12 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey e 12 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 0
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 7
       shell: bash
     - name: reporting split debug info
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 32
       shell: bash
     - name: building igvm file
-      run: flowey e 12 flowey_lib_hvlite::run_igvmfilegen 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 4
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 38
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
       shell: bash
     - name: split debug symbols
-      run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 35
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 36
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
       shell: bash
     - name: unpack kernel package
       run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 0
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 41
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 42
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
       shell: bash
     - name: building igvm file
-      run: flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 49
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 45
       shell: bash
     - name: split debug symbols
-      run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 46
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 47
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 50
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 53
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 54
       shell: bash
     - name: building igvm file
-      run: flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 12
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 12
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 1
       shell: bash
     - name: split debug symbols
-      run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 6
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 2
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 8
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 10
       shell: bash
     - name: building igvm file
-      run: flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 2
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 0
       shell: bash
     - name: unpack kernel package
-      run: flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
+      run: |-
+        flowey e 12 flowey_lib_hvlite::download_openhcl_kernel_package 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 12
       shell: bash
     - name: split debug symbols
-      run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 13
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 14
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 17
       shell: bash
     - name: building openhcl initrd
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 3
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 18
       shell: bash
     - name: enumerate igvm resources
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
+      run: |-
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
       shell: bash
     - name: building igvm file
-      run: flowey e 12 flowey_lib_hvlite::run_igvmfilegen 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 16
-      shell: bash
-    - name: describe OpenHCL igvm artifact
-      run: flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_igvmfilegen 3
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 16
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::publish 0
       shell: bash
     - name: copying OpenHCL igvm files to artifact dir
-      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 10
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 11
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 13
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 14
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 15
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 17
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 18
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 19
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
-      shell: bash
-    - name: 🌼 Zip Vars
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
-      shell: bash
-    - name: describe OpenHCL igvm extras artifact
-      run: flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 26
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 5
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 6
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 7
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 37
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 33
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 9
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 10
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 48
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 44
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 13
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 14
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 15
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 11
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 17
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 18
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 19
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
+        flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 0
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 1
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 2
+        flowey e 12 flowey_lib_hvlite::_jobs::build_and_publish_openhcl_igvm_from_recipe 3
+        flowey e 12 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe_extras::publish 0
       shell: bash
     - name: copying OpenHCL igvm extras to artifact dir
-      run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 12 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey e 12 flowey_lib_common::copy_to_artifact_dir 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build pipette
-      run: flowey e 12 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 7
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 3
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: split debug symbols
       run: flowey e 12 flowey_lib_hvlite::run_split_debug_info 6
       shell: bash
     - name: reporting split debug info
-      run: flowey e 12 flowey_lib_hvlite::run_cargo_build 8
-      shell: bash
-    - name: report built pipette
-      run: flowey e 12 flowey_lib_hvlite::build_pipette 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 12 flowey_lib_hvlite::artifact_pipette::publish 0
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 12 flowey_lib_hvlite::build_pipette 0
+        flowey e 12 flowey_lib_hvlite::artifact_pipette::publish 0
       shell: bash
     - name: copying pipette to artifact dir
       run: flowey e 12 flowey_lib_common::copy_to_artifact_dir 2
@@ -1938,23 +1588,16 @@ jobs:
       run: flowey e 13 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 13 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 13 flowey_lib_common::install_rust 1
+        flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 13 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 13 flowey_lib_common::git_checkout 0
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -1963,14 +1606,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 13 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 13 flowey_lib_common::git_checkout 3
+        flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -1979,30 +1619,22 @@ jobs:
       run: flowey e 13 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 13 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 13 flowey_lib_common::cache 4
         flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 13 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 13 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey e 13 flowey_lib_common::cache 6
+        flowey e 13 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 13 flowey_lib_common::install_dist_pkg 0
@@ -2011,10 +1643,9 @@ jobs:
       run: flowey e 13 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: flowey e 13 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey e 13 flowey_lib_common::download_protoc 0
+        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
@@ -2023,76 +1654,59 @@ jobs:
       run: flowey e 13 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: extract X64 sysroot.tar.gz
-      run: flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 13 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
-      run: flowey e 13 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 2
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: report built xtask
-      run: flowey e 13 flowey_lib_hvlite::build_xtask 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 13 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::build_xtask 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
-      run: flowey e 13 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 13 flowey_lib_hvlite::run_split_debug_info 1
       shell: bash
     - name: reporting split debug info
-      run: flowey e 13 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built openvmm_hcl
-      run: flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
       shell: bash
     - name: create gh cache dir
       run: flowey e 13 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 13 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 13 flowey_lib_common::cache 0
         flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-cli'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 13 flowey_lib_common::cache 2
-      shell: bash
     - name: installing gh
-      run: flowey e 13 flowey_lib_common::download_gh_cli 1
+      run: |-
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 13 flowey_lib_common::cache 2
+        flowey e 13 flowey_lib_common::download_gh_cli 1
+        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-file ${{ github.token }} --is-raw-string
       shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
     - name: setup gh cli
       run: flowey e 13 flowey_lib_common::use_gh_cli 0
       shell: bash
@@ -2100,10 +1714,9 @@ jobs:
       run: flowey e 13 flowey_lib_common::git_merge_commit 0
       shell: bash
     - name: get action id
-      run: flowey e 13 flowey_lib_common::gh_workflow_id 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
+      run: |-
+        flowey e 13 flowey_lib_common::gh_workflow_id 0
+        flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 1
       shell: bash
     - name: download artifacts from github actions run
       run: flowey e 13 flowey_lib_common::download_gh_artifact 0
@@ -2213,23 +1826,16 @@ jobs:
       run: flowey.exe e 14 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 14 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 14 flowey_lib_common::install_rust 1
+        flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 14 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 14 flowey_lib_common::git_checkout 0
+        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -2238,14 +1844,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 14 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 14 flowey_lib_common::git_checkout 3
+        flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -2254,54 +1857,39 @@ jobs:
       run: flowey.exe e 14 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 14 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 14 flowey_lib_common::cache 4
         flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 14 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 14 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 14 flowey_lib_common::cache 6
+        flowey.exe e 14 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 14 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 14 flowey_lib_common::download_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built xtask
-      run: flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
       run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 1
@@ -2316,22 +1904,16 @@ jobs:
       run: flowey.exe e 14 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
       shell: bash
     - name: cargo clippy
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_clippy 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build xtask
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built xtask
-      run: flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine clippy exclusions
       run: flowey.exe e 14 flowey_lib_hvlite::_jobs::check_clippy 0
@@ -2343,85 +1925,54 @@ jobs:
       run: flowey.exe e 14 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 14 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 14 flowey_lib_common::cache 0
         flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 14 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey.exe e 14 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 14 flowey_lib_common::install_rust 2
+      run: |-
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 14 flowey_lib_common::cache 2
+        flowey.exe e 14 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 14 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 5
+      run: |-
+        flowey.exe e 14 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build xtask
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: report built xtask
-      run: flowey.exe e 14 flowey_lib_hvlite::build_xtask 2
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 14 flowey_lib_hvlite::build_xtask 2
       shell: bash
     - name: determine unit test exclusions
-      run: flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey.exe e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 14 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 14 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 14 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 14 flowey_lib_common::publish_test_results 0
+        flowey.exe e 14 flowey_lib_common::publish_test_results 1
+        flowey.exe e 14 flowey_lib_common::publish_test_results 2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -2538,10 +2089,9 @@ jobs:
       run: flowey e 15 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 15 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 15 flowey_lib_common::install_rust 1
+        flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 15 flowey_lib_common::install_dist_pkg 0
@@ -2553,30 +2103,22 @@ jobs:
       run: flowey e 15 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 15 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 15 flowey_lib_common::cache 4
         flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 15 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 15 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey e 15 flowey_lib_common::cache 6
+        flowey e 15 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey e 15 flowey_lib_hvlite::download_lxutil 0
@@ -2585,17 +2127,11 @@ jobs:
       run: flowey e 15 flowey_lib_hvlite::download_lxutil 1
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 15 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 15 flowey_lib_common::git_checkout 0
+        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -2604,17 +2140,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 15 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 15 flowey_lib_common::git_checkout 3
+        flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move lxutil.dll into its magic folder
       run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
@@ -2626,79 +2157,66 @@ jobs:
       run: flowey e 15 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 6
+      run: |-
+        flowey e 15 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 1
+        flowey e 15 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build xtask
-      run: flowey e 15 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 2
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: flowey e 15 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: report built xtask
-      run: flowey e 15 flowey_lib_hvlite::build_xtask 1
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine clippy exclusions
       run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 2
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 5
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_clippy 1
+        flowey e 15 flowey_lib_hvlite::init_cross_build 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build xtask
-      run: flowey e 15 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 2
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 15 flowey_lib_hvlite::run_split_debug_info 3
       shell: bash
     - name: reporting split debug info
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built xtask
-      run: flowey e 15 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
       run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 1
       shell: bash
     - name: cargo clippy
-      run: flowey e 15 flowey_lib_common::run_cargo_clippy 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_clippy 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
-      run: flowey e 15 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 4
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: flowey e 15 flowey_lib_hvlite::run_split_debug_info 1
       shell: bash
     - name: reporting split debug info
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: report built xtask
-      run: flowey e 15 flowey_lib_hvlite::build_xtask 2
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 15 flowey_lib_hvlite::build_xtask 2
       shell: bash
     - name: determine clippy exclusions
       run: flowey e 15 flowey_lib_hvlite::_jobs::check_clippy 0
@@ -2710,91 +2228,61 @@ jobs:
       run: flowey e 15 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 15 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 15 flowey_lib_common::cache 0
         flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 15 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey e 15 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 15 flowey_lib_common::install_rust 2
+      run: |-
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 15 flowey_lib_common::cache 2
+        flowey e 15 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 15 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey e 15 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey e 15 flowey_lib_common::download_cargo_nextest 1
+        flowey e 15 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build xtask
-      run: flowey e 15 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 6
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_build 1
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 6
       shell: bash
     - name: split debug symbols
       run: flowey e 15 flowey_lib_hvlite::run_split_debug_info 2
       shell: bash
     - name: reporting split debug info
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_build 7
-      shell: bash
-    - name: report built xtask
-      run: flowey e 15 flowey_lib_hvlite::build_xtask 3
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 15 flowey_lib_hvlite::build_xtask 3
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 15 flowey_lib_hvlite::init_cross_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 15 flowey_lib_hvlite::init_cross_build 2
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: flowey e 15 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 15 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 15 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 15 flowey_lib_common::publish_test_results 0
+        flowey e 15 flowey_lib_common::publish_test_results 1
+        flowey e 15 flowey_lib_common::publish_test_results 2
+        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -2911,23 +2399,16 @@ jobs:
       run: flowey e 16 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 16 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 16 flowey_lib_common::install_rust 1
+        flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 16 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 16 flowey_lib_common::git_checkout 0
+        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -2936,17 +2417,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 16 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 16 flowey_lib_common::git_checkout 3
+        flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 16 flowey_lib_common::install_dist_pkg 0
@@ -2958,30 +2434,22 @@ jobs:
       run: flowey e 16 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 16 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 16 flowey_lib_common::cache 4
         flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 16 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 16 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey e 16 flowey_lib_common::cache 6
+        flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 16 flowey_lib_hvlite::download_openvmm_deps 0
@@ -3005,28 +2473,23 @@ jobs:
       run: flowey e 16 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 4
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 4
+        flowey e 16 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build xtask
-      run: flowey e 16 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 16 flowey_lib_hvlite::run_split_debug_info 2
       shell: bash
     - name: reporting split debug info
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built xtask
-      run: flowey e 16 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 16 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine clippy exclusions
       run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 1
@@ -3041,31 +2504,27 @@ jobs:
       run: flowey e 16 flowey_lib_common::run_cargo_clippy 1
       shell: bash
     - name: extract Aarch64 sysroot.tar.gz
-      run: flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 16 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo clippy
-      run: flowey e 16 flowey_lib_common::run_cargo_clippy 4
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_clippy 4
+        flowey e 16 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build xtask
-      run: flowey e 16 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 2
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_build 2
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 2
       shell: bash
     - name: split debug symbols
       run: flowey e 16 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 3
-      shell: bash
-    - name: report built xtask
-      run: flowey e 16 flowey_lib_hvlite::build_xtask 1
+      run: |-
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine clippy exclusions
       run: flowey e 16 flowey_lib_hvlite::_jobs::check_clippy 0
@@ -3080,91 +2539,61 @@ jobs:
       run: flowey e 16 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 16 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 16 flowey_lib_common::cache 0
         flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 16 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey e 16 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 16 flowey_lib_common::install_rust 2
+      run: |-
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 16 flowey_lib_common::cache 2
+        flowey e 16 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 16 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey e 16 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 16 flowey_lib_common::download_cargo_nextest 1
+        flowey e 16 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
-      run: flowey e 16 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 4
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_build 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 4
       shell: bash
     - name: split debug symbols
       run: flowey e 16 flowey_lib_hvlite::run_split_debug_info 1
       shell: bash
     - name: reporting split debug info
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_build 5
-      shell: bash
-    - name: report built xtask
-      run: flowey e 16 flowey_lib_hvlite::build_xtask 2
+      run: |-
+        flowey e 16 flowey_lib_hvlite::run_cargo_build 5
+        flowey e 16 flowey_lib_hvlite::build_xtask 2
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 16 flowey_lib_hvlite::init_cross_build 5
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::init_cross_build 5
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: flowey e 16 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 16 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 16 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey e 16 flowey_lib_common::publish_test_results 0
+        flowey e 16 flowey_lib_common::publish_test_results 1
+        flowey e 16 flowey_lib_common::publish_test_results 2
+        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -3278,40 +2707,29 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
-      shell: bash
     - name: create cargo-nextest cache dir
-      run: flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
+      run: |-
+        flowey.exe e 17 flowey_lib_common::cfg_cargo_common_flags 0
+        flowey.exe e 17 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 17 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 17 flowey_lib_common::cache 0
         flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 17 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey.exe e 17 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: install Rust
-      run: flowey.exe e 17 flowey_lib_common::install_rust 0
+      run: |-
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 17 flowey_lib_common::cache 2
+        flowey.exe e 17 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 17 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
       run: flowey.exe e 17 flowey_lib_common::install_rust 1
@@ -3323,17 +2741,11 @@ jobs:
       run: flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 17 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 17 flowey_lib_common::git_checkout 0
+        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar6'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -3342,14 +2754,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar6 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 17 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 17 flowey_lib_common::git_checkout 3
+        flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -3358,51 +2767,38 @@ jobs:
       run: flowey.exe e 17 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 17 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 17 flowey_lib_common::cache 4
         flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 17 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 17 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 17 flowey_lib_common::cache 6
+        flowey.exe e 17 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 17 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 17 flowey_lib_common::download_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build xtask
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built xtask
-      run: flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey.exe e 17 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 17 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: determine unit test exclusions
       run: flowey.exe e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
@@ -3411,41 +2807,24 @@ jobs:
       run: flowey.exe e 17 flowey_lib_hvlite::download_lxutil 0
       shell: bash
     - name: move lxutil.dll into its magic folder
-      run: flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey.exe e 17 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
+        flowey.exe e 17 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: run 'unit-tests' nextest tests
       run: flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 17 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 17 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 17 flowey_lib_hvlite::_jobs::build_and_run_nextest_unit_tests 0
+        flowey.exe e 17 flowey_lib_common::publish_test_results 0
+        flowey.exe e 17 flowey_lib_common::publish_test_results 1
+        flowey.exe e 17 flowey_lib_common::publish_test_results 2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -3546,75 +2925,53 @@ jobs:
       run: flowey.exe e 18 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 18 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 4
         flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - run: |
         flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 18 flowey_lib_common::cache 6
-      shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 18 flowey_lib_common::cache 6
+        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 18 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 8
         flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
         flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar9 }}
         path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 18 flowey_lib_common::cache 10
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 18 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 18 flowey_lib_common::cache 10
+        flowey.exe e 18 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 18 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 18 flowey_lib_common::git_checkout 0
+        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -3623,26 +2980,20 @@ jobs:
         persist-credentials: ${{ env.floweyvar4 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 18 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 18 flowey_lib_common::git_checkout 3
+        flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
       run: flowey.exe e 18 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
       shell: bash
     - name: init hyperv tests
-      run: flowey.exe e 18 flowey_lib_hvlite::init_hyperv_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::init_hyperv_tests 0
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3666,30 +3017,22 @@ jobs:
       run: flowey.exe e 18 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 18 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 18 flowey_lib_common::cache 0
         flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - run: |
         flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar5 }}
         path: ${{ env.floweyvar6 }}
       name: 'Restore cache: azcopy'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 18 flowey_lib_common::cache 2
-      shell: bash
     - name: installing azcopy
-      run: flowey.exe e 18 flowey_lib_common::download_azcopy 1
+      run: |-
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 18 flowey_lib_common::cache 2
+        flowey.exe e 18 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
       run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
@@ -3704,38 +3047,26 @@ jobs:
       run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
-      run: flowey.exe e 18 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 5
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 18 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 18 flowey_lib_common::publish_test_results 4
+        flowey.exe e 18 flowey_lib_common::publish_test_results 5
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
       with:
@@ -3743,21 +3074,13 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: crash-dumps (x64-windows-intel-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 8
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 18 flowey_lib_common::publish_test_results 7
+        flowey.exe e 18 flowey_lib_common::publish_test_results 8
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 18 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
       with:
@@ -3765,27 +3088,15 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: logs (x64-windows-intel-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 18 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 18 flowey_lib_common::publish_test_results 0
+        flowey.exe e 18 flowey_lib_common::publish_test_results 1
+        flowey.exe e 18 flowey_lib_common::publish_test_results 2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -3886,75 +3197,53 @@ jobs:
       run: flowey.exe e 19 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 19 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 4
         flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - run: |
         flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 19 flowey_lib_common::cache 6
-      shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 19 flowey_lib_common::cache 6
+        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 19 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 8
         flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
         flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar9 }}
         path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 19 flowey_lib_common::cache 10
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 19 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 19 flowey_lib_common::cache 10
+        flowey.exe e 19 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey.exe e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 19 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 19 flowey_lib_common::git_checkout 0
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -3963,26 +3252,20 @@ jobs:
         persist-credentials: ${{ env.floweyvar4 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 19 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 19 flowey_lib_common::git_checkout 3
+        flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
       run: flowey.exe e 19 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
       shell: bash
     - name: init hyperv tests
-      run: flowey.exe e 19 flowey_lib_hvlite::init_hyperv_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::init_hyperv_tests 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4006,30 +3289,22 @@ jobs:
       run: flowey.exe e 19 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 19 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 19 flowey_lib_common::cache 0
         flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - run: |
         flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar5 }}
         path: ${{ env.floweyvar6 }}
       name: 'Restore cache: azcopy'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 19 flowey_lib_common::cache 2
-      shell: bash
     - name: installing azcopy
-      run: flowey.exe e 19 flowey_lib_common::download_azcopy 1
+      run: |-
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 19 flowey_lib_common::cache 2
+        flowey.exe e 19 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
       run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
@@ -4044,38 +3319,26 @@ jobs:
       run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
-      run: flowey.exe e 19 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 5
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 4
+        flowey.exe e 19 flowey_lib_common::publish_test_results 5
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
       with:
@@ -4083,21 +3346,13 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: crash-dumps (x64-windows-amd-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 8
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 19 flowey_lib_common::publish_test_results 7
+        flowey.exe e 19 flowey_lib_common::publish_test_results 8
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 19 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
       with:
@@ -4105,27 +3360,15 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: logs (x64-windows-amd-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 19 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 0
+        flowey.exe e 19 flowey_lib_common::publish_test_results 1
+        flowey.exe e 19 flowey_lib_common::publish_test_results 2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -4241,17 +3484,11 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc" | flowey v 2 'artifact_publish_from_x64-linux-rustdoc' --update-from-stdin --is-raw-string
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 2 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 2 flowey_lib_common::git_checkout 0
+        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -4260,14 +3497,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 2 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 2 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 2 flowey_lib_common::git_checkout 3
+        flowey e 2 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 2 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -4276,30 +3510,22 @@ jobs:
       run: flowey e 2 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 2 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 2 flowey_lib_common::cache 0
         flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 2 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 2 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 2 flowey_lib_common::cache 2
+        flowey e 2 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 2 flowey_lib_common::install_dist_pkg 0
@@ -4308,10 +3534,9 @@ jobs:
       run: flowey e 2 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: flowey e 2 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 2 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey e 2 flowey_lib_common::download_protoc 0
+        flowey e 2 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
       run: flowey e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
@@ -4326,10 +3551,9 @@ jobs:
       run: flowey e 2 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 2 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 2 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 2 flowey_lib_common::install_rust 1
+        flowey e 2 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: construct cargo doc command
       run: flowey e 2 flowey_lib_common::run_cargo_doc 0
@@ -4338,10 +3562,9 @@ jobs:
       run: flowey e 2 flowey_lib_hvlite::build_rustdoc 0
       shell: bash
     - name: archive rustdoc dir
-      run: flowey e 2 flowey_lib_hvlite::artifact_rustdoc::publish 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 2 flowey_lib_hvlite::artifact_rustdoc::publish 1
+      run: |-
+        flowey e 2 flowey_lib_hvlite::artifact_rustdoc::publish 0
+        flowey e 2 flowey_lib_hvlite::artifact_rustdoc::publish 1
       shell: bash
     - name: copying rustdoc to artifact dir
       run: flowey e 2 flowey_lib_common::copy_to_artifact_dir 0
@@ -4431,30 +3654,22 @@ jobs:
       run: flowey e 20 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 20 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 20 flowey_lib_common::cache 4
         flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - run: |
         flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 20 flowey_lib_common::cache 6
-      shell: bash
     - name: installing cargo-nextest
-      run: flowey e 20 flowey_lib_common::download_cargo_nextest 1
+      run: |-
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey e 20 flowey_lib_common::cache 6
+        flowey e 20 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 20 flowey_lib_common::install_dist_pkg 0
@@ -4466,46 +3681,32 @@ jobs:
       run: flowey e 20 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 20 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 20 flowey_lib_common::cache 8
         flowey v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
         flowey v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar9 }}
         path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 20 flowey_lib_common::cache 10
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 20 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey e 20 flowey_lib_common::cache 10
+        flowey e 20 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
       run: flowey e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 20 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 20 flowey_lib_common::git_checkout 0
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -4514,23 +3715,17 @@ jobs:
         persist-credentials: ${{ env.floweyvar4 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 20 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 20 flowey_lib_common::git_checkout 3
+        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
-      run: flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4551,30 +3746,22 @@ jobs:
       run: flowey e 20 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 20 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 20 flowey_lib_common::cache 0
         flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - run: |
         flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar5 }}
         path: ${{ env.floweyvar6 }}
       name: 'Restore cache: azcopy'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 20 flowey_lib_common::cache 2
-      shell: bash
     - name: installing azcopy
-      run: flowey e 20 flowey_lib_common::download_azcopy 1
+      run: |-
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 20 flowey_lib_common::cache 2
+        flowey e 20 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
       run: flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
@@ -4589,38 +3776,26 @@ jobs:
       run: flowey e 20 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
+      run: |-
+        flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
-      run: flowey e 20 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      run: |-
+        flowey e 20 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 5
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 20 flowey_lib_common::publish_test_results 4
+        flowey e 20 flowey_lib_common::publish_test_results 5
+        flowey v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
       with:
@@ -4628,21 +3803,13 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: crash-dumps (x64-linux-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 8
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 20 flowey_lib_common::publish_test_results 7
+        flowey e 20 flowey_lib_common::publish_test_results 8
+        flowey v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey v 20 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
       with:
@@ -4650,27 +3817,15 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: logs (x64-linux-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 20 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 20 flowey_lib_common::publish_test_results 0
+        flowey e 20 flowey_lib_common::publish_test_results 1
+        flowey e 20 flowey_lib_common::publish_test_results 2
+        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -4831,75 +3986,53 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 21 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 4
         flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar7 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar7'
-    - run: |
         flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar8'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 21 flowey_lib_common::cache 6
-      shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 21 flowey_lib_common::cache 6
+        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 21 flowey_lib_common::cache 8
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 8
         flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar9 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar9'
-    - run: |
         flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar10'
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar9 }}
         path: ${{ env.floweyvar10 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
-      shell: flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__9.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 21 flowey_lib_common::cache 10
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 21 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 21 flowey_lib_common::cache 10
+        flowey.exe e 21 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (aarch64)
       run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 21 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 21 flowey_lib_common::git_checkout 0
+        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -4908,26 +4041,20 @@ jobs:
         persist-credentials: ${{ env.floweyvar4 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 21 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 21 flowey_lib_common::git_checkout 3
+        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
       run: flowey.exe e 21 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
       shell: bash
     - name: init hyperv tests
-      run: flowey.exe e 21 flowey_lib_hvlite::init_hyperv_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::init_hyperv_tests 0
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4951,30 +4078,22 @@ jobs:
       run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 21 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 21 flowey_lib_common::cache 0
         flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar5 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar5'
-    - run: |
         flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar6'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar5 }}
         path: ${{ env.floweyvar6 }}
       name: 'Restore cache: azcopy'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 21 flowey_lib_common::cache 2
-      shell: bash
     - name: installing azcopy
-      run: flowey.exe e 21 flowey_lib_common::download_azcopy 1
+      run: |-
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 21 flowey_lib_common::cache 2
+        flowey.exe e 21 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
       run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
@@ -4989,38 +4108,26 @@ jobs:
       run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
       shell: bash
     - name: write results
-      run: flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 5
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_lib_common::publish_test_results 4
+        flowey.exe e 21 flowey_lib_common::publish_test_results 5
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
       with:
@@ -5028,21 +4135,13 @@ jobs:
         path: ${{ env.floweyvar2 }}
       name: 'publish test results: crash-dumps (aarch64-windows-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 7
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 8
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 21 flowey_lib_common::publish_test_results 7
+        flowey.exe e 21 flowey_lib_common::publish_test_results 8
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
         flowey.exe v 21 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
       with:
@@ -5050,27 +4149,15 @@ jobs:
         path: ${{ env.floweyvar3 }}
       name: 'publish test results: logs (aarch64-windows-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 21 flowey_lib_common::publish_test_results 2
-      shell: bash
-    - run: |
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 21 flowey_lib_common::publish_test_results 0
+        flowey.exe e 21 flowey_lib_common::publish_test_results 1
+        flowey.exe e 21 flowey_lib_common::publish_test_results 2
+        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
         flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
@@ -5184,17 +4271,11 @@ jobs:
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 22 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 22 flowey_lib_common::git_checkout 0
+        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -5203,21 +4284,17 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 22 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 22 flowey_lib_common::git_checkout 3
+        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: install Rust
-      run: flowey e 22 flowey_lib_common::install_rust 0
+      run: |-
+        flowey e 22 flowey_lib_common::install_rust 0
+        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-file ${{ github.token }} --is-raw-string
       shell: bash
-    - run: ${{ github.token }}
-      shell: flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.token'
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
       run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
@@ -5374,17 +4451,11 @@ jobs:
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 3 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 3 flowey_lib_common::git_checkout 0
+        flowey.exe v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -5393,23 +4464,19 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 3 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 3 flowey_lib_common::git_checkout 3
+        flowey.exe e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: install Rust
       run: flowey.exe e 3 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 3 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 3 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 3 flowey_lib_common::install_rust 1
+        flowey.exe e 3 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 3 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -5418,51 +4485,38 @@ jobs:
       run: flowey.exe e 3 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 3 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 3 flowey_lib_common::cache 0
         flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 3 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 3 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 3 flowey_lib_common::cache 2
+        flowey.exe e 3 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 3 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 3 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 3 flowey_lib_common::download_protoc 0
+        flowey.exe e 3 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 3 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey.exe e 3 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 3 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
-      run: flowey.exe e 3 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built xtask
-      run: flowey.exe e 3 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey.exe e 3 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 3 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 3 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: run xtask fmt
       run: flowey.exe e 3 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
@@ -5564,17 +4618,11 @@ jobs:
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 4 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 4 flowey_lib_common::git_checkout 0
+        flowey v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -5583,23 +4631,19 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 4 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 4 flowey_lib_common::git_checkout 3
+        flowey e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: install Rust
       run: flowey e 4 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 4 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 4 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 4 flowey_lib_common::install_rust 1
+        flowey e 4 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey e 4 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -5608,30 +4652,22 @@ jobs:
       run: flowey e 4 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 4 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 4 flowey_lib_common::cache 0
         flowey v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 4 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 4 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 4 flowey_lib_common::cache 2
+        flowey e 4 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 4 flowey_lib_common::install_dist_pkg 0
@@ -5640,31 +4676,27 @@ jobs:
       run: flowey e 4 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: unpack protoc
-      run: flowey e 4 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 4 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey e 4 flowey_lib_common::download_protoc 0
+        flowey e 4 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 4 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 4 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 4 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build xtask
-      run: flowey e 4 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 4 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 4 flowey_lib_common::run_cargo_build 0
+        flowey e 4 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: split debug symbols
       run: flowey e 4 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 4 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built xtask
-      run: flowey e 4 flowey_lib_hvlite::build_xtask 0
+      run: |-
+        flowey e 4 flowey_lib_hvlite::run_cargo_build 1
+        flowey e 4 flowey_lib_hvlite::build_xtask 0
       shell: bash
     - name: run xtask fmt
       run: flowey e 4 flowey_lib_hvlite::_jobs::check_xtask_fmt 0
@@ -5778,23 +4810,16 @@ jobs:
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 5 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 5 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 5 flowey_lib_common::install_rust 1
+        flowey.exe e 5 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 5 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 5 flowey_lib_common::git_checkout 0
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -5803,14 +4828,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 5 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 5 flowey_lib_common::git_checkout 3
+        flowey.exe e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 5 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -5819,129 +4841,91 @@ jobs:
       run: flowey.exe e 5 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 5 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 5 flowey_lib_common::cache 0
         flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 5 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 5 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 5 flowey_lib_common::cache 2
+        flowey.exe e 5 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 5 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 5 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 5 flowey_lib_common::download_protoc 0
+        flowey.exe e 5 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 5 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey.exe e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build ohcldiag-dev
-      run: flowey.exe e 5 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: report built ohcldiag_dev
-      run: flowey.exe e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 5 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey.exe e 5 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
       shell: bash
     - name: copying ohcldiag-dev to artifact dir
-      run: flowey.exe e 5 flowey_lib_common::copy_to_artifact_dir 2
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey.exe e 5 flowey_lib_common::copy_to_artifact_dir 2
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build vmgstool
-      run: flowey.exe e 5 flowey_lib_common::run_cargo_build 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: report built vmgstool
-      run: flowey.exe e 5 flowey_lib_hvlite::build_vmgstool 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 5 flowey_lib_hvlite::artifact_vmgstool::publish 0
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 5 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 5 flowey_lib_hvlite::artifact_vmgstool::publish 0
       shell: bash
     - name: copying vmgstool to artifact dir
-      run: flowey.exe e 5 flowey_lib_common::copy_to_artifact_dir 4
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey.exe e 5 flowey_lib_common::copy_to_artifact_dir 4
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build hypestv
-      run: flowey.exe e 5 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built hypestv
-      run: flowey.exe e 5 flowey_lib_hvlite::build_hypestv 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 5 flowey_lib_hvlite::artifact_hypestv::publish 0
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 5 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 5 flowey_lib_hvlite::artifact_hypestv::publish 0
       shell: bash
     - name: copying hypestv to artifact dir
-      run: flowey.exe e 5 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey.exe e 5 flowey_lib_common::copy_to_artifact_dir 0
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build vmgs_lib
-      run: flowey.exe e 5 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: check built vmgs_lib
-      run: flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: report built vmgs_lib
-      run: flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 5 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
+      run: |-
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 5 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
       shell: bash
     - name: copying vmgs_lib to artifact dir
-      run: flowey.exe e 5 flowey_lib_common::copy_to_artifact_dir 3
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey.exe e 5 flowey_lib_common::copy_to_artifact_dir 3
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey.exe e 5 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey.exe e 5 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 5 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 5 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 5 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
       shell: bash
     - name: copying igvmfilegen to artifact dir
       run: flowey.exe e 5 flowey_lib_common::copy_to_artifact_dir 1
@@ -6074,55 +5058,40 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 6 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::install_rust 1
+        flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 6 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 6 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 6 flowey_lib_common::cache 4
         flowey.exe v 6 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey.exe v 6 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 6 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 6 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 6 flowey_lib_common::cache 6
+        flowey.exe e 6 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.AARCH64.zip
       run: flowey.exe e 6 flowey_lib_hvlite::download_lxutil 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 6 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 6 flowey_lib_common::git_checkout 0
+        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -6131,17 +5100,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 6 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 6 flowey_lib_common::git_checkout 3
+        flowey.exe e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move lxutil.dll into its magic folder
       run: flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
@@ -6153,37 +5117,27 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 6 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm
-      run: flowey.exe e 6 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built openvmm
-      run: flowey.exe e 6 flowey_lib_hvlite::build_openvmm 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 6 flowey_lib_hvlite::build_openvmm 0
       shell: bash
     - name: copying openvmm to publish dir
-      run: flowey.exe e 6 flowey_lib_hvlite::artifact_openvmm::publish 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 6 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey.exe e 6 flowey_lib_hvlite::artifact_openvmm::publish 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build pipette
-      run: flowey.exe e 6 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built pipette
-      run: flowey.exe e 6 flowey_lib_hvlite::build_pipette 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::artifact_pipette::publish 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 6 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 6 flowey_lib_hvlite::artifact_pipette::publish 0
       shell: bash
     - name: copying pipette to artifact dir
       run: flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 0
@@ -6192,48 +5146,34 @@ jobs:
       run: flowey.exe e 6 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 6 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 6 flowey_lib_common::cache 0
         flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 6 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey.exe e 6 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 6 flowey_lib_common::install_rust 2
+      run: |-
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 6 flowey_lib_common::cache 2
+        flowey.exe e 6 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 6 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 6 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: build + archive 'vmm_tests' nextests
-      run: flowey.exe e 6 flowey_lib_common::run_cargo_nextest_archive 0
-      shell: bash
-    - name: report built vmm_tests
-      run: flowey.exe e 6 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 6 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 6 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 6 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
       shell: bash
     - name: copying vmm_tests to artifact dir
       run: flowey.exe e 6 flowey_lib_common::copy_to_artifact_dir 1
@@ -6365,23 +5305,16 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 7 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::install_rust 1
+        flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 7 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 7 flowey_lib_common::git_checkout 0
+        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -6390,14 +5323,11 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 7 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      run: |-
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 7 flowey_lib_common::git_checkout 3
+        flowey.exe e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
       run: flowey.exe e 7 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
@@ -6406,132 +5336,94 @@ jobs:
       run: flowey.exe e 7 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 7 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 7 flowey_lib_common::cache 0
         flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 7 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 7 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 7 flowey_lib_common::cache 2
+        flowey.exe e 7 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack protoc
-      run: flowey.exe e 7 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::download_protoc 0
+        flowey.exe e 7 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 7 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey.exe e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build vmgstool
-      run: flowey.exe e 7 flowey_lib_common::run_cargo_build 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: report built vmgstool
-      run: flowey.exe e 7 flowey_lib_hvlite::build_vmgstool 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::artifact_vmgstool::publish 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 7 flowey_lib_hvlite::build_vmgstool 0
+        flowey.exe e 7 flowey_lib_hvlite::artifact_vmgstool::publish 0
       shell: bash
     - name: copying vmgstool to artifact dir
-      run: flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 4
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 7 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 4
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build hypestv
-      run: flowey.exe e 7 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built hypestv
-      run: flowey.exe e 7 flowey_lib_hvlite::build_hypestv 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::artifact_hypestv::publish 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 7 flowey_lib_hvlite::build_hypestv 0
+        flowey.exe e 7 flowey_lib_hvlite::artifact_hypestv::publish 0
       shell: bash
     - name: copying hypestv to artifact dir
-      run: flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 7 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build vmgs_lib
-      run: flowey.exe e 7 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: check built vmgs_lib
       run: flowey.exe e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
-      run: flowey.exe e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      shell: bash
-    - name: report built vmgs_lib
-      run: flowey.exe e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
+      run: |-
+        flowey.exe e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey.exe e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 2
+        flowey.exe e 7 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
       shell: bash
     - name: copying vmgs_lib to artifact dir
-      run: flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 3
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 7 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 3
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey.exe e 7 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey.exe e 7 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 7 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey.exe e 7 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
       shell: bash
     - name: copying igvmfilegen to artifact dir
-      run: flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 7 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 1
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build ohcldiag-dev
-      run: flowey.exe e 7 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: report built ohcldiag_dev
-      run: flowey.exe e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 7 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 2
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 2
+        flowey.exe e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey.exe e 7 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
       shell: bash
     - name: copying ohcldiag-dev to artifact dir
       run: flowey.exe e 7 flowey_lib_common::copy_to_artifact_dir 2
@@ -6664,55 +5556,40 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 8 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey.exe e 8 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::install_rust 1
+        flowey.exe e 8 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 8 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 8 flowey_lib_common::cache 4
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 8 flowey_lib_common::cache 4
         flowey.exe v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar4 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar4'
-    - run: |
         flowey.exe v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar5'
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar4 }}
         path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
-      shell: flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__5.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 8 flowey_lib_common::cache 6
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey.exe e 8 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 8 flowey_lib_common::cache 6
+        flowey.exe e 8 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey.exe e 8 flowey_lib_hvlite::download_lxutil 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey.exe e 8 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 8 flowey_lib_common::git_checkout 0
+        flowey.exe v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey.exe v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey.exe v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -6721,17 +5598,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey.exe v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey.exe e 8 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey.exe e 8 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey.exe e 8 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey.exe v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe e 8 flowey_lib_common::git_checkout 3
+        flowey.exe e 8 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 8 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move lxutil.dll into its magic folder
       run: flowey.exe e 8 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
@@ -6743,37 +5615,27 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey.exe e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 8 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey.exe e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm
-      run: flowey.exe e 8 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 0
-      shell: bash
-    - name: report built openvmm
-      run: flowey.exe e 8 flowey_lib_hvlite::build_openvmm 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::run_cargo_build 0
+        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 0
+        flowey.exe e 8 flowey_lib_hvlite::build_openvmm 0
       shell: bash
     - name: copying openvmm to publish dir
-      run: flowey.exe e 8 flowey_lib_hvlite::artifact_openvmm::publish 0
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 8 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey.exe e 8 flowey_lib_hvlite::artifact_openvmm::publish 0
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build pipette
-      run: flowey.exe e 8 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 1
-      shell: bash
-    - name: report built pipette
-      run: flowey.exe e 8 flowey_lib_hvlite::build_pipette 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::artifact_pipette::publish 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::run_cargo_build 1
+        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 1
+        flowey.exe e 8 flowey_lib_hvlite::build_pipette 0
+        flowey.exe e 8 flowey_lib_hvlite::artifact_pipette::publish 0
       shell: bash
     - name: copying pipette to artifact dir
       run: flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 0
@@ -6782,48 +5644,34 @@ jobs:
       run: flowey.exe e 8 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey.exe e 8 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey.exe e 8 flowey_lib_common::cache 0
         flowey.exe v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar2 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar2'
-    - run: |
         flowey.exe v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar3'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey.exe e 8 flowey_lib_common::cache 2
-      shell: bash
-    - name: report cargo install persistent dir
-      run: flowey.exe e 8 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-      shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 8 flowey_lib_common::install_rust 2
+      run: |-
+        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe e 8 flowey_lib_common::cache 2
+        flowey.exe e 8 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 8 flowey_lib_common::install_rust 2
       shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 8 flowey_lib_common::download_cargo_nextest 1
-      shell: bash
-    - name: inject cross env
-      run: flowey.exe e 8 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: build + archive 'vmm_tests' nextests
-      run: flowey.exe e 8 flowey_lib_common::run_cargo_nextest_archive 0
-      shell: bash
-    - name: report built vmm_tests
-      run: flowey.exe e 8 flowey_lib_hvlite::build_nextest_vmm_tests 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey.exe e 8 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
+      run: |-
+        flowey.exe e 8 flowey_lib_common::run_cargo_nextest_archive 0
+        flowey.exe e 8 flowey_lib_hvlite::build_nextest_vmm_tests 0
+        flowey.exe e 8 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::publish 0
       shell: bash
     - name: copying vmm_tests to artifact dir
       run: flowey.exe e 8 flowey_lib_common::copy_to_artifact_dir 1
@@ -6966,10 +5814,9 @@ jobs:
       run: flowey e 9 flowey_lib_common::install_rust 0
       shell: bash
     - name: detect active toolchain
-      run: flowey e 9 flowey_lib_common::install_rust 1
-      shell: bash
-    - name: report common cargo flags
-      run: flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
+      run: |-
+        flowey e 9 flowey_lib_common::install_rust 1
+        flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 9 flowey_lib_common::install_dist_pkg 0
@@ -6981,46 +5828,32 @@ jobs:
       run: flowey e 9 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
-      run: flowey e 9 flowey_lib_common::cache 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 9 flowey_lib_common::cache 0
         flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:458:72' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar1'
-    - run: |
         flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
-      name: 🌼 Write to 'floweyvar2'
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
         key: ${{ env.floweyvar1 }}
         path: ${{ env.floweyvar2 }}
       name: 'Restore cache: gh-release-download'
-    - run: ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-      shell: flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'steps.flowey_lib_common__cache__1.outputs.cache-hit'
-    - name: map Github cache-hit to flowey
-      run: flowey e 9 flowey_lib_common::cache 2
-      shell: bash
     - name: download artifacts from github releases
-      run: flowey e 9 flowey_lib_common::download_gh_release 1
+      run: |-
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey e 9 flowey_lib_common::cache 2
+        flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.AARCH64.zip
       run: flowey e 9 flowey_lib_hvlite::download_lxutil 0
       shell: bash
     - name: check if openvmm needs to be cloned
-      run: flowey e 9 flowey_lib_common::git_checkout 0
-      shell: bash
-    - run: |
+      run: |-
+        flowey e 9 flowey_lib_common::git_checkout 0
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
-      name: 🌼❓ Write to 'FLOWEY_CONDITION'
-    - run: |
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string
-      shell: bash
-      name: 🌼 Write to 'floweyvar3'
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
       with:
@@ -7029,17 +5862,12 @@ jobs:
         persist-credentials: ${{ env.floweyvar3 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - run: ${{ github.workspace }}
-      shell: flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file {0} --is-raw-string
-      name: 🌼 Read from 'github.workspace'
     - name: report cloned repo directories
-      run: flowey e 9 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: resolve OpenVMM repo requests
-      run: flowey e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      shell: bash
-    - name: report openvmm magicpath dir
-      run: flowey e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      run: |-
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey e 9 flowey_lib_common::git_checkout 3
+        flowey e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move lxutil.dll into its magic folder
       run: flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_lxutil 0
@@ -7051,136 +5879,110 @@ jobs:
       run: flowey e 9 flowey_lib_common::download_protoc 0
       shell: bash
     - name: symlink protoc
-      run: flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 9 flowey_lib_hvlite::init_cross_build 1
+      run: |-
+        flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm
-      run: flowey e 9 flowey_lib_common::run_cargo_build 3
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::run_cargo_build 5
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 5
       shell: bash
     - name: split debug symbols
       run: flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
       shell: bash
     - name: reporting split debug info
-      run: flowey e 9 flowey_lib_hvlite::run_cargo_build 6
-      shell: bash
-    - name: report built openvmm
-      run: flowey e 9 flowey_lib_hvlite::build_openvmm 0
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::build_openvmm 0
       shell: bash
     - name: copying openvmm to publish dir
-      run: flowey e 9 flowey_lib_hvlite::artifact_openvmm::publish 0
-      shell: bash
-    - name: inject cross env
-      run: flowey e 9 flowey_lib_hvlite::init_cross_build 3
+      run: |-
+        flowey e 9 flowey_lib_hvlite::artifact_openvmm::publish 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgstool
-      run: flowey e 9 flowey_lib_common::run_cargo_build 5
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
       shell: bash
     - name: split debug symbols
       run: flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
       shell: bash
     - name: reporting split debug info
-      run: flowey e 9 flowey_lib_hvlite::run_cargo_build 9
-      shell: bash
-    - name: report built vmgstool
-      run: flowey e 9 flowey_lib_hvlite::build_vmgstool 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::artifact_vmgstool::publish 0
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_hvlite::build_vmgstool 0
+        flowey e 9 flowey_lib_hvlite::artifact_vmgstool::publish 0
       shell: bash
     - name: copying vmgstool to artifact dir
-      run: flowey e 9 flowey_lib_common::copy_to_artifact_dir 4
-      shell: bash
-    - name: inject cross env
-      run: flowey e 9 flowey_lib_hvlite::init_cross_build 2
+      run: |-
+        flowey e 9 flowey_lib_common::copy_to_artifact_dir 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build vmgs_lib
-      run: flowey e 9 flowey_lib_common::run_cargo_build 4
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
       shell: bash
     - name: check built vmgs_lib
-      run: flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
-      shell: bash
-    - name: report built vmgs_lib
-      run: flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
+      run: |-
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
+        flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
+        flowey e 9 flowey_lib_hvlite::artifact_vmgs_lib::publish 0
       shell: bash
     - name: copying vmgs_lib to artifact dir
-      run: flowey e 9 flowey_lib_common::copy_to_artifact_dir 3
-      shell: bash
-    - name: inject cross env
-      run: flowey e 9 flowey_lib_hvlite::init_cross_build 4
+      run: |-
+        flowey e 9 flowey_lib_common::copy_to_artifact_dir 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
-      run: flowey e 9 flowey_lib_common::run_cargo_build 1
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::run_cargo_build 1
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 1
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 1
       shell: bash
     - name: split debug symbols
       run: flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
       shell: bash
     - name: reporting split debug info
-      run: flowey e 9 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: report built igvmfilegen
-      run: flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 2
+        flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
+        flowey e 9 flowey_lib_hvlite::artifact_igvmfilegen::publish 0
       shell: bash
     - name: copying igvmfilegen to artifact dir
-      run: flowey e 9 flowey_lib_common::copy_to_artifact_dir 1
-      shell: bash
-    - name: inject cross env
-      run: flowey e 9 flowey_lib_hvlite::init_cross_build 0
+      run: |-
+        flowey e 9 flowey_lib_common::copy_to_artifact_dir 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
       shell: bash
     - name: cargo build ohcldiag-dev
-      run: flowey e 9 flowey_lib_common::run_cargo_build 2
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::run_cargo_build 3
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
     - name: split debug symbols
       run: flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
       shell: bash
     - name: reporting split debug info
-      run: flowey e 9 flowey_lib_hvlite::run_cargo_build 4
-      shell: bash
-    - name: report built ohcldiag_dev
-      run: flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
+        flowey e 9 flowey_lib_hvlite::artifact_ohcldiag_dev::publish 0
       shell: bash
     - name: copying ohcldiag-dev to artifact dir
-      run: flowey e 9 flowey_lib_common::copy_to_artifact_dir 2
-      shell: bash
-    - name: inject cross env
-      run: flowey e 9 flowey_lib_hvlite::init_cross_build 5
+      run: |-
+        flowey e 9 flowey_lib_common::copy_to_artifact_dir 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build guest_test_uefi
-      run: flowey e 9 flowey_lib_common::run_cargo_build 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::run_cargo_build 0
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 0
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 0
       shell: bash
     - name: build guest_test_uefi.img
-      run: flowey e 9 flowey_lib_hvlite::build_guest_test_uefi 0
-      shell: bash
-    - name: 🌼 write_into Var
-      run: flowey e 9 flowey_lib_hvlite::artifact_guest_test_uefi::publish 0
+      run: |-
+        flowey e 9 flowey_lib_hvlite::build_guest_test_uefi 0
+        flowey e 9 flowey_lib_hvlite::artifact_guest_test_uefi::publish 0
       shell: bash
     - name: copying guest_test_uefi to artifact dir
       run: flowey e 9 flowey_lib_common::copy_to_artifact_dir 0

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -133,7 +133,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 0 flowey_lib_common::cache 2
         flowey e 0 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -168,7 +170,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 0 flowey_lib_common::git_checkout 3
         flowey e 0 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 0 flowey_lib_hvlite::build_guide 0
@@ -302,7 +306,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 1 flowey_lib_common::git_checkout 3
         flowey.exe e 1 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -326,7 +332,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 1 flowey_lib_common::cache 2
         flowey.exe e 1 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -512,7 +520,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey e 10 flowey_lib_common::cache 6
         flowey e 10 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -535,7 +545,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 10 flowey_lib_common::git_checkout 3
         flowey e 10 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 10 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -678,7 +690,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 10 flowey_lib_common::cache 2
         flowey e 10 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey e 10 flowey_lib_common::install_rust 2
@@ -860,7 +874,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 11 flowey_lib_common::cache 2
         flowey e 11 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -891,7 +907,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 11 flowey_lib_common::git_checkout 3
         flowey e 11 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -1185,7 +1203,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 12 flowey_lib_common::cache 2
         flowey e 12 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -1216,7 +1236,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 12 flowey_lib_common::git_checkout 3
         flowey e 12 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -1608,7 +1630,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 13 flowey_lib_common::git_checkout 3
         flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -1632,7 +1656,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey e 13 flowey_lib_common::cache 6
         flowey e 13 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -1702,10 +1728,14 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 13 flowey_lib_common::cache 2
         flowey e 13 flowey_lib_common::download_gh_cli 1
-        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-file ${{ github.token }} --is-raw-string
+        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
+        ${{ github.token }}
+        EOF
       shell: bash
     - name: setup gh cli
       run: flowey e 13 flowey_lib_common::use_gh_cli 0
@@ -1846,7 +1876,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 14 flowey_lib_common::git_checkout 3
         flowey.exe e 14 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -1870,7 +1902,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 14 flowey_lib_common::cache 6
         flowey.exe e 14 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -1938,7 +1972,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 14 flowey_lib_common::cache 2
         flowey.exe e 14 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 14 flowey_lib_common::install_rust 2
@@ -2116,7 +2152,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey e 15 flowey_lib_common::cache 6
         flowey e 15 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -2142,7 +2180,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 15 flowey_lib_common::git_checkout 3
         flowey e 15 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 15 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -2241,7 +2281,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 15 flowey_lib_common::cache 2
         flowey e 15 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey e 15 flowey_lib_common::install_rust 2
@@ -2419,7 +2461,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 16 flowey_lib_common::git_checkout 3
         flowey e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 16 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -2447,7 +2491,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey e 16 flowey_lib_common::cache 6
         flowey e 16 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -2552,7 +2598,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 16 flowey_lib_common::cache 2
         flowey e 16 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey e 16 flowey_lib_common::install_rust 2
@@ -2726,7 +2774,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: install Rust
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 17 flowey_lib_common::cache 2
         flowey.exe e 17 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 17 flowey_lib_common::install_rust 0
@@ -2756,7 +2806,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 17 flowey_lib_common::git_checkout 3
         flowey.exe e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -2780,7 +2832,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 17 flowey_lib_common::cache 6
         flowey.exe e 17 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -2938,7 +2992,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: installing cargo-nextest
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 18 flowey_lib_common::cache 6
         flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
       shell: bash
@@ -2959,7 +3015,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
         flowey.exe e 18 flowey_lib_common::cache 10
         flowey.exe e 18 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -2982,7 +3040,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 18 flowey_lib_common::git_checkout 3
         flowey.exe e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 18 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -3030,7 +3090,9 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 18 flowey_lib_common::cache 2
         flowey.exe e 18 flowey_lib_common::download_azcopy 1
       shell: bash
@@ -3210,7 +3272,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: installing cargo-nextest
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 19 flowey_lib_common::cache 6
         flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
       shell: bash
@@ -3231,7 +3295,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
         flowey.exe e 19 flowey_lib_common::cache 10
         flowey.exe e 19 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -3254,7 +3320,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 19 flowey_lib_common::git_checkout 3
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 19 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -3302,7 +3370,9 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 19 flowey_lib_common::cache 2
         flowey.exe e 19 flowey_lib_common::download_azcopy 1
       shell: bash
@@ -3499,7 +3569,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 2 flowey_lib_common::git_checkout 3
         flowey e 2 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -3523,7 +3595,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 2 flowey_lib_common::cache 2
         flowey e 2 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -3667,7 +3741,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: installing cargo-nextest
       run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey e 20 flowey_lib_common::cache 6
         flowey e 20 flowey_lib_common::download_cargo_nextest 1
       shell: bash
@@ -3694,7 +3770,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
         flowey e 20 flowey_lib_common::cache 10
         flowey e 20 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -3717,7 +3795,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 20 flowey_lib_common::git_checkout 3
         flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -3759,7 +3839,9 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 20 flowey_lib_common::cache 2
         flowey e 20 flowey_lib_common::download_azcopy 1
       shell: bash
@@ -3999,7 +4081,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: installing cargo-nextest
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 21 flowey_lib_common::cache 6
         flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
       shell: bash
@@ -4020,7 +4104,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
         flowey.exe e 21 flowey_lib_common::cache 10
         flowey.exe e 21 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -4043,7 +4129,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 21 flowey_lib_common::git_checkout 3
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -4091,7 +4179,9 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 21 flowey_lib_common::cache 2
         flowey.exe e 21 flowey_lib_common::download_azcopy 1
       shell: bash
@@ -4286,14 +4376,18 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: install Rust
       run: |-
         flowey e 22 flowey_lib_common::install_rust 0
-        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-file ${{ github.token }} --is-raw-string
+        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
+        ${{ github.token }}
+        EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
       run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
@@ -4466,7 +4560,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 3 flowey_lib_common::git_checkout 3
         flowey.exe e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -4498,7 +4594,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 3 flowey_lib_common::cache 2
         flowey.exe e 3 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -4633,7 +4731,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 4 flowey_lib_common::git_checkout 3
         flowey e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -4665,7 +4765,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 4 flowey_lib_common::cache 2
         flowey e 4 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -4830,7 +4932,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 5 flowey_lib_common::git_checkout 3
         flowey.exe e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -4854,7 +4958,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 5 flowey_lib_common::cache 2
         flowey.exe e 5 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -5079,7 +5185,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 6 flowey_lib_common::cache 6
         flowey.exe e 6 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -5102,7 +5210,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 6 flowey_lib_common::git_checkout 3
         flowey.exe e 6 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 6 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -5159,7 +5269,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 6 flowey_lib_common::cache 2
         flowey.exe e 6 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 6 flowey_lib_common::install_rust 2
@@ -5325,7 +5437,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 7 flowey_lib_common::git_checkout 3
         flowey.exe e 7 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
@@ -5349,7 +5463,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 7 flowey_lib_common::cache 2
         flowey.exe e 7 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -5577,7 +5693,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
         flowey.exe e 8 flowey_lib_common::cache 6
         flowey.exe e 8 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -5600,7 +5718,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey.exe e 8 flowey_lib_common::git_checkout 3
         flowey.exe e 8 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey.exe e 8 flowey_lib_hvlite::cfg_openvmm_magicpath 0
@@ -5657,7 +5777,9 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey.exe e 8 flowey_lib_common::cache 2
         flowey.exe e 8 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 8 flowey_lib_common::install_rust 2
@@ -5841,7 +5963,9 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-file ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }} --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:510:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
         flowey e 9 flowey_lib_common::cache 2
         flowey e 9 flowey_lib_common::download_gh_release 1
       shell: bash
@@ -5864,7 +5988,9 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-file ${{ github.workspace }} --is-raw-string
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
         flowey e 9 flowey_lib_common::git_checkout 3
         flowey e 9 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 9 flowey_lib_hvlite::cfg_openvmm_magicpath 0

--- a/flowey/flowey_cli/src/cli/debug/interrogate.rs
+++ b/flowey/flowey_cli/src/cli/debug/interrogate.rs
@@ -112,6 +112,7 @@ impl flowey_core::node::NodeCtxBackend for InterrogateCtx {
     fn on_emit_rust_step(
         &mut self,
         label: &str,
+        _can_merge: bool,
         _code: Box<
             dyn for<'a> FnOnce(&'a mut RustRuntimeServices<'_>) -> anyhow::Result<()> + 'static,
         >,

--- a/flowey/flowey_cli/src/cli/exec_snippet.rs
+++ b/flowey/flowey_cli/src/cli/exec_snippet.rs
@@ -17,13 +17,7 @@ use flowey_core::pipeline::PipelineBackendHint;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeMap;
-use std::fmt::Write as _;
 use std::path::PathBuf;
-
-pub struct StepIdx<'a> {
-    pub node_modpath: &'a str,
-    pub snippet_idx: usize,
-}
 
 pub fn construct_exec_snippet_cli(
     flowey_bin: &str,
@@ -32,22 +26,6 @@ pub fn construct_exec_snippet_cli(
     job_idx: usize,
 ) -> String {
     format!(r#"{flowey_bin} e {job_idx} {node_modpath} {snippet_idx}"#)
-}
-
-pub fn construct_exec_snippet_cli_multi(
-    flowey_bin: &str,
-    job_idx: usize,
-    steps: Vec<StepIdx<'_>>,
-) -> String {
-    let mut s = format!("{flowey_bin} e {job_idx}");
-    for StepIdx {
-        node_modpath,
-        snippet_idx,
-    } in steps
-    {
-        write!(s, " \\\n    {node_modpath} {snippet_idx}").unwrap();
-    }
-    s
 }
 
 /// (internal) execute an inline code snippet from the given node.
@@ -249,6 +227,7 @@ impl flowey_core::node::NodeCtxBackend for ExecSnippetCtx<'_, '_> {
     fn on_emit_rust_step(
         &mut self,
         label: &str,
+        _can_merge: bool,
         code: Box<
             dyn for<'a> FnOnce(&'a mut RustRuntimeServices<'_>) -> anyhow::Result<()> + 'static,
         >,

--- a/flowey/flowey_cli/src/flow_resolver/stage1_dag.rs
+++ b/flowey/flowey_cli/src/flow_resolver/stage1_dag.rs
@@ -566,6 +566,7 @@ pub(crate) enum Step {
     Rust {
         idx: usize,
         label: String,
+        can_merge: bool,
         // FIXME: this absolutely cursed type is only here due to that Clone
         // bound, which is itself only required due to the really shoddy code in
         // the petgraph viz backend.
@@ -714,6 +715,7 @@ impl flowey_core::node::NodeCtxBackend for EmitFlowCtx<'_> {
     fn on_emit_rust_step(
         &mut self,
         label: &str,
+        can_merge: bool,
         code: Box<
             dyn for<'a> FnOnce(&'a mut RustRuntimeServices<'_>) -> anyhow::Result<()> + 'static,
         >,
@@ -722,6 +724,7 @@ impl flowey_core::node::NodeCtxBackend for EmitFlowCtx<'_> {
             step: Step::Rust {
                 idx: self.step_idx_tracker,
                 label: label.into(),
+                can_merge,
                 #[expect(clippy::arc_with_non_send_sync)]
                 code: Arc::new(Mutex::new(Some(code))),
             },

--- a/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
@@ -196,7 +196,12 @@ fn direct_run_do_work(
                 let mut steps = Vec::new();
                 let (label, code, idx) = match step {
                     Step::Anchor { .. } => continue,
-                    Step::Rust { label, code, idx } => (label, code, idx),
+                    Step::Rust {
+                        label,
+                        code,
+                        idx,
+                        can_merge: _,
+                    } => (label, code, idx),
                     Step::AdoYaml { .. } => {
                         anyhow::bail!(
                             "{} emitted ADO YAML. Fix the node by checking `ctx.backend()` appropriately",

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -3,6 +3,7 @@
 
 //! Code for emitting a pipeline as a single self-contained GitHub Actions yaml file
 
+use super::common_yaml::BashCommands;
 use super::common_yaml::check_generated_yaml_and_json;
 use super::common_yaml::write_generated_yaml_and_json;
 use super::generic::ResolvedJobArtifact;
@@ -234,6 +235,7 @@ pub fn github_yaml(
                 true,
                 None,
                 is_raw_string,
+                None,
                 None,
             )
         };
@@ -736,6 +738,8 @@ fn resolve_flow_as_github_yaml_steps(
         anyhow::bail!("detected unreachable nodes")
     }
 
+    let mut bash_commands = BashCommands::new_github();
+
     let output_order = petgraph::algo::toposort(&output_graph, None)
         .expect("runtime variables cannot introduce a DAG cycle");
 
@@ -749,27 +753,23 @@ fn resolve_flow_as_github_yaml_steps(
             Step::Rust {
                 idx,
                 label,
+                can_merge,
                 code: _,
             } => {
-                let cmd = crate::cli::exec_snippet::construct_exec_snippet_cli(
-                    flowey_bin,
-                    node_modpath,
-                    idx,
-                    job_idx,
-                );
-
-                let mut map = serde_yaml::Mapping::new();
-                map.insert("name".into(), serde_yaml::Value::String(label));
-                map.insert("run".into(), serde_yaml::Value::String(cmd));
-                map.insert("shell".into(), "bash".into());
-                output_steps.push(map.into());
+                output_steps.extend(bash_commands.push(
+                    Some(label),
+                    can_merge,
+                    crate::cli::exec_snippet::construct_exec_snippet_cli(
+                        flowey_bin,
+                        node_modpath,
+                        idx,
+                        job_idx,
+                    ),
+                ));
             }
-            Step::AdoYaml {
-                ado_to_rust: _,
-                rust_to_ado: _,
-                label,
-                ..
-            } => anyhow::bail!("ADO YAML not supported in GitHub. In step '{}'", label),
+            Step::AdoYaml { label, .. } => {
+                anyhow::bail!("ADO YAML not supported in GitHub. In step '{}'", label)
+            }
             Step::GitHubYaml {
                 gh_to_rust,
                 rust_to_gh,
@@ -780,19 +780,24 @@ fn resolve_flow_as_github_yaml_steps(
                 condvar,
                 permissions,
             } => {
-                let var_db_cmd =
-                    |var: &str, is_secret, update_from_file, is_raw_string, write_to_gh_env| {
-                        crate::cli::var_db::construct_var_db_cli(
-                            flowey_bin,
-                            job_idx,
-                            var,
-                            is_secret,
-                            false,
-                            update_from_file,
-                            is_raw_string,
-                            write_to_gh_env,
-                        )
-                    };
+                let var_db_cmd = |var: &str,
+                                  is_secret,
+                                  update_from_file: Option<String>,
+                                  is_raw_string,
+                                  write_to_gh_env: Option<String>,
+                                  condvar: Option<String>| {
+                    crate::cli::var_db::construct_var_db_cli(
+                        flowey_bin,
+                        job_idx,
+                        var,
+                        is_secret,
+                        false,
+                        update_from_file.as_deref(),
+                        is_raw_string,
+                        write_to_gh_env.as_deref(),
+                        condvar.as_deref(),
+                    )
+                };
 
                 for permission in permissions {
                     if let Some(permission_map) = gh_permissions.get(&node_handle) {
@@ -815,30 +820,6 @@ fn resolve_flow_as_github_yaml_steps(
                     }
                 }
 
-                if let Some(condvar) = &condvar {
-                    let mut cmd = String::new();
-
-                    // guaranteed to be a bare bool `true`/`false`, hence
-                    // is_raw_string = false
-                    let set_condvar = var_db_cmd(
-                        condvar,
-                        false,
-                        None,
-                        false,
-                        Some("FLOWEY_CONDITION".to_string()),
-                    );
-                    writeln!(cmd, r#"{set_condvar}"#)?;
-
-                    let mut map = serde_yaml::Mapping::new();
-                    map.insert("run".into(), serde_yaml::Value::String(cmd));
-                    map.insert("shell".into(), "bash".into());
-                    map.insert(
-                        "name".into(),
-                        serde_yaml::Value::String("🌼❓ Write to 'FLOWEY_CONDITION'".into()),
-                    );
-                    output_steps.push(map.into());
-                }
-
                 for gh_var_state in rust_to_gh {
                     let mut cmd = String::new();
 
@@ -847,30 +828,33 @@ fn resolve_flow_as_github_yaml_steps(
                         gh_var_state.is_secret,
                         None,
                         !gh_var_state.is_object,
-                        gh_var_state.raw_name.clone(),
+                        gh_var_state.raw_name,
+                        condvar.clone(),
                     );
                     writeln!(cmd, r#"{set_gh_env_var}"#)?;
 
-                    let mut map = serde_yaml::Mapping::new();
-                    map.insert("run".into(), serde_yaml::Value::String(cmd));
-                    map.insert("shell".into(), "bash".into());
-                    map.insert(
-                        "name".into(),
-                        serde_yaml::Value::String(format!(
-                            "🌼 Write to '{}'",
-                            gh_var_state
-                                .raw_name
-                                .expect("couldn't get raw_name for variable")
-                        )),
-                    );
-
-                    if condvar.is_some() {
-                        map.insert("if".into(), "${{ fromJSON(env.FLOWEY_CONDITION) }}".into());
-                    }
-                    output_steps.push(map.into());
+                    bash_commands.push_minor(cmd);
                 }
 
                 if !uses.is_empty() {
+                    if let Some(condvar) = &condvar {
+                        let mut cmd = String::new();
+
+                        // guaranteed to be a bare bool `true`/`false`, hence
+                        // is_raw_string = false
+                        let set_condvar = var_db_cmd(
+                            condvar,
+                            false,
+                            None,
+                            false,
+                            Some("FLOWEY_CONDITION".to_string()),
+                            None,
+                        );
+                        writeln!(cmd, r#"{set_condvar}"#)?;
+
+                        bash_commands.push_minor(cmd);
+                    }
+
                     let mut map = serde_yaml::Mapping::new();
                     map.insert("id".into(), serde_yaml::Value::String(step_id.clone()));
                     map.insert("uses".into(), serde_yaml::Value::String(uses));
@@ -887,44 +871,37 @@ fn resolve_flow_as_github_yaml_steps(
                     }
 
                     let step: serde_yaml::Value = map.into();
+                    output_steps.extend(bash_commands.flush());
                     output_steps.push(step);
                 }
 
                 for gh_var_state in gh_to_rust {
-                    let write_rust_var = var_db_cmd(
-                        &gh_var_state.backing_var,
-                        gh_var_state.is_secret,
-                        Some("{0}"),
-                        !gh_var_state.is_object,
-                        None,
-                    );
-
                     let raw_name = gh_var_state
                         .raw_name
                         .expect("couldn't get raw name for variable");
 
-                    let cmd = if gh_var_state.is_object {
+                    let file = if gh_var_state.is_object {
                         format!(r#"${{{{ toJSON({}) }}}}"#, raw_name)
                     } else {
                         format!(r#"${{{{ {} }}}}"#, raw_name)
                     };
 
-                    let mut map = serde_yaml::Mapping::new();
-                    map.insert("run".into(), serde_yaml::Value::String(cmd));
-                    map.insert("shell".into(), write_rust_var.into());
-                    map.insert(
-                        "name".into(),
-                        serde_yaml::Value::String(format!("🌼 Read from '{}'", raw_name)),
+                    let cmd = var_db_cmd(
+                        &gh_var_state.backing_var,
+                        gh_var_state.is_secret,
+                        Some(file),
+                        !gh_var_state.is_object,
+                        None,
+                        condvar.clone(),
                     );
-                    if condvar.is_some() {
-                        map.insert("if".into(), "${{ fromJSON(env.FLOWEY_CONDITION) }}".into());
-                    }
 
-                    output_steps.push(map.into());
+                    bash_commands.push_minor(cmd);
                 }
             }
         }
     }
+
+    output_steps.extend(bash_commands.flush());
 
     let request_db = request_db
         .into_iter()

--- a/flowey/flowey_cli/src/pipeline_resolver/viz.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/viz.rs
@@ -181,6 +181,7 @@ pub fn viz_flow_toposort(
             crate::flow_resolver::stage1_dag::Step::Rust {
                 idx: _,
                 label,
+                can_merge: _,
                 code: _,
             } => {
                 println!(
@@ -365,6 +366,7 @@ pub fn viz_flow_dot(
                     crate::flow_resolver::stage1_dag::Step::Rust {
                         idx,
                         label,
+                        can_merge: _,
                         code: _,
                     } => format!("rust{idx}\n\n{}", label),
                     crate::flow_resolver::stage1_dag::Step::AdoYaml {

--- a/flowey/flowey_lib_common/src/cache.rs
+++ b/flowey/flowey_lib_common/src/cache.rs
@@ -526,7 +526,7 @@ impl FlowNode for Node {
                     step.finish(ctx);
 
                     if let Some(hitvar_str_reader) = hitvar_str_reader {
-                        ctx.emit_rust_step("map Github cache-hit to flowey", |ctx| {
+                        ctx.emit_minor_rust_step("map Github cache-hit to flowey", |ctx| {
                             let CacheResult::HitVar(hitvar) = hitvar else {
                                 unreachable!()
                             };
@@ -544,7 +544,6 @@ impl FlowNode for Node {
                                 };
 
                                 rt.write(hitvar, &var);
-                                Ok(())
                             }
                         });
                     }

--- a/flowey/flowey_lib_common/src/cfg_cargo_common_flags.rs
+++ b/flowey/flowey_lib_common/src/cfg_cargo_common_flags.rs
@@ -60,7 +60,7 @@ impl FlowNode for Node {
             return Ok(());
         }
 
-        ctx.emit_rust_step("report common cargo flags", |ctx| {
+        ctx.emit_minor_rust_step("report common cargo flags", |ctx| {
             let get_flags = get_flags.claim(ctx);
             let set_verbose = set_verbose.claim(ctx);
 
@@ -75,7 +75,6 @@ impl FlowNode for Node {
                         },
                     );
                 }
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_common/src/cfg_persistent_dir_cargo_install.rs
+++ b/flowey/flowey_lib_common/src/cfg_persistent_dir_cargo_install.rs
@@ -20,7 +20,7 @@ impl FlowNode for Node {
 
     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
         let persistent_dir = ctx.persistent_dir();
-        ctx.emit_rust_step("report cargo install persistent dir", |ctx| {
+        ctx.emit_minor_rust_step("report cargo install persistent dir", |ctx| {
             let persistent_dir = persistent_dir.claim(ctx);
             let requests = requests
                 .into_iter()
@@ -31,7 +31,6 @@ impl FlowNode for Node {
                 for var in requests {
                     rt.write(var, &persistent_dir)
                 }
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_hvlite/src/artifact_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/artifact_openhcl_igvm_from_recipe.rs
@@ -67,7 +67,7 @@ pub mod publish {
                 done,
             } = request;
 
-            let files = ctx.emit_rust_stepv("describe OpenHCL igvm artifact", |ctx| {
+            let files = ctx.emit_minor_rust_stepv("describe OpenHCL igvm artifact", |ctx| {
                 let openhcl_igvm_files = openhcl_igvm_files.claim(ctx);
                 |rt| {
                     let mut files = Vec::new();
@@ -107,7 +107,7 @@ pub mod publish {
                             ));
                         }
                     }
-                    Ok(files)
+                    files
                 }
             });
 

--- a/flowey/flowey_lib_hvlite/src/artifact_openhcl_igvm_from_recipe_extras.rs
+++ b/flowey/flowey_lib_hvlite/src/artifact_openhcl_igvm_from_recipe_extras.rs
@@ -48,7 +48,7 @@ pub mod publish {
                 done,
             } = request;
 
-            let files = ctx.emit_rust_stepv("describe OpenHCL igvm extras artifact", |ctx| {
+            let files = ctx.emit_minor_rust_stepv("describe OpenHCL igvm extras artifact", |ctx| {
                 let extras = extras.claim(ctx);
                 |rt| {
                     let mut files = Vec::new();
@@ -87,7 +87,7 @@ pub mod publish {
                             files.push((format!("{folder_name}/sidecar.dbg").into(), dbg));
                         }
                     }
-                    Ok(files)
+                    files
                 }
             });
 

--- a/flowey/flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs
+++ b/flowey/flowey_lib_hvlite/src/build_and_test_vmgs_lib.rs
@@ -205,15 +205,13 @@ impl SimpleFlowNode for Node {
             ReadVar::from_static(()).into_side_effect()
         };
 
-        ctx.emit_rust_step("report built vmgs_lib", |ctx| {
+        ctx.emit_minor_rust_step("report built vmgs_lib", |ctx| {
             did_test.claim(ctx);
             let built_vmgs_lib = built_vmgs_lib.claim(ctx);
             let vmgs_lib = vmgs_lib.claim(ctx);
             move |rt| {
                 let built_vmgs_lib = rt.read(built_vmgs_lib);
                 rt.write(vmgs_lib, &built_vmgs_lib);
-
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_hvlite/src/build_hypestv.rs
+++ b/flowey/flowey_lib_hvlite/src/build_hypestv.rs
@@ -50,7 +50,7 @@ impl SimpleFlowNode for Node {
             output: v,
         });
 
-        ctx.emit_rust_step("report built hypestv", |ctx| {
+        ctx.emit_minor_rust_step("report built hypestv", |ctx| {
             let hypestv = hypestv.claim(ctx);
             let output = output.claim(ctx);
             move |rt| {
@@ -62,8 +62,6 @@ impl SimpleFlowNode for Node {
                 };
 
                 rt.write(hypestv, &output);
-
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_hvlite/src/build_igvmfilegen.rs
+++ b/flowey/flowey_lib_hvlite/src/build_igvmfilegen.rs
@@ -63,7 +63,7 @@ impl FlowNode for Node {
                 output: v,
             });
 
-            ctx.emit_rust_step("report built igvmfilegen", |ctx| {
+            ctx.emit_minor_rust_step("report built igvmfilegen", |ctx| {
                 let outvars = outvars.claim(ctx);
                 let output = output.claim(ctx);
                 move |rt| {
@@ -83,8 +83,6 @@ impl FlowNode for Node {
                     for var in outvars {
                         rt.write(var, &output);
                     }
-
-                    Ok(())
                 }
             });
         }

--- a/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_unit_tests.rs
@@ -254,13 +254,12 @@ impl FlowNode for Node {
                             archive_file: v,
                         });
 
-                    ctx.emit_rust_step("report built unit tests", |ctx| {
+                    ctx.emit_minor_rust_step("report built unit tests", |ctx| {
                         let archive_file = archive_file.claim(ctx);
                         let unit_tests = unit_tests_archive.claim(ctx);
                         |rt| {
                             let archive_file = rt.read(archive_file);
                             rt.write(unit_tests, &NextestUnitTestArchive(archive_file));
-                            Ok(())
                         }
                     });
                 }

--- a/flowey/flowey_lib_hvlite/src/build_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/build_nextest_vmm_tests.rs
@@ -162,13 +162,12 @@ impl FlowNode for Node {
                             archive_file: v,
                         });
 
-                    ctx.emit_rust_step("report built vmm_tests", |ctx| {
+                    ctx.emit_minor_rust_step("report built vmm_tests", |ctx| {
                         let archive_file = archive_file.claim(ctx);
                         let unit_tests = unit_tests_archive.claim(ctx);
                         |rt| {
                             let archive_file = rt.read(archive_file);
                             rt.write(unit_tests, &NextestVmmTestsArchive(archive_file));
-                            Ok(())
                         }
                     });
                 }

--- a/flowey/flowey_lib_hvlite/src/build_ohcldiag_dev.rs
+++ b/flowey/flowey_lib_hvlite/src/build_ohcldiag_dev.rs
@@ -50,7 +50,7 @@ impl SimpleFlowNode for Node {
             output: v,
         });
 
-        ctx.emit_rust_step("report built ohcldiag_dev", |ctx| {
+        ctx.emit_minor_rust_step("report built ohcldiag_dev", |ctx| {
             let ohcldiag_dev = ohcldiag_dev.claim(ctx);
             let output = output.claim(ctx);
             move |rt| {
@@ -68,8 +68,6 @@ impl SimpleFlowNode for Node {
                 };
 
                 rt.write(ohcldiag_dev, &output);
-
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_boot.rs
@@ -96,7 +96,7 @@ impl FlowNode for Node {
                 output: v,
             });
 
-            ctx.emit_rust_step("report built openhcl_boot", |ctx| {
+            ctx.emit_minor_rust_step("report built openhcl_boot", |ctx| {
                 let openhcl_boot = openhcl_boot.claim(ctx);
                 let output = output.claim(ctx);
                 move |rt| {
@@ -113,8 +113,6 @@ impl FlowNode for Node {
                     for var in openhcl_boot {
                         rt.write(var, &output);
                     }
-
-                    Ok(())
                 }
             });
         }

--- a/flowey/flowey_lib_hvlite/src/build_openvmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm.rs
@@ -120,7 +120,7 @@ impl FlowNode for Node {
                 output: v,
             });
 
-            ctx.emit_rust_step("report built openvmm", |ctx| {
+            ctx.emit_minor_rust_step("report built openvmm", |ctx| {
                 let openvmm_bin = openvmm_bin.claim(ctx);
                 let output = output.claim(ctx);
                 move |rt| {
@@ -138,8 +138,6 @@ impl FlowNode for Node {
                     };
 
                     rt.write(openvmm_bin, &output);
-
-                    Ok(())
                 }
             });
         }

--- a/flowey/flowey_lib_hvlite/src/build_openvmm_hcl.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openvmm_hcl.rs
@@ -131,7 +131,7 @@ impl FlowNode for Node {
                 output: v,
             });
 
-            ctx.emit_rust_step("report built openvmm_hcl", |ctx| {
+            ctx.emit_minor_rust_step("report built openvmm_hcl", |ctx| {
                 let outvars = outvars.claim(ctx);
                 let output = output.claim(ctx);
                 move |rt| {
@@ -145,8 +145,6 @@ impl FlowNode for Node {
                     for var in outvars {
                         rt.write(var, &output);
                     }
-
-                    Ok(())
                 }
             });
         }

--- a/flowey/flowey_lib_hvlite/src/build_pipette.rs
+++ b/flowey/flowey_lib_hvlite/src/build_pipette.rs
@@ -50,7 +50,7 @@ impl SimpleFlowNode for Node {
             output: v,
         });
 
-        ctx.emit_rust_step("report built pipette", |ctx| {
+        ctx.emit_minor_rust_step("report built pipette", |ctx| {
             let pipette = pipette.claim(ctx);
             let output = output.claim(ctx);
             move |rt| {
@@ -68,8 +68,6 @@ impl SimpleFlowNode for Node {
                 };
 
                 rt.write(pipette, &output);
-
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_hvlite/src/build_sidecar.rs
+++ b/flowey/flowey_lib_hvlite/src/build_sidecar.rs
@@ -96,7 +96,7 @@ impl FlowNode for Node {
                 output: v,
             });
 
-            ctx.emit_rust_step("report built sidecar", |ctx| {
+            ctx.emit_minor_rust_step("report built sidecar", |ctx| {
                 let sidecar = sidecar.claim(ctx);
                 let output = output.claim(ctx);
                 move |rt| {
@@ -113,8 +113,6 @@ impl FlowNode for Node {
                     for var in sidecar {
                         rt.write(var, &output);
                     }
-
-                    Ok(())
                 }
             });
         }

--- a/flowey/flowey_lib_hvlite/src/build_vmfirmwareigvm_dll.rs
+++ b/flowey/flowey_lib_hvlite/src/build_vmfirmwareigvm_dll.rs
@@ -99,7 +99,7 @@ impl SimpleFlowNode for Node {
             output: v,
         });
 
-        ctx.emit_rust_step("report built vmfirmwareigvm_dll", |ctx| {
+        ctx.emit_minor_rust_step("report built vmfirmwareigvm_dll", |ctx| {
             let vmfirmwareigvm_dll = vmfirmwareigvm_dll.claim(ctx);
             let output = output.claim(ctx);
             move |rt| {
@@ -114,8 +114,6 @@ impl SimpleFlowNode for Node {
                 };
 
                 rt.write(vmfirmwareigvm_dll, &output);
-
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
+++ b/flowey/flowey_lib_hvlite/src/build_vmgstool.rs
@@ -73,7 +73,7 @@ impl SimpleFlowNode for Node {
             output: v,
         });
 
-        ctx.emit_rust_step("report built vmgstool", |ctx| {
+        ctx.emit_minor_rust_step("report built vmgstool", |ctx| {
             let vmgstool = vmgstool.claim(ctx);
             let output = output.claim(ctx);
             move |rt| {
@@ -91,8 +91,6 @@ impl SimpleFlowNode for Node {
                 };
 
                 rt.write(vmgstool, &output);
-
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_hvlite/src/build_xtask.rs
+++ b/flowey/flowey_lib_hvlite/src/build_xtask.rs
@@ -46,7 +46,7 @@ impl SimpleFlowNode for Node {
             output: v,
         });
 
-        ctx.emit_rust_step("report built xtask", |ctx| {
+        ctx.emit_minor_rust_step("report built xtask", |ctx| {
             let xtask = xtask.claim(ctx);
             let output = output.claim(ctx);
             move |rt| {
@@ -64,8 +64,6 @@ impl SimpleFlowNode for Node {
                 };
 
                 rt.write(xtask, &output);
-
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs
+++ b/flowey/flowey_lib_hvlite/src/cfg_openvmm_magicpath.rs
@@ -26,7 +26,7 @@ impl FlowNode for Node {
     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
         let repo_path = ctx.reqv(crate::git_checkout_openvmm_repo::req::GetRepoDir);
 
-        ctx.emit_rust_step("report openvmm magicpath dir", |ctx| {
+        ctx.emit_minor_rust_step("report openvmm magicpath dir", |ctx| {
             let repo_path = repo_path.claim(ctx);
             let requests = requests
                 .into_iter()
@@ -35,7 +35,6 @@ impl FlowNode for Node {
             |rt| {
                 let path = rt.read(repo_path).join(".packages");
                 rt.write_all(requests, &path);
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs
+++ b/flowey/flowey_lib_hvlite/src/git_checkout_openvmm_repo.rs
@@ -51,7 +51,7 @@ impl FlowNode for Node {
             persist_credentials: false,
         });
 
-        ctx.emit_rust_step("resolve OpenVMM repo requests", move |ctx| {
+        ctx.emit_minor_rust_step("resolve OpenVMM repo requests", move |ctx| {
             let path = path.claim(ctx);
             let vars = reqs.claim(ctx);
             move |rt| {
@@ -59,8 +59,6 @@ impl FlowNode for Node {
                 for var in vars {
                     rt.write(var, &path)
                 }
-
-                Ok(())
             }
         });
 

--- a/flowey/flowey_lib_hvlite/src/init_cross_build.rs
+++ b/flowey/flowey_lib_hvlite/src/init_cross_build.rs
@@ -113,12 +113,11 @@ impl FlowNode for Node {
                 }
             }
 
-            ctx.emit_rust_step("inject cross env", |ctx| {
+            ctx.emit_minor_rust_step("inject cross env", |ctx| {
                 pre_build_deps.claim(ctx);
                 let injected_env_write = injected_env_write.claim(ctx);
                 move |rt| {
                     rt.write(injected_env_write, &injected_env);
-                    Ok(())
                 }
             });
         }


### PR DESCRIPTION
It is hard to read the output logs of a flowey-based pipeline since
there are so many steps (many of them implicit) that are just shuffling
variables around.

Furthermore, node authors avoid using variable combinators such as `map`
and `zip` since they generate so much noise in the pipeline output.

ADO pipelines partially sidestep these problems by merging all
contiguous Rust steps together, but GitHub pipelines don't do this. And
for ADO, it is difficult to debug the output because so many unrelated
but failure-prone steps get merged into a single ADO step.

To resolve these problems, add a new Rust step property: whether the
step can be merged with adjacent steps. Merge mergable steps with their
neighbors (whether the neighbor itself is mergable or not). Also merge
the generated steps for dealing with conditions, and eliminate the need
for putting conditions in the environment just to conditionalize another
flowey Rust step.

Mark most of the failure-free variable-shuffling steps as mergable
(termed "minor").

This greatly reduces the number of steps in the GH pipelines, but it
increases the number in the ADO pipelines. I think this is probably
worth the tradeoff.