### PR TITLE
tpm: Preserve AK cert across boots for resiliency

### DIFF
--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -662,9 +662,9 @@ async fn get_derived_keys(
 
     // If sources of encryption used last are missing, attempt to unseal VMGS key with hardware key
     if (no_kek && found_dek) || (no_gsp && requires_gsp) || (no_gsp_by_id && requires_gsp_by_id) {
+        tracing::info!("Unseal VMGS key-encryption key with hardware key");
         // If possible, get ingressKey from hardware sealed data
         let (hardware_key_protector, hardware_derived_keys) = if let Some(tee_call) = tee_call {
-            tracing::info!("Unseal VMGS key-encryption key with hardware key");
             let hardware_key_protector = match vmgs::read_hardware_key_protector(vmgs).await {
                 Ok(hardware_key_protector) => Some(hardware_key_protector),
                 Err(e) => {

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -619,6 +619,15 @@ async fn get_derived_keys(
 
         let response = get_gsp_data(get, key_protector).await;
 
+        tracing::info!(
+            CVM_ALLOWED,
+            request_data_length_in_vmgs = key_protector.gsp[ingress_idx].gsp_length,
+            no_rpc_server = response.extended_status_flags.no_rpc_server(),
+            requires_rpc_server = response.extended_status_flags.requires_rpc_server(),
+            encrypted_gsp_length = response.encrypted_gsp.length,
+            "GSP response"
+        );
+
         let no_gsp =
             response.extended_status_flags.no_rpc_server() || response.encrypted_gsp.length == 0;
 

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -653,9 +653,9 @@ async fn get_derived_keys(
 
     // If sources of encryption used last are missing, attempt to unseal VMGS key with hardware key
     if (no_kek && found_dek) || (no_gsp && requires_gsp) || (no_gsp_by_id && requires_gsp_by_id) {
-        tracing::info!("Unseal VMGS key-encryption key with hardware key");
         // If possible, get ingressKey from hardware sealed data
         let (hardware_key_protector, hardware_derived_keys) = if let Some(tee_call) = tee_call {
+            tracing::info!("Unseal VMGS key-encryption key with hardware key");
             let hardware_key_protector = match vmgs::read_hardware_key_protector(vmgs).await {
                 Ok(hardware_key_protector) => Some(hardware_key_protector),
                 Err(e) => {
@@ -726,6 +726,14 @@ async fn get_derived_keys(
             }
         }
     }
+
+    tracing::info!(
+        CVM_ALLOWED,
+        kek = !no_kek,
+        gsp = !no_gsp,
+        gsp_by_id = !no_gsp_by_id,
+        "Encryption sources"
+    );
 
     // Check if sources of encryption are available
     if no_kek && no_gsp && no_gsp_by_id {

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -922,6 +922,7 @@ fn vm_config_from_command_line(
                         },
                     },
                     enable_battery: opt.battery,
+                    no_persistent_secrets: true,
                 }
                 .into_resource(),
             ),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -825,6 +825,7 @@ impl PetriVmConfigSetupCore<'_> {
             secure_boot_enabled: false,
             secure_boot_template: get_resources::ged::GuestSecureBootTemplateType::None,
             enable_battery: false,
+            no_persistent_secrets: true,
         };
 
         Ok((ged, guest_request_send))

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -138,9 +138,11 @@ impl PetriVmConfigOpenVmm {
 
     /// Enable TPM state persistence
     pub fn with_tpm_state_persistence(mut self) -> Self {
-        let Some(ged) = &mut self.ged else {
+        if !self.firmware.is_openhcl() {
             panic!("TPM state persistence is only supported for OpenHCL.")
         };
+
+        let ged = self.ged.as_mut().expect("No GED to configure TPM");
 
         // Disable no_persistent_secrets implies preserving TPM states
         // across boots

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -136,6 +136,19 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
+    /// Enable TPM state persistence
+    pub fn with_tpm_state_persistence(mut self) -> Self {
+        let Some(ged) = &mut self.ged else {
+            panic!("TPM state persistence is only supported for OpenHCL.")
+        };
+
+        // Disable no_persistent_secrets implies preserving TPM states
+        // across boots
+        ged.no_persistent_secrets = false;
+
+        self
+    }
+
     /// Enable an emulated mana device for the VM.
     pub fn with_nic(mut self) -> Self {
         self.config.vpci_devices.push(VpciDeviceConfig {

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -86,7 +86,7 @@ pub mod ged {
         pub secure_boot_template: GuestSecureBootTemplateType,
         /// Enable battery.
         pub enable_battery: bool,
-        /// Suppress attestation.
+        /// Suppress attestation and disable TPM state persistence.
         pub no_persistent_secrets: bool,
     }
 

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -86,6 +86,8 @@ pub mod ged {
         pub secure_boot_template: GuestSecureBootTemplateType,
         /// Enable battery.
         pub enable_battery: bool,
+        /// Suppress attestation.
+        pub no_persistent_secrets: bool,
     }
 
     /// The firmware and chipset configuration for the guest.

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -23,6 +23,8 @@ use futures::FutureExt;
 use futures::StreamExt;
 use get_protocol::BatteryStatusFlags;
 use get_protocol::BatteryStatusNotification;
+use get_protocol::GspCleartextContent;
+use get_protocol::GspExtendedStatusFlags;
 use get_protocol::HeaderGeneric;
 use get_protocol::HostNotifications;
 use get_protocol::HostRequests;
@@ -139,6 +141,8 @@ pub struct GuestConfig {
     pub secure_boot_template: SecureBootTemplateType,
     /// Enable battery.
     pub enable_battery: bool,
+    /// Suppress attestation.
+    pub no_persistent_secrets: bool,
 }
 
 #[derive(Debug, Clone, Inspect)]
@@ -180,6 +184,14 @@ pub enum GuestEvent {
     BootAttempt,
 }
 
+/// Simple state machine to support AK cert preserving test.
+// TODO: add more states to cover other test scenarios.
+#[derive(Debug)]
+enum IgvmAttestState {
+    Init,
+    SendingAkCert,
+}
+
 /// VMBUS device that implements the host side of the Guest Emulation Transport protocol.
 #[derive(InspectMut)]
 pub struct GuestEmulationDevice {
@@ -201,6 +213,9 @@ pub struct GuestEmulationDevice {
     #[inspect(with = "Option::is_some")]
     save_restore_buf: Option<Vec<u8>>,
     last_save_restore_buf_len: usize,
+
+    #[inspect(skip)]
+    igvm_attest_state: IgvmAttestState,
 }
 
 #[derive(Inspect)]
@@ -234,6 +249,7 @@ impl GuestEmulationDevice {
             save_restore_buf: None,
             waiting_for_vtl0_start: Vec::new(),
             last_save_restore_buf_len: 0,
+            igvm_attest_state: IgvmAttestState::Init,
         }
     }
 
@@ -313,8 +329,6 @@ pub struct GedChannel<T: RingMem = GpadlRingMem> {
     vtl0_start_report: Option<Result<(), Vtl0StartError>>,
     #[inspect(with = "Option::is_some")]
     modify: Option<Rpc<(), Result<(), ModifyVtl2SettingsError>>>,
-    // TODO: allow unused temporarily as a follow up change will use it to
-    // implement AK cert renewal.
     #[inspect(skip)]
     gm: GuestMemory,
 }
@@ -584,7 +598,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
             HostRequests::GUEST_STATE_PROTECTION_BY_ID => {
                 self.handle_guest_state_protection_by_id()?;
             }
-            HostRequests::IGVM_ATTEST => self.handle_igvm_attest(message_buf)?,
+            HostRequests::IGVM_ATTEST => self.handle_igvm_attest(message_buf, state)?,
             HostRequests::DEVICE_PLATFORM_SETTINGS_V2 => {
                 self.handle_device_platform_settings_v2(state)?
             }
@@ -813,7 +827,8 @@ impl<T: RingMem + Unpin> GedChannel<T> {
     fn handle_guest_state_protection_by_id(&mut self) -> Result<(), Error> {
         let response = get_protocol::GuestStateProtectionByIdResponse {
             message_header: HeaderGeneric::new(HostRequests::GUEST_STATE_PROTECTION_BY_ID),
-            ..get_protocol::GuestStateProtectionByIdResponse::new_zeroed()
+            seed: GspCleartextContent::new_zeroed(),
+            extended_status_flags: GspExtendedStatusFlags::new().with_no_registry_file(true),
         };
         self.channel
             .try_send(response.as_bytes())
@@ -823,7 +838,13 @@ impl<T: RingMem + Unpin> GedChannel<T> {
 
     /// Stub implementation that simulates the behavior of GED and the host agent.
     /// Used only for test scenarios such as VMM tests.
-    fn handle_igvm_attest(&mut self, message_buf: &[u8]) -> Result<(), Error> {
+    fn handle_igvm_attest(
+        &mut self,
+        message_buf: &[u8],
+        state: &mut GuestEmulationDevice,
+    ) -> Result<(), Error> {
+        tracing::info!(state = ?state.igvm_attest_state, "Handle IGVM Attest request");
+
         let request = IgvmAttestRequest::read_from_prefix(message_buf)
             .map_err(|_| Error::MessageTooSmall)?
             .0; // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
@@ -841,7 +862,9 @@ impl<T: RingMem + Unpin> GedChannel<T> {
             .0; // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
 
         let response = match request_payload.request_type {
-            IgvmAttestRequestType::AK_CERT_REQUEST => {
+            IgvmAttestRequestType::AK_CERT_REQUEST
+                if matches!(state.igvm_attest_state, IgvmAttestState::Init) =>
+            {
                 let data = vec![0xab; 2500];
                 let header = IgvmAttestAkCertResponseHeader {
                     data_size: (data.len() + size_of::<IgvmAttestAkCertResponseHeader>()) as u32,
@@ -853,10 +876,20 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     .write_at(request.shared_gpa[0], &payload)
                     .map_err(Error::SharedMemoryWriteFailed)?;
 
+                state.igvm_attest_state = IgvmAttestState::SendingAkCert;
+
+                tracing::info!("Sending AK_CERT_REQEUST");
+
                 get_protocol::IgvmAttestResponse {
                     message_header: HeaderGeneric::new(HostRequests::IGVM_ATTEST),
                     length: payload.len() as u32,
                 }
+            }
+            IgvmAttestRequestType::AK_CERT_REQUEST => {
+                // Skip if the state is not Init to support sending-response-once behavior
+                // allows for testing AK cert preserving behavior
+                tracing::info!("Skip AK_CERT_REQEUST");
+                return Ok(());
             }
             ty => return Err(Error::UnsupportedIgvmAttestRequestType(ty.0)),
         };
@@ -1270,8 +1303,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     vmbus_redirection_enabled: state.config.vmbus_redirection,
                     vtl2_settings: state.config.vtl2_settings.clone(),
                     firmware_mode_is_pcat,
-                    // no_persist_secrets must be set to True in order to skip attestation.
-                    no_persistent_secrets: true,
+                    no_persistent_secrets: state.config.no_persistent_secrets,
                     legacy_memory_map: false,
                     pause_after_boot_failure: false,
                     pxe_ip_v6: false,

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -214,6 +214,7 @@ pub struct GuestEmulationDevice {
     save_restore_buf: Option<Vec<u8>>,
     last_save_restore_buf_len: usize,
 
+    /// State machine for `handle_igvm_attest`
     #[inspect(skip)]
     igvm_attest_state: IgvmAttestState,
 }

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -142,6 +142,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                     }
                 },
                 enable_battery: resource.enable_battery,
+                no_persistent_secrets: resource.no_persistent_secrets,
             },
             halt,
             resource.firmware_event_send,

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -251,6 +251,7 @@ pub fn create_host_channel(
         secure_boot_enabled: false,
         secure_boot_template: SecureBootTemplateType::SECURE_BOOT_DISABLED,
         enable_battery: false,
+        no_persistent_secrets: true,
     };
 
     let halt_reason = Arc::new(Mutex::new(None));

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -750,7 +750,7 @@ impl Tpm {
     fn create_ak_cert_request(&mut self) -> Result<Vec<u8>, TpmError> {
         let mut guest_attestation_input = [0u8; ATTESTATION_REPORT_DATA_SIZE];
         // No need to check the result as long as it's Ok(..) because the output data will
-        // remain unchanged (all 0's) if the NV index is unallocated or initialized.
+        // remain unchanged (all 0's) if the NV index is unallocated or uninitialized.
         self.tpm_engine_helper
             .read_from_nv_index(
                 TPM_NV_INDEX_GUEST_ATTESTATION_INPUT,

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -512,7 +512,7 @@ impl Tpm {
             self.tpm_engine_helper
                 .allocate_guest_attestation_nv_indices(
                     auth_value,
-                    !self.refresh_tpm_seeds, // Do not preserve the AK cert if TPM seeds are refreshed
+                    !self.refresh_tpm_seeds, // Preserve AK cert if TPM seeds are not refreshed
                     matches!(self.ak_cert_type, TpmAkCertType::HwAttested(_)),
                 )
                 .map_err(TpmErrorKind::AllocateGuestAttestationNvIndices)?;

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -749,6 +749,8 @@ impl Tpm {
     /// This function can only be called when `ak_cert_type` is `Trusted` or `HwAttested`.
     fn create_ak_cert_request(&mut self) -> Result<Vec<u8>, TpmError> {
         let mut guest_attestation_input = [0u8; ATTESTATION_REPORT_DATA_SIZE];
+        // No need to check the result as long as it's Ok(..) because the output data will
+        // remain unchanged (all 0's) if the NV index is unallocated or initialized.
         self.tpm_engine_helper
             .read_from_nv_index(
                 TPM_NV_INDEX_GUEST_ATTESTATION_INPUT,

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -512,7 +512,7 @@ impl Tpm {
             self.tpm_engine_helper
                 .allocate_guest_attestation_nv_indices(
                     auth_value,
-                    self.refresh_tpm_seeds,
+                    !self.refresh_tpm_seeds, // Do not preserve the AK cert if TPM seeds are refreshed
                     matches!(self.ak_cert_type, TpmAkCertType::HwAttested(_)),
                 )
                 .map_err(TpmErrorKind::AllocateGuestAttestationNvIndices)?;

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -1974,7 +1974,6 @@ mod tests {
 
             let result =
                 tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
-            println!("{:?}", result);
             assert!(result.is_ok());
 
             // Ensure only ak cert index remains present but uninitialized
@@ -2045,7 +2044,7 @@ mod tests {
             // Read the data and ensure it is zero-padded
             let result =
                 tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
-            assert!(result.is_ok());
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
             let input_with_padding = {
                 let mut input = AK_CERT_INPUT_512.to_vec();
                 input.resize(MAX_NV_INDEX_SIZE.into(), 0);

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -49,13 +49,7 @@ async fn boot_alias_map(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 )]
 async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
-    let config = config
-        // "OPENHCL_ENABLE_VTL2_GPA_POOL=1" is currently required to make test
-        // pass as the page pool is not enabled by default.
-        //
-        // TODO: Remove this once the page pool is always on.
-        .with_openhcl_command_line("OPENHCL_ENABLE_VTL2_GPA_POOL=1")
-        .with_tpm();
+    let config = config.with_tpm().with_tpm_state_persistence();
 
     let (vm, agent) = match os_flavor {
         OsFlavor::Windows => {


### PR DESCRIPTION
This PR does the following
- Preserves the AK cert (if TPM seeds are not refreshed) across boots that increases the resiliency in case that the boot-time AK cert request succeeds in the first boot but fails in the subsequent boot.
- Ensure the AK cert index is always re-created with consistent properties (index size, platform-created, write permission per-boot auth value)