### PR TITLE
openhcl: disable dbgrd.cpio.gz package for aarch64

### DIFF
--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -209,7 +209,7 @@ impl OpenhclIgvmRecipe {
                 target: CommonTriple::AARCH64_LINUX_MUSL,
                 vtl0_kernel_type: None,
                 with_uefi: true,
-                with_interactive,
+                with_interactive: false, // #1234
                 with_sidecar: false,
             },
             Self::Aarch64Devkern => OpenhclIgvmRecipeDetails {
@@ -223,7 +223,7 @@ impl OpenhclIgvmRecipe {
                 target: CommonTriple::AARCH64_LINUX_MUSL,
                 vtl0_kernel_type: None,
                 with_uefi: true,
-                with_interactive,
+                with_interactive: false, // #1234
                 with_sidecar: false,
             },
         }


### PR DESCRIPTION
The dbgrd.cpio.gz package seems to be broken on aarch64. Disable it for now.

Works around #1234.