### PR TITLE
2411: x64_regs: Flush dirty registry page contents at save.

### DIFF
--- a/openhcl/hcl/src/ioctl/aarch64.rs
+++ b/openhcl/hcl/src/ioctl/aarch64.rs
@@ -159,4 +159,6 @@ impl super::BackingPrivate for MshvArm64 {
         };
         Ok(value)
     }
+
+    fn flush_register_page(_runner: &mut ProcessorRunner<'_, Self>) {}
 }

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -204,6 +204,8 @@ impl super::private::BackingPrivate for Snp {
     ) -> Result<Option<HvRegisterValue>, super::Error> {
         Ok(None)
     }
+
+    fn flush_register_page(_runner: &mut ProcessorRunner<'_, Self>) {}
 }
 
 impl ProcessorRunner<'_, Snp> {

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -341,6 +341,8 @@ impl super::private::BackingPrivate for Tdx {
     ) -> Result<Option<HvRegisterValue>, super::Error> {
         Ok(None)
     }
+
+    fn flush_register_page(_runner: &mut ProcessorRunner<'_, Self>) {}
 }
 
 struct MshvVtlTdcall<'a>(&'a MshvVtl);

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -731,7 +731,7 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
                 }
             }
         }
-        self.runner.flush_deferred_actions();
+        self.runner.flush_deferred_state();
         Ok(())
     }
 

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -3433,11 +3433,17 @@ pub struct HvRegisterVpAssistPage {
     pub gpa_page_number: u64,
 }
 
-pub const HV_X64_REGISTER_CLASS_GENERAL: u8 = 0;
-pub const HV_X64_REGISTER_CLASS_IP: u8 = 1;
-pub const HV_X64_REGISTER_CLASS_XMM: u8 = 2;
-pub const HV_X64_REGISTER_CLASS_SEGMENT: u8 = 3;
-pub const HV_X64_REGISTER_CLASS_FLAGS: u8 = 4;
+#[bitfield(u32)]
+#[derive(AsBytes, FromBytes, FromZeroes)]
+pub struct X64RegisterPageDirtyFlags {
+    pub general_purpose: bool,
+    pub instruction_pointer: bool,
+    pub xmm: bool,
+    pub segments: bool,
+    pub flags: bool,
+    #[bits(27)]
+    reserved: u32,
+}
 
 #[repr(C)]
 #[derive(Debug, AsBytes, FromBytes, FromZeroes)]
@@ -3445,7 +3451,7 @@ pub struct HvX64RegisterPage {
     pub version: u16,
     pub is_valid: u8,
     pub vtl: u8,
-    pub dirty: u32,
+    pub dirty: X64RegisterPageDirtyFlags,
     pub gp_registers: [u64; 16],
     pub rip: u64,
     pub rflags: u64,


### PR DESCRIPTION
Port of #1077
Save/restore will destroy the registry page contents, so flush them out to other locations on save.

---------