### PR TITLE
deps: update tokio to 1.44.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6857,9 +6857,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
Only used by mesh_rpc. Update to remove the dependabot flag.