### PR TITLE
flowey: nextest and rust install fixes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,9 +19,8 @@ threads-required = 4
 [profile.ci]
 # Set the default timeout to 1 second, with tests terminated after 5 seconds
 slow-timeout = { period = "1s", terminate-after = 5 }
-# Print out output for failing tests as soon as they fail, and also at the end
-# of the run (for easy scrollability).
-failure-output = "immediate-final"
+# Print out output for failing tests at the end of the run.
+failure-output = "final"
 # Do not cancel the test run on the first failure.
 fail-fast = false
 

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -110,7 +110,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -154,8 +154,11 @@ jobs:
         flowey e 0 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 0 flowey_lib_hvlite::build_guide 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 0 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 0 flowey_lib_common::install_rust 1
       shell: bash
     - name: build OpenVMM guide (mdbook)
       run: |-
@@ -294,7 +297,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -308,8 +311,11 @@ jobs:
     - name: symlink protoc
       run: flowey.exe e 1 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 1 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 1 flowey_lib_common::install_rust 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey.exe e 1 flowey_lib_hvlite::download_lxutil 0
@@ -319,7 +325,7 @@ jobs:
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 1 flowey_lib_common::install_rust 1
+        flowey.exe e 1 flowey_lib_common::install_rust 2
         flowey.exe e 1 flowey_lib_common::cfg_cargo_common_flags 0
         flowey.exe e 1 flowey_lib_common::run_cargo_doc 0
       shell: bash
@@ -432,12 +438,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 10 'artifact_publish_from_aarch64-linux-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 10 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 10 flowey_lib_common::install_rust 1
+        flowey e 10 flowey_lib_common::install_rust 2
         flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -463,7 +472,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
@@ -727,12 +736,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 11 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 11 flowey_lib_common::install_rust 1
+        flowey e 11 flowey_lib_common::install_rust 2
         flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -758,7 +770,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 6
@@ -918,12 +930,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
         flowey e 11 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 11 flowey_lib_common::install_rust 2
+        flowey e 11 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -1089,7 +1101,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1098,12 +1110,15 @@ jobs:
     - name: unpack mu_msvm package (aarch64)
       run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 12 flowey_lib_common::install_rust 1
+        flowey e 12 flowey_lib_common::install_rust 2
         flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1415,7 +1430,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 2
@@ -1424,12 +1439,15 @@ jobs:
     - name: unpack mu_msvm package (x64)
       run: flowey e 13 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 13 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 13 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 13 flowey_lib_common::install_rust 1
+        flowey e 13 flowey_lib_common::install_rust 2
         flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1811,12 +1829,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 14 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 14 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 14 flowey_lib_common::install_rust 1
+        flowey.exe e 14 flowey_lib_common::install_rust 2
         flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1861,7 +1882,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 6
@@ -1931,12 +1952,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 2
         flowey.exe e 14 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 14 flowey_lib_common::install_rust 2
+        flowey.exe e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -2063,12 +2084,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 15 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 15 flowey_lib_common::install_rust 1
+        flowey e 15 flowey_lib_common::install_rust 2
         flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -2094,7 +2118,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 6
@@ -2217,12 +2241,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 2
         flowey e 15 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -2354,12 +2378,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 16 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 16 flowey_lib_common::install_rust 1
+        flowey e 16 flowey_lib_common::install_rust 2
         flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -2408,7 +2435,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 6
@@ -2511,12 +2538,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 2
         flowey e 16 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -2666,20 +2693,23 @@ jobs:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - name: install Rust
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 2
         flowey.exe e 17 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 17 flowey_lib_common::install_rust 0
       shell: bash
-    - name: detect active toolchain
+    - name: install Rust
       run: flowey.exe e 17 flowey_lib_common::install_rust 1
       shell: bash
-    - name: report $CARGO_HOME
+    - name: detect active toolchain
       run: flowey.exe e 17 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
@@ -2726,7 +2756,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 6
@@ -2852,13 +2882,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 6
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 18 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 18 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 18 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 18 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 18 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
@@ -2877,7 +2920,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 10
@@ -2952,7 +2995,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 2
@@ -3028,14 +3071,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 18 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 18 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 18 flowey_lib_common::cache 11
       shell: bash
   job19:
     name: run vmm-tests [x64-windows-amd]
@@ -3099,13 +3142,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 19 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 19 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 19 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 19 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 19 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
@@ -3124,7 +3180,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -3199,7 +3255,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -3275,14 +3331,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 19 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 19 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 19 flowey_lib_common::cache 11
       shell: bash
   job2:
     name: build and check docs [x64-linux]
@@ -3406,7 +3462,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 2 flowey_lib_common::cache 2
@@ -3426,8 +3482,11 @@ jobs:
     - name: symlink protoc
       run: flowey e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 2 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 2 flowey_lib_common::install_rust 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey e 2 flowey_lib_hvlite::download_lxutil 0
@@ -3437,7 +3496,7 @@ jobs:
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 2 flowey_lib_common::install_rust 1
+        flowey e 2 flowey_lib_common::install_rust 2
         flowey e 2 flowey_lib_common::cfg_cargo_common_flags 0
         flowey e 2 flowey_lib_common::run_cargo_doc 0
       shell: bash
@@ -3531,13 +3590,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey e 20 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 20 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 20 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey e 20 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 20 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey e 20 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 20 flowey_lib_common::install_dist_pkg 0
@@ -3562,7 +3634,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 10
@@ -3631,7 +3703,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 2
@@ -3707,14 +3779,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 20 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey e 20 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 20 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
     name: run vmm-tests [aarch64-windows]
@@ -3828,13 +3900,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 21 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 21 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 21 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 21 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 21 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
@@ -3853,7 +3938,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 10
@@ -3928,7 +4013,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 2
@@ -4004,14 +4089,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 21 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
     name: test flowey local backend
@@ -4113,9 +4198,12 @@ jobs:
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
+    - name: add default cargo home to path
+      run: flowey e 22 flowey_lib_common::install_rust 0
+      shell: bash
     - name: install Rust
       run: |-
-        flowey e 22 flowey_lib_common::install_rust 0
+        flowey e 22 flowey_lib_common::install_rust 1
         flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
         ${{ github.token }}
         EOF
@@ -4284,12 +4372,15 @@ jobs:
         flowey.exe e 4 flowey_lib_common::git_checkout 3
         flowey.exe e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 4 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 4 flowey_lib_common::install_rust 1
+        flowey.exe e 4 flowey_lib_common::install_rust 2
         flowey.exe e 4 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -4312,7 +4403,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -4440,12 +4531,15 @@ jobs:
         flowey e 5 flowey_lib_common::git_checkout 3
         flowey e 5 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 5 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 5 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 5 flowey_lib_common::install_rust 1
+        flowey e 5 flowey_lib_common::install_rust 2
         flowey e 5 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -4468,7 +4562,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 5 flowey_lib_common::cache 2
@@ -4594,12 +4688,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 6 'artifact_publish_from_aarch64-windows-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 6 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 6 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 6 flowey_lib_common::install_rust 1
+        flowey.exe e 6 flowey_lib_common::install_rust 2
         flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -4644,7 +4741,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
@@ -4828,12 +4925,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 7 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 7 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 7 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 7 flowey_lib_common::install_rust 1
+        flowey.exe e 7 flowey_lib_common::install_rust 2
         flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
@@ -4853,7 +4953,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 6
@@ -4937,12 +5037,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
         flowey.exe e 7 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 7 flowey_lib_common::install_rust 2
+        flowey.exe e 7 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -5066,12 +5166,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 8 'artifact_publish_from_x64-windows-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 8 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 8 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 8 flowey_lib_common::install_rust 1
+        flowey.exe e 8 flowey_lib_common::install_rust 2
         flowey.exe e 8 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -5116,7 +5219,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 8 flowey_lib_common::cache 2
@@ -5304,12 +5407,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 9 'artifact_publish_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 9 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 9 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 9 flowey_lib_common::install_rust 1
+        flowey.exe e 9 flowey_lib_common::install_rust 2
         flowey.exe e 9 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
@@ -5329,7 +5435,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 9 flowey_lib_common::cache 6
@@ -5413,12 +5519,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 9 flowey_lib_common::cache 2
         flowey.exe e 9 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 9 flowey_lib_common::install_rust 2
+        flowey.exe e 9 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -118,7 +118,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -162,8 +162,11 @@ jobs:
         flowey e 0 flowey_lib_hvlite::git_checkout_openvmm_repo 0
         flowey e 0 flowey_lib_hvlite::build_guide 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 0 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 0 flowey_lib_common::install_rust 1
       shell: bash
     - name: build OpenVMM guide (mdbook)
       run: |-
@@ -302,7 +305,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -316,8 +319,11 @@ jobs:
     - name: symlink protoc
       run: flowey.exe e 1 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 1 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 1 flowey_lib_common::install_rust 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey.exe e 1 flowey_lib_hvlite::download_lxutil 0
@@ -327,7 +333,7 @@ jobs:
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 1 flowey_lib_common::install_rust 1
+        flowey.exe e 1 flowey_lib_common::install_rust 2
         flowey.exe e 1 flowey_lib_common::cfg_cargo_common_flags 0
         flowey.exe e 1 flowey_lib_common::run_cargo_doc 0
       shell: bash
@@ -442,12 +448,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 10 'artifact_publish_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 10 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 10 flowey_lib_common::install_rust 1
+        flowey e 10 flowey_lib_common::install_rust 2
         flowey e 10 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -473,7 +482,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 6
@@ -633,12 +642,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
         flowey e 10 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 10 flowey_lib_common::install_rust 2
+        flowey e 10 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -802,7 +811,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
@@ -811,12 +820,15 @@ jobs:
     - name: unpack mu_msvm package (aarch64)
       run: flowey e 11 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 11 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 11 flowey_lib_common::install_rust 1
+        flowey e 11 flowey_lib_common::install_rust 2
         flowey e 11 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1102,7 +1114,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1111,12 +1123,15 @@ jobs:
     - name: unpack mu_msvm package (x64)
       run: flowey e 12 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 12 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 12 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 12 flowey_lib_common::install_rust 1
+        flowey e 12 flowey_lib_common::install_rust 2
         flowey e 12 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1478,12 +1493,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 13 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 13 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 13 flowey_lib_common::install_rust 1
+        flowey e 13 flowey_lib_common::install_rust 2
         flowey e 13 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1528,7 +1546,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 6
@@ -1596,7 +1614,7 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 2
@@ -1705,12 +1723,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 14 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 14 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 14 flowey_lib_common::install_rust 1
+        flowey.exe e 14 flowey_lib_common::install_rust 2
         flowey.exe e 14 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -1755,7 +1776,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 6
@@ -1825,12 +1846,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 2
         flowey.exe e 14 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 14 flowey_lib_common::install_rust 2
+        flowey.exe e 14 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -1957,12 +1978,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 15 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 15 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 15 flowey_lib_common::install_rust 1
+        flowey e 15 flowey_lib_common::install_rust 2
         flowey e 15 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -1988,7 +2012,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 6
@@ -2111,12 +2135,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 2
         flowey e 15 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 15 flowey_lib_common::install_rust 2
+        flowey e 15 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -2248,12 +2272,15 @@ jobs:
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 16 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 16 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 16 flowey_lib_common::install_rust 1
+        flowey e 16 flowey_lib_common::install_rust 2
         flowey e 16 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -2302,7 +2329,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 6
@@ -2405,12 +2432,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 2
         flowey e 16 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey e 16 flowey_lib_common::install_rust 2
+        flowey e 16 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -2560,20 +2587,23 @@ jobs:
         key: ${{ env.floweyvar2 }}
         path: ${{ env.floweyvar3 }}
       name: 'Restore cache: cargo-nextest'
-    - name: install Rust
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 2
         flowey.exe e 17 flowey_lib_common::cfg_persistent_dir_cargo_install 0
         flowey.exe e 17 flowey_lib_common::install_rust 0
       shell: bash
-    - name: detect active toolchain
+    - name: install Rust
       run: flowey.exe e 17 flowey_lib_common::install_rust 1
       shell: bash
-    - name: report $CARGO_HOME
+    - name: detect active toolchain
       run: flowey.exe e 17 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 17 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: flowey.exe e 17 flowey_lib_common::download_cargo_nextest 1
@@ -2620,7 +2650,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 6
@@ -2746,13 +2776,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 6
-        flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 18 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 18 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 18 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 18 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 18 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 18 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 18 flowey_lib_common::download_gh_release 0
@@ -2771,7 +2814,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 10
@@ -2846,7 +2889,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 2
@@ -2922,14 +2965,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 18 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 18 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 18 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 18 flowey_lib_common::cache 11
       shell: bash
   job19:
     name: run vmm-tests [x64-windows-amd]
@@ -2993,13 +3036,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
-        flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 19 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 19 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 19 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 19 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 19 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 19 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 19 flowey_lib_common::download_gh_release 0
@@ -3018,7 +3074,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -3093,7 +3149,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -3169,14 +3225,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 19 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 19 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 19 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 19 flowey_lib_common::cache 11
       shell: bash
   job2:
     name: build and check docs [x64-linux]
@@ -3300,7 +3356,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 2 flowey_lib_common::cache 2
@@ -3320,8 +3376,11 @@ jobs:
     - name: symlink protoc
       run: flowey e 2 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 2 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 2 flowey_lib_common::install_rust 1
       shell: bash
     - name: unpack Microsoft.WSL.LxUtil.x64.zip
       run: flowey e 2 flowey_lib_hvlite::download_lxutil 0
@@ -3331,7 +3390,7 @@ jobs:
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 2 flowey_lib_common::install_rust 1
+        flowey e 2 flowey_lib_common::install_rust 2
         flowey e 2 flowey_lib_common::cfg_cargo_common_flags 0
         flowey e 2 flowey_lib_common::run_cargo_doc 0
       shell: bash
@@ -3417,13 +3476,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 6
-        flowey e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey e 20 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey e 20 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 20 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey e 20 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey e 20 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey e 20 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 20 flowey_lib_common::install_dist_pkg 0
@@ -3448,7 +3520,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 10
@@ -3517,7 +3589,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 20 flowey_lib_common::cache 2
@@ -3593,14 +3665,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey e 20 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey e 20 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 20 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey e 20 flowey_lib_common::cache 11
       shell: bash
   job21:
     name: run vmm-tests [aarch64-windows]
@@ -3714,13 +3786,26 @@ jobs:
         key: ${{ env.floweyvar7 }}
         path: ${{ env.floweyvar8 }}
       name: 'Restore cache: cargo-nextest'
-    - name: installing cargo-nextest
+    - name: add default cargo home to path
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 6
-        flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 21 flowey_lib_common::cfg_persistent_dir_cargo_install 0
+        flowey.exe e 21 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 21 flowey_lib_common::install_rust 1
+      shell: bash
+    - name: detect active toolchain
+      run: flowey.exe e 21 flowey_lib_common::install_rust 2
+      shell: bash
+    - name: report $CARGO_HOME
+      run: flowey.exe e 21 flowey_lib_common::install_rust 3
+      shell: bash
+    - name: installing cargo-nextest
+      run: flowey.exe e 21 flowey_lib_common::download_cargo_nextest 1
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey.exe e 21 flowey_lib_common::download_gh_release 0
@@ -3739,7 +3824,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 10
@@ -3814,7 +3899,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 21 flowey_lib_common::cache 2
@@ -3890,14 +3975,14 @@ jobs:
     - name: report test results to overall pipeline status
       run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
-    - name: 'validate cache entry: gh-release-download'
-      run: flowey.exe e 21 flowey_lib_common::cache 11
-      shell: bash
     - name: 'validate cache entry: azcopy'
       run: flowey.exe e 21 flowey_lib_common::cache 3
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 21 flowey_lib_common::cache 7
+      shell: bash
+    - name: 'validate cache entry: gh-release-download'
+      run: flowey.exe e 21 flowey_lib_common::cache 11
       shell: bash
   job22:
     name: test flowey local backend
@@ -3999,9 +4084,12 @@ jobs:
         flowey e 22 flowey_lib_common::git_checkout 3
         flowey e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
+    - name: add default cargo home to path
+      run: flowey e 22 flowey_lib_common::install_rust 0
+      shell: bash
     - name: install Rust
       run: |-
-        flowey e 22 flowey_lib_common::install_rust 0
+        flowey e 22 flowey_lib_common::install_rust 1
         flowey v 22 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
         ${{ github.token }}
         EOF
@@ -4168,12 +4256,15 @@ jobs:
         flowey.exe e 3 flowey_lib_common::git_checkout 3
         flowey.exe e 3 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 3 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 3 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 3 flowey_lib_common::install_rust 1
+        flowey.exe e 3 flowey_lib_common::install_rust 2
         flowey.exe e 3 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -4196,7 +4287,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 3 flowey_lib_common::cache 2
@@ -4324,12 +4415,15 @@ jobs:
         flowey e 4 flowey_lib_common::git_checkout 3
         flowey e 4 flowey_lib_hvlite::git_checkout_openvmm_repo 0
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 4 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 4 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 4 flowey_lib_common::install_rust 1
+        flowey e 4 flowey_lib_common::install_rust 2
         flowey e 4 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: set '-Dwarnings' in .cargo/config.toml
@@ -4352,7 +4446,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 4 flowey_lib_common::cache 2
@@ -4478,12 +4572,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 5 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 5 flowey_lib_common::install_rust 1
+        flowey.exe e 5 flowey_lib_common::install_rust 2
         flowey.exe e 5 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -4528,7 +4625,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -4712,12 +4809,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 6 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 6 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 6 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 6 flowey_lib_common::install_rust 1
+        flowey.exe e 6 flowey_lib_common::install_rust 2
         flowey.exe e 6 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
@@ -4737,7 +4837,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 6
@@ -4821,12 +4921,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
         flowey.exe e 6 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 6 flowey_lib_common::install_rust 2
+        flowey.exe e 6 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -4950,12 +5050,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 7 'artifact_publish_from_x64-windows-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 7 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 7 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 7 flowey_lib_common::install_rust 1
+        flowey.exe e 7 flowey_lib_common::install_rust 2
         flowey.exe e 7 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: check if openvmm needs to be cloned
@@ -5000,7 +5103,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
@@ -5188,12 +5291,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 8 'artifact_publish_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey.exe e 8 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey.exe e 8 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey.exe e 8 flowey_lib_common::install_rust 1
+        flowey.exe e 8 flowey_lib_common::install_rust 2
         flowey.exe e 8 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: create gh-release-download cache dir
@@ -5213,7 +5319,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 8 flowey_lib_common::cache 6
@@ -5297,12 +5403,12 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 8 flowey_lib_common::cache 2
         flowey.exe e 8 flowey_lib_common::cfg_persistent_dir_cargo_install 0
-        flowey.exe e 8 flowey_lib_common::install_rust 2
+        flowey.exe e 8 flowey_lib_common::install_rust 3
       shell: bash
     - name: installing cargo-nextest
       run: |-
@@ -5437,12 +5543,15 @@ jobs:
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgstool' --update-from-stdin --is-raw-string
       shell: bash
-    - name: install Rust
+    - name: add default cargo home to path
       run: flowey e 9 flowey_lib_common::install_rust 0
+      shell: bash
+    - name: install Rust
+      run: flowey e 9 flowey_lib_common::install_rust 1
       shell: bash
     - name: detect active toolchain
       run: |-
-        flowey e 9 flowey_lib_common::install_rust 1
+        flowey e 9 flowey_lib_common::install_rust 2
         flowey e 9 flowey_lib_common::cfg_cargo_common_flags 0
       shell: bash
     - name: checking if packages need to be installed
@@ -5468,7 +5577,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:509:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
  "log",
  "serde",
  "target-lexicon",
+ "vmm_test_images",
 ]
 
 [[package]]

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -296,6 +296,13 @@ pub enum GhRunner {
     RunnerGroup { group: String, labels: Vec<String> },
 }
 
+impl GhRunner {
+    /// Whether this is a self-hosted runner with the provided label
+    pub fn is_self_hosted_with_label(&self, label: &str) -> bool {
+        matches!(self, GhRunner::SelfHosted(labels) if labels.iter().any(|s| s.as_str() == label))
+    }
+}
+
 /// Parameter type (unstable / stable).
 #[derive(Debug, Clone)]
 pub enum ParameterKind {

--- a/flowey/flowey_hvlite/Cargo.toml
+++ b/flowey/flowey_hvlite/Cargo.toml
@@ -12,6 +12,8 @@ flowey_lib_common.workspace = true
 flowey_lib_hvlite.workspace = true
 flowey.workspace = true
 
+vmm_test_images = { workspace = true, features = ["serde"] }
+
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 log.workspace = true

--- a/flowey/flowey_lib_common/src/cache.rs
+++ b/flowey/flowey_lib_common/src/cache.rs
@@ -480,6 +480,7 @@ impl FlowNode for Node {
                                 );
 
                                 let key = rt.read(key);
+                                let key = format!("{key}-{}-{}", rt.arch(), rt.platform());
                                 rt.write(write_processed_key, &key);
 
                                 if let Some(write_processed_keys) = write_processed_keys {
@@ -490,7 +491,11 @@ impl FlowNode for Node {
                                             r#""[{}]""#,
                                             restore_keys
                                                 .into_iter()
-                                                .map(|s| format!("'{s}'"))
+                                                .map(|s| format!(
+                                                    "'{s}-{}-{}'",
+                                                    rt.arch(),
+                                                    rt.platform()
+                                                ))
                                                 .collect::<Vec<_>>()
                                                 .join(", ")
                                         ),

--- a/flowey/flowey_lib_common/src/download_cargo_nextest.rs
+++ b/flowey/flowey_lib_common/src/download_cargo_nextest.rs
@@ -3,7 +3,7 @@
 
 //! Download (and optionally, install) a copy of `cargo-nextest`.
 
-// use crate::cache::CacheHit;
+use crate::cache::CacheHit;
 use crate::cache::CacheResult;
 use flowey::node::prelude::*;
 
@@ -86,7 +86,7 @@ impl FlowNode for Node {
 
             let install_standalone = install_standalone.claim(ctx);
             let cache_dir = cache_dir.claim(ctx);
-            let _hitvar = hitvar.claim(ctx);
+            let hitvar = hitvar.claim(ctx);
             let cargo_install_persistent_dir = cargo_install_persistent_dir.claim(ctx);
             let rust_toolchain = rust_toolchain.claim(ctx);
             let cargo_home = cargo_home.claim(ctx);
@@ -99,14 +99,12 @@ impl FlowNode for Node {
                 let cargo_home = rt.read(cargo_home);
 
                 let cached_bin_path = cache_dir.join(&cargo_nextest_bin);
-                // TODO: testing cargo install, remove before merge
-                let cached = None;
-                // let cached = if matches!(rt.read(hitvar), CacheHit::Hit) {
-                //     assert!(cached_bin_path.exists());
-                //     Some(cached_bin_path.clone())
-                // } else {
-                //     None
-                // };
+                let cached = if matches!(rt.read(hitvar), CacheHit::Hit) {
+                    assert!(cached_bin_path.exists());
+                    Some(cached_bin_path.clone())
+                } else {
+                    None
+                };
 
                 let (cargo_home, path_to_cargo_nextest) = if let Some(cached) = cached {
                     (cargo_home, cached)

--- a/flowey/flowey_lib_common/src/download_cargo_nextest.rs
+++ b/flowey/flowey_lib_common/src/download_cargo_nextest.rs
@@ -3,7 +3,7 @@
 
 //! Download (and optionally, install) a copy of `cargo-nextest`.
 
-use crate::cache::CacheHit;
+// use crate::cache::CacheHit;
 use crate::cache::CacheResult;
 use flowey::node::prelude::*;
 
@@ -73,45 +73,44 @@ impl FlowNode for Node {
             }
         });
 
-        let rust_deps = if !install_with_cargo.is_empty() {
-            // in case we end up doing a cargo-install
-            let cargo_install_persistent_dir =
-                ctx.reqv(crate::cfg_persistent_dir_cargo_install::Request);
-
-            let rust_toolchain = ctx.reqv(crate::install_rust::Request::GetRustupToolchain);
-
-            let cargo_home = ctx.reqv(crate::install_rust::Request::GetCargoHome);
-
-            Some((cargo_install_persistent_dir, rust_toolchain, cargo_home))
-        } else {
-            None
-        };
+        // rust deps in case we end up doing a cargo-install
+        // TODO: only install rust if we can't find nextest
+        let cargo_install_persistent_dir =
+            ctx.reqv(crate::cfg_persistent_dir_cargo_install::Request);
+        let rust_toolchain = ctx.reqv(crate::install_rust::Request::GetRustupToolchain);
+        let cargo_home = ctx.reqv(crate::install_rust::Request::GetCargoHome);
+        let rust_installed = ctx.reqv(crate::install_rust::Request::EnsureInstalled);
 
         ctx.emit_rust_step("installing cargo-nextest", |ctx| {
             install_with_cargo.claim(ctx);
 
             let install_standalone = install_standalone.claim(ctx);
             let cache_dir = cache_dir.claim(ctx);
-            let hitvar = hitvar.claim(ctx);
-            let rust_deps = rust_deps.map(|(a, b, c)| (a.claim(ctx), b.claim(ctx), c.claim(ctx)));
+            let _hitvar = hitvar.claim(ctx);
+            let cargo_install_persistent_dir = cargo_install_persistent_dir.claim(ctx);
+            let rust_toolchain = rust_toolchain.claim(ctx);
+            let cargo_home = cargo_home.claim(ctx);
+            rust_installed.claim(ctx);
 
             move |rt| {
                 let cache_dir = rt.read(cache_dir);
-                let rust_deps = rust_deps.map(|(a, b, c)| (rt.read(a), rt.read(b), rt.read(c)));
+                let cargo_install_persistent_dir = rt.read(cargo_install_persistent_dir);
+                let rust_toolchain = rt.read(rust_toolchain);
+                let cargo_home = rt.read(cargo_home);
 
                 let cached_bin_path = cache_dir.join(&cargo_nextest_bin);
-                let cached = if matches!(rt.read(hitvar), CacheHit::Hit) {
-                    assert!(cached_bin_path.exists());
-                    Some(cached_bin_path.clone())
-                } else {
-                    None
-                };
+                // TODO: testing cargo install, remove before merge
+                let cached = None;
+                // let cached = if matches!(rt.read(hitvar), CacheHit::Hit) {
+                //     assert!(cached_bin_path.exists());
+                //     Some(cached_bin_path.clone())
+                // } else {
+                //     None
+                // };
 
                 let (cargo_home, path_to_cargo_nextest) = if let Some(cached) = cached {
-                    (rust_deps.map(|(_, _, cargo_home)| cargo_home), cached)
-                } else if let Some((cargo_install_persistent_dir, rust_toolchain, cargo_home)) =
-                    rust_deps
-                {
+                    (cargo_home, cached)
+                } else {
                     let root = cargo_install_persistent_dir.unwrap_or("./".into());
 
                     let sh = xshell::Shell::new()?;
@@ -146,22 +145,15 @@ impl FlowNode for Node {
                     fs_err::rename(out_bin, &cached_bin_path)?;
                     let final_bin = cached_bin_path.absolute()?;
 
-                    (Some(cargo_home), final_bin)
-                } else {
-                    log::error!(
-                        "specified standalone installation, but not standalone bin could be found!"
-                    );
-                    anyhow::bail!("could not install cargo-nextest")
+                    (cargo_home, final_bin)
                 };
 
                 // is installing with cargo, make sure the bin we built /
                 // downloaded is accessible via cargo nextest
-                if let Some(cargo_home) = cargo_home {
-                    fs_err::copy(
-                        &path_to_cargo_nextest,
-                        cargo_home.join("bin").join(&cargo_nextest_bin),
-                    )?;
-                }
+                fs_err::copy(
+                    &path_to_cargo_nextest,
+                    cargo_home.join("bin").join(&cargo_nextest_bin),
+                )?;
 
                 for var in install_standalone {
                     rt.write(var, &path_to_cargo_nextest)


### PR DESCRIPTION
- Fixes an issue where a cached item for the wrong platform/architecture could be downloaded. 
- Installs nextest if the cache isn't working, even on jobs that download a pre-built version of flowey (vmm_tests).
- Changes the nextest configuration to only print failure logs at the end to make the logs more readable.
- Refactors the vmm test flowey nodes to allow VHDs/ISOs to be specified by the caller where the test filter is defined, instead of being inferred based on architecture.