### PR TITLE
petri: default to 2 VPs for Hyper-V VMs

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -250,6 +250,10 @@ impl PetriVmConfigHyperV {
             self.driver.clone(),
         )?;
 
+        // Hard code the processor count to 2 for now, to match the openvmm
+        // configuration.
+        vm.set_processor_count(2)?;
+
         if let Some(igvm_file) = &self.openhcl_igvm {
             // TODO: only increase VTL2 memory on debug builds
             vm.set_openhcl_firmware(

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -145,6 +145,31 @@ pub fn run_remove_vm(vmid: &Guid) -> anyhow::Result<()> {
         .context("remove_vm")
 }
 
+/// Arguments for the Set-VMProcessor powershell cmdlet
+pub struct HyperVSetVMProcessorArgs<'a> {
+    /// Specifies the ID of the virtual machine for which you want to set the
+    /// number of virtual processors.
+    pub vmid: &'a Guid,
+    /// Specifies the number of virtual processors to assign to the virtual
+    /// machine. If not specified, the number of virtual processors is not
+    /// changed.
+    pub count: Option<u32>,
+}
+
+/// Runs Set-VMProcessor with the given arguments.
+pub fn run_set_vm_processor(args: HyperVSetVMProcessorArgs<'_>) -> anyhow::Result<()> {
+    PowerShellBuilder::new()
+        .cmdlet("Get-VM")
+        .arg_string("Id", args.vmid)
+        .pipeline()
+        .cmdlet("Set-VMProcessor")
+        .arg_opt_string("Count", args.count)
+        .finish()
+        .output(true)
+        .map(|_| ())
+        .context("set_vm_processor")
+}
+
 /// Arguments for the Add-VMHardDiskDrive powershell cmdlet
 pub struct HyperVAddVMHardDiskDriveArgs<'a> {
     /// Specifies the ID of the virtual machine to which the hard disk

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -158,6 +158,14 @@ impl HyperVVM {
         Ok(())
     }
 
+    /// Set the VM processor count.
+    pub fn set_processor_count(&mut self, count: u32) -> anyhow::Result<()> {
+        powershell::run_set_vm_processor(powershell::HyperVSetVMProcessorArgs {
+            vmid: &self.vmid,
+            count: Some(count),
+        })
+    }
+
     /// Set the OpenHCL firmware file
     pub fn set_openhcl_firmware(
         &mut self,


### PR DESCRIPTION
Match the openvmm test behavior and get more coverage (especially important for TDX).

This really should be configurable per test, but skip that for now and just make this simple change.