### PR TITLE
virt_mshv_vtl: Optimize and cleanup cvm_handle_cross_vtl_interrupts

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1460,7 +1460,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
         let mut reprocessing_required = false;
         let cvm_state = self.backing.cvm_state();
-        let hv = &self.backing.cvm_state().hv[GuestVtl::Vtl1];
+        let hv = &cvm_state.hv[GuestVtl::Vtl1];
         let vina = hv.synic.vina();
         let vp_index = self.vp_index();
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -889,12 +889,6 @@ impl BackingPrivate for TdxBacked {
                 return true;
             }
 
-            if check_rflags
-                && !RFlags::from_bits(backing_vtl.private_regs.rflags).interrupt_enable()
-            {
-                return false;
-            }
-
             let (vector, ppr) = if this.backing.cvm.lapics[vtl].lapic.is_offloaded() {
                 let vector = backing_vtl.private_regs.rvi;
                 let ppr = std::cmp::max(
@@ -920,6 +914,12 @@ impl BackingPrivate for TdxBacked {
             let ppr_priority = ppr >> 4;
 
             if vector_priority <= ppr_priority {
+                return false;
+            }
+
+            if check_rflags
+                && !RFlags::from_bits(backing_vtl.private_regs.rflags).interrupt_enable()
+            {
                 return false;
             }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -889,15 +889,8 @@ impl BackingPrivate for TdxBacked {
                 return true;
             }
 
-            let interruptibility: Interruptibility = this
-                .runner
-                .read_vmcs32(vtl, VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY)
-                .into();
-
-            if (check_rflags
-                && !RFlags::from_bits(backing_vtl.private_regs.rflags).interrupt_enable())
-                || interruptibility.blocked_by_sti()
-                || interruptibility.blocked_by_movss()
+            if check_rflags
+                && !RFlags::from_bits(backing_vtl.private_regs.rflags).interrupt_enable()
             {
                 return false;
             }
@@ -925,7 +918,21 @@ impl BackingPrivate for TdxBacked {
             };
             let vector_priority = (vector as u32) >> 4;
             let ppr_priority = ppr >> 4;
-            vector_priority > ppr_priority
+
+            if vector_priority <= ppr_priority {
+                return false;
+            }
+
+            let interruptibility: Interruptibility = this
+                .runner
+                .read_vmcs32(vtl, VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY)
+                .into();
+
+            if interruptibility.blocked_by_sti() || interruptibility.blocked_by_movss() {
+                return false;
+            }
+
+            true
         })
     }
 


### PR DESCRIPTION
Checking for VINA in every exit is hurting TDX perf due to the read of VMX_VMCS_GUEST_INTERRUPTIBILITY. Tweak cvm_handle_cross_vtl_interrupts so that we don't do anything if VTL 1 isn't yet enabled to avoid this as much as we can. Also tweak the order of operations so this is checked later in the process, allowing earlier easier checks to bail us out. Also, thanks to how we've been moving around state everywhere, flatten out these ifs so things aren't so deeply nested.