### PR TITLE
hyperv_ic_protocol: add more protocol defs

### DIFF
--- a/vm/devices/hyperv_ic_protocol/src/heartbeat.rs
+++ b/vm/devices/hyperv_ic_protocol/src/heartbeat.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Heartbeat component protocol.
+use open_enum::open_enum;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+/// Heartbeat message from guest to host.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct HeartbeatMessage {
+    /// Incrementing sequence counter.
+    pub sequence_number: u64,
+    /// Current state of the guest.
+    pub application_state: ApplicationState,
+    /// Reserved.
+    pub reserved: [u8; 4],
+}
+
+open_enum! {
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    /// Current state of guest.
+    pub enum ApplicationState: u32 {
+        /// Guest is in an unknown state.
+        UNKNOWN = 0,
+        /// Guest is healthy.
+        HEALTHY = 1,
+        /// Guest encountered a critical error.
+        CRITICAL = 2,
+        /// Guest is no longer running.
+        STOPPED = 3,
+    }
+}

--- a/vm/devices/hyperv_ic_protocol/src/kvp.rs
+++ b/vm/devices/hyperv_ic_protocol/src/kvp.rs
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Protocol definitions for the KVP (Key-Value Pair) protocol.
+
+use crate::Version;
+use open_enum::open_enum;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+/// Version 3.0.
+pub const KVP_VERSION_3: Version = Version::new(3, 0);
+/// Version 4.0.
+pub const KVP_VERSION_4: Version = Version::new(4, 0);
+/// Version 5.0.
+pub const KVP_VERSION_5: Version = Version::new(5, 0);
+
+/// The header for KVP messages.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct KvpHeader {
+    /// The operation to perform.
+    pub operation: KvpOperation,
+    /// The pool to use.
+    pub pool: KvpPool,
+}
+
+open_enum! {
+    /// The operation to perform.
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum KvpOperation: u8 {
+        /// Get a value.
+        GET = 0,
+        /// Set a value.
+        SET = 1,
+        /// Delete a value.
+        DELETE = 2,
+        /// Enumerate values.
+        ENUMERATE = 3,
+        /// Get IP address information.
+        GET_IP_ADDRESS_INFO = 4,
+        /// Set IP address information.
+        SET_IP_ADDRESS_INFO = 5,
+    }
+}
+
+open_enum! {
+    /// The pool to use for a value.
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum KvpPool: u8 {
+        #![allow(missing_docs)] // TODO: figure out what the semantics of these actually are.
+        EXTERNAL = 0,
+        GUEST = 1,
+        AUTO = 2,
+        AUTO_EXTERNAL = 3,
+        // There is an "internal" pool defined in some places, but this is never
+        // exchanged between host and guest.
+    }
+}
+
+/// The maximum key size, in bytes.
+pub const MAX_KEY_BYTES: usize = 512;
+/// The maximum value size, in bytes.
+pub const MAX_VALUE_BYTES: usize = 2048;
+
+/// A value request or response.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct Value {
+    /// The type of the value.
+    pub value_type: ValueType,
+    /// The size of the key, in bytes (including the null terminator).
+    pub key_size: u32,
+    /// The size of the value, in bytes.
+    pub value_size: u32,
+    /// The key, as a null-terminated UTF-16 string.
+    pub key: [u16; MAX_KEY_BYTES / 2],
+    /// The value.
+    pub value: [u8; MAX_VALUE_BYTES],
+}
+
+open_enum! {
+    /// The type of the value.
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum ValueType: u32 {
+        /// A UTF-16 string.
+        STRING = 1,         // REG_SZ
+        /// A UTF-16 string, with environment variables expanded.
+        EXPAND_STRING = 2,  // REG_EXPAND_SZ
+        /// A 32-bit integer.
+        DWORD = 4,          // REG_DWORD
+        /// A 64-bit integer.
+        QWORD = 11,         // REG_QWORD
+    }
+}
+
+/// A message to get or set a key-value pair.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageGetSet {
+    /// The value.
+    pub value: Value,
+}
+
+/// A message to delete a key-value pair.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageDelete {
+    /// The size of the key, in bytes (including the null terminator).
+    pub key_size: u32,
+    /// The key, as a null-terminated UTF-16 string.
+    pub key: [u16; MAX_KEY_BYTES / 2],
+}
+
+/// A message to enumerate key-value pairs.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageEnumerate {
+    /// The index of the enumeration.
+    pub index: u32,
+    /// The value.
+    pub value: Value,
+}
+
+/// A get, set, enumerate, or delete message.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct KvpMessage {
+    /// The header.
+    pub header: KvpHeader,
+    /// Zero padding.
+    pub padding: [u8; 2],
+    /// The body of the message.
+    pub body: [u8; 2576],
+}
+
+/// IP address information, in UTF-16 string form.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct IpAddressInfo {
+    /// The adapter ID, as a null-terminated UTF-16 string.
+    pub adapter_id: [u16; 128],
+    /// The protocols this message applies to.
+    pub address_family: AddressFamily,
+    /// Whether DHCP is enabled for the adapter.
+    pub dhcp_enabled: u8,
+    /// The IP addresses, as a semicolon-delimited, null-terminated UTF-16 string.
+    pub ip_address: [u16; 1024],
+    /// The subnets, as a semicolon-delimited, null-terminated UTF-16 string.
+    pub subnet: [u16; 1024],
+    /// The gateways, as a semicolon-delimited, null-terminated UTF-16 string.
+    pub gateway: [u16; 512],
+    /// The DNS server addresses, as a semicolon-delimited, null-terminated
+    /// UTF-16 string.
+    pub dns_server_addresses: [u16; 1024],
+}
+
+open_enum! {
+    /// The address family of a network protocol, for specifying the scope of a request.
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum AddressFamily: u8 {
+        /// No protocol.
+        NONE = 0,
+        /// IPv4.
+        IPV4 = 1,
+        /// IPv6.
+        IPV6 = 2,
+        /// Both IPv4 and IPv6.
+        IPV4V6 = 3,
+    }
+}
+
+/// IP address information, in binary form.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct IpAddressValueBinary {
+    /// The number of IPv4 addresses.
+    pub ipv4_address_count: u32,
+    /// The number of IPv6 addresses.
+    pub ipv6_address_count: u32,
+    /// The number of IPv4 subnets.
+    pub ipv4_gateway_count: u32,
+    /// The number of IPv6 subnets.
+    pub ipv6_gateway_count: u32,
+    /// The number of IPv4 gateways.
+    pub ipv4_dns_server_count: u32,
+    /// The number of IPv6 gateways.
+    pub ipv6_dns_server_count: u32,
+    /// The adapter ID, as a null-terminated UTF-16 string.
+    pub adapter_id: [u16; 128],
+    /// The protocols this message applies to.
+    pub address_family: AddressFamily,
+    /// Whether DHCP is enabled for the adapter.
+    pub dhcp_enabled: u8,
+    /// Zero padding.
+    pub padding: u16,
+    /// The IPv4 addresses.
+    pub ipv4_addressese: [IpAddressV4; 64],
+    /// The IPv6 addresses.
+    pub ipv6_addressese: [IpAddressV6; 64],
+    /// The IPv4 subnets.
+    pub ipv4_subnets: [IpAddressV4; 64],
+    /// The IPv6 subnets.
+    pub ipv6_subnets: [IpAddressV6; 64],
+    /// The IPv4 gateways.
+    pub ipv4_gateways: [IpAddressV4; 5],
+    /// The IPv6 gateways.
+    pub ipv6_gateways: [IpAddressV6; 5],
+    /// The IPv4 DNS servers.
+    pub ipv4_dns_servers: [IpAddressV4; 64],
+    /// The IPv6 DNS servers.
+    pub ipv6_dns_servers: [IpAddressV6; 64],
+    /// The IPv4 and IPv6 address origins. This is flattened into a single
+    /// array, without gaps between the IPv4 and IPv6 addresses.
+    pub ip_address_origins: [IpAddressOrigin; 128],
+}
+
+open_enum! {
+    /// The origin of an IP address.
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum IpAddressOrigin: u32 {
+        /// Unknown origin.
+        UNKNOWN = 0,
+        /// Non-static assignment (probably DHCP).
+        OTHER = 1,
+        /// Static assignment.
+        STATIC = 2,
+    }
+}
+
+/// An IPv4 address, encoded as four octets in network byte order.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct IpAddressV4(pub [u8; 4]);
+
+/// An IPv6 address, encoded as sixteen segments in network byte order.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct IpAddressV6(pub [u8; 16]);
+
+/// A message for exchanging IP address information in string format.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageIpAddressInfo {
+    /// The message header.
+    pub header: KvpHeader,
+    /// The IP address information.
+    pub value: IpAddressInfo,
+}
+
+/// A message for exchanging IP address information in binary format.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageIpAddressInfoBinary {
+    /// The message header.
+    pub header: KvpHeader,
+    /// Zero padding.
+    pub padding: u16,
+    /// The IP address information.
+    pub value: IpAddressValueBinary,
+}

--- a/vm/devices/hyperv_ic_protocol/src/lib.rs
+++ b/vm/devices/hyperv_ic_protocol/src/lib.rs
@@ -3,6 +3,12 @@
 
 //! IC protocol definitions.
 
+pub mod heartbeat;
+pub mod kvp;
+pub mod shutdown;
+pub mod timesync;
+pub mod vss;
+
 use bitfield_struct::bitfield;
 use open_enum::open_enum;
 use std::fmt::Display;
@@ -111,100 +117,4 @@ pub struct NegotiateMessage {
     pub message_version_count: u16,
     /// Reserved -- must be zero.
     pub reserved: u32,
-}
-
-/// Heartbeat component protocol.
-pub mod heartbeat {
-    use open_enum::open_enum;
-    use zerocopy::FromBytes;
-    use zerocopy::Immutable;
-    use zerocopy::IntoBytes;
-    use zerocopy::KnownLayout;
-
-    /// Heartbeat message from guest to host.
-    #[repr(C)]
-    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
-    pub struct HeartbeatMessage {
-        /// Incrementing sequence counter.
-        pub sequence_number: u64,
-        /// Current state of the guest.
-        pub application_state: ApplicationState,
-        /// Reserved.
-        pub reserved: [u8; 4],
-    }
-
-    open_enum! {
-        #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
-        /// Current state of guest.
-        pub enum ApplicationState: u32 {
-            /// Guest is in an unknown state.
-            UNKNOWN = 0,
-            /// Guest is healthy.
-            HEALTHY = 1,
-            /// Guest encountered a critical error.
-            CRITICAL = 2,
-            /// Guest is no longer running.
-            STOPPED = 3,
-        }
-    }
-}
-
-/// Protocol for shutdown IC.
-pub mod shutdown {
-    use crate::Version;
-    use bitfield_struct::bitfield;
-    use guid::Guid;
-    use zerocopy::FromBytes;
-    use zerocopy::Immutable;
-    use zerocopy::IntoBytes;
-    use zerocopy::KnownLayout;
-
-    /// The unique vmbus interface ID of the shutdown IC.
-    pub const INTERFACE_ID: Guid = guid::guid!("0e0b6031-5213-4934-818b-38d90ced39db");
-    /// The unique vmbus instance ID of the shutdown IC.
-    pub const INSTANCE_ID: Guid = guid::guid!("b6650ff7-33bc-4840-8048-e0676786f393");
-
-    /// Supported framework versions.
-    pub const FRAMEWORK_VERSIONS: &[Version] = &[Version::new(1, 0), Version::new(3, 0)];
-
-    /// Supported message versions.
-    pub const SHUTDOWN_VERSIONS: &[Version] = &[
-        Version::new(1, 0),
-        Version::new(3, 0),
-        Version::new(3, 1),
-        Version::new(3, 2),
-    ];
-
-    /// The message for shutdown initiated from the host.
-    #[repr(C)]
-    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
-    pub struct ShutdownMessage {
-        /// The shutdown reason.
-        pub reason_code: u32,
-        /// The maximum amount of time allotted to the guest to perform the
-        /// shutdown.
-        pub timeout_secs: u32,
-        /// Flags for the shutdown request.
-        pub flags: ShutdownFlags,
-        /// Friendly text string for the shutdown request.
-        pub message: [u8; 2048],
-    }
-
-    /// Flags for shutdown.
-    #[bitfield(u32)]
-    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
-    pub struct ShutdownFlags {
-        /// Whether the shutdown operation is being forced.
-        pub force: bool,
-        /// Flag indicating the shutdown behavior is guest restart.
-        pub restart: bool,
-        /// Flag indicating the shutdown behavior is guest hibernate.
-        pub hibernate: bool,
-        /// Reserved -- must be zero.
-        #[bits(29)]
-        _reserved: u32,
-    }
-
-    /// Reason code for '[ShutdownMessage]', from Windows SDK.
-    pub const SHTDN_REASON_FLAG_PLANNED: u32 = 0x80000000;
 }

--- a/vm/devices/hyperv_ic_protocol/src/shutdown.rs
+++ b/vm/devices/hyperv_ic_protocol/src/shutdown.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Protocol for shutdown IC.
+
+use crate::Version;
+use bitfield_struct::bitfield;
+use guid::Guid;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+/// The unique vmbus interface ID of the shutdown IC.
+pub const INTERFACE_ID: Guid = guid::guid!("0e0b6031-5213-4934-818b-38d90ced39db");
+/// The unique vmbus instance ID of the shutdown IC.
+pub const INSTANCE_ID: Guid = guid::guid!("b6650ff7-33bc-4840-8048-e0676786f393");
+
+/// Supported framework versions.
+pub const FRAMEWORK_VERSIONS: &[Version] = &[Version::new(1, 0), Version::new(3, 0)];
+
+/// Supported message versions.
+pub const SHUTDOWN_VERSIONS: &[Version] = &[
+    Version::new(1, 0),
+    Version::new(3, 0),
+    Version::new(3, 1),
+    Version::new(3, 2),
+];
+
+/// The message for shutdown initiated from the host.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct ShutdownMessage {
+    /// The shutdown reason.
+    pub reason_code: u32,
+    /// The maximum amount of time allotted to the guest to perform the
+    /// shutdown.
+    pub timeout_secs: u32,
+    /// Flags for the shutdown request.
+    pub flags: ShutdownFlags,
+    /// Friendly text string for the shutdown request.
+    pub message: [u8; 2048],
+}
+
+/// Flags for shutdown.
+#[bitfield(u32)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct ShutdownFlags {
+    /// Whether the shutdown operation is being forced.
+    pub force: bool,
+    /// Flag indicating the shutdown behavior is guest restart.
+    pub restart: bool,
+    /// Flag indicating the shutdown behavior is guest hibernate.
+    pub hibernate: bool,
+    /// Reserved -- must be zero.
+    #[bits(29)]
+    _reserved: u32,
+}
+
+/// Reason code for '[ShutdownMessage]', from Windows SDK.
+pub const SHTDN_REASON_FLAG_PLANNED: u32 = 0x80000000;

--- a/vm/devices/hyperv_ic_protocol/src/timesync.rs
+++ b/vm/devices/hyperv_ic_protocol/src/timesync.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Protocol definitions for the timesync IC.
+
+use crate::Version;
+use bitfield_struct::bitfield;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+use zerocopy::little_endian::U64 as U64LE;
+
+/// Version 1.0.
+pub const TIMESYNC_VERSION_1: Version = Version::new(1, 0);
+/// Version 3.0.
+pub const TIMESYNC_VERSION_3: Version = Version::new(3, 0);
+/// Version 4.0. Introduced a new message format.
+pub const TIMESYNC_VERSION_4: Version = Version::new(4, 0);
+
+/// Timesync messages used before version 4.0.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct TimesyncMessage {
+    /// The time of day measured in the parent, in UTC (or TAI? unclear).
+    pub parent_time: U64LE,
+    /// Unused.
+    pub child_time: U64LE,
+    /// The measured round trip time by the parent.
+    pub round_trip_time: U64LE,
+    /// Flags indicating the message's purpose.
+    pub flags: TimesyncFlags,
+    /// Reserved.
+    pub reserved: [u8; 3],
+}
+
+/// Timesync messages used in version 4.0 and later.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct TimesyncMessageV4 {
+    /// The wall clock time measured in the parent, in UTC (or TAI? unclear).
+    pub parent_time: U64LE,
+    /// The VM reference time of the child, at the time the parent measured the
+    /// wall clock time.
+    pub vm_reference_time: u64,
+    /// Flags indicating the message's purpose.
+    pub flags: TimesyncFlags,
+    /// The NTP leap indicator.
+    pub leap_indicator: u8,
+    /// The NTP stratum.
+    pub stratum: u8,
+    /// Reserved.
+    pub reserved: [u8; 5],
+}
+
+/// Flags for timesync messages.
+#[bitfield(u8)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct TimesyncFlags {
+    /// This is a sync message.
+    pub sync: bool,
+    /// This is a sample message.
+    pub sample: bool,
+    #[bits(6)]
+    _rsvd: u8,
+}

--- a/vm/devices/hyperv_ic_protocol/src/vss.rs
+++ b/vm/devices/hyperv_ic_protocol/src/vss.rs
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Protocol definitions for the VSS (Volume Shadow Service) IC.
+
+#![allow(missing_docs)]
+
+use crate::Version;
+use guid::Guid;
+use open_enum::open_enum;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
+
+pub const VSS_VERSION_WIN8: Version = Version::new(4, 0);
+pub const VSS_VERSION_WINBLUE: Version = Version::new(5, 0);
+pub const VSS_VERSION_THRESHOLD: Version = Version::new(6, 0);
+pub const VSS_VERSION_THRESHOLD_UR1: Version = Version::new(7, 0);
+
+pub const MAX_VHD_COUNT: usize = 260;
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct VssMessage {
+    pub header: VssHeader,
+    pub reserved: [u8; 7],
+    pub data: [u8; 24],
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct VssHeader {
+    pub operation: Operation,
+    pub reserved: [u8; 7],
+}
+
+open_enum! {
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum Operation: u8 {
+        CREATE = 0,
+        DELETE = 1,
+        CHECK_HOT_BACKUP = 2,
+        GET_DIRECT_MAPPED_DEVICES_INFO = 3,
+        // Messages below this are only valid for message version >= 4.0
+        BACKUP_COMPLETE = 4,
+        // Messages below this are only valid for message version >= 5.0
+        FREEZE_APPLICATIONS = 5,
+        THAW_APPLICATIONS = 6,
+        AUTO_RECOVER = 7,
+        // Messages below this are only valid for message version >= 6.0
+        QUERY_GUEST_CLUSTER_INFORMATION = 8,
+    }
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageCheckHotBackup {
+    pub flags: u32,
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageCreate {
+    pub snapshot_set_id: Guid,
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageCreateV2 {
+    pub snapshot_set_id: Guid,
+    pub backup_type: u32,
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageDelete {
+    pub snapshot_set_id: Guid,
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageDirectMappedDevicesInfo {
+    pub flags: u32,
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageCheckHotBackupComplete {
+    pub flags: u32,
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct MessageThawApplications {
+    pub flags: u32,
+}
+
+/// For freeze and autorecover.
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct Message2 {
+    pub header: VssHeader,
+    pub backup_type: u32,
+    pub flags: u32,
+    pub lun_count: u32,
+    pub luns: [LunInfo; MAX_VHD_COUNT],
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct Message2Ex {
+    pub header: VssHeader,
+    pub backup_type: u32,
+    pub flags: u32,
+    pub lun_count: u32,
+    pub luns: [LunInfo; MAX_VHD_COUNT],
+    pub shadow_luns: [LunInfo; MAX_VHD_COUNT],
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct Message3 {
+    pub header: VssHeader,
+    pub cluster_id: Guid,
+    pub cluster_size: u32,
+    pub lun_count: u32,
+    pub shared_luns: [LunInfo; MAX_VHD_COUNT],
+    pub shared_lun_status: [u32; MAX_VHD_COUNT],
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct Message3Ex {
+    pub header: VssHeader,
+    pub cluster_id: Guid,
+    pub cluster_size: u32,
+    pub lun_count: u32,
+    pub shared_luns: [LunInfo; MAX_VHD_COUNT],
+    pub shared_lun_status: [u32; MAX_VHD_COUNT],
+    pub last_move_time: u64,
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct LunInfo {
+    pub bus_type: u8,
+    pub reserved: [u8; 3],
+    pub controller: Guid,
+    pub port: u8,
+    pub target: u8,
+    pub lun: u8,
+    pub reserved2: u8,
+}


### PR DESCRIPTION
Add definitions for KVP, timesync, and VSS.

These aren't tested yet. There is probably some extra or missing padding somewhere.