### PR TITLE
Record a livedump of OpenHCL when hitting a guest or uefi watchdog timeout (#1093)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6826,6 +6826,7 @@ dependencies = [
  "thiserror 2.0.0",
  "tracing",
  "tracing-subscriber",
+ "underhill_confidentiality",
  "vergen",
  "vmbus_async",
  "vmbus_user_channel",
@@ -6841,6 +6842,7 @@ dependencies = [
  "libc",
  "tracing",
  "tracing-subscriber",
+ "underhill_confidentiality",
 ]
 
 [[package]]

--- a/openhcl/underhill_core/src/emuplat/watchdog.rs
+++ b/openhcl/underhill_core/src/emuplat/watchdog.rs
@@ -11,19 +11,24 @@ use watchdog_vmgs_format::WatchdogVmgsFormatStoreError;
 pub struct UnderhillWatchdog {
     store: WatchdogVmgsFormatStore,
     get: guest_emulation_transport::GuestEmulationTransportClient,
-    on_timeout: Box<dyn Fn() + Send + Sync>,
+    hook: Box<dyn WatchdogTimeout>,
+}
+
+#[async_trait::async_trait]
+pub trait WatchdogTimeout: Send + Sync {
+    async fn on_timeout(&self);
 }
 
 impl UnderhillWatchdog {
     pub async fn new(
         store: Box<dyn NonVolatileStore>,
         get: guest_emulation_transport::GuestEmulationTransportClient,
-        on_timeout: Box<dyn Fn() + Send + Sync>,
+        hook: Box<dyn WatchdogTimeout>,
     ) -> Result<Self, WatchdogVmgsFormatStoreError> {
         Ok(UnderhillWatchdog {
             store: WatchdogVmgsFormatStore::new(store).await?,
             get,
-            on_timeout,
+            hook,
         })
     }
 }
@@ -39,13 +44,15 @@ impl WatchdogPlatform for UnderhillWatchdog {
             );
         }
 
+        // Call the hook before reporting this to the GET, as the hook may
+        // want to do something before the host tears us down.
+        self.hook.on_timeout().await;
+
         // FUTURE: consider emitting different events for the UEFI watchdog vs.
         // the guest watchdog
         self.get
             .event_log_fatal(get_protocol::EventLogId::WATCHDOG_TIMEOUT_RESET)
             .await;
-
-        (self.on_timeout)()
     }
 
     async fn read_and_clear_boot_status(&mut self) -> bool {

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -13,6 +13,7 @@ mod emuplat;
 mod get_tracing;
 mod inspect_internal;
 mod inspect_proc;
+mod livedump;
 mod loader;
 mod nvme_manager;
 mod options;

--- a/openhcl/underhill_core/src/livedump.rs
+++ b/openhcl/underhill_core/src/livedump.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::process::Stdio;
+
+pub(crate) async fn livedump() {
+    // If a livedump fails we don't want to panic, just log the error.
+    match livedump_core().await {
+        Err(e) => tracing::error!(?e, "livedump failed"),
+        Ok(()) => tracing::info!("livedump succeeded"),
+    }
+}
+
+async fn livedump_core() -> anyhow::Result<()> {
+    if underhill_confidentiality::confidential_filtering_enabled() {
+        tracing::info!("livedump disabled due to CVM");
+        return Ok(());
+    }
+
+    let (dump_read, dump_write) = pal::unix::pipe::pair()?;
+
+    // Spawn underhill-crash to forward the crash dump to the host.
+    // Give it what arguments we can, but as this is a live dump they're not quite as relevant.
+    let crash_proc = std::process::Command::new("underhill-crash")
+        .stdin(dump_read)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .env("UNDERHILL_CRASH_NO_REDIRECT", "1")
+        .arg(std::process::id().to_string()) // pid
+        .arg(0.to_string()) // tid
+        .arg(0.to_string()) // sig
+        .arg(std::env::current_exe().unwrap_or_default()) // comm
+        .spawn()?;
+
+    // Spawn underhill-dump to create the dump.
+    // This needs to be done after underhill-crash, as underhill-dump will pause us.
+    let dump_result = std::process::Command::new("underhill-dump")
+        .arg(format!("{}", std::process::id()))
+        .stdin(Stdio::null())
+        .stdout(dump_write)
+        .stderr(Stdio::piped())
+        .output()?;
+
+    // underhill-dump should finish first, as it's the producer.
+    let crash_result = crash_proc.wait_with_output()?;
+
+    // Check for errors. If both failed log both outputs, as one crashing may cause the other to fail.
+    if !dump_result.status.success() {
+        let dump_output = String::from_utf8_lossy(&dump_result.stderr);
+        for line in dump_output.lines() {
+            tracing::info!("underhill-dump output: {}", line);
+        }
+    }
+
+    if !crash_result.status.success() {
+        let crash_output = String::from_utf8_lossy(&crash_result.stdout);
+        for line in crash_output.lines() {
+            tracing::info!("underhill-crash output: {}", line);
+        }
+        anyhow::bail!("underhill-crash failed: {}", crash_result.status);
+    }
+
+    if !dump_result.status.success() {
+        anyhow::bail!("underhill-dump failed: {}", dump_result.status);
+    }
+
+    Ok(())
+}

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -33,6 +33,8 @@ use crate::emuplat::netvsp::HclNetworkVFManagerShutdownInProgress;
 use crate::emuplat::netvsp::RuntimeSavedState;
 use crate::emuplat::tpm::resources::GetTpmRequestAkCertHelperHandle;
 use crate::emuplat::vga_proxy::UhRegisterHostIoFastPath;
+use crate::emuplat::watchdog::UnderhillWatchdog;
+use crate::emuplat::watchdog::WatchdogTimeout;
 use crate::emuplat::EmuplatServicing;
 use crate::loader::vtl0_config::MeasuredVtl0Info;
 use crate::loader::vtl2_config::RuntimeParameters;
@@ -2034,36 +2036,21 @@ async fn new_underhill_vm(
                     .await
                     .expect("first time taking chan"),
                 watchdog_platform: {
-                    use crate::emuplat::watchdog::UnderhillWatchdog;
-
                     // UEFI watchdog doesn't persist to VMGS at this time
                     let store = EphemeralNonVolatileStore::new_boxed();
 
                     #[cfg(guest_arch = "x86_64")]
-                    let watchdog_reset = {
-                        let partition = partition.clone();
-                        Box::new(move || {
-                            // Unlike Hyper-V, we only send the NMI to the BSP.
-                            partition.request_msi(
-                                Vtl::Vtl0,
-                                MsiRequest::new_x86(
-                                    virt::irqcon::DeliveryMode::NMI,
-                                    0,
-                                    false,
-                                    0,
-                                    false,
-                                ),
-                            );
-                        })
+                    let watchdog_reset = WatchdogTimeoutNmi {
+                        partition: partition.clone(),
                     };
                     #[cfg(guest_arch = "aarch64")]
-                    let watchdog_reset = {
-                        let halt = halt_vps.clone();
-                        Box::new(move || halt.halt(HaltReason::Reset))
+                    let watchdog_reset = WatchdogTimeoutHalt {
+                        halt_vps: halt_vps.clone(),
                     };
 
                     Box::new(
-                        UnderhillWatchdog::new(store, get_client.clone(), watchdog_reset).await?,
+                        UnderhillWatchdog::new(store, get_client.clone(), Box::new(watchdog_reset))
+                            .await?,
                     )
                 },
                 vsm_config: Some(Box::new(UnderhillVsmConfig {
@@ -2377,17 +2364,17 @@ async fn new_underhill_vm(
         Some(dev::HyperVGuestWatchdogDeps {
             port_base: WDAT_PORT,
             watchdog_platform: {
-                use crate::emuplat::watchdog::UnderhillWatchdog;
-
                 let store = vmgs_client
                     .as_non_volatile_store(vmgs::FileId::GUEST_WATCHDOG, false)
                     .context("failed to instantiate guest watchdog store")?;
-                let trigger_reset = {
-                    let halt = halt_vps.clone();
-                    Box::new(move || halt.halt(HaltReason::Reset))
+                let trigger_reset = WatchdogTimeoutHalt {
+                    halt_vps: halt_vps.clone(),
                 };
 
-                Box::new(UnderhillWatchdog::new(store, get_client.clone(), trigger_reset).await?)
+                Box::new(
+                    UnderhillWatchdog::new(store, get_client.clone(), Box::new(trigger_reset))
+                        .await?,
+                )
             },
         })
     } else {
@@ -3326,5 +3313,37 @@ impl chipset_device::mmio::MmioIntercept for FallbackMmioDevice {
 impl ChipsetDevice for FallbackMmioDevice {
     fn supports_mmio(&mut self) -> Option<&mut dyn chipset_device::mmio::MmioIntercept> {
         Some(self)
+    }
+}
+
+#[cfg(guest_arch = "x86_64")]
+struct WatchdogTimeoutNmi {
+    partition: Arc<UhPartition>,
+}
+
+#[cfg(guest_arch = "x86_64")]
+#[async_trait::async_trait]
+impl WatchdogTimeout for WatchdogTimeoutNmi {
+    async fn on_timeout(&self) {
+        crate::livedump::livedump().await;
+
+        // Unlike Hyper-V, we only send the NMI to the BSP.
+        self.partition.request_msi(
+            Vtl::Vtl0,
+            MsiRequest::new_x86(virt::irqcon::DeliveryMode::NMI, 0, false, 0, false),
+        );
+    }
+}
+
+struct WatchdogTimeoutHalt {
+    halt_vps: Arc<Halt>,
+}
+
+#[async_trait::async_trait]
+impl WatchdogTimeout for WatchdogTimeoutHalt {
+    async fn on_timeout(&self) {
+        crate::livedump::livedump().await;
+
+        self.halt_vps.halt(HaltReason::Reset)
     }
 }

--- a/openhcl/underhill_crash/Cargo.toml
+++ b/openhcl/underhill_crash/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]
 get_protocol.workspace = true
 pal_async.workspace = true
+underhill_confidentiality = { workspace = true, features = ["std"] }
 vmbus_async.workspace = true
 vmbus_user_channel.workspace = true
 

--- a/openhcl/underhill_crash/src/lib.rs
+++ b/openhcl/underhill_crash/src/lib.rs
@@ -39,7 +39,6 @@ use std::io::ErrorKind;
 use std::io::Read;
 use std::os::fd::AsRawFd;
 use std::pin::pin;
-use tracing_subscriber::fmt::time::uptime;
 use vmbus_async::async_dgram::AsyncRecvExt;
 use vmbus_async::async_dgram::AsyncSendExt;
 use vmbus_async::pipe::MessagePipe;
@@ -246,12 +245,14 @@ pub fn main() -> ! {
     let options = Options::parse();
 
     // Now set stderr and stdout to /dev/ttyprintk to catch any other output.
-    let ttyprintk = OpenOptions::new().write(true).open("/dev/ttyprintk");
-    if let Ok(ttyprintk) = &ttyprintk {
-        // SAFETY: calling as documented.
-        unsafe {
-            libc::dup2(ttyprintk.as_raw_fd(), STDOUT_FILENO);
-            libc::dup2(ttyprintk.as_raw_fd(), STDERR_FILENO);
+    if !options.no_redirect {
+        let ttyprintk = OpenOptions::new().write(true).open("/dev/ttyprintk");
+        if let Ok(ttyprintk) = &ttyprintk {
+            // SAFETY: calling as documented.
+            unsafe {
+                libc::dup2(ttyprintk.as_raw_fd(), STDOUT_FILENO);
+                libc::dup2(ttyprintk.as_raw_fd(), STDERR_FILENO);
+            }
         }
     }
 
@@ -263,10 +264,16 @@ pub fn main() -> ! {
             tracing::Level::INFO
         })
         .log_internal_errors(true)
-        .with_timer(uptime())
+        .with_timer(tracing_subscriber::fmt::time::uptime())
         .compact()
         .with_ansi(false)
         .init();
+
+    // We should have checks in our callers so this is never hit, but let's be safe.
+    if underhill_confidentiality::confidential_filtering_enabled() {
+        tracing::info!("crash reporting disabled due to CVM");
+        std::process::exit(libc::EXIT_FAILURE);
+    }
 
     let os_version = OsVersionInfo::new();
 

--- a/openhcl/underhill_crash/src/options.rs
+++ b/openhcl/underhill_crash/src/options.rs
@@ -24,6 +24,8 @@ pub struct Options {
 
     /// Be verbose
     pub verbose: bool,
+    /// Don't redirect output
+    pub no_redirect: bool,
     /// Timeout
     pub timeout: Duration,
 }
@@ -61,6 +63,9 @@ impl Options {
                 .expect(Self::usage()),
         );
 
+        let no_redirect_var = std::env::var("UNDERHILL_CRASH_NO_REDIRECT").unwrap_or_default();
+        let no_redirect = no_redirect_var == "1" || no_redirect_var.eq_ignore_ascii_case("true");
+
         let verbose_var = std::env::var("UNDERHILL_CRASH_VERBOSE").unwrap_or_default();
         let verbose = verbose_var == "1" || verbose_var.to_ascii_lowercase() == "true";
 
@@ -71,6 +76,7 @@ impl Options {
             comm,
 
             verbose,
+            no_redirect,
             timeout,
         }
     }

--- a/openhcl/underhill_dump/Cargo.toml
+++ b/openhcl/underhill_dump/Cargo.toml
@@ -9,6 +9,8 @@ rust-version.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]
 elfcore.workspace = true
 
+underhill_confidentiality = { workspace = true, features = ["std"] }
+
 anyhow.workspace = true
 libc.workspace = true
 tracing.workspace = true

--- a/openhcl/underhill_dump/src/lib.rs
+++ b/openhcl/underhill_dump/src/lib.rs
@@ -48,7 +48,16 @@ pub fn do_main() -> anyhow::Result<()> {
         .with_writer(std::io::stderr)
         .log_internal_errors(true)
         .with_max_level(level)
+        .with_timer(tracing_subscriber::fmt::time::uptime())
+        .compact()
+        .with_ansi(false)
         .init();
+
+    // We should have checks in our callers so this is never hit, but let's be safe.
+    if underhill_confidentiality::confidential_filtering_enabled() {
+        tracing::info!("crash reporting disabled due to CVM");
+        std::process::exit(libc::EXIT_FAILURE);
+    }
 
     let pid: i32 = args
         .next()

--- a/openvmm/hvlite_entry/src/cli_args.rs
+++ b/openvmm/hvlite_entry/src/cli_args.rs
@@ -491,9 +491,9 @@ flags:
     #[clap(long)]
     pub guest_watchdog: bool,
 
-    /// enable Underhill's guest crash dump device, targeting the specified path
+    /// enable OpenHCL's guest crash dump device, targeting the specified path
     #[clap(long)]
-    pub underhill_dump_path: Option<PathBuf>,
+    pub openhcl_dump_path: Option<PathBuf>,
 
     /// halt the VM when the guest requests a reset, instead of resetting it
     #[clap(long)]

--- a/openvmm/hvlite_entry/src/lib.rs
+++ b/openvmm/hvlite_entry/src/lib.rs
@@ -1063,7 +1063,7 @@ fn vm_config_from_command_line(
         DEFAULT_MMIO_GAPS.into()
     };
 
-    if let Some(path) = &opt.underhill_dump_path {
+    if let Some(path) = &opt.openhcl_dump_path {
         let (resource, task) = spawn_dump_handler(&spawner, path.clone(), None);
         task.detach();
         vmbus_devices.push((openhcl_vtl, resource));


### PR DESCRIPTION
The aim here is to produce as much information as we can to in debugging these timeouts after-the-fact in prod. This dump should end up in watson whenever these timeouts are hit, which gives us something to investigate besides just "we timed out". This does not yet implement our idea of including inspect output in these dumps, that will be a follow up.