### PR TITLE
Fixing net_mana handling of Gdma Errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,6 +4292,7 @@ dependencies = [
  "net_backend_resources",
  "pal_async",
  "parking_lot",
+ "thiserror 2.0.12",
  "tracing",
  "vm_resource",
  "vm_topology",

--- a/vm/devices/net/gdma_defs/src/bnic.rs
+++ b/vm/devices/net/gdma_defs/src/bnic.rs
@@ -268,6 +268,7 @@ pub const CQE_TX_VF_DISABLED: u8 = 38;
 pub const CQE_TX_VPORT_IDX_OUT_OF_RANGE: u8 = 39;
 pub const CQE_TX_VPORT_DISABLED: u8 = 40;
 pub const CQE_TX_VLAN_TAGGING_VIOLATION: u8 = 41;
+pub const CQE_TX_GDMA_ERR: u8 = 42;
 
 pub const MANA_CQE_COMPLETION: u8 = 1;
 

--- a/vm/devices/net/net_backend/Cargo.toml
+++ b/vm/devices/net/net_backend/Cargo.toml
@@ -23,6 +23,7 @@ futures.workspace = true
 futures-concurrency.workspace = true
 parking_lot.workspace = true
 tracing.workspace = true
+thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/vm/devices/net/net_backend/src/loopback.rs
+++ b/vm/devices/net/net_backend/src/loopback.rs
@@ -14,6 +14,7 @@ use crate::QueueConfig;
 use crate::RssConfig;
 use crate::RxId;
 use crate::RxMetadata;
+use crate::TxError;
 use crate::TxId;
 use crate::TxSegment;
 use crate::linearize;
@@ -125,7 +126,7 @@ impl Queue for LoopbackQueue {
         Ok((true, sent))
     }
 
-    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> Result<usize, TxError> {
         Ok(0)
     }
 

--- a/vm/devices/net/net_backend/src/null.rs
+++ b/vm/devices/net/net_backend/src/null.rs
@@ -10,6 +10,7 @@ use crate::Queue;
 use crate::QueueConfig;
 use crate::RssConfig;
 use crate::RxId;
+use crate::TxError;
 use crate::TxId;
 use crate::TxOffloadSupport;
 use crate::TxSegment;
@@ -114,7 +115,7 @@ impl Queue for NullQueue {
         Ok((true, packets.len()))
     }
 
-    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> Result<usize, TxError> {
         Ok(0)
     }
 

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -20,6 +20,7 @@ use net_backend::RssConfig;
 use net_backend::RxChecksumState;
 use net_backend::RxId;
 use net_backend::RxMetadata;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxOffloadSupport;
 use net_backend::TxSegment;
@@ -231,7 +232,7 @@ impl net_backend::Queue for ConsommeQueue {
         Ok((false, segments.len()))
     }
 
-    fn tx_poll(&mut self, done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, done: &mut [TxId]) -> Result<usize, TxError> {
         let n = done.len().min(self.state.tx_ready.len());
         for (x, y) in done.iter_mut().zip(self.state.tx_ready.drain(..n)) {
             *x = y;

--- a/vm/devices/net/net_dio/src/lib.rs
+++ b/vm/devices/net/net_dio/src/lib.rs
@@ -191,7 +191,7 @@ impl Queue for DioQueue {
         Ok((true, n))
     }
 
-    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> Result<usize, TxError> {
         Ok(0)
     }
 

--- a/vm/devices/net/net_dio/src/lib.rs
+++ b/vm/devices/net/net_dio/src/lib.rs
@@ -18,6 +18,7 @@ use net_backend::QueueConfig;
 use net_backend::RssConfig;
 use net_backend::RxId;
 use net_backend::RxMetadata;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxSegment;
 use net_backend::next_packet;

--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -11,6 +11,7 @@ use gdma_defs::Cqe;
 use gdma_defs::GDMA_EQE_COMPLETION;
 use gdma_defs::Sge;
 use gdma_defs::bnic::CQE_RX_OKAY;
+use gdma_defs::bnic::CQE_TX_GDMA_ERR;
 use gdma_defs::bnic::CQE_TX_OKAY;
 use gdma_defs::bnic::MANA_LONG_PKT_FMT;
 use gdma_defs::bnic::MANA_SHORT_PKT_FMT;
@@ -607,6 +608,7 @@ struct QueueStats {
     tx_packets: u64,
     tx_errors: u64,
     tx_dropped: u64,
+    tx_stuck: u64,
 
     rx_events: u64,
     rx_packets: u64,
@@ -622,6 +624,7 @@ impl Inspect for QueueStats {
             .counter("tx_packets", self.tx_packets)
             .counter("tx_errors", self.tx_errors)
             .counter("tx_dropped", self.tx_dropped)
+            .counter("tx_stuck", self.tx_stuck)
             .counter("rx_events", self.rx_events)
             .counter("rx_packets", self.rx_packets)
             .counter("rx_errors", self.rx_errors)
@@ -716,6 +719,26 @@ impl<T: DeviceBacking> ManaQueue<T> {
             true
         } else {
             false
+        }
+    }
+
+    fn trace_tx_wqe(&mut self, tx_oob: ManaTxCompOob) {
+        tracelimit::error_ratelimited!(
+            cqe_hdr_type = tx_oob.cqe_hdr.cqe_type(),
+            cqe_hdr_vendor_err = tx_oob.cqe_hdr.vendor_err(),
+            tx_oob_data_offset = tx_oob.tx_data_offset,
+            tx_oob_sgl_offset = tx_oob.offsets.tx_sgl_offset(),
+            tx_oob_wqe_offset = tx_oob.offsets.tx_wqe_offset(),
+            "tx completion error"
+        );
+
+        if let Some(packet) = self.posted_tx.front() {
+            tracelimit::error_ratelimited!(
+                id = packet.id.0,
+                wqe_len = packet.wqe_len,
+                bounced_len_with_padding = packet.bounced_len_with_padding,
+                "posted tx"
+            );
         }
     }
 }
@@ -903,6 +926,7 @@ impl<T: DeviceBacking + Send> Queue for ManaQueue<T> {
 
     fn tx_poll(&mut self, done: &mut [TxId]) -> anyhow::Result<usize> {
         let mut i = 0;
+        let mut queue_stuck = false;
         while i < done.len() {
             let id = if let Some(cqe) = self.tx_cq.pop() {
                 let tx_oob = ManaTxCompOob::read_from_prefix(&cqe.data[..]).unwrap().0; // TODO: zerocopy: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
@@ -910,10 +934,24 @@ impl<T: DeviceBacking + Send> Queue for ManaQueue<T> {
                     CQE_TX_OKAY => {
                         self.stats.tx_packets += 1;
                     }
+                    CQE_TX_GDMA_ERR => {
+                        queue_stuck = true;
+                    }
                     ty => {
-                        tracelimit::error_ratelimited!(ty, "tx completion error");
+                        let vendor_err = tx_oob.cqe_hdr.vendor_err();
+                        tracelimit::error_ratelimited!(ty, vendor_err, "tx completion error");
                         self.stats.tx_errors += 1;
                     }
+                }
+                if queue_stuck {
+                    // Hardware hit an error with the packet coming from the Guest.
+                    // CQE_TX_GDMA_ERR is how the Hardware indicates that it has disabled the queue.
+                    self.stats.tx_errors += 1;
+                    self.stats.tx_stuck += 1;
+                    self.trace_tx_wqe(tx_oob);
+                    // TODO: attempt to recover by reenabling the queue.
+                    // tracelimit::info_ratelimited!("recreated tx queue");
+                    break;
                 }
                 let packet = self.posted_tx.pop_front().unwrap();
                 self.tx_wq.advance_head(packet.wqe_len);

--- a/vm/devices/net/net_packet_capture/src/lib.rs
+++ b/vm/devices/net/net_packet_capture/src/lib.rs
@@ -23,6 +23,7 @@ use net_backend::Queue;
 use net_backend::QueueConfig;
 use net_backend::RssConfig;
 use net_backend::RxId;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxOffloadSupport;
 use net_backend::TxSegment;
@@ -543,7 +544,7 @@ impl Queue for PacketCaptureQueue {
         self.current_mut().tx_avail(segments)
     }
 
-    fn tx_poll(&mut self, done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, done: &mut [TxId]) -> Result<usize, TxError> {
         self.current_mut().tx_poll(done)
     }
 

--- a/vm/devices/net/net_tap/src/lib.rs
+++ b/vm/devices/net/net_tap/src/lib.rs
@@ -19,6 +19,7 @@ use net_backend::QueueConfig;
 use net_backend::RssConfig;
 use net_backend::RxId;
 use net_backend::RxMetadata;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxSegment;
 use net_backend::linearize;
@@ -234,7 +235,7 @@ impl Queue for TapQueue {
         Ok((completed_synchronously, n))
     }
 
-    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> Result<usize, TxError> {
         // Packets are sent synchronously so there is no no need to check here if
         // sending has been completed.
         Ok(0)

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4377,7 +4377,10 @@ impl<T: RingMem + 'static> Worker<T> {
                             let _ = self.coordinator_send.try_send(restart);
                         }
                         Err(WorkerError::EndpointRequiresQueueRestart(err)) => {
-                            tracing::warn!("Endpoint requires queues to restart. err: {:?}", err);
+                            tracelimit::warn_ratelimited!(
+                                "Endpoint requires queues to restart. err: {:?}",
+                                err
+                            );
                             if let Err(try_send_err) =
                                 self.coordinator_send.try_send(CoordinatorMessage::Restart)
                             {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -1851,8 +1851,6 @@ enum WorkerError {
     Cancelled(task_control::Cancelled),
     #[error("tearing down because send/receive buffer is revoked")]
     BufferRevoked,
-    #[error("tx error: {0}")]
-    EndpointTx(#[source] anyhow::Error),
     #[error("endpoint requires queue restart: {0}")]
     EndpointRequiresQueueRestart(#[source] anyhow::Error),
 }
@@ -4965,10 +4963,9 @@ impl<T: 'static + RingMem> NetChannel<T> {
                     })
                     .collect::<Vec<_>>();
                 state.pending_tx_completions.extend(pending_tx);
-                // TryRestart error indicates the need to restart the queues.
                 Err(WorkerError::EndpointRequiresQueueRestart(err))
             }
-            Err(TxError::Fatal(err)) => Err(WorkerError::EndpointTx(err)),
+            Err(TxError::Fatal(err)) => Err(WorkerError::Endpoint(err)),
         }
     }
 

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -4378,8 +4378,8 @@ impl<T: RingMem + 'static> Worker<T> {
                         }
                         Err(WorkerError::EndpointRequiresQueueRestart(err)) => {
                             tracelimit::warn_ratelimited!(
-                                "Endpoint requires queues to restart. err: {:?}",
-                                err
+                                err = %err,
+                                "Endpoint requires queues to restart",
                             );
                             if let Err(try_send_err) =
                                 self.coordinator_send.try_send(CoordinatorMessage::Restart)

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -52,6 +52,7 @@ use net_backend::EndpointAction;
 use net_backend::L3Protocol;
 use net_backend::QueueConfig;
 use net_backend::RxId;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxSegment;
 use net_backend_resources::mac_address::MacAddress;
@@ -4367,10 +4368,44 @@ impl<T: RingMem + 'static> Worker<T> {
                         stop.until_stopped(pending()).await?
                     };
 
-                    let restart = self.channel.main_loop(stop, state, queue_state).await?;
+                    let result = self.channel.main_loop(stop, state, queue_state).await;
+                    match result {
+                        Ok(restart) => {
+                            assert_eq!(self.channel_idx, 0);
+                            let _ = self.coordinator_send.try_send(restart);
+                        }
+                        Err(WorkerError::Endpoint(err)) => {
+                            // Check Endpoint errors to see if they are restartable TxErrors.
+                            match err.downcast::<TxError>() {
+                                Ok(err) => match err {
+                                    TxError::TryRestart(err) => {
+                                        tracing::warn!(
+                                            "TxError detected attempting to restart queues. err: {:?}",
+                                            err
+                                        );
+                                        if let Err(try_send_err) = self
+                                            .coordinator_send
+                                            .try_send(CoordinatorMessage::Restart)
+                                        {
+                                            tracing::error!(
+                                                try_send_err = %try_send_err,
+                                                "failed to restart queues"
+                                            );
+                                            return Err(WorkerError::Endpoint(err));
+                                        }
+                                    }
+                                    TxError::Fatal(err) => {
+                                        return Err(WorkerError::Endpoint(err));
+                                    }
+                                },
+                                Err(err) => {
+                                    return Err(WorkerError::Endpoint(err));
+                                }
+                            }
+                        }
+                        Err(err) => return Err(err),
+                    }
 
-                    assert_eq!(self.channel_idx, 0);
-                    let _ = self.coordinator_send.try_send(restart);
                     stop.until_stopped(pending()).await?
                 }
             }
@@ -4905,23 +4940,45 @@ impl<T: 'static + RingMem> NetChannel<T> {
         epqueue: &mut dyn net_backend::Queue,
     ) -> Result<bool, WorkerError> {
         // Drain completed transmits.
-        let n = epqueue
-            .tx_poll(&mut data.tx_done)
-            .map_err(WorkerError::Endpoint)?;
-        if n == 0 {
-            return Ok(false);
-        }
+        let result = epqueue.tx_poll(&mut data.tx_done);
 
-        for &id in &data.tx_done[..n] {
-            let tx_packet = &mut state.pending_tx_packets[id.0 as usize];
-            assert!(tx_packet.pending_packet_count > 0);
-            tx_packet.pending_packet_count -= 1;
-            if tx_packet.pending_packet_count == 0 {
-                self.complete_tx_packet(state, id)?;
+        match result {
+            Ok(n) => {
+                if n == 0 {
+                    return Ok(false);
+                }
+
+                for &id in &data.tx_done[..n] {
+                    let tx_packet = &mut state.pending_tx_packets[id.0 as usize];
+                    assert!(tx_packet.pending_packet_count > 0);
+                    tx_packet.pending_packet_count -= 1;
+                    if tx_packet.pending_packet_count == 0 {
+                        self.complete_tx_packet(state, id)?;
+                    }
+                }
+
+                Ok(true)
             }
+            Err(TxError::TryRestart(err)) => {
+                // Complete any pending tx prior to restarting queues.
+                let pending_tx: Vec<_> = state
+                    .pending_tx_packets
+                    .iter_mut()
+                    .enumerate()
+                    .filter(|(_id, inflight)| inflight.pending_packet_count > 0)
+                    .collect();
+                for pending_tx_packet in pending_tx {
+                    pending_tx_packet.1.pending_packet_count = 0;
+                    state.pending_tx_completions.push_back(PendingTxCompletion {
+                        transaction_id: pending_tx_packet.1.transaction_id,
+                        tx_id: Some(TxId(pending_tx_packet.0 as u32)),
+                    });
+                }
+                // TryRestart error indicates the need to restart the queues.
+                Err(WorkerError::Endpoint(TxError::TryRestart(err).into()))
+            }
+            Err(TxError::Fatal(err)) => Err(WorkerError::Endpoint(err)),
         }
-
-        Ok(true)
     }
 
     fn switch_data_path(

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -380,7 +380,7 @@ impl NetQueue for TestNicQueue {
         Ok((true, packets.len()))
     }
 
-    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> Result<usize, TxError> {
         Ok(0)
     }
 

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -32,6 +32,7 @@ use net_backend::EndpointAction;
 use net_backend::MultiQueueSupport;
 use net_backend::Queue as NetQueue;
 use net_backend::QueueConfig;
+use net_backend::TxError;
 use net_backend::TxOffloadSupport;
 use net_backend::null::NullEndpoint;
 use pal_async::DefaultDriver;

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -926,7 +926,7 @@ impl Worker {
         // Drain completed transmits.
         let n = epqueue
             .tx_poll(&mut self.active_state.data.tx_done)
-            .map_err(WorkerError::Endpoint)?;
+            .map_err(|tx_error| WorkerError::Endpoint(tx_error.into()))?;
         if n == 0 {
             return Ok(false);
         }


### PR DESCRIPTION
The net_mana::tx_poll() does not properly handle a CQE of type CQE_TX_GDMA_ERR.  GDMA_ERR is sent from the Hardware to indicate that the queue has been disabled. Once the queue is disabled, no further traffic can be sent out from the Guest. The proper way to handle the Gdma error is to recreate/restart the tx queue. 

Changes:
* Adding logging to help track and triage these issues. A Gdma error can be returned due to any number of problems, so the only way to determine the cause is by logging the vendor error and properties of the packet.
* Modifying net_mana::tx_poll to return an error that indicates the queue should be restarted.
* Modifying netvsp to handle the TxError::TryReturn
  * If process_endpoint_tx sees a TryReturn error, it completes any pending tx packets before the queues are restarted.
  * If main_loop returns a TryReturn error, Coordinator is sent a Restart message, which will restart all the queues.

Notes:
* I'm leveraging the existing code to restart all queues, which is disruptive, but better than being unable to send traffic.
* The underlying cause of the Gdma error(s) still need to be addressed. Openvmm netvsp is crafting packets in such a way to cause hardware errors, the logging should help in determining the problem.
* While we observed crashes in openvmm after a Gdma Error when the packet was None, I could not recreate a repro in the lab. It remains unclear if these changes will address the crash.