### PR TITLE
TDX: Quiet a write to an unsupported MSR

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -2596,6 +2596,10 @@ impl UhProcessor<'_, TdxBacked> {
 
             x86defs::X86X_MSR_MTRR_DEF_TYPE => {} // Ignore writes to this MSR
 
+            // Following MSRs are sometimes written by Windows guests.
+            // These are not virtualized and unsupported for L2-VMs
+            x86defs::X86X_MSR_BIOS_UPDT_TRIG => {}
+
             // Following MSRs are unconditionally written by Linux guests.
             // These are not virtualized and unsupported for L2-VMs
             x86defs::X86X_MSR_MISC_FEATURE_ENABLES

--- a/vm/x86/x86defs/src/lib.rs
+++ b/vm/x86/x86defs/src/lib.rs
@@ -179,6 +179,7 @@ pub const X86X_MSR_EBL_CR_POWERON: u32 = 0x2a;
 pub const X86X_IA32_MSR_SMI_COUNT: u32 = 0x34;
 pub const X86X_IA32_MSR_FEATURE_CONTROL: u32 = 0x3a;
 pub const X86X_MSR_PPIN_CTL: u32 = 0x4e;
+pub const X86X_MSR_BIOS_UPDT_TRIG: u32 = 0x79;
 pub const X86X_MSR_MC_UPDATE_PATCH_LEVEL: u32 = 0x8b;
 pub const X86X_MSR_PLATFORM_INFO: u32 = 0xce;
 pub const X86X_MSR_UMWAIT_CONTROL: u32 = 0xe1;


### PR DESCRIPTION
On my TDX VMs I'm seeing a write to this MSR, which is normally used to trigger microcode updates. I'm not sure why Windows is trying to write to it, but we can't support microcode updates, so just quiet the warning.