### PR TITLE
vmm_tests: log KVP IP information

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -107,6 +107,7 @@ async fn kvp_ic(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
         .await?;
 
     // Validate the IP information against the default consomme confiugration.
+    tracing::info!(?ip_info, "ip information");
     assert_eq!(ip_info.ipv4_addresses.len(), 1);
     let ip = &ip_info.ipv4_addresses[0];
     assert_eq!(ip.address.to_string(), "10.0.0.2");


### PR DESCRIPTION
In some environments, we are seeing multiple IP addresses from VMs in the `kvp_ic` test. Log the full IP information in order to be able to diagnose this.