### PR TITLE
openhcl: attach all pending dma restorations at once instead of handing out one by one

### DIFF
--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -105,10 +105,6 @@ impl<T: DmaClient> DmaClient for LowerVtlMemorySpawner<T> {
         }))
     }
 
-    fn attach_dma_buffer(&self, _len: usize, _base_pfn: u64) -> Result<MemoryBlock> {
-        anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
-    }
-
     fn attach_pending_buffers(&self) -> Result<Vec<MemoryBlock>> {
         anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
     }

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -13,6 +13,7 @@ pub use device_dma::LowerVtlDmaBuffer;
 use anyhow::Context;
 use anyhow::Result;
 use inspect::Inspect;
+use std::collections::HashMap;
 use std::sync::Arc;
 use user_driver::DmaClient;
 use user_driver::memory::MemoryBlock;
@@ -109,7 +110,7 @@ impl<T: DmaClient> DmaClient for LowerVtlMemorySpawner<T> {
         anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
     }
 
-    fn attach_pending_buffers(&self) -> Result<Vec<MemoryBlock>> {
+    fn attach_pending_buffers(&self) -> Result<HashMap<(u64, usize), MemoryBlock>> {
         anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
     }
 }

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -13,7 +13,6 @@ pub use device_dma::LowerVtlDmaBuffer;
 use anyhow::Context;
 use anyhow::Result;
 use inspect::Inspect;
-use std::collections::HashMap;
 use std::sync::Arc;
 use user_driver::DmaClient;
 use user_driver::memory::MemoryBlock;
@@ -110,7 +109,7 @@ impl<T: DmaClient> DmaClient for LowerVtlMemorySpawner<T> {
         anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
     }
 
-    fn attach_pending_buffers(&self) -> Result<HashMap<(u64, usize), MemoryBlock>> {
+    fn attach_pending_buffers(&self) -> Result<Vec<MemoryBlock>> {
         anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
     }
 }

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -108,4 +108,8 @@ impl<T: DmaClient> DmaClient for LowerVtlMemorySpawner<T> {
     fn attach_dma_buffer(&self, _len: usize, _base_pfn: u64) -> Result<MemoryBlock> {
         anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
     }
+
+    fn attach_pending_buffers(&self) -> Result<Vec<MemoryBlock>> {
+        anyhow::bail!("restore is not supported for LowerVtlMemorySpawner")
+    }
 }

--- a/openhcl/openhcl_dma_manager/src/lib.rs
+++ b/openhcl/openhcl_dma_manager/src/lib.rs
@@ -16,6 +16,7 @@ use memory_range::MemoryRange;
 use page_pool_alloc::PagePool;
 use page_pool_alloc::PagePoolAllocator;
 use page_pool_alloc::PagePoolAllocatorSpawner;
+use std::collections::HashMap;
 use std::sync::Arc;
 use user_driver::DmaClient;
 use user_driver::lockmem::LockedMemorySpawner;
@@ -438,7 +439,9 @@ impl DmaClientBacking {
         }
     }
 
-    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<user_driver::memory::MemoryBlock>> {
+    fn attach_pending_buffers(
+        &self,
+    ) -> anyhow::Result<HashMap<(u64, usize), user_driver::memory::MemoryBlock>> {
         match self {
             DmaClientBacking::SharedPool(allocator) => allocator.attach_pending_buffers(),
             DmaClientBacking::PrivatePool(allocator) => allocator.attach_pending_buffers(),
@@ -473,7 +476,9 @@ impl DmaClient for OpenhclDmaClient {
         self.backing.attach_dma_buffer(len, base_pfn)
     }
 
-    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<user_driver::memory::MemoryBlock>> {
+    fn attach_pending_buffers(
+        &self,
+    ) -> anyhow::Result<HashMap<(u64, usize), user_driver::memory::MemoryBlock>> {
         self.backing.attach_pending_buffers()
     }
 }

--- a/openhcl/openhcl_dma_manager/src/lib.rs
+++ b/openhcl/openhcl_dma_manager/src/lib.rs
@@ -16,7 +16,6 @@ use memory_range::MemoryRange;
 use page_pool_alloc::PagePool;
 use page_pool_alloc::PagePoolAllocator;
 use page_pool_alloc::PagePoolAllocatorSpawner;
-use std::collections::HashMap;
 use std::sync::Arc;
 use user_driver::DmaClient;
 use user_driver::lockmem::LockedMemorySpawner;
@@ -439,9 +438,7 @@ impl DmaClientBacking {
         }
     }
 
-    fn attach_pending_buffers(
-        &self,
-    ) -> anyhow::Result<HashMap<(u64, usize), user_driver::memory::MemoryBlock>> {
+    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<user_driver::memory::MemoryBlock>> {
         match self {
             DmaClientBacking::SharedPool(allocator) => allocator.attach_pending_buffers(),
             DmaClientBacking::PrivatePool(allocator) => allocator.attach_pending_buffers(),
@@ -476,9 +473,7 @@ impl DmaClient for OpenhclDmaClient {
         self.backing.attach_dma_buffer(len, base_pfn)
     }
 
-    fn attach_pending_buffers(
-        &self,
-    ) -> anyhow::Result<HashMap<(u64, usize), user_driver::memory::MemoryBlock>> {
+    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<user_driver::memory::MemoryBlock>> {
         self.backing.attach_pending_buffers()
     }
 }

--- a/openhcl/openhcl_dma_manager/src/lib.rs
+++ b/openhcl/openhcl_dma_manager/src/lib.rs
@@ -420,24 +420,6 @@ impl DmaClientBacking {
         }
     }
 
-    fn attach_dma_buffer(
-        &self,
-        len: usize,
-        base_pfn: u64,
-    ) -> anyhow::Result<user_driver::memory::MemoryBlock> {
-        match self {
-            DmaClientBacking::SharedPool(allocator) => allocator.attach_dma_buffer(len, base_pfn),
-            DmaClientBacking::PrivatePool(allocator) => allocator.attach_dma_buffer(len, base_pfn),
-            DmaClientBacking::LockedMemory(spawner) => spawner.attach_dma_buffer(len, base_pfn),
-            DmaClientBacking::PrivatePoolLowerVtl(spawner) => {
-                spawner.attach_dma_buffer(len, base_pfn)
-            }
-            DmaClientBacking::LockedMemoryLowerVtl(spawner) => {
-                spawner.attach_dma_buffer(len, base_pfn)
-            }
-        }
-    }
-
     fn attach_pending_buffers(&self) -> anyhow::Result<Vec<user_driver::memory::MemoryBlock>> {
         match self {
             DmaClientBacking::SharedPool(allocator) => allocator.attach_pending_buffers(),
@@ -463,14 +445,6 @@ impl DmaClient for OpenhclDmaClient {
         total_size: usize,
     ) -> anyhow::Result<user_driver::memory::MemoryBlock> {
         self.backing.allocate_dma_buffer(total_size)
-    }
-
-    fn attach_dma_buffer(
-        &self,
-        len: usize,
-        base_pfn: u64,
-    ) -> anyhow::Result<user_driver::memory::MemoryBlock> {
-        self.backing.attach_dma_buffer(len, base_pfn)
     }
 
     fn attach_pending_buffers(&self) -> anyhow::Result<Vec<user_driver::memory::MemoryBlock>> {

--- a/openhcl/openhcl_dma_manager/src/lib.rs
+++ b/openhcl/openhcl_dma_manager/src/lib.rs
@@ -437,6 +437,16 @@ impl DmaClientBacking {
             }
         }
     }
+
+    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<user_driver::memory::MemoryBlock>> {
+        match self {
+            DmaClientBacking::SharedPool(allocator) => allocator.attach_pending_buffers(),
+            DmaClientBacking::PrivatePool(allocator) => allocator.attach_pending_buffers(),
+            DmaClientBacking::LockedMemory(spawner) => spawner.attach_pending_buffers(),
+            DmaClientBacking::PrivatePoolLowerVtl(spawner) => spawner.attach_pending_buffers(),
+            DmaClientBacking::LockedMemoryLowerVtl(spawner) => spawner.attach_pending_buffers(),
+        }
+    }
 }
 
 /// An OpenHCL dma client. This client implements inspect to allow seeing what
@@ -461,5 +471,9 @@ impl DmaClient for OpenhclDmaClient {
         base_pfn: u64,
     ) -> anyhow::Result<user_driver::memory::MemoryBlock> {
         self.backing.attach_dma_buffer(len, base_pfn)
+    }
+
+    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<user_driver::memory::MemoryBlock>> {
+        self.backing.attach_pending_buffers()
     }
 }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -606,10 +606,10 @@ impl<T: DeviceBacking> NvmeDriver<T> {
             .map(|a| {
                 // Restore memory block for admin queue pair.
                 let mem_block = restored_memory
-                    .iter()
-                    .find(|mem| mem.len() == a.mem_len && a.base_pfn == mem.pfns()[0])
+                    .get(&(a.base_pfn, a.mem_len))
                     .expect("unable to find restored mem block")
                     .to_owned();
+
                 QueuePair::restore(driver.clone(), interrupt0, registers.clone(), mem_block, a)
                     .unwrap()
             })
@@ -650,13 +650,12 @@ impl<T: DeviceBacking> NvmeDriver<T> {
                     .device
                     .map_interrupt(q.iv, q.cpu)
                     .context("failed to map interrupt")?;
+
                 let mem_block = restored_memory
-                    .iter()
-                    .find(|mem| {
-                        mem.len() == q.queue_data.mem_len && q.queue_data.base_pfn == mem.pfns()[0]
-                    })
+                    .get(&(q.queue_data.base_pfn, q.queue_data.mem_len))
                     .expect("unable to find restored mem block")
                     .to_owned();
+
                 let q =
                     IoQueue::restore(driver.clone(), interrupt, registers.clone(), mem_block, q)?;
                 let issuer = IoIssuer {

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -10,7 +10,6 @@
 use inspect::Inspect;
 use interrupt::DeviceInterrupt;
 use memory::MemoryBlock;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 pub mod backoff;
@@ -71,6 +70,6 @@ pub trait DmaClient: Send + Sync + Inspect {
     /// Attach to a previously allocated memory block.
     fn attach_dma_buffer(&self, len: usize, base_pfn: u64) -> anyhow::Result<MemoryBlock>;
 
-    /// Attach all previously allocated buffers. Returns a [`HashMap`] keyed on `(base_pfn, len)`.
-    fn attach_pending_buffers(&self) -> anyhow::Result<HashMap<(u64, usize), MemoryBlock>>;
+    /// Attach all pending buffers
+    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<MemoryBlock>>;
 }

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -67,9 +67,6 @@ pub trait DmaClient: Send + Sync + Inspect {
     /// TODO: string tag for allocation?
     fn allocate_dma_buffer(&self, total_size: usize) -> anyhow::Result<MemoryBlock>;
 
-    /// Attach to a previously allocated memory block.
-    fn attach_dma_buffer(&self, len: usize, base_pfn: u64) -> anyhow::Result<MemoryBlock>;
-
     /// Attach all previously allocated memory blocks.
     fn attach_pending_buffers(&self) -> anyhow::Result<Vec<MemoryBlock>>;
 }

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -10,6 +10,7 @@
 use inspect::Inspect;
 use interrupt::DeviceInterrupt;
 use memory::MemoryBlock;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub mod backoff;
@@ -70,6 +71,6 @@ pub trait DmaClient: Send + Sync + Inspect {
     /// Attach to a previously allocated memory block.
     fn attach_dma_buffer(&self, len: usize, base_pfn: u64) -> anyhow::Result<MemoryBlock>;
 
-    /// Attach all pending buffers
-    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<MemoryBlock>>;
+    /// Attach all previously allocated buffers. Returns a [`HashMap`] keyed on `(base_pfn, len)`.
+    fn attach_pending_buffers(&self) -> anyhow::Result<HashMap<(u64, usize), MemoryBlock>>;
 }

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -69,4 +69,7 @@ pub trait DmaClient: Send + Sync + Inspect {
 
     /// Attach to a previously allocated memory block.
     fn attach_dma_buffer(&self, len: usize, base_pfn: u64) -> anyhow::Result<MemoryBlock>;
+
+    /// Attach all pending buffers
+    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<MemoryBlock>>;
 }

--- a/vm/devices/user_driver/src/lib.rs
+++ b/vm/devices/user_driver/src/lib.rs
@@ -70,6 +70,6 @@ pub trait DmaClient: Send + Sync + Inspect {
     /// Attach to a previously allocated memory block.
     fn attach_dma_buffer(&self, len: usize, base_pfn: u64) -> anyhow::Result<MemoryBlock>;
 
-    /// Attach all pending buffers
+    /// Attach all previously allocated memory blocks.
     fn attach_pending_buffers(&self) -> anyhow::Result<Vec<MemoryBlock>>;
 }

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -6,7 +6,6 @@
 use crate::memory::MappedDmaTarget;
 use anyhow::Context;
 use inspect::Inspect;
-use std::collections::HashMap;
 use std::ffi::c_void;
 use std::fs::File;
 use std::io::Read;
@@ -140,9 +139,7 @@ impl crate::DmaClient for LockedMemorySpawner {
         anyhow::bail!("restore not supported for lockmem")
     }
 
-    fn attach_pending_buffers(
-        &self,
-    ) -> anyhow::Result<HashMap<(u64, usize), crate::memory::MemoryBlock>> {
+    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<crate::memory::MemoryBlock>> {
         anyhow::bail!("restore not supported for lockmem")
     }
 }

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -138,4 +138,8 @@ impl crate::DmaClient for LockedMemorySpawner {
     ) -> anyhow::Result<crate::memory::MemoryBlock> {
         anyhow::bail!("restore not supported for lockmem")
     }
+
+    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<crate::memory::MemoryBlock>> {
+        anyhow::bail!("restore not supported for lockmem")
+    }
 }

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -6,6 +6,7 @@
 use crate::memory::MappedDmaTarget;
 use anyhow::Context;
 use inspect::Inspect;
+use std::collections::HashMap;
 use std::ffi::c_void;
 use std::fs::File;
 use std::io::Read;
@@ -139,7 +140,9 @@ impl crate::DmaClient for LockedMemorySpawner {
         anyhow::bail!("restore not supported for lockmem")
     }
 
-    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<crate::memory::MemoryBlock>> {
+    fn attach_pending_buffers(
+        &self,
+    ) -> anyhow::Result<HashMap<(u64, usize), crate::memory::MemoryBlock>> {
         anyhow::bail!("restore not supported for lockmem")
     }
 }

--- a/vm/devices/user_driver/src/lockmem.rs
+++ b/vm/devices/user_driver/src/lockmem.rs
@@ -131,14 +131,6 @@ impl crate::DmaClient for LockedMemorySpawner {
         Ok(crate::memory::MemoryBlock::new(LockedMemory::new(len)?))
     }
 
-    fn attach_dma_buffer(
-        &self,
-        _len: usize,
-        _base_pfn: u64,
-    ) -> anyhow::Result<crate::memory::MemoryBlock> {
-        anyhow::bail!("restore not supported for lockmem")
-    }
-
     fn attach_pending_buffers(&self) -> anyhow::Result<Vec<crate::memory::MemoryBlock>> {
         anyhow::bail!("restore not supported for lockmem")
     }

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -875,29 +875,6 @@ impl user_driver::DmaClient for PagePoolAllocator {
         alloc.into_memory_block()
     }
 
-    /// Restore a dma buffer in the predefined location with the given `len` in
-    /// bytes.
-    fn attach_dma_buffer(
-        &self,
-        len: usize,
-        base_pfn: u64,
-    ) -> anyhow::Result<user_driver::memory::MemoryBlock> {
-        if len as u64 % PAGE_SIZE != 0 {
-            anyhow::bail!("not a page-size multiple");
-        }
-
-        let size_pages = NonZeroU64::new(len as u64 / PAGE_SIZE)
-            .context("allocation of size 0 not supported")?;
-
-        let alloc = self
-            .restore_alloc(base_pfn, size_pages)
-            .context("failed to restore allocation")?;
-
-        // Preserve the existing contents of memory and do not zero the restored
-        // allocation.
-        alloc.into_memory_block()
-    }
-
     fn attach_pending_buffers(&self) -> anyhow::Result<Vec<user_driver::memory::MemoryBlock>> {
         let allocs = self.restore_pending_allocs();
 

--- a/vm/page_pool_alloc/src/lib.rs
+++ b/vm/page_pool_alloc/src/lib.rs
@@ -18,7 +18,6 @@ use sparse_mmap::Mappable;
 use sparse_mmap::MappableRef;
 use sparse_mmap::SparseMapping;
 use sparse_mmap::alloc_shared_memory;
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::num::NonZeroU64;
 use std::sync::Arc;
@@ -899,19 +898,12 @@ impl user_driver::DmaClient for PagePoolAllocator {
         alloc.into_memory_block()
     }
 
-    fn attach_pending_buffers(
-        &self,
-    ) -> anyhow::Result<HashMap<(u64, usize), user_driver::memory::MemoryBlock>> {
+    fn attach_pending_buffers(&self) -> anyhow::Result<Vec<user_driver::memory::MemoryBlock>> {
         let allocs = self.restore_pending_allocs();
 
         allocs
             .into_iter()
-            .map(|alloc| {
-                let base_pfn = alloc.base_pfn;
-                let block = alloc.into_memory_block()?;
-                let key = (base_pfn, block.len());
-                Ok((key, block))
-            })
+            .map(|alloc| alloc.into_memory_block())
             .collect()
     }
 }


### PR DESCRIPTION
Rather than having to call `attach_dma_buffer` for each pending allocation, it would be convenient to just attach them all and get the resulting `MemoryBlock`s. This change adds `attach_pending_buffers` to do that. 