### PR TITLE
CVM: Flatten Cvm inspect state on each VpBacking

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -85,6 +85,7 @@ pub struct SnpBacked {
     hv_sint_notifications: u16,
     general_stats: VtlArray<GeneralStats, 2>,
     exit_stats: VtlArray<ExitStats, 2>,
+    #[inspect(flatten)]
     cvm: UhCvmVpState,
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -403,6 +403,7 @@ pub struct TdxBacked {
     #[inspect(skip)]
     flush_page: user_driver::memory::MemoryBlock,
 
+    #[inspect(flatten)]
     cvm: UhCvmVpState,
 }
 


### PR DESCRIPTION
Makes finding stuff a little more obvious when you're just digging around the tree.