### PR TITLE
attestation: relax the wrapped key response check when VMGS is not encrypted

### DIFF
--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -341,7 +341,7 @@ pub async fn initialize_platform_security(
         false
     };
 
-    let vmgs_encrypted: bool = vmgs.get_encryption_algorithm() != EncryptionAlgorithm::NONE;
+    let vmgs_encrypted: bool = vmgs.is_encrypted();
 
     tracing::info!(tcb_version=?tcb_version, vmgs_encrypted = vmgs_encrypted, "Deriving keys");
     let derived_keys_result = get_derived_keys(

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -18,7 +18,6 @@ use openssl::rsa::Rsa;
 use pal_async::local::LocalDriver;
 use tee_call::TeeCall;
 use thiserror::Error;
-use vmgs::EncryptionAlgorithm;
 use vmgs::Vmgs;
 
 #[derive(Debug, Error)]

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -109,7 +109,7 @@ pub async fn request_vmgs_encryption_keys(
     // Retry attestation call-out if necessary (if VMGS encrypted).
     // The IGVm Agent could be down for servicing, or the TDX service VM might not be ready, or a dynamic firmware
     // update could mean that the report was not verifiable.
-    let vmgs_encrypted = vmgs.get_encryption_algorithm() != EncryptionAlgorithm::NONE;
+    let vmgs_encrypted = vmgs.is_encrypted();
     let max_retry = if vmgs_encrypted {
         MAXIMUM_RETRY_COUNT
     } else {


### PR DESCRIPTION
Fix the logic introduced by #1124 --- only return the error of wrapped key response is required when VMGS is encrypted.