### PR TITLE
hv1_emulator: Add a missing cpuid bit

### DIFF
--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -74,7 +74,8 @@ pub fn hv_cpuid_leaves(
                 .with_privileges(privileges)
                 .with_frequency_regs_available(true)
                 .with_direct_synthetic_timers(true)
-                .with_extended_gva_ranges_for_flush_virtual_address_list_available(true);
+                .with_extended_gva_ranges_for_flush_virtual_address_list_available(true)
+                .with_register_pat_available(true);
 
             // TODO SNP
             //    .with_fast_hypercall_output_available(true);


### PR DESCRIPTION
This bit is always set in the HCL, and we support accessing PAT through our hypercalls already, so we can just set it too.