### PR TITLE
tmk: log test name and parameters

### DIFF
--- a/tmk/tmk_core/src/lib.rs
+++ b/tmk/tmk_core/src/lib.rs
@@ -111,6 +111,13 @@ fn entry(input: &tmk_protocol::StartInput) -> ! {
         panic!("invalid test index {}", input.test_index);
     }
     let test = &tests[input.test_index as usize];
+
+    let test_name = core::str::from_utf8(test.name).expect("test name in UTF-8");
+    log!(
+        "running test {test_name}, entrypoint {:#x?}, with input {input:#x?}",
+        test.entrypoint
+    );
+
     (test.entrypoint)(TestContext {
         scope: &mut Scope {
             arch: Scope::arch_init(),
@@ -118,6 +125,8 @@ fn entry(input: &tmk_protocol::StartInput) -> ! {
             _env: PhantomData,
         },
     });
+
+    log!("test {test_name} completed");
 
     // SAFETY: the command is valid.
     unsafe { command(&tmk_protocol::Command::Complete { success: true }) };

--- a/tmk/tmk_protocol/src/lib.rs
+++ b/tmk/tmk_protocol/src/lib.rs
@@ -12,7 +12,7 @@ use zerocopy::TryFromBytes;
 
 /// Start input from the VMM to the TMK.
 #[repr(C)]
-#[derive(IntoBytes, Immutable)]
+#[derive(Debug, IntoBytes, Immutable)]
 pub struct StartInput {
     /// The address to write commands to.
     pub command: u64,


### PR DESCRIPTION
Shows that what is running is indeed what should be:

```log
2025-04-23T18:19:48.093322Z  INFO test: test started, name: "x86_64::ud2"
2025-04-23T18:19:48.098730Z  INFO tmk: running test x86_64::ud2, entrypoint 0x0000000000204cf0, with input StartInput {
    command: 0xffff0000,
    test_index: 0x3,
    vp_count: 0x1,
}

2025-04-23T18:19:48.098907Z  INFO tmk: ISR: vector = 6, has_error_code = false, error_code = 0x0
2025-04-23T18:19:48.098993Z  INFO tmk: test x86_64::ud2 completed
2025-04-23T18:19:48.099948Z  INFO test: test passed, name: "x86_64::ud2"
```

Perhaps useful, lmk :)