### PR TITLE
virt_mshv_vtl/tdx: log vmcs efer on vm enter failures

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1764,11 +1764,13 @@ impl UhProcessor<'_, TdxBacked> {
                     .read_vmcs64(vtl, VmcsField::VMX_VMCS_CR4_GUEST_HOST_MASK);
                 tracing::error!(physical_cr4, shadow_cr4, cr4_guest_host_mask, "cr4 values");
 
-                let efer = self.backing.efer;
+                let cached_efer = self.backing.efer;
+                let vmcs_efer = self.runner.read_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_EFER);
                 let entry_controls = self
                     .runner
                     .read_vmcs32(vtl, VmcsField::VMX_VMCS_ENTRY_CONTROLS);
-                tracing::error!(efer, entry_controls, "efer & entry controls");
+                tracing::error!(cached_efer, vmcs_efer, "efer");
+                tracing::error!(entry_controls, "entry controls");
 
                 let cs = self.read_segment(vtl, TdxSegmentReg::Cs);
                 let ds = self.read_segment(vtl, TdxSegmentReg::Ds);


### PR DESCRIPTION
The previous logging change https://github.com/microsoft/openvmm/pull/1092 missed logging not just the cached EFER value, but the VMCS efer value.

Backport of #1102. 