### PR TITLE
petri: cloud-init: configure eth0 when present

### DIFF
--- a/petri/guest-bootstrap/network-config
+++ b/petri/guest-bootstrap/network-config
@@ -1,6 +1,8 @@
-# Specify a non-present device to work around https://github.com/canonical/cloud-init/issues/5511
+# Specify an optional device to work around https://github.com/canonical/cloud-init/issues/5511
 version: 1
 config:
   - type: physical
-    name: disabled
+    name: eth0
     optional: true
+    subnets:
+      - type: dhcp


### PR DESCRIPTION
We specify a networking configuration to work around a cloud-init bug. Make sure this networking configuration initializes the NIC configured for the VM when one is present.
