### PR TITLE
TDX: Add support for descriptor table intercepts & some emulation

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -2041,7 +2041,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
     /// intercept.
     #[must_use]
     pub(crate) fn cvm_try_protect_secure_register_write(
-        &mut self,
+        &self,
         vtl: GuestVtl,
         reg: HvX64RegisterName,
         value: u64,

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -68,8 +68,10 @@ use virt::x86::SegmentRegister;
 use virt::x86::TableRegister;
 use virt_support_apic::ApicClient;
 use virt_support_apic::OffloadNotSupported;
+use virt_support_x86emu::emulate::EmulatedMemoryOperation;
 use virt_support_x86emu::emulate::EmulatorSupport as X86EmulatorSupport;
 use virt_support_x86emu::emulate::TranslateMode;
+use virt_support_x86emu::emulate::emulate_insn_memory_op;
 use virt_support_x86emu::emulate::emulate_io;
 use virt_support_x86emu::emulate::emulate_translate_gva;
 use virt_support_x86emu::translate::TranslationRegisters;
@@ -80,6 +82,7 @@ use x86defs::X64_CR0_NE;
 use x86defs::X64_CR0_PE;
 use x86defs::X64_CR0_PG;
 use x86defs::X64_CR4_MCE;
+use x86defs::X64_CR4_UMIP;
 use x86defs::X64_CR4_VMXE;
 use x86defs::X64_EFER_FFXSR;
 use x86defs::X64_EFER_LMA;
@@ -222,7 +225,7 @@ impl ShadowedRegister {
                     | x86defs::X64_CR4_PCE
                     | x86defs::X64_CR4_FXSR
                     | x86defs::X64_CR4_XMMEXCPT
-                    | x86defs::X64_CR4_UMIP
+                    | X64_CR4_UMIP
                     | x86defs::X64_CR4_LA57
                     | x86defs::X64_CR4_RWFSGS
                     | x86defs::X64_CR4_PCIDE
@@ -2084,7 +2087,7 @@ impl UhProcessor<'_, TdxBacked> {
                     && !self.cvm_try_protect_secure_register_write(intercepted_vtl, reg, 0))
                     || !info.instruction().is_write()
                 {
-                    todo!();
+                    self.emulate_gdtr_or_idtr(intercepted_vtl, dev).await?;
                 }
                 &mut self.backing.vtls[intercepted_vtl]
                     .exit_stats
@@ -2104,7 +2107,7 @@ impl UhProcessor<'_, TdxBacked> {
                     && !self.cvm_try_protect_secure_register_write(intercepted_vtl, reg, 0))
                     || !info.instruction().is_write()
                 {
-                    todo!()
+                    self.emulate_ldtr_or_tr(intercepted_vtl, dev).await?;
                 }
                 &mut self.backing.vtls[intercepted_vtl]
                     .exit_stats
@@ -3004,17 +3007,11 @@ impl UhProcessor<'_, TdxBacked> {
         self.backing.vtls[vtl].cr4.write(value, &mut self.runner)
     }
 
-    fn write_table_register(
-        &mut self,
-        vtl: GuestVtl,
-        table: TdxTableReg,
-        reg: TableRegister,
-    ) -> Result<(), vp_state::Error> {
+    fn write_table_register(&mut self, vtl: GuestVtl, table: TdxTableReg, reg: TableRegister) {
         self.runner
             .write_vmcs64(vtl, table.base_code(), !0, reg.base);
         self.runner
             .write_vmcs32(vtl, table.limit_code(), !0, reg.limit.into());
-        Ok(())
     }
 
     fn read_table_register(&self, vtl: GuestVtl, table: TdxTableReg) -> TableRegister {
@@ -3051,6 +3048,136 @@ impl UhProcessor<'_, TdxBacked> {
                 0
             },
         );
+    }
+
+    async fn emulate_gdtr_or_idtr(
+        &mut self,
+        vtl: GuestVtl,
+        dev: &impl CpuIo,
+    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+        let exit_info = TdxExit(self.runner.tdx_vp_enter_exit_info());
+        assert_eq!(
+            exit_info.code().vmx_exit().basic_reason(),
+            VmxExitBasic::GDTR_OR_IDTR
+        );
+        let instr_info = GdtrOrIdtrInstructionInfo::from(exit_info.instr_info().info());
+        let gps = self.runner.tdx_enter_guest_gps();
+
+        // Check if read instructions are blocked by UMIP.
+        if !instr_info.instruction().is_write()
+            && exit_info.cpl() > 0
+            && self.read_cr4(vtl) & X64_CR4_UMIP != 0
+        {
+            self.inject_gpf(vtl);
+            return Ok(());
+        }
+
+        // Displacement is stored in the qualification field for these instructions.
+        let mut gva = exit_info.qualification();
+        if !instr_info.base_register_invalid() {
+            gva += gps[instr_info.base_register() as usize];
+        }
+        if !instr_info.index_register_invalid() {
+            gva += gps[instr_info.index_register() as usize] << instr_info.scaling();
+        }
+        match instr_info.address_size() {
+            // 16-bit address size
+            0 => gva &= 0xFFFF,
+            // 32-bit address size
+            1 => gva &= 0xFFFFFFFF,
+            // 64-bit address size
+            2 => {}
+            _ => unreachable!(),
+        }
+
+        let segment = match instr_info.segment_register() {
+            0 => Segment::ES,
+            1 => Segment::CS,
+            2 => Segment::SS,
+            3 => Segment::DS,
+            4 => Segment::FS,
+            5 => Segment::GS,
+            _ => unreachable!(),
+        };
+
+        let gm = &self.partition.gm[vtl];
+        let interruption_pending = self.backing.vtls[vtl].interruption_information.valid();
+        let len = 2 + if self.long_mode(vtl) { 8 } else { 4 };
+        let mut buf = [0u8; 10];
+
+        match instr_info.instruction() {
+            GdtrOrIdtrInstruction::Sidt | GdtrOrIdtrInstruction::Sgdt => {
+                let table = self.read_table_register(
+                    vtl,
+                    if matches!(instr_info.instruction(), GdtrOrIdtrInstruction::Sidt) {
+                        TdxTableReg::Idtr
+                    } else {
+                        TdxTableReg::Gdtr
+                    },
+                );
+                buf[..2].copy_from_slice(&table.limit.to_le_bytes());
+                buf[2..].copy_from_slice(&table.base.to_le_bytes());
+                let mut emulation_state = UhEmulationState {
+                    vp: &mut *self,
+                    interruption_pending,
+                    devices: dev,
+                    vtl,
+                    cache: TdxEmulationCache::default(),
+                };
+                emulate_insn_memory_op(
+                    &mut emulation_state,
+                    gm,
+                    dev,
+                    gva,
+                    segment,
+                    EmulatedMemoryOperation::Write(&buf[..len]),
+                )
+                .await?;
+            }
+
+            GdtrOrIdtrInstruction::Lgdt | GdtrOrIdtrInstruction::Lidt => {
+                let mut emulation_state = UhEmulationState {
+                    vp: &mut *self,
+                    interruption_pending,
+                    devices: dev,
+                    vtl,
+                    cache: TdxEmulationCache::default(),
+                };
+                emulate_insn_memory_op(
+                    &mut emulation_state,
+                    gm,
+                    dev,
+                    gva,
+                    segment,
+                    EmulatedMemoryOperation::Read(&mut buf[..len]),
+                )
+                .await?;
+                let table = TableRegister {
+                    limit: u16::from_le_bytes(buf[..2].try_into().unwrap()),
+                    base: u64::from_le_bytes(buf[2..len].try_into().unwrap()),
+                };
+                self.write_table_register(
+                    vtl,
+                    if matches!(instr_info.instruction(), GdtrOrIdtrInstruction::Lidt) {
+                        TdxTableReg::Idtr
+                    } else {
+                        TdxTableReg::Gdtr
+                    },
+                    table,
+                );
+            }
+        }
+
+        self.advance_to_next_instruction(vtl);
+        Ok(())
+    }
+
+    async fn emulate_ldtr_or_tr(
+        &mut self,
+        _vtl: GuestVtl,
+        _dev: &impl CpuIo,
+    ) -> Result<(), VpHaltReason<UhRunVpError>> {
+        todo!()
     }
 }
 
@@ -3337,9 +3464,9 @@ impl AccessVpState for UhVpStateAccess<'_, '_, TdxBacked> {
 
         // Set table registers
         self.vp
-            .write_table_register(self.vtl, TdxTableReg::Gdtr, *gdtr)?;
+            .write_table_register(self.vtl, TdxTableReg::Gdtr, *gdtr);
         self.vp
-            .write_table_register(self.vtl, TdxTableReg::Idtr, *idtr)?;
+            .write_table_register(self.vtl, TdxTableReg::Idtr, *idtr);
 
         self.vp.write_cr0(self.vtl, *cr0)?;
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -3124,7 +3124,6 @@ impl UhProcessor<'_, TdxBacked> {
                     vtl,
                     cache: TdxEmulationCache::default(),
                 };
-                // TODO: Check alignment for these instructions.
                 emulate_insn_memory_op(
                     &mut emulation_state,
                     gm,
@@ -3145,7 +3144,6 @@ impl UhProcessor<'_, TdxBacked> {
                     vtl,
                     cache: TdxEmulationCache::default(),
                 };
-                // TODO: Check alignment for these instructions.
                 emulate_insn_memory_op(
                     &mut emulation_state,
                     gm,

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -3124,12 +3124,14 @@ impl UhProcessor<'_, TdxBacked> {
                     vtl,
                     cache: TdxEmulationCache::default(),
                 };
+                // TODO: Check alignment for these instructions.
                 emulate_insn_memory_op(
                     &mut emulation_state,
                     gm,
                     dev,
                     gva,
                     segment,
+                    x86emu::AlignmentMode::Unaligned,
                     EmulatedMemoryOperation::Write(&buf[..len]),
                 )
                 .await?;
@@ -3143,12 +3145,14 @@ impl UhProcessor<'_, TdxBacked> {
                     vtl,
                     cache: TdxEmulationCache::default(),
                 };
+                // TODO: Check alignment for these instructions.
                 emulate_insn_memory_op(
                     &mut emulation_state,
                     gm,
                     dev,
                     gva,
                     segment,
+                    x86emu::AlignmentMode::Unaligned,
                     EmulatedMemoryOperation::Read(&mut buf[..len]),
                 )
                 .await?;

--- a/vm/x86/x86defs/src/tdx.rs
+++ b/vm/x86/x86defs/src/tdx.rs
@@ -504,7 +504,7 @@ pub struct TdxExtendedFieldCode {
 /// Instruction info returned in r11 for a TDG.VP.ENTER call.
 #[bitfield(u64)]
 pub struct TdxInstructionInfo {
-    pub info: u32, // TODO TDX: what is this
+    pub info: u32,
     pub length: u32,
 }
 

--- a/vm/x86/x86defs/src/vmx.rs
+++ b/vm/x86/x86defs/src/vmx.rs
@@ -31,6 +31,8 @@ open_enum! {
         MSR_WRITE = 0x20,
         BAD_GUEST_STATE = 0x21,
         TPR_BELOW_THRESHOLD = 0x2B,
+        GDTR_OR_IDTR = 0x2E,
+        LDTR_OR_TR = 0x2F,
         EPT_VIOLATION = 0x30,
         WBINVD_INSTRUCTION = 0x36,
         XSETBV = 0x37,
@@ -288,6 +290,120 @@ pub struct InterruptionInformation {
     #[bits(19)]
     pub reserved: u32,
     pub valid: bool,
+}
+
+#[bitfield(u32)]
+pub struct GdtrOrIdtrInstructionInfo {
+    #[bits(2)]
+    pub scaling: u8,
+    #[bits(5)]
+    _reserved1: u8,
+    #[bits(3)]
+    pub address_size: u8,
+    _reserved2: bool,
+    pub operand_size: bool,
+    #[bits(3)]
+    _reserved3: u8,
+    #[bits(3)]
+    pub segment_register: u8,
+    #[bits(4)]
+    pub index_register: u8,
+    pub index_register_valid: bool,
+    #[bits(4)]
+    pub base_register: u8,
+    pub base_register_valid: bool,
+    #[bits(2)]
+    pub instruction: GdtrOrIdtrInstruction,
+    #[bits(2)]
+    _reserved4: u8,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum GdtrOrIdtrInstruction {
+    Sgdt = 0,
+    Sidt = 1,
+    Lgdt = 2,
+    Lidt = 3,
+}
+
+impl GdtrOrIdtrInstruction {
+    pub const fn from_bits(value: u8) -> Self {
+        match value {
+            0 => GdtrOrIdtrInstruction::Sgdt,
+            1 => GdtrOrIdtrInstruction::Sidt,
+            2 => GdtrOrIdtrInstruction::Lgdt,
+            3 => GdtrOrIdtrInstruction::Lidt,
+            _ => unreachable!(),
+        }
+    }
+
+    pub const fn into_bits(self) -> u8 {
+        self as u8
+    }
+
+    pub const fn is_write(self) -> bool {
+        match self {
+            GdtrOrIdtrInstruction::Lgdt | GdtrOrIdtrInstruction::Lidt => true,
+            GdtrOrIdtrInstruction::Sgdt | GdtrOrIdtrInstruction::Sidt => false,
+        }
+    }
+}
+
+#[bitfield(u32)]
+pub struct LdtrOrTrInstructionInfo {
+    #[bits(2)]
+    pub scaling: u8,
+    _reserved1: bool,
+    #[bits(4)]
+    pub register_1: u8,
+    #[bits(3)]
+    pub address_size: u8,
+    pub memory_or_register: bool,
+    #[bits(4)]
+    _reserved2: u8,
+    #[bits(3)]
+    pub segment_register: u8,
+    #[bits(4)]
+    pub index_register: u8,
+    pub index_register_valid: bool,
+    #[bits(4)]
+    pub base_register: u8,
+    pub base_register_valid: bool,
+    #[bits(2)]
+    pub instruction: LdtrOrTrInstruction,
+    #[bits(2)]
+    _reserved4: u8,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum LdtrOrTrInstruction {
+    Sldt = 0,
+    Str = 1,
+    Lldt = 2,
+    Ltr = 3,
+}
+
+impl LdtrOrTrInstruction {
+    pub const fn from_bits(value: u8) -> Self {
+        match value {
+            0 => LdtrOrTrInstruction::Sldt,
+            1 => LdtrOrTrInstruction::Str,
+            2 => LdtrOrTrInstruction::Lldt,
+            3 => LdtrOrTrInstruction::Ltr,
+            _ => unreachable!(),
+        }
+    }
+
+    pub const fn into_bits(self) -> u8 {
+        self as u8
+    }
+
+    pub const fn is_write(self) -> bool {
+        match self {
+            LdtrOrTrInstruction::Lldt | LdtrOrTrInstruction::Ltr => true,
+            LdtrOrTrInstruction::Sldt | LdtrOrTrInstruction::Str => false,
+        }
+    }
 }
 
 pub const INTERRUPT_TYPE_EXTERNAL: u8 = 0;

--- a/vm/x86/x86defs/src/vmx.rs
+++ b/vm/x86/x86defs/src/vmx.rs
@@ -308,10 +308,10 @@ pub struct GdtrOrIdtrInstructionInfo {
     pub segment_register: u8,
     #[bits(4)]
     pub index_register: u8,
-    pub index_register_valid: bool,
+    pub index_register_invalid: bool,
     #[bits(4)]
     pub base_register: u8,
-    pub base_register_valid: bool,
+    pub base_register_invalid: bool,
     #[bits(2)]
     pub instruction: GdtrOrIdtrInstruction,
     #[bits(2)]
@@ -365,10 +365,10 @@ pub struct LdtrOrTrInstructionInfo {
     pub segment_register: u8,
     #[bits(4)]
     pub index_register: u8,
-    pub index_register_valid: bool,
+    pub index_register_invalid: bool,
     #[bits(4)]
     pub base_register: u8,
-    pub base_register_valid: bool,
+    pub base_register_invalid: bool,
     #[bits(2)]
     pub instruction: LdtrOrTrInstruction,
     #[bits(2)]

--- a/vm/x86/x86defs/src/vmx.rs
+++ b/vm/x86/x86defs/src/vmx.rs
@@ -327,7 +327,7 @@ pub enum GdtrOrIdtrInstruction {
 }
 
 impl GdtrOrIdtrInstruction {
-    pub const fn from_bits(value: u8) -> Self {
+    const fn from_bits(value: u8) -> Self {
         match value {
             0 => GdtrOrIdtrInstruction::Sgdt,
             1 => GdtrOrIdtrInstruction::Sidt,
@@ -337,7 +337,7 @@ impl GdtrOrIdtrInstruction {
         }
     }
 
-    pub const fn into_bits(self) -> u8 {
+    const fn into_bits(self) -> u8 {
         self as u8
     }
 
@@ -384,7 +384,7 @@ pub enum LdtrOrTrInstruction {
 }
 
 impl LdtrOrTrInstruction {
-    pub const fn from_bits(value: u8) -> Self {
+    const fn from_bits(value: u8) -> Self {
         match value {
             0 => LdtrOrTrInstruction::Sldt,
             1 => LdtrOrTrInstruction::Str,
@@ -394,7 +394,7 @@ impl LdtrOrTrInstruction {
         }
     }
 
-    pub const fn into_bits(self) -> u8 {
+    const fn into_bits(self) -> u8 {
         self as u8
     }
 

--- a/vm/x86/x86emu/src/emulator.rs
+++ b/vm/x86/x86emu/src/emulator.rs
@@ -315,7 +315,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
         );
         let gpindex = Error::InstructionException(
             Exception::GENERAL_PROTECTION_FAULT,
-            Some((segment_value.selector & !0b111).into()),
+            Some(segment_value.selector.into()),
             ExceptionCause::SegmentValidity,
         );
 

--- a/vm/x86/x86emu/src/emulator.rs
+++ b/vm/x86/x86emu/src/emulator.rs
@@ -222,7 +222,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
             Bitness::Bit64 => Some(rip),
             Bitness::Bit32 | Bitness::Bit16 => {
                 self.verify_segment_access(
-                    Register::CS,
+                    Segment::CS,
                     OperationKind::AddressComputation,
                     offset,
                     1,
@@ -255,29 +255,27 @@ impl<'a, T: Cpu> Emulator<'a, T> {
     /// access within the segment is allowed.
     fn compute_and_validate_gva(
         &mut self,
-        segment: Register,
+        segment: Segment,
         offset: u64,
         len: usize,
         op: OperationKind,
         alignment: AlignmentMode,
     ) -> Result<u64, Error<T::Error>> {
-        assert!(segment.is_segment_register());
-
         let cr0 = self.cpu.cr0();
         let efer = self.cpu.efer();
         let cs = self.cpu.segment(Segment::CS);
 
         let base = match bitness(cr0, efer, cs) {
             Bitness::Bit64 => {
-                if segment == Register::FS || segment == Register::GS {
-                    self.cpu.segment(segment.into()).base
+                if matches!(segment, Segment::FS | Segment::GS) {
+                    self.cpu.segment(segment).base
                 } else {
                     0
                 }
             }
             Bitness::Bit32 | Bitness::Bit16 => {
                 self.verify_segment_access(segment, op, offset, len)?;
-                self.cpu.segment(segment.into()).base
+                self.cpu.segment(segment).base
             }
         };
 
@@ -292,7 +290,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
     /// checks are ignored in this case.
     fn verify_segment_access(
         &mut self,
-        segment: Register,
+        segment: Segment,
         op: OperationKind,
         offset: u64,
         len: usize,
@@ -304,8 +302,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
         let bitness = bitness(cr0, efer, cs);
         assert_ne!(bitness, Bitness::Bit64);
 
-        let segment_index = segment.number();
-        let segment = self.cpu.segment(segment.into());
+        let segment_value = self.cpu.segment(segment);
 
         // Since we're not in long mode, offset can be at most u32::MAX, and same goes for len. So this
         // can't overflow.
@@ -318,30 +315,30 @@ impl<'a, T: Cpu> Emulator<'a, T> {
         );
         let gpindex = Error::InstructionException(
             Exception::GENERAL_PROTECTION_FAULT,
-            Some(segment_index as u32),
+            Some((segment_value.selector & !0b111).into()),
             ExceptionCause::SegmentValidity,
         );
 
         // CS is treated differently from data segments. The segment type is treated as a code segment, and
         // writes are forbidden in protected mode. It also can't be expand-down and will always be present.
-        if segment_index == Register::CS.number() {
+        if matches!(segment, Segment::CS) {
             // Forbid writes in protected mode
             if bitness == Bitness::Bit32 && op == OperationKind::Write {
                 return Err(gp0);
             }
 
             // If we're reading, check for the segment not being readable
-            if op == OperationKind::Read && segment.attributes.segment_type() & 0b0010 == 0 {
+            if op == OperationKind::Read && segment_value.attributes.segment_type() & 0b0010 == 0 {
                 return Err(gp0);
             }
 
             // Check that the offset and length are not outside the segment limits
-            if offset_end > segment.limit as u64 {
+            if offset_end > segment_value.limit as u64 {
                 return Err(gp0);
             }
         } else {
             // Check for the segment not being present
-            if !segment.attributes.present() {
+            if !segment_value.attributes.present() {
                 Err(Error::InstructionException(
                     Exception::SEGMENT_NOT_PRESENT,
                     None,
@@ -350,48 +347,48 @@ impl<'a, T: Cpu> Emulator<'a, T> {
             }
 
             // Check for a null selector, ignoring the RPL
-            if bitness == Bitness::Bit32 && segment.selector & !0x3 == 0 {
+            if bitness == Bitness::Bit32 && segment_value.selector & !0x3 == 0 {
                 return Err(gp0);
             }
 
             // Check the RPL (if 32-bit) and CPL against the DPL
             let rpl = if matches!(bitness, Bitness::Bit32) {
-                (segment.selector & 0x3) as u8
+                (segment_value.selector & 0x3) as u8
             } else {
                 0
             };
             let cpl = self.current_privilege_level();
-            let dpl = segment.attributes.descriptor_privilege_level();
+            let dpl = segment_value.attributes.descriptor_privilege_level();
             if rpl > dpl || cpl > dpl {
                 return Err(gpindex);
             }
 
             // Check for the segment not being a data segment
-            if !(segment.attributes.non_system_segment()
-                && segment.attributes.segment_type() & 0b1000 == 0)
+            if !(segment_value.attributes.non_system_segment()
+                && segment_value.attributes.segment_type() & 0b1000 == 0)
             {
                 return Err(gpindex);
             }
 
             // If we're writing, check for the segment not being writable
-            if op == OperationKind::Write && segment.attributes.segment_type() & 0b0010 == 0 {
+            if op == OperationKind::Write && segment_value.attributes.segment_type() & 0b0010 == 0 {
                 return Err(gp0);
             }
 
             // Check that the offset and length are not outside the segment limits
-            if segment.attributes.segment_type() & 0b0100 == 0 {
+            if segment_value.attributes.segment_type() & 0b0100 == 0 {
                 // Segment is not expand-down
-                if offset_end > segment.limit as u64 {
+                if offset_end > segment_value.limit as u64 {
                     return Err(gp0);
                 }
             } else {
                 // Segment is expand-down
-                let max = if segment.attributes.default() {
+                let max = if segment_value.attributes.default() {
                     u32::MAX as u64
                 } else {
                     u16::MAX as u64
                 };
-                if offset <= segment.limit as u64 || offset_end > max {
+                if offset <= segment_value.limit as u64 || offset_end > max {
                     return Err(gp0);
                 }
             };
@@ -440,7 +437,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
     /// Reads memory from the given segment:offset.
     pub async fn read_memory(
         &mut self,
-        segment: Register,
+        segment: Segment,
         offset: u64,
         alignment: AlignmentMode,
         data: &mut [u8],
@@ -464,7 +461,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
     /// Writes memory to the given segment:offset.
     pub async fn write_memory(
         &mut self,
-        segment: Register,
+        segment: Segment,
         offset: u64,
         alignment: AlignmentMode,
         data: &[u8],
@@ -492,7 +489,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
     /// mismatch.
     async fn compare_and_write_memory(
         &mut self,
-        segment: Register,
+        segment: Segment,
         offset: u64,
         alignment: AlignmentMode,
         current: &[u8],
@@ -526,7 +523,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
         let offset = self.memory_op_offset(instr, operand);
         let mut data = R::empty_bytes();
         self.read_memory(
-            instr.memory_segment(),
+            instr.memory_segment().into(),
             offset,
             alignment,
             &mut data[..instr.memory_size().size()],
@@ -545,7 +542,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
     ) -> Result<(), InternalError<T::Error>> {
         let offset = self.memory_op_offset(instr, operand);
         self.write_memory(
-            instr.memory_segment(),
+            instr.memory_segment().into(),
             offset,
             alignment,
             &data.to_le_bytes()[..instr.memory_size().size()],
@@ -574,7 +571,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
         if instr.has_lock_prefix() || instr.mnemonic() == iced_x86::Mnemonic::Xchg {
             if !self
                 .compare_and_write_memory(
-                    instr.memory_segment(),
+                    instr.memory_segment().into(),
                     offset,
                     alignment,
                     &current.to_le_bytes()[..instr.memory_size().size()],
@@ -586,7 +583,7 @@ impl<'a, T: Cpu> Emulator<'a, T> {
             }
         } else {
             self.write_memory(
-                instr.memory_segment(),
+                instr.memory_segment().into(),
                 offset,
                 alignment,
                 &new.to_le_bytes()[..instr.memory_size().size()],

--- a/vm/x86/x86emu/src/emulator/bt.rs
+++ b/vm/x86/x86emu/src/emulator/bt.rs
@@ -34,7 +34,7 @@ impl<T: Cpu> Emulator<'_, T> {
 
         let mut data = [0; 8];
         self.read_memory(
-            instr.memory_segment(),
+            instr.memory_segment().into(),
             address,
             AlignmentMode::Standard,
             &mut data[..op_size as usize],
@@ -50,7 +50,7 @@ impl<T: Cpu> Emulator<'_, T> {
             if instr.has_lock_prefix() {
                 if !self
                     .compare_and_write_memory(
-                        instr.memory_segment(),
+                        instr.memory_segment().into(),
                         address,
                         AlignmentMode::Standard,
                         &val.to_le_bytes()[..op_size as usize],
@@ -62,7 +62,7 @@ impl<T: Cpu> Emulator<'_, T> {
                 }
             } else {
                 self.write_memory(
-                    instr.memory_segment(),
+                    instr.memory_segment().into(),
                     address,
                     AlignmentMode::Standard,
                     &new_val.to_le_bytes()[..op_size as usize],

--- a/vm/x86/x86emu/src/emulator/mov.rs
+++ b/vm/x86/x86emu/src/emulator/mov.rs
@@ -6,9 +6,9 @@ use super::Emulator;
 use super::Error;
 use super::InternalError;
 use crate::Cpu;
+use crate::Segment;
 use iced_x86::Instruction;
 use iced_x86::OpKind;
-use iced_x86::Register;
 
 impl<T: Cpu> Emulator<'_, T> {
     pub(super) async fn mov(&mut self, instr: &Instruction) -> Result<(), InternalError<T::Error>> {
@@ -66,14 +66,14 @@ impl<T: Cpu> Emulator<'_, T> {
         let dst = self.cpu.gp(instr.op0_register().into());
 
         self.read_memory(
-            instr.memory_segment(),
+            instr.memory_segment().into(),
             src,
             AlignmentMode::Unaligned,
             &mut buffer,
         )
         .await?;
 
-        self.write_memory(Register::ES, dst, AlignmentMode::Aligned(64), &buffer)
+        self.write_memory(Segment::ES, dst, AlignmentMode::Aligned(64), &buffer)
             .await?;
 
         Ok(())

--- a/vm/x86/x86emu/src/emulator/rep.rs
+++ b/vm/x86/x86emu/src/emulator/rep.rs
@@ -6,6 +6,7 @@ use super::Emulator;
 use super::InternalError;
 use super::arith::ArithOp;
 use crate::Cpu;
+use crate::Segment;
 use iced_x86::Instruction;
 use iced_x86::OpKind;
 use iced_x86::Register;
@@ -167,7 +168,7 @@ impl<T: Cpu> Emulator<'_, T> {
             let io_register = self.cpu.gp(instr.op0_register().into()) as u16;
 
             self.read_memory(
-                instr.memory_segment(),
+                instr.memory_segment().into(),
                 offset,
                 AlignmentMode::Standard,
                 data,
@@ -193,7 +194,7 @@ impl<T: Cpu> Emulator<'_, T> {
 
             let data = &mut [0; 4][..rep.size];
             self.read_io(io_register, data).await?;
-            self.write_memory(Register::ES, offset, AlignmentMode::Standard, data)
+            self.write_memory(Segment::ES, offset, AlignmentMode::Standard, data)
                 .await?;
 
             self.cpu.set_gp(rdi.into(), offset.wrapping_add(rep.delta));
@@ -215,7 +216,7 @@ impl<T: Cpu> Emulator<'_, T> {
             let offset = self.memory_op_offset(instr, 1);
             let mut data = [0; 8];
             self.read_memory(
-                instr.memory_segment(),
+                instr.memory_segment().into(),
                 offset,
                 AlignmentMode::Standard,
                 &mut data[..rep.size],
@@ -243,7 +244,7 @@ impl<T: Cpu> Emulator<'_, T> {
             let offset = self.memory_op_offset(instr, 0);
             let data = self.cpu.gp(instr.op1_register().into()).to_le_bytes();
             self.write_memory(
-                Register::ES,
+                Segment::ES,
                 offset,
                 AlignmentMode::Standard,
                 &data[..rep.size],
@@ -273,13 +274,13 @@ impl<T: Cpu> Emulator<'_, T> {
             let si_offset = self.memory_op_offset(instr, 1);
 
             self.read_memory(
-                instr.memory_segment(),
+                instr.memory_segment().into(),
                 si_offset,
                 AlignmentMode::Standard,
                 data,
             )
             .await?;
-            self.write_memory(Register::ES, di_offset, AlignmentMode::Standard, data)
+            self.write_memory(Segment::ES, di_offset, AlignmentMode::Standard, data)
                 .await?;
 
             self.cpu
@@ -311,14 +312,14 @@ impl<T: Cpu> Emulator<'_, T> {
             let di_offset = self.memory_op_offset(instr, 1);
 
             self.read_memory(
-                instr.memory_segment(),
+                instr.memory_segment().into(),
                 si_offset,
                 AlignmentMode::Standard,
                 &mut data_left[..rep.size],
             )
             .await?;
             self.read_memory(
-                Register::ES,
+                Segment::ES,
                 di_offset,
                 AlignmentMode::Standard,
                 &mut data_right[..rep.size],
@@ -361,7 +362,7 @@ impl<T: Cpu> Emulator<'_, T> {
             let di_offset = self.memory_op_offset(instr, 1);
 
             self.read_memory(
-                Register::ES,
+                Segment::ES,
                 di_offset,
                 AlignmentMode::Standard,
                 &mut data[..rep.size],

--- a/vm/x86/x86emu/src/lib.rs
+++ b/vm/x86/x86emu/src/lib.rs
@@ -9,6 +9,7 @@ mod emulator;
 mod registers;
 
 pub use cpu::Cpu;
+pub use emulator::AlignmentMode;
 pub use emulator::Emulator;
 pub use emulator::Error;
 pub use emulator::MAX_REP_LOOPS;

--- a/vm/x86/x86emu/tests/tests/segments.rs
+++ b/vm/x86/x86emu/tests/tests/segments.rs
@@ -108,7 +108,7 @@ fn null_selector() {
 }
 
 #[test]
-#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(4096)")]
+#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(4099)")]
 fn rpl() {
     do_data_segment_test(|cpu| {
         let mut emu_ds = cpu.segment(Segment::DS);
@@ -118,7 +118,7 @@ fn rpl() {
 }
 
 #[test]
-#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(4096)")]
+#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(4098)")]
 fn cpl() {
     do_data_segment_test(|cpu| {
         let mut emu_ss = cpu.segment(Segment::SS);
@@ -128,7 +128,7 @@ fn cpl() {
 }
 
 #[test]
-#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(4096)")]
+#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(4098)")]
 fn system_segment() {
     do_data_segment_test(|cpu| {
         let mut emu_ds = cpu.segment(Segment::DS);

--- a/vm/x86/x86emu/tests/tests/segments.rs
+++ b/vm/x86/x86emu/tests/tests/segments.rs
@@ -108,7 +108,7 @@ fn null_selector() {
 }
 
 #[test]
-#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(3)")]
+#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(4096)")]
 fn rpl() {
     do_data_segment_test(|cpu| {
         let mut emu_ds = cpu.segment(Segment::DS);
@@ -118,7 +118,7 @@ fn rpl() {
 }
 
 #[test]
-#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(3)")]
+#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(4096)")]
 fn cpl() {
     do_data_segment_test(|cpu| {
         let mut emu_ss = cpu.segment(Segment::SS);
@@ -128,7 +128,7 @@ fn cpl() {
 }
 
 #[test]
-#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(3)")]
+#[should_panic(expected = "GENERAL_PROTECTION_FAULT, Some(4096)")]
 fn system_segment() {
     do_data_segment_test(|cpu| {
         let mut emu_ds = cpu.segment(Segment::DS);

--- a/vmm_core/virt_support_x86emu/Cargo.toml
+++ b/vmm_core/virt_support_x86emu/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 [dependencies]
 guestmem.workspace = true
 hvdef.workspace = true
+iced-x86.workspace = true
 tracelimit.workspace = true
 vm_topology.workspace = true
 virt.workspace = true
@@ -18,6 +19,7 @@ x86emu.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
+
 [dev-dependencies]
 pal_async.workspace = true
 iced-x86 = { workspace = true, features = ["code_asm"] }

--- a/vmm_core/virt_support_x86emu/Cargo.toml
+++ b/vmm_core/virt_support_x86emu/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 [dependencies]
 guestmem.workspace = true
 hvdef.workspace = true
-iced-x86.workspace = true
 tracelimit.workspace = true
 vm_topology.workspace = true
 virt.workspace = true


### PR DESCRIPTION
Adds support for intercepting descriptor table access instructions and generating intercept messages when appropriate. Because VMX only gives us an 'all-or-nothing' bit to enable exits we have to emulate instructions that generate an exit but were not actually asked for by VTL 1. Adds support for half of these, those that touch GDT or IDT, with the other half to come in a follow up because I need a brain break. Their design will likely be very similar anyways.

Slightly refactor the instruction emulator to allow external emulation of memory accesses, without going through the full decoding pipeline first. This primitive could be useful if we end up having to emulate more instructions like this for specific backends with decoding assistance in the future.

Note that only the two IDT instructions seem to actually be run in my current test workloads, so the GDT instructions are technically untested.

With this PR a single VP TDX Guest VSM VM is able to fully boot, enable credential guard, and be RDP'd into!