### PR TITLE
Adding validation for CPUID leaves

### DIFF
--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -57,9 +57,6 @@ trait CpuidArchInitializer {
 
     /// Processes extended state enumeration subleaves 2+. result is a helper
     /// for retrieving the result of a given subleaf.
-    //
-    // (TODO TDX: This will be to populate them, will need to update the
-    // signature to pass CpuidResults as a mutable reference)
     fn process_extended_state_subleaves(
         &self,
         results: &mut CpuidSubtable,
@@ -296,7 +293,7 @@ impl CpuidResults {
         let mut cached_results = Self {
             results,
             max_extended_state: 0, // will get updated as part of update_extended_state
-            max_xfd: 0,
+            max_xfd: 0,            // will get updated as part of process_extended_state_subleaves
         };
 
         // Validate results before updating leaves because the updates might

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -64,7 +64,8 @@ trait CpuidArchInitializer {
         &self,
         results: &mut CpuidSubtable,
         extended_state_mask: u64,
-    ) -> Result<Option<u32>, CpuidResultsError>;
+        max_xfd: &mut u32,
+    ) -> Result<(), CpuidResultsError>;
 
     /// Computes the Extended Topology results from other leaves if necessary.
     ///
@@ -454,10 +455,11 @@ impl CpuidResults {
 
         let max_extended_state = max_xfem | max_xss;
 
-        let max_xfd = arch_initializer
-            .process_extended_state_subleaves(extended_state_subtable, max_extended_state)?;
-
-        self.max_xfd = max_xfd.expect("Invalid extended state value received");
+        arch_initializer.process_extended_state_subleaves(
+            extended_state_subtable,
+            max_extended_state,
+            &mut self.max_xfd,
+        )?;
 
         let xsave_size = self.xsave_size(max_xfem);
 

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -61,7 +61,6 @@ trait CpuidArchInitializer {
         &self,
         results: &mut CpuidSubtable,
         extended_state_mask: u64,
-        max_xfd: &mut u32,
     ) -> Result<(), CpuidResultsError>;
 
     /// Computes the Extended Topology results from other leaves if necessary.
@@ -452,11 +451,8 @@ impl CpuidResults {
 
         let max_extended_state = max_xfem | max_xss;
 
-        arch_initializer.process_extended_state_subleaves(
-            extended_state_subtable,
-            max_extended_state,
-            &mut self.max_xfd,
-        )?;
+        arch_initializer
+            .process_extended_state_subleaves(extended_state_subtable, max_extended_state)?;
 
         let xsave_size = self.xsave_size(max_xfem);
 

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -169,7 +169,6 @@ pub struct ParsedCpuidEntry {
 struct CpuidResults {
     results: HashMap<CpuidFunction, CpuidEntry>,
     max_extended_state: u64,
-    max_xfd: u32,
 }
 
 // NOTE: Because subtables are used to calculate certain values _in order_ such
@@ -292,7 +291,6 @@ impl CpuidResults {
         let mut cached_results = Self {
             results,
             max_extended_state: 0, // will get updated as part of update_extended_state
-            max_xfd: 0,            // will get updated as part of process_extended_state_subleaves
         };
 
         // Validate results before updating leaves because the updates might

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -253,7 +253,7 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
         &self,
         results: &mut CpuidSubtable,
         extended_state_mask: u64,
-    ) -> Result<(), CpuidResultsError> {
+    ) -> Result<Option<u32>, CpuidResultsError> {
         let summary_mask = extended_state_mask & !xsave::X86X_XSAVE_LEGACY_FEATURES;
 
         for i in 0..=super::MAX_EXTENDED_STATE_ENUMERATION_SUBLEAF {
@@ -265,7 +265,7 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
             }
         }
 
-        Ok(())
+        Ok(Some(0))
     }
 
     fn extended_topology(

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -253,7 +253,8 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
         &self,
         results: &mut CpuidSubtable,
         extended_state_mask: u64,
-    ) -> Result<Option<u32>, CpuidResultsError> {
+        _max_xfd: &mut u32,
+    ) -> Result<(), CpuidResultsError> {
         let summary_mask = extended_state_mask & !xsave::X86X_XSAVE_LEGACY_FEATURES;
 
         for i in 0..=super::MAX_EXTENDED_STATE_ENUMERATION_SUBLEAF {
@@ -265,7 +266,7 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
             }
         }
 
-        Ok(Some(0))
+        Ok(())
     }
 
     fn extended_topology(

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -253,7 +253,6 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
         &self,
         results: &mut CpuidSubtable,
         extended_state_mask: u64,
-        _max_xfd: &mut u32,
     ) -> Result<(), CpuidResultsError> {
         let summary_mask = extended_state_mask & !xsave::X86X_XSAVE_LEGACY_FEATURES;
 

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -163,7 +163,6 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
         &self,
         results: &mut CpuidSubtable,
         extended_state_mask: u64,
-        max_xfd: &mut u32,
     ) -> Result<(), CpuidResultsError> {
         let xfd_supported = if let Some(support) = results.get(&1).map(
             |CpuidResult {
@@ -183,20 +182,18 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
 
         let summary_mask = extended_state_mask & !xsave::X86X_XSAVE_LEGACY_FEATURES;
 
-        let mut max_xfd_value: u32 = 0;
+        let mut _max_xfd_value: u32 = 0;
         for i in 0..=super::MAX_EXTENDED_STATE_ENUMERATION_SUBLEAF {
             if (1 << i) & summary_mask != 0 {
                 let result = Self::cpuid(CpuidFunction::ExtendedStateEnumeration.0, i);
                 let result_xfd = cpuid::ExtendedStateEnumerationSubleafNEcx::from(result.ecx).xfd();
                 if xfd_supported && result_xfd {
-                    max_xfd_value |= 1 << i;
+                    _max_xfd_value |= 1 << i;
                 }
 
                 results.insert(i, result);
             }
         }
-
-        *max_xfd = max_xfd_value;
 
         Ok(())
     }

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -164,7 +164,7 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
         results: &mut CpuidSubtable,
         extended_state_mask: u64,
     ) -> Result<(), CpuidResultsError> {
-        let xfd_supported = if let Some(support) = results.get(&1).map(
+        if let Some(support) = results.get(&1).map(
             |CpuidResult {
                  eax,
                  ebx: _,
@@ -182,14 +182,9 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
 
         let summary_mask = extended_state_mask & !xsave::X86X_XSAVE_LEGACY_FEATURES;
 
-        let mut _max_xfd_value: u32 = 0;
         for i in 0..=super::MAX_EXTENDED_STATE_ENUMERATION_SUBLEAF {
             if (1 << i) & summary_mask != 0 {
                 let result = Self::cpuid(CpuidFunction::ExtendedStateEnumeration.0, i);
-                let result_xfd = cpuid::ExtendedStateEnumerationSubleafNEcx::from(result.ecx).xfd();
-                if xfd_supported && result_xfd {
-                    _max_xfd_value |= 1 << i;
-                }
 
                 results.insert(i, result);
             }

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -3,9 +3,6 @@
 
 //! CPUID definitions and implementation specific to Underhill in TDX CVMs.
 
-// UNSAFETY: Needed to save extended state.
-#![expect(unsafe_code)]
-
 use super::COMMON_REQUIRED_LEAVES;
 use super::CpuidArchInitializer;
 use super::CpuidResultMask;
@@ -218,7 +215,10 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
         if (extended_topology_ecx_0.level_number() != super::CPUID_LEAF_B_LEVEL_NUMBER_SMT)
             || (extended_topology_ecx_0.level_type() != super::CPUID_LEAF_B_LEVEL_TYPE_SMT)
         {
-            tracing::error!("Incorrect values received: {:?}. Level Number should represent sub-leaf 0, while Level Type should represent domain type 1 for logical processor.", extended_topology_ecx_0);
+            tracing::error!(
+                "Incorrect values received: {:?}. Level Number should represent sub-leaf 0, while Level Type should represent domain type 1 for logical processor.",
+                extended_topology_ecx_0
+            );
         }
 
         // Validation for Leaf 0xB subleaf 1
@@ -229,7 +229,10 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
         if (extended_topology_ecx_1.level_number() != super::CPUID_LEAF_B_LEVEL_NUMBER_CORE)
             || (extended_topology_ecx_1.level_type() != super::CPUID_LEAF_B_LEVEL_TYPE_CORE)
         {
-            tracing::error!("Incorrect values received: {:?}. Level Number should represent sub-leaf 1, while Level Type should represent domain type 2 for Core.", extended_topology_ecx_1);
+            tracing::error!(
+                "Incorrect values received: {:?}. Level Number should represent sub-leaf 1, while Level Type should represent domain type 2 for Core.",
+                extended_topology_ecx_1
+            );
         }
 
         Ok(super::ExtendedTopologyResult {

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -34,8 +34,6 @@ pub const TDX_REQUIRED_LEAVES: &[(CpuidFunction, Option<u32>)] = &[
     (CpuidFunction::CacheParameters, Some(3)),
 ];
 
-static mut MAX_XFD: u32 = 0;
-
 /// Implements [`CpuidArchSupport`] for TDX-isolation support
 pub struct TdxCpuidInitializer {}
 
@@ -165,7 +163,7 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
         &self,
         results: &mut CpuidSubtable,
         extended_state_mask: u64,
-    ) -> Result<(), CpuidResultsError> {
+    ) -> Result<Option<u32>, CpuidResultsError> {
         let xfd_supported = if let Some(support) = results.get(&1).map(
             |CpuidResult {
                  eax,
@@ -196,12 +194,7 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
             }
         }
 
-        // SAFETY: no concurrent accessors.
-        unsafe {
-            MAX_XFD = max_xfd;
-        }
-
-        Ok(())
+        Ok(Some(max_xfd))
     }
 
     fn extended_topology(

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -226,7 +226,7 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
         if (extended_topology_ecx_0.level_number() != super::CPUID_LEAF_B_LEVEL_NUMBER_SMT)
             || (extended_topology_ecx_0.level_type() != super::CPUID_LEAF_B_LEVEL_TYPE_SMT)
         {
-            tracing::error!("Incorrect values received: {:?}", extended_topology_ecx_0);
+            tracing::error!("Incorrect values received: {:?}. Level Number should represent sub-leaf 0, while Level Type should represent domain type 1 for logical processor.", extended_topology_ecx_0);
         }
 
         // Validation for Leaf 0xB subleaf 1
@@ -237,7 +237,7 @@ impl CpuidArchInitializer for TdxCpuidInitializer {
         if (extended_topology_ecx_1.level_number() != super::CPUID_LEAF_B_LEVEL_NUMBER_CORE)
             || (extended_topology_ecx_1.level_type() != super::CPUID_LEAF_B_LEVEL_TYPE_CORE)
         {
-            tracing::error!("Incorrect values received: {:?}", extended_topology_ecx_1);
+            tracing::error!("Incorrect values received: {:?}. Level Number should represent sub-leaf 1, while Level Type should represent domain type 2 for Core.", extended_topology_ecx_1);
         }
 
         Ok(super::ExtendedTopologyResult {


### PR DESCRIPTION
Addresses Issue #556. 
Added missing validation for CPUID leaf 0xB.
Maximum xfd calculation could have been used by MSRs 0x1C4 (MSR_XFD) and 0x1C5 (MSR_XFD_ERR). However, the L1 doesn't get any intercept for these MSRs. Hence, removed the related redundant code.
