### PR TITLE
guide: note github sign-in requirement to download artifacts

### DIFF
--- a/Guide/src/user_guide/openvmm/run.md
+++ b/Guide/src/user_guide/openvmm/run.md
@@ -24,7 +24,8 @@ download pre-built copies of the binary from
 
 Simply select a successful pipeline run (should have a Green checkbox), and
 scroll down to select an appropriate `*-openvmm` artifact for your particular
-architecture and operating system.
+architecture and operating system.  **You must be signed into GitHub in order
+to download artifacts**.
 
 **On Windows:** You must also download a copy of `lxutil.dll` from
 [`microsoft/openvmm-deps`](https://github.com/microsoft/openvmm-deps/releases/tag/Microsoft.WSL.LxUtil.10.0.26100.1-240331-1435.ge-release)


### PR DESCRIPTION
Adds a note to the "Obtaining a copy of OpenVMM > Pre-Built Binaries" section, pointing out GitHub's requirement to be signed in in order to download artifacts.

Closes #1072

