### PR TITLE
[DRAFT] [Sneak Peek] DMA hint calculation in OpenHCL bootshim

### DIFF
--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -9,6 +9,7 @@ use crate::ReservedMemoryType;
 use crate::host_params::COMMAND_LINE_SIZE;
 use crate::host_params::PartitionInfo;
 use crate::host_params::shim_params::IsolationType;
+use crate::log; // YSP
 use crate::sidecar::SidecarConfig;
 use crate::single_threaded::off_stack;
 use arrayvec::ArrayString;
@@ -211,6 +212,7 @@ pub fn write_dt(
     let p_enable_method = builder.add_string("enable-method")?;
 
     let num_cpus = partition_info.cpus.len();
+    log!("YSP: num_cpus2 = {}", num_cpus);
 
     let mut root_builder = builder
         .start_node("")?

--- a/openhcl/openhcl_boot/src/host_params/dma_hint.rs
+++ b/openhcl/openhcl_boot/src/host_params/dma_hint.rs
@@ -156,5 +156,15 @@ mod test {
             vnode: 0,
         });
         assert_eq!(vtl2_calculate_dma_hint(4, &storage), 1536);
+
+        // Test VP count higher than max from LOOKUP_TABLE.
+        storage.vtl2_ram.clear();
+        storage.vtl2_ram.push(MemoryEntry {
+            range: MemoryRange::new(0x0..0x7000000),
+            mem_type: MemoryMapEntryType::VTL2_PROTECTABLE,
+            vnode: 0,
+        });
+        // TODO: Unfinished, maybe the return value is incorrect.
+        assert_eq!(vtl2_calculate_dma_hint(112, &storage), 2048);
     }
 }

--- a/openhcl/openhcl_boot/src/host_params/dma_hint.rs
+++ b/openhcl/openhcl_boot/src/host_params/dma_hint.rs
@@ -75,18 +75,86 @@ pub fn vtl2_calculate_dma_hint(vp_count: usize, storage: &PartitionInfo) -> u64 
         let mem_size_mb = (mem_size / 1048576) as u32;
         log!("YSP: mem_size_mb = {}", mem_size_mb);
 
-        LOOKUP_TABLE
-            .iter()
-            .filter(|e| e.vp_count == vp_count as u32)
-            .for_each(|f| {
+        let mut min_vtl2_memory_mb = 1000000;
+        let mut max_vtl2_memory_mb = 0;
+        // TODO: If we won't allow floats in boot-shim, replace with scaled integers
+        let mut min_ratio: f32 = 0.1;
+        let mut max_ratio: f32 = 0.01;
+
+        let mut min_vp_count = 1;
+        let mut max_vp_count = 4096;
+
+        for f in LOOKUP_TABLE {
+            if f.vp_count == vp_count as u32 {
                 if f.vtl2_memory_mb == mem_size_mb {
                     // Found exact match.
                     dma_hint_4k = f.dma_hint_mb as u64 * 1048576 / PAGE_SIZE_4K;
+                    break;
                 } else {
-                    // Try to extrapolate based on similar values.
+                    // Prepare for possible extrapolation.
+                    min_vtl2_memory_mb = min_vtl2_memory_mb.min(f.vtl2_memory_mb);
+                    max_vtl2_memory_mb = max_vtl2_memory_mb.max(f.vtl2_memory_mb);
+                    min_ratio = min_ratio.min(f.dma_hint_mb as f32 / f.vtl2_memory_mb as f32);
+                    max_ratio = max_ratio.max(f.dma_hint_mb as f32 / f.vtl2_memory_mb as f32);
                 }
-        });
+            } else if f.vp_count < vp_count as u32 {
+                // Find the nearest VP counts if exact match is not in the table.
+                min_vp_count = min_vp_count.max(f.vp_count);
+            } else if f.vp_count > vp_count as u32 {
+                max_vp_count = max_vp_count.min(f.vp_count);
+            }
+        }
+
+        // It is possible there were no matching entries in the lookup table.
+        // (i.e. unexpected VP count).
+        if max_vtl2_memory_mb == 0 {
+            LOOKUP_TABLE
+            .iter()
+            .filter(|e| e.vp_count == min_vp_count || e.vp_count == max_vp_count)
+            .for_each(|f| {
+                // Prepare for possible extrapolation.
+                min_vtl2_memory_mb = min_vtl2_memory_mb.min(f.vtl2_memory_mb);
+                max_vtl2_memory_mb = max_vtl2_memory_mb.max(f.vtl2_memory_mb);
+                min_ratio = min_ratio.min(f.dma_hint_mb as f32 / f.vtl2_memory_mb as f32);
+                max_ratio = max_ratio.max(f.dma_hint_mb as f32 / f.vtl2_memory_mb as f32);
+            });
+        }
+        
+        if dma_hint_4k == 0 {
+            // If we didn't find an exact match for our vp_count, try to extrapolate.
+            dma_hint_4k = (mem_size_mb as f32 * ((min_ratio + max_ratio) / 2.0)) as u64 *
+                1048576 /
+                PAGE_SIZE_4K;
+        }
     }
 
     dma_hint_4k
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::host_params::MemoryEntry;
+    use crate::MemoryRange;
+
+    #[test]
+    fn test_vtl2_calculate_dma_hint() {
+        let mut storage = PartitionInfo::new();
+        
+        storage.vtl2_ram.clear();
+        storage.vtl2_ram.push(MemoryEntry {
+            range: MemoryRange::new(0x0..0x6200000),
+            mem_type: MemoryMapEntryType::VTL2_PROTECTABLE,
+            vnode: 0,
+        });
+        assert_eq!(vtl2_calculate_dma_hint(2, &storage), 1024);
+        
+        storage.vtl2_ram.clear();
+        storage.vtl2_ram.push(MemoryEntry {
+            range: MemoryRange::new(0x0..0x6E00000),
+            mem_type: MemoryMapEntryType::VTL2_PROTECTABLE,
+            vnode: 0,
+        });
+        assert_eq!(vtl2_calculate_dma_hint(4, &storage), 1536);
+    }
 }

--- a/openhcl/openhcl_boot/src/host_params/dma_hint.rs
+++ b/openhcl/openhcl_boot/src/host_params/dma_hint.rs
@@ -7,7 +7,61 @@ use crate::log;
 use igvm_defs::MemoryMapEntryType;
 use super::PartitionInfo;
 
+struct DmaLookupStruct {
+    /// Logical processors for VM.
+    vp_count: u32,
+    /// Vtl2AddressRangeSize - Vtl2MmioAddressRangeSize.
+    vtl2_memory_mb: u32,
+    /// DMA hint in MiB.
+    dma_hint_mb: u32,
+}
+
+/// Lookup table for DMA hint calculation.
+const LookupTable: &'static [DmaLookupStruct] = &[
+    DmaLookupStruct {
+        vp_count: 2,
+        vtl2_memory_mb: 98,
+        dma_hint_mb: 4,
+    },
+    DmaLookupStruct {
+        vp_count: 4,
+        vtl2_memory_mb: 110,
+        dma_hint_mb: 6,
+    },
+    DmaLookupStruct {
+        vp_count: 8,
+        vtl2_memory_mb: 148,
+        dma_hint_mb: 10,
+    },
+    DmaLookupStruct {
+        vp_count: 16,
+        vtl2_memory_mb: 256,
+        dma_hint_mb: 18,
+    },
+    DmaLookupStruct {
+        vp_count: 32,
+        vtl2_memory_mb: 516,
+        dma_hint_mb: 36,
+    },
+    DmaLookupStruct {
+        vp_count: 48,
+        vtl2_memory_mb: 718,
+        dma_hint_mb: 52,
+    },
+    DmaLookupStruct {
+        vp_count: 64,
+        vtl2_memory_mb: 924,
+        dma_hint_mb: 68,
+    },
+    DmaLookupStruct {
+        vp_count: 96,
+        vtl2_memory_mb: 1340,
+        dma_hint_mb: 102,
+    },
+];
+
 pub fn vtl2_calculate_dma_hint(vp_count: usize, storage: &PartitionInfo) -> u64 {
+    let mut dma_hint = 0;
     log!("YSP: vp_count = {}", vp_count);
     let mem_size = storage
         .vtl2_ram
@@ -15,6 +69,23 @@ pub fn vtl2_calculate_dma_hint(vp_count: usize, storage: &PartitionInfo) -> u64 
         .filter(|m| m.mem_type == MemoryMapEntryType::VTL2_PROTECTABLE)
         .map(|e| e.range.len())
         .sum::<u64>();
-    log!("YSP: mem_size = {}", mem_size);
-    16384
+    // Sanity check for the calculated memory size.
+    if mem_size > 0 && mem_size < 0xFFFFFFFF00000 {
+        let mem_size_mb = (mem_size / 1048576) as u32;
+        log!("YSP: mem_size_mb = {}", mem_size_mb);
+
+        LookupTable
+            .iter()
+            .filter(|e| e.vp_count == vp_count as u32)
+            .for_each(|f| {
+                if f.vtl2_memory_mb == mem_size_mb {
+                    // Found exact match.
+                    dma_hint = f.dma_hint_mb as u64;
+                } else {
+                    // Try to extrapolate based on similar values.
+                }
+        });
+    }
+
+    dma_hint
 }

--- a/openhcl/openhcl_boot/src/host_params/dma_hint.rs
+++ b/openhcl/openhcl_boot/src/host_params/dma_hint.rs
@@ -3,6 +3,18 @@
 
 //! Calculate DMA hint value if not provided by host.
 
-pub fn vtl2_calculate_dma_hint() -> u64 {
+use crate::log;
+use igvm_defs::MemoryMapEntryType;
+use super::PartitionInfo;
+
+pub fn vtl2_calculate_dma_hint(vp_count: usize, storage: &PartitionInfo) -> u64 {
+    log!("YSP: vp_count = {}", vp_count);
+    let mem_size = storage
+        .vtl2_ram
+        .iter()
+        .filter(|m| m.mem_type == MemoryMapEntryType::VTL2_PROTECTABLE)
+        .map(|e| e.range.len())
+        .sum::<u64>();
+    log!("YSP: mem_size = {}", mem_size);
     16384
 }

--- a/openhcl/openhcl_boot/src/host_params/dma_hint.rs
+++ b/openhcl/openhcl_boot/src/host_params/dma_hint.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Calculate DMA hint value if not provided by host.
+
+pub fn vtl2_calculate_dma_hint() -> u64 {
+    16384
+}

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -461,23 +461,21 @@ impl PartitionInfo {
 
         // Decide if we will reserve memory for a VTL2 private pool. Parse this
         // from the final command line, or the host provided device tree value.
-        let mut vtl2_gpa_pool_size = {
+        let vtl2_gpa_pool_size = {
             let dt_page_count = parsed.device_dma_page_count;
             let cmdline_page_count =
                 crate::cmdline::parse_boot_command_line(storage.cmdline.as_str())
                     .enable_vtl2_gpa_pool;
 
-            max(dt_page_count.unwrap_or(0), cmdline_page_count.unwrap_or(0))
-        };
-        // If host did not provide the DMA hint value, re-evaluate
-        // it internally if conditions satisfy.
-        if vtl2_gpa_pool_size == 0 && parsed.nvme_keepalive {
-            let dma_hint = vtl2_calculate_dma_hint();
-            if dma_hint != 0 {
-                vtl2_gpa_pool_size = dma_hint;
-                //*parsed.device_dma_page_count = Some(dma_hint);
+            let hostval = max(dt_page_count.unwrap_or(0), cmdline_page_count.unwrap_or(0));
+            if hostval == 0 && parsed.nvme_keepalive {
+                // If host did not provide the DMA hint value, re-evaluate
+                // it internally if conditions satisfy.
+                vtl2_calculate_dma_hint()
+            } else {
+                hostval
             }
-        }
+        };
         if vtl2_gpa_pool_size != 0 {
             // Reserve the specified number of pages for the pool. Use the used
             // ranges to figure out which VTL2 memory is free to allocate from.

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -13,6 +13,7 @@ use crate::host_params::MAX_ENTROPY_SIZE;
 use crate::host_params::MAX_NUMA_NODES;
 use crate::host_params::MAX_PARTITION_RAM_RANGES;
 use crate::host_params::MAX_VTL2_USED_RANGES;
+use crate::host_params::dma_hint::vtl2_calculate_dma_hint;
 use crate::single_threaded::OffStackRef;
 use crate::single_threaded::off_stack;
 use arrayvec::ArrayVec;
@@ -337,6 +338,7 @@ impl PartitionInfo {
         let parsed = ParsedDeviceTree::parse(dt, &mut *dt_storage).map_err(DtError::DeviceTree)?;
 
         let command_line = params.command_line();
+        log!("YSP: device_dma_page_count {}", parsed.device_dma_page_count.unwrap_or(0));
 
         // Always write the measured command line.
         write!(
@@ -358,6 +360,7 @@ impl PartitionInfo {
 
         match parsed.memory_allocation_mode {
             MemoryAllocationMode::Host => {
+                log!("YSP: MemoryAllocationMode::Host");
                 storage.vtl2_ram.clear();
                 storage
                     .vtl2_ram
@@ -369,6 +372,7 @@ impl PartitionInfo {
                 memory_size,
                 mmio_size,
             } => {
+                log!("YSP: MemoryAllocationMode::Vtl2");
                 storage.vtl2_ram.clear();
                 storage
                     .vtl2_ram
@@ -457,7 +461,7 @@ impl PartitionInfo {
 
         // Decide if we will reserve memory for a VTL2 private pool. Parse this
         // from the final command line, or the host provided device tree value.
-        let vtl2_gpa_pool_size = {
+        let mut vtl2_gpa_pool_size = {
             let dt_page_count = parsed.device_dma_page_count;
             let cmdline_page_count =
                 crate::cmdline::parse_boot_command_line(storage.cmdline.as_str())
@@ -465,6 +469,15 @@ impl PartitionInfo {
 
             max(dt_page_count.unwrap_or(0), cmdline_page_count.unwrap_or(0))
         };
+        // If host did not provide the DMA hint value, re-evaluate
+        // it internally if conditions satisfy.
+        if vtl2_gpa_pool_size == 0 && parsed.nvme_keepalive {
+            let dma_hint = vtl2_calculate_dma_hint();
+            if dma_hint != 0 {
+                vtl2_gpa_pool_size = dma_hint;
+                //*parsed.device_dma_page_count = Some(dma_hint);
+            }
+        }
         if vtl2_gpa_pool_size != 0 {
             // Reserve the specified number of pages for the pool. Use the used
             // ranges to figure out which VTL2 memory is free to allocate from.
@@ -501,6 +514,7 @@ impl PartitionInfo {
 
             storage.vtl2_pool_memory = pool;
         }
+        log!("YSP: vtl2_gpa_pool_size {}", vtl2_gpa_pool_size);
 
         // If we can trust the host, use the provided alias map
         if can_trust_host {

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -468,10 +468,13 @@ impl PartitionInfo {
                     .enable_vtl2_gpa_pool;
 
             let hostval = max(dt_page_count.unwrap_or(0), cmdline_page_count.unwrap_or(0));
-            if hostval == 0 && parsed.nvme_keepalive {
+            if hostval == 0 &&
+                parsed.nvme_keepalive &&
+                params.isolation_type == IsolationType::None &&
+                storage.memory_allocation_mode == MemoryAllocationMode::Host {
                 // If host did not provide the DMA hint value, re-evaluate
                 // it internally if conditions satisfy.
-                vtl2_calculate_dma_hint()
+                vtl2_calculate_dma_hint(parsed.cpu_count(), storage)
             } else {
                 hostval
             }

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -15,6 +15,7 @@ use memory_range::MemoryRange;
 use memory_range::subtract_ranges;
 use shim_params::IsolationType;
 
+mod dma_hint;
 mod dt;
 mod mmio;
 pub mod shim_params;


### PR DESCRIPTION
To get some early feedback before creating a proper PR.

There is a comment that we should not be creating a big lookup table and always use heuristics instead. There is a problem with that: heuristics might significantly change depending on the device types assigned to this specific VM (MFND, ASAP, MANA) so if we really want heuristics then some host changes are needed:
1. Host (worker process) must check if at least one MFND device is assigned to VTL2 and then append "nvme" flag.
2. WP must check if at least one ASAP device is assigned to VTL2 and then append "asap" flag.
3. WP must check if at least one MANA device is assigned to VTL2 and then append "mana" flag.

Currently, in AH2025+, "nvme" flag is always present and the deistinction is made by non-zero dma-pages property. We may need to rework that to make "nvme" flag optional only if MFND devices are detected.