### PR TITLE
petri-tool: add CLI for petri-related functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5385,6 +5385,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petri-tool"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "petri",
+ "petri_artifact_resolver_openvmm_known_paths",
+ "petri_artifacts_common",
+]
+
+[[package]]
 name = "petri_artifact_resolver_openvmm_known_paths"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
   "petri/pipette",
   # tools
   "petri/make_imc_hive",
+  "petri/petri-tool",
   "vm/loader/igvmfilegen",
   "vm/vmgs/vmgs_lib",
   "vm/vmgs/vmgstool",

--- a/petri/petri-tool/Cargo.toml
+++ b/petri/petri-tool/Cargo.toml
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "petri-tool"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+petri.workspace = true
+petri_artifacts_common.workspace = true
+petri_artifact_resolver_openvmm_known_paths.workspace = true
+
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true
+
+[package.metadata.xtask.house-rules]
+# emits a binary, where kebab-case is more natural
+allow-dash-in-name = true

--- a/petri/petri-tool/src/main.rs
+++ b/petri/petri-tool/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> anyhow::Result<()> {
     match args.command {
         Command::CloudInit { output, arch } => {
             let image = build_with_artifacts(|resolver: ArtifactResolver<'_>| {
-                let image = petri::disk_image::AgentImage::new(
+                petri::disk_image::AgentImage::new(
                     &resolver,
                     match arch {
                         MachineArch::X86_64 => petri_artifacts_common::tags::MachineArch::X86_64,
@@ -50,7 +50,6 @@ fn main() -> anyhow::Result<()> {
                     },
                     petri_artifacts_common::tags::OsFlavor::Linux,
                 );
-                image
             })?;
 
             let disk = image.build().context("failed to build disk image")?;

--- a/petri/petri-tool/src/main.rs
+++ b/petri/petri-tool/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> anyhow::Result<()> {
                         MachineArch::Aarch64 => petri_artifacts_common::tags::MachineArch::Aarch64,
                     },
                     petri_artifacts_common::tags::OsFlavor::Linux,
-                );
+                )
             })?;
 
             let disk = image.build().context("failed to build disk image")?;

--- a/petri/petri-tool/src/main.rs
+++ b/petri/petri-tool/src/main.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Tool for using petri functionality from the command line.
+
+use anyhow::Context as _;
+use clap::Parser;
+use petri::ArtifactResolver;
+use petri::TestArtifactRequirements;
+
+/// Command line interface for petri-related tasks.
+#[derive(Parser)]
+struct CliArgs {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(clap::Subcommand)]
+enum Command {
+    /// Builds a cloud-init disk image for a Linux VM image.
+    ///
+    /// This image creates a petri user with the password "petri".
+    CloudInit {
+        /// The architecture of the VM image.
+        #[clap(long)]
+        arch: MachineArch,
+
+        /// Path to the output disk image.
+        output: std::path::PathBuf,
+    },
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+enum MachineArch {
+    #[clap(name = "x86_64")]
+    X86_64,
+    Aarch64,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = CliArgs::parse();
+    match args.command {
+        Command::CloudInit { output, arch } => {
+            let image = build_with_artifacts(|resolver: ArtifactResolver<'_>| {
+                let image = petri::disk_image::AgentImage::new(
+                    &resolver,
+                    match arch {
+                        MachineArch::X86_64 => petri_artifacts_common::tags::MachineArch::X86_64,
+                        MachineArch::Aarch64 => petri_artifacts_common::tags::MachineArch::Aarch64,
+                    },
+                    petri_artifacts_common::tags::OsFlavor::Linux,
+                );
+                image
+            })?;
+
+            let disk = image.build().context("failed to build disk image")?;
+            disk.persist(output)
+                .context("failed to persist disk image")?;
+
+            Ok(())
+        }
+    }
+}
+
+fn build_with_artifacts<R>(mut f: impl FnMut(ArtifactResolver<'_>) -> R) -> anyhow::Result<R> {
+    let resolver =
+        petri_artifact_resolver_openvmm_known_paths::OpenvmmKnownPathsTestArtifactResolver::new("");
+    let mut requirements = TestArtifactRequirements::new();
+    f(ArtifactResolver::collector(&mut requirements));
+    let artifacts = requirements.resolve(&resolver)?;
+    Ok(f(ArtifactResolver::resolver(&artifacts)))
+}

--- a/petri/src/disk_image.rs
+++ b/petri/src/disk_image.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! Tools for building a disk image for a VM.
+
 use anyhow::Context;
 use fatfs::FormatVolumeOptions;
 use fatfs::FsOptions;

--- a/petri/src/lib.rs
+++ b/petri/src/lib.rs
@@ -8,7 +8,7 @@
 
 #![forbid(unsafe_code)]
 
-mod disk_image;
+pub mod disk_image;
 mod linux_direct_serial_agent;
 mod openhcl_diag;
 mod test;


### PR DESCRIPTION
For now, just have a command to build the cloud-init disk image. In the future, this could include commands to interact with running petri tests or even to launch test VMs using petri code.
