### PR TITLE
snp guest vsm: register intercepts

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -2113,6 +2113,7 @@ impl<'a, T: Backing<'a>> ProcessorRunner<'a, T> {
                     | HvX64RegisterName::VsmVpWaitForTlbLock
                     | HvX64RegisterName::VsmVpSecureConfigVtl0
                     | HvX64RegisterName::VsmVpSecureConfigVtl1
+                    | HvX64RegisterName::CrInterceptControl
             )
         ));
         self.set_vp_registers_hvcall_inner(vtl, &registers)

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -398,9 +398,8 @@ impl UhCvmVpState {
         let lapics = VtlArray::from_fn(|vtl| {
             let apic_set = &cvm_partition.lapic[vtl];
 
-            // The APIC is software-enabled after reset for
-            // secure VTLs, to maintain compatibility with released versions of secure
-            // kernel
+            // The APIC is software-enabled after reset for secure VTLs, to
+            // maintain compatibility with released versions of secure kernel
             let mut lapic = apic_set.add_apic(vp_info, vtl == Vtl::Vtl1);
             // Initialize APIC base to match the reset VM state.
             lapic.set_apic_base(apic_base).unwrap();

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -354,6 +354,16 @@ struct GuestVsmVpState {
 }
 
 #[cfg(guest_arch = "x86_64")]
+impl GuestVsmVpState {
+    fn new() -> Self {
+        GuestVsmVpState {
+            vtl0_exit_pending_event: None,
+            reg_intercept: Default::default(),
+        }
+    }
+}
+
+#[cfg(guest_arch = "x86_64")]
 #[derive(Inspect)]
 /// VP state for CVMs.
 struct UhCvmVpState {
@@ -368,7 +378,6 @@ struct UhCvmVpState {
     lapics: VtlArray<LapicState, 2>,
     /// Guest VSM state for this vp. Some when VTL 1 is enabled.
     vtl1: Option<GuestVsmVpState>,
-    vtl1_reg_intercept: SecureRegisterInterceptState, // TODO: move into vtl 1 state
 }
 
 #[cfg(guest_arch = "x86_64")]
@@ -412,13 +421,13 @@ impl UhCvmVpState {
             hv,
             lapics,
             vtl1: None,
-            vtl1_reg_intercept: Default::default(),
         })
     }
 }
 
 #[cfg(guest_arch = "x86_64")]
 #[derive(Inspect, Default)]
+/// Configuration of VTL 1 registration for intercepts on certain registers
 pub struct SecureRegisterInterceptState {
     #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
     intercept_control: hvdef::HvRegisterCrInterceptControl,
@@ -427,7 +436,6 @@ pub struct SecureRegisterInterceptState {
     ia32_misc_enable_mask: u64,
 }
 
-#[cfg(guest_arch = "x86_64")]
 #[derive(Inspect)]
 /// Partition-wide state for CVMs.
 struct UhCvmPartitionState {

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -433,6 +433,8 @@ pub struct SecureRegisterInterceptState {
     intercept_control: hvdef::HvRegisterCrInterceptControl,
     cr0_mask: u64,
     cr4_mask: u64,
+    // Writes to X86X_IA32_MSR_MISC_ENABLE are dropped, so this is only used so
+    // that get_vp_register returns the correct value from a set_vp_register
     ia32_misc_enable_mask: u64,
 }
 

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -367,6 +367,7 @@ struct UhCvmVpState {
     lapics: VtlArray<LapicState, 2>,
     /// Guest VSM state for this vp. Some when VTL 1 is enabled.
     vtl1: Option<GuestVsmVpState>,
+    vtl1_cr_intercept: ControlRegisterInterceptState,
 }
 
 #[cfg(guest_arch = "x86_64")]
@@ -406,10 +407,22 @@ impl UhCvmVpState {
             hv,
             lapics,
             vtl1: None,
+            vtl1_cr_intercept: Default::default(),
         })
     }
 }
 
+#[cfg(guest_arch = "x86_64")]
+#[derive(Inspect, Default)]
+pub struct ControlRegisterInterceptState {
+    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    intercept_control: hvdef::HvRegisterCrInterceptControl,
+    cr0_mask: u64,
+    cr4_mask: u64,
+    ia32_misc_enable_mask: u64,
+}
+
+#[cfg(guest_arch = "x86_64")]
 #[derive(Inspect)]
 /// Partition-wide state for CVMs.
 struct UhCvmPartitionState {

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -350,6 +350,7 @@ struct GuestVsmVpState {
     /// next exit to VTL 0.
     #[inspect(with = "|x| x.as_ref().map(inspect::AsDebug)")]
     vtl0_exit_pending_event: Option<hvdef::HvX64PendingExceptionEvent>,
+    reg_intercept: SecureRegisterInterceptState,
 }
 
 #[cfg(guest_arch = "x86_64")]

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -555,9 +555,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
                 self.set_vtl0_pending_event(HvX64PendingExceptionEvent::from(reg.value.as_u128()))
             }
             HvX64RegisterName::CrInterceptControl => {
-                tracing::info!(?reg, "handling write to cr intercept control register");
                 if vtl != GuestVtl::Vtl1 {
-                    tracing::info!("cr intercept control register can only be written by VTL 1");
                     return Err(HvError::AccessDenied);
                 }
 
@@ -593,9 +591,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             mask_reg @ (HvX64RegisterName::CrInterceptCr0Mask
             | HvX64RegisterName::CrInterceptCr4Mask
             | HvX64RegisterName::CrInterceptIa32MiscEnableMask) => {
-                tracing::info!(?reg, "handling write to cr intercept mask register");
                 if vtl != GuestVtl::Vtl1 {
-                    tracing::info!("cr intercept mask register can only be written by VTL 1");
                     return Err(HvError::AccessDenied);
                 }
                 let mask = match mask_reg {

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -554,6 +554,65 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
 
                 self.set_vtl0_pending_event(HvX64PendingExceptionEvent::from(reg.value.as_u128()))
             }
+            HvX64RegisterName::CrInterceptControl => {
+                tracing::info!(?reg, "handling write to cr intercept control register");
+                if vtl != GuestVtl::Vtl1 {
+                    tracing::info!("cr intercept control register can only be written by VTL 1");
+                    return Err(HvError::AccessDenied);
+                }
+
+                let supported_controls = hvdef::HvRegisterCrInterceptControl::new()
+                    .with_cr0_write(true)
+                    .with_cr4_write(true)
+                    .with_xcr0_write(true)
+                    .with_ia32_misc_enable_write(true)
+                    .with_msr_lstar_write(true)
+                    .with_msr_star_write(true)
+                    .with_msr_cstar_write(true)
+                    .with_apic_base_msr_write(true)
+                    .with_msr_efer_write(true)
+                    .with_gdtr_write(true)
+                    .with_idtr_write(true)
+                    .with_ldtr_write(true)
+                    .with_tr_write(true)
+                    .with_msr_sysenter_cs_write(true)
+                    .with_msr_sysenter_eip_write(true)
+                    .with_msr_sysenter_esp_write(true)
+                    .with_msr_sfmask_write(true)
+                    .with_msr_tsc_aux_write(true);
+
+                if reg.value.as_u64() & !u64::from(supported_controls) != 0 {
+                    return Err(HvError::InvalidRegisterValue);
+                }
+
+                B::set_intercept_control_register(
+                    self.vp,
+                    hvdef::HvRegisterCrInterceptControl::from(reg.value.as_u64()),
+                )
+            }
+            mask_reg @ (HvX64RegisterName::CrInterceptCr0Mask
+            | HvX64RegisterName::CrInterceptCr4Mask
+            | HvX64RegisterName::CrInterceptIa32MiscEnableMask) => {
+                tracing::info!(?reg, "handling write to cr intercept mask register");
+                if vtl != GuestVtl::Vtl1 {
+                    tracing::info!("cr intercept mask register can only be written by VTL 1");
+                    return Err(HvError::AccessDenied);
+                }
+                let mask = match mask_reg {
+                    HvX64RegisterName::CrInterceptCr0Mask => {
+                        super::ControlRegisterMask::Cr0(reg.value.as_u64())
+                    }
+                    HvX64RegisterName::CrInterceptCr4Mask => {
+                        super::ControlRegisterMask::Cr4(reg.value.as_u64())
+                    }
+                    HvX64RegisterName::CrInterceptIa32MiscEnableMask => {
+                        super::ControlRegisterMask::Ia32MiscEnable(reg.value.as_u64())
+                    }
+                    _ => unreachable!(),
+                };
+                B::set_control_register_mask_register(self.vp, mask);
+                Ok(())
+            }
             _ => {
                 tracing::error!(
                     ?reg,
@@ -1677,6 +1736,8 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                 ?start_enable_vtl_state.operation,
                 "setting up vp with initial registers"
             );
+
+            // TODO GUEST VSM: check for register intercepts
 
             hv1_emulator::hypercall::set_x86_vp_context(
                 &mut self.access_state(vtl.into()),

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -748,10 +748,6 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
 
         // TODO TDX GUEST VSM
         if let virt::IsolationType::Snp = self.vp.partition.isolation {
-            // Intercept control is always managed by the hypervisor, so any request
-            // here is only opportunistic. Make the request directly with the
-            // hypervisor. Since intercept control always applies to VTL 1 control of
-            // VTL 0 state, the VTL 1 intercept control register is set here.
             B::cr_intercept_registration(self.vp, intercept_control);
         }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -325,17 +325,19 @@ trait HardwareIsolatedBacking: Backing {
 =======
 
     fn generate_register_intercept_message(
-        this: &mut UhProcessor<'_, Self>,
+        this: &UhProcessor<'_, Self>,
         vtl: GuestVtl,
         vp_index: VpIndex,
         reg: HvX64RegisterName,
         value: u64,
     ) -> hvdef::HvX64RegisterInterceptMessage;
 
-    // fn generate_msr_intercept(
-    //     this: &mut UhProcessor<'_, Self>,
-    //     vtl: GuestVtl,
-    // ) -> hvdef::HvX64MsrInterceptMessage;
+    fn generate_msr_intercept_message(
+        this: &UhProcessor<'_, Self>,
+        vtl: GuestVtl,
+        vp_index: VpIndex,
+        msr: u32,
+    ) -> hvdef::HvX64MsrInterceptMessage;
 
     fn cr0(this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64;
     fn cr4(this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64;

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -318,9 +318,28 @@ trait HardwareIsolatedBacking: Backing {
         vtl: GuestVtl,
         event: hvdef::HvX64PendingExceptionEvent,
     );
+<<<<<<< HEAD
     /// Individual register for CPUID, since AccessVpState::registers is
     /// relatively slow on TDX.
     fn cr4_for_cpuid(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> u64;
+=======
+
+    fn set_intercept_control_register(
+        this: &mut UhProcessor<'_, Self>,
+        intercept_control: hvdef::HvRegisterCrInterceptControl,
+    ) -> Result<(), HvError>;
+
+    fn set_control_register_mask_register(
+        this: &mut UhProcessor<'_, Self>,
+        mask: ControlRegisterMask,
+    );
+}
+
+pub enum ControlRegisterMask {
+    Cr0(u64),
+    Cr4(u64),
+    Ia32MiscEnable(u64),
+>>>>>>> b5e66ad3... sketch cr0 and cr4 intercept handling
 }
 
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -324,22 +324,33 @@ trait HardwareIsolatedBacking: Backing {
     fn cr4_for_cpuid(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> u64;
 =======
 
-    fn set_intercept_control_register(
+    fn generate_register_intercept_message(
         this: &mut UhProcessor<'_, Self>,
-        intercept_control: hvdef::HvRegisterCrInterceptControl,
-    ) -> Result<(), HvError>;
+        vtl: GuestVtl,
+        vp_index: VpIndex,
+        reg: HvX64RegisterName,
+        value: u64,
+    ) -> hvdef::HvX64RegisterInterceptMessage;
 
-    fn set_control_register_mask_register(
-        this: &mut UhProcessor<'_, Self>,
-        mask: ControlRegisterMask,
-    );
-}
+    // fn generate_msr_intercept(
+    //     this: &mut UhProcessor<'_, Self>,
+    //     vtl: GuestVtl,
+    // ) -> hvdef::HvX64MsrInterceptMessage;
 
+    fn cr0(this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64;
+    fn cr4(this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64;
+
+<<<<<<< HEAD
 pub enum ControlRegisterMask {
     Cr0(u64),
     Cr4(u64),
     Ia32MiscEnable(u64),
 >>>>>>> b5e66ad3... sketch cr0 and cr4 intercept handling
+=======
+    fn set_cr0(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl, cr0: u64);
+    fn set_cr4(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl, cr4: u64);
+    fn advance_to_next_instruction(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl);
+>>>>>>> bda761df... cleanup
 }
 
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -281,6 +281,12 @@ pub(crate) struct BackingSharedParams<'a> {
     pub _phantom: PhantomData<&'a ()>,
 }
 
+#[cfg(guest_arch = "x86_64")]
+enum InterceptMessageType {
+    Register { reg: HvX64RegisterName, value: u64 },
+    Msr { msr: u32 },
+}
+
 /// Trait for processor backings that have hardware isolation support.
 #[cfg(guest_arch = "x86_64")]
 trait HardwareIsolatedBacking: Backing {
@@ -324,23 +330,16 @@ trait HardwareIsolatedBacking: Backing {
     fn cr4_for_cpuid(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> u64;
 =======
 
-    fn generate_register_intercept_message(
+    fn generate_intercept_message(
         this: &UhProcessor<'_, Self>,
         vtl: GuestVtl,
         vp_index: VpIndex,
-        reg: HvX64RegisterName,
-        value: u64,
-    ) -> hvdef::HvX64RegisterInterceptMessage;
-
-    fn generate_msr_intercept_message(
-        this: &UhProcessor<'_, Self>,
-        vtl: GuestVtl,
-        vp_index: VpIndex,
-        msr: u32,
-    ) -> hvdef::HvX64MsrInterceptMessage;
+        message_type: InterceptMessageType,
+    ) -> HvMessage;
 
     fn cr0(this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64;
     fn cr4(this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64;
+<<<<<<< HEAD
 
 <<<<<<< HEAD
 pub enum ControlRegisterMask {
@@ -353,6 +352,8 @@ pub enum ControlRegisterMask {
     fn set_cr4(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl, cr4: u64);
     fn advance_to_next_instruction(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl);
 >>>>>>> bda761df... cleanup
+=======
+>>>>>>> af56d641... cleanup
 }
 
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
@@ -489,6 +490,8 @@ pub enum UhRunVpError {
     /// Handling an intercept on behalf of an invalid Lower VTL
     #[error("invalid intercepted vtl {0:?}")]
     InvalidInterceptedVtl(u8),
+    #[error("access to state blocked by another vtl")]
+    StateAccessDenied,
 }
 
 /// Underhill processor run error

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -6,6 +6,7 @@
 use super::BackingParams;
 use super::BackingPrivate;
 use super::BackingSharedParams;
+use super::ControlRegisterMask;
 use super::HardwareIsolatedBacking;
 use super::UhEmulationState;
 use super::UhRunVpError;
@@ -34,6 +35,7 @@ use hv1_structs::VtlArray;
 use hvdef::HV_PAGE_SIZE;
 use hvdef::HvDeliverabilityNotificationsRegister;
 use hvdef::HvError;
+use hvdef::HvInterceptAccessType;
 use hvdef::HvMessageType;
 use hvdef::HvX64PendingExceptionEvent;
 use hvdef::HvX64RegisterName;
@@ -65,6 +67,7 @@ use virt_support_x86emu::translate::TranslationRegisters;
 use vmcore::vmtime::VmTimeAccess;
 use x86defs::RFlags;
 use x86defs::cpuid::CpuidFunction;
+use x86defs::snp;
 use x86defs::snp::SevEventInjectInfo;
 use x86defs::snp::SevExitCode;
 use x86defs::snp::SevInvlpgbEcx;
@@ -114,6 +117,7 @@ struct ExitStats {
     vmmcall: Counter,
     xsetbv: Counter,
     excp_db: Counter,
+    cr_write: Counter,
 }
 
 enum UhDirectOverlay {
@@ -261,6 +265,38 @@ impl HardwareIsolatedBacking for SnpBacked {
 
     fn cr4_for_cpuid(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> u64 {
         this.runner.vmsa(vtl).cr4()
+    }
+
+    fn set_intercept_control_register(
+        this: &mut UhProcessor<'_, Self>,
+        intercept_control: hvdef::HvRegisterCrInterceptControl,
+    ) -> Result<(), HvError> {
+        this.backing.cvm.vtl1_cr_intercept.intercept_control = intercept_control;
+        // TODO: panic if this fails?
+        this.runner.set_vp_registers_hvcall(
+            Vtl::Vtl1,
+            [(
+                HvX64RegisterName::CrInterceptControl,
+                u64::from(intercept_control),
+            )],
+        )
+    }
+
+    fn set_control_register_mask_register(
+        this: &mut UhProcessor<'_, Self>,
+        mask: ControlRegisterMask,
+    ) {
+        match mask {
+            ControlRegisterMask::Cr0(mask) => {
+                this.backing.cvm.vtl1_cr_intercept.cr0_mask = mask;
+            }
+            ControlRegisterMask::Cr4(mask) => {
+                this.backing.cvm.vtl1_cr_intercept.cr4_mask = mask;
+            }
+            ControlRegisterMask::Ia32MiscEnable(mask) => {
+                this.backing.cvm.vtl1_cr_intercept.ia32_misc_enable_mask = mask;
+            }
+        }
     }
 }
 
@@ -839,6 +875,130 @@ impl UhProcessor<'_, SnpBacked> {
         self.deliver_synic_messages(GuestVtl::Vtl0, message.deliverable_sints);
     }
 
+    fn handle_secure_register_write(&mut self, vtl: GuestVtl, reg: HvX64RegisterName, value: u64) {
+        tracing::info!(?reg, ?value, "handling write to secure register");
+        if vtl == GuestVtl::Vtl0 {
+            let vmsa = self.runner.vmsa(vtl);
+            let generate_intercept = match reg {
+                HvX64RegisterName::Cr0 => {
+                    if self
+                        .backing
+                        .cvm
+                        .vtl1_cr_intercept
+                        .intercept_control
+                        .cr0_write()
+                    {
+                        tracing::info!(?reg, "should intercept this register");
+                        true
+                    } else {
+                        tracing::info!(?reg, "register is changing, should intercept");
+                        vmsa.cr0() ^ value != 0
+                    }
+                }
+                HvX64RegisterName::Cr4 => {
+                    if self
+                        .backing
+                        .cvm
+                        .vtl1_cr_intercept
+                        .intercept_control
+                        .cr4_write()
+                    {
+                        tracing::info!(?reg, "should intercept this register");
+                        true
+                    } else {
+                        tracing::info!(?reg, "register is changing, should intercept");
+                        vmsa.cr4() ^ value != 0
+                    }
+                }
+                _ => unreachable!("unexpected secure register"),
+            };
+
+            if generate_intercept {
+                // messageHeader = (PHV_X64_INTERCEPT_MESSAGE_HEADER)Message->Payload;
+                // messageHeader->VpIndex = Cpu->CpuNumber;
+                // messageHeader->ExecutionState.AsUINT16 = 0;
+                // messageHeader->ExecutionState.Cpl = vmsa->Cpl;
+                // messageHeader->ExecutionState.Vtl = Vtl;
+                // if ((SevpReadRegister64(vmsa, HvX64RegisterEfer) & X64_EFER_LMA) != 0)
+                // {
+                //     messageHeader->ExecutionState.EferLma = 1;
+                // }
+
+                // messageHeader->CsSegment = SevpGetSegmentRegister(vmsa, HvX64RegisterCs);
+                // messageHeader->Rflags = SevpReadRegister64(vmsa, HvX64RegisterRflags);
+                // messageHeader->Rip = SevpReadRegister64(vmsa, HvX64RegisterRip);
+                // messageHeader->InstructionLength = SevpGetInstructionLength(vmsa);
+
+                // PHV_REGISTER_INTERCEPT_MESSAGE registerMessage;
+
+                // registerMessage = (PHV_REGISTER_INTERCEPT_MESSAGE)Message->Payload;
+                // Message->Header.MessageType = HvMessageTypeRegisterIntercept;
+                // Message->Header.PayloadSize = sizeof(HV_REGISTER_INTERCEPT_MESSAGE);
+                // registerMessage->Header.InterceptAccessType = HV_INTERCEPT_ACCESS_WRITE;
+                // HtZeroMemory(&registerMessage->AccessInfo, sizeof(registerMessage->AccessInfo));
+                // registerMessage->RegisterName = RegisterName;
+
+                // return registerMessage;
+
+                let intercept_message = hvdef::HvX64RegisterInterceptMessage {
+                    header: hvdef::HvX64InterceptMessageHeader {
+                        vp_index: self.vp_index().index(),
+                        instruction_length_and_cr8: (vmsa.next_rip() - vmsa.rip()) as u8,
+                        intercept_access_type: HvInterceptAccessType::WRITE,
+                        execution_state: hvdef::HvX64VpExecutionState::new()
+                            .with_cpl(vmsa.cpl())
+                            .with_vtl(vtl.into())
+                            .with_efer_lma(vmsa.efer() & x86defs::X64_EFER_LMA != 0),
+                        cs_segment: hvdef::HvRegisterValue::from(vmsa.cs().as_u128()).into(),
+                        rip: vmsa.rip(),
+                        rflags: vmsa.rflags(),
+                    },
+                    flags: hvdef::HvX64RegisterInterceptMessageFlags::new(),
+                    rsvd: 0,
+                    rsvd2: 0,
+                    register_name: reg,
+                    access_info: value as u128,
+                };
+
+                let hv_message = hvdef::HvMessage::new(
+                    HvMessageType::HvMessageTypeRegisterIntercept,
+                    0,
+                    intercept_message.as_bytes(),
+                );
+
+                // TODO: access_info value only valid for cr0 and cr4?
+
+                tracing::info!(?reg, "sending intercept to vtl 1 for secure register write");
+
+                self.inner.post_message(
+                    GuestVtl::Vtl1,
+                    hvdef::HV_SYNIC_INTERCEPTION_SINT_INDEX,
+                    &hv_message,
+                );
+
+                // Once the intercept message has been posted, no further
+                // processing is required.  Do not advance the instruction
+                // pointer here, since the instruction pointer must continue to
+                // point to the instruction that generated the intercept.
+
+                return;
+            }
+        }
+
+        let mut vmsa = self.runner.vmsa_mut(vtl);
+        match reg {
+            HvX64RegisterName::Cr0 => {
+                vmsa.set_cr0(value);
+            }
+            HvX64RegisterName::Cr4 => {
+                vmsa.set_cr4(value);
+            }
+            _ => unreachable!("unexpected secure register"),
+        }
+
+        advance_to_next_instruction(&mut vmsa);
+    }
+
     fn handle_vmgexit(
         &mut self,
         dev: &impl CpuIo,
@@ -1333,12 +1493,13 @@ impl UhProcessor<'_, SnpBacked> {
                         cpl: vmsa.cpl(),
                     })
                 {
+                    // TODO GUEST VSM: determine if this should send an interrupt to VTL 1
                     vmsa.set_xcr0(value);
                     advance_to_next_instruction(&mut vmsa);
                 } else {
                     vmsa.set_event_inject(
                         SevEventInjectInfo::new()
-                            .with_interruption_type(x86defs::snp::SEV_INTR_TYPE_EXCEPT)
+                            .with_interruption_type(snp::SEV_INTR_TYPE_EXCEPT)
                             .with_vector(x86defs::Exception::GENERAL_PROTECTION_FAULT.0)
                             .with_deliver_error_code(true)
                             .with_valid(true),
@@ -1348,6 +1509,53 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::EXCP_DB => &mut self.backing.exit_stats[entered_from_vtl].excp_db,
+
+            SevExitCode::CR0_WRITE | SevExitCode::CR4_WRITE => {
+                tracing::info!(?sev_error_code, "handling secure register write");
+                let mov_crx_drx = snp::MovCrxDrxInfo::from(vmsa.exit_info1());
+                let reg_name = if sev_error_code == SevExitCode::CR0_WRITE {
+                    HvX64RegisterName::Cr0
+                } else {
+                    HvX64RegisterName::Cr4
+                };
+                let reg_value = {
+                    // TODO: is this correct, or even necessary?
+                    let gpr_name = HvX64RegisterName(
+                        HvX64RegisterName::Rax.0 + mov_crx_drx.gpr_number() as u32,
+                    );
+
+                    match gpr_name {
+                        HvX64RegisterName::Rax => vmsa.rax(),
+                        HvX64RegisterName::Rbx => vmsa.rbx(),
+                        HvX64RegisterName::Rcx => vmsa.rcx(),
+                        HvX64RegisterName::Rdx => vmsa.rdx(),
+                        HvX64RegisterName::Rsp => vmsa.rsp(),
+                        HvX64RegisterName::Rbp => vmsa.rbp(),
+                        HvX64RegisterName::Rsi => vmsa.rsi(),
+                        HvX64RegisterName::Rdi => vmsa.rdi(),
+                        HvX64RegisterName::R8 => vmsa.r8(),
+                        HvX64RegisterName::R9 => vmsa.r9(),
+                        HvX64RegisterName::R10 => vmsa.r10(),
+                        HvX64RegisterName::R11 => vmsa.r11(),
+                        HvX64RegisterName::R12 => vmsa.r12(),
+                        HvX64RegisterName::R13 => vmsa.r13(),
+                        HvX64RegisterName::R14 => vmsa.r14(),
+                        HvX64RegisterName::R15 => vmsa.r15(),
+                        _ => unreachable!("unexpected register"),
+                    }
+                };
+
+                if u64::from(mov_crx_drx) != 0 {
+                    self.handle_secure_register_write(entered_from_vtl, reg_name, reg_value);
+                } else {
+                    // Special case: LMSW/CLTS/SMSW intercepts do not provide
+                    // decode assist information.
+                    //
+                    // TODO: the HCL has a debug assert, but otherwise ignores
+                    // this case. Is that what we want?
+                }
+                &mut self.backing.exit_stats[entered_from_vtl].cr_write
+            }
 
             _ => {
                 debug_assert!(

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -67,7 +67,6 @@ use virt_support_x86emu::translate::TranslationRegisters;
 use vmcore::vmtime::VmTimeAccess;
 use x86defs::RFlags;
 use x86defs::cpuid::CpuidFunction;
-use x86defs::snp;
 use x86defs::snp::SevEventInjectInfo;
 use x86defs::snp::SevExitCode;
 use x86defs::snp::SevInvlpgbEcx;
@@ -117,7 +116,7 @@ struct ExitStats {
     vmmcall: Counter,
     xsetbv: Counter,
     excp_db: Counter,
-    cr_write: Counter,
+    secure_reg_write: Counter,
 }
 
 enum UhDirectOverlay {
@@ -271,7 +270,7 @@ impl HardwareIsolatedBacking for SnpBacked {
         this: &mut UhProcessor<'_, Self>,
         intercept_control: hvdef::HvRegisterCrInterceptControl,
     ) -> Result<(), HvError> {
-        this.backing.cvm.vtl1_cr_intercept.intercept_control = intercept_control;
+        this.backing.cvm.vtl1_reg_intercept.intercept_control = intercept_control;
         // TODO: panic if this fails?
         this.runner.set_vp_registers_hvcall(
             Vtl::Vtl1,
@@ -288,13 +287,13 @@ impl HardwareIsolatedBacking for SnpBacked {
     ) {
         match mask {
             ControlRegisterMask::Cr0(mask) => {
-                this.backing.cvm.vtl1_cr_intercept.cr0_mask = mask;
+                this.backing.cvm.vtl1_reg_intercept.cr0_mask = mask;
             }
             ControlRegisterMask::Cr4(mask) => {
-                this.backing.cvm.vtl1_cr_intercept.cr4_mask = mask;
+                this.backing.cvm.vtl1_reg_intercept.cr4_mask = mask;
             }
             ControlRegisterMask::Ia32MiscEnable(mask) => {
-                this.backing.cvm.vtl1_cr_intercept.ia32_misc_enable_mask = mask;
+                this.backing.cvm.vtl1_reg_intercept.ia32_misc_enable_mask = mask;
             }
         }
     }
@@ -879,37 +878,26 @@ impl UhProcessor<'_, SnpBacked> {
         tracing::info!(?reg, ?value, "handling write to secure register");
         if vtl == GuestVtl::Vtl0 {
             let vmsa = self.runner.vmsa(vtl);
+            let configured_intercepts = self.backing.cvm.vtl1_reg_intercept.intercept_control;
             let generate_intercept = match reg {
                 HvX64RegisterName::Cr0 => {
-                    if self
-                        .backing
-                        .cvm
-                        .vtl1_cr_intercept
-                        .intercept_control
-                        .cr0_write()
-                    {
-                        tracing::info!(?reg, "should intercept this register");
+                    if configured_intercepts.cr0_write() {
                         true
                     } else {
-                        tracing::info!(?reg, "register is changing, should intercept");
                         vmsa.cr0() ^ value != 0
                     }
                 }
                 HvX64RegisterName::Cr4 => {
-                    if self
-                        .backing
-                        .cvm
-                        .vtl1_cr_intercept
-                        .intercept_control
-                        .cr4_write()
-                    {
-                        tracing::info!(?reg, "should intercept this register");
+                    if configured_intercepts.cr4_write() {
                         true
                     } else {
-                        tracing::info!(?reg, "register is changing, should intercept");
                         vmsa.cr4() ^ value != 0
                     }
                 }
+                HvX64RegisterName::Gdtr => configured_intercepts.gdtr_write(),
+                HvX64RegisterName::Idtr => configured_intercepts.idtr_write(),
+                HvX64RegisterName::Ldtr => configured_intercepts.ldtr_write(),
+                HvX64RegisterName::Tr => configured_intercepts.tr_write(),
                 _ => unreachable!("unexpected secure register"),
             };
 
@@ -966,8 +954,6 @@ impl UhProcessor<'_, SnpBacked> {
                     intercept_message.as_bytes(),
                 );
 
-                // TODO: access_info value only valid for cr0 and cr4?
-
                 tracing::info!(?reg, "sending intercept to vtl 1 for secure register write");
 
                 self.inner.post_message(
@@ -993,7 +979,13 @@ impl UhProcessor<'_, SnpBacked> {
             HvX64RegisterName::Cr4 => {
                 vmsa.set_cr4(value);
             }
-            _ => unreachable!("unexpected secure register"),
+            _ => {
+                // If an unexpected intercept has been received, then the host
+                // must have enabled an intercept that was not desired. Since
+                // the intercept cannot correctly be emulated, this must be
+                // treated as a fatal error.
+                panic!("unexpected secure register")
+            }
         }
 
         advance_to_next_instruction(&mut vmsa);
@@ -1499,7 +1491,7 @@ impl UhProcessor<'_, SnpBacked> {
                 } else {
                     vmsa.set_event_inject(
                         SevEventInjectInfo::new()
-                            .with_interruption_type(snp::SEV_INTR_TYPE_EXCEPT)
+                            .with_interruption_type(x86defs::snp::SEV_INTR_TYPE_EXCEPT)
                             .with_vector(x86defs::Exception::GENERAL_PROTECTION_FAULT.0)
                             .with_deliver_error_code(true)
                             .with_valid(true),
@@ -1510,13 +1502,13 @@ impl UhProcessor<'_, SnpBacked> {
 
             SevExitCode::EXCP_DB => &mut self.backing.exit_stats[entered_from_vtl].excp_db,
 
-            SevExitCode::CR0_WRITE | SevExitCode::CR4_WRITE => {
-                tracing::info!(?sev_error_code, "handling secure register write");
-                let mov_crx_drx = snp::MovCrxDrxInfo::from(vmsa.exit_info1());
-                let reg_name = if sev_error_code == SevExitCode::CR0_WRITE {
-                    HvX64RegisterName::Cr0
-                } else {
-                    HvX64RegisterName::Cr4
+            cr_exit_code @ (SevExitCode::CR0_WRITE | SevExitCode::CR4_WRITE) => {
+                tracing::info!(?cr_exit_code, "handling secure register write");
+                let mov_crx_drx = x86defs::snp::MovCrxDrxInfo::from(vmsa.exit_info1());
+                let reg_name = match cr_exit_code {
+                    SevExitCode::CR0_WRITE => HvX64RegisterName::Cr0,
+                    SevExitCode::CR4_WRITE => HvX64RegisterName::Cr4,
+                    _ => unreachable!(),
                 };
                 let reg_value = {
                     // TODO: is this correct, or even necessary?
@@ -1554,7 +1546,25 @@ impl UhProcessor<'_, SnpBacked> {
                     // TODO: the HCL has a debug assert, but otherwise ignores
                     // this case. Is that what we want?
                 }
-                &mut self.backing.exit_stats[entered_from_vtl].cr_write
+                &mut self.backing.exit_stats[entered_from_vtl].secure_reg_write
+            }
+
+            tr_exit_code @ (SevExitCode::GDTR_WRITE
+            | SevExitCode::IDTR_WRITE
+            | SevExitCode::LDTR_WRITE
+            | SevExitCode::TR_WRITE) => {
+                tracing::info!(?tr_exit_code, "handling secure register write");
+                let reg = match tr_exit_code {
+                    SevExitCode::GDTR_WRITE => HvX64RegisterName::Gdtr,
+                    SevExitCode::IDTR_WRITE => HvX64RegisterName::Idtr,
+                    SevExitCode::LDTR_WRITE => HvX64RegisterName::Ldtr,
+                    SevExitCode::TR_WRITE => HvX64RegisterName::Tr,
+                    _ => unreachable!(),
+                };
+
+                self.handle_secure_register_write(entered_from_vtl, reg, 0);
+
+                &mut self.backing.exit_stats[entered_from_vtl].secure_reg_write
             }
 
             _ => {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -291,6 +291,10 @@ impl HardwareIsolatedBacking for SnpBacked {
         this: &mut UhProcessor<'_, Self>,
         intercept_control: hvdef::HvRegisterCrInterceptControl,
     ) {
+        // Intercept control is always managed by the hypervisor, so any request
+        // here is only opportunistic. Make the request directly with the
+        // hypervisor. Since intercept control always applies to VTL 1 control of
+        // VTL 0 state, the VTL 1 intercept control register is set here.
         this.runner
             .set_vp_registers_hvcall(
                 Vtl::Vtl1,

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -8,8 +8,6 @@ use super::BackingPrivate;
 use super::BackingSharedParams;
 use super::HardwareIsolatedBacking;
 use super::InterceptMessageState;
-use super::InterceptMessageType;
-use super::InterceptMessageTypeState;
 use super::UhEmulationState;
 use super::UhRunVpError;
 use super::hardware_cvm;
@@ -274,7 +272,6 @@ impl HardwareIsolatedBacking for SnpBacked {
     fn intercept_message_state(
         this: &UhProcessor<'_, Self>,
         vtl: GuestVtl,
-        message_type: &InterceptMessageType,
     ) -> InterceptMessageState {
         let vmsa = this.runner.vmsa(vtl);
 
@@ -285,18 +282,8 @@ impl HardwareIsolatedBacking for SnpBacked {
             cs_segment: virt_seg_from_snp(vmsa.cs()).into(),
             rip: vmsa.rip(),
             rflags: vmsa.rflags(),
-            per_type_state: {
-                match message_type {
-                    InterceptMessageType::Register { reg: _, value: _ } => {
-                        InterceptMessageTypeState::Register
-                    }
-
-                    InterceptMessageType::Msr { msr: _ } => InterceptMessageTypeState::Msr {
-                        rax: vmsa.rax(),
-                        rdx: vmsa.rdx(),
-                    },
-                }
-            },
+            rax: vmsa.rax(),
+            rdx: vmsa.rdx(),
         }
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -571,12 +571,12 @@ impl HardwareIsolatedBacking for TdxBacked {
         todo!()
     }
 
-    fn generate_intercept_message(
+    fn intercept_message_state(
         _this: &UhProcessor<'_, Self>,
         _vtl: GuestVtl,
         _vp_index: VpIndex,
-        _message_type: super::InterceptMessageType,
-    ) -> hvdef::HvMessage {
+        _message_type: &super::InterceptMessageType,
+    ) -> super::InterceptMessageState {
         todo!()
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -563,19 +563,33 @@ impl HardwareIsolatedBacking for TdxBacked {
         this.backing.vtls[vtl].cr4.read(&this.runner)
     }
 
-    fn set_intercept_control_register(
-        _this: &mut UhProcessor<'_, Self>,
-        _intercept_control: hvdef::HvRegisterCrInterceptControl,
-    ) -> Result<(), HvError> {
-        // TODO TDX GUEST VSM
+    fn cr0(_this: &UhProcessor<'_, Self>, _vtl: GuestVtl) -> u64 {
         todo!()
     }
 
-    fn set_control_register_mask_register(
+    fn cr4(_this: &UhProcessor<'_, Self>, _vtl: GuestVtl) -> u64 {
+        todo!()
+    }
+
+    fn set_cr0(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl, _cr0: u64) {
+        todo!()
+    }
+
+    fn set_cr4(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl, _cr4: u64) {
+        todo!()
+    }
+
+    fn advance_to_next_instruction(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) {
+        this.advance_to_next_instruction(vtl);
+    }
+
+    fn generate_register_intercept_message(
         _this: &mut UhProcessor<'_, Self>,
-        _mask: super::ControlRegisterMask,
-    ) {
-        // TODO TDX GUEST VSM
+        _vtl: GuestVtl,
+        _vp_index: VpIndex,
+        _reg: HvX64RegisterName,
+        _value: u64,
+    ) -> hvdef::HvX64RegisterInterceptMessage {
         todo!()
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -584,12 +584,21 @@ impl HardwareIsolatedBacking for TdxBacked {
     }
 
     fn generate_register_intercept_message(
-        _this: &mut UhProcessor<'_, Self>,
+        _this: &UhProcessor<'_, Self>,
         _vtl: GuestVtl,
         _vp_index: VpIndex,
         _reg: HvX64RegisterName,
         _value: u64,
     ) -> hvdef::HvX64RegisterInterceptMessage {
+        todo!()
+    }
+
+    fn generate_msr_intercept_message(
+        _this: &UhProcessor<'_, Self>,
+        _vtl: GuestVtl,
+        _vp_index: VpIndex,
+        _msr: u32,
+    ) -> hvdef::HvX64MsrInterceptMessage {
         todo!()
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -570,7 +570,6 @@ impl HardwareIsolatedBacking for TdxBacked {
     fn intercept_message_state(
         _this: &UhProcessor<'_, Self>,
         _vtl: GuestVtl,
-        _message_type: &super::InterceptMessageType,
     ) -> super::InterceptMessageState {
         todo!()
     }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -559,24 +559,26 @@ impl HardwareIsolatedBacking for TdxBacked {
         this.backing.vtls[vtl].exception_error_code = event.error_code();
     }
 
-    fn cr4_for_cpuid(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> u64 {
+    fn cr0(this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64 {
+        this.backing.vtls[vtl].cr0.read(&this.runner)
+    }
+
+    fn cr4(this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64 {
         this.backing.vtls[vtl].cr4.read(&this.runner)
-    }
-
-    fn cr0(_this: &UhProcessor<'_, Self>, _vtl: GuestVtl) -> u64 {
-        todo!()
-    }
-
-    fn cr4(_this: &UhProcessor<'_, Self>, _vtl: GuestVtl) -> u64 {
-        todo!()
     }
 
     fn intercept_message_state(
         _this: &UhProcessor<'_, Self>,
         _vtl: GuestVtl,
-        _vp_index: VpIndex,
         _message_type: &super::InterceptMessageType,
     ) -> super::InterceptMessageState {
+        todo!()
+    }
+
+    fn cr_intercept_registration(
+        _this: &mut UhProcessor<'_, Self>,
+        _intercept_control: hvdef::HvRegisterCrInterceptControl,
+    ) {
         todo!()
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -571,34 +571,12 @@ impl HardwareIsolatedBacking for TdxBacked {
         todo!()
     }
 
-    fn set_cr0(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl, _cr0: u64) {
-        todo!()
-    }
-
-    fn set_cr4(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl, _cr4: u64) {
-        todo!()
-    }
-
-    fn advance_to_next_instruction(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) {
-        this.advance_to_next_instruction(vtl);
-    }
-
-    fn generate_register_intercept_message(
+    fn generate_intercept_message(
         _this: &UhProcessor<'_, Self>,
         _vtl: GuestVtl,
         _vp_index: VpIndex,
-        _reg: HvX64RegisterName,
-        _value: u64,
-    ) -> hvdef::HvX64RegisterInterceptMessage {
-        todo!()
-    }
-
-    fn generate_msr_intercept_message(
-        _this: &UhProcessor<'_, Self>,
-        _vtl: GuestVtl,
-        _vp_index: VpIndex,
-        _msr: u32,
-    ) -> hvdef::HvX64MsrInterceptMessage {
+        _message_type: super::InterceptMessageType,
+    ) -> hvdef::HvMessage {
         todo!()
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -562,6 +562,22 @@ impl HardwareIsolatedBacking for TdxBacked {
     fn cr4_for_cpuid(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl) -> u64 {
         this.backing.vtls[vtl].cr4.read(&this.runner)
     }
+
+    fn set_intercept_control_register(
+        _this: &mut UhProcessor<'_, Self>,
+        _intercept_control: hvdef::HvRegisterCrInterceptControl,
+    ) -> Result<(), HvError> {
+        // TODO TDX GUEST VSM
+        todo!()
+    }
+
+    fn set_control_register_mask_register(
+        _this: &mut UhProcessor<'_, Self>,
+        _mask: super::ControlRegisterMask,
+    ) {
+        // TODO TDX GUEST VSM
+        todo!()
+    }
 }
 
 /// Partition-wide shared data for TDX VPs.

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -2978,15 +2978,6 @@ pub struct HvX64RegisterInterceptMessageFlags {
     _rsvd: u8,
 }
 
-// Note: in C, the access_info is a union:
-// typedef union _HV_X64_REGISTER_ACCESS_INFO
-// {
-//     HV_REGISTER_VALUE SourceValue;
-//     HV_REGISTER_NAME DestinationRegister;
-//     UINT64 SourceAddress;
-//     UINT64 DestinationAddress;
-// } HV_X64_REGISTER_ACCESS_INFO, *PHV_X64_REGISTER_ACCESS_INFO;
-
 #[repr(C)]
 #[derive(IntoBytes, Immutable, FromBytes)]
 pub struct HvX64RegisterInterceptMessage {
@@ -2995,7 +2986,17 @@ pub struct HvX64RegisterInterceptMessage {
     pub rsvd: u8,
     pub rsvd2: u16,
     pub register_name: HvX64RegisterName,
-    pub access_info: u128,
+    pub access_info: HvX64RegisterAccessInfo,
+}
+
+#[repr(transparent)]
+#[derive(IntoBytes, Immutable, FromBytes)]
+pub struct HvX64RegisterAccessInfo(u128);
+
+impl HvX64RegisterAccessInfo {
+    pub fn new_source_value(source_value: HvRegisterValue) -> Self {
+        Self(source_value.as_u128())
+    }
 }
 
 open_enum! {

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -755,6 +755,8 @@ impl Default for HvMessageType {
     }
 }
 
+pub const HV_SYNIC_INTERCEPTION_SINT_INDEX: u8 = 0;
+
 pub const NUM_SINTS: usize = 16;
 pub const NUM_TIMERS: usize = 4;
 
@@ -2262,6 +2264,11 @@ registers! {
 
         // AMD SEV configuration MSRs
         SevControl = 0x00090040,
+
+        CrInterceptControl = 0x000E0000,
+        CrInterceptCr0Mask = 0x000E0001,
+        CrInterceptCr4Mask = 0x000E0002,
+        CrInterceptIa32MiscEnableMask = 0x000E0003,
     }
 }
 
@@ -2961,6 +2968,34 @@ open_enum! {
         POWER_OFF = 0,
         REBOOT = 1,
     }
+}
+
+#[bitfield(u8)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
+pub struct HvX64RegisterInterceptMessageFlags {
+    pub is_memory_op: bool,
+    #[bits(7)]
+    _rsvd: u8,
+}
+
+// Note: in C, the access_info is a union:
+// typedef union _HV_X64_REGISTER_ACCESS_INFO
+// {
+//     HV_REGISTER_VALUE SourceValue;
+//     HV_REGISTER_NAME DestinationRegister;
+//     UINT64 SourceAddress;
+//     UINT64 DestinationAddress;
+// } HV_X64_REGISTER_ACCESS_INFO, *PHV_X64_REGISTER_ACCESS_INFO;
+
+#[repr(C)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
+pub struct HvX64RegisterInterceptMessage {
+    pub header: HvX64InterceptMessageHeader,
+    pub flags: HvX64RegisterInterceptMessageFlags,
+    pub rsvd: u8,
+    pub rsvd2: u16,
+    pub register_name: HvX64RegisterName,
+    pub access_info: u128,
 }
 
 open_enum! {
@@ -3671,4 +3706,39 @@ pub struct HvRegisterVsmVpSecureVtlConfig {
     pub hardware_hvpt_enabled: bool,
     #[bits(60)]
     _reserved: u64,
+}
+
+#[bitfield(u64)]
+pub struct HvRegisterCrInterceptControl {
+    pub cr0_write: bool,
+    pub cr4_write: bool,
+    pub xcr0_write: bool,
+    pub ia32_misc_enable_read: bool,
+    pub ia32_misc_enable_write: bool,
+    pub msr_lstar_read: bool,
+    pub msr_lstar_write: bool,
+    pub msr_star_read: bool,
+    pub msr_star_write: bool,
+    pub msr_cstar_read: bool,
+    pub msr_cstar_write: bool,
+    pub apic_base_msr_read: bool,
+    pub apic_base_msr_write: bool,
+    pub msr_efer_read: bool,
+    pub msr_efer_write: bool,
+    pub gdtr_write: bool,
+    pub idtr_write: bool,
+    pub ldtr_write: bool,
+    pub tr_write: bool,
+    pub msr_sysenter_cs_write: bool,
+    pub msr_sysenter_eip_write: bool,
+    pub msr_sysenter_esp_write: bool,
+    pub msr_sfmask_write: bool,
+    pub msr_tsc_aux_write: bool,
+    pub msr_sgx_launch_control_write: bool,
+    pub msr_xss_write: bool,
+    pub msr_scet_write: bool,
+    pub msr_pls_ssp_write: bool,
+    pub msr_interrupt_ssp_table_addr_write: bool,
+    #[bits(35)]
+    pub rsvd_z: u64,
 }

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -2971,7 +2971,7 @@ open_enum! {
 }
 
 #[bitfield(u8)]
-#[derive(AsBytes, FromBytes, FromZeroes)]
+#[derive(IntoBytes, Immutable, FromBytes)]
 pub struct HvX64RegisterInterceptMessageFlags {
     pub is_memory_op: bool,
     #[bits(7)]
@@ -2988,7 +2988,7 @@ pub struct HvX64RegisterInterceptMessageFlags {
 // } HV_X64_REGISTER_ACCESS_INFO, *PHV_X64_REGISTER_ACCESS_INFO;
 
 #[repr(C)]
-#[derive(AsBytes, FromBytes, FromZeroes)]
+#[derive(IntoBytes, Immutable, FromBytes)]
 pub struct HvX64RegisterInterceptMessage {
     pub header: HvX64InterceptMessageHeader,
     pub flags: HvX64RegisterInterceptMessageFlags,

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -3741,5 +3741,5 @@ pub struct HvRegisterCrInterceptControl {
     pub msr_pls_ssp_write: bool,
     pub msr_interrupt_ssp_table_addr_write: bool,
     #[bits(35)]
-    pub rsvd_z: u64,
+    _rsvd_z: u64,
 }

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -786,3 +786,12 @@ pub struct SevInvlpgbEcx {
     reserved: u64,
     pub large_page: bool,
 }
+
+#[bitfield(u64)]
+pub struct MovCrxDrxInfo {
+    #[bits(4)]
+    pub gpr_number: u64,
+    #[bits(59)]
+    pub reserved: u64,
+    pub mov_crx: bool,
+}

--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -741,7 +741,7 @@ pub(crate) struct ApicState {
 impl ApicState {
     pub fn new(table: &LocalApicSet, vp_info: &vm_topology::processor::x86::X86VpInfo) -> Self {
         Self {
-            apic: table.add_apic(vp_info),
+            apic: table.add_apic(vp_info, false),
             startup_suspend: !vp_info.base.is_bsp(),
             nmi_pending: false,
         }


### PR DESCRIPTION
Support for VTL 1 to register for write intercepts on certain registers.

Tested:
- SNP + Guest VSM boots no debugger
- SNP boots