### PR TITLE
virt_mshv_vtl/tdx: log more info for bad guest state exits (#1092)

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -403,6 +403,8 @@ pub enum UhRunVpError {
     InvalidVmcb,
     #[error("unknown exit {0:#x?}")]
     UnknownVmxExit(x86defs::vmx::VmxExit),
+    #[error("bad guest state on VP.ENTER")]
+    VmxBadGuestState,
     /// Failed to read hypercall parameters
     #[error("failed to read hypercall parameters")]
     HypercallParameters(#[source] guestmem::GuestMemoryError),

--- a/vm/x86/x86defs/src/vmx.rs
+++ b/vm/x86/x86defs/src/vmx.rs
@@ -12,38 +12,59 @@ use zerocopy::FromBytes;
 use zerocopy::FromZeroes;
 
 open_enum! {
-    /// VMX exit reason
-    pub enum VmxExit: u32 {
+    /// VMX basic exit reason
+    pub enum VmxExitBasic: u16 {
         EXCEPTION = 0x0,
         HW_INTERRUPT = 0x1,
         TRIPLE_FAULT = 0x2,
         SMI_INTR = 0x6,
-        INTERRUPT_WINDOW = 7,
-        NMI_WINDOW = 8,
+        INTERRUPT_WINDOW = 0x7,
+        NMI_WINDOW = 0x8,
         PAUSE_INSTRUCTION = 0x28,
         CPUID = 0xA,
         HLT_INSTRUCTION = 0xC,
         VMCALL_INSTRUCTION = 0x12,
-        WBINVD_INSTRUCTION = 0x36,
         CR_ACCESS = 0x1C,
         IO_INSTRUCTION = 0x1E,
         MSR_READ = 0x1F,
         MSR_WRITE = 0x20,
+        BAD_GUEST_STATE = 0x21,
         TPR_BELOW_THRESHOLD = 0x2B,
         EPT_VIOLATION = 0x30,
+        WBINVD_INSTRUCTION = 0x36,
         XSETBV = 0x37,
         TDCALL = 0x4D,
     }
 }
 
-impl VmxExit {
+impl VmxExitBasic {
     pub(crate) const fn from_bits(value: u64) -> Self {
-        Self(value as u32)
+        Self(value as u16)
     }
 
     pub(crate) const fn into_bits(self) -> u64 {
         self.0 as u64
     }
+}
+
+/// VMX exit reason
+#[bitfield(u32)]
+#[derive(PartialEq, Eq)]
+pub struct VmxExit {
+    #[bits(16)]
+    pub basic_reason: VmxExitBasic,
+    #[bits(10)]
+    rsvd_0: u64,
+    #[bits(1)]
+    pub bus_lock_preempted: bool,
+    #[bits(1)]
+    pub enclave_interruption: bool,
+    #[bits(1)]
+    pub pending_mtf: bool,
+    #[bits(2)]
+    rsvd_1: u8,
+    #[bits(1)]
+    pub vm_enter_failed: bool,
 }
 
 pub const VMX_ENTRY_CONTROL_LONG_MODE_GUEST: u32 = 0x00000200;


### PR DESCRIPTION
VP.ENTER can fail if the guest's VMCS is in a bad state. This is a VMM bug, so handle it rather specifically than just lumping it into the generic exit type. Add some additional tracing to capture VMCS fields to help debug issues.

Fix the VMX exit definition to correctly have the upper bits that show different error conditions so we can correctly check if VP.ENTER succeeded.

This is to help track down a current issue that has a very low repro rate where we're seeing this exit code. There's an identified issue with CR4 MCE (#1091), but it's unclear if that is the cause or not yet.

Backport of #1092 