### PR TITLE
Guide: add notes on DeviceTree diagnostics

### DIFF
--- a/Guide/src/user_guide/openhcl/troubleshooting.md
+++ b/Guide/src/user_guide/openhcl/troubleshooting.md
@@ -6,7 +6,7 @@ issues you may encounter when running OpenHCL.
 If you are still running into issues, consider filing an issue on the OpenVMM
 GitHub Issue tracker.
 
-## \[Hyper-V] Vtl2/Vtl0 failed to start
+## \[Hyper-V] VTL2/VTL0 failed to start
 
 VTL2/VTL0 fails to boot is when either VTL2 or VTL0 has crashed. When the crash happens, they will emit an event to the Hyper-V worker channel.
 
@@ -21,3 +21,22 @@ Alternatively, some queries you can use to get Hyper-V-Worker logs:
 OpenHCL logging output can be useful for debugging issues with startup or runtime behavior.
 
 See [OpenHCL Tracing](../../reference/openhcl/diag/tracing.md) for more details about how to enable OpenHCL logging.
+
+## DeviceTree errors or warnings in the VTL2 kernel log
+
+1. Retrieve the DeviceTree blob from OpenHCL:
+
+```powershell
+uhdiag-dev.exe linux-uhvm00 file --file-path "/sys/firmware/fdt" > uh.dtb
+```
+
+2. Install the DeviceTree compiler and convert the blob to the textual representation:
+
+```sh 
+sudo apt-get install dtc
+dtc -I dtb -o uh.dts uh.dtb
+```
+
+Check on the errors and warnings and should any have been produced, fix them in the
+DeviceTree generation code. If that doesn't resolve the issues, inspect the DT parsing
+code in the Linux kernel.


### PR DESCRIPTION
When investigating the DT issues, it might be of great help to look at the textual representation of the DT blob.

Add notes to the Guide on how to get that done.