### PR TITLE
TDX: Cleanup some error handling around efer/cr0/cr4

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -139,7 +139,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
         match err {
             super::vp_state::Error::SetRegisters(_) => HvError::OperationFailed,
             super::vp_state::Error::GetRegisters(_) => HvError::OperationFailed,
-            super::vp_state::Error::SetEfer(_, _) => HvError::InvalidRegisterValue,
+            super::vp_state::Error::InvalidValue(_, _, _) => HvError::InvalidRegisterValue,
             super::vp_state::Error::Unimplemented(_) => HvError::InvalidParameter,
             super::vp_state::Error::InvalidApicBase(_) => HvError::InvalidRegisterValue,
         }

--- a/openhcl/virt_mshv_vtl/src/processor/vp_state.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/vp_state.rs
@@ -23,8 +23,8 @@ pub enum Error {
     SetRegisters(#[source] hcl::ioctl::Error),
     #[error("failed to get registers")]
     GetRegisters(#[source] hcl::ioctl::Error),
-    #[error("the value for setting efer {0} is invalid, {1}")]
-    SetEfer(u64, &'static str),
+    #[error("invalid value {0} for register {1}: {2}")]
+    InvalidValue(u64, &'static str, &'static str),
     #[error("'{0}' state is not implemented yet")]
     Unimplemented(&'static str),
     #[error("failed to set apic base MSR")]


### PR DESCRIPTION
Removes some "BUGBUG" messages and overall cleans up this code.