### PR TITLE
Change UefiLogger and PcatLogger to Arc instead of Box

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1951,7 +1951,7 @@ async fn new_underhill_vm(
 
             deps_hyperv_firmware_pcat = Some(dev::HyperVFirmwarePcat {
                 config,
-                logger: Box::new(UnderhillLogger {
+                logger: Arc::new(UnderhillLogger {
                     get: get_client.clone(),
                 }),
                 generation_id_recv: get_client
@@ -2025,7 +2025,7 @@ async fn new_underhill_vm(
 
             deps_hyperv_firmware_uefi = Some(dev::HyperVFirmwareUefi {
                 config,
-                logger: Box::new(UnderhillLogger {
+                logger: Arc::new(UnderhillLogger {
                     get: get_client.clone(),
                 }),
                 nvram_storage: Box::new(HclCompatNvram::new(

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1007,7 +1007,7 @@ impl InitializedVm {
 
         let generation_id_recv = cfg.generation_id_recv.unwrap_or_else(|| mesh::channel().1);
 
-        let logger = Box::new(emuplat::firmware::MeshLogger::new(
+        let logger = Arc::new(emuplat::firmware::MeshLogger::new(
             cfg.firmware_event_send.clone(),
         ));
 

--- a/vm/devices/firmware/firmware_pcat/src/lib.rs
+++ b/vm/devices/firmware/firmware_pcat/src/lib.rs
@@ -37,6 +37,7 @@ use inspect::Inspect;
 use inspect::InspectMut;
 use std::fmt::Debug;
 use std::ops::RangeInclusive;
+use std::sync::Arc;
 use std::task::Context;
 use std::time::Duration;
 use thiserror::Error;
@@ -144,7 +145,7 @@ pub enum PcatEvent {
 }
 
 /// Platform interface to emit PCAT events.
-pub trait PcatLogger: Send {
+pub trait PcatLogger: Send + Sync {
     /// Emit a log corresponding to the provided event.
     fn log_event(&self, event: PcatEvent);
 }
@@ -189,7 +190,7 @@ impl PcatBiosState {
 #[expect(missing_docs)] // self-explanatory fields
 pub struct PcatBiosRuntimeDeps<'a> {
     pub gm: GuestMemory,
-    pub logger: Box<dyn PcatLogger>,
+    pub logger: Arc<dyn PcatLogger>,
     pub generation_id_deps: generation_id::GenerationIdRuntimeDeps,
     pub vmtime: &'a VmTimeSource,
     /// The BIOS ROM.
@@ -211,7 +212,7 @@ pub struct PcatBiosDevice {
     vmtime_wait: VmTimeAccess,
     gm: GuestMemory,
     #[inspect(skip)]
-    logger: Box<dyn PcatLogger>,
+    logger: Arc<dyn PcatLogger>,
     #[inspect(skip)]
     _rom_mems: Vec<Box<dyn UnmapRom>>,
     pre_boot_pio: PreBootStubbedPio,

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -72,6 +72,7 @@ use platform::logger::UefiLogger;
 use platform::nvram::VsmConfig;
 use std::convert::TryInto;
 use std::ops::RangeInclusive;
+use std::sync::Arc;
 use std::task::Context;
 use thiserror::Error;
 use uefi_nvram_storage::InspectableNvramStorage;
@@ -129,7 +130,7 @@ pub struct UefiConfig {
 pub struct UefiRuntimeDeps<'a> {
     pub gm: GuestMemory,
     pub nvram_storage: Box<dyn InspectableNvramStorage>,
-    pub logger: Box<dyn UefiLogger>,
+    pub logger: Arc<dyn UefiLogger>,
     pub vmtime: &'a VmTimeSource,
     pub watchdog_platform: Box<dyn WatchdogPlatform>,
     pub generation_id_deps: generation_id::GenerationIdRuntimeDeps,

--- a/vm/devices/firmware/firmware_uefi/src/platform/logger.rs
+++ b/vm/devices/firmware/firmware_uefi/src/platform/logger.rs
@@ -18,6 +18,6 @@ pub struct BootInfo {
 }
 
 /// Interface to log UEFI events.
-pub trait UefiLogger: Send {
+pub trait UefiLogger: Send + Sync {
     fn log_event(&self, event: UefiEvent);
 }

--- a/vm/devices/firmware/firmware_uefi/src/service/event_log.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/event_log.rs
@@ -11,6 +11,7 @@ use guestmem::GuestMemory;
 use guestmem::GuestMemoryError;
 use inspect::Inspect;
 use std::fmt::Debug;
+use std::sync::Arc;
 use thiserror::Error;
 use zerocopy::FromBytes;
 
@@ -33,11 +34,11 @@ pub enum EventLogError {
 #[derive(Inspect)]
 pub struct EventLogServices {
     #[inspect(skip)]
-    logger: Box<dyn UefiLogger>,
+    logger: Arc<dyn UefiLogger>,
 }
 
 impl EventLogServices {
-    pub fn new(logger: Box<dyn UefiLogger>) -> EventLogServices {
+    pub fn new(logger: Arc<dyn UefiLogger>) -> EventLogServices {
         EventLogServices { logger }
     }
 

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -1297,7 +1297,7 @@ pub mod options {
             /// helper device
             pub config: firmware_pcat::config::PcatBiosConfig,
             /// Interface to log PCAT BIOS events
-            pub logger: Box<dyn firmware_pcat::PcatLogger>,
+            pub logger: Arc<dyn firmware_pcat::PcatLogger>,
             /// Channel to receive updated generation ID values
             pub generation_id_recv: mesh::Receiver<[u8; 16]>,
             /// Interface to map VMBIOS.bin into memory (or None, if that's
@@ -1314,7 +1314,7 @@ pub mod options {
             /// helper device
             pub config: firmware_uefi::UefiConfig,
             /// Interface to log UEFI BIOS events
-            pub logger: Box<dyn firmware_uefi::platform::logger::UefiLogger>,
+            pub logger: Arc<dyn firmware_uefi::platform::logger::UefiLogger>,
             /// Interface for storing/retrieving UEFI NVRAM variables
             pub nvram_storage: Box<dyn uefi_nvram_storage::InspectableNvramStorage>,
             /// Channel to receive updated generation ID values


### PR DESCRIPTION
This change makes the UefiLogger and PcatLogger as atomic reference counted types instead of Box. 

New services in the uefi subsystem can now use the UefiLogger that gets passed to the UEFI device instead of having to plumb through a new trait that has access to a get client.