### PR TITLE
2411: vmbus_channel: Stopped vmbus devices should not see vmbus requests.

### DIFF
--- a/vm/devices/vmbus/vmbus_channel/src/channel.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/channel.rs
@@ -444,7 +444,16 @@ impl From<ChannelRestoreError> for RestoreError {
     }
 }
 
+enum DeviceState {
+    Running,
+    // Track updates while the channel is stopped. If it is restarted, need to
+    // process outstanding requests. If the channel goes through save/restore,
+    // vmbus_server will resend the requests.
+    Stopped(Vec<(usize, ChannelRequest)>),
+}
+
 struct Device {
+    state: DeviceState,
     server_requests: Vec<mesh::Sender<ChannelServerRequest>>,
     open: Vec<bool>,
     subchannel_gpadls: Vec<BTreeSet<GpadlId>>,
@@ -468,6 +477,7 @@ impl Device {
             SelectAll::new();
         requests.push(TaggedStream::new(0, request_recv));
         Self {
+            state: DeviceState::Running,
             server_requests: vec![server_request_send],
             open,
             subchannel_gpadls,
@@ -553,6 +563,18 @@ impl Device {
         request: ChannelRequest,
         channel: &mut dyn VmbusDevice,
     ) {
+        // When the device is stopped, the wrapped channel should not receive
+        // any new vmbus requests. The 'close' callback is special-cased to
+        // handle vmbus_server reset, and the GPADL requests are handled without a
+        // callback. This leaves 'open' and 'modify' which will be pended until
+        // restart.
+        if matches!(request, ChannelRequest::Open(_) | ChannelRequest::Modify(_)) {
+            if let DeviceState::Stopped(pending_messages) = &mut self.state {
+                pending_messages.push((channel_idx, request));
+                return;
+            }
+        }
+
         match request {
             ChannelRequest::Open(rpc) => {
                 rpc.handle(|open_request| async {
@@ -686,14 +708,30 @@ impl Device {
         match request {
             StateRequest::Start => {
                 channel.start();
+                if let DeviceState::Stopped(pending_messages) =
+                    std::mem::replace(&mut self.state, DeviceState::Running)
+                {
+                    for (channel_idx, request) in pending_messages.into_iter() {
+                        self.handle_channel_request(channel_idx, request, channel)
+                            .await;
+                    }
+                }
             }
             StateRequest::Stop(rpc) => {
-                rpc.handle(|()| async {
-                    channel.stop().await;
-                })
-                .await;
+                if matches!(self.state, DeviceState::Running) {
+                    self.state = DeviceState::Stopped(Vec::new());
+                    rpc.handle(|()| async {
+                        channel.stop().await;
+                    })
+                    .await;
+                } else {
+                    rpc.complete(());
+                }
             }
             StateRequest::Reset(rpc) => {
+                if let DeviceState::Stopped(pending_messages) = &mut self.state {
+                    pending_messages.clear();
+                }
                 rpc.complete(());
             }
             StateRequest::Save(rpc) => {

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1596,10 +1596,19 @@ impl ParentBus for VmbusServerControl {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use inspect::InspectMut;
+    use mesh::CancelReason;
     use pal_async::async_test;
+    use pal_async::DefaultDriver;
     use parking_lot::Mutex;
     use protocol::UserDefinedData;
+    use std::time::Duration;
     use vmbus_channel::bus::OfferParams;
+    use vmbus_channel::channel::offer_channel;
+    use vmbus_channel::channel::ChannelOpenError;
+    use vmbus_channel::channel::DeviceResources;
+    use vmbus_channel::channel::SaveRestoreVmbusDevice;
+    use vmbus_channel::channel::VmbusDevice;
     use vmbus_core::protocol::ChannelId;
     use vmbus_core::protocol::VmbusMessage;
     use vmcore::synic::SynicPortAccess;
@@ -1959,6 +1968,248 @@ mod tests {
         env.synic.send_message(protocol::RelIdReleased {
             channel_id: ChannelId(1),
         });
+    }
+
+    struct TestDeviceState {
+        id: u32,
+        started: bool,
+        resources: Option<DeviceResources>,
+        open_requests: HashMap<u16, OpenRequest>,
+        target_vps: HashMap<u16, u32>,
+    }
+
+    impl TestDeviceState {
+        pub fn id(this: &Arc<Mutex<Self>>) -> u32 {
+            this.lock().id
+        }
+
+        pub fn started(this: &Arc<Mutex<Self>>) -> bool {
+            this.lock().started
+        }
+        pub fn set_started(this: &Arc<Mutex<Self>>, started: bool) {
+            this.lock().started = started;
+        }
+
+        pub fn open_request(this: &Arc<Mutex<Self>>, channel_idx: u16) -> Option<OpenRequest> {
+            this.lock().open_requests.get(&channel_idx).cloned()
+        }
+        pub fn set_open_request(
+            this: &Arc<Mutex<Self>>,
+            channel_idx: u16,
+            open_request: OpenRequest,
+        ) {
+            assert!(this
+                .lock()
+                .open_requests
+                .insert(channel_idx, open_request)
+                .is_none());
+        }
+        pub fn remove_open_request(
+            this: &Arc<Mutex<Self>>,
+            channel_idx: u16,
+        ) -> Option<OpenRequest> {
+            this.lock().open_requests.remove(&channel_idx)
+        }
+
+        pub fn target_vp(this: &Arc<Mutex<Self>>, channel_idx: u16) -> Option<u32> {
+            this.lock().target_vps.get(&channel_idx).copied()
+        }
+        pub fn set_target_vp(this: &Arc<Mutex<Self>>, channel_idx: u16, target_vp: u32) {
+            let _ = this.lock().target_vps.insert(channel_idx, target_vp);
+        }
+    }
+
+    #[derive(InspectMut)]
+    struct TestDevice {
+        #[inspect(skip)]
+        pub state: Arc<Mutex<TestDeviceState>>,
+    }
+
+    impl TestDevice {
+        pub fn new_and_state(id: u32) -> (Self, Arc<Mutex<TestDeviceState>>) {
+            let state = TestDeviceState {
+                id,
+                resources: None,
+                open_requests: HashMap::new(),
+                target_vps: HashMap::new(),
+                started: false,
+            };
+            let state = Arc::new(Mutex::new(state));
+            let this = Self {
+                state: state.clone(),
+            };
+            (this, state)
+        }
+    }
+
+    #[async_trait]
+    impl VmbusDevice for TestDevice {
+        fn offer(&self) -> OfferParams {
+            let guid = Guid {
+                data1: TestDeviceState::id(&self.state),
+                ..Guid::ZERO
+            };
+
+            OfferParams {
+                interface_name: "test".into(),
+                instance_id: guid,
+                interface_id: guid,
+                mmio_megabytes: 0,
+                mmio_megabytes_optional: 0,
+                channel_type: vmbus_channel::bus::ChannelType::Device {
+                    pipe_packets: false,
+                },
+                subchannel_index: 0,
+                use_mnf: false,
+                offer_order: None,
+                allow_confidential_external_memory: false,
+            }
+        }
+
+        fn max_subchannels(&self) -> u16 {
+            0
+        }
+
+        fn install(&mut self, resources: DeviceResources) {
+            self.state.lock().resources = Some(resources);
+        }
+
+        async fn open(
+            &mut self,
+            channel_idx: u16,
+            open_request: &OpenRequest,
+        ) -> Result<(), ChannelOpenError> {
+            tracing::info!("OPEN");
+            TestDeviceState::set_open_request(&self.state, channel_idx, open_request.clone());
+            Ok(())
+        }
+
+        async fn close(&mut self, channel_idx: u16) {
+            tracing::info!("CLOSE");
+            assert!(TestDeviceState::remove_open_request(&self.state, channel_idx).is_some());
+        }
+
+        async fn retarget_vp(&mut self, channel_idx: u16, target_vp: u32) {
+            TestDeviceState::set_target_vp(&self.state, channel_idx, target_vp);
+        }
+
+        fn start(&mut self) {
+            tracing::info!("START");
+            TestDeviceState::set_started(&self.state, true);
+        }
+
+        async fn stop(&mut self) {
+            tracing::info!("STOP");
+            TestDeviceState::set_started(&self.state, false);
+        }
+
+        fn supports_save_restore(&mut self) -> Option<&mut dyn SaveRestoreVmbusDevice> {
+            None
+        }
+    }
+
+    #[async_test]
+    async fn test_stopped_child(spawner: DefaultDriver) {
+        // This is mostly testing vmbus_channel behavior when a channel is
+        // stopped but vbmus_server is not and continues to receive
+        // messages.
+        let mut env = TestEnv::new(spawner.clone());
+        let (test_device, test_device_state) = TestDevice::new_and_state(1);
+        let control = env.vmbus.control();
+        let channel = offer_channel(&spawner, control.as_ref(), test_device)
+            .await
+            .expect("test device failed to offer");
+
+        env.vmbus.start();
+        env.connect(1, protocol::FeatureFlags::new(), false).await;
+
+        // Stop the channel.
+        channel.stop().await;
+
+        assert_eq!(TestDeviceState::started(&test_device_state), false);
+
+        // GPADL processing is currently allowed while the channel is stopped,
+        // so this should complete.
+        env.synic.send_message_core(
+            OutgoingMessage::with_data(
+                &protocol::GpadlHeader {
+                    channel_id: ChannelId(1),
+                    gpadl_id: GpadlId(1),
+                    count: 1,
+                    len: 16,
+                },
+                [1u64, 0u64].as_bytes(),
+            ),
+            false,
+        );
+        env.expect_response(protocol::MessageType::GPADL_CREATED)
+            .await;
+
+        // Open will pend while the channel is stopped.
+        env.synic.send_message_core(
+            OutgoingMessage::new(&protocol::OpenChannel {
+                channel_id: ChannelId(1),
+                open_id: 0,
+                ring_buffer_gpadl_id: GpadlId(1),
+                target_vp: 0,
+                downstream_ring_buffer_page_offset: 0,
+                user_data: UserDefinedData::default(),
+            }),
+            false,
+        );
+        let wait_for_response = mesh::CancelContext::new()
+            .with_timeout(Duration::from_millis(150))
+            .until_cancelled(env.expect_response(protocol::MessageType::OPEN_CHANNEL_RESULT))
+            .await;
+        assert!(matches!(
+            wait_for_response,
+            Err(CancelReason::DeadlineExceeded)
+        ));
+        assert!(TestDeviceState::open_request(&test_device_state, 0).is_none());
+
+        // Restart the channel and confirm that open completes.
+        channel.start();
+        env.expect_response(protocol::MessageType::OPEN_CHANNEL_RESULT)
+            .await;
+        assert!(TestDeviceState::open_request(&test_device_state, 0).is_some());
+
+        // Stop the channel and send a modify request.
+        assert!(TestDeviceState::target_vp(&test_device_state, 0).is_none());
+        channel.stop().await;
+        env.synic.send_message_core(
+            OutgoingMessage::new(&protocol::ModifyChannel {
+                channel_id: ChannelId(1),
+                target_vp: 2,
+            }),
+            false,
+        );
+        let wait_for_response = mesh::CancelContext::new()
+            .with_timeout(Duration::from_millis(150))
+            .until_cancelled(env.expect_response(protocol::MessageType::MODIFY_CHANNEL_RESPONSE))
+            .await;
+        assert!(matches!(
+            wait_for_response,
+            Err(CancelReason::DeadlineExceeded)
+        ));
+
+        // Restart the channel and verify the modify request completes.
+        channel.start();
+        env.expect_response(protocol::MessageType::MODIFY_CHANNEL_RESPONSE)
+            .await;
+        assert_eq!(
+            TestDeviceState::target_vp(&test_device_state, 0)
+                .expect("Modify channel request received"),
+            2
+        );
+
+        // Stop the channel and send a close request. Close is currently
+        // allowed through in order to support reset of the vmbus
+        // server, so try that.
+        channel.stop().await;
+        env.vmbus.reset().await;
+        assert!(TestDeviceState::open_request(&test_device_state, 0).is_none());
+
+        env.vmbus.stop().await;
     }
 
     #[async_test]


### PR DESCRIPTION
Port of #1128

During stop, the vmbus channels are stopped before the vmbus server, which leaves a small window where a vmbus request from the guest can arrive after the channel is stopped. Handle this by pending the message in the vmbus channel code. These pended messages do not need to be saved, because vmbus_server will replay them on restore. The maximum number of pended requests should be two per channel_idx, for the case of a pended modify request followed by a pended close. Any other combination should be rejected by vmbus as the device will not be in a valid state.

---------