### PR TITLE
mesh_protobuf: add encoding for Ipv4Addr/Ipv6Addr

### DIFF
--- a/support/mesh/mesh_protobuf/src/encoding.rs
+++ b/support/mesh/mesh_protobuf/src/encoding.rs
@@ -343,7 +343,12 @@ impl FixedNumber for f64 {
     }
 }
 
-// Note that this is encoded in host network order (native endian).
+// This encodes the address as a u32, with the first octet in the high 8 bits of
+// the u32 and so on.
+//
+// In particular, this is not byte swapped to network byte order on
+// little-endian platforms, as you might naively expect, since this would result
+// in a different wire format across different architectures.
 impl FixedNumber for core::net::Ipv4Addr {
     type Type = u32;
 
@@ -444,6 +449,8 @@ pub struct Fixed32Field;
 builtin_field_type!(u32, Fixed32Field, "fixed32");
 builtin_field_type!(i32, Fixed32Field, "sfixed32");
 builtin_field_type!(f32, Fixed32Field, "float");
+
+builtin_field_type!(core::net::Ipv4Addr, Fixed32Field, "fixed32");
 
 impl<T: FixedNumber<Type = u32>, R> FieldEncode<T, R> for Fixed32Field {
     fn write_field(item: T, writer: FieldWriter<'_, '_, R>) {
@@ -794,45 +801,43 @@ impl<T: From<u128>, R> FieldDecode<'_, T, R> for U128LittleEndianField {
     }
 }
 
-/// A field encoder for u128.
+/// A field encoder for an IPv6 address.
 ///
-/// Writes the value as a big-endian-encoded 16-byte byte array.
-pub struct U128BigEndianField;
+/// Writes the value in octet order as a 16-byte array.
+pub struct Ipv6AddrField;
 
-builtin_field_type!(u128, U128BigEndianField, "bytes");
+builtin_field_type!(core::net::Ipv6Addr, Ipv6AddrField, "bytes");
 
-impl<T: Copy + Into<u128>, R> FieldEncode<T, R> for U128BigEndianField {
-    fn write_field(item: T, writer: FieldWriter<'_, '_, R>) {
-        let item = item.into();
-        if item != 0 || writer.write_empty() {
-            writer.bytes(&item.to_be_bytes());
+impl<R> FieldEncode<core::net::Ipv6Addr, R> for Ipv6AddrField {
+    fn write_field(item: core::net::Ipv6Addr, writer: FieldWriter<'_, '_, R>) {
+        if !item.is_unspecified() || writer.write_empty() {
+            writer.bytes(&item.octets());
         }
     }
 
-    fn compute_field_size(item: &mut T, sizer: FieldSizer<'_>) {
-        let item = (*item).into();
-        if item != 0 || sizer.write_empty() {
+    fn compute_field_size(item: &mut core::net::Ipv6Addr, sizer: FieldSizer<'_>) {
+        if !item.is_unspecified() || sizer.write_empty() {
             sizer.bytes(16);
         }
     }
 }
 
-impl<T: From<u128>, R> FieldDecode<'_, T, R> for U128BigEndianField {
-    fn read_field(item: &mut InplaceOption<'_, T>, reader: FieldReader<'_, '_, R>) -> Result<()> {
-        item.set(
-            u128::from_be_bytes(
-                reader
-                    .bytes()?
-                    .try_into()
-                    .map_err(|_| DecodeError::BadU128)?,
-            )
-            .into(),
-        );
+impl<R> FieldDecode<'_, core::net::Ipv6Addr, R> for Ipv6AddrField {
+    fn read_field(
+        item: &mut InplaceOption<'_, core::net::Ipv6Addr>,
+        reader: FieldReader<'_, '_, R>,
+    ) -> Result<()> {
+        let v: [u8; 16] = reader
+            .bytes()?
+            .try_into()
+            .map_err(|_| DecodeError::BadIpv6)?;
+
+        item.set(v.into());
         Ok(())
     }
 
-    fn default_field(item: &mut InplaceOption<'_, T>) -> Result<()> {
-        item.set(0.into());
+    fn default_field(item: &mut InplaceOption<'_, core::net::Ipv6Addr>) -> Result<()> {
+        item.set(core::net::Ipv6Addr::UNSPECIFIED);
         Ok(())
     }
 }
@@ -1714,7 +1719,7 @@ default_encodings! {
     Infallible: ImpossibleField,
 
     core::net::Ipv4Addr: Fixed32Field,
-    core::net::Ipv6Addr: U128BigEndianField,
+    core::net::Ipv6Addr: Ipv6AddrField,
 }
 
 impl DefaultEncoding for &str {

--- a/support/mesh/mesh_protobuf/src/encoding.rs
+++ b/support/mesh/mesh_protobuf/src/encoding.rs
@@ -343,9 +343,8 @@ impl FixedNumber for f64 {
     }
 }
 
-#[cfg(feature = "std")]
 // Note that this is encoded in host network order (native endian).
-impl FixedNumber for std::net::Ipv4Addr {
+impl FixedNumber for core::net::Ipv4Addr {
     type Type = u32;
 
     fn to_fixed(self) -> u32 {
@@ -1714,10 +1713,8 @@ default_encodings! {
 
     Infallible: ImpossibleField,
 
-    #[cfg(feature = "std")]
-    std::net::Ipv4Addr: Fixed32Field,
-    #[cfg(feature = "std")]
-    std::net::Ipv6Addr: U128BigEndianField,
+    core::net::Ipv4Addr: Fixed32Field,
+    core::net::Ipv6Addr: U128BigEndianField,
 }
 
 impl DefaultEncoding for &str {


### PR DESCRIPTION
This is useful for sending IP addresses across mesh processes.
