### PR TITLE
flowey: use KnownTestArtifacts instead of KnownVhds and KnownIsos

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3034,12 +3034,12 @@ jobs:
         flowey.exe e 18 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_deps 0
@@ -3296,12 +3296,12 @@ jobs:
         flowey.exe e 19 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_deps 0
@@ -3743,12 +3743,12 @@ jobs:
         flowey.exe e 20 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_deps 0
@@ -4001,12 +4001,12 @@ jobs:
         flowey e 21 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 21 flowey_lib_hvlite::download_openvmm_deps 0
@@ -4311,12 +4311,12 @@ jobs:
         flowey.exe e 22 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_deps 0

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -2928,12 +2928,12 @@ jobs:
         flowey.exe e 18 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey.exe e 18 flowey_lib_hvlite::download_openvmm_deps 0
@@ -3190,12 +3190,12 @@ jobs:
         flowey.exe e 19 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey.exe e 19 flowey_lib_hvlite::download_openvmm_deps 0
@@ -3629,12 +3629,12 @@ jobs:
         flowey.exe e 20 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey.exe e 20 flowey_lib_hvlite::download_openvmm_deps 0
@@ -3887,12 +3887,12 @@ jobs:
         flowey e 21 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey e 21 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 21 flowey_lib_hvlite::download_openvmm_deps 0
@@ -4197,12 +4197,12 @@ jobs:
         flowey.exe e 22 flowey_lib_common::download_azcopy 1
       shell: bash
     - name: calculating required VMM tests disk images
-      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 0
+      run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
       shell: bash
     - name: downloading VMM test disk images
       run: |-
-        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 1
-        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_vhds 2
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+        flowey.exe e 22 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
       shell: bash
     - name: unpack openvmm-deps archive
       run: flowey.exe e 22 flowey_lib_hvlite::download_openvmm_deps 0

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -18,8 +18,7 @@ use flowey_lib_hvlite::run_cargo_build::common::CommonProfile;
 use flowey_lib_hvlite::run_cargo_build::common::CommonTriple;
 use std::path::PathBuf;
 use target_lexicon::Triple;
-use vmm_test_images::KnownIso;
-use vmm_test_images::KnownVhd;
+use vmm_test_images::KnownTestArtifacts;
 
 #[derive(Copy, Clone, clap::ValueEnum)]
 enum PipelineConfig {
@@ -944,22 +943,21 @@ impl IntoPipeline for CheckinGatesCli {
             target: CommonTriple,
             resolve_vmm_tests_artifacts: vmm_tests_artifact_builders::ResolveVmmTestsDepArtifacts,
             nextest_filter_expr: String,
-            vhds: Vec<KnownVhd>,
-            isos: Vec<KnownIso>,
+            test_artifacts: Vec<KnownTestArtifacts>,
         }
 
         // standard VM-based CI machines should be able to run all tests except
         // those that require special hardware features (tdx) or need to be run
         // on a baremetal host (hyper-v vbs doesn't seem to work nested)
         let standard_filter = "all() & !test(tdx) & !(test(vbs) & test(hyperv))".to_string();
-        let standard_x64_vhds = vec![
-            KnownVhd::FreeBsd13_2,
-            KnownVhd::Gen1WindowsDataCenterCore2022,
-            KnownVhd::Gen2WindowsDataCenterCore2022,
-            KnownVhd::Ubuntu2204Server,
-            KnownVhd::VmgsWithBootEntry,
+        let standard_x64_test_artifacts = vec![
+            KnownTestArtifacts::FreeBsd13_2X64Vhd,
+            KnownTestArtifacts::FreeBsd13_2X64Iso,
+            KnownTestArtifacts::Gen1WindowsDataCenterCore2022X64Vhd,
+            KnownTestArtifacts::Gen2WindowsDataCenterCore2022X64Vhd,
+            KnownTestArtifacts::Ubuntu2204ServerX64Vhd,
+            KnownTestArtifacts::VmgsWithBootEntry,
         ];
-        let standard_x64_isos = vec![KnownIso::FreeBsd13_2];
 
         for VmmTestJobParams {
             platform,
@@ -969,8 +967,7 @@ impl IntoPipeline for CheckinGatesCli {
             target,
             resolve_vmm_tests_artifacts,
             nextest_filter_expr,
-            vhds,
-            isos,
+            test_artifacts,
         } in [
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
@@ -980,8 +977,7 @@ impl IntoPipeline for CheckinGatesCli {
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_x86,
                 nextest_filter_expr: standard_filter.clone(),
-                vhds: standard_x64_vhds.clone(),
-                isos: standard_x64_isos.clone(),
+                test_artifacts: standard_x64_test_artifacts.clone(),
             },
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
@@ -991,8 +987,7 @@ impl IntoPipeline for CheckinGatesCli {
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_intel_tdx_x86,
                 nextest_filter_expr: "test(tdx) + (test(vbs) & test(hyperv))".to_string(),
-                vhds: vec![KnownVhd::Gen2WindowsDataCenterCore2025],
-                isos: vec![],
+                test_artifacts: vec![KnownTestArtifacts::Gen2WindowsDataCenterCore2025X64Vhd],
             },
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
@@ -1002,8 +997,7 @@ impl IntoPipeline for CheckinGatesCli {
                 target: CommonTriple::X86_64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_amd_x86,
                 nextest_filter_expr: standard_filter.clone(),
-                vhds: standard_x64_vhds.clone(),
-                isos: standard_x64_isos.clone(),
+                test_artifacts: standard_x64_test_artifacts.clone(),
             },
             VmmTestJobParams {
                 platform: FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu),
@@ -1017,8 +1011,7 @@ impl IntoPipeline for CheckinGatesCli {
                 nextest_filter_expr: format!(
                     "{standard_filter} & !test(openhcl) & !test(pcat_x64)"
                 ),
-                vhds: standard_x64_vhds,
-                isos: standard_x64_isos,
+                test_artifacts: standard_x64_test_artifacts,
             },
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
@@ -1028,11 +1021,10 @@ impl IntoPipeline for CheckinGatesCli {
                 target: CommonTriple::AARCH64_WINDOWS_MSVC,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_windows_aarch64,
                 nextest_filter_expr: "all()".to_string(),
-                vhds: vec![
-                    KnownVhd::Ubuntu2404ServerAarch64,
-                    KnownVhd::VmgsWithBootEntry,
+                test_artifacts: vec![
+                    KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd,
+                    KnownTestArtifacts::VmgsWithBootEntry,
                 ],
-                isos: vec![],
             },
         ] {
             let test_label = format!("{label}-vmm-tests");
@@ -1062,8 +1054,7 @@ impl IntoPipeline for CheckinGatesCli {
                             flowey_lib_hvlite::run_cargo_nextest_run::NextestProfile::Ci,
                         nextest_filter_expr: Some(nextest_filter_expr),
                         dep_artifact_dirs: resolve_vmm_tests_artifacts(ctx),
-                        vhds,
-                        isos,
+                        test_artifacts,
                         fail_job_on_test_fail: true,
                         artifact_dir: pub_vmm_tests_results.map(|x| ctx.publish_artifact(x)),
                         done: ctx.new_done_handle(),
@@ -1072,7 +1063,7 @@ impl IntoPipeline for CheckinGatesCli {
 
             if let Some(vmm_tests_disk_cache_dir) = vmm_tests_disk_cache_dir.clone() {
                 vmm_tests_run_job = vmm_tests_run_job.dep_on(|_| {
-                    flowey_lib_hvlite::download_openvmm_vmm_tests_vhds::Request::CustomCacheDir(
+                    flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts::Request::CustomCacheDir(
                         vmm_tests_disk_cache_dir,
                     )
                 })

--- a/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/build_and_run_nextest_vmm_tests.rs
@@ -11,8 +11,7 @@ use crate::run_cargo_build::common::CommonTriple;
 use crate::run_cargo_nextest_run::NextestProfile;
 use flowey::node::prelude::*;
 use std::collections::BTreeMap;
-use vmm_test_images::KnownIso;
-use vmm_test_images::KnownVhd;
+use vmm_test_images::KnownTestArtifacts;
 
 flowey_request! {
     pub struct Params {
@@ -28,10 +27,8 @@ flowey_request! {
         pub nextest_filter_expr: Option<String>,
         /// If the VMM tests requires openhcl - specify a custom target for it.
         pub openhcl_custom_target: Option<CommonTriple>,
-        /// VHDs to download
-        pub vhds: Vec<KnownVhd>,
-        /// ISOs to download
-        pub isos: Vec<KnownIso>,
+        /// Test artifacts to download
+        pub test_artifacts: Vec<KnownTestArtifacts>,
 
         /// Whether the job should fail if any test has failed
         pub fail_job_on_test_fail: bool,
@@ -53,7 +50,7 @@ impl SimpleFlowNode for Node {
         ctx.import::<crate::build_openhcl_igvm_from_recipe::Node>();
         ctx.import::<crate::build_openvmm::Node>();
         ctx.import::<crate::build_pipette::Node>();
-        ctx.import::<crate::download_openvmm_vmm_tests_vhds::Node>();
+        ctx.import::<crate::download_openvmm_vmm_tests_artifacts::Node>();
         ctx.import::<crate::init_vmm_tests_env::Node>();
         ctx.import::<flowey_lib_common::publish_test_results::Node>();
     }
@@ -66,8 +63,7 @@ impl SimpleFlowNode for Node {
             nextest_profile,
             nextest_filter_expr,
             openhcl_custom_target,
-            vhds,
-            isos,
+            test_artifacts,
             fail_job_on_test_fail,
             artifact_dir,
             done,
@@ -199,13 +195,10 @@ impl SimpleFlowNode for Node {
             tmk_vmm: v,
         });
 
-        ctx.requests::<crate::download_openvmm_vmm_tests_vhds::Node>([
-            crate::download_openvmm_vmm_tests_vhds::Request::DownloadVhds(vhds),
-            crate::download_openvmm_vmm_tests_vhds::Request::DownloadIsos(isos),
-        ]);
+        ctx.req(crate::download_openvmm_vmm_tests_artifacts::Request::Download(test_artifacts));
 
         let disk_images_dir =
-            ctx.reqv(crate::download_openvmm_vmm_tests_vhds::Request::GetDownloadFolder);
+            ctx.reqv(crate::download_openvmm_vmm_tests_artifacts::Request::GetDownloadFolder);
 
         let test_content_dir = ctx.persistent_dir().ok_or(anyhow::anyhow!(
             "build and run VMM tests only works locally"

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -12,8 +12,7 @@ use crate::build_tmks::TmksOutput;
 use crate::run_cargo_nextest_run::NextestProfile;
 use flowey::node::prelude::*;
 use std::collections::BTreeMap;
-use vmm_test_images::KnownIso;
-use vmm_test_images::KnownVhd;
+use vmm_test_images::KnownTestArtifacts;
 
 #[derive(Serialize, Deserialize)]
 pub struct VmmTestsDepArtifacts {
@@ -41,10 +40,8 @@ flowey_request! {
         pub nextest_filter_expr: Option<String>,
         /// Artifacts corresponding to required test dependencies
         pub dep_artifact_dirs: VmmTestsDepArtifacts,
-        /// VHDs to download
-        pub vhds: Vec<KnownVhd>,
-        /// ISOs to download
-        pub isos: Vec<KnownIso>,
+        /// Test artifacts to download
+        pub test_artifacts: Vec<KnownTestArtifacts>,
 
         /// Whether the job should fail if any test has failed
         pub fail_job_on_test_fail: bool,
@@ -62,7 +59,7 @@ impl SimpleFlowNode for Node {
     fn imports(ctx: &mut ImportCtx<'_>) {
         ctx.import::<crate::artifact_openhcl_igvm_from_recipe_extras::resolve::Node>();
         ctx.import::<crate::artifact_openhcl_igvm_from_recipe::resolve::Node>();
-        ctx.import::<crate::download_openvmm_vmm_tests_vhds::Node>();
+        ctx.import::<crate::download_openvmm_vmm_tests_artifacts::Node>();
         ctx.import::<crate::init_openvmm_magicpath_uefi_mu_msvm::Node>();
         ctx.import::<crate::init_hyperv_tests::Node>();
         ctx.import::<crate::init_vmm_tests_env::Node>();
@@ -78,8 +75,7 @@ impl SimpleFlowNode for Node {
             nextest_profile,
             nextest_filter_expr,
             dep_artifact_dirs,
-            vhds,
-            isos,
+            test_artifacts,
             fail_job_on_test_fail,
             artifact_dir,
             done,
@@ -110,13 +106,10 @@ impl SimpleFlowNode for Node {
             )
         });
 
-        ctx.requests::<crate::download_openvmm_vmm_tests_vhds::Node>([
-            crate::download_openvmm_vmm_tests_vhds::Request::DownloadVhds(vhds),
-            crate::download_openvmm_vmm_tests_vhds::Request::DownloadIsos(isos),
-        ]);
+        ctx.req(crate::download_openvmm_vmm_tests_artifacts::Request::Download(test_artifacts));
 
         let disk_images_dir =
-            ctx.reqv(crate::download_openvmm_vmm_tests_vhds::Request::GetDownloadFolder);
+            ctx.reqv(crate::download_openvmm_vmm_tests_artifacts::Request::GetDownloadFolder);
 
         // FUTURE: once we move away from the known_paths resolver, this will no
         // longer be an ambient pre-run dependency.

--- a/flowey/flowey_lib_hvlite/src/lib.rs
+++ b/flowey/flowey_lib_hvlite/src/lib.rs
@@ -38,7 +38,7 @@ pub mod cfg_openvmm_magicpath;
 pub mod download_lxutil;
 pub mod download_openhcl_kernel_package;
 pub mod download_openvmm_deps;
-pub mod download_openvmm_vmm_tests_vhds;
+pub mod download_openvmm_vmm_tests_artifacts;
 pub mod download_uefi_mu_msvm;
 pub mod git_checkout_openvmm_repo;
 pub mod init_cross_build;

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -71,7 +71,7 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
             _ if id == test_iso::FREE_BSD_13_2_X64 => get_test_artifact_path(KnownTestArtifacts::FreeBsd13_2X64Iso),
 
             _ if id == test_vmgs::VMGS_WITH_BOOT_ENTRY => get_test_artifact_path(KnownTestArtifacts::VmgsWithBootEntry),
-            
+
             _ if id == tmks::TMK_VMM_NATIVE => tmk_vmm_native_executable_path(),
             _ if id == tmks::TMK_VMM_LINUX_X64_MUSL => tmk_vmm_paravisor_path(MachineArch::X86_64),
             _ if id == tmks::TMK_VMM_LINUX_AARCH64_MUSL => tmk_vmm_paravisor_path(MachineArch::Aarch64),

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -10,8 +10,7 @@ use petri_artifacts_core::ErasedArtifactHandle;
 use std::env::consts::EXE_EXTENSION;
 use std::path::Path;
 use std::path::PathBuf;
-use vmm_test_images::KnownIso;
-use vmm_test_images::KnownVhd;
+use vmm_test_images::KnownTestArtifacts;
 
 /// An implementation of [`petri_artifacts_core::ResolveTestArtifact`]
 /// that resolves artifacts to various "known paths" within the context of
@@ -62,17 +61,17 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
 
             _ if id == test_vhd::GUEST_TEST_UEFI_X64 => guest_test_uefi_disk_path(MachineArch::X86_64),
             _ if id == test_vhd::GUEST_TEST_UEFI_AARCH64 => guest_test_uefi_disk_path(MachineArch::Aarch64),
-            _ if id == test_vhd::GEN1_WINDOWS_DATA_CENTER_CORE2022_X64 => get_guest_vhd_path(KnownVhd::Gen1WindowsDataCenterCore2022),
-            _ if id == test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64 => get_guest_vhd_path(KnownVhd::Gen2WindowsDataCenterCore2022),
-            _ if id == test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64 => get_guest_vhd_path(KnownVhd::Gen2WindowsDataCenterCore2025),
-            _ if id == test_vhd::FREE_BSD_13_2_X64 => get_guest_vhd_path(KnownVhd::FreeBsd13_2),
-            _ if id == test_vhd::UBUNTU_2204_SERVER_X64 => get_guest_vhd_path(KnownVhd::Ubuntu2204Server),
-            _ if id == test_vhd::UBUNTU_2404_SERVER_AARCH64 => get_guest_vhd_path(KnownVhd::Ubuntu2404ServerAarch64),
+            _ if id == test_vhd::GEN1_WINDOWS_DATA_CENTER_CORE2022_X64 => get_test_artifact_path(KnownTestArtifacts::Gen1WindowsDataCenterCore2022X64Vhd),
+            _ if id == test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64 => get_test_artifact_path(KnownTestArtifacts::Gen2WindowsDataCenterCore2022X64Vhd),
+            _ if id == test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64 => get_test_artifact_path(KnownTestArtifacts::Gen2WindowsDataCenterCore2025X64Vhd),
+            _ if id == test_vhd::FREE_BSD_13_2_X64 => get_test_artifact_path(KnownTestArtifacts::FreeBsd13_2X64Vhd),
+            _ if id == test_vhd::UBUNTU_2204_SERVER_X64 => get_test_artifact_path(KnownTestArtifacts::Ubuntu2204ServerX64Vhd),
+            _ if id == test_vhd::UBUNTU_2404_SERVER_AARCH64 => get_test_artifact_path(KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd),
 
-            _ if id == test_iso::FREE_BSD_13_2_X64 => get_guest_iso_path(KnownIso::FreeBsd13_2),
+            _ if id == test_iso::FREE_BSD_13_2_X64 => get_test_artifact_path(KnownTestArtifacts::FreeBsd13_2X64Iso),
 
-            _ if id == test_vmgs::VMGS_WITH_BOOT_ENTRY => get_guest_vhd_path(KnownVhd::VmgsWithBootEntry),
-
+            _ if id == test_vmgs::VMGS_WITH_BOOT_ENTRY => get_test_artifact_path(KnownTestArtifacts::VmgsWithBootEntry),
+            
             _ if id == tmks::TMK_VMM_NATIVE => tmk_vmm_native_executable_path(),
             _ if id == tmks::TMK_VMM_LINUX_X64_MUSL => tmk_vmm_paravisor_path(MachineArch::X86_64),
             _ if id == tmks::TMK_VMM_LINUX_AARCH64_MUSL => tmk_vmm_paravisor_path(MachineArch::Aarch64),
@@ -117,7 +116,7 @@ fn target_arch_path(arch: MachineArch) -> &'static str {
     }
 }
 
-fn get_guest_vhd_path(vhd: KnownVhd) -> Result<PathBuf, anyhow::Error> {
+fn get_test_artifact_path(vhd: KnownTestArtifacts) -> Result<PathBuf, anyhow::Error> {
     let images_dir = std::env::var("VMM_TEST_IMAGES");
     let full_path = Path::new(images_dir.as_deref().unwrap_or("images"));
 
@@ -127,20 +126,6 @@ fn get_guest_vhd_path(vhd: KnownVhd) -> Result<PathBuf, anyhow::Error> {
         MissingCommand::Xtask {
             xtask_args: &["guest-test", "download-image", "--vhds", &vhd.name()],
             description: "guest vhd image",
-        },
-    )
-}
-
-fn get_guest_iso_path(iso: KnownIso) -> Result<PathBuf, anyhow::Error> {
-    let images_dir = std::env::var("VMM_TEST_IMAGES");
-    let full_path = Path::new(images_dir.as_deref().unwrap_or("images"));
-
-    get_path(
-        full_path,
-        iso.filename(),
-        MissingCommand::Xtask {
-            xtask_args: &["guest-test", "download-image", "--isos", &iso.name()],
-            description: "guest iso image",
         },
     )
 }

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -116,16 +116,21 @@ fn target_arch_path(arch: MachineArch) -> &'static str {
     }
 }
 
-fn get_test_artifact_path(vhd: KnownTestArtifacts) -> Result<PathBuf, anyhow::Error> {
+fn get_test_artifact_path(artifact: KnownTestArtifacts) -> Result<PathBuf, anyhow::Error> {
     let images_dir = std::env::var("VMM_TEST_IMAGES");
     let full_path = Path::new(images_dir.as_deref().unwrap_or("images"));
 
     get_path(
         full_path,
-        vhd.filename(),
+        artifact.filename(),
         MissingCommand::Xtask {
-            xtask_args: &["guest-test", "download-image", "--vhds", &vhd.name()],
-            description: "guest vhd image",
+            xtask_args: &[
+                "guest-test",
+                "download-image",
+                "--artifacts",
+                &artifact.name(),
+            ],
+            description: "test artifact",
         },
     )
 }

--- a/vmm_tests/vmm_test_images/src/lib.rs
+++ b/vmm_tests/vmm_test_images/src/lib.rs
@@ -23,24 +23,25 @@ use petri_artifacts_vmm_test::tags::IsHostedOnHvliteAzureBlobStore;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[expect(missing_docs)] // Self-describing names
-pub enum KnownVhd {
-    Gen1WindowsDataCenterCore2022,
-    Gen2WindowsDataCenterCore2022,
-    Gen2WindowsDataCenterCore2025,
-    FreeBsd13_2,
-    Ubuntu2204Server,
-    Ubuntu2404ServerAarch64,
+pub enum KnownTestArtifacts {
+    Gen1WindowsDataCenterCore2022X64Vhd,
+    Gen2WindowsDataCenterCore2022X64Vhd,
+    Gen2WindowsDataCenterCore2025X64Vhd,
+    FreeBsd13_2X64Vhd,
+    FreeBsd13_2X64Iso,
+    Ubuntu2204ServerX64Vhd,
+    Ubuntu2404ServerAarch64Vhd,
     VmgsWithBootEntry,
 }
 
-struct KnownVhdMeta {
-    variant: KnownVhd,
+struct KnownTestArtifactMeta {
+    variant: KnownTestArtifacts,
     filename: &'static str,
     size: u64,
 }
 
-impl KnownVhdMeta {
-    const fn new(variant: KnownVhd, filename: &'static str, size: u64) -> Self {
+impl KnownTestArtifactMeta {
+    const fn new(variant: KnownTestArtifacts, filename: &'static str, size: u64) -> Self {
         Self {
             variant,
             filename,
@@ -50,45 +51,50 @@ impl KnownVhdMeta {
 }
 
 // linear scan to find entries is OK, given how few entries there are
-const KNOWN_VHD_METADATA: &[KnownVhdMeta] = &[
-    KnownVhdMeta::new(
-        KnownVhd::Gen1WindowsDataCenterCore2022,
+const KNOWN_TEST_ARTIFACT_METADATA: &[KnownTestArtifactMeta] = &[
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::Gen1WindowsDataCenterCore2022X64Vhd,
         petri_artifacts_vmm_test::artifacts::test_vhd::GEN1_WINDOWS_DATA_CENTER_CORE2022_X64::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vhd::GEN1_WINDOWS_DATA_CENTER_CORE2022_X64::SIZE,
     ),
-    KnownVhdMeta::new(
-        KnownVhd::Gen2WindowsDataCenterCore2022,
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::Gen2WindowsDataCenterCore2022X64Vhd,
         petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2022_X64::SIZE,
     ),
-    KnownVhdMeta::new(
-        KnownVhd::Gen2WindowsDataCenterCore2025,
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::Gen2WindowsDataCenterCore2025X64Vhd,
         petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vhd::GEN2_WINDOWS_DATA_CENTER_CORE2025_X64::SIZE,
     ),
-    KnownVhdMeta::new(
-        KnownVhd::FreeBsd13_2,
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::FreeBsd13_2X64Vhd,
         petri_artifacts_vmm_test::artifacts::test_vhd::FREE_BSD_13_2_X64::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vhd::FREE_BSD_13_2_X64::SIZE,
     ),
-    KnownVhdMeta::new(
-        KnownVhd::Ubuntu2204Server,
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::FreeBsd13_2X64Iso,
+        petri_artifacts_vmm_test::artifacts::test_iso::FREE_BSD_13_2_X64::FILENAME,
+        petri_artifacts_vmm_test::artifacts::test_iso::FREE_BSD_13_2_X64::SIZE,
+    ),
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::Ubuntu2204ServerX64Vhd,
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2204_SERVER_X64::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2204_SERVER_X64::SIZE,
     ),
-    KnownVhdMeta::new(
-        KnownVhd::Ubuntu2404ServerAarch64,
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd,
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_AARCH64::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_AARCH64::SIZE,
     ),
-    KnownVhdMeta::new(
-        KnownVhd::VmgsWithBootEntry,
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::VmgsWithBootEntry,
         petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_BOOT_ENTRY::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_BOOT_ENTRY::SIZE,
     ),
 ];
 
-impl KnownVhd {
+impl KnownTestArtifacts {
     /// Get the name of the image.
     pub fn name(self) -> String {
         format!("{:?}", self)
@@ -96,9 +102,9 @@ impl KnownVhd {
 
     /// Get the filename of the image.
     pub fn filename(self) -> &'static str {
-        KNOWN_VHD_METADATA
+        KNOWN_TEST_ARTIFACT_METADATA
             .iter()
-            .find(|KnownVhdMeta { variant, .. }| *variant == self)
+            .find(|KnownTestArtifactMeta { variant, .. }| *variant == self)
             .unwrap()
             .filename
     }
@@ -106,86 +112,18 @@ impl KnownVhd {
     /// Get the image from its filename.
     pub fn from_filename(filename: &str) -> Option<Self> {
         Some(
-            KNOWN_VHD_METADATA
+            KNOWN_TEST_ARTIFACT_METADATA
                 .iter()
-                .find(|KnownVhdMeta { filename: s, .. }| *s == filename)?
+                .find(|KnownTestArtifactMeta { filename: s, .. }| *s == filename)?
                 .variant,
         )
     }
 
     /// Get the expected file size of the image.
     pub fn file_size(self) -> u64 {
-        KNOWN_VHD_METADATA
+        KNOWN_TEST_ARTIFACT_METADATA
             .iter()
-            .find(|KnownVhdMeta { variant, .. }| *variant == self)
-            .unwrap()
-            .size
-    }
-}
-
-/// The ISOs currently stored in Azure Blob Storage.
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "clap", clap(rename_all = "verbatim"))]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[expect(missing_docs)] // Self-describing names
-pub enum KnownIso {
-    FreeBsd13_2,
-}
-
-struct KnownIsoMeta {
-    variant: KnownIso,
-    filename: &'static str,
-    size: u64,
-}
-
-impl KnownIsoMeta {
-    const fn new(variant: KnownIso, filename: &'static str, size: u64) -> Self {
-        Self {
-            variant,
-            filename,
-            size,
-        }
-    }
-}
-
-// linear scan to find entries is OK, given how few entries there are
-const KNOWN_ISO_METADATA: &[KnownIsoMeta] = &[KnownIsoMeta::new(
-    KnownIso::FreeBsd13_2,
-    petri_artifacts_vmm_test::artifacts::test_iso::FREE_BSD_13_2_X64::FILENAME,
-    petri_artifacts_vmm_test::artifacts::test_iso::FREE_BSD_13_2_X64::SIZE,
-)];
-
-impl KnownIso {
-    /// Get the name of the image.
-    pub fn name(self) -> String {
-        format!("{:?}", self)
-    }
-
-    /// Get the filename of the image.
-    pub fn filename(self) -> &'static str {
-        KNOWN_ISO_METADATA
-            .iter()
-            .find(|KnownIsoMeta { variant, .. }| *variant == self)
-            .unwrap()
-            .filename
-    }
-
-    /// Get the image from its filename.
-    pub fn from_filename(filename: &str) -> Option<Self> {
-        Some(
-            KNOWN_ISO_METADATA
-                .iter()
-                .find(|KnownIsoMeta { filename: s, .. }| *s == filename)?
-                .variant,
-        )
-    }
-
-    /// Get the expected file size of the image.
-    pub fn file_size(self) -> u64 {
-        KNOWN_ISO_METADATA
-            .iter()
-            .find(|KnownIsoMeta { variant, .. }| *variant == self)
+            .find(|KnownTestArtifactMeta { variant, .. }| *variant == self)
             .unwrap()
             .size
     }

--- a/xtask/src/tasks/guest_test/download_image.rs
+++ b/xtask/src/tasks/guest_test/download_image.rs
@@ -7,8 +7,7 @@ use clap::Parser;
 use clap::ValueEnum;
 use std::path::PathBuf;
 use std::process::Command;
-use vmm_test_images::KnownIso;
-use vmm_test_images::KnownVhd;
+use vmm_test_images::KnownTestArtifacts;
 
 /// Download an image from Azure Blob Storage.
 ///
@@ -18,12 +17,9 @@ pub struct DownloadImageTask {
     /// The folder to download the images to.
     #[clap(short, long, default_value = "images")]
     output_folder: PathBuf,
-    /// The VHDs to download.
+    /// The test artifacts to download.
     #[clap(long)]
-    vhds: Vec<KnownVhd>,
-    /// The ISOs to download.
-    #[clap(long)]
-    isos: Vec<KnownIso>,
+    artifacts: Vec<KnownTestArtifacts>,
     /// Redownload images even if the file already exists.
     #[clap(short, long)]
     force: bool,
@@ -34,16 +30,14 @@ const CONTAINER: &str = "vhds";
 
 impl Xtask for DownloadImageTask {
     fn run(mut self, _ctx: crate::XtaskCtx) -> anyhow::Result<()> {
-        if self.vhds.is_empty() && self.isos.is_empty() {
-            self.vhds = KnownVhd::value_variants().to_vec();
-            self.isos = KnownIso::value_variants().to_vec();
+        if self.artifacts.is_empty() {
+            self.artifacts = KnownTestArtifacts::value_variants().to_vec();
         }
 
         let filenames = self
-            .vhds
+            .artifacts
             .into_iter()
             .map(|x| x.filename())
-            .chain(self.isos.into_iter().map(|x| x.filename()))
             .collect::<Vec<_>>();
 
         if !self.output_folder.exists() {


### PR DESCRIPTION
Since flowey does not care whether an artifact is a VHD, ISO, or something else, we can make this more loosely typed and simplify the code. This also allows us to add different types of artifacts that have different characteristics (like VMGS). The type information is still enforced in the `petri_artifacts_vmm_test` crate.