### PR TITLE
guest_memory: Refactor error types and expose publicly

### DIFF
--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -328,9 +328,12 @@ unsafe impl GuestMemoryAccess for GuestMemoryMapping {
 
     fn expose_va(&self, address: u64, len: u64) -> Result<(), GuestMemoryBackingError> {
         if let Some(registrar) = &self.registrar {
-            registrar
-                .register(address, len)
-                .map_err(|start| GuestMemoryBackingError::new(start, RegistrationError))
+            registrar.register(address, len).map_err(|start| {
+                GuestMemoryBackingError::new(
+                    start,
+                    guestmem::GuestMemoryErrorKind::Other(RegistrationError.into()),
+                )
+            })
         } else {
             // TODO: fail this call once we have a way to avoid calling this for
             // user-mode-only accesses to locked memory (e.g., for vmbus ring

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -295,7 +295,7 @@ unsafe impl GuestMemoryAccess for VaMapper {
             self.inner
                 .request_mapping(MemoryRange::bounding(address..address + len as u64), write),
         ) {
-            return PageFaultAction::Fail(err.into());
+            return PageFaultAction::Fail(guestmem::GuestMemoryErrorKind::Other(err.into()));
         }
         PageFaultAction::Retry
     }


### PR DESCRIPTION
This avoids some boxing and feels cleaner overall. It also will allow for future changes to match on the specific error kind to determine how to react (currently planned for the instruction emulator, coming soon).