### PR TITLE
virt_mshv_vtl/hv1_emulator: Move hypervisor cpuid construction into cvm_cpuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.0.0"
 dependencies = [
  "bitfield-struct 0.10.1",
  "open_enum",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -17,7 +17,7 @@ version = "0.0.0"
 dependencies = [
  "aarch64defs",
  "futures",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "inspect",
  "pal_async",
  "parking_lot",
@@ -32,7 +32,7 @@ dependencies = [
  "acpi_spec",
  "memory_range",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -43,7 +43,7 @@ dependencies = [
  "open_enum",
  "static_assertions",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arbitrary"
@@ -174,9 +174,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.87"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -385,6 +385,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "byteorder_slice"
@@ -438,9 +444,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "jobserver",
  "libc",
@@ -452,6 +458,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chipset"
@@ -513,7 +525,7 @@ dependencies = [
  "parking_lot",
  "range_map_vec",
  "tracing",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -607,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -617,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -699,7 +711,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "futures",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "pal_async",
  "term",
  "tracing",
@@ -711,7 +723,7 @@ name = "consomme"
 version = "0.0.0"
 dependencies = [
  "futures",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "inspect",
  "inspect_counters",
  "libc",
@@ -733,9 +745,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cordyceps"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec10f0a762d93c4498d2e97a333805cb6250d60bead623f71d8034f9a4152ba3"
+checksum = "a0392f465ceba1713d30708f61c160ebf4dc1cf86bb166039d16b11ad4f3b5b6"
 dependencies = [
  "loom",
  "tracing",
@@ -894,12 +906,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.2"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
+checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
 dependencies = [
- "nix 0.27.1",
- "windows-sys 0.52.0",
+ "nix 0.29.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -947,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -969,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -1145,7 +1157,7 @@ dependencies = [
  "tokio",
  "vhd1_defs",
  "vm_resource",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1180,7 +1192,7 @@ dependencies = [
  "tracing",
  "uevent",
  "vm_resource",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1323,7 +1335,7 @@ dependencies = [
  "thiserror 2.0.12",
  "vhd1_defs",
  "vm_resource",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1365,7 +1377,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "vm_resource",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1503,9 +1515,9 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1522,9 +1534,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1555,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -1618,7 +1630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.0.2",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -1636,7 +1648,7 @@ name = "fdt"
 version = "0.0.0"
 dependencies = [
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1655,7 +1667,7 @@ version = "0.0.0"
 dependencies = [
  "chipset_device",
  "generation_id",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guestmem",
  "guid",
  "inspect",
@@ -1668,7 +1680,7 @@ dependencies = [
  "tracing",
  "vm_topology",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1681,7 +1693,7 @@ dependencies = [
  "der",
  "firmware_uefi_custom_vars",
  "generation_id",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guestmem",
  "guid",
  "inspect",
@@ -1702,7 +1714,7 @@ dependencies = [
  "vmcore",
  "watchdog_core",
  "wchar",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1729,9 +1741,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1854,7 +1866,7 @@ dependencies = [
  "serde_json",
  "target-lexicon",
  "toml_edit",
- "which 7.0.2",
+ "which 7.0.3",
  "xshell",
 ]
 
@@ -1872,7 +1884,7 @@ dependencies = [
  "serde_json",
  "target-lexicon",
  "vmm_test_images",
- "which 7.0.2",
+ "which 7.0.3",
  "xshell",
 ]
 
@@ -1888,9 +1900,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1961,7 +1973,7 @@ dependencies = [
  "test_with_tracing",
  "thiserror 2.0.12",
  "tracing",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2122,7 +2134,7 @@ dependencies = [
  "ucs2 0.0.0",
  "uefi_nvram_specvars",
  "xtask_fuzz",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2250,7 +2262,7 @@ dependencies = [
  "vmbus_channel",
  "vmbus_ring",
  "xtask_fuzz",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2323,7 +2335,7 @@ dependencies = [
  "tracing",
  "vm_resource",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2334,7 +2346,7 @@ dependencies = [
  "guestmem",
  "inspect",
  "open_enum",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2350,7 +2362,7 @@ dependencies = [
 name = "generation_id"
 version = "0.0.0"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guestmem",
  "inspect",
  "mesh",
@@ -2361,15 +2373,15 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.7.5"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
 dependencies = [
- "cc",
+ "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows 0.48.0",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -2388,7 +2400,7 @@ version = "0.0.0"
 dependencies = [
  "get_protocol",
  "guid",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2402,7 +2414,7 @@ dependencies = [
  "serde_helpers",
  "serde_json",
  "static_assertions",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2427,14 +2439,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2530,7 +2542,7 @@ dependencies = [
  "vmbus_async",
  "vmbus_channel",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2564,7 +2576,7 @@ dependencies = [
  "vmbus_channel",
  "vmbus_ring",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2586,7 +2598,7 @@ dependencies = [
  "vmbus_channel",
  "vmbus_ring",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2598,7 +2610,7 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "get_protocol",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guest_emulation_device",
  "guid",
  "hvdef",
@@ -2621,7 +2633,7 @@ dependencies = [
  "vmbus_ring",
  "vmbus_user_channel",
  "vpci",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2652,28 +2664,28 @@ dependencies = [
  "pal_event",
  "sparse_mmap",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
 name = "guid"
 version = "0.0.0"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "inspect",
  "mesh_protobuf",
  "thiserror 2.0.12",
  "winapi",
  "windows 0.59.0",
  "windows-sys 0.59.0",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2690,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -2724,7 +2736,7 @@ dependencies = [
  "bitfield-struct 0.10.1",
  "build_rs_guest_arch",
  "fs-err",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "hv1_structs",
  "hvdef",
  "inspect",
@@ -2743,7 +2755,7 @@ dependencies = [
  "tracing",
  "user_driver",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2762,7 +2774,7 @@ dependencies = [
  "ucs2 0.0.0",
  "uefi_nvram_storage",
  "wchar",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2886,7 +2898,7 @@ dependencies = [
  "vm_topology",
  "vmcore",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2902,7 +2914,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tracelimit",
  "tracing",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2921,7 +2933,7 @@ dependencies = [
  "bitfield-struct 0.10.1",
  "open_enum",
  "static_assertions",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2949,7 +2961,7 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "get_resources",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guestmem",
  "guid",
  "hcl_compat_uefi_nvram_storage",
@@ -3008,7 +3020,7 @@ dependencies = [
  "vpci",
  "watchdog_core",
  "watchdog_vmgs_format",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3114,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3124,6 +3136,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3154,7 +3167,7 @@ dependencies = [
  "vmbus_async",
  "vmbus_channel",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3176,7 +3189,7 @@ dependencies = [
  "vmbus_relay_intercept_device",
  "vmbus_ring",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3187,7 +3200,7 @@ dependencies = [
  "guid",
  "jiff",
  "open_enum",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3218,7 +3231,7 @@ dependencies = [
  "serde_helpers",
  "serde_json",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3280,7 +3293,7 @@ dependencies = [
  "tracing",
  "tracing_helpers",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3323,7 +3336,7 @@ dependencies = [
  "static_assertions",
  "thiserror 1.0.69",
  "tracing",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3334,7 +3347,7 @@ dependencies = [
  "bitfield-struct 0.7.0",
  "open-enum",
  "static_assertions",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3362,7 +3375,7 @@ dependencies = [
  "underhill_confidentiality",
  "vbs_defs",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3375,21 +3388,21 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.1"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
 dependencies = [
  "bytemuck",
- "byteorder",
+ "byteorder-lite",
  "num-traits",
  "png",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -3514,9 +3527,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.4"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -3529,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.4"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3540,25 +3553,26 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962e1dfe9b2d75a84536cf5bf5eaaa4319aa7906c7160134a22883ac316d5f31"
+checksum = "c1283705eb0a21404d2bfd6eef2a7593d240bc42a0bdb39db0ad6fa2ec026524"
 
 [[package]]
 name = "jiff-tzdb-platform"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -3611,9 +3625,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3627,9 +3641,9 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.39"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
 dependencies = [
  "cc",
  "libc",
@@ -3696,9 +3710,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "linux_net_bindings"
@@ -3728,7 +3742,7 @@ dependencies = [
  "tracing",
  "vm_topology",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3740,7 +3754,7 @@ dependencies = [
  "inspect",
  "open_enum",
  "static_assertions",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3771,15 +3785,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "loom"
-version = "0.5.6"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
  "cfg-if",
  "generator",
@@ -3823,7 +3837,7 @@ dependencies = [
  "widestring",
  "winapi",
  "windows 0.59.0",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3849,7 +3863,7 @@ dependencies = [
  "futures",
  "gdma",
  "gdma_defs",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "inspect",
  "mesh",
  "net_backend",
@@ -3863,7 +3877,7 @@ dependencies = [
  "user_driver",
  "user_driver_emulated_mock",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3908,7 +3922,7 @@ name = "membacking"
 version = "0.0.0"
 dependencies = [
  "futures",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guestmem",
  "hvdef",
  "inspect",
@@ -4021,7 +4035,7 @@ dependencies = [
  "bitfield-struct 0.10.1",
  "futures",
  "futures-channel",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "mesh_derive",
  "mesh_protobuf",
  "open_enum",
@@ -4031,7 +4045,7 @@ dependencies = [
  "test_with_tracing",
  "thiserror 2.0.12",
  "tracing",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4068,7 +4082,7 @@ dependencies = [
  "prost-types",
  "socket2",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4094,7 +4108,7 @@ dependencies = [
  "tracing_helpers",
  "unicycle",
  "unix_socket",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4122,7 +4136,7 @@ dependencies = [
  "unicycle",
  "unix_socket",
  "urlencoding",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4157,9 +4171,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.43"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -4172,7 +4186,7 @@ dependencies = [
  "cfg-if",
  "hvdef",
  "minimal_rt_build",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4181,9 +4195,9 @@ version = "0.0.0"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -4238,23 +4252,23 @@ dependencies = [
 
 [[package]]
 name = "mshv-bindings"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c369385758f81ca937414dc2147737c92032e4fb399669f287abf94d89252d"
+checksum = "cd4aa8157010f69f380a86a0ba087167b0a01e2e3f2bcca5b576bd26a9206dc8"
 dependencies = [
  "libc",
  "num_enum",
  "serde",
  "serde_derive",
  "vmm-sys-util",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53efb6110ead2e8788f79f2455b21464cb416ba9154112527b11584cb7fceea6"
+checksum = "f2bdc151fdc265efbb20f6c74e235dcdbce9a54e695655ac88b4db7385b26319"
 dependencies = [
  "libc",
  "mshv-bindings",
@@ -4376,7 +4390,7 @@ dependencies = [
  "user_driver",
  "user_driver_emulated_mock",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4451,7 +4465,7 @@ dependencies = [
  "vmbus_core",
  "vmbus_ring",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4492,6 +4506,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -4589,7 +4615,7 @@ dependencies = [
  "user_driver",
  "vm_resource",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4631,7 +4657,7 @@ dependencies = [
  "user_driver",
  "user_driver_emulated_mock",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4651,7 +4677,7 @@ dependencies = [
  "inspect",
  "open_enum",
  "storage_string",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4689,9 +4715,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
@@ -4737,7 +4763,7 @@ dependencies = [
  "serde_json",
  "sev_guest_device",
  "tdx_guest_device",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4762,7 +4788,7 @@ dependencies = [
  "tdcall",
  "underhill_confidentiality",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4817,9 +4843,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.2+3.4.1"
+version = "300.5.0+3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
 dependencies = [
  "cc",
 ]
@@ -4884,7 +4910,7 @@ dependencies = [
  "futures-concurrency",
  "gdma_resources",
  "get_resources",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guid",
  "hvlite_defs",
  "hvlite_helpers",
@@ -5077,7 +5103,7 @@ version = "0.0.0"
 dependencies = [
  "bitfield-struct 0.10.1",
  "tracing",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -5086,7 +5112,7 @@ version = "0.0.0"
 dependencies = [
  "caps",
  "fs-err",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "headervec",
  "landlock",
  "libc",
@@ -5110,7 +5136,7 @@ dependencies = [
  "async-task",
  "cfg-if",
  "futures",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "headervec",
  "libc",
  "loan_cell",
@@ -5127,7 +5153,7 @@ dependencies = [
  "unix_socket",
  "winapi",
  "windows-sys 0.59.0",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -5143,7 +5169,7 @@ dependencies = [
 name = "pal_event"
 version = "0.0.0"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "libc",
  "mesh_protobuf",
  "windows-sys 0.59.0",
@@ -5263,7 +5289,7 @@ dependencies = [
  "tracelimit",
  "tracing",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -5281,7 +5307,7 @@ dependencies = [
  "tracelimit",
  "tracing",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -5609,9 +5635,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -5714,6 +5740,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5757,9 +5789,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -5821,9 +5853,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48375394603e3dd4b2d64371f7148fd8c7baa2680e28741f2cb8d23b59e3d4c4"
+checksum = "877fdb7f2aecf02d29791392e273d5240dcdef9af11bda8ab67d296a6dd56756"
 
 [[package]]
 name = "rlimit"
@@ -5884,14 +5916,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -5949,7 +5981,7 @@ version = "0.0.0"
 name = "safeatomic"
 version = "0.0.0"
 dependencies = [
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6006,7 +6038,7 @@ dependencies = [
  "guestmem",
  "safeatomic",
  "smallvec",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6029,7 +6061,7 @@ dependencies = [
  "arbitrary",
  "bitfield-struct 0.10.1",
  "open_enum",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6041,7 +6073,7 @@ dependencies = [
  "disk_backend",
  "disk_prwrap",
  "futures",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guestmem",
  "guid",
  "hvdef",
@@ -6060,7 +6092,7 @@ dependencies = [
  "tracing_helpers",
  "vm_resource",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6307,7 +6339,7 @@ dependencies = [
  "nix 0.27.1",
  "static_assertions",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6353,7 +6385,7 @@ dependencies = [
  "minimal_rt_build",
  "sidecar_defs",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6369,7 +6401,7 @@ dependencies = [
  "sidecar_defs",
  "thiserror 2.0.12",
  "tracing",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6379,7 +6411,7 @@ dependencies = [
  "hvdef",
  "open_enum",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6405,9 +6437,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -6445,9 +6477,9 @@ checksum = "43d92e0947c1c04c508c9fd39608a1557226141410fd33b5b314d73fa76508d3"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smoltcp"
@@ -6462,9 +6494,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6476,13 +6508,13 @@ version = "0.0.0"
 dependencies = [
  "cc",
  "criterion",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "libc",
  "pal",
  "parking_lot",
  "thiserror 2.0.12",
  "windows-sys 0.59.0",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6528,7 +6560,7 @@ dependencies = [
  "inspect",
  "mesh_protobuf",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6570,7 +6602,7 @@ dependencies = [
  "vmbus_core",
  "vmbus_ring",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6581,7 +6613,7 @@ dependencies = [
  "guid",
  "open_enum",
  "scsi_defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6665,7 +6697,7 @@ dependencies = [
  "nix 0.27.1",
  "static_assertions",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6676,19 +6708,19 @@ dependencies = [
  "static_assertions",
  "tdx_guest_device",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.2",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -6708,7 +6740,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.2",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -6783,9 +6815,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.39"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -6800,15 +6832,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6847,7 +6879,7 @@ dependencies = [
 name = "tmk_protocol"
 version = "0.0.0"
 dependencies = [
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6894,7 +6926,7 @@ dependencies = [
  "vm_topology",
  "vmcore",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -6983,7 +7015,7 @@ dependencies = [
  "bitfield-struct 0.10.1",
  "chipset_device",
  "chipset_device_resources",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guestmem",
  "inspect",
  "mesh",
@@ -6997,7 +7029,7 @@ dependencies = [
  "tracing",
  "vm_resource",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7179,7 +7211,7 @@ dependencies = [
  "thiserror 2.0.12",
  "ucs2 0.0.0",
  "uefi_specs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7194,7 +7226,7 @@ dependencies = [
  "ucs2 0.0.0",
  "uefi_specs",
  "wchar",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7208,7 +7240,7 @@ dependencies = [
  "static_assertions",
  "ucs2 0.0.0",
  "wchar",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7229,9 +7261,9 @@ dependencies = [
 
 [[package]]
 name = "uguid"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab14ea9660d240e7865ce9d54ecdbd1cd9fa5802ae6f4512f093c7907e921533"
+checksum = "0c8352f8c05e47892e7eaf13b34abd76a7f4aeaf817b716e88789381927f199c"
 
 [[package]]
 name = "uidevices"
@@ -7260,7 +7292,7 @@ dependencies = [
  "vmbus_channel",
  "vmbus_ring",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7281,7 +7313,7 @@ dependencies = [
  "disk_backend",
  "disklayer_ram",
  "get_protocol",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guest_emulation_transport",
  "guid",
  "mesh",
@@ -7298,7 +7330,7 @@ dependencies = [
  "tracing",
  "vmgs",
  "vmgs_format",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7356,7 +7388,7 @@ dependencies = [
  "futures-concurrency",
  "get_helpers",
  "get_protocol",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guest_emulation_transport",
  "guestmem",
  "guid",
@@ -7462,7 +7494,7 @@ dependencies = [
  "watchdog_core",
  "watchdog_vmgs_format",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7483,7 +7515,7 @@ dependencies = [
  "vergen",
  "vmbus_async",
  "vmbus_user_channel",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7606,7 +7638,7 @@ checksum = "40789245bbff5f31eb773c9ac4ee5c4e15eab9640d975e124d6ce4c34a6410d7"
 name = "unix_socket"
 version = "0.0.0"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "mesh_protobuf",
  "socket2",
  "windows-sys 0.59.0",
@@ -7649,7 +7681,7 @@ dependencies = [
  "vfio-bindings",
  "vfio_sys",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7688,7 +7720,7 @@ dependencies = [
  "igvm_defs",
  "open_enum",
  "static_assertions",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7751,7 +7783,7 @@ dependencies = [
  "tracing",
  "video_core",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7771,7 +7803,7 @@ name = "vhd1_defs"
 version = "0.0.0"
 dependencies = [
  "guid",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7806,7 +7838,7 @@ dependencies = [
  "vm_topology",
  "vmcore",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7860,7 +7892,7 @@ dependencies = [
  "vm_topology",
  "vmcore",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7890,7 +7922,7 @@ dependencies = [
  "vmcore",
  "x86defs",
  "x86emu",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7936,7 +7968,7 @@ dependencies = [
  "vmcore",
  "x86defs",
  "x86emu",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -7952,7 +7984,7 @@ dependencies = [
  "tracing",
  "virt",
  "vm_topology",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8001,7 +8033,7 @@ dependencies = [
  "vm_topology",
  "x86defs",
  "x86emu",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8041,7 +8073,7 @@ dependencies = [
  "winapi",
  "x86defs",
  "x86emu",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8071,7 +8103,7 @@ dependencies = [
  "virtio_resources",
  "vm_resource",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8099,7 +8131,7 @@ dependencies = [
  "virtio_resources",
  "vm_resource",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8178,7 +8210,7 @@ dependencies = [
  "virtio_resources",
  "vm_resource",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8259,7 +8291,7 @@ dependencies = [
  "vmbus_async",
  "vmbus_channel",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8283,7 +8315,7 @@ dependencies = [
  "thiserror 2.0.12",
  "vmbus_channel",
  "vmbus_ring",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8317,7 +8349,7 @@ dependencies = [
  "anyhow",
  "futures",
  "futures-concurrency",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guid",
  "inspect",
  "mesh",
@@ -8331,7 +8363,7 @@ dependencies = [
  "vmbus_channel",
  "vmbus_core",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8347,7 +8379,7 @@ dependencies = [
  "tracing",
  "vmbus_async",
  "vmbus_client",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8363,7 +8395,7 @@ dependencies = [
  "open_enum",
  "static_assertions",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8381,7 +8413,7 @@ dependencies = [
  "vmbus_core",
  "widestring",
  "windows 0.59.0",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8428,7 +8460,7 @@ dependencies = [
  "vmbus_relay",
  "vmbus_ring",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8441,7 +8473,7 @@ dependencies = [
  "safeatomic",
  "smallvec",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8466,7 +8498,7 @@ dependencies = [
  "vmbus_serial_host",
  "vmbus_serial_protocol",
  "vmbus_user_channel",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8489,7 +8521,7 @@ dependencies = [
  "vmbus_serial_protocol",
  "vmbus_serial_resources",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8499,7 +8531,7 @@ dependencies = [
  "guid",
  "open_enum",
  "static_assertions",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8518,7 +8550,7 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-concurrency",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guestmem",
  "guid",
  "hvdef",
@@ -8542,7 +8574,7 @@ dependencies = [
  "vmbus_ring",
  "vmcore",
  "windows 0.59.0",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8562,7 +8594,7 @@ dependencies = [
  "vmbus_async",
  "vmbus_channel",
  "vmbus_ring",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8588,7 +8620,7 @@ dependencies = [
  "tracelimit",
  "tracing",
  "vm_resource",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8608,7 +8640,7 @@ dependencies = [
  "crc32fast",
  "disk_backend",
  "disklayer_ram",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guestmem",
  "inspect",
  "inspect_counters",
@@ -8621,7 +8653,7 @@ dependencies = [
  "tracing",
  "vmgs_format",
  "windows 0.59.0",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8649,7 +8681,7 @@ dependencies = [
  "inspect",
  "open_enum",
  "static_assertions",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8700,9 +8732,9 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
+checksum = "945fecc32d9b44069437b7aacd2257556a91a2054ae10e9e7538fe498e442db9"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -8751,7 +8783,7 @@ dependencies = [
  "vmotherboard",
  "vpci",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8880,7 +8912,7 @@ name = "vmswitch"
 version = "0.0.0"
 dependencies = [
  "futures",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "guid",
  "pal",
  "pal_async",
@@ -8889,7 +8921,7 @@ dependencies = [
  "tracing",
  "widestring",
  "winapi",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8900,7 +8932,7 @@ dependencies = [
  "pal_async",
  "socket2",
  "thiserror 2.0.12",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -8962,7 +8994,7 @@ dependencies = [
  "vmbus_channel",
  "vmbus_ring",
  "vmcore",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -9033,9 +9065,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -9096,13 +9128,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.2"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 0.38.44",
+ "rustix 1.0.5",
  "winsafe",
 ]
 
@@ -9117,9 +9149,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "win_etw_metadata"
@@ -9198,11 +9230,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.48.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9211,8 +9244,21 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
 dependencies = [
- "windows-core",
+ "windows-core 0.59.0",
  "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9221,11 +9267,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.59.0",
+ "windows-interface 0.59.1",
+ "windows-result 0.3.2",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -9241,9 +9298,20 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26fd936d991781ea39e87c3a27285081e3c0da5ca0fcbc02d368cc6f52ff01"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9252,15 +9320,24 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
-version = "0.3.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
  "windows-link",
 ]
@@ -9274,6 +9351,16 @@ dependencies = [
  "bitflags 2.9.0",
  "widestring",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9499,9 +9586,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]
@@ -9524,9 +9611,9 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -9547,7 +9634,7 @@ dependencies = [
  "arbitrary",
  "bitfield-struct 0.10.1",
  "open_enum",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -9559,7 +9646,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "x86defs",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -9604,9 +9691,9 @@ dependencies = [
  "toml_edit",
  "vmm_test_images",
  "walkdir",
- "which 7.0.2",
+ "which 7.0.3",
  "xshell",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -9629,11 +9716,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -9649,9 +9736,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -96,7 +96,7 @@ pub enum CpuidResultsIsolationType<'a> {
         vtom: u64,
     },
     Tdx {
-        topology: ProcessorTopology<X86Topology>,
+        topology: &'a ProcessorTopology<X86Topology>,
         access_vsm: bool,
         vtom: u64,
     },

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -14,6 +14,8 @@ use std::collections::HashMap;
 use thiserror::Error;
 use virt::CpuidLeaf;
 use virt::CpuidLeafSet;
+use vm_topology::processor::ProcessorTopology;
+use vm_topology::processor::x86::X86Topology;
 use x86defs::cpuid;
 use x86defs::cpuid::CpuidFunction;
 use x86defs::snp::HvPspCpuidPage;
@@ -81,12 +83,23 @@ trait CpuidArchInitializer {
 
     /// Whether TSC aux virtualization is supported
     fn supports_tsc_aux_virtualization(&self, results: &CpuidResults) -> bool;
+
+    /// Returns the synthetic hypervisor cpuid leafs for the architecture.
+    fn hv_cpuid_leaves(&self) -> [(CpuidFunction, CpuidResult); 5];
 }
 
 /// Initialization parameters per isolation type for parsing cpuid results
 pub enum CpuidResultsIsolationType<'a> {
-    Snp { cpuid_pages: &'a [u8] },
-    Tdx,
+    Snp {
+        cpuid_pages: &'a [u8],
+        access_vsm: bool,
+        vtom: u64,
+    },
+    Tdx {
+        topology: ProcessorTopology<X86Topology>,
+        access_vsm: bool,
+        vtom: u64,
+    },
 }
 
 impl CpuidResultsIsolationType<'_> {
@@ -194,16 +207,24 @@ impl CpuidResults {
         let snp_init;
         let tdx_init;
         let arch_initializer = match params {
-            CpuidResultsIsolationType::Snp { cpuid_pages } => {
+            CpuidResultsIsolationType::Snp {
+                cpuid_pages,
+                access_vsm,
+                vtom,
+            } => {
                 assert!(
                     cpuid_pages.len() % size_of::<HvPspCpuidPage>() == 0 && !cpuid_pages.is_empty()
                 );
 
-                snp_init = SnpCpuidInitializer::new(cpuid_pages);
+                snp_init = SnpCpuidInitializer::new(cpuid_pages, access_vsm, vtom);
                 &snp_init as &dyn CpuidArchInitializer
             }
-            CpuidResultsIsolationType::Tdx => {
-                tdx_init = TdxCpuidInitializer {};
+            CpuidResultsIsolationType::Tdx {
+                topology,
+                access_vsm,
+                vtom,
+            } => {
+                tdx_init = TdxCpuidInitializer::new(topology, access_vsm, vtom);
                 &tdx_init as &dyn CpuidArchInitializer
             }
         };
@@ -286,6 +307,10 @@ impl CpuidResults {
             } else {
                 tracing::trace!("Filtering out leaf {:x} subleaf {:x}", leaf.0, subleaf);
             }
+        }
+
+        for (function, result) in arch_initializer.hv_cpuid_leaves() {
+            results.insert(function, CpuidEntry::Leaf(result));
         }
 
         let mut cached_results = Self {

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -94,10 +94,12 @@ pub const SNP_REQUIRED_LEAVES: &[(CpuidFunction, Option<u32>)] = &[
 /// Implements [`CpuidArchSupport`] for SNP-isolation support
 pub struct SnpCpuidInitializer {
     cpuid_pages: Vec<HvPspCpuidPage>,
+    access_vsm: bool,
+    vtom: u64,
 }
 
 impl SnpCpuidInitializer {
-    pub fn new(cpuid_pages_data: &[u8]) -> Self {
+    pub fn new(cpuid_pages_data: &[u8], access_vsm: bool, vtom: u64) -> Self {
         let mut cpuid_pages = vec![
             HvPspCpuidPage::new_zeroed();
             cpuid_pages_data.len() / size_of::<HvPspCpuidPage>()
@@ -107,7 +109,11 @@ impl SnpCpuidInitializer {
             .as_mut_bytes()
             .copy_from_slice(cpuid_pages_data);
 
-        Self { cpuid_pages }
+        Self {
+            cpuid_pages,
+            access_vsm,
+            vtom,
+        }
     }
 }
 
@@ -391,6 +397,109 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
         );
 
         sev_features_eax.tsc_aux_virtualization()
+    }
+
+    fn hv_cpuid_leaves(&self) -> [(CpuidFunction, CpuidResult); 5] {
+        const MAX_CPUS: u32 = 2048;
+        const fn split_u128(x: u128) -> CpuidResult {
+            let bytes: [u32; 4] = zerocopy::transmute!(x);
+            CpuidResult {
+                eax: bytes[0],
+                ebx: bytes[1],
+                ecx: bytes[2],
+                edx: bytes[3],
+            }
+        }
+
+        [
+            (CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES), {
+                let privileges = hvdef::HvPartitionPrivilege::new()
+                    .with_access_partition_reference_counter(true)
+                    .with_access_hypercall_msrs(true)
+                    .with_access_vp_index(true)
+                    .with_access_frequency_msrs(true)
+                    .with_access_synic_msrs(true)
+                    .with_access_synthetic_timer_msrs(true)
+                    .with_access_apic_msrs(true)
+                    .with_access_vp_runtime_msr(true)
+                    .with_access_partition_reference_tsc(true)
+                    .with_start_virtual_processor(true)
+                    .with_enable_extended_gva_ranges_flush_va_list(true)
+                    .with_access_guest_idle_msr(true)
+                    .with_access_vsm(self.access_vsm)
+                    .with_isolation(true);
+                // TODO SNP
+                //     .with_fast_hypercall_output(true);
+
+                let features = hvdef::HvFeatures::new()
+                    .with_privileges(privileges)
+                    .with_frequency_regs_available(true)
+                    .with_direct_synthetic_timers(true)
+                    .with_extended_gva_ranges_for_flush_virtual_address_list_available(true)
+                    .with_guest_idle_available(true)
+                    .with_xmm_registers_for_fast_hypercall_available(true)
+                    .with_register_pat_available(true);
+                // TODO SNP
+                //    .with_fast_hypercall_output_available(true);
+
+                split_u128(features.into_bits())
+            }),
+            (
+                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION),
+                {
+                    let enlightenments = hvdef::HvEnlightenmentInformation::new()
+                        .with_deprecate_auto_eoi(true)
+                        .with_use_relaxed_timing(true)
+                        .with_use_ex_processor_masks(true)
+                        // If only xAPIC is supported, then the Hyper-V MSRs are
+                        // more efficient for EOIs.
+                        // If X2APIC is supported, then we can use the X2APIC MSRs. These
+                        // are as efficient as the Hyper-V MSRs, and they are
+                        // compatible with APIC hardware offloads.
+                        // However, Lazy EOI on SNP is beneficial and requires the
+                        // Hyper-V MSRs to function. Enable it here always.
+                        .with_use_apic_msrs(true)
+                        .with_long_spin_wait_count(!0)
+                        .with_use_hypercall_for_remote_flush_and_local_flush_entire(true);
+                    // TODO SNP
+                    //    .with_use_synthetic_cluster_ipi(true);
+
+                    split_u128(enlightenments.into_bits())
+                },
+            ),
+            (
+                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_IMPLEMENTATION_LIMITS),
+                CpuidResult {
+                    eax: MAX_CPUS,
+                    ebx: MAX_CPUS,
+                    ecx: 0,
+                    edx: 0,
+                },
+            ),
+            (
+                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_HARDWARE_FEATURES),
+                split_u128(
+                    hvdef::HvHardwareFeatures::new()
+                        .with_apic_overlay_assist_in_use(true)
+                        .with_msr_bitmaps_in_use(true)
+                        .with_second_level_address_translation_in_use(true)
+                        .with_dma_remapping_in_use(false)
+                        .with_interrupt_remapping_in_use(false)
+                        .into_bits(),
+                ),
+            ),
+            (
+                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION),
+                split_u128(
+                    hvdef::HvIsolationConfiguration::new()
+                        .with_paravisor_present(true)
+                        .with_isolation_type(virt::IsolationType::Snp.to_hv().0)
+                        .with_shared_gpa_boundary_active(true)
+                        .with_shared_gpa_boundary_bits(self.vtom.trailing_zeros() as u8)
+                        .into_bits(),
+                ),
+            ),
+        ]
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -437,8 +437,9 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
             // Hyper-V MSRs to function. Enable it here always.
             .with_use_apic_msrs(true)
             .with_long_spin_wait_count(!0)
-            .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
-            .with_use_synthetic_cluster_ipi(true);
+            .with_use_hypercall_for_remote_flush_and_local_flush_entire(true);
+        // TODO SNP
+        //  .with_use_synthetic_cluster_ipi(true);
 
         let hardware_features = hvdef::HvHardwareFeatures::new()
             .with_apic_overlay_assist_in_use(true)

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -454,17 +454,12 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
             .with_shared_gpa_boundary_active(true)
             .with_shared_gpa_boundary_bits(self.vtom.trailing_zeros() as u8);
 
-        let leaves = hv1_emulator::cpuid::make_hv_cpuid_leaves(features, enlightenments, MAX_CPUS);
-        let isolated_leaves =
+        let [l0, l1, l2] =
+            hv1_emulator::cpuid::make_hv_cpuid_leaves(features, enlightenments, MAX_CPUS);
+        let [l3, l4] =
             hv1_emulator::cpuid::make_isolated_hv_cpuid_leaves(hardware_features, isolation_config);
 
-        [
-            leaves[0],
-            leaves[1],
-            leaves[2],
-            isolated_leaves[0],
-            isolated_leaves[1],
-        ]
+        [l0, l1, l2, l3, l4]
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -401,104 +401,68 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
 
     fn hv_cpuid_leaves(&self) -> [(CpuidFunction, CpuidResult); 5] {
         const MAX_CPUS: u32 = 2048;
-        const fn split_u128(x: u128) -> CpuidResult {
-            let bytes: [u32; 4] = zerocopy::transmute!(x);
-            CpuidResult {
-                eax: bytes[0],
-                ebx: bytes[1],
-                ecx: bytes[2],
-                edx: bytes[3],
-            }
-        }
+
+        let privileges = hv1_emulator::cpuid::SUPPORTED_PRIVILEGES
+            .with_access_frequency_msrs(true)
+            .with_access_apic_msrs(true)
+            .with_start_virtual_processor(true)
+            .with_enable_extended_gva_ranges_flush_va_list(true)
+            .with_access_guest_idle_msr(true)
+            .with_access_vsm(self.access_vsm)
+            .with_isolation(true);
+        // TODO SNP
+        //     .with_fast_hypercall_output(true);
+
+        let features = hv1_emulator::cpuid::SUPPORTED_FEATURES
+            .with_privileges(privileges)
+            .with_frequency_regs_available(true)
+            .with_direct_synthetic_timers(true)
+            .with_extended_gva_ranges_for_flush_virtual_address_list_available(true)
+            .with_guest_idle_available(true)
+            .with_xmm_registers_for_fast_hypercall_available(true)
+            .with_register_pat_available(true);
+        // TODO SNP
+        //    .with_fast_hypercall_output_available(true);
+
+        let enlightenments = hvdef::HvEnlightenmentInformation::new()
+            .with_deprecate_auto_eoi(true)
+            .with_use_relaxed_timing(true)
+            .with_use_ex_processor_masks(true)
+            // If only xAPIC is supported, then the Hyper-V MSRs are
+            // more efficient for EOIs.
+            // If X2APIC is supported, then we can use the X2APIC MSRs. These
+            // are as efficient as the Hyper-V MSRs, and they are
+            // compatible with APIC hardware offloads.
+            // However, Lazy EOI on SNP is beneficial and requires the
+            // Hyper-V MSRs to function. Enable it here always.
+            .with_use_apic_msrs(true)
+            .with_long_spin_wait_count(!0)
+            .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
+            .with_use_synthetic_cluster_ipi(true);
+
+        let hardware_features = hvdef::HvHardwareFeatures::new()
+            .with_apic_overlay_assist_in_use(true)
+            .with_msr_bitmaps_in_use(true)
+            .with_second_level_address_translation_in_use(true)
+            .with_dma_remapping_in_use(false)
+            .with_interrupt_remapping_in_use(false);
+
+        let isolation_config = hvdef::HvIsolationConfiguration::new()
+            .with_paravisor_present(true)
+            .with_isolation_type(virt::IsolationType::Snp.to_hv().0)
+            .with_shared_gpa_boundary_active(true)
+            .with_shared_gpa_boundary_bits(self.vtom.trailing_zeros() as u8);
+
+        let leaves = hv1_emulator::cpuid::make_hv_cpuid_leaves(features, enlightenments, MAX_CPUS);
+        let isolated_leaves =
+            hv1_emulator::cpuid::make_isolated_hv_cpuid_leaves(hardware_features, isolation_config);
 
         [
-            (CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES), {
-                let privileges = hvdef::HvPartitionPrivilege::new()
-                    .with_access_partition_reference_counter(true)
-                    .with_access_hypercall_msrs(true)
-                    .with_access_vp_index(true)
-                    .with_access_frequency_msrs(true)
-                    .with_access_synic_msrs(true)
-                    .with_access_synthetic_timer_msrs(true)
-                    .with_access_apic_msrs(true)
-                    .with_access_vp_runtime_msr(true)
-                    .with_access_partition_reference_tsc(true)
-                    .with_start_virtual_processor(true)
-                    .with_enable_extended_gva_ranges_flush_va_list(true)
-                    .with_access_guest_idle_msr(true)
-                    .with_access_vsm(self.access_vsm)
-                    .with_isolation(true);
-                // TODO SNP
-                //     .with_fast_hypercall_output(true);
-
-                let features = hvdef::HvFeatures::new()
-                    .with_privileges(privileges)
-                    .with_frequency_regs_available(true)
-                    .with_direct_synthetic_timers(true)
-                    .with_extended_gva_ranges_for_flush_virtual_address_list_available(true)
-                    .with_guest_idle_available(true)
-                    .with_xmm_registers_for_fast_hypercall_available(true)
-                    .with_register_pat_available(true);
-                // TODO SNP
-                //    .with_fast_hypercall_output_available(true);
-
-                split_u128(features.into_bits())
-            }),
-            (
-                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION),
-                {
-                    let enlightenments = hvdef::HvEnlightenmentInformation::new()
-                        .with_deprecate_auto_eoi(true)
-                        .with_use_relaxed_timing(true)
-                        .with_use_ex_processor_masks(true)
-                        // If only xAPIC is supported, then the Hyper-V MSRs are
-                        // more efficient for EOIs.
-                        // If X2APIC is supported, then we can use the X2APIC MSRs. These
-                        // are as efficient as the Hyper-V MSRs, and they are
-                        // compatible with APIC hardware offloads.
-                        // However, Lazy EOI on SNP is beneficial and requires the
-                        // Hyper-V MSRs to function. Enable it here always.
-                        .with_use_apic_msrs(true)
-                        .with_long_spin_wait_count(!0)
-                        .with_use_hypercall_for_remote_flush_and_local_flush_entire(true);
-                    // TODO SNP
-                    //    .with_use_synthetic_cluster_ipi(true);
-
-                    split_u128(enlightenments.into_bits())
-                },
-            ),
-            (
-                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_IMPLEMENTATION_LIMITS),
-                CpuidResult {
-                    eax: MAX_CPUS,
-                    ebx: MAX_CPUS,
-                    ecx: 0,
-                    edx: 0,
-                },
-            ),
-            (
-                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_HARDWARE_FEATURES),
-                split_u128(
-                    hvdef::HvHardwareFeatures::new()
-                        .with_apic_overlay_assist_in_use(true)
-                        .with_msr_bitmaps_in_use(true)
-                        .with_second_level_address_translation_in_use(true)
-                        .with_dma_remapping_in_use(false)
-                        .with_interrupt_remapping_in_use(false)
-                        .into_bits(),
-                ),
-            ),
-            (
-                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION),
-                split_u128(
-                    hvdef::HvIsolationConfiguration::new()
-                        .with_paravisor_present(true)
-                        .with_isolation_type(virt::IsolationType::Snp.to_hv().0)
-                        .with_shared_gpa_boundary_active(true)
-                        .with_shared_gpa_boundary_bits(self.vtom.trailing_zeros() as u8)
-                        .into_bits(),
-                ),
-            ),
+            leaves[0],
+            leaves[1],
+            leaves[2],
+            isolated_leaves[0],
+            isolated_leaves[1],
         ]
     }
 }

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -265,113 +265,76 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
 
     fn hv_cpuid_leaves(&self) -> [(CpuidFunction, CpuidResult); 5] {
         const MAX_CPUS: u32 = 2048;
-        const fn split_u128(x: u128) -> CpuidResult {
-            let bytes: [u32; 4] = zerocopy::transmute!(x);
-            CpuidResult {
-                eax: bytes[0],
-                ebx: bytes[1],
-                ecx: bytes[2],
-                edx: bytes[3],
+
+        let privileges = hv1_emulator::cpuid::SUPPORTED_PRIVILEGES
+            .with_access_frequency_msrs(true)
+            .with_access_apic_msrs(true)
+            .with_start_virtual_processor(true)
+            .with_enable_extended_gva_ranges_flush_va_list(true)
+            .with_access_guest_idle_msr(true)
+            .with_access_vsm(self.access_vsm)
+            .with_isolation(true);
+        // TODO TDX
+        //     .with_fast_hypercall_output(true);
+
+        let features = hv1_emulator::cpuid::SUPPORTED_FEATURES
+            .with_privileges(privileges)
+            .with_frequency_regs_available(true)
+            .with_extended_gva_ranges_for_flush_virtual_address_list_available(true)
+            .with_guest_idle_available(true)
+            .with_xmm_registers_for_fast_hypercall_available(true)
+            .with_register_pat_available(true);
+        // TODO TDX
+        //    .with_fast_hypercall_output_available(true);
+
+        let use_apic_msrs = match self.topology.apic_mode() {
+            vm_topology::processor::x86::ApicMode::XApic => {
+                // If only xAPIC is supported, then the Hyper-V MSRs are
+                // more efficient for EOIs.
+                true
             }
-        }
+            vm_topology::processor::x86::ApicMode::X2ApicSupported
+            | vm_topology::processor::x86::ApicMode::X2ApicEnabled => {
+                // If X2APIC is supported, then use the X2APIC MSRs. These
+                // are as efficient as the Hyper-V MSRs, and they are
+                // compatible with APIC hardware offloads.
+                false
+            }
+        };
+
+        let enlightenments = hvdef::HvEnlightenmentInformation::new()
+            .with_deprecate_auto_eoi(true)
+            .with_use_relaxed_timing(true)
+            .with_use_ex_processor_masks(true)
+            .with_use_apic_msrs(use_apic_msrs)
+            .with_long_spin_wait_count(!0)
+            .with_use_synthetic_cluster_ipi(true);
+        // TODO TDX
+        //    .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
+
+        let hardware_features = hvdef::HvHardwareFeatures::new()
+            .with_apic_overlay_assist_in_use(true)
+            .with_msr_bitmaps_in_use(true)
+            .with_second_level_address_translation_in_use(true)
+            .with_dma_remapping_in_use(false)
+            .with_interrupt_remapping_in_use(false);
+
+        let isolation_config = hvdef::HvIsolationConfiguration::new()
+            .with_paravisor_present(true)
+            .with_isolation_type(virt::IsolationType::Tdx.to_hv().0)
+            .with_shared_gpa_boundary_active(true)
+            .with_shared_gpa_boundary_bits(self.vtom.trailing_zeros() as u8);
+
+        let leaves = hv1_emulator::cpuid::make_hv_cpuid_leaves(features, enlightenments, MAX_CPUS);
+        let isolated_leaves =
+            hv1_emulator::cpuid::make_isolated_hv_cpuid_leaves(hardware_features, isolation_config);
 
         [
-            (CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES), {
-                let privileges = hvdef::HvPartitionPrivilege::new()
-                    .with_access_partition_reference_counter(true)
-                    .with_access_hypercall_msrs(true)
-                    .with_access_vp_index(true)
-                    .with_access_frequency_msrs(true)
-                    .with_access_synic_msrs(true)
-                    .with_access_synthetic_timer_msrs(true)
-                    .with_access_apic_msrs(true)
-                    .with_access_vp_runtime_msr(true)
-                    .with_access_partition_reference_tsc(true)
-                    .with_start_virtual_processor(true)
-                    .with_enable_extended_gva_ranges_flush_va_list(true)
-                    .with_access_guest_idle_msr(true)
-                    .with_access_vsm(self.access_vsm)
-                    .with_isolation(true);
-                // TODO TDX
-                //     .with_fast_hypercall_output(true);
-
-                let features = hvdef::HvFeatures::new()
-                    .with_privileges(privileges)
-                    .with_frequency_regs_available(true)
-                    .with_direct_synthetic_timers(true)
-                    .with_extended_gva_ranges_for_flush_virtual_address_list_available(true)
-                    .with_guest_idle_available(true)
-                    .with_xmm_registers_for_fast_hypercall_available(true)
-                    .with_register_pat_available(true);
-                // TODO TDX
-                //    .with_fast_hypercall_output_available(true);
-
-                split_u128(features.into_bits())
-            }),
-            (
-                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION),
-                {
-                    let use_apic_msrs = match self.topology.apic_mode() {
-                        vm_topology::processor::x86::ApicMode::XApic => {
-                            // If only xAPIC is supported, then the Hyper-V MSRs are
-                            // more efficient for EOIs.
-                            true
-                        }
-                        vm_topology::processor::x86::ApicMode::X2ApicSupported
-                        | vm_topology::processor::x86::ApicMode::X2ApicEnabled => {
-                            // If X2APIC is supported, then use the X2APIC MSRs. These
-                            // are as efficient as the Hyper-V MSRs, and they are
-                            // compatible with APIC hardware offloads.
-                            false
-                        }
-                    };
-
-                    let enlightenments = hvdef::HvEnlightenmentInformation::new()
-                        .with_deprecate_auto_eoi(true)
-                        .with_use_relaxed_timing(true)
-                        .with_use_ex_processor_masks(true)
-                        .with_use_apic_msrs(use_apic_msrs)
-                        .with_long_spin_wait_count(!0);
-
-                    // TODO TDX
-                    //    .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
-                    //    .with_use_synthetic_cluster_ipi(true);
-
-                    split_u128(enlightenments.into_bits())
-                },
-            ),
-            (
-                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_IMPLEMENTATION_LIMITS),
-                CpuidResult {
-                    eax: MAX_CPUS,
-                    ebx: MAX_CPUS,
-                    ecx: 0,
-                    edx: 0,
-                },
-            ),
-            (
-                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_HARDWARE_FEATURES),
-                split_u128(
-                    hvdef::HvHardwareFeatures::new()
-                        .with_apic_overlay_assist_in_use(true)
-                        .with_msr_bitmaps_in_use(true)
-                        .with_second_level_address_translation_in_use(true)
-                        .with_dma_remapping_in_use(false)
-                        .with_interrupt_remapping_in_use(false)
-                        .into_bits(),
-                ),
-            ),
-            (
-                CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION),
-                split_u128(
-                    hvdef::HvIsolationConfiguration::new()
-                        .with_paravisor_present(true)
-                        .with_isolation_type(virt::IsolationType::Tdx.to_hv().0)
-                        .with_shared_gpa_boundary_active(true)
-                        .with_shared_gpa_boundary_bits(self.vtom.trailing_zeros() as u8)
-                        .into_bits(),
-                ),
-            ),
+            leaves[0],
+            leaves[1],
+            leaves[2],
+            isolated_leaves[0],
+            isolated_leaves[1],
         ]
     }
 }

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -34,14 +34,14 @@ pub const TDX_REQUIRED_LEAVES: &[(CpuidFunction, Option<u32>)] = &[
 ];
 
 /// Implements [`CpuidArchSupport`] for TDX-isolation support
-pub struct TdxCpuidInitializer {
-    topology: ProcessorTopology<X86Topology>,
+pub struct TdxCpuidInitializer<'a> {
+    topology: &'a ProcessorTopology<X86Topology>,
     access_vsm: bool,
     vtom: u64,
 }
 
-impl TdxCpuidInitializer {
-    pub fn new(topology: ProcessorTopology<X86Topology>, access_vsm: bool, vtom: u64) -> Self {
+impl<'a> TdxCpuidInitializer<'a> {
+    pub fn new(topology: &'a ProcessorTopology<X86Topology>, access_vsm: bool, vtom: u64) -> Self {
         Self {
             topology,
             access_vsm,
@@ -54,7 +54,7 @@ impl TdxCpuidInitializer {
     }
 }
 
-impl CpuidArchInitializer for TdxCpuidInitializer {
+impl CpuidArchInitializer for TdxCpuidInitializer<'_> {
     fn vendor(&self) -> cpuid::Vendor {
         cpuid::Vendor::INTEL
     }

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -307,10 +307,10 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
             .with_use_relaxed_timing(true)
             .with_use_ex_processor_masks(true)
             .with_use_apic_msrs(use_apic_msrs)
-            .with_long_spin_wait_count(!0)
-            .with_use_synthetic_cluster_ipi(true);
+            .with_long_spin_wait_count(!0);
         // TODO TDX
-        //    .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
+        //  .with_use_synthetic_cluster_ipi(true)
+        //  .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
 
         let hardware_features = hvdef::HvHardwareFeatures::new()
             .with_apic_overlay_assist_in_use(true)

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -325,16 +325,11 @@ impl CpuidArchInitializer for TdxCpuidInitializer<'_> {
             .with_shared_gpa_boundary_active(true)
             .with_shared_gpa_boundary_bits(self.vtom.trailing_zeros() as u8);
 
-        let leaves = hv1_emulator::cpuid::make_hv_cpuid_leaves(features, enlightenments, MAX_CPUS);
-        let isolated_leaves =
+        let [l0, l1, l2] =
+            hv1_emulator::cpuid::make_hv_cpuid_leaves(features, enlightenments, MAX_CPUS);
+        let [l3, l4] =
             hv1_emulator::cpuid::make_isolated_hv_cpuid_leaves(hardware_features, isolation_config);
 
-        [
-            leaves[0],
-            leaves[1],
-            leaves[2],
-            isolated_leaves[0],
-            isolated_leaves[1],
-        ]
+        [l0, l1, l2, l3, l4]
     }
 }

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/mod.rs
@@ -251,6 +251,8 @@ fn populate_and_filter() {
     fill_required_leaves(&mut pages, None);
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();
@@ -362,6 +364,8 @@ fn subleaf() {
 
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();
@@ -414,6 +418,8 @@ fn invlpgb() {
     assert!(matches!(
         CpuidResultsIsolationType::Snp {
             cpuid_pages: pages.as_slice().as_bytes(),
+            access_vsm: false,
+            vtom: 0x80000000,
         }
         .build(),
         Err(CpuidResultsError::InvlpgbUnavailable)
@@ -447,6 +453,8 @@ fn extended_address_space_sizes() {
 
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();
@@ -468,6 +476,8 @@ fn hypervisor_present() {
 
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();
@@ -494,6 +504,8 @@ fn validate_required_snp() {
         assert!(matches!(
             CpuidResultsIsolationType::Snp {
                 cpuid_pages: pages.as_slice().as_bytes().as_bytes(),
+                access_vsm: false,
+                vtom: 0x80000000,
             }.build(),
             Err(CpuidResultsError::MissingRequiredResult(err_leaf, err_subleaf)) if (err_leaf == leaf && err_subleaf == subleaf)
         ));
@@ -529,6 +541,8 @@ fn zeros_unsupported_leaf() {
     fill_required_leaves(&mut pages, None);
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();
@@ -562,6 +576,8 @@ fn tsc_aux() {
     fill_required_leaves(&mut pages, Some(&[CpuidFunction::ExtendedSevFeatures]));
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();
@@ -1111,6 +1127,8 @@ fn real_values() {
 
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/topology.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/topology.rs
@@ -52,6 +52,8 @@ fn real_topology() {
 
     let cpuid = CpuidResults::new(CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     })
     .unwrap();
 
@@ -157,6 +159,8 @@ fn initialize_topology(
 
     CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
 }

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/xfem.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tests/xfem.rs
@@ -49,6 +49,8 @@ fn extended_state_enumeration_wrong_page() {
 
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();
@@ -164,6 +166,8 @@ fn real_xfem() {
 
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();
@@ -335,6 +339,8 @@ fn run_fake_xfem_test(
 
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();
@@ -940,6 +946,8 @@ fn xfem_bounds() {
 
     let cpuid = CpuidResultsIsolationType::Snp {
         cpuid_pages: pages.as_slice().as_bytes(),
+        access_vsm: false,
+        vtom: 0x80000000,
     }
     .build()
     .unwrap();
@@ -1034,6 +1042,8 @@ fn xfem_missing_subleaf0() {
     assert!(matches!(
         CpuidResultsIsolationType::Snp {
             cpuid_pages: pages.as_slice().as_bytes(),
+            access_vsm: false,
+            vtom: 0x80000000,
         }
         .build(),
         Err(CpuidResultsError::MissingRequiredResult(
@@ -1082,6 +1092,8 @@ fn xfem_missing_subleaf1() {
     assert!(matches!(
         CpuidResultsIsolationType::Snp {
             cpuid_pages: pages.as_slice().as_bytes(),
+            access_vsm: false,
+            vtom: 0x80000000,
         }
         .build(),
         Err(CpuidResultsError::MissingRequiredResult(
@@ -1144,6 +1156,8 @@ fn xfem_missing_additional_subleaf() {
     assert!(matches!(
         CpuidResultsIsolationType::Snp {
             cpuid_pages: pages.as_slice().as_bytes(),
+            access_vsm: false,
+            vtom: 0x80000000,
         }
         .build(),
         Err(CpuidResultsError::MissingRequiredResult(

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1496,7 +1496,7 @@ impl<'a> UhProtoPartition<'a> {
             .map_err(Error::CvmCpuid)?,
 
             IsolationType::Tdx => cvm_cpuid::CpuidResultsIsolationType::Tdx {
-                topology: params.topology.clone(),
+                topology: params.topology,
                 vtom: params.vtom.unwrap(),
                 access_vsm: guest_vsm_available,
             }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1988,8 +1988,7 @@ impl UhPartition {
             // trusted.
             let hv_version = safe_intrinsics::cpuid(hvdef::HV_CPUID_FUNCTION_MS_HV_VERSION, 0);
 
-            // Add the standard hypervisor leaves and version, and filter out
-            // leaves we shouldn't expose if we're hiding isolation.
+            // Perform final processing steps for synthetic leaves.
             hv1_emulator::cpuid::process_hv_cpuid_leaves(
                 &mut cpuid,
                 hide_isolation,

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1483,26 +1483,27 @@ impl<'a> UhProtoPartition<'a> {
 
         set_vtl2_vsm_partition_config(&hcl)?;
 
+        let guest_vsm_available = Self::check_guest_vsm_support(&hcl, &params)?;
+
         #[cfg(guest_arch = "x86_64")]
         let cpuid = match params.isolation {
             IsolationType::Snp => cvm_cpuid::CpuidResultsIsolationType::Snp {
                 cpuid_pages: params.cvm_cpuid_info.unwrap(),
+                vtom: params.vtom.unwrap(),
+                access_vsm: guest_vsm_available,
             }
             .build()
             .map_err(Error::CvmCpuid)?,
 
-            IsolationType::Tdx => cvm_cpuid::CpuidResultsIsolationType::Tdx
-                .build()
-                .map_err(Error::CvmCpuid)?,
+            IsolationType::Tdx => cvm_cpuid::CpuidResultsIsolationType::Tdx {
+                topology: params.topology.clone(),
+                vtom: params.vtom.unwrap(),
+                access_vsm: guest_vsm_available,
+            }
+            .build()
+            .map_err(Error::CvmCpuid)?,
             IsolationType::Vbs | IsolationType::None => Default::default(),
         };
-
-        let guest_vsm_available = Self::check_guest_vsm_support(
-            &hcl,
-            &params,
-            #[cfg(guest_arch = "x86_64")]
-            &cpuid,
-        )?;
 
         Ok(UhProtoPartition {
             hcl,
@@ -1666,12 +1667,6 @@ impl<'a> UhProtoPartition<'a> {
             cpuid,
             &late_params.cpuid,
             params.topology,
-            // Note: currently, guest_vsm_available can only set to true for
-            // hardware-isolated VMs. There aren't any other scenarios at the
-            // moment that will require underhill to expose vsm support through
-            // the cpuid results.
-            guest_vsm_available,
-            params.vtom,
             isolation,
             params.hide_isolation,
         );
@@ -1838,7 +1833,6 @@ impl UhProtoPartition<'_> {
     fn check_guest_vsm_support(
         hcl: &Hcl,
         params: &UhPartitionNewParams<'_>,
-        #[cfg(guest_arch = "x86_64")] cvm_cpuid: &virt::CpuidLeafSet,
     ) -> Result<bool, Error> {
         match params.isolation {
             IsolationType::None | IsolationType::Vbs => {}
@@ -1855,11 +1849,8 @@ impl UhProtoPartition<'_> {
                 }
                 // Require RMP Query
                 let rmp_query = x86defs::cpuid::ExtendedSevFeaturesEax::from(
-                    cvm_cpuid.result(
-                        x86defs::cpuid::CpuidFunction::ExtendedSevFeatures.0,
-                        0,
-                        &[0; 4],
-                    )[0],
+                    safe_intrinsics::cpuid(x86defs::cpuid::CpuidFunction::ExtendedSevFeatures.0, 0)
+                        .eax,
                 )
                 .rmp_query();
 
@@ -1971,51 +1962,44 @@ impl UhPartition {
         cpuid: virt::CpuidLeafSet,
         initial_cpuid: &[CpuidLeaf],
         topology: &ProcessorTopology<vm_topology::processor::x86::X86Topology>,
-        access_vsm: bool,
-        vtom: Option<u64>,
         isolation: IsolationType,
         hide_isolation: bool,
     ) -> virt::CpuidLeafSet {
         let mut cpuid = cpuid.into_leaves();
         if isolation.is_hardware_isolated() {
             // Update the x2apic leaf based on the topology.
-            {
-                let x2apic = match topology.apic_mode() {
-                    vm_topology::processor::x86::ApicMode::XApic => false,
-                    vm_topology::processor::x86::ApicMode::X2ApicSupported => true,
-                    vm_topology::processor::x86::ApicMode::X2ApicEnabled => true,
-                };
-                let ecx = x86defs::cpuid::VersionAndFeaturesEcx::new().with_x2_apic(x2apic);
-                let ecx_mask = x86defs::cpuid::VersionAndFeaturesEcx::new().with_x2_apic(true);
-                cpuid.push(
-                    CpuidLeaf::new(
-                        x86defs::cpuid::CpuidFunction::VersionAndFeatures.0,
-                        [0, 0, ecx.into(), 0],
-                    )
-                    .masked([0, 0, ecx_mask.into(), 0]),
-                );
-            }
+            let x2apic = match topology.apic_mode() {
+                vm_topology::processor::x86::ApicMode::XApic => false,
+                vm_topology::processor::x86::ApicMode::X2ApicSupported => true,
+                vm_topology::processor::x86::ApicMode::X2ApicEnabled => true,
+            };
+            let ecx = x86defs::cpuid::VersionAndFeaturesEcx::new().with_x2_apic(x2apic);
+            let ecx_mask = x86defs::cpuid::VersionAndFeaturesEcx::new().with_x2_apic(true);
+            cpuid.push(
+                CpuidLeaf::new(
+                    x86defs::cpuid::CpuidFunction::VersionAndFeatures.0,
+                    [0, 0, ecx.into(), 0],
+                )
+                .masked([0, 0, ecx_mask.into(), 0]),
+            );
 
             // Get the hypervisor version from the host. This is just for
             // reporting purposes, so it is safe even if the hypervisor is not
             // trusted.
             let hv_version = safe_intrinsics::cpuid(hvdef::HV_CPUID_FUNCTION_MS_HV_VERSION, 0);
-            cpuid.extend(hv1_emulator::cpuid::hv_cpuid_leaves(
-                topology,
-                if hide_isolation {
-                    IsolationType::None
-                } else {
-                    isolation
-                },
-                access_vsm,
+
+            // Add the standard hypervisor leaves and version, and filter out
+            // leaves we shouldn't expose if we're hiding isolation.
+            hv1_emulator::cpuid::process_hv_cpuid_leaves(
+                &mut cpuid,
+                hide_isolation,
                 [
                     hv_version.eax,
                     hv_version.ebx,
                     hv_version.ecx,
                     hv_version.edx,
                 ],
-                vtom,
-            ));
+            );
         }
         cpuid.extend(initial_cpuid);
         virt::CpuidLeafSet::new(cpuid)

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1729,16 +1729,7 @@ impl UhProcessor<'_, TdxBacked> {
                     })
                     .msr_read(msr)
                     .or_else_if_unknown(|| self.read_msr(msr, intercepted_vtl))
-                    .or_else_if_unknown(|| self.read_msr_cvm(msr, intercepted_vtl))
-                    .or_else_if_unknown(|| match msr {
-                        hvdef::HV_X64_MSR_GUEST_IDLE => {
-                            self.backing.cvm.lapics[intercepted_vtl].activity = MpState::Idle;
-                            self.clear_interrupt_shadow(intercepted_vtl);
-                            Ok(0)
-                        }
-                        X86X_MSR_EFER => Ok(self.backing.vtls[intercepted_vtl].efer),
-                        _ => Err(MsrError::Unknown),
-                    });
+                    .or_else_if_unknown(|| self.read_msr_tdx(msr, intercepted_vtl));
 
                 let value = match result {
                     Ok(v) => Some(v),
@@ -2407,7 +2398,7 @@ impl UhProcessor<'_, TdxBacked> {
         Ok(())
     }
 
-    fn read_msr_cvm(&self, msr: u32, vtl: GuestVtl) -> Result<u64, MsrError> {
+    fn read_msr_tdx(&mut self, msr: u32, vtl: GuestVtl) -> Result<u64, MsrError> {
         // TODO TDX: port remaining tdx and common values
         //
         // TODO TDX: consider if this can be shared with SnpBacked's
@@ -2466,6 +2457,13 @@ impl UhProcessor<'_, TdxBacked> {
             | x86defs::X86X_IA32_MSR_PKG_ENERGY_STATUS
             | x86defs::X86X_IA32_MSR_DRAM_ENERGY_STATUS
             | x86defs::X86X_IA32_MSR_PP0_ENERGY_STATUS => Ok(0),
+
+            hvdef::HV_X64_MSR_GUEST_IDLE => {
+                self.backing.cvm.lapics[vtl].activity = MpState::Idle;
+                self.clear_interrupt_shadow(vtl);
+                Ok(0)
+            }
+            X86X_MSR_EFER => Ok(self.backing.vtls[vtl].efer),
 
             _ => Err(MsrError::Unknown),
         }

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -4,6 +4,8 @@
 //! Provides the synthetic hypervisor cpuid leaves matching this hv1 emulator's
 //! capabilities.
 
+#![cfg(guest_arch = "x86_64")]
+
 use hvdef::HvEnlightenmentInformation;
 use hvdef::HvFeatures;
 use hvdef::HvHardwareFeatures;

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -44,13 +44,13 @@ pub fn process_hv_cpuid_leaves(
                 true
             }
         });
-    }
 
-    // And don't report that we're isolated.
-    let isolated_mask = hvdef::HvFeatures::new()
-        .with_privileges(hvdef::HvPartitionPrivilege::new().with_isolation(true));
-    leaves.push(
-        CpuidLeaf::new(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES, [0, 0, 0, 0])
-            .masked(zerocopy::transmute!(isolated_mask)),
-    );
+        // And don't report that we're isolated.
+        let isolated_mask = hvdef::HvFeatures::new()
+            .with_privileges(hvdef::HvPartitionPrivilege::new().with_isolation(true));
+        leaves.push(
+            CpuidLeaf::new(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES, [0, 0, 0, 0])
+                .masked(zerocopy::transmute!(isolated_mask)),
+        );
+    }
 }

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -45,4 +45,12 @@ pub fn process_hv_cpuid_leaves(
             }
         });
     }
+
+    // And don't report that we're isolated.
+    let isolated_mask = hvdef::HvFeatures::new()
+        .with_privileges(hvdef::HvPartitionPrivilege::new().with_isolation(true));
+    leaves.push(
+        CpuidLeaf::new(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES, [0, 0, 0, 0])
+            .masked(zerocopy::transmute!(isolated_mask)),
+    );
 }

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -4,9 +4,96 @@
 //! Provides the synthetic hypervisor cpuid leaves matching this hv1 emulator's
 //! capabilities.
 
+use hvdef::HvEnlightenmentInformation;
+use hvdef::HvFeatures;
+use hvdef::HvHardwareFeatures;
+use hvdef::HvIsolationConfiguration;
+use hvdef::HvPartitionPrivilege;
+use std::arch::x86_64::CpuidResult;
 use virt::CpuidLeaf;
+use x86defs::cpuid::CpuidFunction;
 
-/// Modify the given set of cpuid leaves to match the given parameters.
+/// The partition privileges that this emulator supports.
+pub const SUPPORTED_PRIVILEGES: HvPartitionPrivilege = HvPartitionPrivilege::new()
+    .with_access_partition_reference_counter(true)
+    .with_access_hypercall_msrs(true)
+    .with_access_vp_index(true)
+    .with_access_synic_msrs(true)
+    .with_access_synthetic_timer_msrs(true)
+    .with_access_partition_reference_tsc(true);
+
+/// The hypervisor features that this emulator supports.
+pub const SUPPORTED_FEATURES: HvFeatures = HvFeatures::new()
+    .with_privileges(SUPPORTED_PRIVILEGES)
+    .with_direct_synthetic_timers(true);
+
+const fn split_u128(x: u128) -> CpuidResult {
+    let bytes: [u32; 4] = zerocopy::transmute!(x);
+    CpuidResult {
+        eax: bytes[0],
+        ebx: bytes[1],
+        ecx: bytes[2],
+        edx: bytes[3],
+    }
+}
+
+/// Converts the given features and enlightenment information into a set of
+/// synthetic cpuid leaves.
+pub fn make_hv_cpuid_leaves(
+    features: HvFeatures,
+    enlightenments: HvEnlightenmentInformation,
+    max_cpus: u32,
+) -> [(CpuidFunction, CpuidResult); 3] {
+    const fn split_u128(x: u128) -> CpuidResult {
+        let bytes: [u32; 4] = zerocopy::transmute!(x);
+        CpuidResult {
+            eax: bytes[0],
+            ebx: bytes[1],
+            ecx: bytes[2],
+            edx: bytes[3],
+        }
+    }
+
+    [
+        (CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES), {
+            split_u128(features.into_bits())
+        }),
+        (
+            CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION),
+            split_u128(enlightenments.into_bits()),
+        ),
+        (
+            CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_IMPLEMENTATION_LIMITS),
+            CpuidResult {
+                eax: max_cpus,
+                ebx: max_cpus,
+                ecx: 0,
+                edx: 0,
+            },
+        ),
+    ]
+}
+
+/// Converts the given features and enlightenment information into a set of
+/// synthetic cpuid leaves for isolated VMs.
+pub fn make_isolated_hv_cpuid_leaves(
+    hardware_features: HvHardwareFeatures,
+    isolation_config: HvIsolationConfiguration,
+) -> [(CpuidFunction, CpuidResult); 2] {
+    [
+        (
+            CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_HARDWARE_FEATURES),
+            split_u128(hardware_features.into_bits()),
+        ),
+        (
+            CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION),
+            split_u128(isolation_config.into_bits()),
+        ),
+    ]
+}
+
+/// Adds the standard hypervisor leaves and version information, and filters out
+/// information we shouldn't expose if we're hiding isolation.
 pub fn process_hv_cpuid_leaves(
     leaves: &mut Vec<CpuidLeaf>,
     hide_isolation: bool,
@@ -46,8 +133,8 @@ pub fn process_hv_cpuid_leaves(
         });
 
         // And don't report that we're isolated.
-        let isolated_mask = hvdef::HvFeatures::new()
-            .with_privileges(hvdef::HvPartitionPrivilege::new().with_isolation(true));
+        let isolated_mask =
+            HvFeatures::new().with_privileges(HvPartitionPrivilege::new().with_isolation(true));
         leaves.push(
             CpuidLeaf::new(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES, [0, 0, 0, 0])
                 .masked(zerocopy::transmute!(isolated_mask)),

--- a/vm/hv1/hv1_emulator/src/cpuid.rs
+++ b/vm/hv1/hv1_emulator/src/cpuid.rs
@@ -5,164 +5,44 @@
 //! capabilities.
 
 use virt::CpuidLeaf;
-use virt::IsolationType;
-use vm_topology::processor::ProcessorTopology;
-use vm_topology::processor::x86::X86Topology;
 
-const MAX_CPUS: usize = 2048;
-
-/// Provides the values for the synthetic hypervisor cpuid leaves.
-pub fn hv_cpuid_leaves(
-    topology: &ProcessorTopology<X86Topology>,
-    isolation: IsolationType,
-    access_vsm: bool,
+/// Modify the given set of cpuid leaves to match the given parameters.
+pub fn process_hv_cpuid_leaves(
+    leaves: &mut Vec<CpuidLeaf>,
+    hide_isolation: bool,
     hv_version: [u32; 4],
-    vtom: Option<u64>,
-) -> Vec<CpuidLeaf> {
-    let hardware_isolated = isolation.is_hardware_isolated();
-    let split_u128 = |x: u128| -> [u32; 4] { zerocopy::transmute!(x) };
+) {
+    // Add the standard leaves.
+    leaves.push(CpuidLeaf::new(
+        hvdef::HV_CPUID_FUNCTION_HV_VENDOR_AND_MAX_FUNCTION,
+        [
+            if hide_isolation {
+                hvdef::HV_CPUID_FUNCTION_MS_HV_IMPLEMENTATION_LIMITS
+            } else {
+                hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION
+            },
+            u32::from_le_bytes(*b"Micr"),
+            u32::from_le_bytes(*b"osof"),
+            u32::from_le_bytes(*b"t Hv"),
+        ],
+    ));
+    leaves.push(CpuidLeaf::new(
+        hvdef::HV_CPUID_FUNCTION_HV_INTERFACE,
+        [u32::from_le_bytes(*b"Hv#1"), 0, 0, 0],
+    ));
+    leaves.push(CpuidLeaf::new(
+        hvdef::HV_CPUID_FUNCTION_MS_HV_VERSION,
+        hv_version,
+    ));
 
-    let privileges = {
-        let mut privileges = hvdef::HvPartitionPrivilege::new()
-            .with_access_partition_reference_counter(true)
-            .with_access_hypercall_msrs(true)
-            .with_access_vp_index(true)
-            .with_access_frequency_msrs(true)
-            .with_access_synic_msrs(true)
-            .with_access_synthetic_timer_msrs(true)
-            .with_access_apic_msrs(true)
-            .with_access_vp_runtime_msr(true)
-            .with_access_partition_reference_tsc(true)
-            .with_start_virtual_processor(true)
-            .with_access_vsm(access_vsm)
-            .with_enable_extended_gva_ranges_flush_va_list(true);
-
-        if hardware_isolated {
-            privileges = privileges
-                .with_isolation(true)
-                // Some guests require enhanced idle for tick skipping support
-                .with_access_guest_idle_msr(true);
-
-            // TODO SNP:
-            //     .with_fast_hypercall_output(true);
-        }
-
-        privileges
-    };
-
-    let mut hv_cpuid = vec![
-        CpuidLeaf::new(
-            hvdef::HV_CPUID_FUNCTION_HV_VENDOR_AND_MAX_FUNCTION,
-            [
-                if hardware_isolated {
-                    hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION
-                } else {
-                    hvdef::HV_CPUID_FUNCTION_MS_HV_IMPLEMENTATION_LIMITS
-                },
-                u32::from_le_bytes(*b"Micr"),
-                u32::from_le_bytes(*b"osof"),
-                u32::from_le_bytes(*b"t Hv"),
-            ],
-        ),
-        CpuidLeaf::new(
-            hvdef::HV_CPUID_FUNCTION_HV_INTERFACE,
-            [u32::from_le_bytes(*b"Hv#1"), 0, 0, 0],
-        ),
-        CpuidLeaf::new(hvdef::HV_CPUID_FUNCTION_MS_HV_VERSION, hv_version),
-        CpuidLeaf::new(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES, {
-            let mut features = hvdef::HvFeatures::new()
-                .with_privileges(privileges)
-                .with_frequency_regs_available(true)
-                .with_direct_synthetic_timers(true)
-                .with_extended_gva_ranges_for_flush_virtual_address_list_available(true);
-
-            // TODO SNP
-            //    .with_fast_hypercall_output_available(true);
-
-            if hardware_isolated {
-                // Some guests require enhanced idle for tick skipping support
-                features = features.with_guest_idle_available(true);
+    // If we're hiding isolation, remove any HV leaves above the lowered limit.
+    if hide_isolation {
+        leaves.retain(|leaf| {
+            if leaf.function & 0xF0000000 == hvdef::HV_CPUID_FUNCTION_HV_VENDOR_AND_MAX_FUNCTION {
+                leaf.function <= hvdef::HV_CPUID_FUNCTION_MS_HV_IMPLEMENTATION_LIMITS
+            } else {
+                true
             }
-
-            if cfg!(guest_arch = "x86_64") {
-                features = features.with_xmm_registers_for_fast_hypercall_available(true);
-            }
-
-            split_u128(features.into())
-        }),
-        CpuidLeaf::new(hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION, {
-            let use_apic_msrs = match topology.apic_mode() {
-                vm_topology::processor::x86::ApicMode::XApic => {
-                    // If only xAPIC is supported, then the Hyper-V MSRs are
-                    // more efficient for EOIs.
-                    true
-                }
-                vm_topology::processor::x86::ApicMode::X2ApicSupported
-                | vm_topology::processor::x86::ApicMode::X2ApicEnabled => {
-                    // If X2APIC is supported, then use the X2APIC MSRs. These
-                    // are as efficient as the Hyper-V MSRs, and they are
-                    // compatible with APIC hardware offloads.
-                    // However, Lazy EOI on SNP is beneficial and requires the
-                    // Hyper-V MSRs to function. Enable it there regardless.
-                    isolation == IsolationType::Snp
-                }
-            };
-
-            let mut enlightenments = hvdef::HvEnlightenmentInformation::new()
-                .with_deprecate_auto_eoi(true)
-                .with_use_relaxed_timing(true)
-                .with_use_ex_processor_masks(true)
-                .with_use_apic_msrs(use_apic_msrs);
-
-            if hardware_isolated {
-                enlightenments = enlightenments.with_long_spin_wait_count(!0); // no spin wait notifications;
-
-                // TODO TDX GUEST VSM
-                if isolation != IsolationType::Tdx {
-                    enlightenments = enlightenments
-                        .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
-                }
-
-                // TODO HCVM:
-                //    .with_use_synthetic_cluster_ipi(true);
-            };
-            split_u128(enlightenments.into())
-        }),
-        CpuidLeaf::new(
-            hvdef::HV_CPUID_FUNCTION_MS_HV_IMPLEMENTATION_LIMITS,
-            [MAX_CPUS as u32, MAX_CPUS as u32, 0, 0],
-        ),
-    ];
-
-    if hardware_isolated {
-        hv_cpuid.append(&mut vec![
-            CpuidLeaf::new(
-                hvdef::HV_CPUID_FUNCTION_MS_HV_HARDWARE_FEATURES,
-                split_u128(
-                    hvdef::HvHardwareFeatures::new()
-                        .with_apic_overlay_assist_in_use(true)
-                        .with_msr_bitmaps_in_use(true)
-                        .with_second_level_address_translation_in_use(true)
-                        .with_dma_remapping_in_use(false)
-                        .with_interrupt_remapping_in_use(false)
-                        .into(),
-                ),
-            ),
-            CpuidLeaf::new(
-                hvdef::HV_CPUID_FUNCTION_MS_HV_ISOLATION_CONFIGURATION,
-                split_u128(
-                    hvdef::HvIsolationConfiguration::new()
-                        .with_paravisor_present(true)
-                        .with_isolation_type(isolation.to_hv().0)
-                        .with_shared_gpa_boundary_active(true)
-                        .with_shared_gpa_boundary_bits(
-                            vtom.expect("cvm requires vtom").trailing_zeros() as u8,
-                        )
-                        .into(),
-                ),
-            ),
-        ]);
+        });
     }
-
-    hv_cpuid
 }

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -93,7 +93,7 @@ impl IsolationType {
 pub struct UnexpectedIsolationType;
 
 impl IsolationType {
-    pub fn from_hv(
+    pub const fn from_hv(
         value: hvdef::HvPartitionIsolationType,
     ) -> Result<Self, UnexpectedIsolationType> {
         match value {
@@ -105,7 +105,7 @@ impl IsolationType {
         }
     }
 
-    pub fn to_hv(self) -> hvdef::HvPartitionIsolationType {
+    pub const fn to_hv(self) -> hvdef::HvPartitionIsolationType {
         match self {
             IsolationType::None => hvdef::HvPartitionIsolationType::NONE,
             IsolationType::Vbs => hvdef::HvPartitionIsolationType::VBS,

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -32,7 +32,6 @@ use hv1_emulator::message_queues::MessageQueues;
 use hv1_structs::VtlArray;
 use hv1_structs::VtlSet;
 use hvdef::HvDeliverabilityNotificationsRegister;
-use hvdef::HvEnlightenmentInformation;
 use hvdef::HvMessage;
 use hvdef::HvMessageType;
 use hvdef::Vtl;
@@ -914,7 +913,7 @@ impl WhpPartitionInner {
             // Add in the synthetic hv leaves if necessary.
             if let Some(hv_config) = &proto_config.hv_config {
                 if !hv_config.offload_enlightenments || proto_config.user_mode_apic {
-                    let enlightenments = HvEnlightenmentInformation::new()
+                    let enlightenments = hvdef::HvEnlightenmentInformation::new()
                         .with_deprecate_auto_eoi(true)
                         .with_use_relaxed_timing(true)
                         .with_use_ex_processor_masks(true)

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -32,6 +32,7 @@ use hv1_emulator::message_queues::MessageQueues;
 use hv1_structs::VtlArray;
 use hv1_structs::VtlSet;
 use hvdef::HvDeliverabilityNotificationsRegister;
+use hvdef::HvEnlightenmentInformation;
 use hvdef::HvMessage;
 use hvdef::HvMessageType;
 use hvdef::Vtl;
@@ -901,9 +902,9 @@ impl WhpPartitionInner {
             // hypervisor will do this automatically, but it doesn't hurt to do this
             // again.
             let mask = [0, 0, 1 << 21, 0];
-            let value = match proto_config.processor_topology.apic_mode() {
-                ApicMode::XApic => [0; 4],
-                ApicMode::X2ApicSupported | ApicMode::X2ApicEnabled => mask,
+            let (value, use_apic_msrs) = match proto_config.processor_topology.apic_mode() {
+                ApicMode::XApic => ([0; 4], true),
+                ApicMode::X2ApicSupported | ApicMode::X2ApicEnabled => (mask, false),
             };
             cpuid.push(
                 virt::CpuidLeaf::new(x86defs::cpuid::CpuidFunction::VersionAndFeatures.0, value)
@@ -913,6 +914,20 @@ impl WhpPartitionInner {
             // Add in the synthetic hv leaves if necessary.
             if let Some(hv_config) = &proto_config.hv_config {
                 if !hv_config.offload_enlightenments || proto_config.user_mode_apic {
+                    let enlightenments = HvEnlightenmentInformation::new()
+                        .with_deprecate_auto_eoi(true)
+                        .with_use_relaxed_timing(true)
+                        .with_use_ex_processor_masks(true)
+                        .with_use_apic_msrs(use_apic_msrs);
+                    const MAX_CPUS: u32 = 2048;
+                    cpuid.extend_from_slice(
+                        &hv1_emulator::cpuid::make_hv_cpuid_leaves(
+                            hv1_emulator::cpuid::SUPPORTED_FEATURES,
+                            enlightenments,
+                            MAX_CPUS,
+                        )
+                        .map(|(f, v)| virt::CpuidLeaf::new(f.0, [v.eax, v.ebx, v.ecx, v.edx])),
+                    );
                     hv1_emulator::cpuid::process_hv_cpuid_leaves(&mut cpuid, false, [0; 4]);
                 }
             }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -913,13 +913,7 @@ impl WhpPartitionInner {
             // Add in the synthetic hv leaves if necessary.
             if let Some(hv_config) = &proto_config.hv_config {
                 if !hv_config.offload_enlightenments || proto_config.user_mode_apic {
-                    cpuid.extend(hv1_emulator::cpuid::hv_cpuid_leaves(
-                        proto_config.processor_topology,
-                        IsolationType::None,
-                        false,
-                        [0; 4],
-                        None,
-                    ));
+                    hv1_emulator::cpuid::process_hv_cpuid_leaves(&mut cpuid, false, [0; 4]);
                 }
             }
 


### PR DESCRIPTION
As previously discussed, this moves the creation of various CPUID leaves into per-backing code inside virt_mshv_vtl, instead of being lumped together in hv1_emulator. It also adds the previously missing register_pat_available bit to both SNP and TDX, since we support reading PAT. It also removes the bit for access_vp_runtime_msr, as it is not an msr we implement anywhere.