### PR TITLE
CVM Guest VSM: Synthetic Cluster IPI hypercall handling

### DIFF
--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -437,9 +437,8 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
             // Hyper-V MSRs to function. Enable it here always.
             .with_use_apic_msrs(true)
             .with_long_spin_wait_count(!0)
-            .with_use_hypercall_for_remote_flush_and_local_flush_entire(true);
-        // TODO SNP
-        //  .with_use_synthetic_cluster_ipi(true);
+            .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
+            .with_use_synthetic_cluster_ipi(true);
 
         let hardware_features = hvdef::HvHardwareFeatures::new()
             .with_apic_overlay_assist_in_use(true)

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -307,9 +307,9 @@ impl CpuidArchInitializer for TdxCpuidInitializer<'_> {
             .with_use_relaxed_timing(true)
             .with_use_ex_processor_masks(true)
             .with_use_apic_msrs(use_apic_msrs)
-            .with_long_spin_wait_count(!0);
+            .with_long_spin_wait_count(!0)
+            .with_use_synthetic_cluster_ipi(true);
         // TODO TDX
-        //  .with_use_synthetic_cluster_ipi(true)
         //  .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
 
         let hardware_features = hvdef::HvHardwareFeatures::new()

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1053,6 +1053,8 @@ impl UhPartitionInner {
         vp_index: VpIndex,
         vtl: GuestVtl,
     ) -> impl '_ + hv1_emulator::RequestInterrupt {
+        // TODO CVM: optimize for SNP with secure avic to avoid internal wake
+        // and for TDX to avoid trip to user mode
         move |vector, auto_eoi| {
             self.lapic(vtl).unwrap().synic_interrupt(
                 vp_index,

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -729,6 +729,8 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, SnpBacked> {
             hv1_hypercall::HvSetVpRegisters,
             hv1_hypercall::HvModifyVtlProtectionMask,
             hv1_hypercall::HvX64TranslateVirtualAddress,
+            hv1_hypercall::HvSendSyntheticClusterIpi,
+            hv1_hypercall::HvSendSyntheticClusterIpiEx,
         ],
     );
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -3300,6 +3300,8 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
             hv1_hypercall::HvVtlReturn,
             hv1_hypercall::HvModifyVtlProtectionMask,
             hv1_hypercall::HvX64TranslateVirtualAddress,
+            hv1_hypercall::HvSendSyntheticClusterIpi,
+            hv1_hypercall::HvSendSyntheticClusterIpiEx,
         ]
     );
 

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -1758,13 +1758,37 @@ pub mod hypercall {
     pub struct FlushVirtualAddressSpaceEx {
         pub address_space: u64,
         pub flags: HvFlushFlags,
-        // Followed by an HvVpSet
+        pub vp_set_format: u64,
+        pub vp_set_valid_banks_mask: u64,
+        // Followed by the variable-sized part of an HvVpSet
     }
 
     #[repr(C)]
     #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
     pub struct PinUnpinGpaPageRangesHeader {
         pub reserved: u64,
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub struct SendSyntheticClusterIpi {
+        pub vector: u32,
+        pub target_vtl: HvInputVtl,
+        pub flags: u8,
+        pub reserved: u16,
+        pub processor_mask: u64,
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+    pub struct SendSyntheticClusterIpiEx {
+        pub vector: u32,
+        pub target_vtl: HvInputVtl,
+        pub flags: u8,
+        pub reserved: u16,
+        pub vp_set_format: u64,
+        pub vp_set_valid_banks_mask: u64,
+        // Followed by the variable-sized part of an HvVpSet
     }
 
     #[bitfield(u64)]


### PR DESCRIPTION
Implements handling of the synthetic cluster ipi hypercalls for CVM guest vsm support.

Tested:
SNP with and without guest vsm boots