### PR TITLE
deps: update openssl to 0.10.72

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4777,9 +4777,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -4818,9 +4818,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -467,7 +467,7 @@ nix = { version = "0.27", default-features = false }
 ntapi = "0.4"
 object = { version = "0.36.7", default-features = false }
 once_cell = "1.7"
-openssl = "0.10.66"
+openssl = "0.10.72"
 openssl-sys = "0.9"
 parking_lot = "0.12"
 paste = "1.0"


### PR DESCRIPTION
Update openssl to 0.10.72 to remove the dependabot flagged issue. We don't use the methods that had the use-after-free, so there's not a security issue for us. 