### PR TITLE
underhill_core: add OPENHCL_SIGNAL_VTL0_STARTED option

### DIFF
--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -41,6 +41,12 @@ pub struct Options {
     ///  wait for a diagnostics start request before initializing and starting the VM
     pub wait_for_start: bool,
 
+    /// (OPENHCL_SIGNAL_VTL0_STARTED=1)
+    /// immediately signal that VTL0 has started, before doing any
+    /// initialization. This allows VM boot to proceed even if initialization
+    /// may hang (e.g., because you specified OPENHCL_WAIT_FOR_START=1).
+    pub signal_vtl0_started: bool,
+
     /// (OPENHCL_REFORMAT_VMGS=1 | --reformat-vmgs)
     /// reformat the VMGS file on boot. useful for running potentially destructive VMGS tests.
     pub reformat_vmgs: bool,
@@ -244,6 +250,7 @@ impl Options {
                 .ok()
         });
         let disable_uefi_frontpage = parse_env_bool("OPENHCL_DISABLE_UEFI_FRONTPAGE");
+        let signal_vtl0_started = parse_env_bool("OPENHCL_SIGNAL_VTL0_STARTED");
 
         let mut args = std::env::args().chain(extra_args);
         // Skip our own filename.
@@ -276,6 +283,7 @@ impl Options {
 
         Ok(Self {
             wait_for_start,
+            signal_vtl0_started,
             reformat_vmgs,
             pid,
             vmbus_max_version,


### PR DESCRIPTION
Add a new option, `OPENHCL_SIGNAL_VTL0_STARTED`, for signaling the host that VTL0 is ready very early in paravisor start. This is useful when you don't want a Hyper-V host to wait for VTL0 to start (e.g., because it will never start or will delayed indefinitely via `OPENHCL_WAIT_FOR_START`).