### PR TITLE
tmk: run in CI as part of vmm tests

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -437,6 +437,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 10 'artifact_publish_from_aarch64-linux-vmgs_lib' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 10 'artifact_publish_from_aarch64-linux-vmgstool' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 10 'artifact_publish_from_aarch64-tmks' --update-from-stdin --is-raw-string
       shell: bash
     - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
@@ -516,7 +518,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -529,29 +531,29 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_cargo_build 6
         flowey e 10 flowey_lib_hvlite::build_openvmm 0
         flowey e 10 flowey_core::pipeline::artifact::publish 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 5
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_common::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 12
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 13
         flowey e 10 flowey_lib_hvlite::build_vmgstool 0
         flowey e 10 flowey_core::pipeline::artifact::publish 1
-        flowey e 10 flowey_lib_hvlite::init_cross_build 2
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 4
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 10 flowey_lib_common::run_cargo_build 5
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 11
         flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 10 flowey_core::pipeline::artifact::publish 2
-        flowey e 10 flowey_lib_hvlite::init_cross_build 4
+        flowey e 10 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -560,11 +562,11 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 10 flowey_core::pipeline::artifact::publish 3
-        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -577,7 +579,7 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_cargo_build 4
         flowey e 10 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 10 flowey_core::pipeline::artifact::publish 4
-        flowey e 10 flowey_lib_hvlite::init_cross_build 5
+        flowey e 10 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -588,6 +590,21 @@ jobs:
       run: |-
         flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 10 flowey_core::pipeline::artifact::publish 5
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build simple_tmk
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 10 flowey_lib_hvlite::build_tmks 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 10 flowey_lib_common::cache 3
@@ -622,6 +639,11 @@ jobs:
       with:
         name: aarch64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
+    - name: 🌼📦 Publish aarch64-tmks
+      uses: actions/upload-artifact@v4
+      with:
+        name: aarch64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
   job11:
     name: build artifacts [x64-linux]
     runs-on:
@@ -713,6 +735,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 11 'artifact_publish_from_x64-linux-vmgstool' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 11 'artifact_publish_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 11 'artifact_publish_from_x64-tmks' --update-from-stdin --is-raw-string
       shell: bash
     - name: add default cargo home to path
       run: flowey e 11 flowey_lib_common::install_rust 0
@@ -792,7 +816,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 11 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 2
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -805,25 +829,25 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 6
         flowey e 11 flowey_lib_hvlite::build_openvmm 0
         flowey e 11 flowey_core::pipeline::artifact::publish 0
-        flowey e 11 flowey_lib_hvlite::init_cross_build 4
+        flowey e 11 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 5
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 11 flowey_lib_common::run_cargo_build 6
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 12
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 13
         flowey e 11 flowey_lib_hvlite::build_vmgstool 0
         flowey e 11 flowey_core::pipeline::artifact::publish 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 11 flowey_lib_common::run_cargo_build 4
-        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 11 flowey_lib_common::run_cargo_build 5
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 11
         flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
@@ -831,7 +855,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 11 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 11 flowey_core::pipeline::artifact::publish 2
-        flowey e 11 flowey_lib_hvlite::init_cross_build 5
+        flowey e 11 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -840,11 +864,11 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 11 flowey_lib_hvlite::run_cargo_build 2
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 11 flowey_core::pipeline::artifact::publish 3
-        flowey e 11 flowey_lib_hvlite::init_cross_build 1
+        flowey e 11 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -857,7 +881,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 4
         flowey e 11 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 11 flowey_core::pipeline::artifact::publish 4
-        flowey e 11 flowey_lib_hvlite::init_cross_build 6
+        flowey e 11 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -868,6 +892,21 @@ jobs:
       run: |-
         flowey e 11 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 11 flowey_core::pipeline::artifact::publish 5
+        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build simple_tmk
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::build_tmks 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: create cargo-nextest cache dir
       run: flowey e 11 flowey_lib_common::download_cargo_nextest 0
@@ -896,13 +935,13 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 11 flowey_lib_common::download_cargo_nextest 1
-        flowey e 11 flowey_lib_hvlite::init_cross_build 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
         flowey e 11 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 11 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 11 flowey_core::pipeline::artifact::publish 6
+        flowey e 11 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 11 flowey_lib_common::cache 3
@@ -945,6 +984,11 @@ jobs:
       with:
         name: x64-linux-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
   job12:
     name: build openhcl [aarch64-linux]
     runs-on:
@@ -1024,6 +1068,8 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 12 'artifact_publish_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 12 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 12 'artifact_publish_from_aarch64-openhcl-baseline' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
@@ -1153,7 +1199,7 @@ jobs:
         flowey e 12 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -1162,7 +1208,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 6
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
@@ -1218,7 +1264,7 @@ jobs:
     - name: extract X64 sysroot.tar.gz
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 1
-        flowey e 12 flowey_lib_hvlite::init_cross_build 4
+        flowey e 12 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build openvmm_hcl
       run: |-
@@ -1227,7 +1273,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 8
         flowey e 12 flowey_lib_hvlite::build_openvmm_hcl 1
       shell: bash
@@ -1247,6 +1293,19 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_cargo_build 10
         flowey e 12 flowey_lib_hvlite::build_pipette 0
         flowey e 12 flowey_core::pipeline::artifact::publish 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 5
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 11
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 12
+        flowey e 12 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 12 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
@@ -1256,6 +1315,11 @@ jobs:
       with:
         name: aarch64-linux-musl-pipette
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v4
+      with:
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
     - name: 🌼📦 Publish aarch64-openhcl-baseline
       uses: actions/upload-artifact@v4
       with:
@@ -1350,6 +1414,8 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 13 'artifact_publish_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 13 'artifact_publish_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 13 'artifact_publish_from_x64-openhcl-baseline' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
@@ -1433,7 +1499,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 4
+        flowey e 13 flowey_lib_hvlite::init_cross_build 5
         flowey e 13 flowey_lib_hvlite::run_cargo_build 11
         flowey e 13 flowey_lib_hvlite::run_cargo_build 12
       shell: bash
@@ -1447,7 +1513,7 @@ jobs:
         flowey e 13 flowey_lib_hvlite::run_split_debug_info 8
         flowey e 13 flowey_lib_hvlite::run_cargo_build 14
         flowey e 13 flowey_lib_hvlite::build_sidecar 0
-        flowey e 13 flowey_lib_hvlite::init_cross_build 5
+        flowey e 13 flowey_lib_hvlite::init_cross_build 6
         flowey e 13 flowey_lib_hvlite::run_cargo_build 2
         flowey e 13 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
@@ -1667,6 +1733,19 @@ jobs:
         flowey e 13 flowey_lib_hvlite::run_cargo_build 10
         flowey e 13 flowey_lib_hvlite::build_pipette 0
         flowey e 13 flowey_core::pipeline::artifact::publish 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 4
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 6
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 15
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 10
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 16
+        flowey e 13 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 13 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 13 flowey_lib_common::cache 3
@@ -1676,6 +1755,11 @@ jobs:
       with:
         name: x64-linux-musl-pipette
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
     - name: 🌼📦 Publish x64-openhcl-baseline
       uses: actions/upload-artifact@v4
       with:
@@ -2779,7 +2863,10 @@ jobs:
     needs:
     - job13
     - job13
+    - job13
     - job11
+    - job11
+    - job8
     - job9
     - job9
     - job9
@@ -2788,7 +2875,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-10,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-10,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-tmk_vmm,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10" >> $GITHUB_PATH
       shell: bash
@@ -2809,9 +2896,12 @@ jobs:
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 18 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 18 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
     - name: create cargo-nextest cache dir
@@ -2906,10 +2996,13 @@ jobs:
       run: |-
         flowey.exe e 18 flowey_lib_hvlite::init_hyperv_tests 0
         flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 18 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 18 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -2955,7 +3048,7 @@ jobs:
       run: |-
         flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
@@ -3032,7 +3125,10 @@ jobs:
     needs:
     - job13
     - job13
+    - job13
     - job11
+    - job11
+    - job8
     - job9
     - job9
     - job9
@@ -3041,7 +3137,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-10,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-10,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-tmk_vmm,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10" >> $GITHUB_PATH
       shell: bash
@@ -3062,9 +3158,12 @@ jobs:
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
     - name: create cargo-nextest cache dir
@@ -3159,10 +3258,13 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::init_hyperv_tests 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3208,7 +3310,7 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
@@ -3470,7 +3572,10 @@ jobs:
     needs:
     - job13
     - job13
+    - job13
     - job11
+    - job11
+    - job8
     - job9
     - job9
     - job9
@@ -3479,7 +3584,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-10,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-10,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-tmk_vmm,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10" >> $GITHUB_PATH
       shell: bash
@@ -3500,9 +3605,12 @@ jobs:
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 20 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
     - name: create cargo-nextest cache dir
@@ -3597,10 +3705,13 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::init_hyperv_tests 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3646,7 +3757,7 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
@@ -3720,6 +3831,8 @@ jobs:
       id-token: write
     needs:
     - job13
+    - job13
+    - job11
     - job11
     - job11
     - job9
@@ -3729,7 +3842,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-openvmm,x64-linux-vmm-tests-archive,x64-windows-pipette}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-6,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-6" >> $GITHUB_PATH
       shell: bash
@@ -3750,8 +3863,10 @@ jobs:
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
       shell: bash
     - name: ensure /dev/kvm is accessible
@@ -3852,10 +3967,12 @@ jobs:
       run: |-
         flowey e 21 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
         flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 6
         flowey e 21 flowey_core::pipeline::artifact::resolve 1
         flowey e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey e 21 flowey_core::pipeline::artifact::resolve 5
       shell: bash
     - name: creating new test content dir
       run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3898,7 +4015,7 @@ jobs:
       run: |-
         flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 4
         flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: run 'vmm_tests' nextest tests
@@ -3974,7 +4091,10 @@ jobs:
     needs:
     - job12
     - job12
+    - job12
     - job10
+    - job10
+    - job6
     - job7
     - job7
     - job7
@@ -4023,7 +4143,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-openhcl-igvm,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-vmm-tests-archive}'
+        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -4053,9 +4173,12 @@ jobs:
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 22 'artifact_use_from_aarch64-tmks' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
     - name: create cargo-nextest cache dir
@@ -4150,10 +4273,13 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_hyperv_tests 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4199,7 +4325,7 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
@@ -4847,6 +4973,8 @@ jobs:
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 6 'artifact_publish_from_aarch64-windows-igvmfilegen' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-ohcldiag-dev"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 6 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 6 'artifact_publish_from_aarch64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 6 'artifact_publish_from_aarch64-windows-vmgs_lib' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
@@ -4919,7 +5047,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 6 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -4927,7 +5055,7 @@ jobs:
         flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 6 flowey_lib_hvlite::build_igvmfilegen 0
         flowey.exe e 6 flowey_core::pipeline::artifact::publish 3
-        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 4
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -4935,15 +5063,23 @@ jobs:
         flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 2
         flowey.exe e 6 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey.exe e 6 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 6 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 6 flowey_core::pipeline::artifact::publish 5
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey.exe e 6 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 5
         flowey.exe e 6 flowey_lib_hvlite::build_vmgstool 0
         flowey.exe e 6 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build hypestv
       run: |-
@@ -4951,12 +5087,12 @@ jobs:
         flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 0
         flowey.exe e 6 flowey_lib_hvlite::build_hypestv 0
         flowey.exe e 6 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 6 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey.exe e 6 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 6 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 6 flowey_lib_hvlite::run_cargo_build 4
         flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey.exe e 6 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey.exe e 6 flowey_core::pipeline::artifact::publish 2
@@ -4979,6 +5115,11 @@ jobs:
       with:
         name: aarch64-windows-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-ohcldiag-dev/
+    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
+      uses: actions/upload-artifact@v4
+      with:
+        name: aarch64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
     - name: 🌼📦 Publish aarch64-windows-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
@@ -5297,6 +5438,8 @@ jobs:
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 8 'artifact_publish_from_x64-windows-igvmfilegen' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 8 'artifact_publish_from_x64-windows-ohcldiag-dev' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 8 'artifact_publish_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 8 'artifact_publish_from_x64-windows-vmgs_lib' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
@@ -5369,51 +5512,59 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 8 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey.exe e 8 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 8 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 5
         flowey.exe e 8 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 8 flowey_core::pipeline::artifact::publish 3
-        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 8 flowey_core::pipeline::artifact::publish 5
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build hypestv
       run: |-
         flowey.exe e 8 flowey_lib_common::run_cargo_build 0
         flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 0
         flowey.exe e 8 flowey_lib_hvlite::build_hypestv 0
-        flowey.exe e 8 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 8 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey.exe e 8 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 8 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 4
         flowey.exe e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
       run: |-
         flowey.exe e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey.exe e 8 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey.exe e 8 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 8 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
         flowey.exe e 8 flowey_lib_common::run_cargo_build 1
         flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 8 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey.exe e 8 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 4
+        flowey.exe e 8 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
         flowey.exe e 8 flowey_lib_common::run_cargo_build 2
         flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 2
         flowey.exe e 8 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey.exe e 8 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 8 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 8 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey.exe e 8 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 8 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 8 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 8 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 8 flowey_lib_common::cache 3
@@ -5433,6 +5584,11 @@ jobs:
       with:
         name: x64-windows-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+    - name: 🌼📦 Publish x64-windows-tmk_vmm
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-tmk_vmm/
     - name: 🌼📦 Publish x64-windows-vmgs_lib
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -447,6 +447,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 10 'artifact_publish_from_x64-linux-vmgstool' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 10 'artifact_publish_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 10 'artifact_publish_from_x64-tmks' --update-from-stdin --is-raw-string
       shell: bash
     - name: add default cargo home to path
       run: flowey e 10 flowey_lib_common::install_rust 0
@@ -526,7 +528,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 10 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 2
+        flowey e 10 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -539,25 +541,25 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_cargo_build 6
         flowey e 10 flowey_lib_hvlite::build_openvmm 0
         flowey e 10 flowey_core::pipeline::artifact::publish 0
-        flowey e 10 flowey_lib_hvlite::init_cross_build 4
+        flowey e 10 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 5
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 10 flowey_lib_common::run_cargo_build 6
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 12
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 13
         flowey e 10 flowey_lib_hvlite::build_vmgstool 0
         flowey e 10 flowey_core::pipeline::artifact::publish 1
-        flowey e 10 flowey_lib_hvlite::init_cross_build 3
+        flowey e 10 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 10 flowey_lib_common::run_cargo_build 4
-        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 10 flowey_lib_common::run_cargo_build 5
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 11
         flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
@@ -565,7 +567,7 @@ jobs:
         flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 10 flowey_lib_hvlite::build_and_test_vmgs_lib 2
         flowey e 10 flowey_core::pipeline::artifact::publish 2
-        flowey e 10 flowey_lib_hvlite::init_cross_build 5
+        flowey e 10 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -574,11 +576,11 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 10 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 10 flowey_lib_hvlite::run_cargo_build 2
         flowey e 10 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 10 flowey_core::pipeline::artifact::publish 3
-        flowey e 10 flowey_lib_hvlite::init_cross_build 1
+        flowey e 10 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -591,7 +593,7 @@ jobs:
         flowey e 10 flowey_lib_hvlite::run_cargo_build 4
         flowey e 10 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 10 flowey_core::pipeline::artifact::publish 4
-        flowey e 10 flowey_lib_hvlite::init_cross_build 6
+        flowey e 10 flowey_lib_hvlite::init_cross_build 7
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -602,6 +604,21 @@ jobs:
       run: |-
         flowey e 10 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 10 flowey_core::pipeline::artifact::publish 5
+        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build simple_tmk
+      run: |-
+        flowey e 10 flowey_lib_common::run_cargo_build 4
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 10 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 10 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 10 flowey_lib_hvlite::build_tmks 0
+        flowey e 10 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: create cargo-nextest cache dir
       run: flowey e 10 flowey_lib_common::download_cargo_nextest 0
@@ -630,13 +647,13 @@ jobs:
     - name: installing cargo-nextest
       run: |-
         flowey e 10 flowey_lib_common::download_cargo_nextest 1
-        flowey e 10 flowey_lib_hvlite::init_cross_build 0
+        flowey e 10 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: build + archive 'vmm_tests' nextests
       run: |-
         flowey e 10 flowey_lib_common::run_cargo_nextest_archive 0
         flowey e 10 flowey_lib_hvlite::build_nextest_vmm_tests 0
-        flowey e 10 flowey_core::pipeline::artifact::publish 6
+        flowey e 10 flowey_core::pipeline::artifact::publish 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 10 flowey_lib_common::cache 3
@@ -679,6 +696,11 @@ jobs:
       with:
         name: x64-linux-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+    - name: 🌼📦 Publish x64-tmks
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
   job11:
     name: build openhcl [aarch64-linux]
     runs-on:
@@ -758,6 +780,8 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 11 'artifact_publish_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 11 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 11 'artifact_publish_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
@@ -885,7 +909,7 @@ jobs:
         flowey e 11 flowey_lib_hvlite::build_openhcl_initrd 1
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 20
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 21
-        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+        flowey e 11 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -894,7 +918,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 5
         flowey e 11 flowey_lib_hvlite::run_cargo_build 1
         flowey e 11 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 11 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 22
@@ -960,6 +984,19 @@ jobs:
         flowey e 11 flowey_lib_hvlite::run_cargo_build 8
         flowey e 11 flowey_lib_hvlite::build_pipette 0
         flowey e 11 flowey_core::pipeline::artifact::publish 0
+        flowey e 11 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 11 flowey_lib_common::run_cargo_build 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 11 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 11 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 11 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 11 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 11 flowey_lib_common::cache 3
@@ -969,6 +1006,11 @@ jobs:
       with:
         name: aarch64-linux-musl-pipette
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+    - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v4
+      with:
+        name: aarch64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
     - name: 🌼📦 Publish aarch64-openhcl-igvm
       uses: actions/upload-artifact@v4
       with:
@@ -1058,6 +1100,8 @@ jobs:
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
         echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 12 'artifact_publish_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 12 'artifact_publish_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
         echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 12 'artifact_publish_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
@@ -1139,7 +1183,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 12 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+        flowey e 12 flowey_lib_hvlite::init_cross_build 4
         flowey e 12 flowey_lib_hvlite::run_cargo_build 9
         flowey e 12 flowey_lib_hvlite::run_cargo_build 10
       shell: bash
@@ -1153,7 +1197,7 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_split_debug_info 7
         flowey e 12 flowey_lib_hvlite::run_cargo_build 12
         flowey e 12 flowey_lib_hvlite::build_sidecar 0
-        flowey e 12 flowey_lib_hvlite::init_cross_build 4
+        flowey e 12 flowey_lib_hvlite::init_cross_build 5
         flowey e 12 flowey_lib_hvlite::run_cargo_build 2
         flowey e 12 flowey_lib_hvlite::run_cargo_build 3
       shell: bash
@@ -1209,7 +1253,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 12 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 9
         flowey e 12 flowey_lib_hvlite::run_cargo_build 1
         flowey e 12 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 12 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 34
@@ -1357,6 +1401,19 @@ jobs:
         flowey e 12 flowey_lib_hvlite::run_cargo_build 8
         flowey e 12 flowey_lib_hvlite::build_pipette 0
         flowey e 12 flowey_core::pipeline::artifact::publish 0
+        flowey e 12 flowey_lib_hvlite::init_cross_build 3
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey e 12 flowey_lib_common::run_cargo_build 5
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 13
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 12 flowey_lib_hvlite::run_split_debug_info 8
+        flowey e 12 flowey_lib_hvlite::run_cargo_build 14
+        flowey e 12 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey e 12 flowey_core::pipeline::artifact::publish 1
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 12 flowey_lib_common::cache 3
@@ -1366,6 +1423,11 @@ jobs:
       with:
         name: x64-linux-musl-pipette
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+    - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-linux-musl-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
     - name: 🌼📦 Publish x64-openhcl-igvm
       uses: actions/upload-artifact@v4
       with:
@@ -2695,7 +2757,10 @@ jobs:
     needs:
     - job12
     - job12
+    - job12
     - job10
+    - job10
+    - job7
     - job8
     - job8
     - job8
@@ -2704,7 +2769,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-tmk_vmm,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11" >> $GITHUB_PATH
       shell: bash
@@ -2725,9 +2790,12 @@ jobs:
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 18 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 18 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
     - name: create cargo-nextest cache dir
@@ -2822,10 +2890,13 @@ jobs:
       run: |-
         flowey.exe e 18 flowey_lib_hvlite::init_hyperv_tests 0
         flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 18 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 18 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -2871,7 +2942,7 @@ jobs:
       run: |-
         flowey.exe e 18 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 18 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
@@ -2948,7 +3019,10 @@ jobs:
     needs:
     - job12
     - job12
+    - job12
     - job10
+    - job10
+    - job7
     - job8
     - job8
     - job8
@@ -2957,7 +3031,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-tmk_vmm,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11" >> $GITHUB_PATH
       shell: bash
@@ -2978,9 +3052,12 @@ jobs:
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 19 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 19 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
     - name: create cargo-nextest cache dir
@@ -3075,10 +3152,13 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::init_hyperv_tests 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3124,7 +3204,7 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 19 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
@@ -3378,7 +3458,10 @@ jobs:
     needs:
     - job12
     - job12
+    - job12
     - job10
+    - job10
+    - job7
     - job8
     - job8
     - job8
@@ -3387,7 +3470,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-openhcl-igvm,x64-windows-openvmm,x64-windows-pipette,x64-windows-vmm-tests-archive}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-windows-uid-11,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-openhcl-igvm,x64-tmks,x64-windows-openvmm,x64-windows-pipette,x64-windows-tmk_vmm,x64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11" >> $GITHUB_PATH
       shell: bash
@@ -3408,9 +3491,12 @@ jobs:
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 20 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 20 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 20 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 20 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 20 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 20 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
     - name: create cargo-nextest cache dir
@@ -3505,10 +3591,13 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::init_hyperv_tests 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3554,7 +3643,7 @@ jobs:
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 20 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
@@ -3628,6 +3717,8 @@ jobs:
       id-token: write
     needs:
     - job12
+    - job12
+    - job10
     - job10
     - job10
     - job8
@@ -3637,7 +3728,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-7,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-openvmm,x64-linux-vmm-tests-archive,x64-windows-pipette}'
+        pattern: '{_internal-flowey-bootstrap-x86_64-linux-uid-7,x64-guest_test_uefi,x64-linux-musl-pipette,x64-linux-musl-tmk_vmm,x64-linux-openvmm,x64-linux-vmm-tests-archive,x64-tmks,x64-windows-pipette}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-7" >> $GITHUB_PATH
       shell: bash
@@ -3658,8 +3749,10 @@ jobs:
         EOF
         echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 21 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 21 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 21 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 21 'artifact_use_from_x64-linux-openvmm' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 21 'artifact_use_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 21 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 21 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
       shell: bash
     - name: ensure /dev/kvm is accessible
@@ -3760,10 +3853,12 @@ jobs:
       run: |-
         flowey e 21 flowey_lib_hvlite::init_openvmm_magicpath_uefi_mu_msvm 0
         flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 21 flowey_core::pipeline::artifact::resolve 2
-        flowey e 21 flowey_core::pipeline::artifact::resolve 4
+        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 6
         flowey e 21 flowey_core::pipeline::artifact::resolve 1
         flowey e 21 flowey_core::pipeline::artifact::resolve 0
+        flowey e 21 flowey_core::pipeline::artifact::resolve 2
+        flowey e 21 flowey_core::pipeline::artifact::resolve 5
       shell: bash
     - name: creating new test content dir
       run: flowey e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -3806,7 +3901,7 @@ jobs:
       run: |-
         flowey e 21 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 21 flowey_core::pipeline::artifact::resolve 3
+        flowey e 21 flowey_core::pipeline::artifact::resolve 4
         flowey e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
       shell: bash
     - name: run 'vmm_tests' nextest tests
@@ -3882,7 +3977,10 @@ jobs:
     needs:
     - job11
     - job11
+    - job11
     - job9
+    - job9
+    - job5
     - job6
     - job6
     - job6
@@ -3931,7 +4029,7 @@ jobs:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@v4
       with:
-        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-openhcl-igvm,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-vmm-tests-archive}'
+        pattern: '{aarch64-guest_test_uefi,aarch64-linux-musl-pipette,aarch64-linux-musl-tmk_vmm,aarch64-openhcl-igvm,aarch64-tmks,aarch64-windows-openvmm,aarch64-windows-pipette,aarch64-windows-tmk_vmm,aarch64-windows-vmm-tests-archive}'
         path: ${{ runner.temp }}/used_artifacts/
     - run: echo "${{ runner.temp }}/bootstrapped-flowey" >> $GITHUB_PATH
       shell: bash
@@ -3961,9 +4059,12 @@ jobs:
         EOF
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 22 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 22 'artifact_use_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 22 'artifact_use_from_aarch64-tmks' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 22 'artifact_use_from_aarch64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 22 'artifact_use_from_aarch64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
       shell: bash
     - name: create cargo-nextest cache dir
@@ -4058,10 +4159,13 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_hyperv_tests 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 1
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 0
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 6
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 2
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 3
       shell: bash
     - name: creating new test content dir
       run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 0
@@ -4107,7 +4211,7 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
+        flowey.exe e 22 flowey_core::pipeline::artifact::resolve 7
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
@@ -4754,6 +4858,8 @@ jobs:
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-igvmfilegen' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-ohcldiag-dev"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
         echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 5 'artifact_publish_from_aarch64-windows-vmgs_lib' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
@@ -4826,7 +4932,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 5 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 4
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -4834,15 +4940,23 @@ jobs:
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 2
         flowey.exe e 5 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 5 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 5 flowey_core::pipeline::artifact::publish 5
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 5
         flowey.exe e 5 flowey_lib_hvlite::build_vmgstool 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build hypestv
       run: |-
@@ -4850,16 +4964,16 @@ jobs:
         flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 0
         flowey.exe e 5 flowey_lib_hvlite::build_hypestv 0
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey.exe e 5 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 5 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 5 flowey_lib_hvlite::run_cargo_build 4
         flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey.exe e 5 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey.exe e 5 flowey_core::pipeline::artifact::publish 2
-        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 5 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -4886,6 +5000,11 @@ jobs:
       with:
         name: aarch64-windows-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-ohcldiag-dev/
+    - name: 🌼📦 Publish aarch64-windows-tmk_vmm
+      uses: actions/upload-artifact@v4
+      with:
+        name: aarch64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
     - name: 🌼📦 Publish aarch64-windows-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
@@ -5204,6 +5323,8 @@ jobs:
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 7 'artifact_publish_from_x64-windows-igvmfilegen' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 7 'artifact_publish_from_x64-windows-ohcldiag-dev' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tmk_vmm"
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 7 'artifact_publish_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
         echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 7 'artifact_publish_from_x64-windows-vmgs_lib' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
@@ -5276,51 +5397,59 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey.exe e 7 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 1
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey.exe e 7 flowey_lib_common::run_cargo_build 4
-        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 4
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 5
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 5
         flowey.exe e 7 flowey_lib_hvlite::build_vmgstool 0
-        flowey.exe e 7 flowey_core::pipeline::artifact::publish 3
-        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 2
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 5
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build hypestv
       run: |-
         flowey.exe e 7 flowey_lib_common::run_cargo_build 0
         flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 0
         flowey.exe e 7 flowey_lib_hvlite::build_hypestv 0
-        flowey.exe e 7 flowey_core::pipeline::artifact::publish 4
-        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 0
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey.exe e 7 flowey_lib_common::run_cargo_build 3
-        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 4
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 4
         flowey.exe e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 0
       shell: bash
     - name: test vmgs_lib
       run: |-
         flowey.exe e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey.exe e 7 flowey_lib_hvlite::build_and_test_vmgs_lib 2
-        flowey.exe e 7 flowey_core::pipeline::artifact::publish 0
-        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 3
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 1
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
         flowey.exe e 7 flowey_lib_common::run_cargo_build 1
         flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 1
         flowey.exe e 7 flowey_lib_hvlite::build_igvmfilegen 0
-        flowey.exe e 7 flowey_core::pipeline::artifact::publish 1
-        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 4
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
         flowey.exe e 7 flowey_lib_common::run_cargo_build 2
         flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 2
         flowey.exe e 7 flowey_lib_hvlite::build_ohcldiag_dev 0
-        flowey.exe e 7 flowey_core::pipeline::artifact::publish 2
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 3
+        flowey.exe e 7 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build tmk_vmm
+      run: |-
+        flowey.exe e 7 flowey_lib_common::run_cargo_build 3
+        flowey.exe e 7 flowey_lib_hvlite::run_cargo_build 3
+        flowey.exe e 7 flowey_lib_hvlite::build_tmk_vmm 0
+        flowey.exe e 7 flowey_core::pipeline::artifact::publish 4
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey.exe e 7 flowey_lib_common::cache 3
@@ -5340,6 +5469,11 @@ jobs:
       with:
         name: x64-windows-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+    - name: 🌼📦 Publish x64-windows-tmk_vmm
+      uses: actions/upload-artifact@v4
+      with:
+        name: x64-windows-tmk_vmm
+        path: ${{ runner.temp }}/publish_artifacts/x64-windows-tmk_vmm/
     - name: 🌼📦 Publish x64-windows-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
@@ -5673,6 +5807,8 @@ jobs:
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgs_lib' --update-from-stdin --is-raw-string
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
         echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 9 'artifact_publish_from_aarch64-linux-vmgstool' --update-from-stdin --is-raw-string
+        mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 9 'artifact_publish_from_aarch64-tmks' --update-from-stdin --is-raw-string
       shell: bash
     - name: add default cargo home to path
       run: flowey e 9 flowey_lib_common::install_rust 0
@@ -5752,7 +5888,7 @@ jobs:
     - name: symlink protoc
       run: |-
         flowey e 9 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 1
+        flowey e 9 flowey_lib_hvlite::init_cross_build 2
       shell: bash
     - name: cargo build openvmm
       run: |-
@@ -5765,29 +5901,29 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 6
         flowey e 9 flowey_lib_hvlite::build_openvmm 0
         flowey e 9 flowey_core::pipeline::artifact::publish 0
-        flowey e 9 flowey_lib_hvlite::init_cross_build 3
+        flowey e 9 flowey_lib_hvlite::init_cross_build 4
       shell: bash
     - name: cargo build vmgstool
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 5
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+        flowey e 9 flowey_lib_common::run_cargo_build 6
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 12
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 13
         flowey e 9 flowey_lib_hvlite::build_vmgstool 0
         flowey e 9 flowey_core::pipeline::artifact::publish 1
-        flowey e 9 flowey_lib_hvlite::init_cross_build 2
+        flowey e 9 flowey_lib_hvlite::init_cross_build 3
       shell: bash
     - name: cargo build vmgs_lib
       run: |-
-        flowey e 9 flowey_lib_common::run_cargo_build 4
-        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_common::run_cargo_build 5
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 11
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 0
         flowey e 9 flowey_lib_hvlite::build_and_test_vmgs_lib 1
         flowey e 9 flowey_core::pipeline::artifact::publish 2
-        flowey e 9 flowey_lib_hvlite::init_cross_build 4
+        flowey e 9 flowey_lib_hvlite::init_cross_build 5
       shell: bash
     - name: cargo build igvmfilegen
       run: |-
@@ -5796,11 +5932,11 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 9 flowey_lib_hvlite::run_cargo_build 2
         flowey e 9 flowey_lib_hvlite::build_igvmfilegen 0
         flowey e 9 flowey_core::pipeline::artifact::publish 3
-        flowey e 9 flowey_lib_hvlite::init_cross_build 0
+        flowey e 9 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build ohcldiag-dev
       run: |-
@@ -5813,7 +5949,7 @@ jobs:
         flowey e 9 flowey_lib_hvlite::run_cargo_build 4
         flowey e 9 flowey_lib_hvlite::build_ohcldiag_dev 0
         flowey e 9 flowey_core::pipeline::artifact::publish 4
-        flowey e 9 flowey_lib_hvlite::init_cross_build 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 6
       shell: bash
     - name: cargo build guest_test_uefi
       run: |-
@@ -5824,6 +5960,21 @@ jobs:
       run: |-
         flowey e 9 flowey_lib_hvlite::build_guest_test_uefi 0
         flowey e 9 flowey_core::pipeline::artifact::publish 5
+        flowey e 9 flowey_lib_hvlite::init_cross_build 0
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 7
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 8
+      shell: bash
+    - name: cargo build simple_tmk
+      run: |-
+        flowey e 9 flowey_lib_common::run_cargo_build 4
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 9
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_cargo_build 10
+        flowey e 9 flowey_lib_hvlite::build_tmks 0
+        flowey e 9 flowey_core::pipeline::artifact::publish 6
       shell: bash
     - name: 'validate cache entry: gh-release-download'
       run: flowey e 9 flowey_lib_common::cache 3
@@ -5858,3 +6009,8 @@ jobs:
       with:
         name: aarch64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
+    - name: 🌼📦 Publish aarch64-tmks
+      uses: actions/upload-artifact@v4
+      with:
+        name: aarch64-tmks
+        path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6855,6 +6855,7 @@ name = "tmk_tests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "build_rs_guest_arch",
  "pal_async",
  "petri",
  "petri_artifacts_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6857,7 +6857,6 @@ dependencies = [
  "anyhow",
  "pal_async",
  "petri",
- "petri_artifact_resolver_openvmm_known_paths",
  "petri_artifacts_common",
  "petri_artifacts_vmm_test",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6851,6 +6851,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tmk_tests"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "pal_async",
+ "petri",
+ "petri_artifact_resolver_openvmm_known_paths",
+ "petri_artifacts_common",
+ "petri_artifacts_vmm_test",
+]
+
+[[package]]
 name = "tmk_vmm"
 version = "0.0.0"
 dependencies = [
@@ -8795,6 +8807,7 @@ dependencies = [
  "scsidisk_resources",
  "storvsp_resources",
  "tempfile",
+ "tmk_tests",
  "tracing",
  "unix_socket",
  "vm_resource",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ virt_mshv_vtl = { path = "openhcl/virt_mshv_vtl" }
 tmk_core = { path = "tmk/tmk_core" }
 tmk_macros = { path = "tmk/tmk_macros" }
 tmk_protocol = { path = "tmk/tmk_protocol" }
+tmk_tests = { path = "tmk/tmk_tests" }
 
 aarch64defs = { path = "vm/aarch64/aarch64defs" }
 aarch64emu = { path = "vm/aarch64/aarch64emu" }

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -407,6 +407,7 @@ impl IntoPipeline for CheckinGatesCli {
                         arch,
                         platform: CommonPlatform::WindowsMsvc,
                     },
+                    unstable_whp: true, // The ARM64 CI runner supports the unstable WHP interface
                     profile: CommonProfile::from_release(release),
                     tmk_vmm: ctx.publish_typed_artifact(pub_tmk_vmm),
                 });
@@ -736,6 +737,7 @@ impl IntoPipeline for CheckinGatesCli {
                         platform: CommonPlatform::LinuxMusl,
                     },
                     profile: CommonProfile::from_release(release),
+                    unstable_whp: false,
                     tmk_vmm: ctx.publish_typed_artifact(pub_tmk_vmm),
                 });
 

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -316,6 +316,9 @@ impl IntoPipeline for CheckinGatesCli {
             let (pub_pipette_windows, use_pipette_windows) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-windows-pipette"));
 
+            let (pub_tmk_vmm, use_tmk_vmm) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-windows-tmk_vmm"));
+
             // filter off interesting artifacts required by the VMM tests job
             match arch {
                 CommonArch::X86_64 => {
@@ -324,11 +327,13 @@ impl IntoPipeline for CheckinGatesCli {
                     vmm_tests_artifacts_windows_x86.use_openvmm = Some(use_openvmm.clone());
                     vmm_tests_artifacts_windows_x86.use_pipette_windows =
                         Some(use_pipette_windows.clone());
+                    vmm_tests_artifacts_windows_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
                 }
                 CommonArch::Aarch64 => {
                     vmm_tests_artifacts_windows_aarch64.use_openvmm = Some(use_openvmm.clone());
                     vmm_tests_artifacts_windows_aarch64.use_pipette_windows =
                         Some(use_pipette_windows.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_tmk_vmm = Some(use_tmk_vmm.clone());
                 }
             }
             // emit a job for artifacts which _are not_ in the VMM tests "hot
@@ -396,6 +401,14 @@ impl IntoPipeline for CheckinGatesCli {
                     },
                     profile: CommonProfile::from_release(release),
                     ohcldiag_dev: ctx.publish_typed_artifact(pub_ohcldiag_dev),
+                })
+                .dep_on(|ctx| flowey_lib_hvlite::build_tmk_vmm::Request {
+                    target: CommonTriple::Common {
+                        arch,
+                        platform: CommonPlatform::WindowsMsvc,
+                    },
+                    profile: CommonProfile::from_release(release),
+                    tmk_vmm: ctx.publish_typed_artifact(pub_tmk_vmm),
                 });
 
             all_jobs.push(job.finish());
@@ -486,6 +499,7 @@ impl IntoPipeline for CheckinGatesCli {
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-vmgstool"));
             let (pub_ohcldiag_dev, _) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-ohcldiag-dev"));
+            let (pub_tmks, use_tmks) = pipeline.new_typed_artifact(format!("{arch_tag}-tmks"));
 
             // NOTE: the choice to build it as part of this linux job was pretty
             // arbitrary. It could just as well hang off the windows job.
@@ -504,10 +518,13 @@ impl IntoPipeline for CheckinGatesCli {
                         Some(use_guest_test_uefi.clone());
                     vmm_tests_artifacts_windows_x86.use_guest_test_uefi =
                         Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_windows_x86.use_tmks = Some(use_tmks.clone());
+                    vmm_tests_artifacts_linux_x86.use_tmks = Some(use_tmks.clone());
                 }
                 CommonArch::Aarch64 => {
                     vmm_tests_artifacts_windows_aarch64.use_guest_test_uefi =
                         Some(use_guest_test_uefi.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_tmks = Some(use_tmks.clone());
                 }
             }
 
@@ -574,6 +591,11 @@ impl IntoPipeline for CheckinGatesCli {
                     arch,
                     profile: CommonProfile::from_release(release),
                     guest_test_uefi: ctx.publish_typed_artifact(pub_guest_test_uefi),
+                })
+                .dep_on(|ctx| flowey_lib_hvlite::build_tmks::Request {
+                    arch,
+                    profile: CommonProfile::from_release(release),
+                    tmks: ctx.publish_typed_artifact(pub_tmks),
                 });
 
             // Hang building the linux VMM tests off this big linux job.
@@ -627,6 +649,9 @@ impl IntoPipeline for CheckinGatesCli {
             let (pub_pipette_linux_musl, use_pipette_linux_musl) =
                 pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-pipette"));
 
+            let (pub_tmk_vmm, use_tmk_vmm) =
+                pipeline.new_typed_artifact(format!("{arch_tag}-linux-musl-tmk_vmm"));
+
             // skim off interesting artifacts required by the VMM tests job
             match arch {
                 CommonArch::X86_64 => {
@@ -636,12 +661,17 @@ impl IntoPipeline for CheckinGatesCli {
                         Some(use_pipette_linux_musl.clone());
                     vmm_tests_artifacts_linux_x86.use_pipette_linux_musl =
                         Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_linux_x86.use_tmk_vmm = Some(use_tmk_vmm.clone());
+                    vmm_tests_artifacts_windows_x86.use_tmk_vmm_linux_musl =
+                        Some(use_tmk_vmm.clone());
                 }
                 CommonArch::Aarch64 => {
                     vmm_tests_artifacts_windows_aarch64.use_openhcl_igvm_files =
                         Some(use_openhcl_igvm.clone());
                     vmm_tests_artifacts_windows_aarch64.use_pipette_linux_musl =
                         Some(use_pipette_linux_musl.clone());
+                    vmm_tests_artifacts_windows_aarch64.use_tmk_vmm_linux_musl =
+                        Some(use_tmk_vmm.clone());
                 }
             }
             let igvm_recipes = match arch {
@@ -699,6 +729,14 @@ impl IntoPipeline for CheckinGatesCli {
                     },
                     profile: CommonProfile::from_release(release),
                     pipette: ctx.publish_typed_artifact(pub_pipette_linux_musl),
+                })
+                .dep_on(|ctx| flowey_lib_hvlite::build_tmk_vmm::Request {
+                    target: CommonTriple::Common {
+                        arch,
+                        platform: CommonPlatform::LinuxMusl,
+                    },
+                    profile: CommonProfile::from_release(release),
+                    tmk_vmm: ctx.publish_typed_artifact(pub_tmk_vmm),
                 });
 
             all_jobs.push(job.finish());
@@ -1106,6 +1144,8 @@ mod vmm_tests_artifact_builders {
     use flowey_lib_hvlite::build_guest_test_uefi::GuestTestUefiOutput;
     use flowey_lib_hvlite::build_openvmm::OpenvmmOutput;
     use flowey_lib_hvlite::build_pipette::PipetteOutput;
+    use flowey_lib_hvlite::build_tmk_vmm::TmkVmmOutput;
+    use flowey_lib_hvlite::build_tmks::TmksOutput;
 
     pub type ResolveVmmTestsDepArtifacts =
         Box<dyn Fn(&mut PipelineJobCtx<'_>) -> VmmTestsDepArtifacts>;
@@ -1114,11 +1154,13 @@ mod vmm_tests_artifact_builders {
     pub struct VmmTestsArtifactsBuilderLinuxX86 {
         // windows build machine
         pub use_pipette_windows: Option<UseTypedArtifact<PipetteOutput>>,
+        pub use_tmk_vmm: Option<UseTypedArtifact<TmkVmmOutput>>,
         // linux build machine
         pub use_openvmm: Option<UseTypedArtifact<OpenvmmOutput>>,
         pub use_pipette_linux_musl: Option<UseTypedArtifact<PipetteOutput>>,
         // any machine
         pub use_guest_test_uefi: Option<UseTypedArtifact<GuestTestUefiOutput>>,
+        pub use_tmks: Option<UseTypedArtifact<TmksOutput>>,
     }
 
     impl VmmTestsArtifactsBuilderLinuxX86 {
@@ -1128,20 +1170,27 @@ mod vmm_tests_artifact_builders {
                 use_guest_test_uefi,
                 use_pipette_windows,
                 use_pipette_linux_musl,
+                use_tmk_vmm,
+                use_tmks,
             } = self;
 
             let use_guest_test_uefi = use_guest_test_uefi.ok_or("guest_test_uefi")?;
             let use_openvmm = use_openvmm.ok_or("openvmm")?;
             let use_pipette_linux_musl = use_pipette_linux_musl.ok_or("pipette_linux_musl")?;
             let use_pipette_windows = use_pipette_windows.ok_or("pipette_windows")?;
+            let use_tmk_vmm = use_tmk_vmm.ok_or("tmk_vmm")?;
+            let use_tmks = use_tmks.ok_or("tmks")?;
 
             Ok(Box::new(move |ctx| VmmTestsDepArtifacts {
                 openvmm: Some(ctx.use_typed_artifact(&use_openvmm)),
                 pipette_windows: Some(ctx.use_typed_artifact(&use_pipette_windows)),
                 pipette_linux_musl: Some(ctx.use_typed_artifact(&use_pipette_linux_musl)),
                 guest_test_uefi: Some(ctx.use_typed_artifact(&use_guest_test_uefi)),
+                tmk_vmm: Some(ctx.use_typed_artifact(&use_tmk_vmm)),
+                tmks: Some(ctx.use_typed_artifact(&use_tmks)),
                 // not currently required, since OpenHCL tests cannot be run on OpenVMM on linux
                 artifact_dir_openhcl_igvm_files: None,
+                tmk_vmm_linux_musl: None,
             }))
         }
     }
@@ -1151,11 +1200,14 @@ mod vmm_tests_artifact_builders {
         // windows build machine
         pub use_openvmm: Option<UseTypedArtifact<OpenvmmOutput>>,
         pub use_pipette_windows: Option<UseTypedArtifact<PipetteOutput>>,
+        pub use_tmk_vmm: Option<UseTypedArtifact<TmkVmmOutput>>,
         // linux build machine
         pub use_openhcl_igvm_files: Option<UseArtifact>,
         pub use_pipette_linux_musl: Option<UseTypedArtifact<PipetteOutput>>,
+        pub use_tmk_vmm_linux_musl: Option<UseTypedArtifact<TmkVmmOutput>>,
         // any machine
         pub use_guest_test_uefi: Option<UseTypedArtifact<GuestTestUefiOutput>>,
+        pub use_tmks: Option<UseTypedArtifact<TmksOutput>>,
     }
 
     impl VmmTestsArtifactsBuilderWindowsX86 {
@@ -1166,6 +1218,9 @@ mod vmm_tests_artifact_builders {
                 use_pipette_linux_musl,
                 use_guest_test_uefi,
                 use_openhcl_igvm_files,
+                use_tmk_vmm,
+                use_tmk_vmm_linux_musl,
+                use_tmks,
             } = self;
 
             let use_openvmm = use_openvmm.ok_or("openvmm")?;
@@ -1173,6 +1228,9 @@ mod vmm_tests_artifact_builders {
             let use_pipette_linux_musl = use_pipette_linux_musl.ok_or("pipette_linux_musl")?;
             let use_guest_test_uefi = use_guest_test_uefi.ok_or("guest_test_uefi")?;
             let use_openhcl_igvm_files = use_openhcl_igvm_files.ok_or("openhcl_igvm_files")?;
+            let use_tmk_vmm = use_tmk_vmm.ok_or("tmk_vmm")?;
+            let use_tmk_vmm_linux_musl = use_tmk_vmm_linux_musl.ok_or("tmk_vmm_linux_musl")?;
+            let use_tmks = use_tmks.ok_or("tmks")?;
 
             Ok(Box::new(move |ctx| VmmTestsDepArtifacts {
                 openvmm: Some(ctx.use_typed_artifact(&use_openvmm)),
@@ -1180,6 +1238,9 @@ mod vmm_tests_artifact_builders {
                 pipette_linux_musl: Some(ctx.use_typed_artifact(&use_pipette_linux_musl)),
                 guest_test_uefi: Some(ctx.use_typed_artifact(&use_guest_test_uefi)),
                 artifact_dir_openhcl_igvm_files: Some(ctx.use_artifact(&use_openhcl_igvm_files)),
+                tmk_vmm: Some(ctx.use_typed_artifact(&use_tmk_vmm)),
+                tmk_vmm_linux_musl: Some(ctx.use_typed_artifact(&use_tmk_vmm_linux_musl)),
+                tmks: Some(ctx.use_typed_artifact(&use_tmks)),
             }))
         }
     }
@@ -1189,11 +1250,14 @@ mod vmm_tests_artifact_builders {
         // windows build machine
         pub use_openvmm: Option<UseTypedArtifact<OpenvmmOutput>>,
         pub use_pipette_windows: Option<UseTypedArtifact<PipetteOutput>>,
+        pub use_tmk_vmm: Option<UseTypedArtifact<TmkVmmOutput>>,
         // linux build machine
         pub use_openhcl_igvm_files: Option<UseArtifact>,
         pub use_pipette_linux_musl: Option<UseTypedArtifact<PipetteOutput>>,
+        pub use_tmk_vmm_linux_musl: Option<UseTypedArtifact<TmkVmmOutput>>,
         // any machine
         pub use_guest_test_uefi: Option<UseTypedArtifact<GuestTestUefiOutput>>,
+        pub use_tmks: Option<UseTypedArtifact<TmksOutput>>,
     }
 
     impl VmmTestsArtifactsBuilderWindowsAarch64 {
@@ -1204,6 +1268,9 @@ mod vmm_tests_artifact_builders {
                 use_pipette_linux_musl,
                 use_guest_test_uefi,
                 use_openhcl_igvm_files,
+                use_tmk_vmm,
+                use_tmk_vmm_linux_musl,
+                use_tmks,
             } = self;
 
             let use_openvmm = use_openvmm.ok_or("openvmm")?;
@@ -1211,6 +1278,9 @@ mod vmm_tests_artifact_builders {
             let use_pipette_linux_musl = use_pipette_linux_musl.ok_or("pipette_linux_musl")?;
             let use_guest_test_uefi = use_guest_test_uefi.ok_or("guest_test_uefi")?;
             let use_openhcl_igvm_files = use_openhcl_igvm_files.ok_or("openhcl_igvm_files")?;
+            let use_tmk_vmm = use_tmk_vmm.ok_or("tmk_vmm")?;
+            let use_tmk_vmm_linux_musl = use_tmk_vmm_linux_musl.ok_or("tmk_vmm_linux_musl")?;
+            let use_tmks = use_tmks.ok_or("tmks")?;
 
             Ok(Box::new(move |ctx| VmmTestsDepArtifacts {
                 openvmm: Some(ctx.use_typed_artifact(&use_openvmm)),
@@ -1218,6 +1288,9 @@ mod vmm_tests_artifact_builders {
                 pipette_linux_musl: Some(ctx.use_typed_artifact(&use_pipette_linux_musl)),
                 guest_test_uefi: Some(ctx.use_typed_artifact(&use_guest_test_uefi)),
                 artifact_dir_openhcl_igvm_files: Some(ctx.use_artifact(&use_openhcl_igvm_files)),
+                tmk_vmm: Some(ctx.use_typed_artifact(&use_tmk_vmm)),
+                tmk_vmm_linux_musl: Some(ctx.use_typed_artifact(&use_tmk_vmm_linux_musl)),
+                tmks: Some(ctx.use_typed_artifact(&use_tmks)),
             }))
         }
     }

--- a/flowey/flowey_lib_common/src/install_rust.rs
+++ b/flowey/flowey_lib_common/src/install_rust.rs
@@ -39,6 +39,9 @@ flowey_request! {
         /// commands)
         GetRustupToolchain(WriteVar<Option<String>>),
 
+        /// Install the specified component.
+        InstallComponent(String),
+
         /// Get the path to $CARGO_HOME
         GetCargoHome(WriteVar<PathBuf>),
 
@@ -64,6 +67,7 @@ impl FlowNode for Node {
         let mut auto_install = None;
         let mut ignore_version = None;
         let mut additional_target_triples = BTreeSet::new();
+        let mut additional_components = BTreeSet::new();
         let mut get_rust_toolchain = Vec::new();
         let mut get_cargo_home = Vec::new();
 
@@ -79,6 +83,9 @@ impl FlowNode for Node {
                 Request::Version(v) => same_across_all_reqs("Version", &mut rust_toolchain, v)?,
                 Request::InstallTargetTriple(s) => {
                     additional_target_triples.insert(s.to_string());
+                }
+                Request::InstallComponent(v) => {
+                    additional_components.insert(v);
                 }
                 Request::GetRustupToolchain(v) => get_rust_toolchain.push(v),
                 Request::GetCargoHome(v) => get_cargo_home.push(v),
@@ -99,6 +106,7 @@ impl FlowNode for Node {
         let rust_toolchain =
             rust_toolchain.ok_or(anyhow::anyhow!("Missing essential request: RustToolchain"))?;
         let additional_target_triples = additional_target_triples;
+        let additional_components = additional_components;
         let get_rust_toolchain = get_rust_toolchain;
         let get_cargo_home = get_cargo_home;
 
@@ -109,6 +117,7 @@ impl FlowNode for Node {
         let check_rust_install = {
             let rust_toolchain = rust_toolchain.clone();
             let additional_target_triples = additional_target_triples.clone();
+            let additional_components = additional_components.clone();
 
             move |_: &mut RustRuntimeServices<'_>| {
                 if which::which("cargo").is_err() {
@@ -116,53 +125,60 @@ impl FlowNode for Node {
                 }
 
                 let rust_toolchain = rust_toolchain.map(|s| format!("+{s}"));
+                let rust_toolchain = rust_toolchain.as_ref();
 
                 // make sure the specific rust version was installed
                 let sh = xshell::Shell::new()?;
-                {
-                    let rust_toolchain = rust_toolchain.clone();
-                    xshell::cmd!(sh, "rustc {rust_toolchain...} -vV").run()?;
-                }
+                xshell::cmd!(sh, "rustc {rust_toolchain...} -vV").run()?;
 
                 // make sure the additional target triples were installed
                 if let Ok(rustup) = which::which("rustup") {
-                    let output =
-                        xshell::cmd!(sh, "{rustup} {rust_toolchain...} target list --installed")
-                            .ignore_status()
-                            .output()?;
-                    let stderr = String::from_utf8(output.stderr)?;
-                    let stdout = String::from_utf8(output.stdout)?;
+                    for (thing, expected_things) in [
+                        ("target", &additional_target_triples),
+                        ("compoment", &additional_components),
+                    ] {
+                        let output = xshell::cmd!(
+                            sh,
+                            "{rustup} {rust_toolchain...} {thing} list --installed"
+                        )
+                        .ignore_status()
+                        .output()?;
+                        let stderr = String::from_utf8(output.stderr)?;
+                        let stdout = String::from_utf8(output.stdout)?;
 
-                    // This error message may occur if the user has rustup
-                    // installed, but is using a custom custom toolchain.
-                    //
-                    // NOTE: not thrilled that we are sniffing a magic string
-                    // from stderr... but I'm also not sure if there's a better
-                    // way to detect this...
-                    if stderr.contains("does not support components") {
-                        log::warn!("Detected a non-standard `rustup default` toolchain!");
-                        log::warn!(
-                            "Will not be able to double-check that all required target-triples are available."
-                        );
-                    } else {
-                        let mut installed_target_triples = BTreeSet::new();
+                        // This error message may occur if the user has rustup
+                        // installed, but is using a custom custom toolchain.
+                        //
+                        // NOTE: not thrilled that we are sniffing a magic string
+                        // from stderr... but I'm also not sure if there's a better
+                        // way to detect this...
+                        if stderr.contains("does not support components") {
+                            log::warn!("Detected a non-standard `rustup default` toolchain!");
+                            log::warn!(
+                                "Will not be able to double-check that all required target-triples and components are available."
+                            );
+                        } else {
+                            let mut installed_things = BTreeSet::new();
 
-                        for line in stdout.lines() {
-                            let triple = line.trim();
-                            installed_target_triples.insert(triple);
-                        }
+                            for line in stdout.lines() {
+                                let triple = line.trim();
+                                installed_things.insert(triple);
+                            }
 
-                        for expected_target in additional_target_triples {
-                            if !installed_target_triples.contains(expected_target.as_str()) {
-                                anyhow::bail!(
-                                    "missing required target-triple: {expected_target}; to intsall: `rustup target add {expected_target}`"
-                                )
+                            for expected_thing in expected_things {
+                                if !installed_things.contains(expected_thing.as_str()) {
+                                    anyhow::bail!(
+                                        "missing required {thing}: {expected_thing}; to install: `rustup {thing} add {expected_thing}`"
+                                    )
+                                }
                             }
                         }
                     }
                 } else {
                     log::warn!("`rustup` was not found!");
-                    log::warn!("Unable to double-check that all target-triples are available.")
+                    log::warn!(
+                        "Unable to double-check that all target-triples and components are available."
+                    )
                 }
 
                 anyhow::Ok(())
@@ -267,6 +283,10 @@ impl FlowNode for Node {
 
                             if !additional_target_triples.is_empty() {
                                 xshell::cmd!(sh, "rustup target add {additional_target_triples...}")
+                                    .run()?;
+                            }
+                            if !additional_components.is_empty() {
+                                xshell::cmd!(sh, "rustup component add {additional_components...}")
                                     .run()?;
                             }
 

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -121,14 +121,13 @@ impl FlowNode for Node {
             features,
             output_kind,
             target,
-            skip_target_install,
             extra_env,
             config,
             pre_build_deps,
             output,
         } in requests
         {
-            if !skip_target_install {
+            if let Some(target) = &target {
                 ctx.req(crate::install_rust::Request::InstallTargetTriple(
                     target.clone(),
                 ));
@@ -193,8 +192,10 @@ impl FlowNode for Node {
                                 v.push("--features".into());
                                 v.push(features);
                             }
+                            if let Some(target) = &target {
                             v.push("--target".into());
                             v.push(target.to_string());
+                            }
                             v.push("--profile".into());
                             v.push(cargo_profile.into());
                             v.extend(config.iter().flat_map(|x| ["--config", x]).map(Into::into));

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -88,6 +88,7 @@ flowey_request! {
         pub features: BTreeSet<String>,
         pub output_kind: CargoCrateType,
         pub target: target_lexicon::Triple,
+        pub skip_target_install: bool,
         pub extra_env: Option<ReadVar<BTreeMap<String, String>>>,
         pub config: Vec<String>,
         /// Wait for specified side-effects to resolve before running cargo-run.
@@ -121,15 +122,18 @@ impl FlowNode for Node {
             features,
             output_kind,
             target,
+            skip_target_install,
             extra_env,
             config,
             pre_build_deps,
             output,
         } in requests
         {
-            ctx.req(crate::install_rust::Request::InstallTargetTriple(
-                target.clone(),
-            ));
+            if !skip_target_install {
+                ctx.req(crate::install_rust::Request::InstallTargetTriple(
+                    target.clone(),
+                ));
+            }
 
             ctx.emit_rust_step(format!("cargo build {crate_name}"), |ctx| {
                 pre_build_deps.claim(ctx);

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -193,8 +193,8 @@ impl FlowNode for Node {
                                 v.push(features);
                             }
                             if let Some(target) = &target {
-                            v.push("--target".into());
-                            v.push(target.to_string());
+                                v.push("--target".into());
+                                v.push(target.to_string());
                             }
                             v.push("--profile".into());
                             v.push(cargo_profile.into());

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -89,6 +89,7 @@ flowey_request! {
         pub output_kind: CargoCrateType,
         pub target: target_lexicon::Triple,
         pub extra_env: Option<ReadVar<BTreeMap<String, String>>>,
+        pub config: Vec<String>,
         /// Wait for specified side-effects to resolve before running cargo-run.
         ///
         /// (e.g: to allow for some ambient packages / dependencies to get
@@ -121,6 +122,7 @@ impl FlowNode for Node {
             output_kind,
             target,
             extra_env,
+            config,
             pre_build_deps,
             output,
         } in requests
@@ -192,6 +194,7 @@ impl FlowNode for Node {
                             v.push(target.to_string());
                             v.push("--profile".into());
                             v.push(cargo_profile.into());
+                            v.extend(config.iter().flat_map(|x| ["--config", x]).map(Into::into));
                             match output_kind {
                                 CargoCrateType::Bin => {
                                     v.push("--bin".into());

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -87,8 +87,7 @@ flowey_request! {
         pub profile: CargoBuildProfile,
         pub features: BTreeSet<String>,
         pub output_kind: CargoCrateType,
-        pub target: target_lexicon::Triple,
-        pub skip_target_install: bool,
+        pub target: Option<target_lexicon::Triple>,
         pub extra_env: Option<ReadVar<BTreeMap<String, String>>>,
         pub config: Vec<String>,
         /// Wait for specified side-effects to resolve before running cargo-run.

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_nextest_vmm_tests.rs
@@ -168,7 +168,7 @@ impl SimpleFlowNode for Node {
         });
 
         let register_pipette_linux_musl = ctx.reqv(|v| crate::build_pipette::Request {
-            target: targets.linux,
+            target: targets.linux.clone(),
             profile,
             pipette: v,
         });
@@ -177,6 +177,24 @@ impl SimpleFlowNode for Node {
             arch,
             profile,
             guest_test_uefi: v,
+        });
+
+        let register_tmks = ctx.reqv(|v| crate::build_tmks::Request {
+            arch,
+            profile,
+            tmks: v,
+        });
+
+        let register_tmk_vmm = ctx.reqv(|v| crate::build_tmk_vmm::Request {
+            profile,
+            target: targets.linux.clone(),
+            tmk_vmm: v,
+        });
+
+        let register_tmk_vmm_linux_musl = ctx.reqv(|v| crate::build_tmk_vmm::Request {
+            profile,
+            target: targets.linux,
+            tmk_vmm: v,
         });
 
         ctx.requests::<crate::download_openvmm_vmm_tests_vhds::Node>([
@@ -200,6 +218,9 @@ impl SimpleFlowNode for Node {
             register_pipette_windows: Some(register_pipette_windows),
             register_pipette_linux_musl: Some(register_pipette_linux_musl),
             register_guest_test_uefi: Some(register_guest_test_uefi),
+            register_tmks: Some(register_tmks),
+            register_tmk_vmm: Some(register_tmk_vmm),
+            register_tmk_vmm_linux_musl: Some(register_tmk_vmm_linux_musl),
             disk_images_dir: Some(disk_images_dir),
             register_openhcl_igvm_files: Some(register_openhcl_igvm_files),
             get_test_log_path: Some(get_test_log_path),

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_nextest_vmm_tests.rs
@@ -188,12 +188,14 @@ impl SimpleFlowNode for Node {
         let register_tmk_vmm = ctx.reqv(|v| crate::build_tmk_vmm::Request {
             profile,
             target: targets.linux.clone(),
+            unstable_whp: false,
             tmk_vmm: v,
         });
 
         let register_tmk_vmm_linux_musl = ctx.reqv(|v| crate::build_tmk_vmm::Request {
             profile,
             target: targets.linux,
+            unstable_whp: false,
             tmk_vmm: v,
         });
 

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -7,6 +7,8 @@ use crate::build_guest_test_uefi::GuestTestUefiOutput;
 use crate::build_nextest_vmm_tests::NextestVmmTestsArchive;
 use crate::build_openvmm::OpenvmmOutput;
 use crate::build_pipette::PipetteOutput;
+use crate::build_tmk_vmm::TmkVmmOutput;
+use crate::build_tmks::TmksOutput;
 use crate::run_cargo_nextest_run::NextestProfile;
 use flowey::node::prelude::*;
 use std::collections::BTreeMap;
@@ -20,6 +22,9 @@ pub struct VmmTestsDepArtifacts {
     pub pipette_linux_musl: Option<ReadVar<PipetteOutput>>,
     pub guest_test_uefi: Option<ReadVar<GuestTestUefiOutput>>,
     pub artifact_dir_openhcl_igvm_files: Option<ReadVar<PathBuf>>,
+    pub tmks: Option<ReadVar<TmksOutput>>,
+    pub tmk_vmm: Option<ReadVar<TmkVmmOutput>>,
+    pub tmk_vmm_linux_musl: Option<ReadVar<TmkVmmOutput>>,
 }
 
 flowey_request! {
@@ -91,6 +96,9 @@ impl SimpleFlowNode for Node {
             pipette_linux_musl: register_pipette_linux_musl,
             guest_test_uefi: register_guest_test_uefi,
             artifact_dir_openhcl_igvm_files,
+            tmks: register_tmks,
+            tmk_vmm: register_tmk_vmm,
+            tmk_vmm_linux_musl: register_tmk_vmm_linux_musl,
         } = dep_artifact_dirs;
 
         let register_openhcl_igvm_files = artifact_dir_openhcl_igvm_files.map(|artifact_dir| {
@@ -138,6 +146,9 @@ impl SimpleFlowNode for Node {
             register_pipette_windows,
             register_pipette_linux_musl,
             register_guest_test_uefi,
+            register_tmks,
+            register_tmk_vmm,
+            register_tmk_vmm_linux_musl,
             disk_images_dir: Some(disk_images_dir),
             register_openhcl_igvm_files,
             get_test_log_path: Some(get_test_log_path),

--- a/flowey/flowey_lib_hvlite/src/build_tmk_vmm.rs
+++ b/flowey/flowey_lib_hvlite/src/build_tmk_vmm.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Build TMK binaries
+
+use crate::run_cargo_build::common::CommonProfile;
+use crate::run_cargo_build::common::CommonTriple;
+use flowey::node::prelude::*;
+use std::collections::BTreeMap;
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TmkVmmOutput {
+    WindowsBin {
+        #[serde(rename = "tmk_vmm.exe")]
+        exe: PathBuf,
+        #[serde(rename = "tmk_vmm.pdb")]
+        pdb: PathBuf,
+    },
+    LinuxBin {
+        #[serde(rename = "tmk_vmm")]
+        bin: PathBuf,
+        #[serde(rename = "tmk_vmm.dbg")]
+        dbg: PathBuf,
+    },
+}
+
+impl Artifact for TmkVmmOutput {}
+
+flowey_request! {
+    pub struct Request {
+        pub profile: CommonProfile,
+        pub target: CommonTriple,
+        pub tmk_vmm: WriteVar<TmkVmmOutput>,
+    }
+}
+
+new_flow_node!(struct Node);
+
+impl FlowNode for Node {
+    type Request = Request;
+
+    fn imports(ctx: &mut ImportCtx<'_>) {
+        ctx.import::<crate::run_cargo_build::Node>();
+    }
+
+    fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
+        // de-dupe incoming requests
+        let requests = requests
+            .into_iter()
+            .fold(BTreeMap::<_, Vec<_>>::new(), |mut m, r| {
+                let Request {
+                    target,
+                    profile,
+                    tmk_vmm,
+                } = r;
+                m.entry((target, profile)).or_default().push(tmk_vmm);
+                m
+            });
+
+        for ((target, profile), tmk_vmm) in requests {
+            let output = ctx.reqv(|v| crate::run_cargo_build::Request {
+                crate_name: "tmk_vmm".into(),
+                out_name: "tmk_vmm".into(),
+                crate_type: flowey_lib_common::run_cargo_build::CargoCrateType::Bin,
+                profile: profile.into(),
+                features: Default::default(),
+                target: target.as_triple(),
+                no_split_dbg_info: false,
+                extra_env: None,
+                pre_build_deps: Vec::new(),
+                output: v,
+            });
+
+            ctx.emit_minor_rust_step("report built tmk_vmm", |ctx| {
+                let tmk_vmm = tmk_vmm.claim(ctx);
+                let output = output.claim(ctx);
+                move |rt| {
+                    let output = match rt.read(output) {
+                        crate::run_cargo_build::CargoBuildOutput::WindowsBin { exe, pdb } => {
+                            TmkVmmOutput::WindowsBin { exe, pdb }
+                        }
+                        crate::run_cargo_build::CargoBuildOutput::ElfBin { bin, dbg } => {
+                            TmkVmmOutput::LinuxBin {
+                                bin,
+                                dbg: dbg.unwrap(),
+                            }
+                        }
+                        _ => unreachable!(),
+                    };
+
+                    for var in tmk_vmm {
+                        rt.write(var, &output);
+                    }
+                }
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/flowey/flowey_lib_hvlite/src/build_tmks.rs
+++ b/flowey/flowey_lib_hvlite/src/build_tmks.rs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Build TMK binaries
+
+use crate::run_cargo_build::common::CommonArch;
+use crate::run_cargo_build::common::CommonProfile;
+use flowey::node::prelude::*;
+use std::collections::BTreeMap;
+
+#[derive(Serialize, Deserialize)]
+pub struct TmksOutput {
+    #[serde(rename = "simple_tmk")]
+    pub bin: PathBuf,
+    #[serde(rename = "simple_tmk.dbg")]
+    pub dbg: PathBuf,
+}
+
+impl Artifact for TmksOutput {}
+
+flowey_request! {
+    pub struct Request {
+        pub arch: CommonArch,
+        pub profile: CommonProfile,
+        pub tmks: WriteVar<TmksOutput>,
+    }
+}
+
+new_flow_node!(struct Node);
+
+impl FlowNode for Node {
+    type Request = Request;
+
+    fn imports(ctx: &mut ImportCtx<'_>) {
+        ctx.import::<crate::run_cargo_build::Node>();
+    }
+
+    fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
+        // de-dupe incoming requests
+        let requests = requests
+            .into_iter()
+            .fold(BTreeMap::<_, Vec<_>>::new(), |mut m, r| {
+                let Request {
+                    arch,
+                    profile,
+                    tmks,
+                } = r;
+                m.entry((arch, profile)).or_default().push(tmks);
+                m
+            });
+
+        for ((arch, profile), tmks) in requests {
+            let target = target_lexicon::Triple {
+                architecture: arch.as_arch(),
+                operating_system: target_lexicon::OperatingSystem::None_,
+                environment: target_lexicon::Environment::Unknown,
+                vendor: target_lexicon::Vendor::Custom(target_lexicon::CustomVendor::Static(
+                    "minimal_rt",
+                )),
+                binary_format: target_lexicon::BinaryFormat::Unknown,
+            };
+
+            let output = ctx.reqv(|v| crate::run_cargo_build::Request {
+                crate_name: "simple_tmk".into(),
+                out_name: "simple_tmk".into(),
+                crate_type: flowey_lib_common::run_cargo_build::CargoCrateType::Bin,
+                profile: profile.into(),
+                features: Default::default(),
+                target,
+                no_split_dbg_info: false,
+                extra_env: Some(ReadVar::from_static(
+                    [("RUSTC_BOOTSTRAP".to_string(), "1".to_string())]
+                        .into_iter()
+                        .collect(),
+                )),
+                pre_build_deps: Vec::new(),
+                output: v,
+            });
+
+            ctx.emit_minor_rust_step("report built tmks", |ctx| {
+                let tmks = tmks.claim(ctx);
+                let output = output.claim(ctx);
+                move |rt| {
+                    let output = match rt.read(output) {
+                        crate::run_cargo_build::CargoBuildOutput::ElfBin { bin, dbg } => {
+                            TmksOutput {
+                                bin,
+                                dbg: dbg.unwrap(),
+                            }
+                        }
+                        _ => unreachable!(),
+                    };
+
+                    for var in tmks {
+                        rt.write(var, &output);
+                    }
+                }
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/flowey/flowey_lib_hvlite/src/lib.rs
+++ b/flowey/flowey_lib_hvlite/src/lib.rs
@@ -29,6 +29,8 @@ pub mod build_openvmm_hcl;
 pub mod build_pipette;
 pub mod build_rustdoc;
 pub mod build_sidecar;
+pub mod build_tmk_vmm;
+pub mod build_tmks;
 pub mod build_vmfirmwareigvm_dll;
 pub mod build_vmgstool;
 pub mod build_xtask;

--- a/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
@@ -320,7 +320,7 @@ impl FlowNode for Node {
             profile,
             features,
             crate_type,
-            target,
+            mut target,
             no_split_dbg_info,
             extra_env,
             pre_build_deps: user_pre_build_deps,
@@ -372,6 +372,17 @@ impl FlowNode for Node {
                 injected_env
             };
 
+            let mut config = Vec::new();
+            if target.vendor.as_str() == "minimal_rt" {
+                config.push(format!(
+                    "openhcl/minimal_rt/{arch}-config.toml",
+                    arch = target.architecture.into_str()
+                ));
+                if target.architecture == target_lexicon::Architecture::X86_64 {
+                    target.vendor = target_lexicon::Vendor::Unknown;
+                }
+            }
+
             let base_output = ctx.reqv(|v| flowey_lib_common::run_cargo_build::Request {
                 in_folder: openvmm_repo_path.clone(),
                 crate_name,
@@ -390,6 +401,7 @@ impl FlowNode for Node {
                 output_kind: crate_type,
                 target: target.clone(),
                 extra_env: Some(extra_env),
+                config,
                 pre_build_deps,
                 output: v,
             });

--- a/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
@@ -306,6 +306,7 @@ impl FlowNode for Node {
         ctx.import::<crate::run_split_debug_info::Node>();
         ctx.import::<crate::init_cross_build::Node>();
         ctx.import::<flowey_lib_common::run_cargo_build::Node>();
+        ctx.import::<flowey_lib_common::install_rust::Node>();
     }
 
     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
@@ -390,7 +391,11 @@ impl FlowNode for Node {
                     Some(target.clone())
                 } else {
                     // We are building the target from source, so don't try to
-                    // install it via rustup.
+                    // install it via rustup. But do make sure the rust-src
+                    // component is available.
+                    ctx.req(flowey_lib_common::install_rust::Request::InstallComponent(
+                        "rust-src".into(),
+                    ));
                     None
                 }
             } else {

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -398,6 +398,12 @@ impl PetriVmConfigHyperV {
         self.secure_boot_template = Some(powershell::HyperVSecureBootTemplate::MicrosoftWindows);
         self
     }
+
+    /// Adds a file to the agent image.
+    pub fn with_agent_file(mut self, name: &str, artifact: ResolvedArtifact) -> Self {
+        self.agent_image.add_file(name, artifact);
+        self
+    }
 }
 
 impl PetriVmHyperV {

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -168,8 +168,8 @@ impl PetriVmConfigOpenVmm {
             let (vtl2_vsock_listener, vtl2_vsock_path) = make_vsock_listener()?;
             (
                 Some(Vtl2Config {
-                    vtl0_alias_map: false, // TODO: enable when OpenVMM supports it for DMA
-                    late_map_vtl0_memory: Some(LateMapVtl0MemoryPolicy::InjectException),
+                    vtl0_alias_map: false,      // TODO: enable when OpenVMM supports it for DMA
+                    late_map_vtl0_memory: None, //Some(LateMapVtl0MemoryPolicy::InjectException),
                 }),
                 Some(VmbusConfig {
                     vsock_listener: Some(vtl2_vsock_listener),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -168,8 +168,8 @@ impl PetriVmConfigOpenVmm {
             let (vtl2_vsock_listener, vtl2_vsock_path) = make_vsock_listener()?;
             (
                 Some(Vtl2Config {
-                    vtl0_alias_map: false,      // TODO: enable when OpenVMM supports it for DMA
-                    late_map_vtl0_memory: None, //Some(LateMapVtl0MemoryPolicy::InjectException),
+                    vtl0_alias_map: false, // TODO: enable when OpenVMM supports it for DMA
+                    late_map_vtl0_memory: Some(LateMapVtl0MemoryPolicy::InjectException),
                 }),
                 Some(VmbusConfig {
                     vsock_listener: Some(vtl2_vsock_listener),

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -315,4 +315,19 @@ impl PetriVmConfigOpenVmm {
             .add_file(name, artifact);
         self
     }
+
+    /// Specifies whether VTL2 should be allowed to access VTL0 memory before it
+    /// sets any VTL protections.
+    ///
+    /// This is needed just for the TMK VMM, and only until it gains support for
+    /// setting VTL protections.
+    pub fn with_allow_early_vtl0_access(mut self, allow: bool) -> Self {
+        self.config
+            .hypervisor
+            .with_vtl2
+            .as_mut()
+            .unwrap()
+            .late_map_vtl0_memory =
+            (!allow).then_some(hvlite_defs::config::LateMapVtl0MemoryPolicy::InjectException);
+    }
 }

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -299,4 +299,20 @@ impl PetriVmConfigOpenVmm {
         f(&mut self.config);
         self
     }
+
+    /// Adds a file to the agent image.
+    pub fn with_agent_file(mut self, name: &str, artifact: ResolvedArtifact) -> Self {
+        self.resources.agent_image.add_file(name, artifact);
+        self
+    }
+
+    /// Adds a file to the OpenHCL agent image.
+    pub fn with_openhcl_agent_file(mut self, name: &str, artifact: ResolvedArtifact) -> Self {
+        self.resources
+            .openhcl_agent_image
+            .as_mut()
+            .unwrap()
+            .add_file(name, artifact);
+        self
+    }
 }

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -329,5 +329,7 @@ impl PetriVmConfigOpenVmm {
             .unwrap()
             .late_map_vtl0_memory =
             (!allow).then_some(hvlite_defs::config::LateMapVtl0MemoryPolicy::InjectException);
+
+        self
     }
 }

--- a/tmk/tmk_tests/Cargo.toml
+++ b/tmk/tmk_tests/Cargo.toml
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "tmk_tests"
+rust-version.workspace = true
+edition.workspace = true
+
+[dependencies]
+petri.workspace = true
+petri_artifact_resolver_openvmm_known_paths.workspace = true
+petri_artifacts_common.workspace = true
+petri_artifacts_vmm_test.workspace = true
+
+pal_async.workspace = true
+
+anyhow.workspace = true
+
+[lints]
+workspace = true

--- a/tmk/tmk_tests/Cargo.toml
+++ b/tmk/tmk_tests/Cargo.toml
@@ -15,5 +15,8 @@ pal_async.workspace = true
 
 anyhow.workspace = true
 
+[build-dependencies]
+build_rs_guest_arch.workspace = true
+
 [lints]
 workspace = true

--- a/tmk/tmk_tests/Cargo.toml
+++ b/tmk/tmk_tests/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 
 [dependencies]
 petri.workspace = true
-petri_artifact_resolver_openvmm_known_paths.workspace = true
 petri_artifacts_common.workspace = true
 petri_artifacts_vmm_test.workspace = true
 

--- a/tmk/tmk_tests/build.rs
+++ b/tmk/tmk_tests/build.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! Build script for TMK tests.
 
 fn main() {

--- a/tmk/tmk_tests/build.rs
+++ b/tmk/tmk_tests/build.rs
@@ -1,0 +1,5 @@
+//! Build script for TMK tests.
+
+fn main() {
+    build_rs_guest_arch::emit_guest_arch();
+}

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -58,6 +58,7 @@ fn host_tmks(
     Ok(())
 }
 
+#[cfg(guest_arch = "x86_64")] // We don't support openvmm+openhcl tests on aarch64 yet
 petri::test!(openvmm_openhcl_tmks, resolve_openvmm_openhcl_tmks);
 
 struct OpenvmmOpenhclArtifacts {
@@ -66,6 +67,7 @@ struct OpenvmmOpenhclArtifacts {
     tmk: ResolvedArtifact,
 }
 
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 fn resolve_openvmm_openhcl_tmks(resolver: &petri::ArtifactResolver<'_>) -> OpenvmmOpenhclArtifacts {
     let igvm_path;
     let tmk_vmm;
@@ -108,6 +110,7 @@ fn resolve_openvmm_openhcl_tmks(resolver: &petri::ArtifactResolver<'_>) -> Openv
     OpenvmmOpenhclArtifacts { vm, tmk_vmm, tmk }
 }
 
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 fn openvmm_openhcl_tmks(
     params: petri::PetriTestParams<'_>,
     artifacts: OpenvmmOpenhclArtifacts,

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -86,6 +86,7 @@ fn openvmm_openhcl_tmks(
             .with_openhcl_agent_file("tmk_vmm", tmk_vmm)
             .with_openhcl_agent_file("simple_tmk", tmk)
             .with_processors(1)
+            .with_allow_early_vtl0_access(true) // TODO: remove once the TMK VMM initializes memory properly.
             .run_without_agent()
             .await?;
 

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Test code for running TMK tests in different environments.
+
+use anyhow::Context as _;
+use pal_async::DefaultPool;
+use pal_async::task::Spawn as _;
+use petri::ResolvedArtifact;
+
+petri::test!(host_tmks, |resolver| {
+    let tmk_vmm = resolver
+        .require(petri_artifacts_vmm_test::artifacts::tmks::TMK_VMM_NATIVE)
+        .erase();
+    let tmk = resolver
+        .require(petri_artifacts_vmm_test::artifacts::tmks::SIMPLE_TMK_X64)
+        .erase();
+    (tmk_vmm, tmk)
+});
+
+fn host_tmks(
+    params: petri::PetriTestParams<'_>,
+    (tmk_vmm, tmk): (ResolvedArtifact, ResolvedArtifact),
+) -> anyhow::Result<()> {
+    let (_, driver) = DefaultPool::spawn_on_thread("pool");
+    let (stdout, stdout_write) = pal_async::pipe::PolledPipe::pair(&driver)?;
+    driver
+        .spawn(
+            "log",
+            petri::log_stream(params.logger.log_file("tmk_vmm")?, stdout),
+        )
+        .detach();
+
+    let output = std::process::Command::new(tmk_vmm)
+        .arg("--tmk")
+        .arg(tmk)
+        .stdout(stdout_write.into_inner())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .context("failed to launch tmk_vmm")?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "tmk_vmm exited with status {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(())
+}
+
+petri::test!(openvmm_openhcl_tmks, |resolver| {
+    let vm = petri::openvmm::PetriVmArtifactsOpenVmm::new(
+        resolver,
+        petri::Firmware::OpenhclUefi {
+            guest: petri::UefiGuest::None,
+            isolation: None,
+            vtl2_nvme_boot: false,
+            igvm_path: resolver
+                .require(petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64)
+                .erase(),
+        },
+        petri_artifacts_common::tags::MachineArch::X86_64,
+    );
+    let tmk_vmm = resolver
+        .require(petri_artifacts_vmm_test::artifacts::tmks::TMK_VMM_LINUX_X64_MUSL)
+        .erase();
+    let tmk = resolver
+        .require(petri_artifacts_vmm_test::artifacts::tmks::SIMPLE_TMK_X64)
+        .erase();
+    (vm, tmk_vmm, tmk)
+});
+
+fn openvmm_openhcl_tmks(
+    params: petri::PetriTestParams<'_>,
+    (artifacts, tmk_vmm, tmk): (
+        petri::openvmm::PetriVmArtifactsOpenVmm,
+        ResolvedArtifact,
+        ResolvedArtifact,
+    ),
+) -> anyhow::Result<()> {
+    DefaultPool::run_with(async |driver| {
+        let mut vm = petri::openvmm::PetriVmConfigOpenVmm::new(&params, artifacts, &driver)?
+            .with_openhcl_command_line("OPENHCL_WAIT_FOR_START=1")
+            .with_openhcl_agent_file("tmk_vmm", tmk_vmm)
+            .with_openhcl_agent_file("simple_tmk", tmk)
+            .with_processors(1)
+            .run_without_agent()
+            .await?;
+
+        let agent = vm.wait_for_vtl2_agent().await?;
+        let mut child = agent
+            .command("/cidata/tmk_vmm")
+            .arg("--tmk")
+            .arg("/cidata/simple_tmk")
+            .arg("--hv")
+            .arg("mshv-vtl")
+            .stdout(petri::pipette::process::Stdio::piped())
+            .stderr(petri::pipette::process::Stdio::piped())
+            .spawn()
+            .await?;
+
+        driver
+            .spawn(
+                "log",
+                petri::log_stream(
+                    params.logger.log_file("tmk_vmm")?,
+                    child.stdout.take().unwrap(),
+                ),
+            )
+            .detach();
+
+        let output = child.wait_with_output().await?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "tmk_vmm exited with status {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        Ok(())
+    })
+}

--- a/tmk/tmk_vmm/Cargo.toml
+++ b/tmk/tmk_vmm/Cargo.toml
@@ -6,6 +6,9 @@ name = "tmk_vmm"
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+unstable_whp = ["virt_whp/unstable_whp"]
+
 [dependencies]
 tmk_protocol.workspace = true
 

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -128,11 +128,14 @@ async fn do_main(driver: DefaultDriver) -> anyhow::Result<()> {
 }
 
 fn choose_hypervisor() -> anyhow::Result<HypervisorOpt> {
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", guest_arch = "x86_64"))]
     {
         if virt::Hypervisor::is_available(&virt_mshv::LinuxMshv)? {
             return Ok(HypervisorOpt::Mshv);
         }
+    }
+    #[cfg(target_os = "linux")]
+    {
         if virt::Hypervisor::is_available(&virt_kvm::Kvm)? {
             return Ok(HypervisorOpt::Kvm);
         }

--- a/tmk/tmk_vmm/src/main.rs
+++ b/tmk/tmk_vmm/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> anyhow::Result<()> {
 #[derive(Parser)]
 struct Options {
     /// The hypervisor interface to use to run the TMK.
-    #[clap(long, required_unless_present("list"))]
+    #[clap(long)]
     hv: Option<HypervisorOpt>,
     /// Disable offloads to the hypervisor. This disables WHP APIC emulation,
     /// for example.
@@ -100,7 +100,10 @@ async fn do_main(driver: DefaultDriver) -> anyhow::Result<()> {
         }
         Ok(())
     } else {
-        let hv = opts.hv.context("missing --hv option")?;
+        let hv = match opts.hv {
+            Some(hv) => hv,
+            None => choose_hypervisor()?,
+        };
         let mut state = CommonState::new(driver, opts).await?;
 
         state
@@ -122,4 +125,30 @@ async fn do_main(driver: DefaultDriver) -> anyhow::Result<()> {
             })
             .await
     }
+}
+
+fn choose_hypervisor() -> anyhow::Result<HypervisorOpt> {
+    #[cfg(target_os = "linux")]
+    {
+        if virt::Hypervisor::is_available(&virt_mshv::LinuxMshv)? {
+            return Ok(HypervisorOpt::Mshv);
+        }
+        if virt::Hypervisor::is_available(&virt_kvm::Kvm)? {
+            return Ok(HypervisorOpt::Kvm);
+        }
+    }
+    #[cfg(windows)]
+    {
+        if virt::Hypervisor::is_available(&virt_whp::Whp)? {
+            return Ok(HypervisorOpt::Whp);
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if virt::Hypervisor::is_available(&virt_hvf::HvfHypervisor)? {
+            return Ok(HypervisorOpt::Hvf);
+        }
+    }
+
+    anyhow::bail!("no hypervisor available");
 }

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -360,6 +360,48 @@ pub mod artifacts {
             const SIZE: u64 = 4245487616;
         }
     }
+
+    /// TMK-related artifacts
+    pub mod tmks {
+        use petri_artifacts_core::declare_artifacts;
+
+        macro_rules! tmk_native {
+            ($id_ty:ty, $os:literal, $arch:literal) => {
+                /// tmk_vmm "native" executable
+                // xtask-fmt allow-target-arch oneoff-petri-native-test-deps
+                #[cfg(all(target_os = $os, target_arch = $arch))]
+                pub const TMK_VMM_NATIVE: petri_artifacts_core::ArtifactHandle<$id_ty> =
+                    petri_artifacts_core::ArtifactHandle::new();
+            };
+        }
+
+        tmk_native!(TMK_VMM_WIN_X64, "windows", "x86_64");
+        tmk_native!(TMK_VMM_LINUX_X64, "linux", "x86_64");
+        tmk_native!(TMK_VMM_WIN_AARCH64, "windows", "aarch64");
+        tmk_native!(TMK_VMM_LINUX_AARCH64, "linux", "aarch64");
+        tmk_native!(TMK_VMM_MACOS_AARCH64, "macos", "aarch64");
+
+        declare_artifacts! {
+            /// TMK VMM for Windows x64
+            TMK_VMM_WIN_X64,
+            /// TMK VMM for Linux x64
+            TMK_VMM_LINUX_X64,
+            /// TMK VMM for MacOS x64
+            TMK_VMM_WIN_AARCH64,
+            /// TMK VMM for Linux aarch64
+            TMK_VMM_LINUX_AARCH64,
+            /// TMK VMM for MacOS aarch64
+            TMK_VMM_MACOS_AARCH64,
+            /// TMK VMM for Linux musl x64
+            TMK_VMM_LINUX_X64_MUSL,
+            /// TMK VMM for Linux musl aarch64
+            TMK_VMM_LINUX_AARCH64_MUSL,
+            /// TMK binary for x64
+            SIMPLE_TMK_X64,
+            /// TMK binary for aarch64
+            SIMPLE_TMK_AARCH64,
+        }
+    }
 }
 
 /// Artifact tag trait declarations

--- a/vmm_tests/vmm_tests/Cargo.toml
+++ b/vmm_tests/vmm_tests/Cargo.toml
@@ -10,10 +10,15 @@ rust-version.workspace = true
 name = "tests"
 harness = false
 
+[[test]]
+name = "tmks"
+harness = false
+
 [dev-dependencies]
 petri_artifact_resolver_openvmm_known_paths.workspace = true
 petri_artifacts_vmm_test.workspace = true
 vmm_test_macros.workspace = true
+tmk_tests.workspace = true
 
 petri_artifacts_common.workspace = true
 petri.workspace = true

--- a/vmm_tests/vmm_tests/tests/tmks.rs
+++ b/vmm_tests/vmm_tests/tests/tmks.rs
@@ -4,6 +4,10 @@
 //! Test entrypoint for running TMK tests in different environments.
 
 // Include all the tests.
+//
+// FUTURE: probably the tmk_tests package should own this crate, rather than
+// reuse vmm_tests. But this creates a bunch of work for CI. Revisit this once
+// CI is a little less cumbersome to modify.
 use tmk_tests as _;
 
 fn main() {

--- a/vmm_tests/vmm_tests/tests/tmks.rs
+++ b/vmm_tests/vmm_tests/tests/tmks.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Test entrypoint for running TMK tests in different environments.
+
+// Include all the tests.
+use tmk_tests as _;
+
+fn main() {
+    petri::test_main(|name, requirements| {
+        requirements.resolve(
+            petri_artifact_resolver_openvmm_known_paths::OpenvmmKnownPathsTestArtifactResolver::new(
+                name,
+            ),
+        )
+    })
+}


### PR DESCRIPTION
Enable the TMKs to run in CI. Run them both in host VMM mode and in paravisor mode.