### PR TITLE
loader: use the x86 selector definition

### DIFF
--- a/vm/x86/x86defs/src/lib.rs
+++ b/vm/x86/x86defs/src/lib.rs
@@ -116,6 +116,30 @@ impl<'a> arbitrary::Arbitrary<'a> for SegmentAttributes {
     }
 }
 
+/// Segment selector (what goes into a segment register)
+#[bitfield(u16)]
+#[derive(PartialEq, Eq)]
+pub struct SegmentSelector {
+    #[bits(2)]
+    /// Request Privilege Level (ring 0-3, where 0 is the highest)
+    pub rpl: u8,
+    /// Table indicator: 0 - GDT, 1 - LDT
+    pub ti: bool,
+    #[bits(13)]
+    /// Index in the descriptor table
+    pub index: u16,
+}
+
+impl SegmentSelector {
+    pub const fn as_bits(&self) -> u16 {
+        self.0
+    }
+
+    pub fn from_gdt_index(index: u16, rpl: u8) -> Self {
+        Self::new().with_index(index).with_rpl(rpl).with_ti(false)
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct SegmentRegister {
     pub base: u64,
@@ -373,6 +397,17 @@ impl LargeGdtEntry {
         entries.as_mut_bytes().copy_from_slice(self.as_bytes());
         entries
     }
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy, Immutable, KnownLayout, IntoBytes, FromBytes)]
+pub struct Tss64 {
+    pub _mbz0: u32,
+    pub rsp: [u64; 3],
+    pub ist: [u64; 8],
+    pub _mbz1: u64,
+    pub _mbz2: u16,
+    pub io_map_base: u16,
 }
 
 open_enum! {


### PR DESCRIPTION
The existing code works by luck because we use the ring 0
GDT selectors. The selector is computed by multiplying the
index by the size of the small GDT entry (by 8 bytes), and
the ring 0 GDT selectors can be computed by shifting by 3.
That gives the correct result by chance rather than by
following the specification.

Extend the x86 definitions, calculate the selectors as the
specification defines.
