### PR TITLE
SNP: Secure AVIC support

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -80,9 +80,10 @@ use std::sync::atomic::Ordering;
 use thiserror::Error;
 use user_driver::DmaClient;
 use user_driver::memory::MemoryBlock;
+use x86defs::snp::SevAvicPage;
 use x86defs::snp::SevVmsa;
 use x86defs::tdx::TdCallResultCode;
-use x86defs::vmx::ApicPage;
+use x86defs::vmx::VmxApicPage;
 use zerocopy::FromBytes;
 use zerocopy::FromZeros;
 use zerocopy::Immutable;
@@ -394,6 +395,7 @@ mod ioctls {
     const MSHV_INVLPGB: u16 = 0x36;
     const MSHV_TLBSYNC: u16 = 0x37;
     const MSHV_KICKCPUS: u16 = 0x38;
+    const MSHV_VTL_SECURE_AVIC_VTL0_PFN: u16 = 0x39;
 
     #[repr(C)]
     #[derive(Copy, Clone)]
@@ -568,6 +570,13 @@ mod ioctls {
         hcl_read_guest_vsm_page_pfn,
         MSHV_IOCTL,
         MSHV_VTL_GUEST_VSM_VMSA_PFN,
+        u64
+    );
+
+    ioctl_readwrite!(
+        hcl_read_secure_avic_vtl0_pfn,
+        MSHV_IOCTL,
+        MSHV_VTL_SECURE_AVIC_VTL0_PFN,
         u64
     );
 
@@ -1662,9 +1671,12 @@ enum BackingState {
     },
     Snp {
         vmsa: VtlArray<MappedPage<SevVmsa>, 2>,
+        vtl0_apic_page: MappedPage<SevAvicPage>,
+        /// VTL1 runs with the alternate interrupt injection.
+        vtl1_apic_page: MemoryBlock,
     },
     Tdx {
-        vtl0_apic_page: MappedPage<ApicPage>,
+        vtl0_apic_page: MappedPage<VmxApicPage>,
         vtl1_apic_page: MemoryBlock,
     },
 }
@@ -1728,6 +1740,12 @@ impl HclVp {
                     .map_err(|e| Error::MmapVp(e, Some(Vtl::Vtl1)))?;
                 BackingState::Snp {
                     vmsa: [vmsa_vtl0, vmsa_vtl1].into(),
+                    vtl0_apic_page: MappedPage::new(fd, MSHV_APIC_PAGE_OFFSET | vp as i64)
+                        .map_err(|e| Error::MmapVp(e, Some(Vtl::Vtl0)))?,
+                    vtl1_apic_page: private_dma_client
+                        .ok_or(Error::MissingPrivateMemory)?
+                        .allocate_dma_buffer(HV_PAGE_SIZE as usize)
+                        .map_err(Error::AllocVp)?,
                 }
             }
             IsolationType::Tdx => BackingState::Tdx {
@@ -2254,6 +2272,8 @@ impl<'a, T: Backing<'a>> ProcessorRunner<'a, T> {
                     | HvX64RegisterName::VsmVpSecureConfigVtl0
                     | HvX64RegisterName::VsmVpSecureConfigVtl1
                     | HvX64RegisterName::CrInterceptControl
+                    | HvX64RegisterName::SevAvicGpa
+                    | HvX64RegisterName::GuestVsmPartitionConfig
             )
         ));
         self.set_vp_registers_hvcall_inner(vtl, &registers)
@@ -3206,6 +3226,21 @@ impl Hcl {
         }
 
         vp_pfn
+    }
+
+    /// Gets the PFN for the VTL 0 secure AVIC
+    pub fn secure_avic_vtl0_pfn(&self, cpu_index: u32) -> u64 {
+        let mut savic_pfn = cpu_index as u64; // input vp, output pfn
+
+        // SAFETY: The ioctl requires no prerequisites other than the Secure AVIC VTL 0
+        // should be mapped. This ioctl should never fail as long as the VTL 0
+        // Secure AVIC was mapped.
+        unsafe {
+            hcl_read_secure_avic_vtl0_pfn(self.mshv_vtl.file.as_raw_fd(), &mut savic_pfn)
+                .expect("should always succeed");
+        }
+
+        savic_pfn
     }
 
     /// Returns the isolation type for the partition.

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -39,12 +39,12 @@ use x86defs::tdx::TdxGp;
 use x86defs::tdx::TdxL2Ctls;
 use x86defs::tdx::TdxL2EnterGuestState;
 use x86defs::tdx::TdxVmFlags;
-use x86defs::vmx::ApicPage;
 use x86defs::vmx::VmcsField;
+use x86defs::vmx::VmxApicPage;
 
 /// Runner backing for TDX partitions.
 pub struct Tdx<'a> {
-    apic_pages: VtlArray<&'a UnsafeCell<ApicPage>, 2>,
+    apic_pages: VtlArray<&'a UnsafeCell<VmxApicPage>, 2>,
 }
 
 impl MshvVtl {
@@ -123,14 +123,14 @@ impl<'a> ProcessorRunner<'a, Tdx<'a>> {
     }
 
     /// Gets a reference to the tdx APIC page for the given VTL.
-    pub fn tdx_apic_page(&self, vtl: GuestVtl) -> &ApicPage {
+    pub fn tdx_apic_page(&self, vtl: GuestVtl) -> &VmxApicPage {
         // SAFETY: the APIC pages will not be concurrently accessed by the processor
         // while this VP is in VTL2.
         unsafe { &*self.state.apic_pages[vtl].get() }
     }
 
     /// Gets a mutable reference to the tdx APIC page for the given VTL.
-    pub fn tdx_apic_page_mut(&mut self, vtl: GuestVtl) -> &mut ApicPage {
+    pub fn tdx_apic_page_mut(&mut self, vtl: GuestVtl) -> &mut VmxApicPage {
         // SAFETY: the APIC pages will not be concurrently accessed by the processor
         // while this VP is in VTL2.
         unsafe { &mut *self.state.apic_pages[vtl].get() }

--- a/openhcl/hcl/src/vmsa.rs
+++ b/openhcl/hcl/src/vmsa.rs
@@ -7,6 +7,7 @@
 use std::array;
 use std::ops::Deref;
 use std::ops::DerefMut;
+use x86defs::snp::SecureAvicControl;
 use x86defs::snp::SevEventInjectInfo;
 use x86defs::snp::SevFeatures;
 use x86defs::snp::SevSelector;
@@ -267,6 +268,11 @@ reg_direct_mut!(v_intr_cntrl, v_intr_cntrl_mut, SevVirtualInterruptControl);
 reg_direct!(virtual_tom, set_virtual_tom, u64);
 reg_direct!(event_inject, set_event_inject, SevEventInjectInfo);
 reg_direct!(guest_error_code, set_guest_error_code, u64);
+reg_direct_mut!(
+    secure_avic_control,
+    secure_avic_control_mut,
+    SecureAvicControl
+);
 regss!(es, set_es);
 regss!(cs, set_cs);
 regss!(ss, set_ss);

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -215,6 +215,7 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
                     .with_vmpl(true)
                     .with_rmp_query(true)
                     .with_tsc_aux_virtualization(true)
+                    .with_secure_avic(true)
                     .into(),
                 cpuid::ExtendedSevFeaturesEbx::new()
                     .with_cbit_position(0x3f)
@@ -430,12 +431,21 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
             .with_use_ex_processor_masks(true)
             // If only xAPIC is supported, then the Hyper-V MSRs are
             // more efficient for EOIs.
+            //
             // If X2APIC is supported, then we can use the X2APIC MSRs. These
             // are as efficient as the Hyper-V MSRs, and they are
             // compatible with APIC hardware offloads.
             // However, Lazy EOI on SNP is beneficial and requires the
             // Hyper-V MSRs to function. Enable it here always.
-            .with_use_apic_msrs(true)
+            //
+            // When Secure AVIC is enabled, x2APIC MSR accesses are
+            // not intercepted and are always intercepted when Secure AVIC is
+            // disabled (15.36.21.5 Guest APIC Accesses). As the production
+            // scenario is to have Secure AVIC enabled, we can disable the use
+            // of Hyper-V MSRs to save some performance overhead of intercept processing.
+            //
+            // Secure AVIC accelerates EOIs (15.36.21.5 Guest APIC Accesses).
+            .with_use_apic_msrs(false)
             .with_long_spin_wait_count(!0)
             .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
             .with_use_synthetic_cluster_ipi(true);

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -79,6 +79,7 @@ use virt_support_x86emu::emulate::emulate_io;
 use virt_support_x86emu::emulate::emulate_translate_gva;
 use virt_support_x86emu::translate::TranslationRegisters;
 use vmcore::vmtime::VmTimeAccess;
+use x86defs::ApicRegister;
 use x86defs::RFlags;
 use x86defs::X64_CR0_ET;
 use x86defs::X64_CR0_NE;
@@ -100,8 +101,6 @@ use x86defs::tdx::TdxGp;
 use x86defs::tdx::TdxInstructionInfo;
 use x86defs::tdx::TdxL2Ctls;
 use x86defs::tdx::TdxVpEnterRaxResult;
-use x86defs::vmx::ApicPage;
-use x86defs::vmx::ApicRegister;
 use x86defs::vmx::CR_ACCESS_TYPE_LMSW;
 use x86defs::vmx::CR_ACCESS_TYPE_MOV_TO_CR;
 use x86defs::vmx::CrAccessQualification;
@@ -123,6 +122,7 @@ use x86defs::vmx::SecondaryProcessorControls;
 use x86defs::vmx::VMX_ENTRY_CONTROL_LONG_MODE_GUEST;
 use x86defs::vmx::VMX_FEATURE_CONTROL_LOCKED;
 use x86defs::vmx::VmcsField;
+use x86defs::vmx::VmxApicPage;
 use x86defs::vmx::VmxEptExitQualification;
 use x86defs::vmx::VmxExit;
 use x86defs::vmx::VmxExitBasic;
@@ -3447,7 +3447,7 @@ impl UhProcessor<'_, TdxBacked> {
 
 struct TdxApicClient<'a, T> {
     partition: &'a UhPartitionInner,
-    apic_page: &'a mut ApicPage,
+    apic_page: &'a mut VmxApicPage,
     dev: &'a T,
     vmtime: &'a VmTimeAccess,
     vtl: GuestVtl,
@@ -3483,7 +3483,7 @@ impl<T: CpuIo> ApicClient for TdxApicClient<'_, T> {
     }
 }
 
-fn pull_apic_offload(page: &mut ApicPage) -> ([u32; 8], [u32; 8]) {
+fn pull_apic_offload(page: &mut VmxApicPage) -> ([u32; 8], [u32; 8]) {
     let mut irr = [0; 8];
     let mut isr = [0; 8];
     for (((irr, page_irr), isr), page_isr) in irr

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -2329,6 +2329,8 @@ registers! {
 
         // AMD SEV configuration MSRs
         SevControl = 0x00090040,
+        SevGhcbGpa = 0x00090041,
+        SevAvicGpa = 0x00090043,
 
         CrInterceptControl = 0x000E0000,
         CrInterceptCr0Mask = 0x000E0001,
@@ -3178,11 +3180,37 @@ pub struct HvRegisterVsmPartitionStatus {
     pub reserved: u64,
 }
 
+open_enum! {
+    #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub enum HvSnpInterruptInjection : u8  {
+        #![allow(non_upper_case_globals)]
+        HvSnpRestricted = 0x0,
+        HvSnpNormal = 0x1,
+        HvSnpAlternate = 0x2,
+        HvSnpSecureAvic = 0x3,
+    }
+}
+
+// Support for bitfield structures.
+impl HvSnpInterruptInjection {
+    const fn from_bits(val: u8) -> Self {
+        HvSnpInterruptInjection(val)
+    }
+
+    const fn into_bits(self) -> u8 {
+        self.0
+    }
+}
+
 #[bitfield(u64)]
 pub struct HvRegisterGuestVsmPartitionConfig {
     #[bits(4)]
     pub maximum_vtl: u8,
-    #[bits(60)]
+    #[bits(2)]
+    pub vtl0_interrupt_injection: HvSnpInterruptInjection,
+    #[bits(2)]
+    pub vtl1_interrupt_injection: HvSnpInterruptInjection,
+    #[bits(56)]
     pub reserved: u64,
 }
 
@@ -3643,6 +3671,16 @@ pub struct HvX64RegisterSevControl {
     _rsvd1: u64,
     #[bits(52)]
     pub vmsa_gpa_page_number: u64,
+}
+
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct HvX64RegisterSevAvic {
+    pub enable_secure_apic: bool,
+    #[bits(11)]
+    _rsvd1: u64,
+    #[bits(52)]
+    pub avic_gpa_page_number: u64,
 }
 
 #[bitfield(u64)]

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -14,6 +14,7 @@ use crate::vp_context_builder::VpContextBuilder;
 use crate::vp_context_builder::VpContextPageState;
 use crate::vp_context_builder::VpContextState;
 use crate::vp_context_builder::snp::InjectionType;
+use crate::vp_context_builder::snp::SecureAvic;
 use crate::vp_context_builder::snp::SnpHardwareContext;
 use crate::vp_context_builder::tdx::TdxHardwareContext;
 use crate::vp_context_builder::vbs::VbsRegister;
@@ -149,6 +150,7 @@ pub enum LoaderIsolationType {
         shared_gpa_boundary_bits: Option<u8>,
         policy: SnpPolicy,
         injection_type: InjectionType,
+        secure_avic: SecureAvic,
         // TODO SNP: SNP Keys? Other data?
     },
     Tdx {
@@ -201,6 +203,7 @@ impl IgvmLoaderRegister for X86Register {
                 shared_gpa_boundary_bits,
                 policy,
                 injection_type,
+                secure_avic,
             } => {
                 // TODO SNP: assumed that shared_gpa_boundary is always available.
                 let shared_gpa_boundary =
@@ -227,6 +230,7 @@ impl IgvmLoaderRegister for X86Register {
                     !with_paravisor,
                     shared_gpa_boundary,
                     injection_type,
+                    secure_avic,
                 ));
 
                 (platform_header, vec![init_header], vp_context_builder)
@@ -900,6 +904,7 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmVtlLoader
                 shared_gpa_boundary_bits,
                 policy: _,
                 injection_type: _,
+                secure_avic: _,
             } => IsolationConfig {
                 paravisor_present: self.loader.paravisor_present,
                 isolation_type: IsolationType::Snp,
@@ -1260,6 +1265,7 @@ mod tests {
                 shared_gpa_boundary_bits: Some(39),
                 policy: SnpPolicy::from((0x1 << 17) | (0x1 << 16) | (0x1f)),
                 injection_type: InjectionType::Restricted,
+                secure_avic: SecureAvic::Enabled,
             },
         );
         let data = vec![0, 5];

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -25,6 +25,7 @@ use igvmfilegen_config::Image;
 use igvmfilegen_config::LinuxImage;
 use igvmfilegen_config::ResourceType;
 use igvmfilegen_config::Resources;
+use igvmfilegen_config::SecureAvicType;
 use igvmfilegen_config::SnpInjectionType;
 use igvmfilegen_config::UefiConfigType;
 use loader::importer::Aarch64Register;
@@ -181,6 +182,7 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                 policy,
                 enable_debug,
                 injection_type,
+                secure_avic,
             } => LoaderIsolationType::Snp {
                 shared_gpa_boundary_bits,
                 policy: SnpPolicy::from(policy).with_debug(enable_debug as u8),
@@ -189,6 +191,10 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                     SnpInjectionType::Restricted => {
                         vp_context_builder::snp::InjectionType::Restricted
                     }
+                },
+                secure_avic: match secure_avic {
+                    SecureAvicType::Enabled => vp_context_builder::snp::SecureAvic::Enabled,
+                    SecureAvicType::Disabled => vp_context_builder::snp::SecureAvic::Disabled,
                 },
             },
             ConfigIsolationType::Tdx {

--- a/vm/loader/igvmfilegen_config/src/lib.rs
+++ b/vm/loader/igvmfilegen_config/src/lib.rs
@@ -33,6 +33,16 @@ pub enum SnpInjectionType {
     Restricted,
 }
 
+/// Secure AVIC type.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum SecureAvicType {
+    /// Offload AVIC to the hardware.
+    Enabled,
+    /// The paravisor emulates APIC.
+    Disabled,
+}
+
 /// The isolation type that should be used for the loader.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -56,6 +66,8 @@ pub enum ConfigIsolationType {
         enable_debug: bool,
         /// The interrupt injection type to use for the highest vmpl.
         injection_type: SnpInjectionType,
+        /// Secure AVIC
+        secure_avic: SecureAvicType,
     },
     /// Intel TDX.
     Tdx {

--- a/vm/loader/manifests/openhcl-x64-cvm-dev.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-dev.json
@@ -9,7 +9,8 @@
                     "shared_gpa_boundary_bits": 46,
                     "policy": 196639,
                     "enable_debug": true,
-                    "injection_type": "normal"
+                    "injection_type": "normal",
+                    "secure_avic": "enabled"
                 }
             },
             "image": {

--- a/vm/loader/manifests/openhcl-x64-cvm-release.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-release.json
@@ -8,8 +8,9 @@
                 "snp": {
                     "shared_gpa_boundary_bits": 46,
                     "policy": 196639,
-                    "enable_debug": false,
-                    "injection_type": "normal"
+                    "enable_debug": true,
+                    "injection_type": "normal",
+                    "secure_avic": "enabled"
                 }
             },
             "image": {

--- a/vm/x86/x86defs/src/cpuid.rs
+++ b/vm/x86/x86defs/src/cpuid.rs
@@ -700,14 +700,18 @@ pub struct ExtendedSevFeaturesEax {
     pub vmgexit_parameter: bool,
     pub virtual_tom_msr: bool,
     pub ibs_virtualization: bool,
-    #[bits(4)]
+    #[bits(2)]
     _reserved1: u32,
+    pub guest_intercept_control: bool,
+    pub segmented_rmp: bool,
     pub vmsa_register_protection: bool,
-    #[bits(4)]
-    _reserved2: u32,
+    _reserved2: bool,
+    pub secure_avic: bool,
+    pub allowed_sev_features: bool,
+    _reserved3: bool,
     pub nested_virt_msr_snp: bool,
     #[bits(2)]
-    _reserved3: u32,
+    _reserved4: u32,
 }
 
 #[bitfield(u32)]

--- a/vm/x86/x86defs/src/lib.rs
+++ b/vm/x86/x86defs/src/lib.rs
@@ -275,6 +275,7 @@ pub const X86X_AMD_MSR_NB_CFG: u32 = 0xC001001F;
 pub const X86X_AMD_MSR_VM_CR: u32 = 0xC0010114;
 pub const X86X_AMD_MSR_GHCB: u32 = 0xC0010130;
 pub const X86X_AMD_MSR_SEV: u32 = 0xC0010131;
+pub const X86X_AMD_MSR_SECURE_AVIC_CONTROL: u32 = 0xc0010138;
 pub const X86X_AMD_MSR_OSVW_ID_LENGTH: u32 = 0xc0010140;
 pub const X86X_AMD_MSR_OSVW_ID_STATUS: u32 = 0xc0010141;
 pub const X86X_AMD_MSR_DE_CFG: u32 = 0xc0011029;
@@ -517,4 +518,11 @@ pub struct X86xMcgStatusRegister {
     pub mcip: bool, // Machine check is in progress
     #[bits(61)]
     pub reserved0: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct ApicRegister {
+    pub value: u32,
+    _reserved: [u32; 3],
 }

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -3,7 +3,9 @@
 
 //! AMD SEV-SNP specific definitions.
 
+use crate::ApicRegister;
 use bitfield_struct::bitfield;
+use static_assertions::const_assert_eq;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -120,12 +122,16 @@ pub struct SevFeatures {
     pub vmgexit_param: bool,
     pub pmc_virt: bool,
     pub ibs_virt: bool,
-    rsvd: bool,
+    pub guest_intercept_control: bool,
     pub vmsa_reg_prot: bool,
     pub smt_prot: bool,
     pub secure_avic: bool,
-    #[bits(47)]
-    _unused: u64,
+    #[bits(4)]
+    _reserved0: u64,
+    pub ibpb_on_entry: bool,
+    #[bits(41)]
+    _reserved1: u64,
+    pub allowed_sev_features_enable: bool,
 }
 
 #[bitfield(u64)]
@@ -135,16 +141,21 @@ pub struct SevVirtualInterruptControl {
     pub irq: bool,
     pub gif: bool,
     pub intr_shadow: bool,
-    #[bits(5)]
+    pub nmi: bool,
+    pub nmi_mask: bool,
+    #[bits(3)]
     _rsvd1: u64,
     #[bits(4)]
     pub priority: u64,
     pub ignore_tpr: bool,
-    #[bits(11)]
+    #[bits(5)]
     _rsvd2: u64,
+    pub nmi_enable: bool,
+    #[bits(5)]
+    _rsvd3: u64,
     pub vector: u8,
     #[bits(23)]
-    _rsvd3: u64,
+    _rsvd4: u64,
     pub guest_busy: bool,
 }
 
@@ -206,6 +217,162 @@ pub struct SevNpfInfo {
     pub npt_supervisor_shadow_stack: bool,
     #[bits(26)]
     rsvd38_63: u64,
+}
+
+/// SEV secure AVIC control register
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq, Eq)]
+pub struct SecureAvicControl {
+    #[bits(1)]
+    pub secure_avic_en: u64,
+    #[bits(1)]
+    pub allowed_nmi: u64,
+    #[bits(10)]
+    _rsvd: u64,
+    #[bits(52)]
+    pub guest_apic_backing_page_ptr: u64,
+}
+
+/// AVIC exit info1 for the incopmplete IPI exit
+#[bitfield(u64)]
+pub struct SevAvicIncompleteIpiInfo1 {
+    pub icr_low: u32,
+    pub icr_high: u32,
+}
+
+open_enum::open_enum! {
+    pub enum SevAvicIpiFailure: u32 {
+        INVALID_TYPE = 0,
+        NOT_RUNNING = 1,
+        INVALID_TARGET = 2,
+        INVALID_BACKING_PAGE = 3,
+        INVALID_VECTOR = 4,
+        UNACCELERATED_IPI = 5,
+    }
+}
+
+impl SevAvicIpiFailure {
+    const fn into_bits(self) -> u32 {
+        self.0
+    }
+
+    const fn from_bits(bits: u32) -> Self {
+        Self(bits)
+    }
+}
+
+/// AVIC exit info2 for the incopmplete IPI exit
+#[bitfield(u64)]
+pub struct SevAvicIncompleteIpiInfo2 {
+    #[bits(8)]
+    pub index: u32,
+    #[bits(24)]
+    _mbz: u32,
+    #[bits(32)]
+    pub failure: SevAvicIpiFailure,
+}
+
+open_enum::open_enum! {
+    pub enum SevAvicRegisterNumber: u32 {
+        /// APIC ID Register.
+        APIC_ID = 0x2,
+        /// APIC Version Register.
+        VERSION = 0x3,
+        /// Task Priority Register
+        TPR = 0x8,
+        /// Arbitration Priority Register.
+        APR = 0x9,
+        /// Processor Priority Register.
+        PPR = 0xA,
+        /// End Of Interrupt Register.
+        EOI = 0xB,
+        /// Remote Read Register
+        REMOTE_READ = 0xC,
+        /// Logical Destination Register.
+        LDR = 0xD,
+        /// Destination Format Register.
+        DFR = 0xE,
+        /// Spurious Interrupt Vector.
+        SPURIOUS = 0xF,
+        /// In-Service Registers.
+        ISR0 = 0x10,
+        ISR1 = 0x11,
+        ISR2 = 0x12,
+        ISR3 = 0x13,
+        ISR4 = 0x14,
+        ISR5 = 0x15,
+        ISR6 = 0x16,
+        ISR7 = 0x17,
+        /// Trigger Mode Registers.
+        TMR0 = 0x18,
+        TMR1 = 0x19,
+        TMR2 = 0x1A,
+        TMR3 = 0x1B,
+        TMR4 = 0x1C,
+        TMR5 = 0x1D,
+        TMR6 = 0x1E,
+        TMR7 = 0x1F,
+        /// Interrupt Request Registers.
+        IRR0 = 0x20,
+        IRR1 = 0x21,
+        IRR2 = 0x22,
+        IRR3 = 0x23,
+        IRR4 = 0x24,
+        IRR5 = 0x25,
+        IRR6 = 0x26,
+        IRR7 = 0x27,
+        /// Error Status Register.
+        ERROR = 0x28,
+        /// ICR Low.
+        ICR_LOW = 0x30,
+        /// ICR High.
+        ICR_HIGH = 0x31,
+        /// LVT Timer Register.
+        TIMER_LVT = 0x32,
+        /// LVT Thermal Register.
+        THERMAL_LVT = 0x33,
+        /// LVT Performance Monitor Register.
+        PERFMON_LVT = 0x34,
+        /// LVT Local Int0 Register.
+        LINT0_LVT = 0x35,
+        /// LVT Local Int1 Register.
+        LINT1_LVT = 0x36,
+        /// LVT Error Register.
+        ERROR_LVT = 0x37,
+        /// Initial count Register.
+        INITIAL_COUNT = 0x38,
+        /// R/O Current count Register.
+        CURRENT_COUNT = 0x39,
+        /// Divide configuration Register.
+        DIVIDER = 0x3e,
+        /// Self IPI register, only present in x2APIC.
+        SELF_IPI = 0x3f,
+    }
+}
+
+impl SevAvicRegisterNumber {
+    const fn into_bits(self) -> u32 {
+        self.0
+    }
+
+    const fn from_bits(bits: u32) -> Self {
+        Self(bits)
+    }
+}
+
+/// AVIC SEV exit info1 for the no acceleration exit
+#[bitfield(u64)]
+pub struct SevAvicNoAccelInfo {
+    #[bits(4)]
+    _rsvd1: u64,
+    #[bits(8)]
+    pub apic_register_number: SevAvicRegisterNumber,
+    #[bits(20)]
+    _rsvd2: u64,
+    #[bits(1)]
+    pub write_access: bool,
+    #[bits(31)]
+    _rsvd3: u64,
 }
 
 /// SEV VMSA structure representing CPU state
@@ -346,7 +513,7 @@ pub struct SevVmsa {
     pub rcx: u64,
     pub rdx: u64,
     pub rbx: u64,
-    pub vmsa_reserved8: u64, // MBZ
+    pub secure_avic_control: SecureAvicControl,
     pub rbp: u64,
     pub rsi: u64,
     pub rdi: u64,
@@ -417,6 +584,65 @@ pub struct SevVmsa {
     // YMM high registers
     pub ymm_registers: [SevXmmRegister; 16],
 }
+
+#[repr(C)]
+#[derive(Debug, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+/// Structure representing the SEV-ES AVIC IRR register.
+///
+/// If the UpdateIRR bit is set in the VMCB, the guest-controlled AllowedIRR mask
+/// is logically AND-ed with the host-controlled RequestedIRR and then is logically
+/// OR-ed into the IRR field in the Guest APIC Backing page.
+pub struct SevAvicIrrRegister {
+    pub value: u32,
+    pub allowed: u32,
+    _reserved: [u32; 2],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
+/// Structure representing the SEV-ES AVIC backing page.
+/// Specification: "AMD64 PPR Vol3 System Programming", 15.29.3  AVIC Backing Page.
+pub struct SevAvicPage {
+    pub reserved_0: [ApicRegister; 2],
+    pub id: ApicRegister,
+    pub version: ApicRegister,
+    pub reserved_4: [ApicRegister; 4],
+    pub tpr: ApicRegister,
+    pub apr: ApicRegister,
+    pub ppr: ApicRegister,
+    pub eoi: ApicRegister,
+    pub rrd: ApicRegister,
+    pub ldr: ApicRegister,
+    pub dfr: ApicRegister,
+    pub svr: ApicRegister,
+    pub isr: [ApicRegister; 8],
+    pub tmr: [ApicRegister; 8],
+    pub irr: [SevAvicIrrRegister; 8],
+    pub esr: ApicRegister,
+    pub reserved_29: [ApicRegister; 6],
+    pub lvt_cmci: ApicRegister,
+    pub icr: [ApicRegister; 2],
+    pub lvt_timer: ApicRegister,
+    pub lvt_thermal: ApicRegister,
+    pub lvt_pmc: ApicRegister,
+    pub lvt_lint0: ApicRegister,
+    pub lvt_lint1: ApicRegister,
+    pub lvt_error: ApicRegister,
+    pub timer_icr: ApicRegister,
+    pub timer_ccr: ApicRegister,
+    pub reserved_3a: [ApicRegister; 4],
+    pub timer_dcr: ApicRegister,
+    pub self_ipi: ApicRegister,
+    pub eafr: ApicRegister,
+    pub eacr: ApicRegister,
+    pub seoi: ApicRegister,
+    pub reserved_44: [ApicRegister; 0x5],
+    pub ier: [ApicRegister; 8],
+    pub ei_lv_tr: [ApicRegister; 3],
+    pub reserved_54: [ApicRegister; 0xad],
+}
+
+const_assert_eq!(size_of::<SevAvicPage>(), 4096);
 
 // Info codes for the GHCB MSR protocol.
 open_enum::open_enum! {
@@ -772,14 +998,16 @@ pub struct SevStatusMsr {
     pub debug_swap: bool,
     pub prevent_host_ibs: bool,
     pub snp_btb_isolation: bool,
-    pub _rsvd1: bool,
+    pub vmpl_sss: bool,
     pub secure_tsc: bool,
-    pub _rsvd2: bool,
+    pub vmgexit_param: bool,
     pub _rsvd3: bool,
-    pub _rsvd4: bool,
+    pub ibs_virt: bool,
     pub _rsvd5: bool,
     pub vmsa_reg_prot: bool,
-    #[bits(47)]
+    pub smt_prot: bool,
+    pub secure_avic: bool,
+    #[bits(45)]
     _unused: u64,
 }
 

--- a/vm/x86/x86defs/src/vmx.rs
+++ b/vm/x86/x86defs/src/vmx.rs
@@ -5,8 +5,10 @@
 
 // TODO: move VMX defs somewhere?
 
+use crate::ApicRegister;
 use bitfield_struct::bitfield;
 use open_enum::open_enum;
+use static_assertions::const_assert_eq;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -497,15 +499,8 @@ pub struct SecondaryProcessorControls {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
-pub struct ApicRegister {
-    pub value: u32,
-    _reserved: [u32; 3],
-}
-
-#[repr(C)]
 #[derive(Debug, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
-pub struct ApicPage {
+pub struct VmxApicPage {
     pub reserved_0: [ApicRegister; 2],
     pub id: ApicRegister,
     pub version: ApicRegister,
@@ -538,3 +533,5 @@ pub struct ApicPage {
     pub reserved_3f: ApicRegister,
     pub reserved_40: [ApicRegister; 0xc0],
 }
+
+const_assert_eq!(size_of::<VmxApicPage>(), 4096);


### PR DESCRIPTION
Enable secure AVIC support to offload interrupt state computation to the hardware to be fast and secure.

In AMD's own words:

"The Secure AVIC feature provides support for managing guest-owned APIC state for SEV-SNP guests using a private, guest-owned backing page per vCPU."
-- SEV-ES GHCB Standartizarion

"In a virtualized computer system, each guest operating system needs access to an interrupt controller to  send and receive device and interprocessor interrupts. When there is no hardware acceleration, it falls to the virtual machine monitor (VMM) to intercept guest-initiated attempts to access the interrupt controller registers and provide direct emulation of the controller system programming interface allowing the guest to initiate and process interrupts. The VMM uses the underlying physical and virtual interrupt delivery mechanisms of the system to deliver interrupts from I/O devices and virtual processors to the target guest virtual processor and to handle any required end of interrupt processing. 

Given the high rate of device and interprocessor interrupt generation in certain scenarios, in particular on server-class systems, the emulation of a local APIC can be a significant burden for the VMM. The AVIC architecture addresses the overhead of guest interrupt processing in a virtualized environment by applying hardware acceleration to the following components of interrupt processing:
 * Providing a guest operating system access to performance-critical interrupt controller registers
 * Initiating intra- and inter-processor interrupts (IPIs) in and between virtual processors in a guest"
-- AMD64 PPR Vol. 3

Laundry list:

- [x] IGVM parameter for disabling secure AVIC (would someone like that for testing maybe??)
- [x] Definitions
- [x] High-level wiring
- [x] resolve TODOs in the IGVM file generator
- [x] Auto-enable secure AVIC in the boot shim (from the hw arch pov considered dicey, not doing that)
- [x] need the secure AVIC kernel patch (comes with kernel 6.12)
- [x] update the VTL driver to allocate, RMP adjust, and fill out the AVIC backing page, 
- [x] update the kernel interface to map the AVIC page
- [x] plumbing for (un)registering the backing page in the user mode
- [x] Implement handling for the non-accelerated AVIC SEV exit
- [x] Implement handling for the incomplete IPI AVIC SEV exit
- [x] Make sure INIT and SIPI are delivered
- [x] Make sure IPIs are delivered
- [x] Support `MpState::Idle` and kernel idle and halt state offloading for better performance
- [x] Fix the existing logic for  advancing the RIP (assumes the next RIP is always provided which is true for the automatic exits only, and Windows reads the CCR AVIC register that results in non-AE so the RIP was set to `0` due to next RIP not filled out)
- [ ] Make sure TPR and CR8 are not trashed
- [ ] Fix TMR handling to service level-triggered interrupts reliably
- [x] Boot multi-proc WIndows
- [ ] Test save/restore, pause/resume, servicing, stress-test

OHCL-Linux-Kernel draft: https://github.com/microsoft/OHCL-Linux-Kernel/pull/67

The change boots multi-proc Linux guests and multi-proc Windows guests.
Sometimes the serial console hangs on MP Linux.