### PR TITLE
petri: extra wait for shutdown IC

### DIFF
--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -301,7 +301,15 @@ impl HyperVVM {
             240.seconds(),
         )
         .await
-        .context("wait_for_shutdown_ic")
+        .context("wait_for_shutdown_ic")?;
+
+        // Wait an extra second for the shutdown IC to *really* be ready
+        // Otherwise, the VM can get into a state where it cannot be stopped
+        // or deleted. This has been observed with Ubuntu VMs.
+        PolledTimer::new(&self.driver)
+            .sleep(Duration::from_secs(1))
+            .await;
+        Ok(())
     }
 
     fn shutdown_ic_status(&self) -> anyhow::Result<powershell::VmShutdownIcStatus> {


### PR DESCRIPTION
Attempts to work around an intermittent issue where the shutdown IC on Ubuntu claims to be "OK" but the VM gets into a stuck state if you try to shut it down too quickly. 
Failure: https://github.com/microsoft/openvmm/actions/runs/14369372946/job/40290052502