### PR TITLE
vmm_tests: add windows arm tests

### DIFF
--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1618,7 +1618,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 2
-        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_core/src/node.rs:997:34' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_core/src/node.rs:1054:34' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__3
       uses: actions/upload-artifact@v4

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1020,6 +1020,7 @@ impl IntoPipeline for CheckinGatesCli {
                 nextest_filter_expr: "all()".to_string(),
                 test_artifacts: vec![
                     KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd,
+                    KnownTestArtifacts::Windows11Aarch64Vhdx,
                     KnownTestArtifacts::VmgsWithBootEntry,
                 ],
             },

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1020,7 +1020,7 @@ impl IntoPipeline for CheckinGatesCli {
                 nextest_filter_expr: "all()".to_string(),
                 test_artifacts: vec![
                     KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd,
-                    KnownTestArtifacts::Windows11Aarch64Vhdx,
+                    KnownTestArtifacts::Windows11EnterpriseAarch64Vhdx,
                     KnownTestArtifacts::VmgsWithBootEntry,
                 ],
             },

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -67,7 +67,7 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
             _ if id == test_vhd::FREE_BSD_13_2_X64 => get_test_artifact_path(KnownTestArtifacts::FreeBsd13_2X64Vhd),
             _ if id == test_vhd::UBUNTU_2204_SERVER_X64 => get_test_artifact_path(KnownTestArtifacts::Ubuntu2204ServerX64Vhd),
             _ if id == test_vhd::UBUNTU_2404_SERVER_AARCH64 => get_test_artifact_path(KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd),
-            _ if id == test_vhd::WINDOWS_11_AARCH64 => get_test_artifact_path(KnownTestArtifacts::Windows11Aarch64Vhdx),
+            _ if id == test_vhd::WINDOWS_11_ENTERPRISE_AARCH64 => get_test_artifact_path(KnownTestArtifacts::Windows11EnterpriseAarch64Vhdx),
 
             _ if id == test_iso::FREE_BSD_13_2_X64 => get_test_artifact_path(KnownTestArtifacts::FreeBsd13_2X64Iso),
 

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -67,6 +67,7 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
             _ if id == test_vhd::FREE_BSD_13_2_X64 => get_test_artifact_path(KnownTestArtifacts::FreeBsd13_2X64Vhd),
             _ if id == test_vhd::UBUNTU_2204_SERVER_X64 => get_test_artifact_path(KnownTestArtifacts::Ubuntu2204ServerX64Vhd),
             _ if id == test_vhd::UBUNTU_2404_SERVER_AARCH64 => get_test_artifact_path(KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd),
+            _ if id == test_vhd::WINDOWS_11_AARCH64 => get_test_artifact_path(KnownTestArtifacts::Windows11Aarch64Vhdx),
 
             _ if id == test_iso::FREE_BSD_13_2_X64 => get_test_artifact_path(KnownTestArtifacts::FreeBsd13_2X64Iso),
 

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -323,6 +323,22 @@ pub mod artifacts {
             const FILENAME: &'static str = "ubuntu-24.04-server-cloudimg-arm64.vhd";
             const SIZE: u64 = 3758211584;
         }
+
+        declare_artifacts! {
+            /// Ubuntu 24.04 Server Aarch64
+            WINDOWS_11_AARCH64
+        }
+
+        impl IsTestVhd for WINDOWS_11_AARCH64 {
+            const OS_FLAVOR: OsFlavor = OsFlavor::Windows;
+            const ARCH: MachineArch = MachineArch::Aarch64;
+        }
+
+        impl IsHostedOnHvliteAzureBlobStore for WINDOWS_11_AARCH64 {
+            const FILENAME: &'static str =
+                "windows11preview-arm64-win11-24h2-ent-26100.3775.250406-1.vhdx";
+            const SIZE: u64 = 24398266368;
+        }
     }
 
     /// Test ISO artifacts

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -325,16 +325,16 @@ pub mod artifacts {
         }
 
         declare_artifacts! {
-            /// Ubuntu 24.04 Server Aarch64
-            WINDOWS_11_AARCH64
+            /// Windows 11 Enterprise ARM64 24H2
+            WINDOWS_11_ENTERPRISE_AARCH64
         }
 
-        impl IsTestVhd for WINDOWS_11_AARCH64 {
+        impl IsTestVhd for WINDOWS_11_ENTERPRISE_AARCH64 {
             const OS_FLAVOR: OsFlavor = OsFlavor::Windows;
             const ARCH: MachineArch = MachineArch::Aarch64;
         }
 
-        impl IsHostedOnHvliteAzureBlobStore for WINDOWS_11_AARCH64 {
+        impl IsHostedOnHvliteAzureBlobStore for WINDOWS_11_ENTERPRISE_AARCH64 {
             const FILENAME: &'static str =
                 "windows11preview-arm64-win11-24h2-ent-26100.3775.250406-1.vhdx";
             const SIZE: u64 = 24398266368;

--- a/vmm_tests/vmm_test_images/src/lib.rs
+++ b/vmm_tests/vmm_test_images/src/lib.rs
@@ -31,7 +31,7 @@ pub enum KnownTestArtifacts {
     FreeBsd13_2X64Iso,
     Ubuntu2204ServerX64Vhd,
     Ubuntu2404ServerAarch64Vhd,
-    Windows11Aarch64Vhdx,
+    Windows11EnterpriseAarch64Vhdx,
     VmgsWithBootEntry,
 }
 
@@ -89,9 +89,9 @@ const KNOWN_TEST_ARTIFACT_METADATA: &[KnownTestArtifactMeta] = &[
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_AARCH64::SIZE,
     ),
     KnownTestArtifactMeta::new(
-        KnownTestArtifacts::Windows11Aarch64Vhdx,
-        petri_artifacts_vmm_test::artifacts::test_vhd::WINDOWS_11_AARCH64::FILENAME,
-        petri_artifacts_vmm_test::artifacts::test_vhd::WINDOWS_11_AARCH64::SIZE
+        KnownTestArtifacts::Windows11EnterpriseAarch64Vhdx,
+        petri_artifacts_vmm_test::artifacts::test_vhd::WINDOWS_11_ENTERPRISE_AARCH64::FILENAME,
+        petri_artifacts_vmm_test::artifacts::test_vhd::WINDOWS_11_ENTERPRISE_AARCH64::SIZE
     ),
     KnownTestArtifactMeta::new(
         KnownTestArtifacts::VmgsWithBootEntry,

--- a/vmm_tests/vmm_test_images/src/lib.rs
+++ b/vmm_tests/vmm_test_images/src/lib.rs
@@ -31,6 +31,7 @@ pub enum KnownTestArtifacts {
     FreeBsd13_2X64Iso,
     Ubuntu2204ServerX64Vhd,
     Ubuntu2404ServerAarch64Vhd,
+    Windows11Aarch64Vhdx,
     VmgsWithBootEntry,
 }
 
@@ -86,6 +87,11 @@ const KNOWN_TEST_ARTIFACT_METADATA: &[KnownTestArtifactMeta] = &[
         KnownTestArtifacts::Ubuntu2404ServerAarch64Vhd,
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_AARCH64::FILENAME,
         petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_AARCH64::SIZE,
+    ),
+    KnownTestArtifactMeta::new(
+        KnownTestArtifacts::Windows11Aarch64Vhdx,
+        petri_artifacts_vmm_test::artifacts::test_vhd::WINDOWS_11_AARCH64::FILENAME,
+        petri_artifacts_vmm_test::artifacts::test_vhd::WINDOWS_11_AARCH64::SIZE
     ),
     KnownTestArtifactMeta::new(
         KnownTestArtifacts::VmgsWithBootEntry,

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -407,8 +407,8 @@ fn parse_vhd(input: ParseStream<'_>, generation: Generation) -> syn::Result<Imag
         "ubuntu_2404_server_aarch64" => Ok(image_info!(
             ::petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_AARCH64
         )),
-        "windows_11_aarch64" => Ok(image_info!(
-            ::petri_artifacts_vmm_test::artifacts::test_vhd::WINDOWS_11_AARCH64
+        "windows_11_enterprise_aarch64" => Ok(image_info!(
+            ::petri_artifacts_vmm_test::artifacts::test_vhd::WINDOWS_11_ENTERPRISE_AARCH64
         )),
         _ => Err(Error::new(word.span(), "unrecognized vhd")),
     }

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -407,6 +407,9 @@ fn parse_vhd(input: ParseStream<'_>, generation: Generation) -> syn::Result<Imag
         "ubuntu_2404_server_aarch64" => Ok(image_info!(
             ::petri_artifacts_vmm_test::artifacts::test_vhd::UBUNTU_2404_SERVER_AARCH64
         )),
+        "windows_11_aarch64" => Ok(image_info!(
+            ::petri_artifacts_vmm_test::artifacts::test_vhd::WINDOWS_11_AARCH64
+        )),
         _ => Err(Error::new(word.span(), "unrecognized vhd")),
     }
 }

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -43,7 +43,7 @@ async fn frontpage(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     openvmm_openhcl_linux_direct_x64,
     openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
-    // openvmm_uefi_aarch64(vhd(windows_11_aarch64)),
+    // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -51,11 +51,11 @@ async fn frontpage(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_pcat_x64(vhd(ubuntu_2204_server_x64)),
-    hyperv_uefi_aarch64(vhd(windows_11_aarch64)),
+    hyperv_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_uefi_x64(vhd(ubuntu_2204_server_x64)),
-    hyperv_openhcl_uefi_aarch64(vhd(windows_11_aarch64)),
+    hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
@@ -72,7 +72,7 @@ async fn boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
 // once we figure out how to get the guest to not reboot via IMC or other
 // means. At that point, we can also use Windows Server 2025 for x64 tests.
 // Hyper-V VMs work for now since we don't notice that they reboot
-#[openvmm_test(openvmm_uefi_aarch64(vhd(windows_11_aarch64)))]
+#[openvmm_test(openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)))]
 async fn boot_reset_expected(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     let mut vm = config.run_with_lazy_pipette().await?;
     assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
@@ -168,7 +168,7 @@ async fn kvp_ic(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 #[openvmm_test(
     uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     uefi_x64(vhd(ubuntu_2204_server_x64)),
-    // uefi_aarch64(vhd(windows_11_aarch64)),
+    // uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     linux_direct_x64
 )]
@@ -213,7 +213,7 @@ async fn timesync_ic(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     openvmm_openhcl_linux_direct_x64,
     // openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     // openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
-    // openvmm_uefi_aarch64(vhd(windows_11_aarch64)),
+    // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     // openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     // openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -249,7 +249,7 @@ async fn reboot(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     openvmm_pcat_x64(iso(freebsd_13_2_x64)),
     openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
-    // openvmm_uefi_aarch64(vhd(windows_11_aarch64)),
+    // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -257,7 +257,7 @@ async fn reboot(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
-    hyperv_openhcl_uefi_aarch64(vhd(windows_11_aarch64)),
+    hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     // hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -300,7 +300,7 @@ async fn boot_no_agent_single_proc(config: Box<dyn PetriVmConfig>) -> anyhow::Re
     openvmm_openhcl_linux_direct_x64,
     // openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     // openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
-    // openvmm_uefi_aarch64(vhd(windows_11_aarch64)),
+    // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     // openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     // openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -349,13 +349,13 @@ async fn guest_test_uefi(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
 #[vmm_test(
     openvmm_linux_direct_x64,
     openvmm_openhcl_linux_direct_x64,
-    // openvmm_uefi_aarch64(vhd(windows_11_aarch64)),
+    // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
     openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
-    hyperv_openhcl_uefi_aarch64(vhd(windows_11_aarch64)),
+    hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
@@ -416,7 +416,7 @@ async fn five_gb(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
 /// Verify that UEFI default boots even if invalid boot entries exist
 /// when `default_boot_always_attempt` is enabled.
 #[openvmm_test(
-    // openvmm_uefi_aarch64(vhd(windows_11_aarch64))[VMGS_WITH_BOOT_ENTRY],
+    // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY],
@@ -444,7 +444,7 @@ async fn default_boot(
 /// This test exists to ensure we are not getting a false positive for
 /// the `default_boot` test above.
 #[openvmm_test(
-    // openvmm_uefi_aarch64(vhd(windows_11_aarch64))[VMGS_WITH_BOOT_ENTRY],
+    // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY],

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -43,6 +43,7 @@ async fn frontpage(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     openvmm_openhcl_linux_direct_x64,
     openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
+    // openvmm_uefi_aarch64(vhd(windows_11_aarch64)),
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -50,15 +51,32 @@ async fn frontpage(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_pcat_x64(vhd(ubuntu_2204_server_x64)),
+    hyperv_uefi_aarch64(vhd(windows_11_aarch64)),
     hyperv_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_uefi_x64(vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_aarch64(vhd(windows_11_aarch64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
 async fn boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     let (vm, agent) = config.run().await?;
+    agent.power_off().await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+    Ok(())
+}
+
+/// Basic boot test for guests that are expected to reboot
+// TODO: Remove this test and other enable Windows 11 ARM OpenVMM tests
+// once we figure out how to get the guest to not reboot via IMC or other
+// means. At that point, we can also use Windows Server 2025 for x64 tests.
+// Hyper-V VMs work for now since we don't notice that they reboot
+#[openvmm_test(openvmm_uefi_aarch64(vhd(windows_11_aarch64)))]
+async fn boot_reset_expected(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+    let (mut vm, agent) = config.run().await?;
+    assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
+    vm.reset().await?;
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
     Ok(())
@@ -149,6 +167,7 @@ async fn kvp_ic(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 #[openvmm_test(
     uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     uefi_x64(vhd(ubuntu_2204_server_x64)),
+    // uefi_aarch64(vhd(windows_11_aarch64)),
     uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     linux_direct_x64
 )]
@@ -193,6 +212,7 @@ async fn timesync_ic(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     openvmm_openhcl_linux_direct_x64,
     // openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     // openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
+    // openvmm_uefi_aarch64(vhd(windows_11_aarch64)),
     // openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     // openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -228,6 +248,7 @@ async fn reboot(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     openvmm_pcat_x64(iso(freebsd_13_2_x64)),
     openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
+    // openvmm_uefi_aarch64(vhd(windows_11_aarch64)),
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -235,6 +256,7 @@ async fn reboot(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_aarch64(vhd(windows_11_aarch64)),
     // hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -277,6 +299,7 @@ async fn boot_no_agent_single_proc(config: Box<dyn PetriVmConfig>) -> anyhow::Re
     openvmm_openhcl_linux_direct_x64,
     // openvmm_pcat_x64(vhd(windows_datacenter_core_2022_x64)),
     // openvmm_pcat_x64(vhd(ubuntu_2204_server_x64)),
+    // openvmm_uefi_aarch64(vhd(windows_11_aarch64)),
     // openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     // openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
@@ -325,11 +348,13 @@ async fn guest_test_uefi(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
 #[vmm_test(
     openvmm_linux_direct_x64,
     openvmm_openhcl_linux_direct_x64,
+    // openvmm_uefi_aarch64(vhd(windows_11_aarch64)),
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64)),
     openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_aarch64(vhd(windows_11_aarch64)),
     hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
@@ -390,6 +415,7 @@ async fn five_gb(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
 /// Verify that UEFI default boots even if invalid boot entries exist
 /// when `default_boot_always_attempt` is enabled.
 #[openvmm_test(
+    // openvmm_uefi_aarch64(vhd(windows_11_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY],
@@ -417,6 +443,7 @@ async fn default_boot(
 /// This test exists to ensure we are not getting a false positive for
 /// the `default_boot` test above.
 #[openvmm_test(
+    // openvmm_uefi_aarch64(vhd(windows_11_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY],

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -74,9 +74,10 @@ async fn boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
 // Hyper-V VMs work for now since we don't notice that they reboot
 #[openvmm_test(openvmm_uefi_aarch64(vhd(windows_11_aarch64)))]
 async fn boot_reset_expected(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
-    let (mut vm, agent) = config.run().await?;
+    let mut vm = config.run_with_lazy_pipette().await?;
     assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
     vm.reset().await?;
+    let agent = vm.wait_for_agent().await?;
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
     Ok(())


### PR DESCRIPTION
Add Windows 11 ARM64 tests. Windows 11 (and Windows Server 2025) reboot once on first boot, so add a temporary workaround for OpenVMM tests (Hyper-V tests work fine since we don't notice that it reboots).