### PR TITLE
hv1_emulator: Pass GuestMemory in on construction instead of on access

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -386,11 +386,7 @@ impl UhCvmVpState {
             LapicState::new(lapic, activity)
         });
 
-        let hv = VtlArray::from_fn(|vtl| {
-            cvm_partition
-                .hv
-                .add_vp(inner.gm[vtl].clone(), vp_info.base.vp_index, vtl)
-        });
+        let hv = VtlArray::from_fn(|vtl| cvm_partition.hv.add_vp(vp_info.base.vp_index, vtl));
 
         Ok(Self {
             direct_overlay_handle,
@@ -1050,7 +1046,6 @@ impl vmcore::synic::GuestEventPort for UhEventPort {
             tracing::trace!(vp = vp.index(), sint, flag, "signal_event");
             if let Some(hv) = partition.hv() {
                 match hv.synic[vtl].signal_event(
-                    &partition.gm[vtl],
                     vp,
                     sint,
                     flag,
@@ -1067,7 +1062,6 @@ impl vmcore::synic::GuestEventPort for UhEventPort {
                         if let Some(synic) = partition.backing_shared.untrusted_synic() {
                             synic
                                 .signal_event(
-                                    &partition.gm[vtl],
                                     vp,
                                     sint,
                                     flag,
@@ -1659,6 +1653,7 @@ impl<'a> UhProtoPartition<'a> {
                 late_params.cvm_params.unwrap(),
                 &caps,
                 cvm_cpuid.unwrap(),
+                late_params.gm.clone(),
                 guest_vsm_available,
             )?)
         } else {
@@ -1677,6 +1672,15 @@ impl<'a> UhProtoPartition<'a> {
             caps,
             enter_modes: Mutex::new(enter_modes),
             enter_modes_atomic: u8::from(hcl::protocol::EnterModes::from(enter_modes)).into(),
+            backing_shared: BackingShared::new(
+                isolation,
+                &params,
+                BackingSharedParams {
+                    cvm_state,
+                    guest_memory: late_params.gm.clone(),
+                    guest_vsm_available,
+                },
+            )?,
             gm: late_params.gm,
             cpuid,
             crash_notification_send: late_params.crash_notification_send,
@@ -1687,14 +1691,6 @@ impl<'a> UhProtoPartition<'a> {
             isolation,
             no_sidecar_hotplug: params.no_sidecar_hotplug.into(),
             use_mmio_hypercalls: params.use_mmio_hypercalls,
-            backing_shared: BackingShared::new(
-                isolation,
-                &params,
-                BackingSharedParams {
-                    cvm_state,
-                    guest_vsm_available,
-                },
-            )?,
             #[cfg(guest_arch = "x86_64")]
             device_vector_table: RwLock::new(IrrBitmap::new(Default::default())),
             intercept_debug_exceptions: params.intercept_debug_exceptions,
@@ -1846,6 +1842,7 @@ impl UhProtoPartition<'_> {
         late_params: CvmLateParams,
         caps: &PartitionCapabilities,
         cpuid: cvm_cpuid::CpuidResults,
+        guest_memory: VtlArray<GuestMemory, 2>,
         guest_vsm_available: bool,
     ) -> Result<UhCvmPartitionState, Error> {
         let vp_count = params.topology.vp_count() as usize;
@@ -1881,6 +1878,7 @@ impl UhProtoPartition<'_> {
             vendor: caps.vendor,
             tsc_frequency,
             ref_time,
+            guest_memory,
         });
 
         if guest_vsm_available {

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -525,7 +525,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             | HvX64RegisterName::Stimer3Count
             | HvX64RegisterName::VsmVina) => self.vp.backing.cvm_state_mut().hv[vtl]
                 .synic
-                .write_reg(&self.vp.partition.gm[vtl], synic_reg.into(), reg.value),
+                .write_reg(synic_reg.into(), reg.value),
             HvX64RegisterName::ApicBase => {
                 // No changes are allowed on this path.
                 let current = self.vp.backing.cvm_state_mut().lapics[vtl]

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -37,6 +37,7 @@ use super::UhPartitionInner;
 use super::UhVpInner;
 use crate::GuestVtl;
 use crate::WakeReason;
+use guestmem::GuestMemory;
 use hcl::ioctl::ProcessorRunner;
 use hv1_emulator::message_queues::MessageQueues;
 use hv1_hypercall::HvRepResult;
@@ -266,6 +267,7 @@ impl<T: BackingPrivate> Backing for T {}
 
 pub(crate) struct BackingSharedParams {
     pub cvm_state: Option<crate::UhCvmPartitionState>,
+    pub guest_memory: VtlArray<GuestMemory, 2>,
     pub guest_vsm_available: bool,
 }
 
@@ -495,7 +497,6 @@ impl<T: Backing> UhProcessor<'_, T> {
             };
             let (ready_sints, next_ref_time) = synic.scan(
                 ref_time_now,
-                &self.partition.gm[vtl],
                 &mut self
                     .partition
                     .synic_interrupt(self.inner.vp_info.base.vp_index, vtl),
@@ -1020,7 +1021,6 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                 if proxied_sints & (1 << sint) != 0 {
                     if let Some(synic) = self.backing.untrusted_synic_mut().as_mut() {
                         synic.post_message(
-                            &self.partition.gm[vtl],
                             sint,
                             message,
                             &mut self
@@ -1041,7 +1041,6 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                         .unwrap()
                         .synic
                         .post_message(
-                            &self.partition.gm[vtl],
                             sint,
                             message,
                             &mut self

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -567,7 +567,12 @@ impl TdxBackedShared {
         // performance would be poor for cases where the L1 implements
         // high-performance devices.
         let untrusted_synic = (partition_params.handle_synic && !partition_params.hide_isolation)
-            .then(|| GlobalSynic::new(partition_params.topology.vp_count()));
+            .then(|| {
+                GlobalSynic::new(
+                    params.guest_memory[GuestVtl::Vtl0].clone(),
+                    partition_params.topology.vp_count(),
+                )
+            });
         Ok(Self {
             untrusted_synic,
             flush_state: VtlArray::from_fn(|_| RwLock::new(TdxPartitionFlushState::new())),
@@ -803,14 +808,8 @@ impl BackingPrivate for TdxBacked {
         ];
 
         let reg_count = if let Some(synic) = &mut this.backing.untrusted_synic {
-            synic.set_simp(
-                &this.partition.gm[GuestVtl::Vtl0],
-                reg(pfns[UhDirectOverlay::Sipp as usize]),
-            );
-            synic.set_siefp(
-                &this.partition.gm[GuestVtl::Vtl0],
-                reg(pfns[UhDirectOverlay::Sifp as usize]),
-            );
+            synic.set_simp(reg(pfns[UhDirectOverlay::Sipp as usize]));
+            synic.set_siefp(reg(pfns[UhDirectOverlay::Sifp as usize]));
             // Set the SIEFP in the hypervisor so that the hypervisor can
             // directly signal synic events. Don't set the SIMP, since the
             // message page is owned by the paravisor.
@@ -2159,7 +2158,7 @@ impl UhProcessor<'_, TdxBacked> {
                     .untrusted_synic
                     .as_mut()
                     .unwrap()
-                    .write_nontimer_msr(&self.partition.gm[intercepted_vtl], msr, value)?;
+                    .write_nontimer_msr(msr, value)?;
                 // Propagate sint MSR writes to the hypervisor as well
                 // so that the hypervisor can directly inject events.
                 if matches!(msr, hvdef::HV_X64_MSR_SINT0..=hvdef::HV_X64_MSR_SINT15) {


### PR DESCRIPTION
This makes the structs themselves a little bigger, but makes interacting with them cleaner IMO.