### PR TITLE
flowey: download artifacts in parallel

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -2808,42 +2808,12 @@ jobs:
     - job9
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼🥾 Download bootstrapped flowey
+    - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: _internal-flowey-bootstrap-x86_64-windows-uid-10
-        path: ${{ runner.temp }}/bootstrapped-flowey
-    - name: 🌼📦 Download x64-guest_test_uefi
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/used_artifacts/x64-guest_test_uefi/
-    - name: 🌼📦 Download x64-linux-musl-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-musl-pipette/
-    - name: 🌼📦 Download x64-openhcl-igvm
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/used_artifacts/x64-openhcl-igvm/
-    - name: 🌼📦 Download x64-windows-openvmm
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-openvmm
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-openvmm/
-    - name: 🌼📦 Download x64-windows-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-pipette/
-    - name: 🌼📦 Download x64-windows-vmm-tests-archive
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-vmm-tests-archive/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-10,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -2852,7 +2822,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10/flowey.exe
 
         echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
@@ -3085,42 +3055,12 @@ jobs:
     - job9
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼🥾 Download bootstrapped flowey
+    - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: _internal-flowey-bootstrap-x86_64-windows-uid-10
-        path: ${{ runner.temp }}/bootstrapped-flowey
-    - name: 🌼📦 Download x64-guest_test_uefi
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/used_artifacts/x64-guest_test_uefi/
-    - name: 🌼📦 Download x64-linux-musl-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-musl-pipette/
-    - name: 🌼📦 Download x64-openhcl-igvm
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/used_artifacts/x64-openhcl-igvm/
-    - name: 🌼📦 Download x64-windows-openvmm
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-openvmm
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-openvmm/
-    - name: 🌼📦 Download x64-windows-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-pipette/
-    - name: 🌼📦 Download x64-windows-vmm-tests-archive
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-vmm-tests-archive/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-10,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -3129,7 +3069,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10/flowey.exe
 
         echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
@@ -3545,37 +3485,12 @@ jobs:
     - job11
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼🥾 Download bootstrapped flowey
+    - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-6
-        path: ${{ runner.temp }}/bootstrapped-flowey
-    - name: 🌼📦 Download x64-guest_test_uefi
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/used_artifacts/x64-guest_test_uefi/
-    - name: 🌼📦 Download x64-linux-musl-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-musl-pipette/
-    - name: 🌼📦 Download x64-linux-openvmm
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-openvmm/
-    - name: 🌼📦 Download x64-linux-vmm-tests-archive
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-vmm-tests-archive/
-    - name: 🌼📦 Download x64-windows-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-pipette/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-openvmm,x64-linux-vmm-tests-archive,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-6" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -3584,7 +3499,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-6/flowey
 
         echo '"debug"' | flowey v 20 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
@@ -3860,36 +3775,11 @@ jobs:
         mv target/aarch64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
       working-directory: flowey_bootstrap
       shell: bash
-    - name: 🌼📦 Download aarch64-guest_test_uefi
+    - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: aarch64-guest_test_uefi
-        path: ${{ runner.temp }}/used_artifacts/aarch64-guest_test_uefi/
-    - name: 🌼📦 Download aarch64-linux-musl-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/used_artifacts/aarch64-linux-musl-pipette/
-    - name: 🌼📦 Download aarch64-openhcl-igvm
-      uses: actions/download-artifact@v4
-      with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/used_artifacts/aarch64-openhcl-igvm/
-    - name: 🌼📦 Download aarch64-windows-openvmm
-      uses: actions/download-artifact@v4
-      with:
-        name: aarch64-windows-openvmm
-        path: ${{ runner.temp }}/used_artifacts/aarch64-windows-openvmm/
-    - name: 🌼📦 Download aarch64-windows-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: aarch64-windows-pipette
-        path: ${{ runner.temp }}/used_artifacts/aarch64-windows-pipette/
-    - name: 🌼📦 Download aarch64-windows-vmm-tests-archive
-      uses: actions/download-artifact@v4
-      with:
-        name: aarch64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/used_artifacts/aarch64-windows-vmm-tests-archive/
+        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-openhcl-igvm,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
@@ -4246,27 +4136,12 @@ jobs:
     - job0
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼🥾 Download bootstrapped flowey
+    - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-17
-        path: ${{ runner.temp }}/bootstrapped-flowey
-    - name: 🌼📦 Download guide
-      uses: actions/download-artifact@v4
-      with:
-        name: guide
-        path: ${{ runner.temp }}/used_artifacts/guide/
-    - name: 🌼📦 Download x64-linux-rustdoc
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-rustdoc
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-rustdoc/
-    - name: 🌼📦 Download x64-windows-rustdoc
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-rustdoc
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-rustdoc/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-17,guide,x64-linux-rustdoc,x64-windows-rustdoc}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-17" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -4275,7 +4150,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-17/flowey
 
         echo '"debug"' | flowey v 3 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 3 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -2702,42 +2702,12 @@ jobs:
     - job8
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼🥾 Download bootstrapped flowey
+    - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: _internal-flowey-bootstrap-x86_64-windows-uid-11
-        path: ${{ runner.temp }}/bootstrapped-flowey
-    - name: 🌼📦 Download x64-guest_test_uefi
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/used_artifacts/x64-guest_test_uefi/
-    - name: 🌼📦 Download x64-linux-musl-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-musl-pipette/
-    - name: 🌼📦 Download x64-openhcl-igvm
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/used_artifacts/x64-openhcl-igvm/
-    - name: 🌼📦 Download x64-windows-openvmm
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-openvmm
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-openvmm/
-    - name: 🌼📦 Download x64-windows-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-pipette/
-    - name: 🌼📦 Download x64-windows-vmm-tests-archive
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-vmm-tests-archive/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -2746,7 +2716,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11/flowey.exe
 
         echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
@@ -2979,42 +2949,12 @@ jobs:
     - job8
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼🥾 Download bootstrapped flowey
+    - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: _internal-flowey-bootstrap-x86_64-windows-uid-11
-        path: ${{ runner.temp }}/bootstrapped-flowey
-    - name: 🌼📦 Download x64-guest_test_uefi
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/used_artifacts/x64-guest_test_uefi/
-    - name: 🌼📦 Download x64-linux-musl-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-musl-pipette/
-    - name: 🌼📦 Download x64-openhcl-igvm
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-openhcl-igvm
-        path: ${{ runner.temp }}/used_artifacts/x64-openhcl-igvm/
-    - name: 🌼📦 Download x64-windows-openvmm
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-openvmm
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-openvmm/
-    - name: 🌼📦 Download x64-windows-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-pipette/
-    - name: 🌼📦 Download x64-windows-vmm-tests-archive
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-vmm-tests-archive/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -3023,7 +2963,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11/flowey.exe
 
         echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
@@ -3431,37 +3371,12 @@ jobs:
     - job10
     if: github.event.pull_request.draft == false
     steps:
-    - name: 🌼🥾 Download bootstrapped flowey
+    - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-7
-        path: ${{ runner.temp }}/bootstrapped-flowey
-    - name: 🌼📦 Download x64-guest_test_uefi
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-guest_test_uefi
-        path: ${{ runner.temp }}/used_artifacts/x64-guest_test_uefi/
-    - name: 🌼📦 Download x64-linux-musl-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-musl-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-musl-pipette/
-    - name: 🌼📦 Download x64-linux-openvmm
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-openvmm
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-openvmm/
-    - name: 🌼📦 Download x64-linux-vmm-tests-archive
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-linux-vmm-tests-archive
-        path: ${{ runner.temp }}/used_artifacts/x64-linux-vmm-tests-archive/
-    - name: 🌼📦 Download x64-windows-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: x64-windows-pipette
-        path: ${{ runner.temp }}/used_artifacts/x64-windows-pipette/
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-7,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-openvmm,x64-linux-vmm-tests-archive,x64-windows-pipette}'
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-7" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -3470,7 +3385,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-7/flowey
 
         echo '"debug"' | flowey v 20 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
@@ -3746,36 +3661,11 @@ jobs:
         mv target/aarch64-pc-windows-msvc/flowey-ci/flowey_hvlite.exe "$OutDirNormal/flowey.exe"
       working-directory: flowey_bootstrap
       shell: bash
-    - name: 🌼📦 Download aarch64-guest_test_uefi
+    - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: aarch64-guest_test_uefi
-        path: ${{ runner.temp }}/used_artifacts/aarch64-guest_test_uefi/
-    - name: 🌼📦 Download aarch64-linux-musl-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: aarch64-linux-musl-pipette
-        path: ${{ runner.temp }}/used_artifacts/aarch64-linux-musl-pipette/
-    - name: 🌼📦 Download aarch64-openhcl-igvm
-      uses: actions/download-artifact@v4
-      with:
-        name: aarch64-openhcl-igvm
-        path: ${{ runner.temp }}/used_artifacts/aarch64-openhcl-igvm/
-    - name: 🌼📦 Download aarch64-windows-openvmm
-      uses: actions/download-artifact@v4
-      with:
-        name: aarch64-windows-openvmm
-        path: ${{ runner.temp }}/used_artifacts/aarch64-windows-openvmm/
-    - name: 🌼📦 Download aarch64-windows-pipette
-      uses: actions/download-artifact@v4
-      with:
-        name: aarch64-windows-pipette
-        path: ${{ runner.temp }}/used_artifacts/aarch64-windows-pipette/
-    - name: 🌼📦 Download aarch64-windows-vmm-tests-archive
-      uses: actions/download-artifact@v4
-      with:
-        name: aarch64-windows-vmm-tests-archive
-        path: ${{ runner.temp }}/used_artifacts/aarch64-windows-vmm-tests-archive/
+        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-openhcl-igvm,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-vmm-tests-archive}'
+        path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
@@ -4153,12 +4043,12 @@ jobs:
     env:
       ANY_JOBS_FAILED: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
     steps:
-    - name: 🌼🥾 Download bootstrapped flowey
+    - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: _internal-flowey-bootstrap-x86_64-linux-uid-7
-        path: ${{ runner.temp }}/bootstrapped-flowey
-    - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
+        pattern: _internal-flowey-bootstrap-x86_64-linux-uid-7
+        path: ${{ runner.temp }}/used_artifacts/
+    - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-7" >> $GITHUB_PATH
       shell: bash
       name: 🌼📦 Add flowey to PATH
     - name: 🌼🛫 Initialize job
@@ -4167,7 +4057,7 @@ jobs:
         AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
         echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-        chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
+        chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-7/flowey
 
         echo '"debug"' | flowey v 23 'FLOWEY_LOG' --update-from-stdin
         echo "${{ runner.temp }}/work" | flowey v 23 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -125,82 +125,74 @@ pub fn github_yaml(
 
         let flowey_source = job_flowey_source.remove(&job_idx).unwrap();
 
-        // actual artifact publish happens at the end of the job
-        if let FloweySource::Bootstrap(_artifact, _publish) = &flowey_source {
-            if gh_bootstrap_template.is_empty() {
-                anyhow::bail!(
-                    "Did not specify flowey bootstrap template. Please provide one using `Pipeline::gh_set_flowey_bootstrap_template`"
-                )
+        let mut artifact_names = Vec::new();
+
+        let flowey_path = match &flowey_source {
+            FloweySource::Bootstrap { .. } => {
+                let flowey_path = "bootstrapped-flowey".to_string();
+
+                // actual artifact publish happens at the end of the job
+                if gh_bootstrap_template.is_empty() {
+                    anyhow::bail!(
+                        "Did not specify flowey bootstrap template. Please provide one using `Pipeline::gh_set_flowey_bootstrap_template`"
+                    )
+                }
+
+                let gh_bootstrap_template = gh_bootstrap_template
+                    .replace("{{FLOWEY_BIN_EXTENSION}}", platform.exe_suffix())
+                    .replace("{{FLOWEY_CRATE}}", flowey_crate)
+                    .replace(
+                        "{{FLOWEY_PIPELINE_PATH}}",
+                        &pipeline_file.with_extension("").display().to_string(),
+                    )
+                    .replace(
+                        "{{FLOWEY_TARGET}}",
+                        match (platform, arch) {
+                            (FlowPlatform::Windows, FlowArch::X86_64) => "x86_64-pc-windows-msvc",
+                            (FlowPlatform::Windows, FlowArch::Aarch64) => "aarch64-pc-windows-msvc",
+                            (FlowPlatform::Linux(_), FlowArch::X86_64) => {
+                                "x86_64-unknown-linux-gnu"
+                            }
+                            (FlowPlatform::Linux(_), FlowArch::Aarch64) => {
+                                "aarch64-unknown-linux-gnu"
+                            }
+                            (platform, arch) => {
+                                anyhow::bail!("unsupported platform {platform} / arch {arch}")
+                            }
+                        },
+                    )
+                    .replace("{{FLOWEY_OUTDIR}}", &format!("{RUNNER_TEMP}/{flowey_path}"));
+
+                let bootstrap_steps: serde_yaml::Sequence =
+                    serde_yaml::from_str(&gh_bootstrap_template)
+                        .context("malformed flowey bootstrap template")?;
+
+                gh_steps.extend(bootstrap_steps);
+                flowey_path
             }
+            FloweySource::Consume(artifact) => {
+                // download previously bootstrapped flowey
+                artifact_names.push(artifact.as_str());
+                format!("used_artifacts/{artifact}")
+            }
+        };
 
-            let gh_bootstrap_template = gh_bootstrap_template
-                .replace("{{FLOWEY_BIN_EXTENSION}}", platform.exe_suffix())
-                .replace("{{FLOWEY_CRATE}}", flowey_crate)
-                .replace(
-                    "{{FLOWEY_PIPELINE_PATH}}",
-                    &pipeline_file.with_extension("").display().to_string(),
-                )
-                .replace(
-                    "{{FLOWEY_TARGET}}",
-                    match (platform, arch) {
-                        (FlowPlatform::Windows, FlowArch::X86_64) => "x86_64-pc-windows-msvc",
-                        (FlowPlatform::Windows, FlowArch::Aarch64) => "aarch64-pc-windows-msvc",
-                        (FlowPlatform::Linux(_), FlowArch::X86_64) => "x86_64-unknown-linux-gnu",
-                        (FlowPlatform::Linux(_), FlowArch::Aarch64) => "aarch64-unknown-linux-gnu",
-                        (platform, arch) => {
-                            anyhow::bail!("unsupported platform {platform} / arch {arch}")
-                        }
-                    },
-                )
-                .replace(
-                    "{{FLOWEY_OUTDIR}}",
-                    &format!("{RUNNER_TEMP}/bootstrapped-flowey"),
-                );
-
-            let bootstrap_steps: serde_yaml::Sequence =
-                serde_yaml::from_str(&gh_bootstrap_template)
-                    .context("malformed flowey bootstrap template")?;
-
-            gh_steps.extend(bootstrap_steps);
-        }
-
-        // the first few steps in any job are some "artisan" code, which
-        // downloads the previously bootstrapped flowey artifact and set up
-        // various vars that flowey will then rely on throughout the rest
-        // of the job
-
-        // download previously bootstrapped flowey
-        if let FloweySource::Consume(artifact) = &flowey_source {
+        // download any artifacts that'll be used
+        artifact_names.extend(artifacts_used.iter().map(|a| a.name.as_str()));
+        if !artifact_names.is_empty() {
+            let pattern = if let &[name] = artifact_names.as_slice() {
+                name.to_string()
+            } else {
+                format!("{{{}}}", artifact_names.join(","))
+            };
             gh_steps.push({
                 let map: serde_yaml::Mapping = serde_yaml::from_str(&format!(
                     r#"
-                        name: 🌼🥾 Download bootstrapped flowey
+                        name: '🌼📦 Download artifacts'
                         uses: actions/download-artifact@v4
                         with:
-                          name: {artifact}
-                          path: {RUNNER_TEMP}/bootstrapped-flowey
-                    "#
-                ))?;
-                map.into()
-            });
-        }
-
-        // also download any artifacts that'll be used
-        // TODO: Use a single download job to download all artifacts at once
-        // https://github.com/actions/download-artifact?tab=readme-ov-file#download-multiple-filtered-artifacts-to-the-same-directory
-        for ResolvedJobArtifact {
-            flowey_var: _,
-            name,
-        } in artifacts_used
-        {
-            gh_steps.push({
-                let map: serde_yaml::Mapping = serde_yaml::from_str(&format!(
-                    r#"
-                        name: '🌼📦 Download {name}'
-                        uses: actions/download-artifact@v4
-                        with:
-                          name: {name}
-                          path: {RUNNER_TEMP}/used_artifacts/{name}/
+                          pattern: '{pattern}'
+                          path: {RUNNER_TEMP}/used_artifacts/
                     "#
                 ))
                 .unwrap();
@@ -212,7 +204,7 @@ pub fn github_yaml(
             let mut map = serde_yaml::Mapping::new();
             map.insert(
                 "run".into(),
-                format!(r#"echo "{RUNNER_TEMP}/bootstrapped-flowey" >> $GITHUB_PATH"#).into(),
+                format!(r#"echo "{RUNNER_TEMP}/{flowey_path}" >> $GITHUB_PATH"#).into(),
             );
             map.insert("shell".into(), "bash".into());
             map.insert("name".into(), "🌼📦 Add flowey to PATH".into());
@@ -268,10 +260,11 @@ pub fn github_yaml(
 
                 let current_yaml = match platform.kind() {
                     FlowPlatformKind::Windows => {
-                        r#"$ESCAPED_AGENT_TEMPDIR\\bootstrapped-flowey\\pipeline.yaml"#
+                        let win_path = flowey_path.replace('/', "\\");
+                        format!(r#"$ESCAPED_AGENT_TEMPDIR\\{win_path}\\pipeline.yaml"#)
                     }
                     FlowPlatformKind::Unix => {
-                        r#"$ESCAPED_AGENT_TEMPDIR/bootstrapped-flowey/pipeline.yaml"#
+                        format!(r#"$ESCAPED_AGENT_TEMPDIR/{flowey_path}/pipeline.yaml"#)
                     }
                 };
 
@@ -327,7 +320,7 @@ AgentTempDirNormal="{RUNNER_TEMP}"
 AgentTempDirNormal=$(echo "$AgentTempDirNormal" | sed -e 's|\\|\/|g' -e 's|^\([A-Za-z]\)\:/\(.*\)|/\L\1\E/\2|')
 echo "AgentTempDirNormal=$AgentTempDirNormal" >> $GITHUB_ENV
 
-chmod +x $AgentTempDirNormal/bootstrapped-flowey/{flowey_bin}
+chmod +x $AgentTempDirNormal/{flowey_path}/{flowey_bin}
 
 echo '"{runtime_debug_level}"' | {var_db_insert_runtime_debug_level}
 echo "{RUNNER_TEMP}/work" | {var_db_insert_working_dir}
@@ -468,7 +461,7 @@ EOF
                 map.insert(
                     "run".into(),
                     serde_yaml::Value::String(format!(
-                        "rm $AgentTempDirNormal/bootstrapped-flowey/job{}.json",
+                        "rm $AgentTempDirNormal/{flowey_path}/job{}.json",
                         job_idx.index()
                     )),
                 );
@@ -483,7 +476,7 @@ EOF
                     uses: actions/upload-artifact@v4
                     with:
                         name: {artifact}
-                        path: {RUNNER_TEMP}/bootstrapped-flowey
+                        path: {RUNNER_TEMP}/{flowey_path}
                 "#
                 ))
                 .unwrap();

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -268,7 +268,7 @@ pub fn github_yaml(
                     }
                 };
 
-                current_invocation.insert(i, current_yaml.into());
+                current_invocation.insert(i, current_yaml);
                 current_invocation.insert(i, "--runtime".into());
             }
 


### PR DESCRIPTION
Download all the artifacts a job needs (including flowey, if consuming via artifact) in parallel instead of one at a time, using the `pattern` feature of the `download-artifact` action.