### PR TITLE
Tx GDMA error handling on 2411

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3925,6 +3925,7 @@ dependencies = [
  "net_backend_resources",
  "pal_async",
  "parking_lot",
+ "thiserror 2.0.0",
  "tracing",
  "vm_resource",
  "vm_topology",

--- a/vm/devices/net/gdma_defs/src/bnic.rs
+++ b/vm/devices/net/gdma_defs/src/bnic.rs
@@ -269,6 +269,7 @@ pub const CQE_TX_VF_DISABLED: u8 = 38;
 pub const CQE_TX_VPORT_IDX_OUT_OF_RANGE: u8 = 39;
 pub const CQE_TX_VPORT_DISABLED: u8 = 40;
 pub const CQE_TX_VLAN_TAGGING_VIOLATION: u8 = 41;
+pub const CQE_TX_GDMA_ERR: u8 = 42;
 
 pub const MANA_CQE_COMPLETION: u8 = 1;
 

--- a/vm/devices/net/net_backend/Cargo.toml
+++ b/vm/devices/net/net_backend/Cargo.toml
@@ -23,6 +23,7 @@ futures.workspace = true
 futures-concurrency.workspace = true
 parking_lot.workspace = true
 tracing.workspace = true
+thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/vm/devices/net/net_backend/src/lib.rs
+++ b/vm/devices/net/net_backend/src/lib.rs
@@ -26,6 +26,7 @@ use std::future::pending;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
+use thiserror::Error;
 
 /// Per-queue configuration.
 pub struct QueueConfig<'a> {
@@ -133,6 +134,14 @@ pub struct RssConfig<'a> {
     pub flags: u32, // TODO
 }
 
+#[derive(Error, Debug)]
+pub enum TxError {
+    #[error("error requiring queue restart. {0}")]
+    TryRestart(#[source] anyhow::Error),
+    #[error("unrecoverable error. {0}")]
+    Fatal(#[source] anyhow::Error),
+}
+
 /// A trait for sending and receiving network packets.
 #[async_trait]
 pub trait Queue: Send + InspectMut {
@@ -156,7 +165,7 @@ pub trait Queue: Send + InspectMut {
     fn tx_avail(&mut self, segments: &[TxSegment]) -> anyhow::Result<(bool, usize)>;
 
     /// Polls the device for transmit completions.
-    fn tx_poll(&mut self, done: &mut [TxId]) -> anyhow::Result<usize>;
+    fn tx_poll(&mut self, done: &mut [TxId]) -> Result<usize, TxError>;
 
     /// Get the buffer access.
     fn buffer_access(&mut self) -> Option<&mut dyn BufferAccess>;

--- a/vm/devices/net/net_backend/src/loopback.rs
+++ b/vm/devices/net/net_backend/src/loopback.rs
@@ -16,6 +16,7 @@ use crate::QueueConfig;
 use crate::RssConfig;
 use crate::RxId;
 use crate::RxMetadata;
+use crate::TxError;
 use crate::TxId;
 use crate::TxSegment;
 use async_trait::async_trait;
@@ -125,7 +126,7 @@ impl Queue for LoopbackQueue {
         Ok((true, sent))
     }
 
-    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> Result<usize, TxError> {
         Ok(0)
     }
 

--- a/vm/devices/net/net_backend/src/null.rs
+++ b/vm/devices/net/net_backend/src/null.rs
@@ -12,6 +12,7 @@ use crate::Queue;
 use crate::QueueConfig;
 use crate::RssConfig;
 use crate::RxId;
+use crate::TxError;
 use crate::TxId;
 use crate::TxOffloadSupport;
 use crate::TxSegment;
@@ -114,7 +115,7 @@ impl Queue for NullQueue {
         Ok((true, packets.len()))
     }
 
-    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> Result<usize, TxError> {
         Ok(0)
     }
 

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -18,6 +18,7 @@ use net_backend::RssConfig;
 use net_backend::RxChecksumState;
 use net_backend::RxId;
 use net_backend::RxMetadata;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxOffloadSupport;
 use net_backend::TxSegment;
@@ -229,7 +230,7 @@ impl net_backend::Queue for ConsommeQueue {
         Ok((false, segments.len()))
     }
 
-    fn tx_poll(&mut self, done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, done: &mut [TxId]) -> Result<usize, TxError> {
         let n = done.len().min(self.state.tx_ready.len());
         for (x, y) in done.iter_mut().zip(self.state.tx_ready.drain(..n)) {
             *x = y;

--- a/vm/devices/net/net_dio/src/lib.rs
+++ b/vm/devices/net/net_dio/src/lib.rs
@@ -18,6 +18,7 @@ use net_backend::QueueConfig;
 use net_backend::RssConfig;
 use net_backend::RxId;
 use net_backend::RxMetadata;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxSegment;
 use pal_async::driver::Driver;
@@ -190,7 +191,7 @@ impl Queue for DioQueue {
         Ok((true, n))
     }
 
-    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> Result<usize, TxError> {
         Ok(0)
     }
 

--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -10,6 +10,7 @@ use gdma_defs::bnic::ManaRxcompOob;
 use gdma_defs::bnic::ManaTxCompOob;
 use gdma_defs::bnic::ManaTxOob;
 use gdma_defs::bnic::CQE_RX_OKAY;
+use gdma_defs::bnic::CQE_TX_GDMA_ERR;
 use gdma_defs::bnic::CQE_TX_OKAY;
 use gdma_defs::bnic::MANA_LONG_PKT_FMT;
 use gdma_defs::bnic::MANA_SHORT_PKT_FMT;
@@ -41,6 +42,7 @@ use net_backend::RssConfig;
 use net_backend::RxChecksumState;
 use net_backend::RxId;
 use net_backend::RxMetadata;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxOffloadSupport;
 use net_backend::TxSegment;
@@ -556,6 +558,7 @@ struct QueueStats {
     tx_packets: u64,
     tx_errors: u64,
     tx_dropped: u64,
+    tx_stuck: u64,
 
     rx_events: u64,
     rx_packets: u64,
@@ -571,6 +574,7 @@ impl Inspect for QueueStats {
             .counter("tx_packets", self.tx_packets)
             .counter("tx_errors", self.tx_errors)
             .counter("tx_dropped", self.tx_dropped)
+            .counter("tx_stuck", self.tx_stuck)
             .counter("rx_events", self.rx_events)
             .counter("rx_packets", self.rx_packets)
             .counter("rx_errors", self.rx_errors)
@@ -632,6 +636,32 @@ impl<T: DeviceBacking> ManaQueue<T> {
             true
         } else {
             false
+        }
+    }
+
+    fn trace_tx_wqe(&mut self, tx_oob: ManaTxCompOob, done_length: usize) {
+        tracelimit::error_ratelimited!(
+            cqe_hdr_type = tx_oob.cqe_hdr.cqe_type(),
+            cqe_hdr_vendor_err = tx_oob.cqe_hdr.vendor_err(),
+            tx_oob_data_offset = tx_oob.tx_data_offset,
+            tx_oob_sgl_offset = tx_oob.offsets.tx_sgl_offset(),
+            tx_oob_wqe_offset = tx_oob.offsets.tx_wqe_offset(),
+            done_length,
+            posted_tx_len = self.posted_tx.len(),
+            "tx completion error"
+        );
+
+        // TODO: Use tx_wqe_offset to read the Wqe.
+        // Use Wqe.ClientOob to read the ManaTxOob.s_oob.
+        // Log properties of s_oob like checksum, etc.
+
+        if let Some(packet) = self.posted_tx.front() {
+            tracelimit::error_ratelimited!(
+                id = packet.id.0,
+                wqe_len = packet.wqe_len,
+                bounced_len_with_padding = packet.bounced_len_with_padding,
+                "posted tx"
+            );
         }
     }
 }
@@ -1039,8 +1069,9 @@ impl<T: DeviceBacking + Send> Queue for ManaQueue<T> {
         Ok((false, i))
     }
 
-    fn tx_poll(&mut self, done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, done: &mut [TxId]) -> Result<usize, TxError> {
         let mut i = 0;
+        let mut queue_stuck = false;
         while i < done.len() {
             let id = if let Some(cqe) = self.tx_cq.pop() {
                 let tx_oob = ManaTxCompOob::read_from_prefix(&cqe.data[..]).unwrap();
@@ -1048,10 +1079,22 @@ impl<T: DeviceBacking + Send> Queue for ManaQueue<T> {
                     CQE_TX_OKAY => {
                         self.stats.tx_packets += 1;
                     }
+                    CQE_TX_GDMA_ERR => {
+                        queue_stuck = true;
+                    }
                     ty => {
                         tracelimit::error_ratelimited!(ty, "tx completion error");
                         self.stats.tx_errors += 1;
                     }
+                }
+                if queue_stuck {
+                    // Hardware hit an error with the packet coming from the Guest.
+                    // CQE_TX_GDMA_ERR is how the Hardware indicates that it has disabled the queue.
+                    self.stats.tx_errors += 1;
+                    self.stats.tx_stuck += 1;
+                    self.trace_tx_wqe(tx_oob, done.len());
+                    // Return a TryRestart error to indicate that the queue needs to be restarted.
+                    return Err(TxError::TryRestart(anyhow::anyhow!("GDMA error")));
                 }
                 let packet = self.posted_tx.pop_front().unwrap();
                 self.tx_wq.advance_head(packet.wqe_len);

--- a/vm/devices/net/net_packet_capture/src/lib.rs
+++ b/vm/devices/net/net_packet_capture/src/lib.rs
@@ -22,6 +22,7 @@ use net_backend::Queue;
 use net_backend::QueueConfig;
 use net_backend::RssConfig;
 use net_backend::RxId;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxOffloadSupport;
 use net_backend::TxSegment;
@@ -542,7 +543,7 @@ impl Queue for PacketCaptureQueue {
         self.current_mut().tx_avail(segments)
     }
 
-    fn tx_poll(&mut self, done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, done: &mut [TxId]) -> Result<usize, TxError> {
         self.current_mut().tx_poll(done)
     }
 

--- a/vm/devices/net/net_tap/src/lib.rs
+++ b/vm/devices/net/net_tap/src/lib.rs
@@ -19,6 +19,7 @@ use net_backend::QueueConfig;
 use net_backend::RssConfig;
 use net_backend::RxId;
 use net_backend::RxMetadata;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxSegment;
 use pal_async::driver::Driver;
@@ -233,7 +234,7 @@ impl Queue for TapQueue {
         Ok((completed_synchronously, n))
     }
 
-    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> Result<usize, TxError> {
         // Packets are sent synchronously so there is no no need to check here if
         // sending has been completed.
         Ok(0)

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -51,6 +51,7 @@ use net_backend::EndpointAction;
 use net_backend::L3Protocol;
 use net_backend::QueueConfig;
 use net_backend::RxId;
+use net_backend::TxError;
 use net_backend::TxId;
 use net_backend::TxSegment;
 use net_backend_resources::mac_address::MacAddress;
@@ -1839,6 +1840,8 @@ enum WorkerError {
     Cancelled(task_control::Cancelled),
     #[error("tearing down because send/receive buffer is revoked")]
     BufferRevoked,
+    #[error("endpoint requires queue restart: {0}")]
+    EndpointRequiresQueueRestart(#[source] anyhow::Error),
 }
 
 impl From<task_control::Cancelled> for WorkerError {
@@ -4346,10 +4349,30 @@ impl<T: RingMem + 'static> Worker<T> {
                         stop.until_stopped(pending()).await?
                     };
 
-                    let restart = self.channel.main_loop(stop, state, queue_state).await?;
+                    let result = self.channel.main_loop(stop, state, queue_state).await;
+                    match result {
+                        Ok(restart) => {
+                            assert_eq!(self.channel_idx, 0);
+                            let _ = self.coordinator_send.try_send(restart);
+                        }
+                        Err(WorkerError::EndpointRequiresQueueRestart(err)) => {
+                            tracelimit::warn_ratelimited!(
+                                err = %err,
+                                "Endpoint requires queues to restart",
+                            );
+                            if let Err(try_send_err) =
+                                self.coordinator_send.try_send(CoordinatorMessage::Restart)
+                            {
+                                tracing::error!(
+                                    try_send_err = %try_send_err,
+                                    "failed to restart queues"
+                                );
+                                return Err(WorkerError::Endpoint(err));
+                            }
+                        }
+                        Err(err) => return Err(err),
+                    }
 
-                    assert_eq!(self.channel_idx, 0);
-                    let _ = self.coordinator_send.try_send(restart);
                     stop.until_stopped(pending()).await?
                 }
             }
@@ -4884,23 +4907,48 @@ impl<T: 'static + RingMem> NetChannel<T> {
         epqueue: &mut dyn net_backend::Queue,
     ) -> Result<bool, WorkerError> {
         // Drain completed transmits.
-        let n = epqueue
-            .tx_poll(&mut data.tx_done)
-            .map_err(WorkerError::Endpoint)?;
-        if n == 0 {
-            return Ok(false);
-        }
+        let result = epqueue.tx_poll(&mut data.tx_done);
 
-        for &id in &data.tx_done[..n] {
-            let tx_packet = &mut state.pending_tx_packets[id.0 as usize];
-            assert!(tx_packet.pending_packet_count > 0);
-            tx_packet.pending_packet_count -= 1;
-            if tx_packet.pending_packet_count == 0 {
-                self.complete_tx_packet(state, id)?;
+        match result {
+            Ok(n) => {
+                if n == 0 {
+                    return Ok(false);
+                }
+
+                for &id in &data.tx_done[..n] {
+                    let tx_packet = &mut state.pending_tx_packets[id.0 as usize];
+                    assert!(tx_packet.pending_packet_count > 0);
+                    tx_packet.pending_packet_count -= 1;
+                    if tx_packet.pending_packet_count == 0 {
+                        self.complete_tx_packet(state, id)?;
+                    }
+                }
+
+                Ok(true)
             }
+            Err(TxError::TryRestart(err)) => {
+                // Complete any pending tx prior to restarting queues.
+                let pending_tx = state
+                    .pending_tx_packets
+                    .iter_mut()
+                    .enumerate()
+                    .filter_map(|(id, inflight)| {
+                        if inflight.pending_packet_count > 0 {
+                            inflight.pending_packet_count = 0;
+                            Some(PendingTxCompletion {
+                                transaction_id: inflight.transaction_id,
+                                tx_id: Some(TxId(id as u32)),
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                state.pending_tx_completions.extend(pending_tx);
+                Err(WorkerError::EndpointRequiresQueueRestart(err))
+            }
+            Err(TxError::Fatal(err)) => Err(WorkerError::Endpoint(err)),
         }
-
-        Ok(true)
     }
 
     fn switch_data_path(

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -33,6 +33,7 @@ use net_backend::EndpointAction;
 use net_backend::MultiQueueSupport;
 use net_backend::Queue as NetQueue;
 use net_backend::QueueConfig;
+use net_backend::TxError;
 use net_backend::TxOffloadSupport;
 use pal_async::async_test;
 use pal_async::DefaultDriver;
@@ -378,7 +379,7 @@ impl NetQueue for TestNicQueue {
         Ok((true, packets.len()))
     }
 
-    fn tx_poll(&mut self, _done: &mut [TxId]) -> anyhow::Result<usize> {
+    fn tx_poll(&mut self, _done: &mut [TxId]) -> Result<usize, TxError> {
         Ok(0)
     }
 

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -923,7 +923,7 @@ impl Worker {
         // Drain completed transmits.
         let n = epqueue
             .tx_poll(&mut self.active_state.data.tx_done)
-            .map_err(WorkerError::Endpoint)?;
+            .map_err(|tx_error| WorkerError::Endpoint(tx_error.into()))?;
         if n == 0 {
             return Ok(false);
         }


### PR DESCRIPTION
The net_mana::tx_poll() does not properly handle a CQE of type CQE_TX_GDMA_ERR. GDMA_ERR is sent from the Hardware to indicate that the queue has been disabled. Once the queue is disabled, no further traffic can be sent out from the Guest. The proper way to handle the Gdma error is to recreate/restart the tx queue.

Changes:

* Adding logging to help track and triage these issues. A Gdma error can be returned due to any number of problems, so the only way to determine the cause is by logging the vendor error and properties of the packet.
* Modifying net_mana::tx_poll to return an error that indicates the queue should be restarted.
* Modifying netvsp to handle the TxError::TryReturn
* If process_endpoint_tx sees a TryReturn error, it completes any pending tx packets before the queues are restarted.
* If main_loop returns a TryReturn error, Coordinator is sent a Restart message, which will restart all the queues.
* 
Notes:

* I'm leveraging the existing code to restart all queues, which is disruptive, but better than being unable to send traffic.
* The underlying cause of the Gdma error(s) still need to be addressed. Openvmm netvsp is crafting packets in such a way to cause hardware errors, the logging should help in determining the problem.
* While we observed crashes in openvmm after a Gdma Error when the packet was None, I could not recreate a repro in the lab. It remains unclear if these changes will address the crash.