### PR TITLE
petri: hyper-v vbs and tdx tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,9 +19,8 @@ threads-required = 4
 [profile.ci]
 # Set the default timeout to 1 second, with tests terminated after 5 seconds
 slow-timeout = { period = "1s", terminate-after = 5 }
-# Print out output for failing tests as soon as they fail, and also at the end
-# of the run (for easy scrollability).
-failure-output = "immediate-final"
+# Print out output for failing tests at the end of the run.
+failure-output = "final"
 # Do not cancel the test run on the first failure.
 fail-fast = false
 

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3081,11 +3081,13 @@ jobs:
       run: flowey.exe e 18 flowey_lib_common::cache 11
       shell: bash
   job19:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
-    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
-    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
+    - Windows
+    - X64
+    - TDX
+    - Baremetal
     permissions:
       contents: read
       id-token: write
@@ -3294,9 +3296,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
       with:
-        name: x64-windows-amd-vmm-tests-crash-dumps
+        name: x64-windows-intel-tdx-vmm-tests-crash-dumps
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: crash-dumps (x64-windows-amd-vmm-tests)'
+      name: 'publish test results: crash-dumps (x64-windows-intel-tdx-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3308,9 +3310,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-tdx-vmm-tests-logs
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: logs (x64-windows-amd-vmm-tests)'
+      name: 'publish test results: logs (x64-windows-intel-tdx-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3324,9 +3326,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
@@ -3528,6 +3530,266 @@ jobs:
         name: _internal-flowey-bootstrap-x86_64-linux-uid-17
         path: ${{ runner.temp }}/bootstrapped-flowey
   job20:
+    name: run vmm-tests [x64-windows-amd]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job13
+    - job13
+    - job11
+    - job9
+    - job9
+    - job9
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-10,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10/flowey.exe
+
+        echo '"debug"' | flowey.exe v 20 'FLOWEY_LOG' --update-from-stdin
+        echo "${{ runner.temp }}/work" | flowey.exe v 20 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+
+        cat <<'EOF' | flowey.exe v 20 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 20 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 4
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v4
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: add default cargo home to path
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 6
+        flowey.exe e 20 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 20 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 20 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 20 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 20 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 8
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v4
+      with:
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 10
+        flowey.exe e 20 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 20 flowey_lib_common::git_checkout 0
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar4 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::git_checkout 3
+        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: move MSVM.fd into its magic folder
+      run: flowey.exe e 20 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
+      shell: bash
+    - name: init hyperv tests
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::init_hyperv_tests 0
+        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve openvmm artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openvmm::resolve 0
+      shell: bash
+    - name: resolve pipette artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_pipette::resolve 1
+      shell: bash
+    - name: resolve pipette artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_pipette::resolve 0
+      shell: bash
+    - name: resolve guest_test_uefi artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_guest_test_uefi::resolve 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create azcopy cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 0
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v4
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: azcopy'
+    - name: installing azcopy
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 2
+        flowey.exe e 20 flowey_lib_common::download_azcopy 1
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_deps 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
+      shell: bash
+    - name: resolve vmm tests archive artifact
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 20 flowey_lib_common::publish_test_results 4
+        flowey.exe e 20 flowey_lib_common::publish_test_results 5
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-windows-amd-vmm-tests-crash-dumps
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: crash-dumps (x64-windows-amd-vmm-tests)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 20 flowey_lib_common::publish_test_results 7
+        flowey.exe e 20 flowey_lib_common::publish_test_results 8
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__9
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-windows-amd-vmm-tests-logs
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: logs (x64-windows-amd-vmm-tests)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 20 flowey_lib_common::publish_test_results 0
+        flowey.exe e 20 flowey_lib_common::publish_test_results 1
+        flowey.exe e 20 flowey_lib_common::publish_test_results 2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-windows-amd-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: 'validate cache entry: azcopy'
+      run: flowey.exe e 20 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 20 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 20 flowey_lib_common::cache 11
+      shell: bash
+  job21:
     name: run vmm-tests [x64-linux]
     runs-on:
     - self-hosted
@@ -3560,29 +3822,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-6/flowey
 
-        echo '"debug"' | flowey v 20 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 21 'FLOWEY_LOG' --update-from-stdin
+        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 20 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 21 'verbose' --update-from-stdin
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 20 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 20 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 20 'artifact_use_from_x64-linux-openvmm' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 20 'artifact_use_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 20 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
       shell: bash
     - name: ensure /dev/kvm is accessible
-      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
-      run: flowey e 20 flowey_lib_common::download_cargo_nextest 0
+      run: flowey e 21 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey e 21 flowey_lib_common::cache 4
+        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3592,39 +3854,39 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 20 flowey_lib_common::install_rust 0
+        flowey e 21 flowey_lib_common::cache 6
+        flowey e 21 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 21 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 20 flowey_lib_common::install_rust 1
+      run: flowey e 21 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
-      run: flowey e 20 flowey_lib_common::install_rust 2
+      run: flowey e 21 flowey_lib_common::install_rust 2
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 20 flowey_lib_common::install_rust 3
+      run: flowey e 21 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
-      run: flowey e 20 flowey_lib_common::download_cargo_nextest 1
+      run: flowey e 21 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 20 flowey_lib_common::download_gh_release 0
+      run: flowey e 21 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 20 flowey_lib_common::cache 8
-        flowey v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
-        flowey v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey e 21 flowey_lib_common::cache 8
+        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -3634,20 +3896,20 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 20 flowey_lib_common::cache 10
-        flowey e 20 flowey_lib_common::download_gh_release 1
+        flowey e 21 flowey_lib_common::cache 10
+        flowey e 21 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey e 21 flowey_lib_common::git_checkout 0
+        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
+        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3659,41 +3921,41 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 20 flowey_lib_common::git_checkout 3
-        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 21 flowey_lib_common::git_checkout 3
+        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
       run: |-
-        flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
-      run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve openvmm artifact
-      run: flowey e 20 flowey_lib_hvlite::artifact_openvmm::resolve 0
+      run: flowey e 21 flowey_lib_hvlite::artifact_openvmm::resolve 0
       shell: bash
     - name: resolve pipette artifact
-      run: flowey e 20 flowey_lib_hvlite::artifact_pipette::resolve 1
+      run: flowey e 21 flowey_lib_hvlite::artifact_pipette::resolve 1
       shell: bash
     - name: resolve pipette artifact
-      run: flowey e 20 flowey_lib_hvlite::artifact_pipette::resolve 0
+      run: flowey e 21 flowey_lib_hvlite::artifact_pipette::resolve 0
       shell: bash
     - name: resolve guest_test_uefi artifact
-      run: flowey e 20 flowey_lib_hvlite::artifact_guest_test_uefi::resolve 0
+      run: flowey e 21 flowey_lib_hvlite::artifact_guest_test_uefi::resolve 0
       shell: bash
     - name: create azcopy cache dir
-      run: flowey e 20 flowey_lib_common::download_azcopy 0
+      run: flowey e 21 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 20 flowey_lib_common::cache 0
-        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey e 21 flowey_lib_common::cache 0
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3703,41 +3965,41 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 20 flowey_lib_common::cache 2
-        flowey e 20 flowey_lib_common::download_azcopy 1
+        flowey e 21 flowey_lib_common::cache 2
+        flowey e 21 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 20 flowey_lib_hvlite::download_openvmm_deps 0
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
       run: |-
-        flowey e 20 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 21 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 20 flowey_lib_common::publish_test_results 4
-        flowey e 20 flowey_lib_common::publish_test_results 5
-        flowey v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 21 flowey_lib_common::publish_test_results 4
+        flowey e 21 flowey_lib_common::publish_test_results 5
+        flowey v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -3748,10 +4010,10 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 20 flowey_lib_common::publish_test_results 7
-        flowey e 20 flowey_lib_common::publish_test_results 8
-        flowey v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey v 20 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey e 21 flowey_lib_common::publish_test_results 7
+        flowey e 21 flowey_lib_common::publish_test_results 8
+        flowey v 21 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey v 21 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
@@ -3762,12 +4024,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 20 flowey_lib_common::publish_test_results 0
-        flowey e 20 flowey_lib_common::publish_test_results 1
-        flowey e 20 flowey_lib_common::publish_test_results 2
-        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 21 flowey_lib_common::publish_test_results 0
+        flowey e 21 flowey_lib_common::publish_test_results 1
+        flowey e 21 flowey_lib_common::publish_test_results 2
+        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
+        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -3777,18 +4039,18 @@ jobs:
       name: 'publish test results: x64-linux-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: 'validate cache entry: azcopy'
-      run: flowey e 20 flowey_lib_common::cache 3
+      run: flowey e 21 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 20 flowey_lib_common::cache 7
+      run: flowey e 21 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 20 flowey_lib_common::cache 11
+      run: flowey e 21 flowey_lib_common::cache 11
       shell: bash
-  job21:
+  job22:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -3872,27 +4134,27 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' --update-from-stdin
+        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 21 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 22 'verbose' --update-from-stdin
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-windows-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
     - name: create cargo-nextest cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
+      run: flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe e 22 flowey_lib_common::cache 4
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3902,33 +4164,33 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 21 flowey_lib_common::install_rust 0
+        flowey.exe e 22 flowey_lib_common::cache 6
+        flowey.exe e 22 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 22 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 21 flowey_lib_common::install_rust 1
+      run: flowey.exe e 22 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 21 flowey_lib_common::install_rust 2
+      run: flowey.exe e 22 flowey_lib_common::install_rust 2
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 21 flowey_lib_common::install_rust 3
+      run: flowey.exe e 22 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+      run: flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey.exe e 22 flowey_lib_common::cache 8
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -3938,20 +4200,20 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 10
-        flowey.exe e 21 flowey_lib_common::download_gh_release 1
+        flowey.exe e 22 flowey_lib_common::cache 10
+        flowey.exe e 22 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3963,47 +4225,47 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 21 flowey_lib_common::git_checkout 3
-        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
-      run: flowey.exe e 21 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
+      run: flowey.exe e 22 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
       shell: bash
     - name: init hyperv tests
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::init_hyperv_tests 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_hvlite::init_hyperv_tests 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve openvmm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openvmm::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openvmm::resolve 0
       shell: bash
     - name: resolve pipette artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_pipette::resolve 1
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_pipette::resolve 1
       shell: bash
     - name: resolve pipette artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_pipette::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_pipette::resolve 0
       shell: bash
     - name: resolve guest_test_uefi artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_guest_test_uefi::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_guest_test_uefi::resolve 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create azcopy cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4013,41 +4275,41 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 2
-        flowey.exe e 21 flowey_lib_common::download_azcopy 1
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_deps 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 22 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 5
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -4058,10 +4320,10 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 21 flowey_lib_common::publish_test_results 7
-        flowey.exe e 21 flowey_lib_common::publish_test_results 8
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_common::publish_test_results 7
+        flowey.exe e 22 flowey_lib_common::publish_test_results 8
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
@@ -4072,12 +4334,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 0
-        flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 0
+        flowey.exe e 22 flowey_lib_common::publish_test_results 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -4087,18 +4349,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: 'validate cache entry: azcopy'
-      run: flowey.exe e 21 flowey_lib_common::cache 3
+      run: flowey.exe e 22 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 21 flowey_lib_common::cache 7
+      run: flowey.exe e 22 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
+      run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
-  job22:
+  job23:
     name: test flowey local backend
     runs-on:
     - self-hosted
@@ -4169,18 +4431,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 22 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 23 'FLOWEY_LOG' --update-from-stdin
+        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 22 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 23 'verbose' --update-from-stdin
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -4192,24 +4454,24 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 22 flowey_lib_common::git_checkout 3
-        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_common::git_checkout 3
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 22 flowey_lib_common::install_rust 0
+      run: flowey e 23 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
       run: |-
-        flowey e 22 flowey_lib_common::install_rust 1
-        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
+        flowey e 23 flowey_lib_common::install_rust 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey e 23 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
   job3:
     name: publish openvmm.dev

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -2824,10 +2824,8 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -110,7 +110,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -154,8 +154,11 @@ jobs:
         flowey e 0 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 0 flowey_lib_hvlite::build_guide 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 0 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 0 flowey_lib_common::install_rust 1
       shell: bash
     - name: build OpenVMM guide (mdbook)
       run: |-
@@ -294,7 +297,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -308,8 +311,11 @@ jobs:
     - name: symlink protoc
       run: flowey.exe e 1 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 1 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 1 flowey_lib_common::install_rust 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey.exe e 1 flowey_lib_hvlite::download_lxutil 0
@@ -319,7 +325,7 @@ jobs:
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 1 flowey_lib_common::install_rust 1
+        flowey.exe e 1 flowey_lib_common::install_rust 2
         flowey.exe e 1 flowey_lib_common::cfg_cargo_common_flags 0
         flowey.exe e 1 flowey_lib_common::run_cargo_doc 0
       shell: bash
@@ -432,12 +438,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 10 'artifact_publish_from_aarch64-linux-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 10 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 10 flowey_lib_common::install_rust 1
+        flowey e 10 flowey_lib_common::install_rust 2
         flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -463,7 +472,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
@@ -727,12 +736,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 11 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 11 flowey_lib_common::install_rust 1
+        flowey e 11 flowey_lib_common::install_rust 2
         flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -758,7 +770,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 6
@@ -918,12 +930,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
         flowey e 11 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 11 flowey_lib_common::install_rust 2
+        flowey e 11 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -1089,7 +1101,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1098,12 +1110,15 @@ jobs:
     - name: unpack mu_msvm package (aarch64)
       run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 12 flowey_lib_common::install_rust 1
+        flowey e 12 flowey_lib_common::install_rust 2
         flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1415,7 +1430,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 2
@@ -1424,12 +1439,15 @@ jobs:
     - name: unpack mu_msvm package (x64)
       run: flowey e 13 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 13 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 13 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 13 flowey_lib_common::install_rust 1
+        flowey e 13 flowey_lib_common::install_rust 2
         flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1811,12 +1829,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 14 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 14 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 14 flowey_lib_common::install_rust 1
+        flowey.exe e 14 flowey_lib_common::install_rust 2
         flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1861,7 +1882,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 6
@@ -1931,12 +1952,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 2
         flowey.exe e 14 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 14 flowey_lib_common::install_rust 2
+        flowey.exe e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -2063,12 +2084,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 15 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 15 flowey_lib_common::install_rust 1
+        flowey e 15 flowey_lib_common::install_rust 2
         flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -2094,7 +2118,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 6
@@ -2217,12 +2241,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 2
         flowey e 15 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -2354,12 +2378,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 16 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 16 flowey_lib_common::install_rust 1
+        flowey e 16 flowey_lib_common::install_rust 2
         flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -2408,7 +2435,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 6
@@ -2511,12 +2538,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 2
         flowey e 16 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -2666,20 +2693,23 @@ jobs:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - name: install Rust
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 2
         flowey.exe e 17 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 17 flowey_lib_common::install_rust 0
       shell: bash
-    - name: detect active toolchain
+    - name: install Rust
       run: flowey.exe e 17 flowey_lib_common::install_rust 1
       shell: bash
-    - name: report $CARGO_HOME
+    - name: detect active toolchain
       run: flowey.exe e 17 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
@@ -2726,7 +2756,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 6
@@ -2794,8 +2824,10 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
-    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
+    - Windows
+    - X64
+    - TDX
+    - Baremetal
     permissions:
       contents: read
       id-token: write
@@ -2852,13 +2884,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 6
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 18 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 18 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 18 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 18 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 18 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
@@ -2877,7 +2922,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 10
@@ -2952,7 +2997,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 2
@@ -3028,14 +3073,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 18 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 18 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 18 flowey_lib_common::cache 11
       shell: bash
   job19:
     name: run vmm-tests [x64-windows-amd]
@@ -3099,13 +3144,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 19 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 19 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 19 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 19 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 19 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
@@ -3124,7 +3182,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -3199,7 +3257,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -3275,14 +3333,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 19 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 19 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 19 flowey_lib_common::cache 11
       shell: bash
   job2:
     name: build and check docs [x64-linux]
@@ -3406,7 +3464,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 2 flowey_lib_common::cache 2
@@ -3426,8 +3484,11 @@ jobs:
     - name: symlink protoc
       run: flowey e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 2 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 2 flowey_lib_common::install_rust 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey e 2 flowey_lib_hvlite::download_lxutil 0
@@ -3437,7 +3498,7 @@ jobs:
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 2 flowey_lib_common::install_rust 1
+        flowey e 2 flowey_lib_common::install_rust 2
         flowey e 2 flowey_lib_common::cfg_cargo_common_flags 0
         flowey e 2 flowey_lib_common::run_cargo_doc 0
       shell: bash
@@ -3531,13 +3592,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey e 20 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 20 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 20 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey e 20 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 20 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey e 20 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 20 flowey_lib_common::install_dist_pkg 0
@@ -3562,7 +3636,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 10
@@ -3631,7 +3705,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 2
@@ -3707,14 +3781,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 20 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey e 20 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 20 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
     name: run vmm-tests [aarch64-windows]
@@ -3828,13 +3902,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 21 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 21 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 21 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 21 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 21 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
@@ -3853,7 +3940,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 10
@@ -3928,7 +4015,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 2
@@ -4004,14 +4091,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 21 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
     name: test flowey local backend
@@ -4113,9 +4200,12 @@ jobs:
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
+    - name: add default cargo home to path
+      run: flowey e 22 flowey_lib_common::install_rust 0
+      shell: bash
     - name: install Rust
       run: |-
-        flowey e 22 flowey_lib_common::install_rust 0
+        flowey e 22 flowey_lib_common::install_rust 1
         flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
         ${{ github.token }}
         EOF
@@ -4284,12 +4374,15 @@ jobs:
         flowey.exe e 4 flowey_lib_common::git_checkout 3
         flowey.exe e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 4 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 4 flowey_lib_common::install_rust 1
+        flowey.exe e 4 flowey_lib_common::install_rust 2
         flowey.exe e 4 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -4312,7 +4405,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -4440,12 +4533,15 @@ jobs:
         flowey e 5 flowey_lib_common::git_checkout 3
         flowey e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 5 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 5 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 5 flowey_lib_common::install_rust 1
+        flowey e 5 flowey_lib_common::install_rust 2
         flowey e 5 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -4468,7 +4564,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 5 flowey_lib_common::cache 2
@@ -4594,12 +4690,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 6 'artifact_publish_from_aarch64-windows-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 6 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 6 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 6 flowey_lib_common::install_rust 1
+        flowey.exe e 6 flowey_lib_common::install_rust 2
         flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -4644,7 +4743,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
@@ -4828,12 +4927,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 7 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 7 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 7 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 7 flowey_lib_common::install_rust 1
+        flowey.exe e 7 flowey_lib_common::install_rust 2
         flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
@@ -4853,7 +4955,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 6
@@ -4937,12 +5039,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
         flowey.exe e 7 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 7 flowey_lib_common::install_rust 2
+        flowey.exe e 7 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -5066,12 +5168,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 8 'artifact_publish_from_x64-windows-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 8 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 8 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 8 flowey_lib_common::install_rust 1
+        flowey.exe e 8 flowey_lib_common::install_rust 2
         flowey.exe e 8 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -5116,7 +5221,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 8 flowey_lib_common::cache 2
@@ -5304,12 +5409,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 9 'artifact_publish_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 9 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 9 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 9 flowey_lib_common::install_rust 1
+        flowey.exe e 9 flowey_lib_common::install_rust 2
         flowey.exe e 9 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
@@ -5329,7 +5437,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 9 flowey_lib_common::cache 6
@@ -5413,12 +5521,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 9 flowey_lib_common::cache 2
         flowey.exe e 9 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 9 flowey_lib_common::install_rust 2
+        flowey.exe e 9 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -2975,11 +2975,13 @@ jobs:
       run: flowey.exe e 18 flowey_lib_common::cache 11
       shell: bash
   job19:
-    name: run vmm-tests [x64-windows-amd]
+    name: run vmm-tests [x64-windows-intel-tdx]
     runs-on:
     - self-hosted
-    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
-    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
+    - Windows
+    - X64
+    - TDX
+    - Baremetal
     permissions:
       contents: read
       id-token: write
@@ -3188,9 +3190,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
       with:
-        name: x64-windows-amd-vmm-tests-crash-dumps
+        name: x64-windows-intel-tdx-vmm-tests-crash-dumps
         path: ${{ env.floweyvar2 }}
-      name: 'publish test results: crash-dumps (x64-windows-amd-vmm-tests)'
+      name: 'publish test results: crash-dumps (x64-windows-intel-tdx-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3202,9 +3204,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
       with:
-        name: x64-windows-amd-vmm-tests-logs
+        name: x64-windows-intel-tdx-vmm-tests-logs
         path: ${{ env.floweyvar3 }}
-      name: 'publish test results: logs (x64-windows-amd-vmm-tests)'
+      name: 'publish test results: logs (x64-windows-intel-tdx-vmm-tests)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
@@ -3218,9 +3220,9 @@ jobs:
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
       with:
-        name: x64-windows-amd-vmm-tests-junit-xml
+        name: x64-windows-intel-tdx-vmm-tests-junit-xml
         path: ${{ env.floweyvar1 }}
-      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      name: 'publish test results: x64-windows-intel-tdx-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
@@ -3414,6 +3416,266 @@ jobs:
         name: x64-linux-rustdoc
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-rustdoc/
   job20:
+    name: run vmm-tests [x64-windows-amd]
+    runs-on:
+    - self-hosted
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+    - job12
+    - job12
+    - job10
+    - job8
+    - job8
+    - job8
+    if: github.event.pull_request.draft == false
+    steps:
+    - name: 🌼📦 Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11" >> $GITHUB_PATH
+      shell: bash
+      name: 🌼📦 Add flowey to PATH
+    - name: 🌼🛫 Initialize job
+      run: |
+        AgentTempDirNormal="${{ runner.temp }}"
+        AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
+        echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
+
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11/flowey.exe
+
+        echo '"debug"' | flowey.exe v 20 'FLOWEY_LOG' --update-from-stdin
+        echo "${{ runner.temp }}/work" | flowey.exe v 20 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+
+        cat <<'EOF' | flowey.exe v 20 'verbose' --update-from-stdin
+        ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
+        EOF
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 20 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+      shell: bash
+    - name: create cargo-nextest cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 4
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+      shell: bash
+    - id: flowey_lib_common__cache__5
+      uses: actions/cache@v4
+      with:
+        key: ${{ env.floweyvar7 }}
+        path: ${{ env.floweyvar8 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: add default cargo home to path
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 6
+        flowey.exe e 20 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 20 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 20 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 20 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 20 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 8
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+      shell: bash
+    - id: flowey_lib_common__cache__9
+      uses: actions/cache@v4
+      with:
+        key: ${{ env.floweyvar9 }}
+        path: ${{ env.floweyvar10 }}
+      name: 'Restore cache: gh-release-download'
+    - name: download artifacts from github releases
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 10
+        flowey.exe e 20 flowey_lib_common::download_gh_release 1
+      shell: bash
+    - name: unpack mu_msvm package (x64)
+      run: flowey.exe e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 20 flowey_lib_common::git_checkout 0
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar4 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::git_checkout 3
+        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: move MSVM.fd into its magic folder
+      run: flowey.exe e 20 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
+      shell: bash
+    - name: init hyperv tests
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::init_hyperv_tests 0
+        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+      shell: bash
+    - name: creating new test content dir
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: resolve openvmm artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openvmm::resolve 0
+      shell: bash
+    - name: resolve pipette artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_pipette::resolve 1
+      shell: bash
+    - name: resolve pipette artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_pipette::resolve 0
+      shell: bash
+    - name: resolve guest_test_uefi artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_guest_test_uefi::resolve 0
+      shell: bash
+    - name: resolve OpenHCL igvm artifact
+      run: flowey.exe e 20 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      shell: bash
+    - name: create azcopy cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_azcopy 0
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 0
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@v4
+      with:
+        key: ${{ env.floweyvar5 }}
+        path: ${{ env.floweyvar6 }}
+      name: 'Restore cache: azcopy'
+    - name: installing azcopy
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 2
+        flowey.exe e 20 flowey_lib_common::download_azcopy 1
+      shell: bash
+    - name: calculating required VMM tests disk images
+      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      shell: bash
+    - name: downloading VMM test disk images
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+      shell: bash
+    - name: unpack openvmm-deps archive
+      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_deps 0
+      shell: bash
+    - name: setting up vmm_tests env
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
+      shell: bash
+    - name: resolve vmm tests archive artifact
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      shell: bash
+    - name: run 'vmm_tests' nextest tests
+      run: |-
+        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 20 flowey_lib_common::publish_test_results 4
+        flowey.exe e 20 flowey_lib_common::publish_test_results 5
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__6
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-windows-amd-vmm-tests-crash-dumps
+        path: ${{ env.floweyvar2 }}
+      name: 'publish test results: crash-dumps (x64-windows-amd-vmm-tests)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 20 flowey_lib_common::publish_test_results 7
+        flowey.exe e 20 flowey_lib_common::publish_test_results 8
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__9
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-windows-amd-vmm-tests-logs
+        path: ${{ env.floweyvar3 }}
+      name: 'publish test results: logs (x64-windows-amd-vmm-tests)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: 🦀 flowey rust steps
+      run: |-
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 20 flowey_lib_common::publish_test_results 0
+        flowey.exe e 20 flowey_lib_common::publish_test_results 1
+        flowey.exe e 20 flowey_lib_common::publish_test_results 2
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
+        flowey.exe v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__publish_test_results__3
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-windows-amd-vmm-tests-junit-xml
+        path: ${{ env.floweyvar1 }}
+      name: 'publish test results: x64-windows-amd-vmm-tests (JUnit XML)'
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report test results to overall pipeline status
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      shell: bash
+    - name: 'validate cache entry: azcopy'
+      run: flowey.exe e 20 flowey_lib_common::cache 3
+      shell: bash
+    - name: 'validate cache entry: cargo-nextest'
+      run: flowey.exe e 20 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 20 flowey_lib_common::cache 11
+      shell: bash
+  job21:
     name: run vmm-tests [x64-linux]
     runs-on:
     - self-hosted
@@ -3446,29 +3708,29 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-7/flowey
 
-        echo '"debug"' | flowey v 20 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 21 'FLOWEY_LOG' --update-from-stdin
+        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 20 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 21 'verbose' --update-from-stdin
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 20 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 20 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 20 'artifact_use_from_x64-linux-openvmm' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 20 'artifact_use_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 20 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
       shell: bash
     - name: ensure /dev/kvm is accessible
-      run: flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+      run: flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: create cargo-nextest cache dir
-      run: flowey e 20 flowey_lib_common::download_cargo_nextest 0
+      run: flowey e 21 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 20 flowey_lib_common::cache 4
-        flowey v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-        flowey v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey e 21 flowey_lib_common::cache 4
+        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3478,39 +3740,39 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 20 flowey_lib_common::install_rust 0
+        flowey e 21 flowey_lib_common::cache 6
+        flowey e 21 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 21 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey e 20 flowey_lib_common::install_rust 1
+      run: flowey e 21 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
-      run: flowey e 20 flowey_lib_common::install_rust 2
+      run: flowey e 21 flowey_lib_common::install_rust 2
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey e 20 flowey_lib_common::install_rust 3
+      run: flowey e 21 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
-      run: flowey e 20 flowey_lib_common::download_cargo_nextest 1
+      run: flowey e 21 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: checking if packages need to be installed
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 0
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
-      run: flowey e 20 flowey_lib_common::install_dist_pkg 1
+      run: flowey e 21 flowey_lib_common::install_dist_pkg 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey e 20 flowey_lib_common::download_gh_release 0
+      run: flowey e 21 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 20 flowey_lib_common::cache 8
-        flowey v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
-        flowey v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey e 21 flowey_lib_common::cache 8
+        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -3520,20 +3782,20 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey e 20 flowey_lib_common::cache 10
-        flowey e 20 flowey_lib_common::download_gh_release 1
+        flowey e 21 flowey_lib_common::cache 10
+        flowey e 21 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (x64)
-      run: flowey e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey e 21 flowey_lib_common::git_checkout 0
+        flowey v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
+        flowey v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3545,41 +3807,41 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 20 flowey_lib_common::git_checkout 3
-        flowey e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 20 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey e 21 flowey_lib_common::git_checkout 3
+        flowey e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
       run: |-
-        flowey e 20 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
-      run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve openvmm artifact
-      run: flowey e 20 flowey_lib_hvlite::artifact_openvmm::resolve 0
+      run: flowey e 21 flowey_lib_hvlite::artifact_openvmm::resolve 0
       shell: bash
     - name: resolve pipette artifact
-      run: flowey e 20 flowey_lib_hvlite::artifact_pipette::resolve 1
+      run: flowey e 21 flowey_lib_hvlite::artifact_pipette::resolve 1
       shell: bash
     - name: resolve pipette artifact
-      run: flowey e 20 flowey_lib_hvlite::artifact_pipette::resolve 0
+      run: flowey e 21 flowey_lib_hvlite::artifact_pipette::resolve 0
       shell: bash
     - name: resolve guest_test_uefi artifact
-      run: flowey e 20 flowey_lib_hvlite::artifact_guest_test_uefi::resolve 0
+      run: flowey e 21 flowey_lib_hvlite::artifact_guest_test_uefi::resolve 0
       shell: bash
     - name: create azcopy cache dir
-      run: flowey e 20 flowey_lib_common::download_azcopy 0
+      run: flowey e 21 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey e 20 flowey_lib_common::cache 0
-        flowey v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-        flowey v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey e 21 flowey_lib_common::cache 0
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3589,41 +3851,41 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey e 20 flowey_lib_common::cache 2
-        flowey e 20 flowey_lib_common::download_azcopy 1
+        flowey e 21 flowey_lib_common::cache 2
+        flowey e 21 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey e 20 flowey_lib_hvlite::download_openvmm_deps 0
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey e 20 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
       run: |-
-        flowey e 20 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-        flowey e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 21 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 0
-        flowey e 20 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 20 flowey_lib_common::publish_test_results 4
-        flowey e 20 flowey_lib_common::publish_test_results 5
-        flowey v 20 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey v 20 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 0
+        flowey e 21 flowey_lib_common::run_cargo_nextest_run 1
+        flowey e 21 flowey_lib_common::publish_test_results 4
+        flowey e 21 flowey_lib_common::publish_test_results 5
+        flowey v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -3634,10 +3896,10 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 20 flowey_lib_common::publish_test_results 7
-        flowey e 20 flowey_lib_common::publish_test_results 8
-        flowey v 20 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey v 20 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey e 21 flowey_lib_common::publish_test_results 7
+        flowey e 21 flowey_lib_common::publish_test_results 8
+        flowey v 21 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey v 21 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
@@ -3648,12 +3910,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 20 flowey_lib_common::publish_test_results 0
-        flowey e 20 flowey_lib_common::publish_test_results 1
-        flowey e 20 flowey_lib_common::publish_test_results 2
-        flowey v 20 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey v 20 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey e 21 flowey_lib_common::publish_test_results 0
+        flowey e 21 flowey_lib_common::publish_test_results 1
+        flowey e 21 flowey_lib_common::publish_test_results 2
+        flowey v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
+        flowey v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -3663,18 +3925,18 @@ jobs:
       name: 'publish test results: x64-linux-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: 'validate cache entry: azcopy'
-      run: flowey e 20 flowey_lib_common::cache 3
+      run: flowey e 21 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey e 20 flowey_lib_common::cache 7
+      run: flowey e 21 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey e 20 flowey_lib_common::cache 11
+      run: flowey e 21 flowey_lib_common::cache 11
       shell: bash
-  job21:
+  job22:
     name: run vmm-tests [aarch64-windows]
     runs-on:
     - self-hosted
@@ -3758,27 +4020,27 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 21 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 21 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 22 'FLOWEY_LOG' --update-from-stdin
+        echo "${{ runner.temp }}/work" | flowey.exe v 22 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey.exe v 21 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 22 'verbose' --update-from-stdin
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 21 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 21 'artifact_use_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 21 'artifact_use_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 21 'artifact_use_from_aarch64-windows-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 21 'artifact_use_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
     - name: create cargo-nextest cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 0
+      run: flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 4
-        flowey.exe v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
-        flowey.exe v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe e 22 flowey_lib_common::cache 4
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar8 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3788,33 +4050,33 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 21 flowey_lib_common::install_rust 0
+        flowey.exe e 22 flowey_lib_common::cache 6
+        flowey.exe e 22 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 22 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
-      run: flowey.exe e 21 flowey_lib_common::install_rust 1
+      run: flowey.exe e 22 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
-      run: flowey.exe e 21 flowey_lib_common::install_rust 2
+      run: flowey.exe e 22 flowey_lib_common::install_rust 2
       shell: bash
     - name: report $CARGO_HOME
-      run: flowey.exe e 21 flowey_lib_common::install_rust 3
+      run: flowey.exe e 22 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
-      run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+      run: flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 8
-        flowey.exe v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
-        flowey.exe v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
+        flowey.exe e 22 flowey_lib_common::cache 8
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar10 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -3824,20 +4086,20 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 10
-        flowey.exe e 21 flowey_lib_common::download_gh_release 1
+        flowey.exe e 22 flowey_lib_common::cache 10
+        flowey.exe e 22 flowey_lib_common::download_gh_release 1
       shell: bash
     - name: unpack mu_msvm package (aarch64)
-      run: flowey.exe e 21 flowey_lib_hvlite::download_uefi_mu_msvm 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey.exe e 21 flowey_lib_common::git_checkout 0
-        flowey.exe v 21 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 21 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar4 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3849,47 +4111,47 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 21 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
         ${{ github.workspace }}
         EOF
-        flowey.exe e 21 flowey_lib_common::git_checkout 3
-        flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
     - name: move MSVM.fd into its magic folder
-      run: flowey.exe e 21 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
+      run: flowey.exe e 22 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
       shell: bash
     - name: init hyperv tests
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::init_hyperv_tests 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_hvlite::init_hyperv_tests 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: creating new test content dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
       shell: bash
     - name: resolve openvmm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openvmm::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openvmm::resolve 0
       shell: bash
     - name: resolve pipette artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_pipette::resolve 1
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_pipette::resolve 1
       shell: bash
     - name: resolve pipette artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_pipette::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_pipette::resolve 0
       shell: bash
     - name: resolve guest_test_uefi artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_guest_test_uefi::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_guest_test_uefi::resolve 0
       shell: bash
     - name: resolve OpenHCL igvm artifact
-      run: flowey.exe e 21 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
+      run: flowey.exe e 22 flowey_lib_hvlite::artifact_openhcl_igvm_from_recipe::resolve 0
       shell: bash
     - name: create azcopy cache dir
-      run: flowey.exe e 21 flowey_lib_common::download_azcopy 0
+      run: flowey.exe e 22 flowey_lib_common::download_azcopy 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
-        flowey.exe e 21 flowey_lib_common::cache 0
-        flowey.exe v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-        flowey.exe v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3899,41 +4161,41 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
-        flowey.exe e 21 flowey_lib_common::cache 2
-        flowey.exe e 21 flowey_lib_common::download_azcopy 1
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey.exe e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
       shell: bash
     - name: unpack openvmm-deps archive
-      run: flowey.exe e 21 flowey_lib_hvlite::download_openvmm_deps 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: setting up vmm_tests env
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
       shell: bash
     - name: resolve vmm tests archive artifact
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
-        flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+        flowey.exe e 22 flowey_lib_hvlite::artifact_nextest_vmm_tests_archive::resolve 0
+        flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
-        flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 4
-        flowey.exe e 21 flowey_lib_common::publish_test_results 5
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 4
+        flowey.exe e 22 flowey_lib_common::publish_test_results 5
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -3944,10 +4206,10 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 21 flowey_lib_common::publish_test_results 7
-        flowey.exe e 21 flowey_lib_common::publish_test_results 8
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_common::publish_test_results 7
+        flowey.exe e 22 flowey_lib_common::publish_test_results 8
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:14:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:12:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__9
       uses: actions/upload-artifact@v4
@@ -3958,12 +4220,12 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: 🦀 flowey rust steps
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 0
-        flowey.exe e 21 flowey_lib_common::publish_test_results 1
-        flowey.exe e 21 flowey_lib_common::publish_test_results 2
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 21 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 0
+        flowey.exe e 22 flowey_lib_common::publish_test_results 1
+        flowey.exe e 22 flowey_lib_common::publish_test_results 2
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
+        flowey.exe v 22 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -3973,18 +4235,18 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: 'validate cache entry: azcopy'
-      run: flowey.exe e 21 flowey_lib_common::cache 3
+      run: flowey.exe e 22 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
-      run: flowey.exe e 21 flowey_lib_common::cache 7
+      run: flowey.exe e 22 flowey_lib_common::cache 7
       shell: bash
     - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
+      run: flowey.exe e 22 flowey_lib_common::cache 11
       shell: bash
-  job22:
+  job23:
     name: test flowey local backend
     runs-on:
     - self-hosted
@@ -4055,18 +4317,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 22 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 22 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 23 'FLOWEY_LOG' --update-from-stdin
+        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 22 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 23 'verbose' --update-from-stdin
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
-        flowey e 22 flowey_lib_common::git_checkout 0
-        flowey v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey e 23 flowey_lib_common::git_checkout 0
+        flowey v 23 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
+        flowey v 23 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -4078,32 +4340,33 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 23 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
         ${{ github.workspace }}
         EOF
-        flowey e 22 flowey_lib_common::git_checkout 3
-        flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 23 flowey_lib_common::git_checkout 3
+        flowey e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
     - name: add default cargo home to path
-      run: flowey e 22 flowey_lib_common::install_rust 0
+      run: flowey e 23 flowey_lib_common::install_rust 0
       shell: bash
     - name: install Rust
       run: |-
-        flowey e 22 flowey_lib_common::install_rust 1
-        flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
+        flowey e 23 flowey_lib_common::install_rust 1
+        flowey v 23 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
         ${{ github.token }}
         EOF
       shell: bash
     - name: test cargo xflowey build-igvm x64 --install-missing-deps
-      run: flowey e 22 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
+      run: flowey e 23 flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm 1
       shell: bash
-  job23:
+  job24:
     name: openvmm checkin gates
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     needs:
+    - job23
     - job22
     - job21
     - job20
@@ -4147,15 +4410,15 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-7/flowey
 
-        echo '"debug"' | flowey v 23 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 24 'FLOWEY_LOG' --update-from-stdin
+        echo "${{ runner.temp }}/work" | flowey v 24 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
 
-        cat <<'EOF' | flowey v 23 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 24 'verbose' --update-from-stdin
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: Check if any jobs failed
-      run: flowey e 23 flowey_lib_hvlite::_jobs::all_good_job 0
+      run: flowey e 24 flowey_lib_hvlite::_jobs::all_good_job 0
       shell: bash
   job3:
     name: xtask fmt (windows)

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -118,7 +118,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -162,8 +162,11 @@ jobs:
         flowey e 0 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 0 flowey_lib_hvlite::build_guide 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 0 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 0 flowey_lib_common::install_rust 1
       shell: bash
     - name: build OpenVMM guide (mdbook)
       run: |-
@@ -302,7 +305,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -316,8 +319,11 @@ jobs:
     - name: symlink protoc
       run: flowey.exe e 1 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 1 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 1 flowey_lib_common::install_rust 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey.exe e 1 flowey_lib_hvlite::download_lxutil 0
@@ -327,7 +333,7 @@ jobs:
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 1 flowey_lib_common::install_rust 1
+        flowey.exe e 1 flowey_lib_common::install_rust 2
         flowey.exe e 1 flowey_lib_common::cfg_cargo_common_flags 0
         flowey.exe e 1 flowey_lib_common::run_cargo_doc 0
       shell: bash
@@ -442,12 +448,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 10 'artifact_publish_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 10 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 10 flowey_lib_common::install_rust 1
+        flowey e 10 flowey_lib_common::install_rust 2
         flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -473,7 +482,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 6
@@ -633,12 +642,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
         flowey e 10 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 10 flowey_lib_common::install_rust 2
+        flowey e 10 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -802,7 +811,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
@@ -811,12 +820,15 @@ jobs:
     - name: unpack mu_msvm package (aarch64)
       run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 11 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 11 flowey_lib_common::install_rust 1
+        flowey e 11 flowey_lib_common::install_rust 2
         flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1102,7 +1114,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1111,12 +1123,15 @@ jobs:
     - name: unpack mu_msvm package (x64)
       run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 12 flowey_lib_common::install_rust 1
+        flowey e 12 flowey_lib_common::install_rust 2
         flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1478,12 +1493,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 13 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 13 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 13 flowey_lib_common::install_rust 1
+        flowey e 13 flowey_lib_common::install_rust 2
         flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1528,7 +1546,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 6
@@ -1596,7 +1614,7 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 2
@@ -1705,12 +1723,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 14 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 14 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 14 flowey_lib_common::install_rust 1
+        flowey.exe e 14 flowey_lib_common::install_rust 2
         flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1755,7 +1776,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 6
@@ -1825,12 +1846,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 2
         flowey.exe e 14 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 14 flowey_lib_common::install_rust 2
+        flowey.exe e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -1957,12 +1978,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 15 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 15 flowey_lib_common::install_rust 1
+        flowey e 15 flowey_lib_common::install_rust 2
         flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -1988,7 +2012,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 6
@@ -2111,12 +2135,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 2
         flowey e 15 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -2248,12 +2272,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 16 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 16 flowey_lib_common::install_rust 1
+        flowey e 16 flowey_lib_common::install_rust 2
         flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -2302,7 +2329,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 6
@@ -2405,12 +2432,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 2
         flowey e 16 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -2560,20 +2587,23 @@ jobs:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - name: install Rust
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 2
         flowey.exe e 17 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 17 flowey_lib_common::install_rust 0
       shell: bash
-    - name: detect active toolchain
+    - name: install Rust
       run: flowey.exe e 17 flowey_lib_common::install_rust 1
       shell: bash
-    - name: report $CARGO_HOME
+    - name: detect active toolchain
       run: flowey.exe e 17 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
@@ -2620,7 +2650,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 6
@@ -2688,8 +2718,10 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
-    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
+    - Windows
+    - X64
+    - TDX
+    - Baremetal
     permissions:
       contents: read
       id-token: write
@@ -2746,13 +2778,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 6
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 18 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 18 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 18 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 18 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 18 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
@@ -2771,7 +2816,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 10
@@ -2846,7 +2891,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 2
@@ -2922,14 +2967,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 18 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 18 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 18 flowey_lib_common::cache 11
       shell: bash
   job19:
     name: run vmm-tests [x64-windows-amd]
@@ -2993,13 +3038,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 19 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 19 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 19 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 19 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 19 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
@@ -3018,7 +3076,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -3093,7 +3151,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -3169,14 +3227,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 19 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 19 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 19 flowey_lib_common::cache 11
       shell: bash
   job2:
     name: build and check docs [x64-linux]
@@ -3300,7 +3358,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 2 flowey_lib_common::cache 2
@@ -3320,8 +3378,11 @@ jobs:
     - name: symlink protoc
       run: flowey e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 2 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 2 flowey_lib_common::install_rust 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey e 2 flowey_lib_hvlite::download_lxutil 0
@@ -3331,7 +3392,7 @@ jobs:
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 2 flowey_lib_common::install_rust 1
+        flowey e 2 flowey_lib_common::install_rust 2
         flowey e 2 flowey_lib_common::cfg_cargo_common_flags 0
         flowey e 2 flowey_lib_common::run_cargo_doc 0
       shell: bash
@@ -3417,13 +3478,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey e 20 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 20 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 20 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey e 20 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 20 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey e 20 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 20 flowey_lib_common::install_dist_pkg 0
@@ -3448,7 +3522,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 10
@@ -3517,7 +3591,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 2
@@ -3593,14 +3667,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 20 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey e 20 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 20 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
     name: run vmm-tests [aarch64-windows]
@@ -3714,13 +3788,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 21 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 21 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 21 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 21 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 21 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
@@ -3739,7 +3826,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 10
@@ -3814,7 +3901,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 2
@@ -3890,14 +3977,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 21 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
     name: test flowey local backend
@@ -3999,9 +4086,12 @@ jobs:
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
+    - name: add default cargo home to path
+      run: flowey e 22 flowey_lib_common::install_rust 0
+      shell: bash
     - name: install Rust
       run: |-
-        flowey e 22 flowey_lib_common::install_rust 0
+        flowey e 22 flowey_lib_common::install_rust 1
         flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
         ${{ github.token }}
         EOF
@@ -4168,12 +4258,15 @@ jobs:
         flowey.exe e 3 flowey_lib_common::git_checkout 3
         flowey.exe e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 3 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 3 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 3 flowey_lib_common::install_rust 1
+        flowey.exe e 3 flowey_lib_common::install_rust 2
         flowey.exe e 3 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -4196,7 +4289,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 3 flowey_lib_common::cache 2
@@ -4324,12 +4417,15 @@ jobs:
         flowey e 4 flowey_lib_common::git_checkout 3
         flowey e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 4 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 4 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 4 flowey_lib_common::install_rust 1
+        flowey e 4 flowey_lib_common::install_rust 2
         flowey e 4 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -4352,7 +4448,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 4 flowey_lib_common::cache 2
@@ -4478,12 +4574,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 5 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 5 flowey_lib_common::install_rust 1
+        flowey.exe e 5 flowey_lib_common::install_rust 2
         flowey.exe e 5 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -4528,7 +4627,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -4712,12 +4811,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 6 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 6 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 6 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 6 flowey_lib_common::install_rust 1
+        flowey.exe e 6 flowey_lib_common::install_rust 2
         flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
@@ -4737,7 +4839,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 6
@@ -4821,12 +4923,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
         flowey.exe e 6 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 6 flowey_lib_common::install_rust 2
+        flowey.exe e 6 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -4950,12 +5052,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 7 'artifact_publish_from_x64-windows-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 7 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 7 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 7 flowey_lib_common::install_rust 1
+        flowey.exe e 7 flowey_lib_common::install_rust 2
         flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -5000,7 +5105,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
@@ -5188,12 +5293,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 8 'artifact_publish_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 8 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 8 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 8 flowey_lib_common::install_rust 1
+        flowey.exe e 8 flowey_lib_common::install_rust 2
         flowey.exe e 8 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
@@ -5213,7 +5321,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 8 flowey_lib_common::cache 6
@@ -5297,12 +5405,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 8 flowey_lib_common::cache 2
         flowey.exe e 8 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 8 flowey_lib_common::install_rust 2
+        flowey.exe e 8 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -5437,12 +5545,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 9 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 9 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 9 flowey_lib_common::install_rust 1
+        flowey e 9 flowey_lib_common::install_rust 2
         flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -5468,7 +5579,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -2718,10 +2718,8 @@ jobs:
     name: run vmm-tests [x64-windows-intel]
     runs-on:
     - self-hosted
-    - Windows
-    - X64
-    - TDX
-    - Baremetal
+    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-Intel-WestUS3
+    - 1ES.ImageOverride=HvLite-CI-Win-Ge-Image-256GB
     permissions:
       contents: read
       id-token: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
  "log",
  "serde",
  "target-lexicon",
+ "vmm_test_images",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5363,6 +5363,7 @@ dependencies = [
  "sparse_mmap",
  "storvsp_resources",
  "tempfile",
+ "thiserror 2.0.12",
  "tpm_resources",
  "tracing",
  "tracing-subscriber",

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -296,6 +296,12 @@ pub enum GhRunner {
     RunnerGroup { group: String, labels: Vec<String> },
 }
 
+impl GhRunner {
+    pub fn is_self_hosted_with_label(&self, label: &str) -> bool {
+        matches!(self, GhRunner::SelfHosted(labels) if labels.iter().any(|s| s.as_str() == label))
+    }
+}
+
 /// Parameter type (unstable / stable).
 #[derive(Debug, Clone)]
 pub enum ParameterKind {

--- a/flowey/flowey_hvlite/Cargo.toml
+++ b/flowey/flowey_hvlite/Cargo.toml
@@ -12,6 +12,8 @@ flowey_lib_common.workspace = true
 flowey_lib_hvlite.workspace = true
 flowey.workspace = true
 
+vmm_test_images = { workspace = true, features = ["serde"] }
+
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 log.workspace = true

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -936,7 +936,7 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: crate::pipelines_shared::gh_pools::windows_tdx_self_hosted_baremetal(),
+                gh_pool: crate::pipelines_shared::gh_pools::windows_intel_self_hosted_largedisk(),
                 label: "x64-windows-intel",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_x86,

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -992,7 +992,7 @@ impl IntoPipeline for CheckinGatesCli {
                 // Run TDX and VBS tests only when using a TDX test runner
                 let mut expr = if matches!(&gh_pool, GhRunner::SelfHosted(labels) if labels.iter().any(|s| s.as_str() == "TDX"))
                 {
-                    "test(tdx) and test(vbs)".to_string()
+                    "test(tdx) + test(vbs)".to_string()
                 } else {
                     // start with `all()` to allow easy `and`-based refinements
                     "all() and not test(tdx) and not test(vbs)".to_string()

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -936,7 +936,7 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: crate::pipelines_shared::gh_pools::windows_intel_self_hosted_largedisk(),
+                gh_pool: crate::pipelines_shared::gh_pools::windows_tdx_self_hosted_baremetal(),
                 label: "x64-windows-intel",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_x86,

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -83,3 +83,13 @@ pub fn windows_arm_self_hosted_baremetal() -> GhRunner {
         "Baremetal".to_string(),
     ])
 }
+
+pub fn windows_tdx_self_hosted_baremetal() -> GhRunner {
+    GhRunner::SelfHosted(vec![
+        "self-hosted".to_string(),
+        "Windows".to_string(),
+        "X64".to_string(),
+        "TDX".to_string(),
+        "Baremetal".to_string(),
+    ])
+}

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -83,13 +83,3 @@ pub fn windows_arm_self_hosted_baremetal() -> GhRunner {
         "Baremetal".to_string(),
     ])
 }
-
-pub fn windows_tdx_self_hosted_baremetal() -> GhRunner {
-    GhRunner::SelfHosted(vec![
-        "self-hosted".to_string(),
-        "Windows".to_string(),
-        "X64".to_string(),
-        "TDX".to_string(),
-        "Baremetal".to_string(),
-    ])
-}

--- a/flowey/flowey_lib_common/src/cache.rs
+++ b/flowey/flowey_lib_common/src/cache.rs
@@ -480,6 +480,7 @@ impl FlowNode for Node {
                                 );
 
                                 let key = rt.read(key);
+                                let key = format!("{key}-{}-{}", rt.arch(), rt.platform());
                                 rt.write(write_processed_key, &key);
 
                                 if let Some(write_processed_keys) = write_processed_keys {
@@ -490,7 +491,11 @@ impl FlowNode for Node {
                                             r#""[{}]""#,
                                             restore_keys
                                                 .into_iter()
-                                                .map(|s| format!("'{s}'"))
+                                                .map(|s| format!(
+                                                    "'{s}-{}-{}'",
+                                                    rt.arch(),
+                                                    rt.platform()
+                                                ))
                                                 .collect::<Vec<_>>()
                                                 .join(", ")
                                         ),

--- a/flowey/flowey_lib_common/src/download_cargo_nextest.rs
+++ b/flowey/flowey_lib_common/src/download_cargo_nextest.rs
@@ -73,24 +73,13 @@ impl FlowNode for Node {
             }
         });
 
-        // in case we end up doing a cargo-install
-        let rust_deps = {
-            let cargo_install_persistent_dir =
-                ctx.reqv(crate::cfg_persistent_dir_cargo_install::Request);
-
-            let rust_toolchain = ctx.reqv(crate::install_rust::Request::GetRustupToolchain);
-
-            let cargo_home = ctx.reqv(crate::install_rust::Request::GetCargoHome);
-
-            let rust_installed = ctx.reqv(crate::install_rust::Request::EnsureInstalled);
-
-            Some((
-                cargo_install_persistent_dir,
-                rust_toolchain,
-                cargo_home,
-                rust_installed,
-            ))
-        };
+        // rust deps in case we end up doing a cargo-install
+        // TODO: only install rust if we can't find nextest
+        let cargo_install_persistent_dir =
+            ctx.reqv(crate::cfg_persistent_dir_cargo_install::Request);
+        let rust_toolchain = ctx.reqv(crate::install_rust::Request::GetRustupToolchain);
+        let cargo_home = ctx.reqv(crate::install_rust::Request::GetCargoHome);
+        let rust_installed = ctx.reqv(crate::install_rust::Request::EnsureInstalled);
 
         ctx.emit_rust_step("installing cargo-nextest", |ctx| {
             install_with_cargo.claim(ctx);
@@ -98,12 +87,16 @@ impl FlowNode for Node {
             let install_standalone = install_standalone.claim(ctx);
             let cache_dir = cache_dir.claim(ctx);
             let hitvar = hitvar.claim(ctx);
-            let rust_deps = rust_deps
-                .map(|(a, b, c, d)| (a.claim(ctx), b.claim(ctx), c.claim(ctx), d.claim(ctx)));
+            let cargo_install_persistent_dir = cargo_install_persistent_dir.claim(ctx);
+            let rust_toolchain = rust_toolchain.claim(ctx);
+            let cargo_home = cargo_home.claim(ctx);
+            rust_installed.claim(ctx);
 
             move |rt| {
                 let cache_dir = rt.read(cache_dir);
-                let rust_deps = rust_deps.map(|(a, b, c, _)| (rt.read(a), rt.read(b), rt.read(c)));
+                let cargo_install_persistent_dir = rt.read(cargo_install_persistent_dir);
+                let rust_toolchain = rt.read(rust_toolchain);
+                let cargo_home = rt.read(cargo_home);
 
                 let cached_bin_path = cache_dir.join(&cargo_nextest_bin);
                 let cached = if matches!(rt.read(hitvar), CacheHit::Hit) {
@@ -114,10 +107,8 @@ impl FlowNode for Node {
                 };
 
                 let (cargo_home, path_to_cargo_nextest) = if let Some(cached) = cached {
-                    (rust_deps.map(|(_, _, cargo_home)| cargo_home), cached)
-                } else if let Some((cargo_install_persistent_dir, rust_toolchain, cargo_home)) =
-                    rust_deps
-                {
+                    (cargo_home, cached)
+                } else {
                     let root = cargo_install_persistent_dir.unwrap_or("./".into());
 
                     let sh = xshell::Shell::new()?;
@@ -152,22 +143,15 @@ impl FlowNode for Node {
                     fs_err::rename(out_bin, &cached_bin_path)?;
                     let final_bin = cached_bin_path.absolute()?;
 
-                    (Some(cargo_home), final_bin)
-                } else {
-                    log::error!(
-                        "specified standalone installation, but not standalone bin could be found!"
-                    );
-                    anyhow::bail!("could not install cargo-nextest")
+                    (cargo_home, final_bin)
                 };
 
                 // is installing with cargo, make sure the bin we built /
                 // downloaded is accessible via cargo nextest
-                if let Some(cargo_home) = cargo_home {
-                    fs_err::copy(
-                        &path_to_cargo_nextest,
-                        cargo_home.join("bin").join(&cargo_nextest_bin),
-                    )?;
-                }
+                fs_err::copy(
+                    &path_to_cargo_nextest,
+                    cargo_home.join("bin").join(&cargo_nextest_bin),
+                )?;
 
                 for var in install_standalone {
                     rt.write(var, &path_to_cargo_nextest)

--- a/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
@@ -370,7 +370,7 @@ impl FlowNode for Node {
 
                     if let Some(nextest_filter_expr) = nextest_filter_expr {
                         args.push("--filter-expr".into());
-                        args.push(nextest_filter_expr.into());
+                        args.push(format!("'{nextest_filter_expr}'").into());
                     }
 
                     if run_ignored {

--- a/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
@@ -370,7 +370,7 @@ impl FlowNode for Node {
 
                     if let Some(nextest_filter_expr) = nextest_filter_expr {
                         args.push("--filter-expr".into());
-                        args.push(format!("'{nextest_filter_expr}'").into());
+                        args.push(nextest_filter_expr.into());
                     }
 
                     if run_ignored {

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -6,6 +6,8 @@
 use crate::run_cargo_nextest_run::NextestProfile;
 use flowey::node::prelude::*;
 use std::collections::BTreeMap;
+use vmm_test_images::KnownIso;
+use vmm_test_images::KnownVhd;
 
 #[derive(Serialize, Deserialize)]
 pub struct VmmTestsDepArtifacts {
@@ -30,6 +32,10 @@ flowey_request! {
         pub nextest_filter_expr: Option<String>,
         /// Artifacts corresponding to required test dependencies
         pub dep_artifact_dirs: VmmTestsDepArtifacts,
+        /// VHDs to download
+        pub vhds: Vec<KnownVhd>,
+        /// ISOs to download
+        pub isos: Vec<KnownIso>,
 
         /// Whether the job should fail if any test has failed
         pub fail_job_on_test_fail: bool,
@@ -67,6 +73,8 @@ impl SimpleFlowNode for Node {
             nextest_profile,
             nextest_filter_expr,
             dep_artifact_dirs,
+            vhds,
+            isos,
             fail_job_on_test_fail,
             artifact_dir,
             done,
@@ -130,38 +138,13 @@ impl SimpleFlowNode for Node {
             )
         });
 
-        // FIXME: share this with build_and_run_nextest_vmm_tests
-        let disk_images_dir = Some({
-            match target.architecture {
-                target_lexicon::Architecture::X86_64 => {
-                    ctx.requests::<crate::download_openvmm_vmm_tests_vhds::Node>([
-                        crate::download_openvmm_vmm_tests_vhds::Request::DownloadVhds(vec![
-                            vmm_test_images::KnownVhd::FreeBsd13_2,
-                            vmm_test_images::KnownVhd::Gen1WindowsDataCenterCore2022,
-                            vmm_test_images::KnownVhd::Gen2WindowsDataCenterCore2022,
-                            vmm_test_images::KnownVhd::Gen2WindowsDataCenterCore2025,
-                            vmm_test_images::KnownVhd::Ubuntu2204Server,
-                        ]),
-                    ]);
+        ctx.requests::<crate::download_openvmm_vmm_tests_vhds::Node>([
+            crate::download_openvmm_vmm_tests_vhds::Request::DownloadVhds(vhds),
+            crate::download_openvmm_vmm_tests_vhds::Request::DownloadIsos(isos),
+        ]);
 
-                    ctx.requests::<crate::download_openvmm_vmm_tests_vhds::Node>([
-                        crate::download_openvmm_vmm_tests_vhds::Request::DownloadIsos(vec![
-                            vmm_test_images::KnownIso::FreeBsd13_2,
-                        ]),
-                    ]);
-                }
-                target_lexicon::Architecture::Aarch64(_) => {
-                    ctx.requests::<crate::download_openvmm_vmm_tests_vhds::Node>([
-                        crate::download_openvmm_vmm_tests_vhds::Request::DownloadVhds(vec![
-                            vmm_test_images::KnownVhd::Ubuntu2404ServerAarch64,
-                        ]),
-                    ]);
-                }
-                arch => anyhow::bail!("unsupported arch {arch}"),
-            }
-
-            ctx.reqv(crate::download_openvmm_vmm_tests_vhds::Request::GetDownloadFolder)
-        });
+        let disk_images_dir =
+            ctx.reqv(crate::download_openvmm_vmm_tests_vhds::Request::GetDownloadFolder);
 
         // FUTURE: once we move away from the known_paths resolver, this will no
         // longer be an ambient pre-run dependency.
@@ -191,7 +174,7 @@ impl SimpleFlowNode for Node {
             register_pipette_windows,
             register_pipette_linux_musl,
             register_guest_test_uefi,
-            disk_images_dir,
+            disk_images_dir: Some(disk_images_dir),
             register_openhcl_igvm_files,
             get_test_log_path: Some(get_test_log_path),
             get_env: v,

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -138,7 +138,7 @@ impl SimpleFlowNode for Node {
                         crate::download_openvmm_vmm_tests_vhds::Request::DownloadVhds(vec![
                             vmm_test_images::KnownVhd::FreeBsd13_2,
                             vmm_test_images::KnownVhd::Gen1WindowsDataCenterCore2022,
-                            vmm_test_images::KnownVhd::Gen2WindowsDataCenterCore2022,
+                            vmm_test_images::KnownVhd::Gen2WindowsDataCenterCore2025,
                             vmm_test_images::KnownVhd::Ubuntu2204Server,
                         ]),
                     ]);

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -138,6 +138,7 @@ impl SimpleFlowNode for Node {
                         crate::download_openvmm_vmm_tests_vhds::Request::DownloadVhds(vec![
                             vmm_test_images::KnownVhd::FreeBsd13_2,
                             vmm_test_images::KnownVhd::Gen1WindowsDataCenterCore2022,
+                            vmm_test_images::KnownVhd::Gen2WindowsDataCenterCore2022,
                             vmm_test_images::KnownVhd::Gen2WindowsDataCenterCore2025,
                             vmm_test_images::KnownVhd::Ubuntu2204Server,
                         ]),

--- a/petri/Cargo.toml
+++ b/petri/Cargo.toml
@@ -77,6 +77,7 @@ prost.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tempfile.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/petri/src/tracing.rs
+++ b/petri/src/tracing.rs
@@ -252,7 +252,7 @@ pub fn try_init_tracing(root_path: &Path) -> anyhow::Result<PetriLogSource> {
         if let Ok(var) = std::env::var("OPENVMM_LOG").or_else(|_| std::env::var("HVLITE_LOG")) {
             var.parse().unwrap()
         } else {
-            Targets::new().with_default(LevelFilter::INFO)
+            Targets::new().with_default(LevelFilter::DEBUG)
         };
 
     // Canonicalize so that printed attachment paths are most likely to work.

--- a/petri/src/tracing.rs
+++ b/petri/src/tracing.rs
@@ -252,7 +252,7 @@ pub fn try_init_tracing(root_path: &Path) -> anyhow::Result<PetriLogSource> {
         if let Ok(var) = std::env::var("OPENVMM_LOG").or_else(|_| std::env::var("HVLITE_LOG")) {
             var.parse().unwrap()
         } else {
-            Targets::new().with_default(LevelFilter::DEBUG)
+            Targets::new().with_default(LevelFilter::INFO)
         };
 
     // Canonicalize so that printed attachment paths are most likely to work.

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -13,10 +13,14 @@ use crate::PetriLogSource;
 use crate::PetriTestParams;
 use crate::PetriVm;
 use crate::PetriVmConfig;
+use crate::ShutdownKind;
 use crate::disk_image::AgentImage;
 use crate::openhcl_diag::OpenHclDiagHandler;
 use anyhow::Context;
 use async_trait::async_trait;
+use get_resources::ged::FirmwareEvent;
+use jiff::Timestamp;
+use jiff::ToSpan;
 use pal_async::DefaultDriver;
 use pal_async::pipe::PolledPipe;
 use pal_async::socket::PolledSocket;
@@ -33,6 +37,7 @@ use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
+use thiserror::Error;
 use vm::HyperVVM;
 use vmm_core_defs::HaltReason;
 
@@ -56,6 +61,7 @@ pub struct PetriVmConfigHyperV {
     agent_image: AgentImage,
 
     os_flavor: OsFlavor,
+    expected_boot_event: Option<FirmwareEvent>,
 
     // Folder to store temporary data for this test
     temp_dir: tempfile::TempDir,
@@ -107,6 +113,14 @@ impl PetriVm for PetriVmHyperV {
 
     async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()> {
         Self::wait_for_vtl2_ready(self).await
+    }
+
+    async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()> {
+        Self::wait_for_successful_boot_event(self).await
+    }
+
+    async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()> {
+        Self::send_enlightened_shutdown(self, kind).await
     }
 }
 
@@ -198,6 +212,7 @@ impl PetriVmConfigHyperV {
             agent_image,
             driver: driver.clone(),
             os_flavor: firmware.os_flavor(),
+            expected_boot_event: firmware.expected_boot_event(),
             temp_dir,
             log_source: params.logger.clone(),
         })
@@ -231,11 +246,21 @@ impl PetriVmConfigHyperV {
             self.guest_state_isolation_type,
             self.memory,
             self.log_source.log_file("hyperv")?,
+            self.expected_boot_event,
+            self.driver.clone(),
         )?;
 
         if let Some(igvm_file) = &self.openhcl_igvm {
             // TODO: only increase VTL2 memory on debug builds
-            vm.set_openhcl_firmware(igvm_file.as_ref(), true)?;
+            vm.set_openhcl_firmware(
+                igvm_file.as_ref(),
+                !matches!(
+                    self.guest_state_isolation_type,
+                    powershell::HyperVGuestStateIsolationType::Vbs
+                        | powershell::HyperVGuestStateIsolationType::Snp
+                        | powershell::HyperVGuestStateIsolationType::Tdx
+                ),
+            )?;
         }
 
         if let Some(secure_boot_template) = self.secure_boot_template {
@@ -336,7 +361,7 @@ impl PetriVmConfigHyperV {
             None
         };
 
-        vm.start()?;
+        vm.start().await?;
 
         Ok(PetriVmHyperV {
             config: self,
@@ -350,7 +375,7 @@ impl PetriVmConfigHyperV {
 impl PetriVmHyperV {
     /// Wait for the VM to halt, returning the reason for the halt.
     pub async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason> {
-        self.vm.wait_for_power_off(&self.config.driver).await?;
+        self.vm.wait_for_halt().await?;
         Ok(HaltReason::PowerOff) // TODO: Get actual halt reason
     }
 
@@ -370,17 +395,17 @@ impl PetriVmHyperV {
         self.openhcl_diag()?.test_inspect().await
     }
 
-    /// Wait for a connection from a pipette agent running in the guest.
-    /// Useful if you've rebooted the vm or are otherwise expecting a fresh connection.
-    pub async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()> {
-        self.openhcl_diag()?.wait_for_vtl2().await
-    }
-
     /// Wait for VTL 2 to report that it is ready to respond to commands.
     /// Will fail if the VM is not running OpenHCL.
     ///
     /// This should only be necessary if you're doing something manual. All
     /// Petri-provided methods will wait for VTL 2 to be ready automatically.
+    pub async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()> {
+        self.openhcl_diag()?.wait_for_vtl2().await
+    }
+
+    /// Wait for a connection from a pipette agent running in the guest.
+    /// Useful if you've rebooted the vm or are otherwise expecting a fresh connection.
     pub async fn wait_for_agent(&mut self) -> anyhow::Result<PipetteClient> {
         Self::wait_for_agent_core(
             &self.config.driver,
@@ -389,6 +414,28 @@ impl PetriVmHyperV {
             false,
         )
         .await
+    }
+
+    /// Waits for an event emitted by the firmware about its boot status, and
+    /// verifies that it is the expected success value.
+    ///
+    /// * Linux Direct guests do not emit a boot event, so this method immediately returns Ok.
+    /// * PCAT guests may not emit an event depending on the PCAT version, this
+    ///   method is best effort for them.
+    pub async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()> {
+        self.vm.wait_for_successful_boot_event().await
+    }
+
+    /// Instruct the guest to shutdown via the Hyper-V shutdown IC.
+    pub async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()> {
+        self.vm.wait_for_heartbeat().await?;
+
+        match kind {
+            ShutdownKind::Shutdown => self.vm.stop().await?,
+            ShutdownKind::Reboot => self.vm.restart().await?,
+        }
+
+        Ok(())
     }
 
     async fn wait_for_agent_core(
@@ -411,24 +458,18 @@ impl PetriVmHyperV {
         //
         // Allow for the slowest test (hyperv_pcat_x64_ubuntu_2204_server_x64_boot)
         // but fail before the nextest timeout. (~1 attempt for second)
-        const PIPETTE_CONNECT_ATTEMPTS: u32 = 240;
-        let mut attempts = 0;
+        let connect_timeout = 240.seconds();
+        let start = Timestamp::now();
+
         let mut socket = PolledSocket::new(driver, socket)?.convert();
-        loop {
-            match socket
-                .connect(&VmAddress::hyperv_vsock(vm_id, pipette_client::PIPETTE_VSOCK_PORT).into())
-                .await
-            {
-                Ok(_) => break,
-                Err(_) => {
-                    if attempts >= PIPETTE_CONNECT_ATTEMPTS {
-                        anyhow::bail!("Pipette connection timed out")
-                    }
-                    attempts += 1;
-                    PolledTimer::new(driver).sleep(Duration::from_secs(1)).await;
-                    continue;
-                }
+        while let Err(e) = socket
+            .connect(&VmAddress::hyperv_vsock(vm_id, pipette_client::PIPETTE_VSOCK_PORT).into())
+            .await
+        {
+            if connect_timeout.compare(Timestamp::now() - start)? == std::cmp::Ordering::Less {
+                anyhow::bail!("Pipette connection timed out: {e}")
             }
+            PolledTimer::new(driver).sleep(Duration::from_secs(1)).await;
         }
 
         PipetteClient::new(driver, socket, output_dir)
@@ -443,4 +484,18 @@ impl PetriVmHyperV {
             anyhow::bail!("VM is not configured with OpenHCL")
         }
     }
+}
+
+/// Error running command
+#[derive(Error, Debug)]
+pub enum CommandError {
+    /// failed to launch command
+    #[error("failed to launch command")]
+    Launch(#[from] std::io::Error),
+    /// command exited with non-zero status
+    #[error("command exited with non-zero status ({0}): {1}")]
+    Command(std::process::ExitStatus, String),
+    /// command output is not utf-8
+    #[error("command output is not utf-8")]
+    Utf8(#[from] std::string::FromUtf8Error),
 }

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -254,6 +254,7 @@ impl PetriVmConfigHyperV {
             // TODO: only increase VTL2 memory on debug builds
             vm.set_openhcl_firmware(
                 igvm_file.as_ref(),
+                // don't increase VTL2 memory on CVMs
                 !matches!(
                     self.guest_state_isolation_type,
                     powershell::HyperVGuestStateIsolationType::Vbs
@@ -428,8 +429,6 @@ impl PetriVmHyperV {
 
     /// Instruct the guest to shutdown via the Hyper-V shutdown IC.
     pub async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()> {
-        self.vm.wait_for_heartbeat().await?;
-
         match kind {
             ShutdownKind::Shutdown => self.vm.stop().await?,
             ShutdownKind::Reboot => self.vm.restart().await?,

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -3,6 +3,7 @@
 
 //! Wrappers for Hyper-V Powershell Cmdlets
 
+use super::CommandError;
 use anyhow::Context;
 use core::str;
 use guid::Guid;
@@ -334,7 +335,7 @@ pub fn run_set_vm_com_port(vmid: &Guid, port: u8, path: &Path) -> anyhow::Result
 }
 
 /// Windows event log as retrieved by `run_get_winevent`
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct WinEvent {
     /// Time of event
@@ -344,51 +345,127 @@ pub struct WinEvent {
     /// Event level (see winmeta.h)
     pub level: u8,
     /// Event ID
-    pub id: u64,
+    pub id: u32,
     /// Message content
     pub message: String,
 }
 
 /// Get event logs
 pub fn run_get_winevent(
-    log_name: &str,
-    start_time: &Timestamp,
-    find: &str,
+    log_name: &[&str],
+    start_time: Option<&Timestamp>,
+    find: Option<&str>,
+    ids: &[u32],
 ) -> anyhow::Result<Vec<WinEvent>> {
-    let logs = PowerShellBuilder::new()
-        .cmdlet("Get-WinEvent")
-        .flag("Oldest")
-        .arg("FilterHashtable",
-            format!(
-                "@{{ LogName=\"{log_name}\"; StartTime=\"{start_time}\" }}"
-            ),
-        )
-        .pipeline()
-        .cmdlet("where")
-        .positional("message")
-        .arg("Match", find)
-        .pipeline()
-        .cmdlet("Select-Object")
-        .positional(r#"@{label="TimeCreated";expression={Get-Date $_.TimeCreated -Format o}}, ProviderName, Level, Id, Message"#)
-        .pipeline()
-        .cmdlet("ConvertTo-Json")
-        .finish()
-        .output(false).context("run_get_winevent")?;
+    let mut filter = Vec::new();
+    if !log_name.is_empty() {
+        filter.push(format!(
+            "LogName={}",
+            log_name
+                .iter()
+                .map(|x| format!("'{x}'"))
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+    }
+    if let Some(start_time) = start_time {
+        filter.push(format!("StartTime=\"{start_time}\""));
+    }
+    if !ids.is_empty() {
+        filter.push(format!(
+            "Id={}",
+            ids.iter()
+                .map(|x| x.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+    }
+    let filter = filter.join("; ");
 
-    serde_json::from_str(&logs).context("parsing winevents")
+    const OUTPUT_VARNAME: &str = "events";
+
+    let mut builder = PowerShellBuilder::new()
+        .cmdlet_to_var("Get-WinEvent", OUTPUT_VARNAME)
+        .flag("Oldest")
+        .arg("FilterHashtable", format!("@{{ {filter} }}"))
+        .pipeline();
+
+    if let Some(find) = find {
+        builder = builder
+            .cmdlet("where")
+            .positional("message")
+            .arg("Match", find)
+            .pipeline();
+    }
+
+    let output = builder.cmdlet("Select-Object")
+        .positional(r#"@{label="TimeCreated";expression={Get-Date $_.TimeCreated -Format o}}, ProviderName, Level, Id, Message"#)
+        .next()
+        .cmdlet("ConvertTo-Json")
+        .arg_var("InputObject", OUTPUT_VARNAME, true)
+        .finish()
+        .output(false);
+
+    match output {
+        Ok(logs) => serde_json::from_str(&logs).context("parsing winevents"),
+        Err(e) => match e {
+            CommandError::Command(_, err_output)
+                if err_output.contains(
+                    "No events were found that match the specified selection criteria.",
+                ) =>
+            {
+                Ok(Vec::new())
+            }
+            e => Err(e).context("run_get_winevent"),
+        },
+    }
 }
+
+const HYPERV_WORKER_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Admin";
+const HYPERV_VMMS_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Admin";
 
 /// Get Hyper-V event logs for a VM
 pub fn hyperv_event_logs(vmid: &Guid, start_time: &Timestamp) -> anyhow::Result<Vec<WinEvent>> {
     let vmid = vmid.to_string();
-    let mut logs = Vec::new();
-    for log_name in [
-        "Microsoft-Windows-Hyper-V-Worker-Admin",
-        "Microsoft-Windows-Hyper-V-VMMS-Admin",
-    ] {
-        logs.append(&mut run_get_winevent(log_name, start_time, &vmid)?);
-    }
-    Ok(logs)
+    run_get_winevent(
+        &[HYPERV_WORKER_TABLE, HYPERV_VMMS_TABLE],
+        Some(start_time),
+        Some(&vmid),
+        &[],
+    )
+}
+
+/// boot succeeded
+pub const EVENT_ID_BOOT_SUCCESS: u32 = 18601;
+/// boot succeeded, secure boot failed
+pub const EVENT_ID_BOOT_SUCCESS_SECURE_BOOT_FAILED: u32 = 18602;
+/// boot failed
+pub const EVENT_ID_BOOT_FAILURE: u32 = 18603;
+/// boot failed due to secure boot failure
+pub const EVENT_ID_BOOT_FAILURE_SECURE_BOOT_FAILED: u32 = 18604;
+/// boot failed because there was no boot device
+pub const EVENT_ID_NO_BOOT_DEVICE: u32 = 18605;
+/// boot attempted (pcat only)
+pub const EVENT_ID_BOOT_ATTEMPT: u32 = 18606;
+
+const BOOT_EVENT_IDS: [u32; 6] = [
+    EVENT_ID_BOOT_SUCCESS,
+    EVENT_ID_BOOT_SUCCESS_SECURE_BOOT_FAILED,
+    EVENT_ID_BOOT_FAILURE,
+    EVENT_ID_BOOT_FAILURE_SECURE_BOOT_FAILED,
+    EVENT_ID_NO_BOOT_DEVICE,
+    EVENT_ID_BOOT_ATTEMPT,
+];
+
+/// Get Hyper-V event logs for a VM
+pub fn hyperv_boot_events(vmid: &Guid, start_time: &Timestamp) -> anyhow::Result<Vec<WinEvent>> {
+    let vmid = vmid.to_string();
+    run_get_winevent(
+        &[HYPERV_WORKER_TABLE],
+        Some(start_time),
+        Some(&vmid),
+        &BOOT_EVENT_IDS,
+    )
 }
 
 /// Get the IDs of the VM(s) with the specified name
@@ -412,40 +489,83 @@ pub fn vm_id_from_name(name: &str) -> anyhow::Result<Vec<Guid>> {
     Ok(vmids)
 }
 
+/// Hyper-V VM Heartbeat Status
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum VmHeartbeatStatus {
+    /// The VM is off
+    Off,
+    /// No VM Heartbeat
+    NoContact,
+    /// VM Hearbeat OK
+    Ok,
+}
+
+/// Wait for VM heartbeat
+pub fn vm_heartbeat(vmid: &Guid) -> anyhow::Result<VmHeartbeatStatus> {
+    let status = PowerShellBuilder::new()
+        .cmdlet("Get-VM")
+        .arg_string("Id", vmid)
+        .pipeline()
+        .cmdlet("Get-VMIntegrationService")
+        .arg("Name", "Heartbeat")
+        .pipeline()
+        .cmdlet("Select-Object")
+        .arg("ExpandProperty", "PrimaryStatusDescription")
+        .finish()
+        .output(true)
+        .context("vm_heartbeat")?;
+
+    Ok(match status.as_str() {
+        "" => VmHeartbeatStatus::Off,
+        "No Contact" => VmHeartbeatStatus::NoContact,
+        "OK" => VmHeartbeatStatus::Ok,
+        s => anyhow::bail!("Unknown VM heartbeat status: {s}"),
+    })
+}
+
 /// A PowerShell script builder
 pub struct PowerShellBuilder(Command);
 
 impl PowerShellBuilder {
     /// Create a new PowerShell command
     pub fn new() -> Self {
-        let mut cmd = Command::new("powershell.exe");
-        cmd.arg("-NoProfile");
-        Self(cmd)
+        PowerShellCmdletBuilder(Command::new("powershell.exe"))
+            .flag("NoProfile")
+            .finish()
     }
 
     /// Start a new Cmdlet
-    pub fn cmdlet<S: AsRef<OsStr>>(mut self, cmdlet: S) -> PowerShellCmdletBuilder {
-        self.0.arg(cmdlet);
+    pub fn cmdlet<S: AsRef<OsStr>>(self, cmdlet: S) -> PowerShellCmdletBuilder {
+        PowerShellCmdletBuilder(self.0).positional(cmdlet)
+    }
+
+    /// Assign the output of the cmdlet to a variable
+    pub fn cmdlet_to_var<S: AsRef<OsStr>, T: AsRef<OsStr>>(
+        self,
+        cmdlet: S,
+        varname: T,
+    ) -> PowerShellCmdletBuilder {
         PowerShellCmdletBuilder(self.0)
+            .positional_var(varname, false)
+            .positional("=")
+            .finish()
+            .cmdlet(cmdlet)
     }
 
     /// Run the PowerShell script and return the output
-    pub fn output(mut self, log_stdout: bool) -> anyhow::Result<String> {
+    pub fn output(mut self, log_stdout: bool) -> Result<String, CommandError> {
         self.0.stderr(Stdio::piped()).stdin(Stdio::null());
-        let output = self.0.output().context("failed to launch powershell")?;
+        let output = self.0.output()?;
 
         let ps_stdout = (log_stdout || !output.status.success())
             .then(|| String::from_utf8_lossy(&output.stdout).to_string());
         let ps_stderr = String::from_utf8_lossy(&output.stderr).to_string();
         tracing::debug!(ps_cmd = self.cmd(), ps_stdout, ps_stderr);
         if !output.status.success() {
-            anyhow::bail!("powershell script failed with exit code: {}", output.status);
+            return Err(CommandError::Command(output.status, ps_stderr));
         }
 
-        Ok(String::from_utf8(output.stdout)
-            .context("powershell output is not utf-8")?
-            .trim()
-            .to_owned())
+        Ok(String::from_utf8(output.stdout)?.trim().to_owned())
     }
 
     /// Get the command to be run
@@ -508,17 +628,31 @@ impl PowerShellCmdletBuilder {
         self.positional_opt(positional.map(|x| x.to_string()))
     }
 
-    /// Add an argument to the cmdlet
+    /// Add a PowerShell variable as a positional argument to the cmdlet
+    pub fn positional_var<S: AsRef<OsStr>>(self, varname: S, as_array: bool) -> Self {
+        let mut ps_var = OsString::new();
+        if as_array {
+            ps_var.push("@(");
+        }
+        ps_var.push("$");
+        ps_var.push(varname);
+        if as_array {
+            ps_var.push(")");
+        }
+        self.positional(ps_var)
+    }
+
+    /// Add a named argument to the cmdlet
     pub fn arg<S: AsRef<OsStr>, T: AsRef<OsStr>>(self, name: S, value: T) -> Self {
         self.flag(name).positional(value)
     }
 
-    /// Add an argument to the cmdlet
+    /// Add a named argument to the cmdlet
     pub fn arg_string<S: AsRef<OsStr>, T: ToString>(self, name: S, value: T) -> Self {
         self.arg(name, value.to_string())
     }
 
-    /// Optionally add an argument to the cmdlet
+    /// Optionally add a named argument to the cmdlet
     pub fn arg_opt<S: AsRef<OsStr>, T: AsRef<OsStr>>(self, name: S, value: Option<T>) -> Self {
         if let Some(value) = value {
             self.arg(name, value)
@@ -527,9 +661,19 @@ impl PowerShellCmdletBuilder {
         }
     }
 
-    /// Optionally add an argument to the cmdlet
+    /// Optionally add a named argument to the cmdlet
     pub fn arg_opt_string<S: AsRef<OsStr>, T: ToString>(self, name: S, value: Option<T>) -> Self {
         self.arg_opt(name, value.map(|x| x.to_string()))
+    }
+
+    /// Add a PowerShell variable as a named argument to the cmdlet
+    pub fn arg_var<S: AsRef<OsStr>, T: AsRef<OsStr>>(
+        self,
+        name: S,
+        varname: T,
+        as_array: bool,
+    ) -> Self {
+        self.flag(name).positional_var(varname, as_array)
     }
 
     /// Finish the cmdlet

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -4,15 +4,20 @@
 //! Provides an interface for creating and managing Hyper-V VMs
 
 use super::hvc;
+use super::hvc::VmState;
 use super::powershell;
 use crate::PetriLogFile;
 use anyhow::Context;
+use get_resources::ged::FirmwareEvent;
 use guid::Guid;
 use jiff::Timestamp;
+use jiff::ToSpan;
 use pal_async::DefaultDriver;
+use pal_async::timer::PolledTimer;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+use std::time::Duration;
 use tempfile::TempDir;
 use tracing::Level;
 
@@ -25,6 +30,8 @@ pub struct HyperVVM {
     ps_mod: PathBuf,
     create_time: Timestamp,
     log_file: PetriLogFile,
+    expected_boot_event: Option<FirmwareEvent>,
+    driver: DefaultDriver,
 }
 
 impl HyperVVM {
@@ -35,6 +42,8 @@ impl HyperVVM {
         guest_state_isolation_type: powershell::HyperVGuestStateIsolationType,
         memory: u64,
         log_file: PetriLogFile,
+        expected_boot_event: Option<FirmwareEvent>,
+        driver: DefaultDriver,
     ) -> anyhow::Result<Self> {
         let create_time = Timestamp::now();
         let name = name.to_owned();
@@ -74,6 +83,8 @@ impl HyperVVM {
             ps_mod,
             create_time,
             log_file,
+            expected_boot_event,
+            driver,
         })
     }
 
@@ -104,6 +115,46 @@ impl HyperVVM {
                 ),
             );
         }
+        Ok(())
+    }
+
+    /// Waits for an event emitted by the firmware about its boot status, and
+    /// verifies that it is the expected success value.
+    pub async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()> {
+        if let Some(expected_boot_event) = self.expected_boot_event {
+            let expected_id = match expected_boot_event {
+                FirmwareEvent::BootSuccess => powershell::EVENT_ID_BOOT_SUCCESS,
+                FirmwareEvent::BootFailed => powershell::EVENT_ID_BOOT_FAILURE,
+                FirmwareEvent::NoBootDevice => powershell::EVENT_ID_NO_BOOT_DEVICE,
+                FirmwareEvent::BootAttempt => powershell::EVENT_ID_BOOT_ATTEMPT,
+            };
+            let boot_timeout = 30.seconds();
+            let start = Timestamp::now();
+            loop {
+                let events = powershell::hyperv_boot_events(&self.vmid, &self.create_time)?;
+
+                if events.len() > 1 {
+                    anyhow::bail!("Got more than one boot event");
+                }
+                if let Some(event) = events.first() {
+                    if event.id == expected_id {
+                        break;
+                    } else {
+                        anyhow::bail!("VM boot failed ({}): {}", event.id, event.message)
+                    }
+                }
+
+                if boot_timeout.compare(Timestamp::now() - start)? == std::cmp::Ordering::Less {
+                    anyhow::bail!("VM boot timed out")
+                }
+                PolledTimer::new(&self.driver)
+                    .sleep(Duration::from_secs(1))
+                    .await;
+            }
+        } else {
+            tracing::warn!("Configured firmware does not emit a boot event, skipping");
+        }
+
         Ok(())
     }
 
@@ -157,9 +208,48 @@ impl HyperVVM {
         powershell::run_set_initial_machine_configuration(&self.vmid, &self.ps_mod, imc_hive)
     }
 
+    fn state(&self) -> anyhow::Result<VmState> {
+        hvc::hvc_state(&self.vmid)
+    }
+
+    fn check_state(&self, expected: VmState) -> anyhow::Result<()> {
+        let state = self.state()?;
+        if state != expected {
+            anyhow::bail!("unexpected VM state {state:?}, should be {expected:?}");
+        }
+        Ok(())
+    }
+
     /// Start the VM
-    pub fn start(&self) -> anyhow::Result<()> {
-        hvc::hvc_start(&self.vmid)
+    pub async fn start(&self) -> anyhow::Result<()> {
+        self.check_state(VmState::Off)?;
+        hvc::hvc_start(&self.vmid)?;
+        self.wait_for_state(VmState::Running).await
+    }
+
+    /// Attempt to gracefully shut down the VM
+    pub async fn stop(&self) -> anyhow::Result<()> {
+        self.check_state(VmState::Running)?;
+        hvc::hvc_stop(&self.vmid)?;
+        self.wait_for_state(VmState::Off).await
+    }
+
+    /// Attempt to gracefully restart the VM
+    pub async fn restart(&self) -> anyhow::Result<()> {
+        self.check_state(VmState::Running)?;
+        hvc::hvc_restart(&self.vmid)?;
+        tracing::warn!("end state checking on restart not yet implemented for hyper-v vms");
+        Ok(())
+    }
+
+    /// Kill the VM
+    pub fn kill(&self) -> anyhow::Result<()> {
+        hvc::hvc_kill(&self.vmid).context("hvc_kill")
+    }
+
+    /// Issue a hard reset to the VM
+    pub fn reset(&self) -> anyhow::Result<()> {
+        hvc::hvc_reset(&self.vmid).context("hvc_reset")
     }
 
     /// Enable serial output and return the named pipe path
@@ -169,9 +259,53 @@ impl HyperVVM {
         Ok(pipe_path)
     }
 
-    /// Wait for the VM to turn off
-    pub async fn wait_for_power_off(&self, driver: &DefaultDriver) -> anyhow::Result<()> {
-        hvc::hvc_wait_for_power_off(driver, &self.vmid).await
+    /// Wait for the VM to stop
+    pub async fn wait_for_halt(&self) -> anyhow::Result<()> {
+        self.wait_for_state(VmState::Off).await
+    }
+
+    async fn wait_for_state(&self, target: VmState) -> anyhow::Result<()> {
+        self.wait_for(Self::state, target, 30.seconds())
+            .await
+            .context("wait_for_state")
+    }
+
+    /// Wait for the VM heartbeat
+    pub async fn wait_for_heartbeat(&self) -> anyhow::Result<()> {
+        self.wait_for(
+            Self::heartbeat,
+            powershell::VmHeartbeatStatus::Ok,
+            30.seconds(),
+        )
+        .await
+        .context("wait_for_heartbeat")
+    }
+
+    fn heartbeat(&self) -> anyhow::Result<powershell::VmHeartbeatStatus> {
+        powershell::vm_heartbeat(&self.vmid)
+    }
+
+    async fn wait_for<T: std::fmt::Debug + PartialEq>(
+        &self,
+        f: fn(&Self) -> anyhow::Result<T>,
+        target: T,
+        timeout: jiff::Span,
+    ) -> anyhow::Result<()> {
+        let start = Timestamp::now();
+        loop {
+            let state = f(self)?;
+            if state == target {
+                break;
+            }
+            if timeout.compare(Timestamp::now() - start)? == std::cmp::Ordering::Less {
+                anyhow::bail!("timed out waiting for {target:?}. current: {state:?}");
+            }
+            PolledTimer::new(&self.driver)
+                .sleep(Duration::from_secs(1))
+                .await;
+        }
+
+        Ok(())
     }
 
     /// Remove the VM
@@ -181,9 +315,13 @@ impl HyperVVM {
 
     fn remove_inner(&mut self) -> anyhow::Result<()> {
         if !self.destroyed {
-            hvc::hvc_ensure_off(&self.vmid)?;
-            powershell::run_remove_vm(&self.vmid)?;
+            let res_off = hvc::hvc_ensure_off(&self.vmid);
+            let res_remove = powershell::run_remove_vm(&self.vmid);
+
             self.flush_logs()?;
+
+            res_off?;
+            res_remove?;
             self.destroyed = true;
         }
 

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -287,6 +287,8 @@ impl HyperVVM {
         powershell::vm_shutdown_ic_status(&self.vmid)
     }
 
+    // TODO: replace timeouts throughout the hyper-v petri infrastructure
+    // with a watchdog
     async fn wait_for<T: std::fmt::Debug + PartialEq>(
         &self,
         f: fn(&Self) -> anyhow::Result<T>,

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -128,7 +128,7 @@ impl HyperVVM {
                 FirmwareEvent::NoBootDevice => powershell::EVENT_ID_NO_BOOT_DEVICE,
                 FirmwareEvent::BootAttempt => powershell::EVENT_ID_BOOT_ATTEMPT,
             };
-            let boot_timeout = 30.seconds();
+            let boot_timeout = 240.seconds();
             let start = Timestamp::now();
             loop {
                 let events = powershell::hyperv_boot_events(&self.vmid, &self.create_time)?;
@@ -267,7 +267,7 @@ impl HyperVVM {
     }
 
     async fn wait_for_state(&self, target: VmState) -> anyhow::Result<()> {
-        self.wait_for(Self::state, target, 30.seconds())
+        self.wait_for(Self::state, target, 240.seconds())
             .await
             .context("wait_for_state")
     }
@@ -277,7 +277,7 @@ impl HyperVVM {
         self.wait_for(
             Self::shutdown_ic_status,
             powershell::VmShutdownIcStatus::Ok,
-            30.seconds(),
+            240.seconds(),
         )
         .await
         .context("wait_for_shutdown_ic")

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -198,7 +198,7 @@ impl PetriVmConfigOpenVmm {
         };
 
         setup.load_boot_disk(&mut devices, vtl2_settings.as_mut())?;
-        let expected_boot_event = setup.get_expected_boot_event();
+        let expected_boot_event = firmware.expected_boot_event();
 
         // Configure the serial ports now that they have been updated by the
         // OpenHCL configuration.
@@ -860,27 +860,6 @@ impl PetriVmConfigSetupCore<'_> {
         } else {
             None
         })
-    }
-
-    fn get_expected_boot_event(&self) -> Option<FirmwareEvent> {
-        match &self.firmware {
-            Firmware::LinuxDirect { .. } | Firmware::OpenhclLinuxDirect { .. } => None,
-            Firmware::Pcat { .. } => {
-                // TODO: Handle older PCAT versions that don't fire the event
-                Some(FirmwareEvent::BootAttempt)
-            }
-            Firmware::Uefi {
-                guest: UefiGuest::None,
-                ..
-            }
-            | Firmware::OpenhclUefi {
-                guest: UefiGuest::None,
-                ..
-            } => Some(FirmwareEvent::NoBootDevice),
-            Firmware::Uefi { .. } | Firmware::OpenhclUefi { .. } => {
-                Some(FirmwareEvent::BootSuccess)
-            }
-        }
     }
 }
 

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -65,6 +65,14 @@ impl PetriVm for PetriVmOpenVmm {
     async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()> {
         Self::wait_for_vtl2_ready(self).await
     }
+
+    async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()> {
+        Self::wait_for_successful_boot_event(self).await
+    }
+
+    async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()> {
+        Self::send_enlightened_shutdown(self, kind).await
+    }
 }
 
 pub(super) struct PetriVmInner {

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -64,6 +64,7 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
             _ if id == test_vhd::GUEST_TEST_UEFI_AARCH64 => guest_test_uefi_disk_path(MachineArch::Aarch64),
             _ if id == test_vhd::GEN1_WINDOWS_DATA_CENTER_CORE2022_X64 => get_guest_vhd_path(KnownVhd::Gen1WindowsDataCenterCore2022),
             _ if id == test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64 => get_guest_vhd_path(KnownVhd::Gen2WindowsDataCenterCore2022),
+            _ if id == test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64 => get_guest_vhd_path(KnownVhd::Gen2WindowsDataCenterCore2025),
             _ if id == test_vhd::FREE_BSD_13_2_X64 => get_guest_vhd_path(KnownVhd::FreeBsd13_2),
             _ if id == test_vhd::UBUNTU_2204_SERVER_X64 => get_guest_vhd_path(KnownVhd::Ubuntu2204Server),
             _ if id == test_vhd::UBUNTU_2404_SERVER_AARCH64 => get_guest_vhd_path(KnownVhd::Ubuntu2404ServerAarch64),

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -256,6 +256,22 @@ pub mod artifacts {
         }
 
         declare_artifacts! {
+            /// Generation 2 windows test image
+            GEN2_WINDOWS_DATA_CENTER_CORE2025_X64
+        }
+
+        impl IsTestVhd for GEN2_WINDOWS_DATA_CENTER_CORE2025_X64 {
+            const OS_FLAVOR: OsFlavor = OsFlavor::Windows;
+            const ARCH: MachineArch = MachineArch::X86_64;
+        }
+
+        impl IsHostedOnHvliteAzureBlobStore for GEN2_WINDOWS_DATA_CENTER_CORE2025_X64 {
+            const FILENAME: &'static str =
+                "WindowsServer-2025-datacenter-core-smalldisk-g2-26100.3476.250306.vhd";
+            const SIZE: u64 = 32214352384;
+        }
+
+        declare_artifacts! {
             /// FreeBSD 13.2
             FREE_BSD_13_2_X64
         }

--- a/vmm_tests/vmm_test_images/src/lib.rs
+++ b/vmm_tests/vmm_test_images/src/lib.rs
@@ -26,6 +26,7 @@ use petri_artifacts_vmm_test::tags::IsHostedOnHvliteAzureBlobStore;
 pub enum KnownVhd {
     Gen1WindowsDataCenterCore2022,
     Gen2WindowsDataCenterCore2022,
+    Gen2WindowsDataCenterCore2025,
     FreeBsd13_2,
     Ubuntu2204Server,
     Ubuntu2404ServerAarch64,
@@ -58,6 +59,11 @@ const KNOWN_VHD_METADATA: &[KnownVhdMeta] = &[
         KnownVhd::Gen2WindowsDataCenterCore2022,
         petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64::SIZE,
+    ),
+    KnownVhdMeta::new(
+        KnownVhd::Gen2WindowsDataCenterCore2025,
+        petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64::FILENAME,
+        petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64::SIZE,
     ),
     KnownVhdMeta::new(
         KnownVhd::FreeBsd13_2,

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -393,6 +393,15 @@ fn parse_vhd(input: ParseStream<'_>, generation: Generation) -> syn::Result<Imag
                 ::petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64
             )),
         },
+        "windows_datacenter_core_2025_x64" => match generation {
+            Generation::Gen1 => Err(Error::new(
+                word.span(),
+                "Windows Server 2025 is not available for PCAT",
+            )),
+            Generation::Gen2 => Ok(image_info!(
+                ::petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64
+            )),
+        },
         "ubuntu_2204_server_x64" => Ok(image_info!(
             ::petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2204_SERVER_X64
         )),

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -25,18 +25,18 @@ async fn frontpage(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    openvmm_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
-    openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_pcat_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    hyperv_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    hyperv_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_uefi_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
-    hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64))
+    hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64))
 )]
 async fn boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     let (vm, agent) = config.run().await?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -4,7 +4,6 @@
 //! Integration tests that run on more than one architecture.
 
 use petri::PetriVmConfig;
-use petri::ShutdownKind;
 use petri::openvmm::PetriVmConfigOpenVmm;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
@@ -43,24 +42,6 @@ async fn frontpage(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 async fn boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     let (vm, agent) = config.run().await?;
     agent.power_off().await?;
-    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
-    Ok(())
-}
-
-/// Basic boot test without agent
-#[vmm_test(
-    openvmm_pcat_x64(vhd(freebsd_13_2_x64)),
-    openvmm_pcat_x64(iso(freebsd_13_2_x64)),
-    openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
-    openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
-    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
-    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
-    hyperv_openhcl_uefi_aarch64[vbs](vhd(ubuntu_2404_server_aarch64))
-)]
-async fn boot_no_agent(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
-    let mut vm = config.run_without_agent().await?;
-    vm.wait_for_successful_boot_event().await?;
-    vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
     Ok(())
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -18,26 +18,25 @@ async fn frontpage(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     Ok(())
 }
 
-// TODO: reorganize tests based on VMM
 /// Basic boot test.
 #[vmm_test(
     openvmm_linux_direct_x64,
     openvmm_openhcl_linux_direct_x64,
-    openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
-    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
-    openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
     openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    hyperv_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    openvmm_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
+    openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
-    hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
-    hyperv_uefi_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_pcat_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
-    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
+    hyperv_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    hyperv_uefi_x64(vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+    hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64))
 )]
 async fn boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     let (vm, agent) = config.run().await?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -4,6 +4,7 @@
 //! Integration tests that run on more than one architecture.
 
 use petri::PetriVmConfig;
+use petri::ShutdownKind;
 use petri::openvmm::PetriVmConfigOpenVmm;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
@@ -24,24 +25,42 @@ async fn frontpage(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     openvmm_linux_direct_x64,
     openvmm_openhcl_linux_direct_x64,
     openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    hyperv_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
-    hyperv_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
-    hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
-    hyperv_uefi_x64(vhd(ubuntu_2204_server_x64)),
     openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
-    hyperv_pcat_x64(vhd(ubuntu_2204_server_x64)),
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+    hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    hyperv_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    hyperv_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
+    hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
+    hyperv_uefi_x64(vhd(ubuntu_2204_server_x64)),
+    hyperv_pcat_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
 )]
 async fn boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     let (vm, agent) = config.run().await?;
     agent.power_off().await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+    Ok(())
+}
+
+/// Basic boot test without agent
+#[vmm_test(
+    openvmm_pcat_x64(vhd(freebsd_13_2_x64)),
+    openvmm_pcat_x64(iso(freebsd_13_2_x64)),
+    openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
+    openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_aarch64[vbs](vhd(ubuntu_2404_server_aarch64))
+)]
+async fn boot_no_agent(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+    let mut vm = config.run_without_agent().await?;
+    vm.wait_for_successful_boot_event().await?;
+    vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
     Ok(())
 }

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -8,6 +8,7 @@ mod openhcl_servicing;
 mod openhcl_uefi;
 
 use anyhow::Context;
+use petri::PetriVmConfig;
 use petri::ResolvedArtifact;
 use petri::SIZE_1_GB;
 use petri::ShutdownKind;
@@ -17,6 +18,24 @@ use petri_artifacts_common::tags::OsFlavor;
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_DEV_KERNEL_X64;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
+use vmm_test_macros::vmm_test;
+
+/// Basic boot test without agent
+#[vmm_test(
+    openvmm_pcat_x64(vhd(freebsd_13_2_x64)),
+    openvmm_pcat_x64(iso(freebsd_13_2_x64)),
+    openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
+    openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64))
+)]
+async fn boot_no_agent(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+    let mut vm = config.run_without_agent().await?;
+    vm.wait_for_successful_boot_event().await?;
+    vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+    Ok(())
+}
 
 /// Basic boot test with the VTL 0 alias map.
 // TODO: Remove once #912 is fixed.

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -24,10 +24,11 @@ use vmm_test_macros::vmm_test;
 #[vmm_test(
     openvmm_pcat_x64(vhd(freebsd_13_2_x64)),
     openvmm_pcat_x64(iso(freebsd_13_2_x64)),
-    openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
+    openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
-    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
-    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64))
+    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
 )]
 async fn boot_no_agent(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     let mut vm = config.run_without_agent().await?;
@@ -41,7 +42,7 @@ async fn boot_no_agent(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
 // TODO: Remove once #912 is fixed.
 #[openvmm_test(
     openhcl_linux_direct_x64,
-    openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
 async fn boot_alias_map(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
@@ -53,7 +54,7 @@ async fn boot_alias_map(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 
 /// Basic boot tests with TPM enabled.
 #[openvmm_test(
-    openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
 async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
@@ -144,8 +145,8 @@ async fn vbs_boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 #[openvmm_test(
     linux_direct_x64,
     openhcl_linux_direct_x64,
-    // openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    // uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    // openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    // uefi_x64(vhd(windows_datacenter_core_2025_x64)),
     // pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     // openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     // uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -261,8 +262,8 @@ async fn five_gb(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
 #[openvmm_test(
     linux_direct_x64,
     openhcl_linux_direct_x64,
-    openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    uefi_x64(vhd(windows_datacenter_core_2025_x64)),
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
@@ -341,9 +342,9 @@ async fn vmbus_redirect(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Erro
 /// Boot with a battery and check the OS-reported capacity.
 #[openvmm_test(
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
-    openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
     uefi_x64(vhd(ubuntu_2204_server_x64)),
-    uefi_x64(vhd(windows_datacenter_core_2022_x64))
+    uefi_x64(vhd(windows_datacenter_core_2025_x64))
 )]
 async fn battery_capacity(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     let os_flavor = config.os_flavor();

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -26,8 +26,7 @@ use vmm_test_macros::vmm_test;
     openvmm_pcat_x64(iso(freebsd_13_2_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
-    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
-    hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
 )]
 async fn boot_no_agent(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -18,16 +18,6 @@ use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_DEV_KERNE
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
 
-/// Basic boot test with no agent for unsupported guests.
-#[openvmm_test(pcat_x64(vhd(freebsd_13_2_x64)), pcat_x64(iso(freebsd_13_2_x64)))]
-async fn boot_no_agent(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
-    let mut vm = config.run_without_agent().await?;
-    vm.wait_for_successful_boot_event().await?;
-    vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
-    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
-    Ok(())
-}
-
 /// Basic boot test with the VTL 0 alias map.
 // TODO: Remove once #912 is fixed.
 #[openvmm_test(
@@ -92,19 +82,6 @@ async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     };
 
     agent.power_off().await?;
-    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
-    Ok(())
-}
-
-/// Basic VBS boot test.
-#[openvmm_test(
-    openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
-    openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64))
-)]
-async fn vbs_boot(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
-    let mut vm = config.run_without_agent().await?;
-    vm.wait_for_successful_boot_event().await?;
-    vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
     Ok(())
 }

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -24,9 +24,9 @@ use vmm_test_macros::vmm_test;
 #[vmm_test(
     openvmm_pcat_x64(vhd(freebsd_13_2_x64)),
     openvmm_pcat_x64(iso(freebsd_13_2_x64)),
-    openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
+    openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
-    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
 )]
@@ -42,7 +42,7 @@ async fn boot_no_agent(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
 // TODO: Remove once #912 is fixed.
 #[openvmm_test(
     openhcl_linux_direct_x64,
-    openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
 async fn boot_alias_map(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
@@ -54,7 +54,7 @@ async fn boot_alias_map(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 
 /// Basic boot tests with TPM enabled.
 #[openvmm_test(
-    openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
 async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
@@ -145,8 +145,8 @@ async fn vbs_boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 #[openvmm_test(
     linux_direct_x64,
     openhcl_linux_direct_x64,
-    // openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
-    // uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    // openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    // uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     // openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     // uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -262,8 +262,8 @@ async fn five_gb(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
 #[openvmm_test(
     linux_direct_x64,
     openhcl_linux_direct_x64,
-    openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
-    uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
@@ -342,9 +342,9 @@ async fn vmbus_redirect(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Erro
 /// Boot with a battery and check the OS-reported capacity.
 #[openvmm_test(
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
-    openhcl_uefi_x64(vhd(windows_datacenter_core_2025_x64)),
+    openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     uefi_x64(vhd(ubuntu_2204_server_x64)),
-    uefi_x64(vhd(windows_datacenter_core_2025_x64))
+    uefi_x64(vhd(windows_datacenter_core_2022_x64))
 )]
 async fn battery_capacity(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     let os_flavor = config.os_flavor();


### PR DESCRIPTION
Adds the necessary infrastructure to support no-agent (integration component only) VBS and TDX tests on Hyper-V using Petri. Improves some error handling in Petri. Currently only works with Windows Server 2025. Further investigation is needed to get Ubuntu / other versions of Windows working. 

Also makes running CI more resilient by labeling cache items and installing cargo nextest if the cache isn't working (this is something I ran into during TDX pool bring-up).

Also changes the nextest configuration to only print failure logs at the end to make the logs more readable.