### PR TITLE
Update to latest openvmm-deps release

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -28,7 +28,7 @@ pub const NEXTEST: &str = "0.9.74";
 pub const NODEJS: &str = "18.x";
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.6.63.2";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.6.63.1";
-pub const OPENVMM_DEPS: &str = "0.1.0-20241014.2";
+pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 
 flowey_request! {


### PR DESCRIPTION
Update build to pull in the most recent openvmm-deps update: https://github.com/microsoft/openvmm-deps/releases/tag/0.1.0-20250403.3.