### PR TITLE
flowey: Ubuntu uses x86-64 for gcc and binutils packages

### DIFF
--- a/flowey/flowey_lib_hvlite/src/init_cross_build.rs
+++ b/flowey/flowey_lib_hvlite/src/init_cross_build.rs
@@ -55,15 +55,15 @@ impl FlowNode for Node {
             if !native(&target) {
                 let platform = ctx.platform();
                 let gcc_arch_str = match target.architecture {
-                    Architecture::X86_64 => {
-                        match platform {
-                            FlowPlatform::Linux(linux_distribution) => match linux_distribution {
-                                FlowPlatformLinuxDistro::Fedora =>"x86_64",
-                                FlowPlatformLinuxDistro::Ubuntu => "x86-64",
-                                FlowPlatformLinuxDistro::Unknown => anyhow::bail!("Unknown Linux distribution"),
-                            },
-                            _ => anyhow::bail!("Unsupported platform"),
-                        }
+                    Architecture::X86_64 => match platform {
+                        FlowPlatform::Linux(linux_distribution) => match linux_distribution {
+                            FlowPlatformLinuxDistro::Fedora => "x86_64",
+                            FlowPlatformLinuxDistro::Ubuntu => "x86-64",
+                            FlowPlatformLinuxDistro::Unknown => {
+                                anyhow::bail!("Unknown Linux distribution")
+                            }
+                        },
+                        _ => anyhow::bail!("Unsupported platform"),
                     },
                     Architecture::Aarch64(_) => "aarch64",
                     arch => anyhow::bail!("unsupported arch {arch}"),
@@ -72,12 +72,14 @@ impl FlowNode for Node {
                 match (platform, target.operating_system) {
                     (FlowPlatform::Linux(_), target_lexicon::OperatingSystem::Linux) => {
                         let (gcc_pkg, bin) = match target.architecture {
-                            Architecture::Aarch64(_) => {
-                                (format!("gcc-{gcc_arch_str}-linux-gnu"), "aarch64-linux-gnu-gcc".to_string())
-                            }
-                            Architecture::X86_64 => {
-                                (format!("gcc-{gcc_arch_str}-linux-gnu"), "x86_64-linux-gnu-gcc".to_string())
-                            }
+                            Architecture::Aarch64(_) => (
+                                format!("gcc-{gcc_arch_str}-linux-gnu"),
+                                "aarch64-linux-gnu-gcc".to_string(),
+                            ),
+                            Architecture::X86_64 => (
+                                format!("gcc-{gcc_arch_str}-linux-gnu"),
+                                "x86_64-linux-gnu-gcc".to_string(),
+                            ),
                             arch => anyhow::bail!("unsupported arch {arch}"),
                         };
 
@@ -92,7 +94,7 @@ impl FlowNode for Node {
                         //   `aarch64-unknown-linux-*`.
                         pre_build_deps.push(ctx.reqv(|v| {
                             flowey_lib_common::install_dist_pkg::Request::Install {
-                                package_names: vec![gcc_pkg.into()],
+                                package_names: vec![gcc_pkg],
                                 done: v,
                             }
                         }));
@@ -110,7 +112,7 @@ impl FlowNode for Node {
                                     "CARGO_TARGET_{}_LINKER",
                                     target.to_string().replace('-', "_").to_uppercase()
                                 ),
-                                bin.into(),
+                                bin,
                             );
                         }
                     }

--- a/flowey/flowey_lib_hvlite/src/init_cross_build.rs
+++ b/flowey/flowey_lib_hvlite/src/init_cross_build.rs
@@ -5,6 +5,7 @@
 
 use flowey::node::prelude::*;
 use std::collections::BTreeMap;
+use target_lexicon::Architecture;
 
 flowey_request! {
     pub struct Request {
@@ -36,8 +37,8 @@ impl FlowNode for Node {
                 _ => return false,
             };
             let arch = match target.architecture {
-                target_lexicon::Architecture::X86_64 => FlowArch::X86_64,
-                target_lexicon::Architecture::Aarch64(_) => FlowArch::Aarch64,
+                Architecture::X86_64 => FlowArch::X86_64,
+                Architecture::Aarch64(_) => FlowArch::Aarch64,
                 _ => return false,
             };
             host_platform == platform && host_arch == arch
@@ -52,14 +53,30 @@ impl FlowNode for Node {
             let mut injected_env = BTreeMap::new();
 
             if !native(&target) {
-                match (ctx.platform(), target.operating_system) {
+                let platform = ctx.platform();
+                let gcc_arch_str = match target.architecture {
+                    Architecture::X86_64 => {
+                        match platform {
+                            FlowPlatform::Linux(linux_distribution) => match linux_distribution {
+                                FlowPlatformLinuxDistro::Fedora =>"x86_64",
+                                FlowPlatformLinuxDistro::Ubuntu => "x86-64",
+                                FlowPlatformLinuxDistro::Unknown => anyhow::bail!("Unknown Linux distribution"),
+                            },
+                            _ => anyhow::bail!("Unsupported platform"),
+                        }
+                    },
+                    Architecture::Aarch64(_) => "aarch64",
+                    arch => anyhow::bail!("unsupported arch {arch}"),
+                };
+
+                match (platform, target.operating_system) {
                     (FlowPlatform::Linux(_), target_lexicon::OperatingSystem::Linux) => {
                         let (gcc_pkg, bin) = match target.architecture {
-                            target_lexicon::Architecture::Aarch64(_) => {
-                                ("gcc-aarch64-linux-gnu", "aarch64-linux-gnu-gcc")
+                            Architecture::Aarch64(_) => {
+                                (format!("gcc-{gcc_arch_str}-linux-gnu"), "aarch64-linux-gnu-gcc".to_string())
                             }
-                            target_lexicon::Architecture::X86_64 => {
-                                ("gcc-x86-64-linux-gnu", "x86_64-linux-gnu-gcc")
+                            Architecture::X86_64 => {
+                                (format!("gcc-{gcc_arch_str}-linux-gnu"), "x86_64-linux-gnu-gcc".to_string())
                             }
                             arch => anyhow::bail!("unsupported arch {arch}"),
                         };

--- a/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
+++ b/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
@@ -34,15 +34,13 @@ impl SimpleFlowNode for Node {
 
         let platform = ctx.platform();
         let arch_str = match arch {
-            CommonArch::X86_64 => {
-                match platform {
-                    FlowPlatform::Linux(linux_distribution) => match linux_distribution {
-                        FlowPlatformLinuxDistro::Fedora =>"x86_64",
-                        FlowPlatformLinuxDistro::Ubuntu => "x86-64",
-                        FlowPlatformLinuxDistro::Unknown => anyhow::bail!("Unknown Linux distribution"),
-                    },
-                    _ => anyhow::bail!("Unsupported platform"),
-                }
+            CommonArch::X86_64 => match platform {
+                FlowPlatform::Linux(linux_distribution) => match linux_distribution {
+                    FlowPlatformLinuxDistro::Fedora => "x86_64",
+                    FlowPlatformLinuxDistro::Ubuntu => "x86-64",
+                    FlowPlatformLinuxDistro::Unknown => anyhow::bail!("Unknown Linux distribution"),
+                },
+                _ => anyhow::bail!("Unsupported platform"),
             },
             CommonArch::Aarch64 => "aarch64",
         };
@@ -50,9 +48,7 @@ impl SimpleFlowNode for Node {
         let installed_objcopy =
             ctx.reqv(
                 |side_effect| flowey_lib_common::install_dist_pkg::Request::Install {
-                    package_names: vec![format!(
-                        "binutils-{arch_str}-linux-gnu"
-                    )],
+                    package_names: vec![format!("binutils-{arch_str}-linux-gnu")],
                     done: side_effect,
                 },
             );

--- a/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
+++ b/flowey/flowey_lib_hvlite/src/run_split_debug_info.rs
@@ -32,16 +32,27 @@ impl SimpleFlowNode for Node {
             out_dbg_info,
         } = request;
 
+        let platform = ctx.platform();
+        let arch_str = match arch {
+            CommonArch::X86_64 => {
+                match platform {
+                    FlowPlatform::Linux(linux_distribution) => match linux_distribution {
+                        FlowPlatformLinuxDistro::Fedora =>"x86_64",
+                        FlowPlatformLinuxDistro::Ubuntu => "x86-64",
+                        FlowPlatformLinuxDistro::Unknown => anyhow::bail!("Unknown Linux distribution"),
+                    },
+                    _ => anyhow::bail!("Unsupported platform"),
+                }
+            },
+            CommonArch::Aarch64 => "aarch64",
+        };
+
         let installed_objcopy =
             ctx.reqv(
                 |side_effect| flowey_lib_common::install_dist_pkg::Request::Install {
-                    package_names: vec![
-                        match arch {
-                            CommonArch::X86_64 => "binutils-x86-64-linux-gnu",
-                            CommonArch::Aarch64 => "binutils-aarch64-linux-gnu",
-                        }
-                        .into(),
-                    ],
+                    package_names: vec![format!(
+                        "binutils-{arch_str}-linux-gnu"
+                    )],
                     done: side_effect,
                 },
             );


### PR DESCRIPTION
For the linker, that's x86_64 though. Flowey code assumes everyone does the same, but at least Fedora doesn't, and Fedora uses x86_64 for both gcc and binutils.