### PR TITLE
Remove the CVM Guest VSM configuration env var

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -313,7 +313,6 @@ async fn launch_workers(
         nvme_vfio: opt.nvme_vfio,
         mcr: opt.mcr,
         enable_shared_visibility_pool: opt.enable_shared_visibility_pool,
-        cvm_guest_vsm: opt.cvm_guest_vsm,
         halt_on_guest_halt: opt.halt_on_guest_halt,
         no_sidecar_hotplug: opt.no_sidecar_hotplug,
         gdbstub: opt.gdbstub,

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -121,10 +121,6 @@ pub struct Options {
     /// hardware isolated platforms, but can be enabled for testing.
     pub enable_shared_visibility_pool: bool,
 
-    /// (OPENHCL_CVM_GUEST_VSM=1)
-    /// Enable support for guest vsm in CVMs. This is disabled by default.
-    pub cvm_guest_vsm: bool,
-
     /// (OPENHCL_HIDE_ISOLATION=1)
     /// Hide the isolation mode from the guest.
     pub hide_isolation: bool,
@@ -231,7 +227,6 @@ impl Options {
         let mcr = parse_legacy_env_bool("OPENHCL_MCR_DEVICE");
         let enable_shared_visibility_pool =
             parse_legacy_env_bool("OPENHCL_ENABLE_SHARED_VISIBILITY_POOL");
-        let cvm_guest_vsm = parse_legacy_env_bool("OPENHCL_CVM_GUEST_VSM");
         let hide_isolation = parse_env_bool("OPENHCL_HIDE_ISOLATION");
         let halt_on_guest_halt = parse_legacy_env_bool("OPENHCL_HALT_ON_GUEST_HALT");
         let no_sidecar_hotplug = parse_legacy_env_bool("OPENHCL_NO_SIDECAR_HOTPLUG");
@@ -300,7 +295,6 @@ impl Options {
             nvme_vfio,
             mcr,
             enable_shared_visibility_pool,
-            cvm_guest_vsm,
             hide_isolation,
             halt_on_guest_halt,
             no_sidecar_hotplug,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -263,15 +263,11 @@ pub struct UnderhillEnvCfg {
     pub force_load_vtl0_image: Option<String>,
     /// Use the user-mode NVMe driver.
     pub nvme_vfio: bool,
-
     // TODO MCR: support closed-source configuration logic for MCR device
     pub mcr: bool,
-
     /// Enable the shared visibility pool. This is enabled by default on
     /// hardware isolated platforms, but can be enabled for testing.
     pub enable_shared_visibility_pool: bool,
-    /// Enable support for guest vsm in CVMs. This is disabled by default.
-    pub cvm_guest_vsm: bool,
     /// Halt on a guest halt request instead of forwarding to the host.
     pub halt_on_guest_halt: bool,
     /// Leave sidecar VPs remote even if they hit exits.
@@ -282,10 +278,8 @@ pub struct UnderhillEnvCfg {
     pub hide_isolation: bool,
     /// Enable nvme keep alive.
     pub nvme_keep_alive: bool,
-
     /// test configuration
     pub test_configuration: Option<TestScenarioConfig>,
-
     /// Disable the UEFI front page.
     pub disable_uefi_frontpage: bool,
 }
@@ -1442,7 +1436,6 @@ async fn new_underhill_vm(
         topology: &processor_topology,
         cvm_cpuid_info: runtime_params.cvm_cpuid_info(),
         snp_secrets: runtime_params.snp_secrets(),
-        env_cvm_guest_vsm: env_cfg.cvm_guest_vsm,
         vtom,
         handle_synic: with_vmbus,
         no_sidecar_hotplug: env_cfg.no_sidecar_hotplug,

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1300,8 +1300,6 @@ pub struct UhPartitionNewParams<'a> {
     pub cvm_cpuid_info: Option<&'a [u8]>,
     /// The unparsed CVM secrets page.
     pub snp_secrets: Option<&'a [u8]>,
-    /// Whether underhill was configured to support guest vsm for CVMs
-    pub env_cvm_guest_vsm: bool,
     /// The virtual top of memory for hardware-isolated VMs.
     ///
     /// Must be a power of two.
@@ -1840,15 +1838,10 @@ impl UhProtoPartition<'_> {
             IsolationType::None | IsolationType::Vbs => {}
             #[cfg(guest_arch = "x86_64")]
             IsolationType::Tdx => {
-                if !params.env_cvm_guest_vsm {
-                    return Ok(false);
-                }
+                // No additional checks needed
             }
             #[cfg(guest_arch = "x86_64")]
             IsolationType::Snp => {
-                if !params.env_cvm_guest_vsm {
-                    return Ok(false);
-                }
                 // Require RMP Query
                 let rmp_query = x86defs::cpuid::ExtendedSevFeaturesEax::from(
                     safe_intrinsics::cpuid(x86defs::cpuid::CpuidFunction::ExtendedSevFeatures.0, 0)

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1928,12 +1928,6 @@ impl UhProtoPartition<'_> {
             guest_memory,
         });
 
-        if guest_vsm_available {
-            tracing::warn!(
-                "Advertising guest vsm as being supported to the guest. This feature is in development, so the guest might crash."
-            );
-        }
-
         Ok(UhCvmPartitionState {
             vps_per_socket: params.topology.reserved_vps_per_socket(),
             tlb_locked_vps,

--- a/tmk/tmk_vmm/src/paravisor_vmm.rs
+++ b/tmk/tmk_vmm/src/paravisor_vmm.rs
@@ -28,7 +28,6 @@ impl RunContext<'_> {
             topology: &self.state.processor_topology,
             cvm_cpuid_info: None,
             snp_secrets: None,
-            env_cvm_guest_vsm: false,
             vtom: None,
             handle_synic: true,
             no_sidecar_hotplug: false,


### PR DESCRIPTION
Now that both SNP and TDX support for guest vsm is nearing preview-feature-complete status this env var is no longer needed. It is up to the guest whether to enable VBS/VSM or not.