### PR TITLE
uefi: make default_boot_always_attempt configurable

### DIFF
--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -652,6 +652,7 @@ pub fn write_uefi_config(
         }
 
         flags.set_cxl_memory_enabled(platform_config.general.cxl_memory_enabled);
+        flags.set_default_boot_always_attempt(platform_config.general.default_boot_always_attempt);
 
         // Some settings do not depend on host config
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3020,6 +3020,7 @@ fn validate_isolated_configuration(dps: &DevicePlatformSettings) -> Result<(), a
         is_servicing_scenario,
         firmware_mode_is_pcat,
         psp_enabled,
+        default_boot_always_attempt,
 
         // Minimum level enforced by UEFI loader
         memory_protection_mode: _,
@@ -3080,6 +3081,9 @@ fn validate_isolated_configuration(dps: &DevicePlatformSettings) -> Result<(), a
     }
     if *psp_enabled {
         anyhow::bail!("PSP is not yet supported");
+    }
+    if *default_boot_always_attempt {
+        anyhow::bail!("default_boot_always_attempt is not supported");
     }
 
     Ok(())

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -2357,6 +2357,7 @@ impl LoadedVmInner {
                 enable_serial,
                 enable_vpci_boot,
                 uefi_console_mode,
+                default_boot_always_attempt,
             } => {
                 let madt = acpi_builder.build_madt();
                 let srat = acpi_builder.build_srat();
@@ -2371,6 +2372,7 @@ impl LoadedVmInner {
                     vpci_boot: enable_vpci_boot,
                     serial: enable_serial,
                     uefi_console_mode,
+                    default_boot_always_attempt,
                 };
                 let regs = super::vm_loaders::uefi::load_uefi(
                     firmware,

--- a/openvmm/hvlite_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/uefi.rs
@@ -36,6 +36,7 @@ pub struct UefiLoadSettings {
     pub vpci_boot: bool,
     pub serial: bool,
     pub uefi_console_mode: Option<UefiConsoleMode>,
+    pub default_boot_always_attempt: bool,
 }
 
 /// Loads the UEFI firmware.
@@ -111,7 +112,8 @@ pub fn load_uefi(
                 UefiConsoleMode::Com2 => config::ConsolePort::Com2,
                 UefiConsoleMode::None => config::ConsolePort::None,
             },
-        );
+        )
+        .with_default_boot_always_attempt(load_settings.default_boot_always_attempt);
 
     let mut cfg = config::Blob::new();
     cfg.add(&config::BiosInformation {

--- a/openvmm/hvlite_defs/src/config.rs
+++ b/openvmm/hvlite_defs/src/config.rs
@@ -104,6 +104,7 @@ pub enum LoadMode {
         enable_serial: bool,
         enable_vpci_boot: bool,
         uefi_console_mode: Option<UefiConsoleMode>,
+        default_boot_always_attempt: bool,
     },
     Pcat {
         firmware: RomFileLocation,

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -529,6 +529,10 @@ flags:
     /// set the uefi console mode
     #[clap(long)]
     pub uefi_console_mode: Option<UefiConsoleModeCli>,
+
+    /// Perform a default boot even if boot entries exist and fail
+    #[clap(long)]
+    pub default_boot_always_attempt: bool,
 }
 
 #[derive(Clone)]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -802,6 +802,7 @@ fn vm_config_from_command_line(
                 UefiConsoleModeCli::Com2 => UefiConsoleMode::Com2,
                 UefiConsoleModeCli::None => UefiConsoleMode::None,
             }),
+            default_boot_always_attempt: opt.default_boot_always_attempt,
         };
     } else {
         // Linux Direct
@@ -917,6 +918,7 @@ fn vm_config_from_command_line(
                                 UefiConsoleModeCli::Com2 => UefiConsoleMode::COM2,
                                 UefiConsoleModeCli::None => UefiConsoleMode::None,
                             },
+                            default_boot_always_attempt: opt.default_boot_always_attempt,
                         }
                     },
                     com1: with_vmbus_com1_serial,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -562,6 +562,7 @@ impl PetriVmConfigSetupCore<'_> {
                     enable_serial: true,
                     enable_vpci_boot: false,
                     uefi_console_mode: Some(hvlite_defs::config::UefiConsoleMode::Com1),
+                    default_boot_always_attempt: false,
                 }
             }
             (
@@ -815,6 +816,7 @@ impl PetriVmConfigSetupCore<'_> {
                 disable_frontpage: true,
                 enable_vpci_boot: false,
                 console_mode: get_resources::ged::UefiConsoleMode::COM1,
+                default_boot_always_attempt: false,
             },
             com1: true,
             com2: true,

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -93,6 +93,7 @@ pub enum PcatBootDevice {
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct HclDevicePlatformSettingsV2Static {
+    //UEFI flags
     pub legacy_memory_map: bool,
     pub pause_after_boot_failure: bool,
     pub pxe_ip_v6: bool,
@@ -101,12 +102,16 @@ pub struct HclDevicePlatformSettingsV2Static {
     pub disable_sha384_pcr: bool,
     pub media_present_enabled_by_default: bool,
     pub memory_protection_mode: u8,
+    #[serde(default)]
+    pub default_boot_always_attempt: bool,
 
+    // UEFI info
     pub vpci_boot_enabled: bool,
     #[serde(default)]
     #[serde(with = "serde_helpers::opt_guid_str")]
     pub vpci_instance_filter: Option<Guid>,
 
+    // PCAT info
     pub num_lock_enabled: bool,
     pub pcat_boot_device_order: Option<[PcatBootDevice; 4]>,
 

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -103,6 +103,8 @@ pub mod ged {
             disable_frontpage: bool,
             /// Where to send UEFI console output
             console_mode: UefiConsoleMode,
+            /// Perform a default boot even if boot entries exist and fail
+            default_boot_always_attempt: bool,
         },
         /// Boot from PC/AT BIOS with Hyper-V generation 1 devices.
         Pcat {

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -158,6 +158,8 @@ pub enum GuestFirmwareConfig {
         /// Where to send UEFI console output
         #[inspect(debug)]
         console_mode: UefiConsoleMode,
+        /// Perform a default boot even if boot entries exist and fail
+        default_boot_always_attempt: bool,
     },
     Pcat {
         #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsDebug)")]
@@ -1245,12 +1247,14 @@ impl<T: RingMem + Unpin> GedChannel<T> {
         let firmware_mode_is_pcat;
         let pcat_boot_device_order;
         let uefi_console_mode;
+        let default_boot_always_attempt;
         match state.config.firmware {
             GuestFirmwareConfig::Uefi {
                 enable_vpci_boot,
                 firmware_debug,
                 disable_frontpage: v_disable_frontpage,
                 console_mode,
+                default_boot_always_attempt: v_default_boot_always_attempt,
             } => {
                 vpci_boot_enabled = enable_vpci_boot;
                 enable_firmware_debugging = firmware_debug;
@@ -1258,6 +1262,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                 firmware_mode_is_pcat = false;
                 pcat_boot_device_order = None;
                 uefi_console_mode = Some(console_mode);
+                default_boot_always_attempt = v_default_boot_always_attempt;
             }
             GuestFirmwareConfig::Pcat { boot_order } => {
                 vpci_boot_enabled = false;
@@ -1266,6 +1271,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                 firmware_mode_is_pcat = true;
                 pcat_boot_device_order = Some(boot_order);
                 uefi_console_mode = None;
+                default_boot_always_attempt = false;
             }
         }
 
@@ -1312,6 +1318,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     disable_sha384_pcr: false,
                     media_present_enabled_by_default: false,
                     memory_protection_mode: 0,
+                    default_boot_always_attempt,
                     vpci_boot_enabled,
                     vpci_instance_filter: None,
                     num_lock_enabled: false,

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -96,6 +96,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                         firmware_debug,
                         disable_frontpage,
                         console_mode,
+                        default_boot_always_attempt,
                     } => crate::GuestFirmwareConfig::Uefi {
                         enable_vpci_boot,
                         firmware_debug,
@@ -106,6 +107,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                             UefiConsoleMode::COM2 => get_protocol::UefiConsoleMode::COM2,
                             UefiConsoleMode::None => get_protocol::UefiConsoleMode::NONE,
                         },
+                        default_boot_always_attempt,
                     },
                     GuestFirmwareConfig::Pcat { boot_order } => crate::GuestFirmwareConfig::Pcat {
                         boot_order: boot_order.map(|x| match x {

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -242,6 +242,7 @@ pub fn create_host_channel(
             enable_vpci_boot: false,
             disable_frontpage: false,
             console_mode: UefiConsoleMode::DEFAULT,
+            default_boot_always_attempt: false,
         },
         com1: true,
         com2: true,

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -101,6 +101,7 @@ pub mod platform_settings {
         pub media_present_enabled_by_default: bool,
         pub vpci_boot_enabled: bool,
         pub memory_protection_mode: MemoryProtectionMode,
+        pub default_boot_always_attempt: bool,
         pub num_lock_enabled: bool,
         #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsDebug)")]
         pub pcat_boot_device_order: [PcatBootDevice; 4],

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -315,6 +315,7 @@ impl GuestEmulationTransportClient {
                         ),
                     }
                 },
+                default_boot_always_attempt: json.v2.r#static.default_boot_always_attempt,
                 nvdimm_count: json.v2.dynamic.nvdimm_count,
                 psp_enabled: json.v2.dynamic.enable_psp,
                 vmbus_redirection_enabled: json.v2.r#static.vmbus_redirection_enabled,


### PR DESCRIPTION
Plumbs UEFI's DefaultBootAlwaysAttempt setting through DevicePlatformSettingsV2 on OpenHCL and to the OpenVMM CLI. This allows a VM with persistent VMGS to recover when the boot disk in replaced or modified in a way that would invalid the existing boot entries.