### PR TITLE
openhcl: add cmdline option to disable uefi frontpage

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -319,6 +319,7 @@ async fn launch_workers(
         hide_isolation: opt.hide_isolation,
         nvme_keep_alive: opt.nvme_keep_alive,
         test_configuration: opt.test_configuration,
+        disable_uefi_frontpage: opt.disable_uefi_frontpage,
     };
 
     let (mut remote_console_cfg, framebuffer_access) =

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -140,6 +140,11 @@ pub struct Options {
     /// Test configurations are designed to replicate specific behaviors and
     /// conditions in order to simulate various test scenarios.
     pub test_configuration: Option<TestScenarioConfig>,
+
+    /// (OPENHCL_DISABLE_UEFI_FRONTPAGE=1) Disable the front page in UEFI, which
+    /// will result in UEFI terminating shutting down the guest instead of
+    /// showing the frontpage.
+    pub disable_uefi_frontpage: bool,
 }
 
 impl Options {
@@ -238,6 +243,7 @@ impl Options {
                 })
                 .ok()
         });
+        let uefi_disable_frontpage = parse_env_bool("OPENHCL_DISABLE_UEFI_FRONTPAGE");
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.
@@ -292,6 +298,7 @@ impl Options {
             no_sidecar_hotplug,
             nvme_keep_alive,
             test_configuration,
+            disable_uefi_frontpage: uefi_disable_frontpage,
         })
     }
 

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -141,8 +141,8 @@ pub struct Options {
     /// conditions in order to simulate various test scenarios.
     pub test_configuration: Option<TestScenarioConfig>,
 
-    /// (OPENHCL_DISABLE_UEFI_FRONTPAGE=1) Disable the front page in UEFI, which
-    /// will result in UEFI terminating shutting down the guest instead of
+    /// (OPENHCL_DISABLE_UEFI_FRONTPAGE=1) Disable the frontpage in UEFI which
+    /// will result in UEFI terminating, shutting down the guest instead of
     /// showing the frontpage.
     pub disable_uefi_frontpage: bool,
 }
@@ -243,7 +243,7 @@ impl Options {
                 })
                 .ok()
         });
-        let uefi_disable_frontpage = parse_env_bool("OPENHCL_DISABLE_UEFI_FRONTPAGE");
+        let disable_uefi_frontpage = parse_env_bool("OPENHCL_DISABLE_UEFI_FRONTPAGE");
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.
@@ -298,7 +298,7 @@ impl Options {
             no_sidecar_hotplug,
             nvme_keep_alive,
             test_configuration,
-            disable_uefi_frontpage: uefi_disable_frontpage,
+            disable_uefi_frontpage,
         })
     }
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -283,6 +283,9 @@ pub struct UnderhillEnvCfg {
 
     /// test configuration
     pub test_configuration: Option<TestScenarioConfig>,
+
+    /// Disable the UEFI front page.
+    pub disable_uefi_frontpage: bool,
 }
 
 /// Bundle of config + runtime objects for hooking into the underhill remote
@@ -2938,6 +2941,7 @@ async fn new_underhill_vm(
             load_kind,
             &dps,
             isolation.is_isolated(),
+            env_cfg.disable_uefi_frontpage,
         )
         .instrument(tracing::info_span!("load_firmware"))
         .await?;
@@ -3228,12 +3232,16 @@ async fn load_firmware(
     load_kind: LoadKind,
     dps: &DevicePlatformSettings,
     isolated: bool,
+    disable_uefi_frontpage: bool,
 ) -> Result<(), anyhow::Error> {
     let cmdline_append = match cmdline_append {
         Some(cmdline) => CString::new(cmdline.as_bytes()).context("bad command line")?,
         None => CString::default(),
     };
-    let loader_config = crate::loader::Config { cmdline_append };
+    let loader_config = crate::loader::Config {
+        cmdline_append,
+        disable_uefi_frontpage,
+    };
     let caps = partition.caps();
     let vtl0_vp_context = crate::loader::load(
         gm,


### PR DESCRIPTION
Add the ability to do this via an environment variable. While the device platform settings also specify this setting, not all hosts (such as Hyper-V) support configuring this setting in all scenarios.

This is to be used in an upcoming petri change to match the correct expected behavior for petri vm configuration. 