### PR TITLE
Begin wiring up TDX intercepts, update CR intercepts

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -85,7 +85,6 @@ use parking_lot::RwLock;
 use processor::BackingSharedParams;
 use processor::SidecarExitReason;
 use sidecar_client::NewSidecarClientError;
-use std::marker::PhantomData;
 use std::ops::RangeInclusive;
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
@@ -1724,8 +1723,8 @@ impl<'a> UhProtoPartition<'a> {
                 guest_memory: late_params.gm.clone(),
                 #[cfg(guest_arch = "x86_64")]
                 cpuid: &cpuid,
+                hcl: &hcl,
                 guest_vsm_available,
-                _phantom: PhantomData,
             },
         )?;
 

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1991,7 +1991,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
     /// Returns whether a higher VTL has registered for write intercepts on the
     /// register.
-    pub(crate) fn cvm_is_protected_register_write(
+    fn cvm_is_protected_register_write(
         &self,
         vtl: GuestVtl,
         reg: HvX64RegisterName,
@@ -2034,7 +2034,12 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
     /// Checks if a higher VTL registered for write intercepts on the register,
     /// and sends the intercept as required.
-    pub(crate) fn cvm_protect_secure_register_write(
+    ///
+    /// If an intercept message is posted then no further processing is required.
+    /// The instruction pointer should not be advanced, since the instruction
+    /// pointer must continue to point to the instruction that generated the
+    /// intercept.
+    pub(crate) fn try_cvm_protect_secure_register_write(
         &mut self,
         vtl: GuestVtl,
         reg: HvX64RegisterName,
@@ -2063,7 +2068,12 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
     /// Checks if a higher VTL registered for write intercepts on the MSR, and
     /// sends the intercept as required.
-    pub(crate) fn cvm_protect_msr_write(&self, vtl: GuestVtl, msr: u32) -> bool {
+    ///
+    /// If an intercept message is posted then no further processing is required.
+    /// The instruction pointer should not be advanced, since the instruction
+    /// pointer must continue to point to the instruction that generated the
+    /// intercept.
+    pub(crate) fn try_cvm_protect_msr_write(&self, vtl: GuestVtl, msr: u32) -> bool {
         if vtl == GuestVtl::Vtl0 && self.backing.cvm_state().vtl1.is_some() {
             let configured_intercepts = self
                 .backing

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -746,10 +746,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             return Err(HvError::InvalidRegisterValue);
         }
 
-        // TODO TDX GUEST VSM
-        if let virt::IsolationType::Snp = self.vp.partition.isolation {
-            B::cr_intercept_registration(self.vp, intercept_control);
-        }
+        B::cr_intercept_registration(self.vp, intercept_control);
 
         self.vp
             .backing

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -2039,7 +2039,8 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
     /// The instruction pointer should not be advanced, since the instruction
     /// pointer must continue to point to the instruction that generated the
     /// intercept.
-    pub(crate) fn try_cvm_protect_secure_register_write(
+    #[must_use]
+    pub(crate) fn cvm_try_protect_secure_register_write(
         &mut self,
         vtl: GuestVtl,
         reg: HvX64RegisterName,
@@ -2073,7 +2074,8 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
     /// The instruction pointer should not be advanced, since the instruction
     /// pointer must continue to point to the instruction that generated the
     /// intercept.
-    pub(crate) fn try_cvm_protect_msr_write(&self, vtl: GuestVtl, msr: u32) -> bool {
+    #[must_use]
+    pub(crate) fn cvm_try_protect_msr_write(&self, vtl: GuestVtl, msr: u32) -> bool {
         if vtl == GuestVtl::Vtl0 && self.backing.cvm_state().vtl1.is_some() {
             let configured_intercepts = self
                 .backing

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -41,6 +41,7 @@ use crate::ExitActivity;
 use crate::GuestVtl;
 use crate::WakeReason;
 use guestmem::GuestMemory;
+use hcl::ioctl::Hcl;
 use hcl::ioctl::ProcessorRunner;
 use hv1_emulator::message_queues::MessageQueues;
 use hv1_hypercall::HvRepResult;
@@ -278,9 +279,8 @@ pub(crate) struct BackingSharedParams<'a> {
     pub guest_memory: VtlArray<GuestMemory, 2>,
     #[cfg(guest_arch = "x86_64")]
     pub cpuid: &'a virt::CpuidLeafSet,
+    pub hcl: &'a Hcl,
     pub guest_vsm_available: bool,
-    /// Not all arches reference 'a.
-    pub _phantom: PhantomData<&'a ()>,
 }
 
 /// Supported intercept message types.

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -273,9 +273,9 @@ pub trait Backing: BackingPrivate {}
 
 impl<T: BackingPrivate> Backing for T {}
 
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 pub(crate) struct BackingSharedParams<'a> {
     pub cvm_state: Option<crate::UhCvmPartitionState>,
-    #[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
     pub guest_memory: VtlArray<GuestMemory, 2>,
     #[cfg(guest_arch = "x86_64")]
     pub cpuid: &'a virt::CpuidLeafSet,

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -979,11 +979,7 @@ impl UhProcessor<'_, SnpBacked> {
         msr: u32,
         is_write: bool,
     ) {
-        if is_write && self.cvm_protect_msr_write(entered_from_vtl, msr) {
-            // An intercept message has been posted, no further processing is
-            // required. Return without advancing instruction pointer, it must
-            // continue to point to the instruction that generated the
-            // intercept.
+        if is_write && self.try_cvm_protect_msr_write(entered_from_vtl, msr) {
             return;
         }
 
@@ -1078,16 +1074,11 @@ impl UhProcessor<'_, SnpBacked> {
             cr4: vmsa.cr4(),
             cpl: vmsa.cpl(),
         }) {
-            if self.cvm_protect_secure_register_write(
+            if !self.try_cvm_protect_secure_register_write(
                 entered_from_vtl,
                 HvX64RegisterName::Xfem,
                 value,
             ) {
-                // Once the intercept message has been posted, no further
-                // processing is required. Do not advance the instruction
-                // pointer here, since the instruction pointer must continue to
-                // point to the instruction that generated the intercept.
-            } else {
                 let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
                 vmsa.set_xcr0(value);
                 advance_to_next_instruction(&mut vmsa);
@@ -1143,12 +1134,7 @@ impl UhProcessor<'_, SnpBacked> {
             return;
         }
 
-        if self.cvm_protect_secure_register_write(entered_from_vtl, reg, reg_value) {
-            // Once the intercept message has been posted, no further
-            // processing is required.  Do not advance the instruction
-            // pointer here, since the instruction pointer must continue to
-            // point to the instruction that generated the intercept.
-        } else {
+        if !self.try_cvm_protect_secure_register_write(entered_from_vtl, reg, reg_value) {
             let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
             match reg {
                 HvX64RegisterName::Cr0 => vmsa.set_cr0(reg_value),
@@ -1502,7 +1488,7 @@ impl UhProcessor<'_, SnpBacked> {
                     _ => unreachable!(),
                 };
 
-                if !self.cvm_protect_secure_register_write(entered_from_vtl, reg, 0) {
+                if !self.try_cvm_protect_secure_register_write(entered_from_vtl, reg, 0) {
                     // This is an unexpected intercept: should only have received an
                     // intercept for these registers if a VTL (i.e. VTL 1) requested
                     // it. If an unexpected intercept has been received, then the

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -979,7 +979,7 @@ impl UhProcessor<'_, SnpBacked> {
         msr: u32,
         is_write: bool,
     ) {
-        if is_write && self.try_cvm_protect_msr_write(entered_from_vtl, msr) {
+        if is_write && self.cvm_try_protect_msr_write(entered_from_vtl, msr) {
             return;
         }
 
@@ -1074,7 +1074,7 @@ impl UhProcessor<'_, SnpBacked> {
             cr4: vmsa.cr4(),
             cpl: vmsa.cpl(),
         }) {
-            if !self.try_cvm_protect_secure_register_write(
+            if !self.cvm_try_protect_secure_register_write(
                 entered_from_vtl,
                 HvX64RegisterName::Xfem,
                 value,
@@ -1134,7 +1134,7 @@ impl UhProcessor<'_, SnpBacked> {
             return;
         }
 
-        if !self.try_cvm_protect_secure_register_write(entered_from_vtl, reg, reg_value) {
+        if !self.cvm_try_protect_secure_register_write(entered_from_vtl, reg, reg_value) {
             let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
             match reg {
                 HvX64RegisterName::Cr0 => vmsa.set_cr0(reg_value),
@@ -1488,7 +1488,7 @@ impl UhProcessor<'_, SnpBacked> {
                     _ => unreachable!(),
                 };
 
-                if !self.try_cvm_protect_secure_register_write(entered_from_vtl, reg, 0) {
+                if !self.cvm_try_protect_secure_register_write(entered_from_vtl, reg, 0) {
                     // This is an unexpected intercept: should only have received an
                     // intercept for these registers if a VTL (i.e. VTL 1) requested
                     // it. If an unexpected intercept has been received, then the

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -244,16 +244,11 @@ struct VirtualRegister {
     /// The value the guest sees.
     shadow_value: u64,
     /// Additional constraints on bits.
-    allowed_bits: Option<u64>,
+    allowed_bits: u64,
 }
 
 impl VirtualRegister {
-    fn new(
-        reg: ShadowedRegister,
-        vtl: GuestVtl,
-        initial_value: u64,
-        allowed_bits: Option<u64>,
-    ) -> Self {
+    fn new(reg: ShadowedRegister, vtl: GuestVtl, initial_value: u64, allowed_bits: u64) -> Self {
         Self {
             register: reg,
             vtl,
@@ -272,7 +267,7 @@ impl VirtualRegister {
     ) -> Result<(), vp_state::Error> {
         tracing::trace!(?self.register, value, "write virtual register");
 
-        if value & !self.allowed_bits.unwrap_or(u64::MAX) != 0 {
+        if value & !self.allowed_bits != 0 {
             return Err(vp_state::Error::InvalidValue(
                 value,
                 self.register.name(),
@@ -560,25 +555,67 @@ impl HardwareIsolatedBacking for TdxBacked {
     }
 
     fn cr0(this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64 {
-        this.backing.vtls[vtl].cr0.read(&this.runner)
+        this.read_cr0(vtl)
     }
 
     fn cr4(this: &UhProcessor<'_, Self>, vtl: GuestVtl) -> u64 {
-        this.backing.vtls[vtl].cr4.read(&this.runner)
+        this.read_cr4(vtl)
     }
 
     fn intercept_message_state(
-        _this: &UhProcessor<'_, Self>,
-        _vtl: GuestVtl,
+        this: &UhProcessor<'_, Self>,
+        vtl: GuestVtl,
     ) -> super::InterceptMessageState {
-        todo!()
+        let exit = TdxExit(this.runner.tdx_vp_enter_exit_info());
+        let backing_vtl = &this.backing.vtls[vtl];
+        let shared_gps = this.runner.tdx_enter_guest_gps();
+
+        super::InterceptMessageState {
+            instruction_length_and_cr8: exit.instr_info().length() as u8,
+            cpl: exit.cpl(),
+            efer_lma: backing_vtl.efer & X64_EFER_LMA != 0,
+            cs_segment: exit.cs().into(),
+            rip: backing_vtl.private_regs.rip,
+            rflags: backing_vtl.private_regs.rflags,
+            rax: shared_gps[TdxGp::RAX],
+            rdx: shared_gps[TdxGp::RDX],
+        }
     }
 
     fn cr_intercept_registration(
-        _this: &mut UhProcessor<'_, Self>,
-        _intercept_control: hvdef::HvRegisterCrInterceptControl,
+        this: &mut UhProcessor<'_, Self>,
+        intercept_control: hvdef::HvRegisterCrInterceptControl,
     ) {
-        todo!()
+        let intercept_masks = &this
+            .backing
+            .cvm_state()
+            .vtl1
+            .as_ref()
+            .unwrap()
+            .reg_intercept;
+        this.runner.write_vmcs64(
+            GuestVtl::Vtl0,
+            VmcsField::VMX_VMCS_CR0_GUEST_HOST_MASK,
+            !0,
+            this.shared.cr_guest_host_mask(ShadowedRegister::Cr0)
+                | if intercept_control.cr0_write() {
+                    intercept_masks.cr0_mask
+                } else {
+                    0
+                },
+        );
+        this.runner.write_vmcs64(
+            GuestVtl::Vtl0,
+            VmcsField::VMX_VMCS_CR4_GUEST_HOST_MASK,
+            !0,
+            this.shared.cr_guest_host_mask(ShadowedRegister::Cr4)
+                | if intercept_control.cr4_write() {
+                    intercept_masks.cr4_mask
+                } else {
+                    0
+                },
+        );
+        // TODO TDX GUEST VSM register for descriptor table exits, update msr bitmap
     }
 }
 
@@ -593,6 +630,8 @@ pub struct TdxBackedShared {
     flush_state: VtlArray<RwLock<TdxPartitionFlushState>, 2>,
     #[inspect(iter_by_index)]
     active_vtl: Vec<AtomicU8>,
+    /// CR4 bits that the guest is allowed to set to 1.
+    cr4_allowed_bits: u64,
 }
 
 impl TdxBackedShared {
@@ -612,6 +651,12 @@ impl TdxBackedShared {
                     partition_params.topology.vp_count(),
                 )
             });
+
+        // TODO TDX: Consider just using MSR kernel module instead of explicit ioctl.
+        let cr4_fixed1 = params.hcl.read_vmx_cr4_fixed1();
+        let cr4_allowed_bits =
+            (ShadowedRegister::Cr4.guest_owned_mask() | X64_CR4_MCE) & cr4_fixed1;
+
         Ok(Self {
             untrusted_synic,
             flush_state: VtlArray::from_fn(|_| RwLock::new(TdxPartitionFlushState::new())),
@@ -620,7 +665,20 @@ impl TdxBackedShared {
             active_vtl: std::iter::repeat_n(2, partition_params.topology.vp_count() as usize)
                 .map(AtomicU8::new)
                 .collect(),
+            cr4_allowed_bits,
         })
+    }
+
+    /// Get the default guest host mask for the specified register.
+    fn cr_guest_host_mask(&self, reg: ShadowedRegister) -> u64 {
+        match reg {
+            ShadowedRegister::Cr0 => {
+                !ShadowedRegister::Cr0.guest_owned_mask() | X64_CR0_PE | X64_CR0_PG
+            }
+            ShadowedRegister::Cr4 => {
+                !(ShadowedRegister::Cr4.guest_owned_mask() & self.cr4_allowed_bits)
+            }
+        }
     }
 }
 
@@ -654,13 +712,6 @@ impl BackingPrivate for TdxBacked {
         // TODO TDX: lapic / APIC setup?
         // TODO TDX: see ValInitializeVplc
         // TODO TDX: XCR_XFMEM setup?
-
-        // Allowed cr4 bits depend on the values allowed by the SEAM.
-        //
-        // TODO TDX: Consider just using MSR kernel module instead of explicit
-        // ioctl.
-        let read_cr4 = params.partition.hcl.read_vmx_cr4_fixed1();
-        let allowed_cr4_bits = (ShadowedRegister::Cr4.guest_owned_mask() | X64_CR4_MCE) & read_cr4;
 
         for vtl in [GuestVtl::Vtl0, GuestVtl::Vtl1] {
             let controls = TdxL2Ctls::new()
@@ -696,7 +747,7 @@ impl BackingPrivate for TdxBacked {
                 vtl,
                 VmcsField::VMX_VMCS_CR0_GUEST_HOST_MASK,
                 !0,
-                !ShadowedRegister::Cr0.guest_owned_mask() | X64_CR0_PE | X64_CR0_PG,
+                shared.cr_guest_host_mask(ShadowedRegister::Cr0),
             );
 
             let initial_cr4 = params
@@ -711,7 +762,7 @@ impl BackingPrivate for TdxBacked {
                 vtl,
                 VmcsField::VMX_VMCS_CR4_GUEST_HOST_MASK,
                 !0,
-                !(ShadowedRegister::Cr4.guest_owned_mask() & allowed_cr4_bits),
+                shared.cr_guest_host_mask(ShadowedRegister::Cr4),
             );
 
             // Configure the MSR bitmap for this VP.  Since the default MSR bitmap
@@ -770,7 +821,7 @@ impl BackingPrivate for TdxBacked {
                         params
                             .runner
                             .read_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_CR0),
-                        None,
+                        !0,
                     ),
                     cr4: VirtualRegister::new(
                         ShadowedRegister::Cr4,
@@ -778,7 +829,7 @@ impl BackingPrivate for TdxBacked {
                         params
                             .runner
                             .read_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_CR4),
-                        Some(allowed_cr4_bits),
+                        shared.cr4_allowed_bits,
                     ),
                     tpr_threshold: 0,
                     processor_controls: params
@@ -1727,33 +1778,40 @@ impl UhProcessor<'_, TdxBacked> {
                 let value =
                     (gps[TdxGp::RAX] as u32 as u64) | ((gps[TdxGp::RDX] as u32 as u64) << 32);
 
-                let result = self.backing.cvm.lapics[intercepted_vtl]
-                    .lapic
-                    .access(&mut TdxApicClient {
-                        partition: self.partition,
-                        vmtime: &self.vmtime,
-                        apic_page: self.runner.tdx_apic_page_mut(intercepted_vtl),
-                        dev,
-                        vtl: intercepted_vtl,
-                    })
-                    .msr_write(msr, value)
-                    .or_else_if_unknown(|| self.write_msr_cvm(msr, value, intercepted_vtl))
-                    .or_else_if_unknown(|| self.write_msr(msr, value, intercepted_vtl))
-                    .or_else_if_unknown(|| self.write_msr_tdx(msr, value, intercepted_vtl));
-
-                let inject_gp = match result {
-                    Ok(()) => false,
-                    Err(MsrError::Unknown) => {
-                        tracelimit::warn_ratelimited!(msr, value, "unknown tdx vm msr write");
-                        false
-                    }
-                    Err(MsrError::InvalidAccess) => true,
-                };
-
-                if inject_gp {
-                    self.inject_gpf(intercepted_vtl);
+                if self.cvm_protect_msr_write(intercepted_vtl, msr) {
+                    // An intercept message has been posted, no further processing is
+                    // required. Return without advancing instruction pointer, it must
+                    // continue to point to the instruction that generated the
+                    // intercept.
                 } else {
-                    self.advance_to_next_instruction(intercepted_vtl);
+                    let result = self.backing.cvm.lapics[intercepted_vtl]
+                        .lapic
+                        .access(&mut TdxApicClient {
+                            partition: self.partition,
+                            vmtime: &self.vmtime,
+                            apic_page: self.runner.tdx_apic_page_mut(intercepted_vtl),
+                            dev,
+                            vtl: intercepted_vtl,
+                        })
+                        .msr_write(msr, value)
+                        .or_else_if_unknown(|| self.write_msr_cvm(msr, value, intercepted_vtl))
+                        .or_else_if_unknown(|| self.write_msr(msr, value, intercepted_vtl))
+                        .or_else_if_unknown(|| self.write_msr_tdx(msr, value, intercepted_vtl));
+
+                    let inject_gp = match result {
+                        Ok(()) => false,
+                        Err(MsrError::Unknown) => {
+                            tracelimit::warn_ratelimited!(msr, value, "unknown tdx vm msr write");
+                            false
+                        }
+                        Err(MsrError::InvalidAccess) => true,
+                    };
+
+                    if inject_gp {
+                        self.inject_gpf(intercepted_vtl);
+                    } else {
+                        self.advance_to_next_instruction(intercepted_vtl);
+                    }
                 }
                 &mut self.backing.vtls[intercepted_vtl].exit_stats.msr_write
             }
@@ -1813,21 +1871,35 @@ impl UhProcessor<'_, TdxBacked> {
                     }
                     access_type => unreachable!("not registered for cr access type {access_type}"),
                 }
-                let r = match cr {
-                    0 => self.backing.vtls[intercepted_vtl]
-                        .cr0
-                        .write(value, &mut self.runner),
-                    4 => self.backing.vtls[intercepted_vtl]
-                        .cr4
-                        .write(value, &mut self.runner),
-                    cr => unreachable!("not registered for cr{cr} accesses"),
+
+                let cr = match cr {
+                    0 => HvX64RegisterName::Cr0,
+                    4 => HvX64RegisterName::Cr4,
+                    _ => unreachable!("not registered for cr{cr} accesses"),
                 };
-                if r.is_ok() {
-                    self.update_execution_mode(intercepted_vtl);
-                    self.advance_to_next_instruction(intercepted_vtl);
+
+                if self.cvm_protect_secure_register_write(intercepted_vtl, cr, value) {
+                    // Once the intercept message has been posted, no further
+                    // processing is required.  Do not advance the instruction
+                    // pointer here, since the instruction pointer must continue to
+                    // point to the instruction that generated the intercept.
                 } else {
-                    tracelimit::warn_ratelimited!(cr, value, "failed to write cr");
-                    self.inject_gpf(intercepted_vtl);
+                    let r = match cr {
+                        HvX64RegisterName::Cr0 => self.backing.vtls[intercepted_vtl]
+                            .cr0
+                            .write(value, &mut self.runner),
+                        HvX64RegisterName::Cr4 => self.backing.vtls[intercepted_vtl]
+                            .cr4
+                            .write(value, &mut self.runner),
+                        _ => unreachable!(),
+                    };
+                    if r.is_ok() {
+                        self.update_execution_mode(intercepted_vtl);
+                        self.advance_to_next_instruction(intercepted_vtl);
+                    } else {
+                        tracelimit::warn_ratelimited!(?cr, value, "failed to write cr");
+                        self.inject_gpf(intercepted_vtl);
+                    }
                 }
                 &mut self.backing.vtls[intercepted_vtl].exit_stats.cr_access
             }
@@ -1842,12 +1914,23 @@ impl UhProcessor<'_, TdxBacked> {
                         cpl: exit_info.cpl(),
                     })
                 {
-                    self.runner
-                        .set_vp_register(intercepted_vtl, HvX64RegisterName::Xfem, value.into())
-                        .map_err(|err| {
-                            VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err))
-                        })?;
-                    self.advance_to_next_instruction(intercepted_vtl);
+                    if self.cvm_protect_secure_register_write(
+                        intercepted_vtl,
+                        HvX64RegisterName::Xfem,
+                        value,
+                    ) {
+                        // Once the intercept message has been posted, no further
+                        // processing is required. Do not advance the instruction
+                        // pointer here, since the instruction pointer must continue to
+                        // point to the instruction that generated the intercept.
+                    } else {
+                        self.runner
+                            .set_vp_register(intercepted_vtl, HvX64RegisterName::Xfem, value.into())
+                            .map_err(|err| {
+                                VpHaltReason::Hypervisor(UhRunVpError::EmulationState(err))
+                            })?;
+                        self.advance_to_next_instruction(intercepted_vtl);
+                    }
                 } else {
                     self.inject_gpf(intercepted_vtl);
                 }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1783,7 +1783,7 @@ impl UhProcessor<'_, TdxBacked> {
                 let value =
                     (gps[TdxGp::RAX] as u32 as u64) | ((gps[TdxGp::RDX] as u32 as u64) << 32);
 
-                if !self.try_cvm_protect_msr_write(intercepted_vtl, msr) {
+                if !self.cvm_try_protect_msr_write(intercepted_vtl, msr) {
                     let result = self.backing.cvm.lapics[intercepted_vtl]
                         .lapic
                         .access(&mut TdxApicClient {
@@ -1878,7 +1878,7 @@ impl UhProcessor<'_, TdxBacked> {
                     _ => unreachable!("not registered for cr{cr} accesses"),
                 };
 
-                if !self.try_cvm_protect_secure_register_write(intercepted_vtl, cr, value) {
+                if !self.cvm_try_protect_secure_register_write(intercepted_vtl, cr, value) {
                     let r = match cr {
                         HvX64RegisterName::Cr0 => self.backing.vtls[intercepted_vtl]
                             .cr0
@@ -1909,7 +1909,7 @@ impl UhProcessor<'_, TdxBacked> {
                         cpl: exit_info.cpl(),
                     })
                 {
-                    if !self.try_cvm_protect_secure_register_write(
+                    if !self.cvm_try_protect_secure_register_write(
                         intercepted_vtl,
                         HvX64RegisterName::Xfem,
                         value,

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -620,23 +620,7 @@ impl HardwareIsolatedBacking for TdxBacked {
                 },
         );
 
-        // Update descriptor table intercepts.
-        let intercept_tables = intercept_control.gdtr_write()
-            | intercept_control.idtr_write()
-            | intercept_control.ldtr_write()
-            | intercept_control.tr_write();
-        this.runner.write_vmcs32(
-            vtl,
-            VmcsField::VMX_VMCS_SECONDARY_PROCESSOR_CONTROLS,
-            SecondaryProcessorControls::new()
-                .with_descriptor_table_exiting(true)
-                .into_bits(),
-            SecondaryProcessorControls::new()
-                .with_descriptor_table_exiting(intercept_tables)
-                .into_bits(),
-        );
-
-        // TODO Update MSR bitmaps
+        // TODO Update descriptor table intercepts and MSR bitmaps
     }
 }
 


### PR DESCRIPTION
The first PR of what will likely be many for TDX VTL 1 intercepts. This fully hooks up CR0, CR4, XCR0/XFEM, and hooks up the handling of MSRs. The remaining items that need work are descriptor table intercept registration and handling, and updating the MSR bitmap registration.