### PR TITLE
petri: unblock commands and use com3 for hyper-v kmsg logs when possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5438,6 +5438,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "blocking",
  "chipset_resources",
  "clap",
  "diag_client",
@@ -5509,7 +5510,7 @@ dependencies = [
  "vmotherboard",
  "vmsocket",
  "vtl2_settings_proto",
- "winver",
+ "windows-version",
 ]
 
 [[package]]
@@ -9421,15 +9422,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -9647,6 +9639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-version"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9808,15 +9809,6 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-
-[[package]]
-name = "winver"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0e7162b9e282fd75a0a832cce93994bdb21208d848a418cd05a5fdd9b9ab33"
-dependencies = [
- "windows 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5509,6 +5509,7 @@ dependencies = [
  "vmotherboard",
  "vmsocket",
  "vtl2_settings_proto",
+ "winver",
 ]
 
 [[package]]
@@ -9420,6 +9421,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -9798,6 +9808,15 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "winver"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0e7162b9e282fd75a0a832cce93994bdb21208d848a418cd05a5fdd9b9ab33"
+dependencies = [
+ "windows 0.48.0",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -537,6 +537,7 @@ winapi = "0.3"
 windows = "0.59"
 windows-service = "0.8"
 windows-sys = "0.59"
+winver = "1.0.0"
 xshell = "=0.2.2" # pin to 0.2.2 to work around https://github.com/matklad/xshell/issues/63
 xshell-macros = "0.2"
 # We add the derive feature here since the vast majority of our crates use it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -537,7 +537,7 @@ winapi = "0.3"
 windows = "0.59"
 windows-service = "0.8"
 windows-sys = "0.59"
-winver = "1.0.0"
+windows-version = "0.1.4"
 xshell = "=0.2.2" # pin to 0.2.2 to work around https://github.com/matklad/xshell/issues/63
 xshell-macros = "0.2"
 # We add the derive feature here since the vast majority of our crates use it.

--- a/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
@@ -155,7 +155,10 @@ Otherwise, press `ctrl-c` to cancel the run.
                         // Select required reg keys
                         let mut reg_keys_to_set = BTreeSet::new();
                         if hyperv {
+                            // Allow loading IGVM from file (to run custom OpenHCL firmware)
                             reg_keys_to_set.insert("AllowFirmwareLoadFromFile");
+                            // Enable COM3 and COM4 for Hyper-V VMs so we can get the OpenHCL KMSG logs over serial
+                            reg_keys_to_set.insert("EnableAdditionalComPorts");
 
                             if hardware_isolation {
                                 reg_keys_to_set.insert("EnableHardwareIsolation");

--- a/petri/Cargo.toml
+++ b/petri/Cargo.toml
@@ -83,6 +83,8 @@ tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[target.'cfg(windows)'.dependencies]
 winver.workspace = true
 
 [lints]

--- a/petri/Cargo.toml
+++ b/petri/Cargo.toml
@@ -63,6 +63,7 @@ sparse_mmap.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true
+blocking.workspace = true
 clap.workspace = true
 fatfs = { workspace = true, features = ["std", "alloc"] }
 fs-err.workspace = true
@@ -85,7 +86,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-winver.workspace = true
+windows-version.workspace = true
 
 [lints]
 workspace = true

--- a/petri/Cargo.toml
+++ b/petri/Cargo.toml
@@ -83,6 +83,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+winver.workspace = true
 
 [lints]
 workspace = true

--- a/petri/src/tracing.rs
+++ b/petri/src/tracing.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use diag_client::kmsg_stream::KmsgStream;
 use fs_err::File;
 use fs_err::PathExt;
 use futures::AsyncBufReadExt;
@@ -305,17 +304,29 @@ impl<'a> MakeWriter<'a> for PetriWriter {
 }
 
 /// Logs lines from `reader` into `log_file`.
-pub async fn log_stream(
+///
+/// Attempts to parse lines as `SyslogParsedEntry`, extracting the log level.
+/// Passes through any non-conforming logs.
+pub async fn log_task(
     log_file: PetriLogFile,
     reader: impl AsyncRead + Unpin + Send + 'static,
+    name: &str,
 ) -> anyhow::Result<()> {
+    tracing::info!("connected to {name}");
     let mut buf = Vec::new();
     let mut reader = BufReader::new(reader);
     loop {
         buf.clear();
-        let n = (&mut reader).take(256).read_until(b'\n', &mut buf).await?;
-        if n == 0 {
-            break;
+        match (&mut reader).take(256).read_until(b'\n', &mut buf).await {
+            Ok(0) => {
+                tracing::info!("disconnected from {name}: EOF");
+                return Ok(());
+            }
+            Err(e) => {
+                tracing::info!("disconnected from {name}: error: {e:#}");
+                return Err(e.into());
+            }
+            _ => {}
         }
 
         let string_buf = String::from_utf8_lossy(&buf);
@@ -328,7 +339,6 @@ pub async fn log_stream(
             log_file.write_entry(string_buf_trimmed);
         }
     }
-    Ok(())
 }
 
 /// Maps kernel log levels to tracing levels.
@@ -345,16 +355,30 @@ fn kernel_level_to_tracing_level(kernel_level: u8) -> Level {
 /// read from the kmsg stream and write entries to the log
 pub async fn kmsg_log_task(
     log_file: PetriLogFile,
-    mut file_stream: KmsgStream,
+    diag_client: diag_client::DiagClient,
 ) -> anyhow::Result<()> {
-    while let Some(data) = file_stream.next().await {
-        let data = data?;
-        let message = KmsgParsedEntry::new(&data).unwrap();
-        let level = kernel_level_to_tracing_level(message.level);
-        log_file.write_entry_fmt(None, level, format_args!("{}", message.display(false)));
+    loop {
+        diag_client.wait_for_server().await?;
+        let mut kmsg = diag_client.kmsg(true).await?;
+        tracing::info!("kmsg connected");
+        while let Some(data) = kmsg.next().await {
+            match data {
+                Ok(data) => {
+                    let message = KmsgParsedEntry::new(&data).unwrap();
+                    let level = kernel_level_to_tracing_level(message.level);
+                    log_file.write_entry_fmt(
+                        None,
+                        level,
+                        format_args!("{}", message.display(false)),
+                    );
+                }
+                Err(err) => {
+                    tracing::info!("kmsg disconnected: {err:?}");
+                    break;
+                }
+            }
+        }
     }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/petri/src/tracing.rs
+++ b/petri/src/tracing.rs
@@ -373,7 +373,7 @@ pub async fn kmsg_log_task(
                     );
                 }
                 Err(err) => {
-                    tracing::info!("kmsg disconnected: {err:?}");
+                    tracing::info!("kmsg disconnected: {err:#}");
                     break;
                 }
             }

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -363,6 +363,7 @@ impl PetriVmmBackend for HyperVPetriBackend {
                 powershell::HyperVGuestStateIsolationType::Vbs
             );
             let openhcl_serial_pipe_path = is_not_vbs.then(|| vm.set_vm_com_port(3).ok()).flatten();
+            let openhcl_log_file = log_source.log_file("openhcl")?;
 
             if let Some(openhcl_serial_pipe_path) = openhcl_serial_pipe_path {
                 log_tasks.push(driver.spawn("openhcl-log", {

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -106,7 +106,7 @@ pub struct HyperVNewVMArgs<'a> {
 }
 
 /// Runs New-VM with the given arguments.
-pub fn run_new_vm(args: HyperVNewVMArgs<'_>) -> anyhow::Result<Guid> {
+pub async fn run_new_vm(args: HyperVNewVMArgs<'_>) -> anyhow::Result<Guid> {
     let vmid = run_cmd(
         PowerShellBuilder::new()
             .cmdlet("New-VM")
@@ -126,13 +126,14 @@ pub fn run_new_vm(args: HyperVNewVMArgs<'_>) -> anyhow::Result<Guid> {
             .finish()
             .build(),
     )
+    .await
     .context("new_vm")?;
 
     Guid::from_str(&vmid).context("invalid vmid")
 }
 
 /// Runs New-VM with the given arguments.
-pub fn run_remove_vm(vmid: &Guid) -> anyhow::Result<()> {
+pub async fn run_remove_vm(vmid: &Guid) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -143,6 +144,7 @@ pub fn run_remove_vm(vmid: &Guid) -> anyhow::Result<()> {
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("remove_vm")
 }
@@ -186,7 +188,10 @@ impl ps::AsVal for HyperVApicMode {
 }
 
 /// Runs Set-VMProcessor with the given arguments.
-pub fn run_set_vm_processor(vmid: &Guid, args: &HyperVSetVMProcessorArgs) -> anyhow::Result<()> {
+pub async fn run_set_vm_processor(
+    vmid: &Guid,
+    args: &HyperVSetVMProcessorArgs,
+) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -200,6 +205,7 @@ pub fn run_set_vm_processor(vmid: &Guid, args: &HyperVSetVMProcessorArgs) -> any
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("set_vm_processor")
 }
@@ -221,7 +227,7 @@ pub struct HyperVSetVMMemoryArgs {
 }
 
 /// Runs Set-VMMemory with the given arguments.
-pub fn run_set_vm_memory(vmid: &Guid, args: &HyperVSetVMMemoryArgs) -> anyhow::Result<()> {
+pub async fn run_set_vm_memory(vmid: &Guid, args: &HyperVSetVMMemoryArgs) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -235,6 +241,7 @@ pub fn run_set_vm_memory(vmid: &Guid, args: &HyperVSetVMMemoryArgs) -> anyhow::R
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("set_vm_memory")
 }
@@ -283,7 +290,9 @@ impl ps::AsVal for ControllerType {
 }
 
 /// Runs Add-VMHardDiskDrive with the given arguments.
-pub fn run_add_vm_hard_disk_drive(args: HyperVAddVMHardDiskDriveArgs<'_>) -> anyhow::Result<()> {
+pub async fn run_add_vm_hard_disk_drive(
+    args: HyperVAddVMHardDiskDriveArgs<'_>,
+) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -297,6 +306,7 @@ pub fn run_add_vm_hard_disk_drive(args: HyperVAddVMHardDiskDriveArgs<'_>) -> any
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("add_vm_hard_disk_drive")
 }
@@ -319,7 +329,7 @@ pub struct HyperVAddVMDvdDriveArgs<'a> {
 }
 
 /// Runs Add-VMDvdDrive with the given arguments.
-pub fn run_add_vm_dvd_drive(args: HyperVAddVMDvdDriveArgs<'_>) -> anyhow::Result<()> {
+pub async fn run_add_vm_dvd_drive(args: HyperVAddVMDvdDriveArgs<'_>) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -332,6 +342,7 @@ pub fn run_add_vm_dvd_drive(args: HyperVAddVMDvdDriveArgs<'_>) -> anyhow::Result
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("add_vm_dvd_drive")
 }
@@ -339,7 +350,7 @@ pub fn run_add_vm_dvd_drive(args: HyperVAddVMDvdDriveArgs<'_>) -> anyhow::Result
 /// Runs Add-VMScsiController with the given arguments.
 ///
 /// Returns the controller number.
-pub fn run_add_vm_scsi_controller(vmid: &Guid) -> anyhow::Result<u32> {
+pub async fn run_add_vm_scsi_controller(vmid: &Guid) -> anyhow::Result<u32> {
     let output = run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -353,12 +364,13 @@ pub fn run_add_vm_scsi_controller(vmid: &Guid) -> anyhow::Result<u32> {
             .finish()
             .build(),
     )
+    .await
     .context("add_vm_scsi_controller")?;
     Ok(output.trim().parse::<u32>()?)
 }
 
 /// Sets the target VTL for a SCSI controller.
-pub fn run_set_vm_scsi_controller_target_vtl(
+pub async fn run_set_vm_scsi_controller_target_vtl(
     ps_mod: &Path,
     vmid: &Guid,
     controller_number: u32,
@@ -378,12 +390,13 @@ pub fn run_set_vm_scsi_controller_target_vtl(
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("set_vm_scsi_controller_target_vtl")
 }
 
 /// Create a new differencing VHD with the provided parent.
-pub fn create_child_vhd(path: &Path, parent_path: &Path) -> anyhow::Result<()> {
+pub async fn create_child_vhd(path: &Path, parent_path: &Path) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("New-VHD")
@@ -393,12 +406,13 @@ pub fn create_child_vhd(path: &Path, parent_path: &Path) -> anyhow::Result<()> {
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("create_child_vhd")
 }
 
 /// Runs Dismount-VHD with the given arguments.
-pub fn run_dismount_vhd(path: &Path) -> anyhow::Result<()> {
+pub async fn run_dismount_vhd(path: &Path) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Dismount-VHD")
@@ -406,6 +420,7 @@ pub fn run_dismount_vhd(path: &Path) -> anyhow::Result<()> {
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("dismount_vhd")
 }
@@ -424,7 +439,7 @@ pub struct HyperVSetVMFirmwareArgs<'a> {
 }
 
 /// Runs Set-VMFirmware with the given arguments.
-pub fn run_set_vm_firmware(args: HyperVSetVMFirmwareArgs<'_>) -> anyhow::Result<()> {
+pub async fn run_set_vm_firmware(args: HyperVSetVMFirmwareArgs<'_>) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -445,12 +460,13 @@ pub fn run_set_vm_firmware(args: HyperVSetVMFirmwareArgs<'_>) -> anyhow::Result<
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("set_vm_firmware")
 }
 
 /// Runs Set-OpenHCLFirmware with the given arguments.
-pub fn run_set_openhcl_firmware(
+pub async fn run_set_openhcl_firmware(
     vmid: &Guid,
     ps_mod: &Path,
     igvm_file: &Path,
@@ -470,12 +486,13 @@ pub fn run_set_openhcl_firmware(
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("set_openhcl_firmware")
 }
 
 /// Runs Set-VmCommandLine with the given arguments.
-pub fn run_set_vm_command_line(
+pub async fn run_set_vm_command_line(
     vmid: &Guid,
     ps_mod: &Path,
     command_line: &str,
@@ -493,12 +510,13 @@ pub fn run_set_vm_command_line(
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("set_vm_command_line")
 }
 
 /// Sets the initial machine configuration for a VM
-pub fn run_set_initial_machine_configuration(
+pub async fn run_set_initial_machine_configuration(
     vmid: &Guid,
     ps_mod: &Path,
     imc_hive: &Path,
@@ -516,12 +534,13 @@ pub fn run_set_initial_machine_configuration(
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("set_initial_machine_configuration")
 }
 
 /// Enables the specified vm com port and binds it to the named pipe path
-pub fn run_set_vm_com_port(vmid: &Guid, port: u8, path: &Path) -> anyhow::Result<()> {
+pub async fn run_set_vm_com_port(vmid: &Guid, port: u8, path: &Path) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -533,12 +552,17 @@ pub fn run_set_vm_com_port(vmid: &Guid, port: u8, path: &Path) -> anyhow::Result
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("set_vm_com_port")
 }
 
 /// Run Set-VMBusRelay commandlet
-pub fn run_set_vmbus_redirect(vmid: &Guid, ps_mod: &Path, enable: bool) -> anyhow::Result<()> {
+pub async fn run_set_vmbus_redirect(
+    vmid: &Guid,
+    ps_mod: &Path,
+    enable: bool,
+) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Import-Module")
@@ -552,12 +576,13 @@ pub fn run_set_vmbus_redirect(vmid: &Guid, ps_mod: &Path, enable: bool) -> anyho
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("set_vmbus_redirect")
 }
 
 /// Runs Restart-OpenHCL, which will perform and OpenHCL servicing operation.
-pub fn run_restart_openhcl(
+pub async fn run_restart_openhcl(
     vmid: &Guid,
     ps_mod: &Path,
     flags: OpenHclServicingFlags,
@@ -588,6 +613,7 @@ pub fn run_restart_openhcl(
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("restart_openhcl")
 }
@@ -609,7 +635,7 @@ pub struct WinEvent {
 }
 
 /// Get event logs
-pub fn run_get_winevent(
+pub async fn run_get_winevent(
     log_name: &[&str],
     start_time: Option<&Timestamp>,
     find: Option<&str>,
@@ -666,7 +692,8 @@ pub fn run_get_winevent(
             .arg("InputObject", ps::Array::new([&output_var]))
             .finish()
             .build(),
-    );
+    )
+    .await;
 
     match output {
         Ok(logs) => serde_json::from_str(&logs).context("parsing winevents"),
@@ -687,7 +714,10 @@ const HYPERV_WORKER_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Admin";
 const HYPERV_VMMS_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Admin";
 
 /// Get Hyper-V event logs for a VM
-pub fn hyperv_event_logs(vmid: &Guid, start_time: &Timestamp) -> anyhow::Result<Vec<WinEvent>> {
+pub async fn hyperv_event_logs(
+    vmid: &Guid,
+    start_time: &Timestamp,
+) -> anyhow::Result<Vec<WinEvent>> {
     let vmid = vmid.to_string();
     run_get_winevent(
         &[HYPERV_WORKER_TABLE, HYPERV_VMMS_TABLE],
@@ -695,6 +725,7 @@ pub fn hyperv_event_logs(vmid: &Guid, start_time: &Timestamp) -> anyhow::Result<
         Some(&vmid),
         &[],
     )
+    .await
 }
 
 /// boot succeeded
@@ -720,7 +751,10 @@ const BOOT_EVENT_IDS: [u32; 6] = [
 ];
 
 /// Get Hyper-V event logs for a VM
-pub fn hyperv_boot_events(vmid: &Guid, start_time: &Timestamp) -> anyhow::Result<Vec<WinEvent>> {
+pub async fn hyperv_boot_events(
+    vmid: &Guid,
+    start_time: &Timestamp,
+) -> anyhow::Result<Vec<WinEvent>> {
     let vmid = vmid.to_string();
     run_get_winevent(
         &[HYPERV_WORKER_TABLE],
@@ -728,10 +762,11 @@ pub fn hyperv_boot_events(vmid: &Guid, start_time: &Timestamp) -> anyhow::Result
         Some(&vmid),
         &BOOT_EVENT_IDS,
     )
+    .await
 }
 
 /// Get the IDs of the VM(s) with the specified name
-pub fn vm_id_from_name(name: &str) -> anyhow::Result<Vec<Guid>> {
+pub async fn vm_id_from_name(name: &str) -> anyhow::Result<Vec<Guid>> {
     let output = run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -745,6 +780,7 @@ pub fn vm_id_from_name(name: &str) -> anyhow::Result<Vec<Guid>> {
             .finish()
             .build(),
     )
+    .await
     .context("vm_id_from_name")?;
     let mut vmids = Vec::new();
     for s in output.lines() {
@@ -772,7 +808,7 @@ pub enum VmShutdownIcStatus {
 }
 
 /// Get the VM's shutdown IC status
-pub fn vm_shutdown_ic_status(vmid: &Guid) -> anyhow::Result<VmShutdownIcStatus> {
+pub async fn vm_shutdown_ic_status(vmid: &Guid) -> anyhow::Result<VmShutdownIcStatus> {
     let status = run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -786,6 +822,7 @@ pub fn vm_shutdown_ic_status(vmid: &Guid) -> anyhow::Result<VmShutdownIcStatus> 
             .finish()
             .build(),
     )
+    .await
     .context("vm_shutdown_ic_status")?;
 
     Ok(match status.as_str() {
@@ -800,7 +837,7 @@ pub fn vm_shutdown_ic_status(vmid: &Guid) -> anyhow::Result<VmShutdownIcStatus> 
 }
 
 /// Runs Remove-VmNetworkAdapter to remove all network adapters from a VM.
-pub fn run_remove_vm_network_adapter(vmid: &Guid) -> anyhow::Result<()> {
+pub async fn run_remove_vm_network_adapter(vmid: &Guid) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -810,12 +847,16 @@ pub fn run_remove_vm_network_adapter(vmid: &Guid) -> anyhow::Result<()> {
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("remove_vm_network_adapters")
 }
 
 /// Runs Remove-VMScsiController with the given arguments.
-pub fn run_remove_vm_scsi_controller(vmid: &Guid, controller_number: u32) -> anyhow::Result<()> {
+pub async fn run_remove_vm_scsi_controller(
+    vmid: &Guid,
+    controller_number: u32,
+) -> anyhow::Result<()> {
     run_cmd(
         PowerShellBuilder::new()
             .cmdlet("Get-VM")
@@ -828,12 +869,13 @@ pub fn run_remove_vm_scsi_controller(vmid: &Guid, controller_number: u32) -> any
             .finish()
             .build(),
     )
+    .await
     .map(|_| ())
     .context("remove_vm_scsi_controller")
 }
 
 /// Run Get-VmScreenshot commandlet
-pub fn run_get_vm_screenshot(
+pub async fn run_get_vm_screenshot(
     vmid: &Guid,
     ps_mod: &Path,
     path: &Path,
@@ -851,6 +893,7 @@ pub fn run_get_vm_screenshot(
             .finish()
             .build(),
     )
+    .await
     .context("get_vm_screenshot")?;
     let (x, y) = output.split_once(',').context("invalid dimensions")?;
     Ok((

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -41,7 +41,7 @@ pub struct HyperVVM {
 
 impl HyperVVM {
     /// Create a new Hyper-V VM
-    pub fn new(
+    pub async fn new(
         name: &str,
         generation: powershell::HyperVGeneration,
         guest_state_isolation_type: powershell::HyperVGuestStateIsolationType,
@@ -62,14 +62,14 @@ impl HyperVVM {
         }
 
         // Delete the VM if it already exists
-        let cleanup = |vmid: &Guid| -> anyhow::Result<()> {
-            hvc::hvc_ensure_off(vmid)?;
-            powershell::run_remove_vm(vmid)
+        let cleanup = async |vmid: &Guid| -> anyhow::Result<()> {
+            hvc::hvc_ensure_off(vmid).await?;
+            powershell::run_remove_vm(vmid).await
         };
 
-        if let Ok(vmids) = powershell::vm_id_from_name(&name) {
+        if let Ok(vmids) = powershell::vm_id_from_name(&name).await {
             for vmid in vmids {
-                match cleanup(&vmid) {
+                match cleanup(&vmid).await {
                     Ok(_) => {
                         tracing::info!("Successfully cleaned up VM from previous test run ({vmid})")
                     }
@@ -89,7 +89,8 @@ impl HyperVVM {
             memory_startup_bytes: Some(memory),
             path: None,
             vhd_path: None,
-        })?;
+        })
+        .await?;
 
         tracing::info!(name, vmid = vmid.to_string(), "Created Hyper-V VM");
 
@@ -109,10 +110,12 @@ impl HyperVVM {
 
         // Remove the default network adapter
         powershell::run_remove_vm_network_adapter(&vmid)
+            .await
             .context("remove default network adapter")?;
 
         // Remove the default SCSI controller
         powershell::run_remove_vm_scsi_controller(&vmid, 0)
+            .await
             .context("remove default SCSI controller")?;
 
         // Disable dynamic memory
@@ -122,7 +125,8 @@ impl HyperVVM {
                 dynamic_memory_enabled: Some(false),
                 ..Default::default()
             },
-        )?;
+        )
+        .await?;
 
         // Disable secure boot for generation 2 VMs
         if generation == powershell::HyperVGeneration::Two {
@@ -130,7 +134,8 @@ impl HyperVVM {
                 vmid: &vmid,
                 secure_boot_enabled: Some(false),
                 secure_boot_template: None,
-            })?;
+            })
+            .await?;
         }
 
         Ok(this)
@@ -147,8 +152,8 @@ impl HyperVVM {
     }
 
     /// Get Hyper-V logs and write them to the log file
-    pub fn flush_logs(&self) -> anyhow::Result<()> {
-        for event in powershell::hyperv_event_logs(&self.vmid, &self.create_time)? {
+    pub async fn flush_logs(&self) -> anyhow::Result<()> {
+        for event in powershell::hyperv_event_logs(&self.vmid, &self.create_time).await? {
             self.log_file.write_entry_fmt(
                 Some(event.time_created),
                 match event.level {
@@ -186,8 +191,8 @@ impl HyperVVM {
         self.wait_for_some(Self::boot_event, 240.seconds()).await
     }
 
-    fn boot_event(&self) -> anyhow::Result<Option<FirmwareEvent>> {
-        let events = powershell::hyperv_boot_events(&self.vmid, &self.create_time)?;
+    async fn boot_event(&self) -> anyhow::Result<Option<FirmwareEvent>> {
+        let events = powershell::hyperv_boot_events(&self.vmid, &self.create_time).await?;
 
         if events.len() > 1 {
             anyhow::bail!("Got more than one boot event");
@@ -209,15 +214,15 @@ impl HyperVVM {
     }
 
     /// Set the VM processor topology.
-    pub fn set_processor(
+    pub async fn set_processor(
         &mut self,
         args: &powershell::HyperVSetVMProcessorArgs,
     ) -> anyhow::Result<()> {
-        powershell::run_set_vm_processor(&self.vmid, args)
+        powershell::run_set_vm_processor(&self.vmid, args).await
     }
 
     /// Set the OpenHCL firmware file
-    pub fn set_openhcl_firmware(
+    pub async fn set_openhcl_firmware(
         &mut self,
         igvm_file: &Path,
         increase_vtl2_memory: bool,
@@ -228,10 +233,11 @@ impl HyperVVM {
             igvm_file,
             increase_vtl2_memory,
         )
+        .await
     }
 
     /// Configure secure boot
-    pub fn set_secure_boot(
+    pub async fn set_secure_boot(
         &mut self,
         secure_boot_enabled: bool,
         secure_boot_template: Option<powershell::HyperVSecureBootTemplate>,
@@ -241,24 +247,26 @@ impl HyperVVM {
             secure_boot_enabled: Some(secure_boot_enabled),
             secure_boot_template,
         })
+        .await
     }
 
     /// Add a SCSI controller
-    pub fn add_scsi_controller(&mut self, target_vtl: u32) -> anyhow::Result<u32> {
-        let controller_number = powershell::run_add_vm_scsi_controller(&self.vmid)?;
+    pub async fn add_scsi_controller(&mut self, target_vtl: u32) -> anyhow::Result<u32> {
+        let controller_number = powershell::run_add_vm_scsi_controller(&self.vmid).await?;
         if target_vtl != 0 {
             powershell::run_set_vm_scsi_controller_target_vtl(
                 &self.ps_mod,
                 &self.vmid,
                 controller_number,
                 target_vtl,
-            )?;
+            )
+            .await?;
         }
         Ok(controller_number)
     }
 
     /// Add a VHD
-    pub fn add_vhd(
+    pub async fn add_vhd(
         &mut self,
         path: &Path,
         controller_type: powershell::ControllerType,
@@ -272,19 +280,20 @@ impl HyperVVM {
             controller_number,
             path: Some(path),
         })
+        .await
     }
 
     /// Set the initial machine configuration (IMC hive file)
-    pub fn set_imc(&mut self, imc_hive: &Path) -> anyhow::Result<()> {
-        powershell::run_set_initial_machine_configuration(&self.vmid, &self.ps_mod, imc_hive)
+    pub async fn set_imc(&mut self, imc_hive: &Path) -> anyhow::Result<()> {
+        powershell::run_set_initial_machine_configuration(&self.vmid, &self.ps_mod, imc_hive).await
     }
 
-    fn state(&self) -> anyhow::Result<VmState> {
-        hvc::hvc_state(&self.vmid)
+    async fn state(&self) -> anyhow::Result<VmState> {
+        hvc::hvc_state(&self.vmid).await
     }
 
-    fn check_state(&self, expected: VmState) -> anyhow::Result<()> {
-        let state = self.state()?;
+    async fn check_state(&self, expected: VmState) -> anyhow::Result<()> {
+        let state = self.state().await?;
         if state != expected {
             anyhow::bail!("unexpected VM state {state:?}, should be {expected:?}");
         }
@@ -292,42 +301,42 @@ impl HyperVVM {
     }
 
     /// Start the VM
-    pub fn start(&self) -> anyhow::Result<()> {
-        self.check_state(VmState::Off)?;
-        hvc::hvc_start(&self.vmid)?;
+    pub async fn start(&self) -> anyhow::Result<()> {
+        self.check_state(VmState::Off).await?;
+        hvc::hvc_start(&self.vmid).await?;
         Ok(())
     }
 
     /// Attempt to gracefully shut down the VM
-    pub fn stop(&self) -> anyhow::Result<()> {
-        self.check_shutdown_ic()?;
-        self.check_state(VmState::Running)?;
-        hvc::hvc_stop(&self.vmid)?;
+    pub async fn stop(&self) -> anyhow::Result<()> {
+        self.check_shutdown_ic().await?;
+        self.check_state(VmState::Running).await?;
+        hvc::hvc_stop(&self.vmid).await?;
         Ok(())
     }
 
     /// Attempt to gracefully restart the VM
-    pub fn restart(&self) -> anyhow::Result<()> {
-        self.check_shutdown_ic()?;
-        self.check_state(VmState::Running)?;
-        hvc::hvc_restart(&self.vmid)?;
+    pub async fn restart(&self) -> anyhow::Result<()> {
+        self.check_shutdown_ic().await?;
+        self.check_state(VmState::Running).await?;
+        hvc::hvc_restart(&self.vmid).await?;
         Ok(())
     }
 
     /// Kill the VM
-    pub fn kill(&self) -> anyhow::Result<()> {
-        hvc::hvc_kill(&self.vmid).context("hvc_kill")
+    pub async fn kill(&self) -> anyhow::Result<()> {
+        hvc::hvc_kill(&self.vmid).await.context("hvc_kill")
     }
 
     /// Issue a hard reset to the VM
-    pub fn reset(&self) -> anyhow::Result<()> {
-        hvc::hvc_reset(&self.vmid).context("hvc_reset")
+    pub async fn reset(&self) -> anyhow::Result<()> {
+        hvc::hvc_reset(&self.vmid).await.context("hvc_reset")
     }
 
     /// Enable serial output and return the named pipe path
-    pub fn set_vm_com_port(&mut self, port: u8) -> anyhow::Result<String> {
+    pub async fn set_vm_com_port(&mut self, port: u8) -> anyhow::Result<String> {
         let pipe_path = format!(r#"\\.\pipe\{}-{}"#, self.vmid, port);
-        powershell::run_set_vm_com_port(&self.vmid, port, Path::new(&pipe_path))?;
+        powershell::run_set_vm_com_port(&self.vmid, port, Path::new(&pipe_path)).await?;
         Ok(pipe_path)
     }
 
@@ -353,29 +362,27 @@ impl HyperVVM {
         .context("wait_for_enlightened_shutdown_ready")
     }
 
-    fn shutdown_ic_status(&self) -> anyhow::Result<powershell::VmShutdownIcStatus> {
-        powershell::vm_shutdown_ic_status(&self.vmid)
+    async fn shutdown_ic_status(&self) -> anyhow::Result<powershell::VmShutdownIcStatus> {
+        powershell::vm_shutdown_ic_status(&self.vmid).await
     }
 
-    fn check_shutdown_ic(&self) -> anyhow::Result<()> {
-        let status = self.shutdown_ic_status()?;
+    async fn check_shutdown_ic(&self) -> anyhow::Result<()> {
+        let status = self.shutdown_ic_status().await?;
         if status != powershell::VmShutdownIcStatus::Ok {
             anyhow::bail!("unexpected shutdown ic status {status:?}, should be Ok");
         }
         Ok(())
     }
 
-    // TODO: replace timeouts throughout the hyper-v petri infrastructure
-    // with a watchdog
     async fn wait_for<T: std::fmt::Debug + PartialEq>(
         &self,
-        f: fn(&Self) -> anyhow::Result<T>,
+        f: impl AsyncFn(&Self) -> anyhow::Result<T>,
         target: T,
         timeout: jiff::Span,
     ) -> anyhow::Result<()> {
         let start = Timestamp::now();
         loop {
-            let state = f(self)?;
+            let state = f(self).await?;
             if state == target {
                 break;
             }
@@ -392,12 +399,12 @@ impl HyperVVM {
 
     async fn wait_for_some<T: std::fmt::Debug + PartialEq>(
         &self,
-        f: fn(&Self) -> anyhow::Result<Option<T>>,
+        f: impl AsyncFn(&Self) -> anyhow::Result<Option<T>>,
         timeout: jiff::Span,
     ) -> anyhow::Result<T> {
         let start = Timestamp::now();
         loop {
-            let state = f(self)?;
+            let state = f(self).await?;
             if let Some(state) = state {
                 return Ok(state);
             }
@@ -411,16 +418,16 @@ impl HyperVVM {
     }
 
     /// Remove the VM
-    pub fn remove(mut self) -> anyhow::Result<()> {
-        self.remove_inner()
+    pub async fn remove(mut self) -> anyhow::Result<()> {
+        self.remove_inner().await
     }
 
-    fn remove_inner(&mut self) -> anyhow::Result<()> {
+    async fn remove_inner(&mut self) -> anyhow::Result<()> {
         if !self.destroyed {
-            let res_off = hvc::hvc_ensure_off(&self.vmid);
-            let res_remove = powershell::run_remove_vm(&self.vmid);
+            let res_off = hvc::hvc_ensure_off(&self.vmid).await;
+            let res_remove = powershell::run_remove_vm(&self.vmid).await;
 
-            self.flush_logs()?;
+            self.flush_logs().await?;
 
             res_off?;
             res_remove?;
@@ -431,27 +438,30 @@ impl HyperVVM {
     }
 
     /// Sets the VM firmware  command line.
-    pub fn set_vm_firmware_command_line(&self, openhcl_command_line: &str) -> anyhow::Result<()> {
-        powershell::run_set_vm_command_line(&self.vmid, &self.ps_mod, openhcl_command_line)
+    pub async fn set_vm_firmware_command_line(
+        &self,
+        openhcl_command_line: &str,
+    ) -> anyhow::Result<()> {
+        powershell::run_set_vm_command_line(&self.vmid, &self.ps_mod, openhcl_command_line).await
     }
 
     /// Enable VMBusRelay
-    pub fn set_vmbus_redirect(&self, enable: bool) -> anyhow::Result<()> {
-        powershell::run_set_vmbus_redirect(&self.vmid, &self.ps_mod, enable)
+    pub async fn set_vmbus_redirect(&self, enable: bool) -> anyhow::Result<()> {
+        powershell::run_set_vmbus_redirect(&self.vmid, &self.ps_mod, enable).await
     }
 
     /// Perform an OpenHCL servicing operation.
     pub async fn restart_openhcl(&self, flags: OpenHclServicingFlags) -> anyhow::Result<()> {
-        powershell::run_restart_openhcl(&self.vmid, &self.ps_mod, flags)
+        powershell::run_restart_openhcl(&self.vmid, &self.ps_mod, flags).await
     }
 
     /// Take a screenshot of the VM
-    pub fn screenshot(&self, image: &mut Vec<u8>) -> anyhow::Result<VmScreenshotMeta> {
+    pub async fn screenshot(&self, image: &mut Vec<u8>) -> anyhow::Result<VmScreenshotMeta> {
         const IN_BYTES_PER_PIXEL: usize = 2;
         const OUT_BYTES_PER_PIXEL: usize = 3;
         let temp_bin_path = self.temp_dir.path().join("screenshot.bin");
         let (width, height) =
-            powershell::run_get_vm_screenshot(&self.vmid, &self.ps_mod, &temp_bin_path)?;
+            powershell::run_get_vm_screenshot(&self.vmid, &self.ps_mod, &temp_bin_path).await?;
         let (widthsize, heightsize) = (width as usize, height as usize);
         let in_len = widthsize * heightsize * IN_BYTES_PER_PIXEL;
         let out_len = widthsize * heightsize * OUT_BYTES_PER_PIXEL;
@@ -491,7 +501,7 @@ impl Drop for HyperVVM {
             .ok()
             .is_none_or(|v| v.is_empty() || v == "0")
         {
-            let _ = self.remove_inner();
+            let _ = futures::executor::block_on(self.remove_inner());
         }
     }
 }
@@ -511,19 +521,20 @@ pub(crate) enum CommandError {
 }
 
 /// Run the PowerShell script and return the output
-pub(crate) fn run_cmd(mut cmd: Command) -> Result<String, CommandError> {
+pub(crate) async fn run_cmd(mut cmd: Command) -> Result<String, CommandError> {
     cmd.stderr(Stdio::piped()).stdin(Stdio::null());
 
-    tracing::debug!(?cmd, "executing command");
+    let cmd_debug = format!("{cmd:?}");
+    tracing::debug!(cmd = cmd_debug, "executing command");
 
     let start = Timestamp::now();
-    let output = cmd.output()?;
+    let output = blocking::unblock(move || cmd.output()).await?;
     let time_elapsed = Timestamp::now() - start;
 
     let stdout_str = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr_str = String::from_utf8_lossy(&output.stderr).to_string();
     tracing::debug!(
-        ?cmd,
+        cmd = cmd_debug,
         stdout_str,
         stderr_str,
         "command exited in {:.3}s with status {}",

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -285,7 +285,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                                 color,
                                 width,
                                 height,
-                            } = match framebuffer_access.screenshot(&mut image) {
+                            } = match framebuffer_access.screenshot(&mut image).await {
                                 Ok(meta) => meta,
                                 Err(e) => {
                                     tracing::error!(?e, "Failed to take screenshot");
@@ -795,16 +795,18 @@ pub struct VmScreenshotMeta {
 }
 
 /// Interface for getting screenshots of the VM
+#[async_trait]
 pub trait PetriVmFramebufferAccess: Send + 'static {
     /// Populates the provided buffer with a screenshot of the VM,
     /// returning the dimensions and color type.
-    fn screenshot(&mut self, image: &mut Vec<u8>) -> anyhow::Result<VmScreenshotMeta>;
+    async fn screenshot(&mut self, image: &mut Vec<u8>) -> anyhow::Result<VmScreenshotMeta>;
 }
 
 /// Use this for the associated type if not supported
 pub struct NoPetriVmFramebufferAccess;
+#[async_trait]
 impl PetriVmFramebufferAccess for NoPetriVmFramebufferAccess {
-    fn screenshot(&mut self, _image: &mut Vec<u8>) -> anyhow::Result<VmScreenshotMeta> {
+    async fn screenshot(&mut self, _image: &mut Vec<u8>) -> anyhow::Result<VmScreenshotMeta> {
         unreachable!()
     }
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -529,7 +529,7 @@ impl PetriVmConfigSetupCore<'_> {
         let (serial0_read, serial0_write) = serial0_host.split();
         let serial0_task = self.driver.spawn(
             "serial0-console",
-            crate::log_stream(serial0_log_file, serial0_read),
+            crate::log_task(serial0_log_file, serial0_read, "serial0-console"),
         );
         serial_tasks.push(serial0_task);
 
@@ -539,7 +539,7 @@ impl PetriVmConfigSetupCore<'_> {
                 .context("failed to create serial2 stream")?;
             let serial2_task = self.driver.spawn(
                 "serial2-openhcl",
-                crate::log_stream(logger.log_file("openhcl")?, serial2_host),
+                crate::log_task(logger.log_file("openhcl")?, serial2_host, "serial2-openhcl"),
             );
             serial_tasks.push(serial2_task);
             serial2

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -542,8 +542,9 @@ pub struct OpenVmmFramebufferAccess {
     view: View,
 }
 
+#[async_trait]
 impl PetriVmFramebufferAccess for OpenVmmFramebufferAccess {
-    fn screenshot(&mut self, image: &mut Vec<u8>) -> anyhow::Result<VmScreenshotMeta> {
+    async fn screenshot(&mut self, image: &mut Vec<u8>) -> anyhow::Result<VmScreenshotMeta> {
         // Our framebuffer uses 4 bytes per pixel, approximating an
         // BGRA image, however it only actually contains BGR data.
         // The fourth byte is effectively noise. We can set the 'alpha'

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -214,10 +214,11 @@ impl PetriVmConfigOpenVmm {
         let (stderr_read, stderr_write) = pal::pipe_pair()?;
         let task = resources.driver.spawn(
             "serial log",
-            crate::log_stream(
+            crate::log_task(
                 log_file,
                 PolledPipe::new(&resources.driver, stderr_read)
                     .context("failed to create polled pipe")?,
+                "tmk_vmm stdout",
             ),
         );
         resources.log_stream_tasks.push(task);

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -218,7 +218,7 @@ impl PetriVmConfigOpenVmm {
                 log_file,
                 PolledPipe::new(&resources.driver, stderr_read)
                     .context("failed to create polled pipe")?,
-                "tmk_vmm stdout",
+                "openvmm stderr",
             ),
         );
         resources.log_stream_tasks.push(task);

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -74,7 +74,7 @@ fn host_tmks_core(
     driver
         .spawn(
             "log",
-            petri::log_stream(params.logger.log_file("tmk_vmm")?, stdout),
+            petri::log_task(params.logger.log_file("tmk_vmm")?, stdout, "tmk_vmm stdout"),
         )
         .detach();
 
@@ -159,9 +159,10 @@ async fn openhcl_tmks_inner<T: PetriVmmBackend>(
     driver
         .spawn(
             "log",
-            petri::log_stream(
+            petri::log_task(
                 params.logger.log_file("tmk_vmm")?,
                 child.stdout.take().unwrap(),
+                "tmk_vmm stdout",
             ),
         )
         .detach();

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -56,9 +56,10 @@ fn test_ttrpc_interface(
         let driver = driver;
         let _stderr_task = driver.spawn(
             "stderr",
-            petri::log_stream(
+            petri::log_task(
                 params.logger.log_file("stderr").unwrap(),
                 PolledPipe::new(&driver, stderr_read).unwrap(),
+                "openvmm stderr",
             ),
         );
 
@@ -112,9 +113,10 @@ fn test_ttrpc_interface(
 
             let _com1_task = driver.spawn(
                 "com1",
-                petri::log_stream(
+                petri::log_task(
                     params.logger.log_file("linux").unwrap(),
                     PolledSocket::new(&driver, com1).unwrap(),
+                    "linux com1",
                 ),
             );
 


### PR DESCRIPTION
Using COM3 instead of diag_client allows us to get OpenHCL logs if it crashes early in boot. Currently this only works on our TDX and SNP runners, since our nested runners have a build of windows that is too old and additional com ports are not yet supported on ARM. To make this work, the powershell and hvc commands needed to be run in a separate process (using the `unblock` function) to avoid blocking the process doing the logging.