### PR TITLE
Preserve TPM AK cert across boots for resiliency and Improve attestation error log and telemetry

### DIFF
--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -624,6 +624,15 @@ async fn get_derived_keys(
 
         let response = get_gsp_data(get, key_protector).await;
 
+        tracing::info!(
+            CVM_ALLOWED,
+            request_data_length_in_vmgs = key_protector.gsp[ingress_idx].gsp_length,
+            no_rpc_server = response.extended_status_flags.no_rpc_server(),
+            requires_rpc_server = response.extended_status_flags.requires_rpc_server(),
+            encrypted_gsp_length = response.encrypted_gsp.length,
+            "GSP response"
+        );
+
         let no_gsp =
             response.extended_status_flags.no_rpc_server() || response.encrypted_gsp.length == 0;
 
@@ -731,6 +740,14 @@ async fn get_derived_keys(
             }
         }
     }
+
+    tracing::info!(
+        CVM_ALLOWED,
+        kek = !no_kek,
+        gsp = !no_gsp,
+        gsp_by_id = !no_gsp_by_id,
+        "Encryption sources"
+    );
 
     // Check if sources of encryption are available
     if no_kek && no_gsp && no_gsp_by_id {

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -667,7 +667,6 @@ async fn get_derived_keys(
 
     // If sources of encryption used last are missing, attempt to unseal VMGS key with hardware key
     if (no_kek && found_dek) || (no_gsp && requires_gsp) || (no_gsp_by_id && requires_gsp_by_id) {
-        tracing::info!("Unseal VMGS key-encryption key with hardware key");
         // If possible, get ingressKey from hardware sealed data
         let (hardware_key_protector, hardware_derived_keys) = if let Some(tee_call) = tee_call {
             let hardware_key_protector = match vmgs::read_hardware_key_protector(vmgs).await {
@@ -722,7 +721,10 @@ async fn get_derived_keys(
             key_protector_settings.should_write_kp = false;
             key_protector_settings.use_hardware_unlock = true;
 
-            tracing::warn!(CVM_ALLOWED, "Using hardware based key derivation");
+            tracing::warn!(
+                CVM_ALLOWED,
+                "Using hardware-derived key to recover VMGS DEK"
+            );
 
             return Ok(DerivedKeyResult {
                 derived_keys: Some(derived_keys),

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -28,11 +28,11 @@ pub(crate) enum RequestVmgsEncryptionKeysError {
     GenerateTransferKey(#[source] openssl::error::ErrorStack),
     #[error("failed to get a TEE attestation report")]
     GetAttestationReport(#[source] tee_call::Error),
-    #[error("failed to create IgvmAttest WRAPPED_KEY request")]
+    #[error("failed to create an IgvmAttest WRAPPED_KEY request")]
     CreateIgvmAttestWrappedKeyRequest(#[source] igvm_attest::Error),
     #[error("failed to make an IgvmAttest WRAPPED_KEY GET request")]
     SendIgvmAttestWrappedKeyRequest(#[source] guest_emulation_transport::error::IgvmAttestError),
-    #[error("failed to parse IgvmAttest WRAPPED_KEY response")]
+    #[error("failed to parse the IgvmAttest WRAPPED_KEY response")]
     ParseIgvmAttestWrappedKeyResponse(#[source] igvm_attest::wrapped_key::WrappedKeyError),
     #[error(
         "failed to get a valid IgvmAttest WRAPPED_KEY response that is required because agent data from VMGS is empty"
@@ -40,18 +40,18 @@ pub(crate) enum RequestVmgsEncryptionKeysError {
     RequiredButInvalidIgvmAttestWrappedKeyResponse,
     #[error("wrapped key from WRAPPED_KEY response is empty")]
     EmptyWrappedKey,
-    #[error("key reference size {key_reference_size} from WRAPPED_KEY response was larger than expected {expected_size}")]
+    #[error("key reference size {key_reference_size} from the WRAPPED_KEY response was larger than expected {expected_size}")]
     InvalidKeyReferenceSize {
         key_reference_size: usize,
         expected_size: usize,
     },
     #[error("key reference from WRAPPED_KEY response is empty")]
     EmptyKeyReference,
-    #[error("failed to create IgvmAttest KEY_RELEASE request")]
+    #[error("failed to create an IgvmAttest KEY_RELEASE request")]
     CreateIgvmAttestKeyReleaseRequest(#[source] igvm_attest::Error),
     #[error("failed to make an IgvmAttest KEY_RELEASE GET request")]
     SendIgvmAttestKeyReleaseRequest(#[source] guest_emulation_transport::error::IgvmAttestError),
-    #[error("failed to parse IgvmAttest KEY_RELEASE response")]
+    #[error("failed to parse the IgvmAttest KEY_RELEASE response")]
     ParseIgvmAttestKeyReleaseResponse(#[source] igvm_attest::key_release::KeyReleaseError),
     #[error("PKCS11 RSA AES key unwrap failed")]
     Pkcs11RsaAesKeyUnwrap(#[source] crypto::Pkcs11RsaAesKeyUnwrapError),

--- a/openvmm/hvlite_entry/src/lib.rs
+++ b/openvmm/hvlite_entry/src/lib.rs
@@ -907,6 +907,7 @@ fn vm_config_from_command_line(
                         },
                     },
                     enable_battery: opt.battery,
+                    no_persistent_secrets: true,
                 }
                 .into_resource(),
             ),

--- a/petri/src/vm/construct.rs
+++ b/petri/src/vm/construct.rs
@@ -930,6 +930,7 @@ impl PetriVmConfigSetupCore<'_> {
             secure_boot_enabled: false,
             secure_boot_template: get_resources::ged::GuestSecureBootTemplateType::None,
             enable_battery: false,
+            no_persistent_secrets: true,
         };
 
         Ok((ged, guest_request_send))

--- a/petri/src/vm/modify.rs
+++ b/petri/src/vm/modify.rs
@@ -132,6 +132,21 @@ impl PetriVmConfig {
         self
     }
 
+    /// Enable TPM state persistence
+    pub fn with_tpm_state_persistence(mut self) -> Self {
+        if !self.firmware.is_openhcl() {
+            panic!("TPM state persistence is only supported for OpenHCL.")
+        };
+
+        let ged = self.ged.as_mut().expect("No GED to configure TPM");
+
+        // Disable no_persistent_secrets implies preserving TPM states
+        // across boots
+        ged.no_persistent_secrets = false;
+
+        self
+    }
+
     /// Add custom command line arguments to OpenHCL.
     pub fn with_openhcl_command_line(mut self, additional_cmdline: &str) -> Self {
         if !self.firmware.is_openhcl() {

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -82,6 +82,8 @@ pub mod ged {
         pub secure_boot_template: GuestSecureBootTemplateType,
         /// Enable battery.
         pub enable_battery: bool,
+        /// Suppress attestation and disable TPM state persistence.
+        pub no_persistent_secrets: bool,
     }
 
     /// The firmware and chipset configuration for the guest.

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -121,6 +121,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                     }
                 },
                 enable_battery: resource.enable_battery,
+                no_persistent_secrets: resource.no_persistent_secrets,
             },
             halt,
             resource.firmware_event_send,

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -243,6 +243,7 @@ pub fn create_host_channel(
         secure_boot_enabled: false,
         secure_boot_template: SecureBootTemplateType::SECURE_BOOT_DISABLED,
         enable_battery: false,
+        no_persistent_secrets: true,
     };
 
     let halt_reason = Arc::new(Mutex::new(None));

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -539,7 +539,7 @@ impl Tpm {
             self.tpm_engine_helper
                 .allocate_guest_attestation_nv_indices(
                     auth_value,
-                    self.refresh_tpm_seeds,
+                    !self.refresh_tpm_seeds, // Preserve AK cert if TPM seeds are not refreshed
                     matches!(self.ak_cert_type, TpmAkCertType::HwAttested(_)),
                 )
                 .map_err(TpmErrorKind::AllocateGuestAttestationNvIndices)?;
@@ -779,6 +779,8 @@ impl Tpm {
     /// This function can only be called when `ak_cert_type` is `Trusted` or `HwAttested`.
     fn create_ak_cert_request(&mut self) -> Result<Vec<u8>, TpmError> {
         let mut guest_attestation_input = [0u8; ATTESTATION_REPORT_DATA_SIZE];
+        // No need to check the result as long as it's Ok(..) because the output data will
+        // remain unchanged (all 0's) if the NV index is unallocated or uninitialized.
         self.tpm_engine_helper
             .read_from_nv_index(
                 TPM_NV_INDEX_GUEST_ATTESTATION_INPUT,

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -94,11 +94,6 @@ pub enum TpmHelperError {
     ExportRsaPublicFromPrimaryObject(#[source] TpmHelperUtilityError),
     #[error("nv index {0:#x} without owner read flag")]
     NoOwnerReadFlag(u32),
-<<<<<<< HEAD
-    #[error("nv index {0:#x} with invalid write permission")]
-    InvalidWritePermission(u32),
-    #[error("input size {input_size} to nv write exceeds the allocated size {allocated_size} of nv index {nv_index:#x}")]
-=======
     #[error(
         "nv index {nv_index:#x} without auth write ({auth_write}) or platform created ({platform_created}) flag"
     )]
@@ -110,7 +105,6 @@ pub enum TpmHelperError {
     #[error(
         "input size {input_size} to nv write exceeds the allocated size {allocated_size} of nv index {nv_index:#x}"
     )]
->>>>>>> 4206685041 (tpm: Preserve AK cert across boots for resiliency (#1120))
     NvWriteInputTooLarge {
         nv_index: u32,
         input_size: usize,

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -94,9 +94,23 @@ pub enum TpmHelperError {
     ExportRsaPublicFromPrimaryObject(#[source] TpmHelperUtilityError),
     #[error("nv index {0:#x} without owner read flag")]
     NoOwnerReadFlag(u32),
+<<<<<<< HEAD
     #[error("nv index {0:#x} with invalid write permission")]
     InvalidWritePermission(u32),
     #[error("input size {input_size} to nv write exceeds the allocated size {allocated_size} of nv index {nv_index:#x}")]
+=======
+    #[error(
+        "nv index {nv_index:#x} without auth write ({auth_write}) or platform created ({platform_created}) flag"
+    )]
+    InvalidPermission {
+        nv_index: u32,
+        auth_write: bool,
+        platform_created: bool,
+    },
+    #[error(
+        "input size {input_size} to nv write exceeds the allocated size {allocated_size} of nv index {nv_index:#x}"
+    )]
+>>>>>>> 4206685041 (tpm: Preserve AK cert across boots for resiliency (#1120))
     NvWriteInputTooLarge {
         nv_index: u32,
         input_size: usize,
@@ -150,6 +164,17 @@ enum EvictOrPersist {
         from: ReservedHandle,
         to: ReservedHandle,
     },
+}
+
+/// State of the NV index returned by `read_from_nv_index`
+#[derive(Debug)]
+pub enum NvIndexState {
+    /// The NV index is available to read
+    Available,
+    /// The NV index does not exist
+    Unallocated,
+    /// The NV index existed but uninitialized
+    Uninitialized,
 }
 
 impl TpmEngineHelper {
@@ -433,26 +458,26 @@ impl TpmEngineHelper {
     ///
     /// # Arguments
     /// * `auth_value`: The password used during the NV indices allocation.
-    /// * `force_create_ak_cert`: Whether to remove the existing AK and re-create one.
+    /// * `preserve_ak_cert`: Whether to preserve the previous AK cert into newly-create NV index.
     /// * `support_attestation_report`: Whether to allocate NV index for attestation report.
     ///
     pub fn allocate_guest_attestation_nv_indices(
         &mut self,
         auth_value: u64,
-        force_create_ak_cert: bool,
+        preserve_ak_cert: bool,
         support_attestation_report: bool,
     ) -> Result<(), TpmHelperError> {
-        let ak_cert_nv_index_present =
-            if let Some(res) = self.find_nv_index(TPM_NV_INDEX_AIK_CERT)? {
-                let nv_bits = TpmaNvBits::from(res.nv_public.nv_public.attributes.0.get());
-                let platform_created = nv_bits.nv_platformcreate();
+        let previous_ak_cert = {
+            let mut output = [0u8; MAX_NV_INDEX_SIZE as usize];
 
-                // Remove previous `TPM_NV_INDEX_AIK_CERT` allocation if `force_create_ak_cert`
-                // is true or the nv index is platform created. The latter condition means that
-                // the nv index is created by previous boot (not pre-provisioned). Clearing the
-                // nv index ensures that we will recreate the nv index with newly-created auth_value
-                // (which does not persist across boots) for each boot.
-                if force_create_ak_cert || platform_created {
+            // Attempt to remove previous `TPM_NV_INDEX_AIK_CERT` regardless it is pre-provisioned
+            // (non-platform-created) or platform-created. Doing so ensures that we always recreate
+            // the nv index with newly-created auth_value (which does not persist across boots) and
+            // consistent index size for each boot.
+            match self.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output)? {
+                NvIndexState::Available => {
+                    tracing::info!("AK cert nv index with available data");
+
                     self.nv_undefine_space(TPM20_RH_PLATFORM, TPM_NV_INDEX_AIK_CERT)
                         .map_err(|error| TpmHelperError::TpmCommandError {
                             command_debug_info: CommandDebugInfo {
@@ -463,35 +488,59 @@ impl TpmEngineHelper {
                             error,
                         })?;
 
-                    // NV index has been undefined
-                    false
-                } else {
-                    // NV index already exists
-                    true
+                    Some(output)
                 }
-            } else {
-                // NV index does not exist
-                false
-            };
+                NvIndexState::Uninitialized => {
+                    tracing::info!("AK cert nv index allocated but uninitialized");
 
-        // Only allocate the `TPM_NV_INDEX_AIK_CERT` if the nv index is not present
-        if !ak_cert_nv_index_present {
-            tracing::info!("Allocate nv index {:x} for AK cert", TPM_NV_INDEX_AIK_CERT);
+                    self.nv_undefine_space(TPM20_RH_PLATFORM, TPM_NV_INDEX_AIK_CERT)
+                        .map_err(|error| TpmHelperError::TpmCommandError {
+                            command_debug_info: CommandDebugInfo {
+                                command_code: CommandCodeEnum::NV_UndefineSpace,
+                                auth_handle: Some(TPM20_RH_PLATFORM),
+                                nv_index: Some(TPM_NV_INDEX_AIK_CERT),
+                            },
+                            error,
+                        })?;
 
-            self.nv_define_space(
-                TPM20_RH_PLATFORM,
-                auth_value,
-                TPM_NV_INDEX_AIK_CERT,
-                MAX_NV_INDEX_SIZE,
-            )
-            .map_err(|error| TpmHelperError::TpmCommandError {
-                command_debug_info: CommandDebugInfo {
-                    command_code: CommandCodeEnum::NV_DefineSpace,
-                    auth_handle: Some(TPM20_RH_PLATFORM),
-                    nv_index: Some(TPM_NV_INDEX_AIK_CERT),
-                },
-                error,
-            })?;
+                    None
+                }
+                NvIndexState::Unallocated => {
+                    tracing::info!("AK cert nv index not allocated yet");
+                    None
+                }
+            }
+        };
+
+        tracing::info!(
+            nv_index = format!("{:x}", TPM_NV_INDEX_AIK_CERT),
+            size = MAX_NV_INDEX_SIZE,
+            "Allocate nv index for AK cert"
+        );
+
+        self.nv_define_space(
+            TPM20_RH_PLATFORM,
+            auth_value,
+            TPM_NV_INDEX_AIK_CERT,
+            MAX_NV_INDEX_SIZE,
+        )
+        .map_err(|error| TpmHelperError::TpmCommandError {
+            command_debug_info: CommandDebugInfo {
+                command_code: CommandCodeEnum::NV_DefineSpace,
+                auth_handle: Some(TPM20_RH_PLATFORM),
+                nv_index: Some(TPM_NV_INDEX_AIK_CERT),
+            },
+            error,
+        })?;
+
+        if preserve_ak_cert {
+            if let Some(data) = previous_ak_cert {
+                // For resiliency, write the previous AK cert to the newly created nv index
+                // in case the following boot-time AK cert request fails.
+                tracing::info!("Preserve previous AK cert across boot");
+
+                self.write_to_nv_index(auth_value, TPM_NV_INDEX_AIK_CERT, &data)?;
+            }
         }
 
         // Allocate `TPM_NV_INDEX_ATTESTATION_REPORT` if `support_attestation_report` is true
@@ -513,8 +562,9 @@ impl TpmEngineHelper {
             }
 
             tracing::info!(
-                "Allocate nv index {:x} for attestation report",
-                TPM_NV_INDEX_ATTESTATION_REPORT
+                nv_index = format!("{:x}", TPM_NV_INDEX_ATTESTATION_REPORT),
+                size = MAX_ATTESTATION_INDEX_SIZE,
+                "Allocate nv index for attestation report",
             );
 
             self.nv_define_space(
@@ -577,12 +627,12 @@ impl TpmEngineHelper {
         }
     }
 
-    /// Write data to a NV index that can be either owner- or platform-created.
+    /// Write data to a NV index that is password-based and platform-created.
     /// If the data size is less than the size of the index, the function applies
     /// zero padding and ensure the entire NV space is filled.
     ///
     /// # Arguments
-    /// * `auth_value` - The authorization value for the platform-created index.
+    /// * `auth_value` - The authorization value for the password-based index.
     /// * `nv_index` - The target NV index.
     /// * `data` - The data to write.
     ///
@@ -622,39 +672,30 @@ impl TpmEngineHelper {
             std::cmp::Ordering::Equal => data.to_vec(),
         };
 
-        // Determine the authorization type based on the nv bits.
-        // ownerwrite and authwrite might both be set, let ownerwrite take precedence.
-        if nv_bits.nv_ownerwrite() {
-            // Owner write (the NV index was pre-provisioned)
-            self.nv_write(TPM20_RH_OWNER, None, nv_index, &data)
-                .map_err(|error| TpmHelperError::TpmCommandError {
-                    command_debug_info: CommandDebugInfo {
-                        command_code: CommandCodeEnum::NV_Write,
-                        auth_handle: Some(TPM20_RH_OWNER),
-                        nv_index: Some(nv_index),
-                    },
-                    error,
-                })?;
-        } else if nv_bits.nv_authwrite() {
-            // Password-based authorization (the NV index was created at boot-time)
-            self.nv_write(
-                ReservedHandle(nv_index.into()),
-                Some(auth_value),
+        // Always expect nv index to be password-based and platform-created given that
+        // the index is always created or re-created at boot-time.
+        if !nv_bits.nv_authwrite() || !nv_bits.nv_platformcreate() {
+            return Err(TpmHelperError::InvalidPermission {
                 nv_index,
-                &data,
-            )
-            .map_err(|error| TpmHelperError::TpmCommandError {
-                command_debug_info: CommandDebugInfo {
-                    command_code: CommandCodeEnum::NV_Write,
-                    auth_handle: Some(ReservedHandle(nv_index.into())),
-                    nv_index: Some(nv_index),
-                },
-                error,
-            })?;
-        } else {
-            // Unexpected scenario
-            Err(TpmHelperError::InvalidWritePermission(nv_index))?
-        };
+                auth_write: nv_bits.nv_authwrite(),
+                platform_created: nv_bits.nv_platformcreate(),
+            });
+        }
+
+        self.nv_write(
+            ReservedHandle(nv_index.into()),
+            Some(auth_value),
+            nv_index,
+            &data,
+        )
+        .map_err(|error| TpmHelperError::TpmCommandError {
+            command_debug_info: CommandDebugInfo {
+                command_code: CommandCodeEnum::NV_Write,
+                auth_handle: Some(ReservedHandle(nv_index.into())),
+                nv_index: Some(nv_index),
+            },
+            error,
+        })?;
 
         Ok(())
     }
@@ -665,16 +706,17 @@ impl TpmEngineHelper {
     /// * `nv_index` - The target NV index.
     /// * `data` - The data to write.
     ///
-    /// Returns Ok(true) if the index is present and read succeeds.
-    /// Returns Ok(false) if the index is not present.
+    /// Returns Ok(NvIndexState::Available) if the index is present and read succeeds.
+    /// Returns Ok(NvIndexState::Unallocated) if the index is not present.
+    /// Returns Ok(NvIndexState::Uninitialized) if the index is present but uninitialized.
     pub fn read_from_nv_index(
         &mut self,
         nv_index: u32,
         data: &mut [u8],
-    ) -> Result<bool, TpmHelperError> {
+    ) -> Result<NvIndexState, TpmHelperError> {
         let Some(res) = self.find_nv_index(nv_index)? else {
             // nv index may not exist before guest makes a request
-            return Ok(false);
+            return Ok(NvIndexState::Unallocated);
         };
 
         let nv_bits = TpmaNvBits::from(res.nv_public.nv_public.attributes.0.get());
@@ -683,17 +725,36 @@ impl TpmEngineHelper {
         }
 
         let nv_index_size = res.nv_public.nv_public.data_size.get();
-        self.nv_read(TPM20_RH_OWNER, nv_index, nv_index_size, data)
-            .map_err(|error| TpmHelperError::TpmCommandError {
-                command_debug_info: CommandDebugInfo {
-                    command_code: CommandCodeEnum::NV_Read,
-                    auth_handle: Some(TPM20_RH_OWNER),
-                    nv_index: Some(nv_index),
-                },
-                error,
-            })?;
-
-        Ok(true)
+        match self.nv_read(TPM20_RH_OWNER, nv_index, nv_index_size, data) {
+            Err(error) => {
+                if let TpmCommandError::TpmCommandFailed { response_code } = error {
+                    if response_code == ResponseCode::NvUninitialized as u32 {
+                        Ok(NvIndexState::Uninitialized)
+                    } else {
+                        // Unexpected response code
+                        Err(TpmHelperError::TpmCommandError {
+                            command_debug_info: CommandDebugInfo {
+                                command_code: CommandCodeEnum::NV_Read,
+                                auth_handle: Some(TPM20_RH_OWNER),
+                                nv_index: Some(nv_index),
+                            },
+                            error,
+                        })?
+                    }
+                } else {
+                    // Unexpected failure
+                    Err(TpmHelperError::TpmCommandError {
+                        command_debug_info: CommandDebugInfo {
+                            command_code: CommandCodeEnum::NV_Read,
+                            auth_handle: Some(TPM20_RH_OWNER),
+                            nv_index: Some(nv_index),
+                        },
+                        error,
+                    })?
+                }
+            }
+            Ok(_) => Ok(NvIndexState::Available),
+        }
     }
 
     /// Check if the object is present using ReadPublic command.
@@ -1824,191 +1885,276 @@ mod tests {
 
     #[test]
     fn test_allocate_guest_attestation_nv_indices() {
-        const AK_CERT_INPUT: [u8; 512] = [7u8; 512];
+        const AK_CERT_INPUT_512: [u8; 512] = [7u8; 512];
+        const AK_CERT_INPUT_1024: [u8; 1024] = [8u8; 1024];
         const ATTESTATION_REPORT_INPUT: [u8; 256] = [6u8; 256];
 
         let mut tpm_engine_helper = create_tpm_engine_helper();
         restart_tpm_engine(&mut tpm_engine_helper, false, true);
 
-        // Test allocation without initial states and with with force_create_ak = true, support_attestation_report = false
-        // Expect only the ak cert nv index to be created
+        // Test allocation without initial states and with with preserve_ak_cert = true, support_attestation_report = false
+        // Expect only the ak cert nv index to be created but with no data
+        // Do not write AK cert data to index after allocation.
         {
-            // Ensure both nv indices are not present
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_AIK_CERT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_none());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_none());
-
-            restart_tpm_engine(&mut tpm_engine_helper, true, true);
-
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
-            assert!(result.is_ok());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_AIK_CERT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_some());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_none());
-
-            // Expect read to fail given that no data has been written
-            let mut output = [0u8; MAX_NV_INDEX_SIZE as usize];
-            let result = tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output);
-            assert!(result.is_err());
-
-            // Write to ak cert nv
-            let result = tpm_engine_helper.write_to_nv_index(
-                AUTH_VALUE,
-                TPM_NV_INDEX_AIK_CERT,
-                &AK_CERT_INPUT,
-            );
-            assert!(result.is_ok());
-
-            // Read the data and ensure it is zero-padded
-            let result = tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output);
-            assert!(result.is_ok());
-            let input_with_padding = {
-                let mut input = AK_CERT_INPUT.to_vec();
-                input.resize(MAX_NV_INDEX_SIZE.into(), 0);
-                input
-            };
-            assert_eq!(&output, input_with_padding.as_slice());
-        }
-
-        // Test allocation after a restart with force_create_ak = false, support_attestation_report = false
-        // Expect the content of ak cert nv index to be re-created given that it's platform-created
-        {
-            restart_tpm_engine(&mut tpm_engine_helper, true, true);
-
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, false, false);
-            assert!(result.is_ok());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_AIK_CERT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_some());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_none());
-
-            // Expect read to fail given that the nv index is re-created and no data has been written
-            let mut output = [0u8; MAX_NV_INDEX_SIZE as usize];
-            let result = tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output);
-            assert!(result.is_err());
-
-            // Write to ak cert nv
-            let result = tpm_engine_helper.write_to_nv_index(
-                AUTH_VALUE,
-                TPM_NV_INDEX_AIK_CERT,
-                &AK_CERT_INPUT,
-            );
-            assert!(result.is_ok());
-
-            // Read the data and ensure it is zero-padded
-            let result = tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output);
-            assert!(result.is_ok());
-            let input_with_padding = {
-                let mut input = AK_CERT_INPUT.to_vec();
-                input.resize(MAX_NV_INDEX_SIZE.into(), 0);
-                input
-            };
-            assert_eq!(&output, input_with_padding.as_slice());
-        }
-
-        // Test allocation after a restart with force_create_ak = true, support_attestation_report = false
-        // Expect ak cert nv index to be re-created
-        {
-            restart_tpm_engine(&mut tpm_engine_helper, true, true);
-
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
-            assert!(result.is_ok());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_AIK_CERT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_some());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_none());
-
-            // Expect read to fail given that the nv index is re-created and no data has been written
-            let mut output = [0u8; MAX_NV_INDEX_SIZE as usize];
-            let result = tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output);
-            assert!(result.is_err());
-
-            // Write to ak cert nv
-            let result = tpm_engine_helper.write_to_nv_index(
-                AUTH_VALUE,
-                TPM_NV_INDEX_AIK_CERT,
-                &AK_CERT_INPUT,
-            );
-            assert!(result.is_ok());
-
-            // Read the data and ensure it is zero-padded
-            let result = tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output);
-            assert!(result.is_ok());
-            let input_with_padding = {
-                let mut input = AK_CERT_INPUT.to_vec();
-                input.resize(MAX_NV_INDEX_SIZE.into(), 0);
-                input
-            };
-            assert_eq!(&output, input_with_padding.as_slice());
-        }
-
-        // Test allocation after a restart force_create_ak = true, support_attestation_report = true
-        // Expect ak cert nv index to be re-created and attestation report nv index to be created
-        {
-            restart_tpm_engine(&mut tpm_engine_helper, true, true);
-
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, true);
-            assert!(result.is_ok());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_AIK_CERT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_some());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_some());
-
-            // Expect read to fail given that the nv index is re-created and no data has been written
             let mut ak_cert_output = [0u8; MAX_NV_INDEX_SIZE as usize];
+            let mut attestation_report_output = [0u8; MAX_ATTESTATION_INDEX_SIZE as usize];
+
+            // Ensure both nv indices are not present
             let result =
                 tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
-            assert!(result.is_err());
+            assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
+
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
+
+            restart_tpm_engine(&mut tpm_engine_helper, true, true);
+
+            let result =
+                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
+            assert!(result.is_ok());
+
+            // Ensure ak cert nv index becomes uninitialized
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Uninitialized));
+
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
+        }
+
+        // Test allocation without initial states and with with preserve_ak_cert = true, support_attestation_report = false
+        // Expect only the ak cert nv index to be created but with no data
+        // Write AK cert data to index after allocation.
+        {
+            let mut ak_cert_output = [0u8; MAX_NV_INDEX_SIZE as usize];
+            let mut attestation_report_output = [0u8; MAX_ATTESTATION_INDEX_SIZE as usize];
+
+            restart_tpm_engine(&mut tpm_engine_helper, true, true);
+
+            // Ensure only ak cert index is present but uninitialized after reboot
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Uninitialized));
+
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
+
+            let result =
+                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
+            assert!(result.is_ok());
+
+            // Ensure only ak cert index remains present but uninitialized
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Uninitialized));
+
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
 
             // Write to ak cert nv
             let result = tpm_engine_helper.write_to_nv_index(
                 AUTH_VALUE,
                 TPM_NV_INDEX_AIK_CERT,
-                &AK_CERT_INPUT,
+                &AK_CERT_INPUT_512,
             );
             assert!(result.is_ok());
 
             // Read the data and ensure it is zero-padded
             let result =
                 tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
-            assert!(result.is_ok());
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
             let input_with_padding = {
-                let mut input = AK_CERT_INPUT.to_vec();
+                let mut input = AK_CERT_INPUT_512.to_vec();
+                input.resize(MAX_NV_INDEX_SIZE.into(), 0);
+                input
+            };
+            assert_eq!(&ak_cert_output, input_with_padding.as_slice());
+        }
+
+        // Test allocation after a restart with preserve_ak_cert = true, support_attestation_report = false
+        // Expect the content of ak cert nv index to be re-created and the ak cert is preserved
+        {
+            let mut ak_cert_output = [0u8; MAX_NV_INDEX_SIZE as usize];
+            let mut attestation_report_output = [0u8; MAX_ATTESTATION_INDEX_SIZE as usize];
+
+            restart_tpm_engine(&mut tpm_engine_helper, true, true);
+
+            // Ensure only ak cert index remains available after reboot
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
+
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
+
+            let result =
+                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
+            assert!(result.is_ok());
+
+            // Ensure only ak cert index remains available
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
+
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
+
+            // Read the data and ensure it is zero-padded
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
+            let input_with_padding = {
+                let mut input = AK_CERT_INPUT_512.to_vec();
                 input.resize(MAX_NV_INDEX_SIZE.into(), 0);
                 input
             };
             assert_eq!(&ak_cert_output, input_with_padding.as_slice());
 
-            // Expect read to fail given that the nv index is created and no data has been written
-            let mut report_output = [0u8; MAX_ATTESTATION_INDEX_SIZE as usize];
-            let result = tpm_engine_helper
-                .read_from_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT, &mut report_output);
-            assert!(result.is_err());
+            // Write to ak cert nv
+            let result = tpm_engine_helper.write_to_nv_index(
+                AUTH_VALUE,
+                TPM_NV_INDEX_AIK_CERT,
+                &AK_CERT_INPUT_1024,
+            );
+            assert!(result.is_ok());
+
+            // Read the data and ensure it is zero-padded
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
+            let input_with_padding = {
+                let mut input = AK_CERT_INPUT_1024.to_vec();
+                input.resize(MAX_NV_INDEX_SIZE.into(), 0);
+                input
+            };
+            assert_eq!(&ak_cert_output, input_with_padding.as_slice());
+        }
+
+        // Test allocation after a restart with preserve_ak_cert = false, support_attestation_report = false
+        // Expect ak cert nv index to be re-created and the ak cert is not preserved
+        {
+            let mut ak_cert_output = [0u8; MAX_NV_INDEX_SIZE as usize];
+            let mut attestation_report_output = [0u8; MAX_ATTESTATION_INDEX_SIZE as usize];
+
+            restart_tpm_engine(&mut tpm_engine_helper, true, true);
+
+            // Ensure only ak cert index remains available after reboot
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
+
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
+
+            let result =
+                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, false, false);
+            assert!(result.is_ok());
+
+            // Ensure read to fail given that the ak cert index is re-created and data is not preserved
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Uninitialized));
+
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
+
+            // Write to ak cert nv
+            let result = tpm_engine_helper.write_to_nv_index(
+                AUTH_VALUE,
+                TPM_NV_INDEX_AIK_CERT,
+                &AK_CERT_INPUT_512,
+            );
+            assert!(result.is_ok());
+
+            // Read the data and ensure it is zero-padded
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
+            let input_with_padding = {
+                let mut input = AK_CERT_INPUT_512.to_vec();
+                input.resize(MAX_NV_INDEX_SIZE.into(), 0);
+                input
+            };
+            assert_eq!(&ak_cert_output, input_with_padding.as_slice());
+        }
+
+        // Test allocation after a restart preserve_ak_cert = false, support_attestation_report = true
+        // Expect ak cert nv index to be re-created and attestation report nv index to be created
+        {
+            let mut ak_cert_output = [0u8; MAX_NV_INDEX_SIZE as usize];
+            let mut attestation_report_output = [0u8; MAX_ATTESTATION_INDEX_SIZE as usize];
+
+            restart_tpm_engine(&mut tpm_engine_helper, true, true);
+
+            // Ensure the state of indices remains the same after reboot
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
+
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
+
+            let result =
+                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, false, true);
+            assert!(result.is_ok());
+
+            // Ensure read to fail given that the ak cert index is re-created and data is not preserved
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Uninitialized));
+
+            // Ensure read to fail given that the report index is created but uninitialized
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Uninitialized));
+
+            // Write to ak cert nv
+            let result = tpm_engine_helper.write_to_nv_index(
+                AUTH_VALUE,
+                TPM_NV_INDEX_AIK_CERT,
+                &AK_CERT_INPUT_512,
+            );
+            assert!(result.is_ok());
+
+            // Read the data and ensure it is zero-padded
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
+            let input_with_padding = {
+                let mut input = AK_CERT_INPUT_512.to_vec();
+                input.resize(MAX_NV_INDEX_SIZE.into(), 0);
+                input
+            };
+            assert_eq!(&ak_cert_output, input_with_padding.as_slice());
 
             // Write to attestation report nv
             let result = tpm_engine_helper.write_to_nv_index(
@@ -2019,45 +2165,53 @@ mod tests {
             assert!(result.is_ok());
 
             // Read the data and ensure it is zero-padded
-            let result = tpm_engine_helper
-                .read_from_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT, &mut report_output);
-            assert!(result.is_ok());
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
             let input_with_padding = {
                 let mut input = ATTESTATION_REPORT_INPUT.to_vec();
                 input.resize(MAX_ATTESTATION_INDEX_SIZE.into(), 0);
                 input
             };
-            assert_eq!(&report_output, input_with_padding.as_slice());
+            assert_eq!(&attestation_report_output, input_with_padding.as_slice());
         }
 
-        // Test allocation after a restart force_create_ak = true, support_attestation_report = true
+        // Test allocation after a restart preserve_ak_cert = false, support_attestation_report = true
         // Expect both ak cert and attestation report nv indices to be re-created
         {
+            let mut ak_cert_output = [0u8; MAX_NV_INDEX_SIZE as usize];
+            let mut attestation_report_output = [0u8; MAX_ATTESTATION_INDEX_SIZE as usize];
+
             restart_tpm_engine(&mut tpm_engine_helper, true, true);
 
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, true);
-            assert!(result.is_ok());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_AIK_CERT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_some());
-
-            let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT);
-            assert!(result.is_ok());
-            assert!(result.unwrap().is_some());
-
-            // Expect read to fail given that the nv index is re-created and no data has been written
-            let mut ak_cert_output = [0u8; MAX_NV_INDEX_SIZE as usize];
+            // Ensure the state of indices remains the same after reboot
             let result =
                 tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
-            assert!(result.is_err());
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
 
-            // Expect read to fail given that the nv index is re-created and no data has been written
-            let mut report_output = [0u8; MAX_ATTESTATION_INDEX_SIZE as usize];
-            let result = tpm_engine_helper
-                .read_from_nv_index(TPM_NV_INDEX_ATTESTATION_REPORT, &mut report_output);
-            assert!(result.is_err());
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Available));
+
+            let result =
+                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, false, true);
+            assert!(result.is_ok());
+
+            // Expect read to return Ok(false) given that the nv index is re-created and data is not preserved
+            let result =
+                tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+            assert!(matches!(result.unwrap(), NvIndexState::Uninitialized));
+
+            // Expect read to return Ok(false) given that the nv index is re-created and no data has been written
+            let result = tpm_engine_helper.read_from_nv_index(
+                TPM_NV_INDEX_ATTESTATION_REPORT,
+                &mut attestation_report_output,
+            );
+            assert!(matches!(result.unwrap(), NvIndexState::Uninitialized));
         }
     }
 
@@ -2294,18 +2448,23 @@ mod tests {
         let mut provisioned_ak_cert = [0u8; MAX_NV_INDEX_SIZE as usize];
         let result =
             tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut provisioned_ak_cert);
+        assert!(matches!(result.unwrap(), NvIndexState::Available));
+
+        // Ensure allocate_guest_attestation_nv_indices with preserve_ak_cert = true preserves the ak cert data
+        let result =
+            tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
         assert!(result.is_ok());
 
-        // Ensure allocate_guest_attestation_nv_indices with force_create_ak_cert = false does not re-create
-        // the nv index.
-        let result =
-            tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, false, false);
+        // Ensure nv index is re-created with new size
+        let result = tpm_engine_helper.nv_read_public(TPM_NV_INDEX_AIK_CERT);
         assert!(result.is_ok());
+        let nv_read_public_reply = result.unwrap();
+        assert!(nv_read_public_reply.nv_public.nv_public.data_size.get() == MAX_NV_INDEX_SIZE);
 
         let mut provisioned_ak_cert_after_call = [0u8; MAX_NV_INDEX_SIZE as usize];
         let result = tpm_engine_helper
             .read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut provisioned_ak_cert_after_call);
-        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), NvIndexState::Available));
         assert_eq!(provisioned_ak_cert_after_call, provisioned_ak_cert);
 
         // Test updating the provisioned nv index (with ownerwrite permission)
@@ -2318,7 +2477,7 @@ mod tests {
         let mut ak_cert_output = [0u8; MAX_NV_INDEX_SIZE as usize];
         let result =
             tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
-        assert!(result.is_ok());
+        assert!(matches!(result.unwrap(), NvIndexState::Available));
         let input_with_padding = {
             let mut input = ak_cert_input.to_vec();
             input.resize(MAX_NV_INDEX_SIZE.into(), 0);

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -46,7 +46,7 @@ async fn boot_alias_map(config: PetriVmConfig) -> anyhow::Result<()> {
 )]
 async fn boot_with_tpm(config: PetriVmConfig) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
-    let config = config.with_tpm();
+    let config = config.with_tpm().with_tpm_state_persistence();
 
     let (vm, agent) = match os_flavor {
         OsFlavor::Windows => {
@@ -56,14 +56,18 @@ async fn boot_with_tpm(config: PetriVmConfig) -> anyhow::Result<()> {
             config.run().await?
         }
         OsFlavor::Linux => {
+            // First boot - AK cert request will be served by GED
             let mut vm = config.run_with_lazy_pipette().await?;
             // Workaround to https://github.com/microsoft/openvmm/issues/379
             assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
+
+            // Second boot - Ak cert request will be bypassed by GED
             vm.reset().await?;
             let agent = vm.wait_for_agent().await?;
             vm.wait_for_successful_boot_event().await?;
 
             // Use the python script to read AK cert from TPM nv index
+            // and verify that the AK cert preserves across boot.
             // TODO: Replace the script with tpm2-tools
             const TEST_FILE: &str = "tpm.py";
             const TEST_CONTENT: &str = include_str!("../../test_data/tpm.py");


### PR DESCRIPTION
This PR ports #1120 and #1124 to 2411 release branch. Changes include the following

- Preserves the AK cert (if TPM seeds are not refreshed) across boots that increases the resiliency in case that the boot-time AK cert request succeeds in the first boot but fails in the subsequent boot.
- Ensure the AK cert index is always re-created with consistent properties (index size, platform-created, write permission per-boot auth value)
- Enable VMM tests to cover this code change
- Improve the error log when WrappedKey response is required but invalid and the telemetry on recovering VMGS KEK with hardware-based sealing key.
- Improve existing attestation logs
