### PR TITLE
hv1_emulator: Lock overlay pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,7 +2878,6 @@ dependencies = [
  "inspect",
  "parking_lot",
  "safeatomic",
- "thiserror 2.0.12",
  "tracelimit",
  "tracing",
  "virt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,6 +2877,8 @@ dependencies = [
  "hvdef",
  "inspect",
  "parking_lot",
+ "safeatomic",
+ "thiserror 2.0.12",
  "tracelimit",
  "tracing",
  "virt",

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -856,13 +856,11 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlCall for UhHypercallHandle
 
     fn vtl_call(&mut self) {
         tracing::trace!("handling vtl call");
-        self.vp
-            .raise_vtl(
-                self.intercepted_vtl,
-                GuestVtl::Vtl1,
-                HvVtlEntryReason::VTL_CALL,
-            )
-            .unwrap();
+        self.vp.raise_vtl(
+            self.intercepted_vtl,
+            GuestVtl::Vtl1,
+            HvVtlEntryReason::VTL_CALL,
+        );
     }
 }
 
@@ -888,7 +886,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlReturn for UhHypercallHand
 
         let hv = &mut self.vp.backing.cvm_state_mut().hv[GuestVtl::Vtl1];
         if hv.synic.vina().auto_reset() {
-            hv.set_vina_asserted(false).unwrap();
+            hv.set_vina_asserted(false);
         }
 
         B::switch_vtl(self.vp, self.intercepted_vtl, GuestVtl::Vtl0);
@@ -897,9 +895,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlReturn for UhHypercallHand
         // - rewind interrupts
 
         if !fast {
-            let [rax, rcx] = self.vp.backing.cvm_state_mut().hv[GuestVtl::Vtl1]
-                .return_registers()
-                .unwrap();
+            let [rax, rcx] = self.vp.backing.cvm_state_mut().hv[GuestVtl::Vtl1].return_registers();
             let mut vp_state = self.vp.access_state(Vtl::Vtl0);
             let mut registers = vp_state.registers().unwrap();
             registers.rax = rax;
@@ -1534,7 +1530,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         // Check for VTL preemption - which ignores RFLAGS.IF
         if cvm_state.exit_vtl == GuestVtl::Vtl0 && is_interrupt_pending(self, GuestVtl::Vtl1, false)
         {
-            self.raise_vtl(GuestVtl::Vtl0, GuestVtl::Vtl1, HvVtlEntryReason::INTERRUPT)?;
+            self.raise_vtl(GuestVtl::Vtl0, GuestVtl::Vtl1, HvVtlEntryReason::INTERRUPT);
         }
 
         let mut reprocessing_required = false;
@@ -1546,9 +1542,8 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             let hv = &mut self.backing.cvm_state_mut().hv[GuestVtl::Vtl1];
             let vina = hv.synic.vina();
 
-            if vina.enabled() && !hv.vina_asserted().map_err(UhRunVpError::VpAssistPage)? {
-                hv.set_vina_asserted(true)
-                    .map_err(UhRunVpError::VpAssistPage)?;
+            if vina.enabled() && !hv.vina_asserted() {
+                hv.set_vina_asserted(true);
                 self.partition
                     .synic_interrupt(self.vp_index(), GuestVtl::Vtl1)
                     .request_interrupt(vina.vector().into(), vina.auto_eoi());
@@ -1798,12 +1793,10 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         source_vtl: GuestVtl,
         target_vtl: GuestVtl,
         entry_reason: HvVtlEntryReason,
-    ) -> Result<(), UhRunVpError> {
+    ) {
         assert!(source_vtl < target_vtl);
         B::switch_vtl(self, source_vtl, target_vtl);
-        self.backing.cvm_state_mut().hv[target_vtl]
-            .set_return_reason(entry_reason)
-            .map_err(UhRunVpError::VpAssistPage)
+        self.backing.cvm_state_mut().hv[target_vtl].set_return_reason(entry_reason);
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -442,7 +442,7 @@ pub enum UhRunVpError {
     #[error("bad guest state on VP.ENTER")]
     VmxBadGuestState,
     #[error("failed to access VP assist page")]
-    VpAssistPage(#[source] guestmem::GuestMemoryError),
+    VpAssistPage(#[source] hv1_emulator::hv::NoVpAssistPage),
     #[error("failed to read hypercall parameters")]
     HypercallParameters(#[source] guestmem::GuestMemoryError),
     #[error("failed to write hypercall result")]

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -441,8 +441,6 @@ pub enum UhRunVpError {
     UnknownVmxExit(x86defs::vmx::VmxExit),
     #[error("bad guest state on VP.ENTER")]
     VmxBadGuestState,
-    #[error("failed to access VP assist page")]
-    VpAssistPage(#[source] hv1_emulator::hv::NoVpAssistPage),
     #[error("failed to read hypercall parameters")]
     HypercallParameters(#[source] guestmem::GuestMemoryError),
     #[error("failed to write hypercall result")]

--- a/vm/hv1/hv1_emulator/Cargo.toml
+++ b/vm/hv1/hv1_emulator/Cargo.toml
@@ -19,7 +19,6 @@ inspect.workspace = true
 tracelimit.workspace = true
 parking_lot.workspace = true
 safeatomic.workspace = true
-thiserror.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
 

--- a/vm/hv1/hv1_emulator/Cargo.toml
+++ b/vm/hv1/hv1_emulator/Cargo.toml
@@ -18,8 +18,11 @@ x86defs.workspace = true
 inspect.workspace = true
 tracelimit.workspace = true
 parking_lot.workspace = true
+safeatomic.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
+
 [build-dependencies]
 build_rs_guest_arch.workspace = true
 

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -2,16 +2,12 @@
 // Licensed under the MIT License.
 
 //! Hypervisor MSR emulation.
-//!
-//! In the future, this will be extended to include virtual processor registers.
 
 use super::synic::GlobalSynic;
 use super::synic::ProcessorSynic;
+use crate::locked_page::LockedPage;
 use guestmem::GuestMemory;
-use guestmem::GuestMemoryError;
 use hv1_structs::VtlArray;
-use hvdef::HV_PAGE_SIZE;
-use hvdef::HV_PAGE_SIZE_USIZE;
 use hvdef::HV_REFERENCE_TSC_SEQUENCE_INVALID;
 use hvdef::HvRegisterVpAssistPage;
 use hvdef::HvVpVtlControl;
@@ -19,13 +15,20 @@ use hvdef::HvVtlEntryReason;
 use hvdef::Vtl;
 use inspect::Inspect;
 use parking_lot::Mutex;
+use safeatomic::AtomicSliceOps;
 use std::mem::offset_of;
 use std::sync::Arc;
+use thiserror::Error;
 use virt::x86::MsrError;
 use vm_topology::processor::VpIndex;
 use vmcore::reference_time_source::ReferenceTimeSource;
 use x86defs::cpuid::Vendor;
 use zerocopy::FromZeros;
+
+#[derive(Error, Debug)]
+#[error("no vp assist page was configured")]
+/// No VP assist page was configured for the given operation.
+pub struct NoVpAssistPage;
 
 /// The partition-wide hypervisor state.
 #[derive(Inspect)]
@@ -53,21 +56,26 @@ struct GlobalHvState {
 #[derive(Inspect)]
 struct MutableHvState {
     #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
-    hypercall: hvdef::hypercall::MsrHypercallContents,
+    hypercall_reg: hvdef::hypercall::MsrHypercallContents,
+    #[inspect(with = "|x| x.is_some()")]
+    hypercall_page: Option<LockedPage>,
     #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
     guest_os_id: hvdef::hypercall::HvGuestOsId,
     #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
-    reference_tsc: hvdef::HvRegisterReferenceTsc,
+    reference_tsc_reg: hvdef::HvRegisterReferenceTsc,
+    #[inspect(with = "|x| x.is_some()")]
+    reference_tsc_page: Option<LockedPage>,
     tsc_sequence: u32,
 }
 
 impl MutableHvState {
     fn new() -> Self {
         Self {
-            hypercall: hvdef::hypercall::MsrHypercallContents::new(),
-
+            hypercall_reg: hvdef::hypercall::MsrHypercallContents::new(),
+            hypercall_page: None,
             guest_os_id: hvdef::hypercall::HvGuestOsId::new(),
-            reference_tsc: hvdef::HvRegisterReferenceTsc::new(),
+            reference_tsc_reg: hvdef::HvRegisterReferenceTsc::new(),
+            reference_tsc_page: None,
             tsc_sequence: 0,
         }
     }
@@ -75,10 +83,21 @@ impl MutableHvState {
     fn reset(&mut self, overlay_access: &mut dyn VtlProtectHypercallOverlay) {
         overlay_access.disable_overlay();
 
-        self.hypercall = hvdef::hypercall::MsrHypercallContents::new();
-        self.guest_os_id = hvdef::hypercall::HvGuestOsId::new();
-        self.reference_tsc = hvdef::HvRegisterReferenceTsc::new();
-        self.tsc_sequence = 0;
+        let Self {
+            hypercall_reg,
+            hypercall_page,
+            guest_os_id,
+            reference_tsc_reg,
+            reference_tsc_page,
+            tsc_sequence,
+        } = self;
+
+        *hypercall_reg = hvdef::hypercall::MsrHypercallContents::new();
+        *hypercall_page = None;
+        *guest_os_id = hvdef::hypercall::HvGuestOsId::new();
+        *reference_tsc_reg = hvdef::HvRegisterReferenceTsc::new();
+        *reference_tsc_page = None;
+        *tsc_sequence = 0;
     }
 }
 
@@ -121,7 +140,8 @@ impl<const VTL_COUNT: usize> GlobalHv<VTL_COUNT> {
             partition_state: self.partition_state.clone(),
             vtl_state: self.vtl_mutable_state[vtl].clone(),
             synic: self.synic[vtl].add_vp(vp_index),
-            vp_assist_page: 0.into(),
+            vp_assist_page_reg: Default::default(),
+            vp_assist_page: None,
             guest_memory: self.guest_memory[vtl].clone(),
         }
     }
@@ -152,7 +172,9 @@ pub struct ProcessorVtlHv {
     /// The virtual processor's synic state.
     pub synic: ProcessorSynic,
     #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
-    vp_assist_page: HvRegisterVpAssistPage,
+    vp_assist_page_reg: HvRegisterVpAssistPage,
+    #[inspect(with = "|x| x.is_some()")]
+    vp_assist_page: Option<LockedPage>,
 }
 
 impl ProcessorVtlHv {
@@ -169,11 +191,13 @@ impl ProcessorVtlHv {
             vtl_state: _,
             guest_memory: _,
             synic,
+            vp_assist_page_reg,
             vp_assist_page,
         } = self;
 
         synic.reset();
-        *vp_assist_page = Default::default();
+        *vp_assist_page_reg = Default::default();
+        *vp_assist_page = None;
     }
 
     /// Emulates an MSR write for the guest OS ID MSR.
@@ -183,32 +207,33 @@ impl ProcessorVtlHv {
 
     /// Emulates an MSR write for the VP assist page MSR.
     pub fn msr_write_vp_assist_page(&mut self, v: u64) -> Result<(), MsrError> {
-        if v & !u64::from(
-            HvRegisterVpAssistPage::new()
-                .with_enabled(true)
-                .with_gpa_page_number(!0 >> 12),
-        ) != 0
-        {
+        if HvRegisterVpAssistPage::from(v).reserved() != 0 {
             return Err(MsrError::InvalidAccess);
         }
-        let vp_assist_page = HvRegisterVpAssistPage::from(v);
+        let new_vp_assist_page_reg = HvRegisterVpAssistPage::from(v);
 
-        // Clear the target page if it is being enabled or moved.
-        if vp_assist_page.enabled()
-            && (!self.vp_assist_page.enabled()
-                || vp_assist_page.gpa_page_number() != self.vp_assist_page.gpa_page_number())
+        if new_vp_assist_page_reg.enabled()
+            && (!self.vp_assist_page_reg.enabled()
+                || new_vp_assist_page_reg.gpa_page_number()
+                    != self.vp_assist_page_reg.gpa_page_number())
         {
-            let gpa = vp_assist_page.gpa_page_number() * HV_PAGE_SIZE;
-            if let Err(err) = self.guest_memory.fill_at(gpa, 0, HV_PAGE_SIZE_USIZE) {
-                tracelimit::warn_ratelimited!(
-                    gpa,
-                    error = &err as &dyn std::error::Error,
-                    "failed to clear vp assist page"
-                );
-                return Err(MsrError::InvalidAccess);
+            let new_page =
+                LockedPage::new(&self.guest_memory, new_vp_assist_page_reg.gpa_page_number())
+                    .map_err(|_| MsrError::InvalidAccess)?;
+
+            // Copy the contents of the old page, if it exists, to the new page.
+            if let Some(current_page) = self.vp_assist_page.as_ref() {
+                new_page.atomic_write_obj(&current_page.atomic_read_obj::<[u8; 4096]>());
+            } else {
+                new_page.atomic_fill(0);
             }
+
+            self.vp_assist_page = Some(new_page);
+        } else if !new_vp_assist_page_reg.enabled() {
+            self.vp_assist_page = None;
         }
-        self.vp_assist_page = vp_assist_page;
+
+        self.vp_assist_page_reg = new_vp_assist_page_reg;
         Ok(())
     }
 
@@ -225,7 +250,7 @@ impl ProcessorVtlHv {
             }
             hvdef::HV_X64_MSR_HYPERCALL => {
                 let mut mutable = self.vtl_state.lock();
-                if mutable.hypercall.locked() {
+                if mutable.hypercall_reg.locked() {
                     return Err(MsrError::InvalidAccess);
                 }
                 let hc = hvdef::hypercall::MsrHypercallContents::from(v);
@@ -233,23 +258,18 @@ impl ProcessorVtlHv {
                     return Err(MsrError::InvalidAccess);
                 }
                 if hc.enable()
-                    && (!mutable.hypercall.enable() || hc.gpn() != mutable.hypercall.gpn())
+                    && (!mutable.hypercall_reg.enable() || hc.gpn() != mutable.hypercall_reg.gpn())
                 {
-                    let gpa = hc.gpn() * HV_PAGE_SIZE;
-                    if let Err(err) = self.write_hypercall_page(gpa) {
-                        tracelimit::warn_ratelimited!(
-                            gpa,
-                            error = &err as &dyn std::error::Error,
-                            "failed to write hypercall page"
-                        );
-                        return Err(MsrError::InvalidAccess);
-                    }
-
+                    let new_page = LockedPage::new(&self.guest_memory, hc.gpn())
+                        .map_err(|_| MsrError::InvalidAccess)?;
+                    self.write_hypercall_page(&new_page);
                     overlay_access.change_overlay(hc.gpn());
+                    mutable.hypercall_page = Some(new_page);
                 } else if !hc.enable() {
                     overlay_access.disable_overlay();
+                    mutable.hypercall_page = None;
                 }
-                mutable.hypercall = hc;
+                mutable.hypercall_reg = hc;
             }
             hvdef::HV_X64_MSR_VP_INDEX => return Err(MsrError::InvalidAccess),
             hvdef::HV_X64_MSR_TIME_REF_COUNT => return Err(MsrError::InvalidAccess),
@@ -259,50 +279,33 @@ impl ProcessorVtlHv {
                 if v.reserved_p() != 0 {
                     return Err(MsrError::InvalidAccess);
                 }
-                if v.enable() && mutable.reference_tsc.gpn() != v.gpn() {
-                    let gm = &self.guest_memory;
-                    let gpa = v.gpn() * HV_PAGE_SIZE;
-                    if let Err(err) = gm.write_plain(gpa, &HV_REFERENCE_TSC_SEQUENCE_INVALID) {
-                        tracelimit::warn_ratelimited!(
-                            gpa,
-                            error = &err as &dyn std::error::Error,
-                            "failed to write reference tsc page"
-                        );
-                        return Err(MsrError::InvalidAccess);
-                    }
+                if v.enable() && mutable.reference_tsc_reg.gpn() != v.gpn() {
+                    let new_page = LockedPage::new(&self.guest_memory, v.gpn())
+                        .map_err(|_| MsrError::InvalidAccess)?;
+                    new_page[0..4].atomic_write_obj(&HV_REFERENCE_TSC_SEQUENCE_INVALID);
+
                     if self.partition_state.is_ref_time_backed_by_tsc {
                         // TDX TODO: offset might need to be included
                         let tsc_scale = (((10_000_000_u128) << 64)
                             / self.partition_state.tsc_frequency as u128)
                             as u64;
-                        let reference_page = hvdef::HvReferenceTscPage {
-                            tsc_scale,
-                            ..FromZeros::new_zeroed()
-                        };
-                        if let Err(err) = gm.write_plain(gpa, &reference_page) {
-                            tracelimit::warn_ratelimited!(
-                                gpa,
-                                error = &err as &dyn std::error::Error,
-                                "failed to write reference tsc page"
-                            );
-                            return Err(MsrError::InvalidAccess);
-                        }
                         mutable.tsc_sequence = mutable.tsc_sequence.wrapping_add(1);
                         if mutable.tsc_sequence == HV_REFERENCE_TSC_SEQUENCE_INVALID {
                             mutable.tsc_sequence = mutable.tsc_sequence.wrapping_add(1);
                         }
-                        if let Err(err) = gm.write_plain(gpa, &mutable.tsc_sequence) {
-                            tracelimit::warn_ratelimited!(
-                                gpa,
-                                error = &err as &dyn std::error::Error,
-                                "failed to write reference tsc page"
-                            );
-                            return Err(MsrError::InvalidAccess);
-                        }
+                        let reference_page = hvdef::HvReferenceTscPage {
+                            tsc_sequence: mutable.tsc_sequence,
+                            tsc_scale,
+                            ..FromZeros::new_zeroed()
+                        };
+                        new_page.atomic_write_obj(&reference_page);
+                        mutable.reference_tsc_page = Some(new_page);
                     }
+                } else if !v.enable() {
+                    mutable.reference_tsc_page = None;
                 }
 
-                mutable.reference_tsc = v;
+                mutable.reference_tsc_reg = v;
             }
             hvdef::HV_X64_MSR_TSC_FREQUENCY => return Err(MsrError::InvalidAccess),
             hvdef::HV_X64_MSR_VP_ASSIST_PAGE => self.msr_write_vp_assist_page(v)?,
@@ -314,7 +317,11 @@ impl ProcessorVtlHv {
         Ok(())
     }
 
-    fn write_hypercall_page(&self, gpa: u64) -> Result<(), GuestMemoryError> {
+    fn write_hypercall_page(&self, page: &LockedPage) {
+        // Fill the page with int3 to catch invalid jumps into the page.
+        let int3 = 0xcc;
+        page.atomic_fill(int3);
+
         let page_contents: &[u8] = if self.partition_state.vendor.is_amd_compatible() {
             &AMD_HYPERCALL_PAGE.page
         } else if self.partition_state.vendor.is_intel_compatible() {
@@ -323,17 +330,7 @@ impl ProcessorVtlHv {
             unreachable!()
         };
 
-        self.guest_memory.write_at(gpa, page_contents)?;
-
-        // Fill the rest with int3 to catch invalid jumps into the page.
-        let int3 = 0xcc;
-        self.guest_memory.fill_at(
-            gpa + page_contents.len() as u64,
-            int3,
-            HV_PAGE_SIZE_USIZE - page_contents.len(),
-        )?;
-
-        Ok(())
+        page[..page_contents.len()].atomic_write(page_contents);
     }
 
     /// Gets the VSM code page offset register that corresponds to the hypercall
@@ -358,12 +355,12 @@ impl ProcessorVtlHv {
     pub fn msr_read(&self, msr: u32) -> Result<u64, MsrError> {
         let v = match msr {
             hvdef::HV_X64_MSR_GUEST_OS_ID => self.vtl_state.lock().guest_os_id.into(),
-            hvdef::HV_X64_MSR_HYPERCALL => self.vtl_state.lock().hypercall.into(),
+            hvdef::HV_X64_MSR_HYPERCALL => self.vtl_state.lock().hypercall_reg.into(),
             hvdef::HV_X64_MSR_VP_INDEX => self.vp_index.index() as u64, // VP index
             hvdef::HV_X64_MSR_TIME_REF_COUNT => self.partition_state.ref_time.now_100ns(),
-            hvdef::HV_X64_MSR_REFERENCE_TSC => self.vtl_state.lock().reference_tsc.into(),
+            hvdef::HV_X64_MSR_REFERENCE_TSC => self.vtl_state.lock().reference_tsc_reg.into(),
             hvdef::HV_X64_MSR_TSC_FREQUENCY => self.partition_state.tsc_frequency,
-            hvdef::HV_X64_MSR_VP_ASSIST_PAGE => self.vp_assist_page.into(),
+            hvdef::HV_X64_MSR_VP_ASSIST_PAGE => self.vp_assist_page_reg.into(),
             msr @ hvdef::HV_X64_MSR_SCONTROL..=hvdef::HV_X64_MSR_STIMER3_COUNT => {
                 self.synic.read_msr(msr)?
             }
@@ -376,7 +373,7 @@ impl ProcessorVtlHv {
 
     /// Returns the current value of the VP assist page register.
     pub fn vp_assist_page(&self) -> u64 {
-        self.vp_assist_page.into()
+        self.vp_assist_page_reg.into()
     }
 
     /// Sets the lazy EOI bit in the VP assist page.
@@ -385,25 +382,13 @@ impl ProcessorVtlHv {
     /// next VP exit but before manipulating the APIC.
     #[must_use]
     pub fn set_lazy_eoi(&mut self) -> bool {
-        if !self.vp_assist_page.enabled() {
+        let Some(page) = self.vp_assist_page.as_mut() else {
             return false;
-        }
-
-        let gpa = self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE
-            + offset_of!(hvdef::HvVpAssistPage, apic_assist) as u64;
-
+        };
+        let offset = offset_of!(hvdef::HvVpAssistPage, apic_assist);
         let v = 1u32;
-
-        match self.guest_memory.write_plain(gpa, &v) {
-            Ok(()) => true,
-            Err(err) => {
-                tracelimit::warn_ratelimited!(
-                    error = &err as &dyn std::error::Error,
-                    "failed to write lazy eoi to assist page"
-                );
-                false
-            }
-        }
+        page[offset..offset + 4].atomic_write_obj(&v);
+        true
     }
 
     /// Clears the lazy EOI bit in the VP assist page.
@@ -414,19 +399,11 @@ impl ProcessorVtlHv {
     /// EOI to the APIC.
     #[must_use]
     pub fn clear_lazy_eoi(&mut self) -> bool {
-        let gpa = self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE
-            + offset_of!(hvdef::HvVpAssistPage, apic_assist) as u64;
-
-        let v: u32 = match self.guest_memory.read_plain(gpa) {
-            Ok(v) => v,
-            Err(err) => {
-                tracelimit::warn_ratelimited!(
-                    error = &err as &dyn std::error::Error,
-                    "failed to read lazy eoi from assist page"
-                );
-                return false;
-            }
+        let Some(page) = self.vp_assist_page.as_mut() else {
+            return false;
         };
+        let offset = offset_of!(hvdef::HvVpAssistPage, apic_assist);
+        let v: u32 = page[offset..offset + 4].atomic_read_obj();
 
         if v & 1 == 0 {
             // The guest cleared the bit. The caller will perform the EOI to the
@@ -436,50 +413,51 @@ impl ProcessorVtlHv {
             // Clear the bit in case the EOI state changes before the guest runs
             // again.
             let v = v & !1;
-            if let Err(err) = self.guest_memory.write_plain(gpa, &v) {
-                tracelimit::warn_ratelimited!(
-                    error = &err as &dyn std::error::Error,
-                    "failed to clear lazy eoi from assist page"
-                );
-            }
+            page[offset..offset + 4].atomic_write_obj(&v);
             false
         }
     }
 
     /// Get the register values to restore on vtl return
-    pub fn return_registers(&self) -> Result<[u64; 2], GuestMemoryError> {
-        let gpa = (self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE)
-            + offset_of!(hvdef::HvVpAssistPage, vtl_control) as u64
-            + offset_of!(HvVpVtlControl, registers) as u64;
-
-        self.guest_memory.read_plain(gpa)
+    pub fn return_registers(&self) -> Result<[u64; 2], NoVpAssistPage> {
+        let Some(page) = self.vp_assist_page.as_ref() else {
+            return Err(NoVpAssistPage);
+        };
+        let offset =
+            offset_of!(hvdef::HvVpAssistPage, vtl_control) + offset_of!(HvVpVtlControl, registers);
+        Ok(page[offset..offset + 16].atomic_read_obj())
     }
 
     /// Set the reason for the vtl return into the vp assist page
-    pub fn set_return_reason(&self, reason: HvVtlEntryReason) -> Result<(), GuestMemoryError> {
-        let gpa = (self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE)
-            + offset_of!(hvdef::HvVpAssistPage, vtl_control) as u64
-            + offset_of!(HvVpVtlControl, entry_reason) as u64;
-
-        self.guest_memory.write_plain(gpa, &(reason.0))
+    pub fn set_return_reason(&mut self, reason: HvVtlEntryReason) -> Result<(), NoVpAssistPage> {
+        let Some(page) = self.vp_assist_page.as_mut() else {
+            return Err(NoVpAssistPage);
+        };
+        let offset = offset_of!(hvdef::HvVpAssistPage, vtl_control)
+            + offset_of!(HvVpVtlControl, entry_reason);
+        page[offset..offset + 4].atomic_write_obj(&reason);
+        Ok(())
     }
 
     /// Gets whether VINA is currently asserted.
-    pub fn vina_asserted(&self) -> Result<bool, GuestMemoryError> {
-        let gpa = (self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE)
-            + offset_of!(hvdef::HvVpAssistPage, vtl_control) as u64
-            + offset_of!(HvVpVtlControl, vina_status) as u64;
-
-        self.guest_memory.read_plain(gpa).map(|v: u8| v != 0)
+    pub fn vina_asserted(&self) -> Result<bool, NoVpAssistPage> {
+        let Some(page) = self.vp_assist_page.as_ref() else {
+            return Err(NoVpAssistPage);
+        };
+        let offset = offset_of!(hvdef::HvVpAssistPage, vtl_control)
+            + offset_of!(HvVpVtlControl, vina_status);
+        Ok(page[offset..offset + 1].atomic_read_obj::<u8>() != 0)
     }
 
     /// Sets whether VINA is currently asserted.
-    pub fn set_vina_asserted(&self, value: bool) -> Result<(), GuestMemoryError> {
-        let gpa = (self.vp_assist_page.gpa_page_number() * HV_PAGE_SIZE)
-            + offset_of!(hvdef::HvVpAssistPage, vtl_control) as u64
-            + offset_of!(HvVpVtlControl, vina_status) as u64;
-
-        self.guest_memory.write_plain(gpa, &(value as u8))
+    pub fn set_vina_asserted(&mut self, value: bool) -> Result<(), NoVpAssistPage> {
+        let Some(page) = self.vp_assist_page.as_mut() else {
+            return Err(NoVpAssistPage);
+        };
+        let offset = offset_of!(hvdef::HvVpAssistPage, vtl_control)
+            + offset_of!(HvVpVtlControl, vina_status);
+        page[offset..offset + 1].atomic_write_obj(&(value as u8));
+        Ok(())
     }
 }
 

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -225,7 +225,12 @@ impl ProcessorVtlHv {
 
     /// Emulates an MSR write for the VP assist page MSR.
     pub fn msr_write_vp_assist_page(&mut self, v: u64) -> Result<(), MsrError> {
-        if HvRegisterVpAssistPage::from(v).reserved() != 0 {
+        if v & !u64::from(
+            HvRegisterVpAssistPage::new()
+                .with_enabled(true)
+                .with_gpa_page_number(!0 >> 12),
+        ) != 0
+        {
             return Err(MsrError::InvalidAccess);
         }
         let new_vp_assist_page_reg = HvRegisterVpAssistPage::from(v);

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -19,6 +19,7 @@ use safeatomic::AtomicSliceOps;
 use std::mem::offset_of;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
 use virt::x86::MsrError;
 use vm_topology::processor::VpIndex;
 use vmcore::reference_time_source::ReferenceTimeSource;
@@ -456,14 +457,14 @@ impl ProcessorVtlHv {
     pub fn vina_asserted(&self) -> bool {
         let offset = offset_of!(hvdef::HvVpAssistPage, vtl_control)
             + offset_of!(HvVpVtlControl, vina_status);
-        self.vp_assist_page[offset..offset + 1].atomic_read_obj::<u8>() != 0
+        self.vp_assist_page[offset].load(Ordering::Relaxed) != 0
     }
 
     /// Sets whether VINA is currently asserted.
     pub fn set_vina_asserted(&mut self, value: bool) {
         let offset = offset_of!(hvdef::HvVpAssistPage, vtl_control)
             + offset_of!(HvVpVtlControl, vina_status);
-        self.vp_assist_page[offset..offset + 1].atomic_write_obj(&(value as u8));
+        self.vp_assist_page[offset].store(value as u8, Ordering::Relaxed);
     }
 }
 

--- a/vm/hv1/hv1_emulator/src/lib.rs
+++ b/vm/hv1/hv1_emulator/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod cpuid;
 pub mod hv;
 pub mod hypercall;
+mod locked_page;
 pub mod message_queues;
 pub mod synic;
 pub mod x86;

--- a/vm/hv1/hv1_emulator/src/locked_page.rs
+++ b/vm/hv1/hv1_emulator/src/locked_page.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use guestmem::GuestMemory;
+use guestmem::LockedPages;
+use guestmem::Page;
+use std::ops::Deref;
+
+pub(crate) struct LockedPage {
+    page: LockedPages,
+}
+
+impl LockedPage {
+    pub fn new(guest_memory: &GuestMemory, gpn: u64) -> Result<Self, guestmem::GuestMemoryError> {
+        let page = guest_memory.lock_gpns(false, &[gpn])?;
+        assert!(page.pages().len() == 1);
+        Ok(Self { page })
+    }
+}
+
+impl Deref for LockedPage {
+    type Target = Page;
+
+    fn deref(&self) -> &Self::Target {
+        self.page.pages()[0]
+    }
+}

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -3611,7 +3611,7 @@ impl MessagePayload for HvX64VmgexitInterceptMessage {}
 pub struct HvRegisterVpAssistPage {
     pub enabled: bool,
     #[bits(11)]
-    _reserved: u64,
+    pub reserved: u64,
     #[bits(52)]
     pub gpa_page_number: u64,
 }

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -3611,7 +3611,7 @@ impl MessagePayload for HvX64VmgexitInterceptMessage {}
 pub struct HvRegisterVpAssistPage {
     pub enabled: bool,
     #[bits(11)]
-    pub reserved: u64,
+    _reserved: u64,
     #[bits(52)]
     pub gpa_page_number: u64,
 }


### PR DESCRIPTION
By locking the pages we are configured for we can guarantee there will be no errors reading or writing to the page. This makes the code shorter and easier to read.

If we like this approach I'll keep going with the rest of hv1_emulator, just wanted to get this out for initial impressions.