### PR TITLE
petri: configurable processor count for hyper-v

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -89,6 +89,10 @@ impl PetriVmConfig for PetriVmConfigHyperV {
     fn with_windows_secure_boot_template(self: Box<Self>) -> Box<dyn PetriVmConfig> {
         Box::new(Self::with_windows_secure_boot_template(*self))
     }
+
+    fn with_processors(self: Box<Self>, count: u32) -> Box<dyn PetriVmConfig> {
+        Box::new(Self::with_processors(*self, count))
+    }
 }
 
 /// A running VM that tests can interact with.
@@ -223,12 +227,6 @@ impl PetriVmConfigHyperV {
             temp_dir,
             log_source: params.logger.clone(),
         })
-    }
-
-    /// Set the VM to use the specified number of virtual processors
-    pub fn with_processors(mut self, count: u32) -> Self {
-        self.proc_count = count;
-        self
     }
 
     /// Build and boot the requested VM. Does not configure and start pipette.
@@ -384,6 +382,12 @@ impl PetriVmConfigHyperV {
             openhcl_diag_handler,
             log_tasks,
         })
+    }
+
+    /// Set the VM to use the specified number of virtual processors.
+    pub fn with_processors(mut self, count: u32) -> Self {
+        self.proc_count = count;
+        self
     }
 
     /// Inject Windows secure boot templates into the VM's UEFI.

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -51,6 +51,8 @@ pub struct PetriVmConfigHyperV {
     guest_state_isolation_type: powershell::HyperVGuestStateIsolationType,
     // Specifies the amount of memory, in bytes, to assign to the virtual machine.
     memory: u64,
+    // Specifies the number of virtual processors to assign to the virtual machine.
+    proc_count: u32,
     // Specifies the path to a virtual hard disk file(s) to attach to the
     // virtual machine as SCSI (Gen2) or IDE (Gen1) drives.
     vhd_paths: Vec<Vec<PathBuf>>,
@@ -201,6 +203,7 @@ impl PetriVmConfigHyperV {
             generation,
             guest_state_isolation_type,
             memory: 0x1_0000_0000,
+            proc_count: 2,
             vhd_paths: vec![vec![reference_disk_path.clone().into()]],
             secure_boot_template: matches!(generation, powershell::HyperVGeneration::Two)
                 .then_some(match firmware.os_flavor() {
@@ -220,6 +223,12 @@ impl PetriVmConfigHyperV {
             temp_dir,
             log_source: params.logger.clone(),
         })
+    }
+
+    /// Set the VM to use the specified number of virtual processors
+    pub fn with_processors(mut self, count: u32) -> Self {
+        self.proc_count = count;
+        self
     }
 
     /// Build and boot the requested VM. Does not configure and start pipette.
@@ -254,9 +263,7 @@ impl PetriVmConfigHyperV {
             self.driver.clone(),
         )?;
 
-        // Hard code the processor count to 2 for now, to match the openvmm
-        // configuration.
-        vm.set_processor_count(2)?;
+        vm.set_processor_count(self.proc_count)?;
 
         if let Some(igvm_file) = &self.openhcl_igvm {
             // TODO: only increase VTL2 memory on debug builds

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -33,8 +33,11 @@ pub trait PetriVmConfig: Send {
     async fn run_with_lazy_pipette(self: Box<Self>) -> anyhow::Result<Box<dyn PetriVm>>;
     /// Run the VM, launching pipette and returning a client to it.
     async fn run(self: Box<Self>) -> anyhow::Result<(Box<dyn PetriVm>, PipetteClient)>;
+
     /// Inject Windows secure boot templates into the VM's UEFI.
     fn with_windows_secure_boot_template(self: Box<Self>) -> Box<dyn PetriVmConfig>;
+    /// Set the VM to use the specified number of virtual processors.
+    fn with_processors(self: Box<Self>, count: u32) -> Box<dyn PetriVmConfig>;
 }
 
 /// A running VM that tests can interact with.

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -131,6 +131,10 @@ impl PetriVmConfig for PetriVmConfigOpenVmm {
     fn with_windows_secure_boot_template(self: Box<Self>) -> Box<dyn PetriVmConfig> {
         Box::new(Self::with_windows_secure_boot_template(*self))
     }
+
+    fn with_processors(self: Box<Self>, count: u32) -> Box<dyn PetriVmConfig> {
+        Box::new(Self::with_processors(*self, count))
+    }
 }
 
 /// Various channels and resources used to interact with the VM while it is running.

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -79,11 +79,12 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
-    /// Set the VM to use a single processor.
-    /// This is useful mainly for heavier OpenHCL tests, as our WHP emulation
+    /// Set the VM to use the specified number of virtual processors.
+    ///
+    /// Use 1 CPU is useful for heavier OpenHCL tests, as our WHP emulation
     /// layer is rather slow when dealing with cross-cpu communication.
-    pub fn with_single_processor(mut self) -> Self {
-        self.config.processor_topology.proc_count = 1;
+    pub fn with_processors(mut self, count: u32) -> Self {
+        self.config.processor_topology.proc_count = count;
         self
     }
 

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -81,7 +81,7 @@ impl PetriVmConfigOpenVmm {
 
     /// Set the VM to use the specified number of virtual processors.
     ///
-    /// Use 1 CPU is useful for heavier OpenHCL tests, as our WHP emulation
+    /// Using 1 CPU is useful for heavier OpenHCL tests, as our WHP emulation
     /// layer is rather slow when dealing with cross-cpu communication.
     pub fn with_processors(mut self, count: u32) -> Self {
         self.config.processor_topology.proc_count = count;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -195,6 +195,21 @@ async fn boot_no_agent(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Basic boot test without agent and with a single VP.
+#[vmm_test(
+    openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
+    openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
+    hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
+)]
+async fn boot_no_agent_single_proc(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+    let mut vm = config.with_processors(1).run_without_agent().await?;
+    vm.wait_for_successful_boot_event().await?;
+    vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+    Ok(())
+}
+
 /// Basic reboot test without agent
 // TODO: Reenable guests that use the framebuffer once #74 is fixed.
 #[openvmm_test(

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -83,19 +83,6 @@ async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Basic VBS boot test with a single VP.
-#[openvmm_test(
-    openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
-    openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64))
-)]
-async fn vbs_boot_single_proc(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
-    let mut vm = config.with_single_processor().run_without_agent().await?;
-    vm.wait_for_successful_boot_event().await?;
-    vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
-    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
-    Ok(())
-}
-
 /// Basic VBS boot test with TPM enabled.
 #[openvmm_test(
     openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -18,7 +18,7 @@ async fn nvme_relay_test_core(
     let (mut vm, agent) = config
         .with_openhcl_command_line(openhcl_cmdline)
         .with_vmbus_redirect()
-        .with_single_processor()
+        .with_processors(1)
         .run()
         .await?;
 


### PR DESCRIPTION
Builds on https://github.com/microsoft/openvmm/commit/b96460a7dbcb510bda1499868213ad02e348f8c1 to allow the number of VPs to be configured for a Hyper-V or generic VMM test. Adds a single proc vbs/tdx test for hyper-v as an example.