### PR TITLE
virt_mshv_vtl: tdx: apply more register state at VP init

### DIFF
--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -490,10 +490,10 @@ pub struct TdxPrivateRegs {
 impl TdxPrivateRegs {
     /// Creates a new register set with the given values.
     /// Other values are initialized to zero.
-    pub fn new(rflags: u64, rip: u64, vtl: GuestVtl) -> Self {
+    pub fn new(vtl: GuestVtl) -> Self {
         Self {
-            rflags,
-            rip,
+            rflags: x86defs::RFlags::at_reset().into(),
+            rip: 0,
             ssp: 0,
             rvi: 0,
             svi: 0,

--- a/openhcl/sidecar/src/arch/x86_64/init.rs
+++ b/openhcl/sidecar/src/arch/x86_64/init.rs
@@ -513,7 +513,7 @@ impl NodeDefinition {
         let context = hvdef::hypercall::InitialVpContextX64 {
             rip: ap_init as usize as u64,
             rsp: addr_space::stack().end() - 8, // start unaligned to match calling convention
-            rflags: x86defs::RFlags::default().into(),
+            rflags: x86defs::RFlags::at_reset().into(),
             cs,
             ds,
             es: ds,

--- a/vm/x86/x86defs/src/lib.rs
+++ b/vm/x86/x86defs/src/lib.rs
@@ -262,7 +262,7 @@ pub const DR6_SINGLE_STEP: u64 = 0x4000;
 pub struct RFlags {
     // FLAGS
     pub carry: bool,
-    _reserved0: bool,
+    pub reserved_must_be_1: bool,
     pub parity: bool,
     _reserved1: bool,
     pub adjust: bool,
@@ -293,9 +293,10 @@ pub struct RFlags {
     _reserved5: u32,
 }
 
-impl Default for RFlags {
-    fn default() -> Self {
-        Self(2)
+impl RFlags {
+    /// Returns the reset value of the RFLAGS register.
+    pub fn at_reset() -> Self {
+        Self::new().with_reserved_must_be_1(true)
     }
 }
 

--- a/vmm_core/virt/src/x86/vp.rs
+++ b/vmm_core/virt/src/x86/vp.rs
@@ -337,7 +337,7 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for Registers {
             r14: 0,
             r15: 0,
             rip: 0xfff0,
-            rflags: RFlags::default().into(),
+            rflags: RFlags::at_reset().into(),
             cs,
             ds,
             es: ds,

--- a/vmm_core/virt_support_x86emu/tests/tests/common.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/common.rs
@@ -39,7 +39,7 @@ pub fn long_protected_mode(user_mode: bool) -> CpuState {
         gps: [0xbadc0ffee0ddf00d; 16],
         segs: [seg; 6],
         rip: 0,
-        rflags: RFlags::default(),
+        rflags: RFlags::at_reset(),
         cr0: x86defs::X64_CR0_PE,
         efer: x86defs::X64_EFER_LMA | x86defs::X64_EFER_LME,
     }


### PR DESCRIPTION
Ensure VMCS and shadow register state is consistent at construction
time, and that VP reset state is properly applied before the AP starts.

This fixes an issue where the shadow efer register value was different
from the one on the VMCS, which was exposed by #1095.
