### PR TITLE
vmm_tests: add default boot test

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -917,6 +917,7 @@ impl IntoPipeline for CheckinGatesCli {
             KnownVhd::Gen1WindowsDataCenterCore2022,
             KnownVhd::Gen2WindowsDataCenterCore2022,
             KnownVhd::Ubuntu2204Server,
+            KnownVhd::SampleVmgs,
         ];
         let standard_x64_isos = vec![KnownIso::FreeBsd13_2];
 
@@ -987,7 +988,7 @@ impl IntoPipeline for CheckinGatesCli {
                 target: CommonTriple::AARCH64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_aarch64,
                 nextest_filter_expr: "all()".to_string(),
-                vhds: vec![KnownVhd::Ubuntu2404ServerAarch64],
+                vhds: vec![KnownVhd::Ubuntu2404ServerAarch64, KnownVhd::SampleVmgs],
                 isos: vec![],
             },
         ] {

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -233,6 +233,45 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
+    /// Specifies whether the UEFI will always attempt a default boot
+    pub fn with_default_boot_always_attempt(mut self, val: bool) -> Self {
+        match self.config.load_mode {
+            LoadMode::Uefi {
+                ref mut default_boot_always_attempt,
+                ..
+            } => {
+                *default_boot_always_attempt = val;
+            }
+            LoadMode::Igvm { .. } => {
+                let ged = self.ged.as_mut().expect("no GED to configure DPS");
+                match ged.firmware {
+                    get_resources::ged::GuestFirmwareConfig::Uefi {
+                        ref mut default_boot_always_attempt,
+                        ..
+                    } => {
+                        *default_boot_always_attempt = val;
+                    }
+                    _ => {
+                        panic!("not a UEFI boot");
+                    }
+                }
+            }
+            _ => panic!("not a UEFI boot"),
+        }
+        self
+    }
+
+    /// Specifies an existing VMGS file to use
+    pub fn with_vmgs(mut self, vmgs_file: std::fs::File) -> Self {
+        let vmgs_disk = disk_backend_resources::FixedVhd1DiskHandle(vmgs_file).into_resource();
+        if self.firmware.is_openhcl() {
+            self.ged.as_mut().unwrap().vmgs_disk = Some(vmgs_disk);
+        } else {
+            self.config.vmgs_disk = Some(vmgs_disk);
+        }
+        self
+    }
+
     /// Add custom command line arguments to OpenHCL.
     pub fn with_openhcl_command_line(mut self, additional_cmdline: &str) -> Self {
         if !self.firmware.is_openhcl() {

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -71,6 +71,8 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
 
             _ if id == test_iso::FREE_BSD_13_2_X64 => get_guest_iso_path(KnownIso::FreeBsd13_2),
 
+            _ if id == test_vmgs::SAMPLE_VMGS => get_guest_vhd_path(KnownVhd::SampleVmgs),
+
             _ => anyhow::bail!("no support for given artifact type"),
         }
     }

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -360,6 +360,22 @@ pub mod artifacts {
             const SIZE: u64 = 4245487616;
         }
     }
+
+    /// Test VMGS artifacts
+    pub mod test_vmgs {
+        use crate::tags::IsHostedOnHvliteAzureBlobStore;
+        use petri_artifacts_core::declare_artifacts;
+
+        declare_artifacts! {
+            /// Sample VMGS for use in tests
+            SAMPLE_VMGS,
+        }
+
+        impl IsHostedOnHvliteAzureBlobStore for SAMPLE_VMGS {
+            const FILENAME: &'static str = "sample-vmgs.vhd";
+            const SIZE: u64 = 4194816;
+        }
+    }
 }
 
 /// Artifact tag trait declarations

--- a/vmm_tests/vmm_test_images/src/lib.rs
+++ b/vmm_tests/vmm_test_images/src/lib.rs
@@ -30,6 +30,7 @@ pub enum KnownVhd {
     FreeBsd13_2,
     Ubuntu2204Server,
     Ubuntu2404ServerAarch64,
+    SampleVmgs,
 }
 
 struct KnownVhdMeta {
@@ -79,6 +80,11 @@ const KNOWN_VHD_METADATA: &[KnownVhdMeta] = &[
         KnownVhd::Ubuntu2404ServerAarch64,
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_AARCH64::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_AARCH64::SIZE,
+    ),
+    KnownVhdMeta::new(
+        KnownVhd::SampleVmgs,
+        petri_artifacts_vmm_test::artifacts::test_vmgs::SAMPLE_VMGS::FILENAME,
+        petri_artifacts_vmm_test::artifacts::test_vmgs::SAMPLE_VMGS::SIZE,
     ),
 ];
 


### PR DESCRIPTION
Tests whether `default_boot_always_attempt` is working by providing an initial VMGS with invalid boot entries