### PR TITLE
Make vmbus SavedState Clone

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -240,7 +240,7 @@ impl EventPort for ChannelEvent {
     }
 }
 
-#[derive(Debug, Protobuf, SavedStateRoot)]
+#[derive(Debug, Protobuf, SavedStateRoot, Clone)]
 #[mesh(package = "vmbus.server")]
 pub struct SavedState {
     #[mesh(1)]


### PR DESCRIPTION
This change derives `Clone` for `vmbus_server::SavedState`. This change will allow us to call `mesh::payload::encode` on a vmbus SavedState to pass bytes between process boundaries.