### PR TITLE
[WIP] Parse and Log the EFI Diagnostics Buffer

### DIFF
--- a/vm/devices/firmware/firmware_uefi/src/service/diagnostics.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/diagnostics.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! UEFI diagnostics subsystem
+//!
+//! This module stores the GPA of the efi dignostics buffer.
+//! When signaled, the diagnostics buffer is parsed and written to
+//! trace logs.
+use crate::UefiDevice;
+use inspect::Inspect;
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DiagnosticsError {
+    #[error("invalid diagnostics address")]
+    InvalidAddress,
+}
+
+#[derive(Inspect)]
+pub struct DiagnosticsServices {
+    gpa: u32,
+}
+
+impl DiagnosticsServices {
+    pub fn new() -> DiagnosticsServices {
+        DiagnosticsServices { gpa: 0 }
+    }
+
+    pub fn reset(&mut self) {
+        self.gpa = 0
+    }
+
+    pub fn set_gpa(&mut self, gpa: u32) -> Result<(), DiagnosticsError> {
+        if gpa == 0 || gpa == u32::MAX {
+            return Err(DiagnosticsError::InvalidAddress);
+        }
+        self.gpa = gpa;
+        Ok(())
+    }
+}
+
+impl UefiDevice {
+    pub(crate) fn _set_diagnostics_gpa(&mut self, gpa: u32) {
+        if let Err(err) = self.service.diagnostics.set_gpa(gpa) {
+            tracelimit::error_ratelimited!(
+                error = &err as &dyn std::error::Error,
+                "Failed to set diagnostics GPA",
+            );
+        }
+    }
+}
+
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::NoSavedState;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    impl SaveRestore for DiagnosticsServices {
+        type SavedState = NoSavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(NoSavedState)
+        }
+
+        fn restore(&mut self, NoSavedState: Self::SavedState) -> Result<(), RestoreError> {
+            Ok(())
+        }
+    }
+}

--- a/vm/devices/firmware/firmware_uefi/src/service/mod.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/mod.rs
@@ -4,6 +4,7 @@
 //! Various UEFI device subsystems.
 
 pub mod crypto;
+pub mod diagnostics;
 pub mod event_log;
 pub mod generation_id;
 pub mod nvram;


### PR DESCRIPTION
This PR is a work in progress.

This PR focuses on a new diagnostics service for firmware_uefi. 

UEFI will write the GPA of the advanced logger buffer (which we formally call EFI Diagnostics here) to an Io port intercept called `SET_EFI_DIAGNOSTICS_GPA`. 

UEFI will also write to a different Io port intercept called `PROCESS_EFI_DIAGNOSTICS`, which signals us to process the EFI Diagnostics buffer.

The diagnostics subsystem's role is to read into guest memory from the specified GPA, collect advanced logger entries and log them to our tracing facilities. This will get triggered by the following conditions:
- UEFI encounters a failure (guest driven via `PROCESS_EFI_DIAGNOSTICS`
- UEFI fails to boot any device (guest driven via `PROCESS_EFI_DIAGNOSTICS`
- UEFI reaches exit boot services
- The VM turns off // resets