### PR TITLE
petri/hyperv: onboard uefi no boot device test

### DIFF
--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -91,7 +91,7 @@ function Set-VmSystemSettings {
     param(
         [ValidateNotNullOrEmpty()]
         [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
-        [Microsoft.Management.Infrastructure.CimInstance]$Vssd
+        [Microsoft.Management.Infrastructure.CimInstance] $Vssd
     )
 
     $vmms = Get-Vmms

--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -91,12 +91,12 @@ function Set-VmSystemSettings {
     param(
         [ValidateNotNullOrEmpty()]
         [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
-        [Microsoft.Management.Infrastructure.CimInstance]$CimRasd
+        [Microsoft.Management.Infrastructure.CimInstance]$Vssd
     )
 
     $vmms = Get-Vmms
     $vmms | Invoke-CimMethod -Name "ModifySystemSettings" -Arguments @{
-        "SystemSettings" = ($vssd | ConvertTo-CimEmbeddedString)
+        "SystemSettings" = ($Vssd | ConvertTo-CimEmbeddedString)
     }
 }
 

--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -87,6 +87,19 @@ function Set-InitialMachineConfiguration
     }
 }
 
+function Set-VmSystemSettings {
+    param(
+        [ValidateNotNullOrEmpty()]
+        [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
+        [Microsoft.Management.Infrastructure.CimInstance]$CimRasd
+    )
+
+    $vmms = Get-Vmms
+    $vmms | Invoke-CimMethod -Name "ModifySystemSettings" -Arguments @{
+        "SystemSettings" = ($vssd | ConvertTo-CimEmbeddedString)
+    }
+}
+
 function Set-OpenHCLFirmware
 {
     [CmdletBinding()]
@@ -104,7 +117,7 @@ function Set-OpenHCLFirmware
     $vssd = Get-Vssd $Vm
     # Enable OpenHCL by feature
     $vssd.GuestFeatureSet = 0x00000201
-    # Set the OpenHCL image file path 
+    # Set the OpenHCL image file path
     $vssd.FirmwareFile = $IgvmFile
 
     if ($IncreaseVtl2Memory) {
@@ -116,9 +129,36 @@ function Set-OpenHCLFirmware
         $vssd.Vtl2MmioAddressRangeSize = 512
     }
 
-    $vmms = Get-Vmms
-    $vmms | Invoke-CimMethod -Name "ModifySystemSettings" -Arguments @{
-        "SystemSettings" = ($vssd | ConvertTo-CimEmbeddedString)
-    }
+    Set-VmSystemSettings $vssd
+}
+
+function Set-VmCommandLine
+{
+    [CmdletBinding()]
+    Param (
+        [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
+        [System.Object]
+        $Vm,
+
+        [Parameter(Mandatory = $true)]
+        [string] $CommandLine
+    )
+
+    $vssd = Get-Vssd $Vm
+    $vssd.FirmwareParameters = [System.Text.Encoding]::UTF8.GetBytes($CommandLine)
+    Set-VmSystemSettings $vssd
+}
+
+function Get-VmCommandLine
+{
+    [CmdletBinding()]
+    Param (
+        [Parameter(Position = 0, Mandatory = $true, ValueFromPipeline = $true)]
+        [System.Object]
+        $Vm
+    )
+
+    $vssd = Get-Vssd $Vm
+    [System.Text.Encoding]::UTF8.GetString($vssd.FirmwareParameters)
 }
 

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -171,7 +171,7 @@ impl PetriVmConfigHyperV {
                 Firmware::Pcat { guest, .. } => (
                     powershell::HyperVGuestStateIsolationType::Disabled,
                     powershell::HyperVGeneration::One,
-                    guest.artifact(),
+                    Some(guest.artifact()),
                     None,
                 ),
                 Firmware::Uefi { guest, .. } => (
@@ -199,7 +199,9 @@ impl PetriVmConfigHyperV {
                 // TODO: OpenHCL PCAT
             };
 
-        let reference_disk_path = guest_artifact;
+        let vhd_paths = guest_artifact
+            .map(|artifact| vec![vec![artifact.into()]])
+            .unwrap_or_default();
         let openhcl_igvm = igvm_artifact.cloned();
 
         Ok(PetriVmConfigHyperV {
@@ -208,7 +210,7 @@ impl PetriVmConfigHyperV {
             guest_state_isolation_type,
             memory: 0x1_0000_0000,
             proc_count: 2,
-            vhd_paths: vec![vec![reference_disk_path.clone().into()]],
+            vhd_paths,
             secure_boot_template: matches!(generation, powershell::HyperVGeneration::Two)
                 .then_some(match firmware.os_flavor() {
                     OsFlavor::Windows => powershell::HyperVSecureBootTemplate::MicrosoftWindows,

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -18,7 +18,7 @@ use std::process::Stdio;
 use std::str::FromStr;
 
 /// Hyper-V VM Generation
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum HyperVGeneration {
     /// Generation 1 (with emulated legacy devices and PCAT BIOS)
     One,

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -145,19 +145,6 @@ pub fn run_remove_vm(vmid: &Guid) -> anyhow::Result<()> {
         .context("remove_vm")
 }
 
-/// Runs Remove-VmNetworkAdapter to remove all network adapters from a VM.
-pub fn run_remove_vm_network_adapter(vmid: &Guid) -> anyhow::Result<()> {
-    PowerShellBuilder::new()
-        .cmdlet("Get-VM")
-        .arg_string("Id", vmid)
-        .pipeline()
-        .cmdlet("Remove-VMNetworkAdapter")
-        .finish()
-        .output(true)
-        .map(|_| ())
-        .context("remove_vm_network_adapters")
-}
-
 /// Arguments for the Set-VMProcessor powershell cmdlet
 pub struct HyperVSetVMProcessorArgs<'a> {
     /// Specifies the ID of the virtual machine for which you want to set the
@@ -598,6 +585,19 @@ pub fn vm_shutdown_ic_status(vmid: &Guid) -> anyhow::Result<VmShutdownIcStatus> 
         "Lost Communication" => VmShutdownIcStatus::LostCommunication,
         s => anyhow::bail!("Unknown VM shutdown status: {s}"),
     })
+}
+
+/// Runs Remove-VmNetworkAdapter to remove all network adapters from a VM.
+pub fn run_remove_vm_network_adapter(vmid: &Guid) -> anyhow::Result<()> {
+    PowerShellBuilder::new()
+        .cmdlet("Get-VM")
+        .arg_string("Id", vmid)
+        .pipeline()
+        .cmdlet("Remove-VMNetworkAdapter")
+        .finish()
+        .output(true)
+        .map(|_| ())
+        .context("remove_vm_network_adapters")
 }
 
 /// A PowerShell script builder

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -600,19 +600,6 @@ pub fn vm_shutdown_ic_status(vmid: &Guid) -> anyhow::Result<VmShutdownIcStatus> 
     })
 }
 
-/// Runs Remove-VmNetworkAdapter to remove all network adapters from a VM.
-pub fn run_remove_vm_network_adapter(vmid: &Guid) -> anyhow::Result<()> {
-    PowerShellBuilder::new()
-        .cmdlet("Get-VM")
-        .arg_string("Id", vmid)
-        .pipeline()
-        .cmdlet("Remove-VMNetworkAdapter")
-        .finish()
-        .output(true)
-        .map(|_| ())
-        .context("remove_vm_network_adapter")
-}
-
 /// A PowerShell script builder
 pub struct PowerShellBuilder(Command);
 

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -86,14 +86,11 @@ impl HyperVVM {
             vhd_path: None,
         })?;
 
-        // Remove the default network adapter
-        powershell::run_remove_vm_network_adapter(&vmid)
-            .context("remove default network adapter")?;
-
         tracing::info!(name, vmid = vmid.to_string(), "Created Hyper-V VM");
 
         // Remove the default network adapter
-        powershell::run_remove_vm_network_adapter(&vmid)?;
+        powershell::run_remove_vm_network_adapter(&vmid)
+            .context("remove default network adapter")?;
 
         // Set the default behavior to disable the UEFI frontpage, via OpenHCL
         // cmdline

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -86,10 +86,20 @@ impl HyperVVM {
             vhd_path: None,
         })?;
 
+        // Remove the default network adapter
+        powershell::run_remove_vm_network_adapter(&vmid)
+            .context("remove default network adapter")?;
+
         tracing::info!(name, vmid = vmid.to_string(), "Created Hyper-V VM");
 
+<<<<<<< HEAD
         // Remove the default network adapter
         powershell::run_remove_vm_network_adapter(&vmid)?;
+=======
+        // Set the default behavior to disable the UEFI frontpage, via OpenHCL
+        // cmdline
+        powershell::run_set_vm_command_line(&vmid, &ps_mod, "OPENHCL_DISABLE_UEFI_FRONTPAGE=1")?;
+>>>>>>> 0836936b (petri/hyperv: disable uefi frontpage by default)
 
         Ok(Self {
             name,
@@ -248,7 +258,7 @@ impl HyperVVM {
     pub async fn start(&self) -> anyhow::Result<()> {
         self.check_state(VmState::Off)?;
         hvc::hvc_start(&self.vmid)?;
-        self.wait_for_state(VmState::Running).await
+        Ok(())
     }
 
     /// Attempt to gracefully shut down the VM
@@ -256,7 +266,7 @@ impl HyperVVM {
         self.wait_for_shutdown_ic().await?;
         self.check_state(VmState::Running)?;
         hvc::hvc_stop(&self.vmid)?;
-        self.wait_for_state(VmState::Off).await
+        Ok(())
     }
 
     /// Attempt to gracefully restart the VM
@@ -264,7 +274,6 @@ impl HyperVVM {
         self.wait_for_shutdown_ic().await?;
         self.check_state(VmState::Running)?;
         hvc::hvc_restart(&self.vmid)?;
-        tracing::warn!("end state checking on restart not yet implemented for hyper-v vms");
         Ok(())
     }
 

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -92,9 +92,18 @@ impl HyperVVM {
         powershell::run_remove_vm_network_adapter(&vmid)
             .context("remove default network adapter")?;
 
-        // Set the default behavior to disable the UEFI frontpage, via OpenHCL
-        // cmdline
-        powershell::run_set_vm_command_line(&vmid, &ps_mod, "OPENHCL_DISABLE_UEFI_FRONTPAGE=1")?;
+        // TODO: Fix vm config so that we get more information at this layer
+        // what kind of VM it is. For now, if it's UEFI, assume that it's
+        // OpenHCL and set the default behavior to disable the UEFI frontpage,
+        // via OpenHCL cmdline, since Hyper-V doesn't support setting this
+        // option thru WMI.
+        if generation == powershell::HyperVGeneration::Two {
+            powershell::run_set_vm_command_line(
+                &vmid,
+                &ps_mod,
+                "OPENHCL_DISABLE_UEFI_FRONTPAGE=1",
+            )?;
+        }
 
         Ok(Self {
             name,

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -92,14 +92,12 @@ impl HyperVVM {
 
         tracing::info!(name, vmid = vmid.to_string(), "Created Hyper-V VM");
 
-<<<<<<< HEAD
         // Remove the default network adapter
         powershell::run_remove_vm_network_adapter(&vmid)?;
-=======
+
         // Set the default behavior to disable the UEFI frontpage, via OpenHCL
         // cmdline
         powershell::run_set_vm_command_line(&vmid, &ps_mod, "OPENHCL_DISABLE_UEFI_FRONTPAGE=1")?;
->>>>>>> 0836936b (petri/hyperv: disable uefi frontpage by default)
 
         Ok(Self {
             name,

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -336,11 +336,11 @@ impl UefiGuest {
         UefiGuest::GuestTestUefi(artifact)
     }
 
-    fn artifact(&self) -> &ResolvedArtifact {
+    fn artifact(&self) -> Option<&ResolvedArtifact> {
         match self {
-            UefiGuest::Vhd(vhd) => &vhd.artifact,
-            UefiGuest::GuestTestUefi(p) => p,
-            UefiGuest::None => unreachable!(),
+            UefiGuest::Vhd(vhd) => Some(&vhd.artifact),
+            UefiGuest::GuestTestUefi(p) => Some(p),
+            UefiGuest::None => None,
         }
     }
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -693,9 +693,12 @@ impl PetriVmConfigSetupCore<'_> {
                                 disk: LayeredDiskHandle {
                                     layers: vec![
                                         RamDiskLayerHandle { len: None }.into_resource().into(),
-                                        DiskLayerHandle(open_disk_type(disk_path.as_ref(), true)?)
-                                            .into_resource()
-                                            .into(),
+                                        DiskLayerHandle(open_disk_type(
+                                            disk_path.expect("not uefi guest none").as_ref(),
+                                            true,
+                                        )?)
+                                        .into_resource()
+                                        .into(),
                                     ],
                                 }
                                 .into_resource(),
@@ -725,9 +728,12 @@ impl PetriVmConfigSetupCore<'_> {
                             disk: LayeredDiskHandle {
                                 layers: vec![
                                     RamDiskLayerHandle { len: None }.into_resource().into(),
-                                    DiskLayerHandle(open_disk_type(disk_path.as_ref(), true)?)
-                                        .into_resource()
-                                        .into(),
+                                    DiskLayerHandle(open_disk_type(
+                                        disk_path.expect("not uefi guest none").as_ref(),
+                                        true,
+                                    )?)
+                                    .into_resource()
+                                    .into(),
                                 ],
                             }
                             .into_resource(),

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -18,8 +18,14 @@ use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;
 
 /// Boot through the UEFI firmware, it will shut itself down after booting.
-#[openvmm_test(uefi_x64(none), openhcl_uefi_x64(none), uefi_aarch64(none))]
-async fn frontpage(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+#[vmm_test(
+    openvmm_uefi_x64(none),
+    openvmm_openhcl_uefi_x64(none),
+    openvmm_uefi_aarch64(none),
+    hyperv_openhcl_uefi_aarch64(none),
+    hyperv_openhcl_uefi_x64(none)
+)]
+async fn frontpage(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     let mut vm = config.run_without_agent().await?;
     vm.wait_for_successful_boot_event().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);


### PR DESCRIPTION
Make the no boot device uefi test now work on Hyper-V. This requires setting all VMs to not enable the UEFI frontpage (which matches openvmm behavior) via configuring this thru an OpenHCL environment override. 