### PR TITLE
livedump: Don't include two copies of kmsg

### DIFF
--- a/openhcl/underhill_core/src/livedump.rs
+++ b/openhcl/underhill_core/src/livedump.rs
@@ -25,7 +25,10 @@ async fn livedump_core() -> anyhow::Result<()> {
         .stdin(dump_read)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
+        // Don't redirect output so we can capture it.
         .env("UNDERHILL_CRASH_NO_REDIRECT", "1")
+        // Don't include kmsg, since underhill-dump will do that.
+        .env("UNDERHILL_CRASH_NO_KMSG", "1")
         .arg(std::process::id().to_string()) // pid
         .arg(0.to_string()) // tid
         .arg(0.to_string()) // sig

--- a/openhcl/underhill_crash/src/options.rs
+++ b/openhcl/underhill_crash/src/options.rs
@@ -26,6 +26,8 @@ pub struct Options {
     pub verbose: bool,
     /// Don't redirect output
     pub no_redirect: bool,
+    /// Don't include KMSG
+    pub no_kmsg: bool,
     /// Timeout
     pub timeout: Duration,
 }
@@ -65,6 +67,9 @@ impl Options {
         let no_redirect_var = std::env::var("UNDERHILL_CRASH_NO_REDIRECT").unwrap_or_default();
         let no_redirect = no_redirect_var == "1" || no_redirect_var.eq_ignore_ascii_case("true");
 
+        let no_kmsg_var = std::env::var("UNDERHILL_CRASH_NO_KMSG").unwrap_or_default();
+        let no_kmsg = no_kmsg_var == "1" || no_kmsg_var.eq_ignore_ascii_case("true");
+
         let verbose_var = std::env::var("UNDERHILL_CRASH_VERBOSE").unwrap_or_default();
         let verbose = verbose_var == "1" || verbose_var.eq_ignore_ascii_case("true");
 
@@ -76,6 +81,7 @@ impl Options {
 
             verbose,
             no_redirect,
+            no_kmsg,
             timeout,
         }
     }

--- a/vm/devices/watchdog/watchdog_core/src/lib.rs
+++ b/vm/devices/watchdog/watchdog_core/src/lib.rs
@@ -201,7 +201,7 @@ impl WatchdogServices {
     }
 
     fn start_timer(&mut self) -> Result<(), WatchdogServiceError> {
-        let seconds = 0; // self.state.count * self.state.resolution;
+        let seconds = self.state.count * self.state.resolution;
 
         let next_tick = self
             .vmtime

--- a/vm/devices/watchdog/watchdog_core/src/lib.rs
+++ b/vm/devices/watchdog/watchdog_core/src/lib.rs
@@ -201,7 +201,7 @@ impl WatchdogServices {
     }
 
     fn start_timer(&mut self) -> Result<(), WatchdogServiceError> {
-        let seconds = self.state.count * self.state.resolution;
+        let seconds = 0; // self.state.count * self.state.resolution;
 
         let next_tick = self
             .vmtime


### PR DESCRIPTION
Both underhill-dump and underhill-crash will include a copy of kmsg in the final dump, as they weren't originally intended to be used together. Using them together works fine, but it means we have two copies of kmsg in the output. This doesn't cause any problems with reading the dump, it just wastes space. underhill-dump has the easier job here, so fix this by adding yet another option to underhill-crash.