### PR TITLE
attestation: Improve error log and telemetry

### DIFF
--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -246,7 +246,7 @@ pub async fn initialize_platform_security(
 
     // Read Security Profile from VMGS
     // Currently this only includes "Key Reference" data, which is not attested data, is opaque to the
-    // Underhill, and is passed to the IGVMm agent outside of the report contents.
+    // OpenHCL, and is passed to the IGVMm agent outside of the report contents.
     let SecurityProfile { mut agent_data } = vmgs::read_security_profile(vmgs)
         .await
         .map_err(AttestationErrorInner::ReadSecurityProfile)?;
@@ -653,7 +653,6 @@ async fn get_derived_keys(
 
     // If sources of encryption used last are missing, attempt to unseal VMGS key with hardware key
     if (no_kek && found_dek) || (no_gsp && requires_gsp) || (no_gsp_by_id && requires_gsp_by_id) {
-        tracing::info!("Unseal VMGS key-encryption key with hardware key");
         // If possible, get ingressKey from hardware sealed data
         let (hardware_key_protector, hardware_derived_keys) = if let Some(tee_call) = tee_call {
             let hardware_key_protector = match vmgs::read_hardware_key_protector(vmgs).await {
@@ -708,7 +707,10 @@ async fn get_derived_keys(
             key_protector_settings.should_write_kp = false;
             key_protector_settings.use_hardware_unlock = true;
 
-            tracing::warn!(CVM_ALLOWED, "Using hardware based key derivation");
+            tracing::warn!(
+                CVM_ALLOWED,
+                "Using hardware-derived key to recover VMGS DEK"
+            );
 
             return Ok(DerivedKeyResult {
                 derived_keys: Some(derived_keys),

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -27,28 +27,32 @@ pub(crate) enum RequestVmgsEncryptionKeysError {
     GenerateTransferKey(#[source] openssl::error::ErrorStack),
     #[error("failed to get a TEE attestation report")]
     GetAttestationReport(#[source] tee_call::Error),
-    #[error("failed to create IgvmAttest WRAPPED_KEY request")]
+    #[error("failed to create an IgvmAttest WRAPPED_KEY request")]
     CreateIgvmAttestWrappedKeyRequest(#[source] igvm_attest::Error),
     #[error("failed to make an IgvmAttest WRAPPED_KEY GET request")]
     SendIgvmAttestWrappedKeyRequest(#[source] guest_emulation_transport::error::IgvmAttestError),
-    #[error("failed to parse IgvmAttest WRAPPED_KEY response")]
+    #[error("failed to parse the IgvmAttest WRAPPED_KEY response")]
     ParseIgvmAttestWrappedKeyResponse(#[source] igvm_attest::wrapped_key::WrappedKeyError),
+    #[error(
+        "failed to get a valid IgvmAttest WRAPPED_KEY response that is required because agent data from VMGS is empty"
+    )]
+    RequiredButInvalidIgvmAttestWrappedKeyResponse,
     #[error("wrapped key from WRAPPED_KEY response is empty")]
     EmptyWrappedKey,
     #[error(
-        "key reference size {key_reference_size} from WRAPPED_KEY response was larger than expected {expected_size}"
+        "key reference size {key_reference_size} from the WRAPPED_KEY response was larger than expected {expected_size}"
     )]
     InvalidKeyReferenceSize {
         key_reference_size: usize,
         expected_size: usize,
     },
-    #[error("key reference from WRAPPED_KEY response is empty")]
+    #[error("key reference from the WRAPPED_KEY response is empty")]
     EmptyKeyReference,
-    #[error("failed to create IgvmAttest KEY_RELEASE request")]
+    #[error("failed to create an IgvmAttest KEY_RELEASE request")]
     CreateIgvmAttestKeyReleaseRequest(#[source] igvm_attest::Error),
     #[error("failed to make an IgvmAttest KEY_RELEASE GET request")]
     SendIgvmAttestKeyReleaseRequest(#[source] guest_emulation_transport::error::IgvmAttestError),
-    #[error("failed to parse IgvmAttest KEY_RELEASE response")]
+    #[error("failed to parse the IgvmAttest KEY_RELEASE response")]
     ParseIgvmAttestKeyReleaseResponse(#[source] igvm_attest::key_release::KeyReleaseError),
     #[error("PKCS11 RSA AES key unwrap failed")]
     Pkcs11RsaAesKeyUnwrap(#[source] crypto::Pkcs11RsaAesKeyUnwrapError),
@@ -286,8 +290,19 @@ async fn make_igvm_attest_requests(
 
             Some(parsed_response.wrapped_key)
         }
-        // The request does not succeed. Ignore the wrapped des key.
-        Err(igvm_attest::wrapped_key::WrappedKeyError::ResponseSizeTooSmall) => None,
+        Err(igvm_attest::wrapped_key::WrappedKeyError::ResponseSizeTooSmall) => {
+            // The request does not succeed.
+            // Empty `agent_data` from VMGS implies that the data required by KeyRelesae request needs to
+            // be from the WrappedKey response. Return an error for this case, otherwise ignore and
+            // set the `wrapped_des_key` to None.
+            if agent_data.iter().all(|&x| x == 0) {
+                return Err(
+                    RequestVmgsEncryptionKeysError::RequiredButInvalidIgvmAttestWrappedKeyResponse,
+                );
+            } else {
+                None
+            }
+        }
         Err(e) => Err(RequestVmgsEncryptionKeysError::ParseIgvmAttestWrappedKeyResponse(e))?,
     };
 


### PR DESCRIPTION
This PR improves the error log when `WrappedKey` response is required but invalid and the telemetry on recovering VMGS KEK with hardware-based sealing key.