### PR TITLE
gdma: save/restore functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,6 +3865,7 @@ dependencies = [
  "gdma_defs",
  "getrandom 0.3.2",
  "inspect",
+ "mana_save_restore",
  "mesh",
  "net_backend",
  "net_backend_resources",
@@ -3878,6 +3879,13 @@ dependencies = [
  "user_driver_emulated_mock",
  "vmcore",
  "zerocopy 0.8.24",
+]
+
+[[package]]
+name = "mana_save_restore"
+version = "0.0.0"
+dependencies = [
+ "mesh",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,6 +229,7 @@ gdma_defs = { path = "vm/devices/net/gdma_defs" }
 gdma_resources = { path = "vm/devices/net/gdma_resources" }
 linux_net_bindings = { path = "vm/devices/net/linux_net_bindings" }
 mana_driver = { path = "vm/devices/net/mana_driver" }
+mana_save_restore = { path = "vm/devices/net/mana_save_restore" }
 vfio_sys = { path = "vm/devices/user_driver/vfio_sys" }
 net_backend = { path = "vm/devices/net/net_backend" }
 net_backend_resources = { path = "vm/devices/net/net_backend_resources" }

--- a/vm/devices/net/mana_driver/Cargo.toml
+++ b/vm/devices/net/mana_driver/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 gdma_defs.workspace = true
 net_backend.workspace = true
 net_backend_resources.workspace = true
+mana_save_restore.workspace = true
 
 chipset_device.workspace = true
 user_driver.workspace = true

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -9,6 +9,8 @@ use crate::queues::Eq;
 use crate::queues::Wq;
 use crate::resources::Resource;
 use crate::resources::ResourceArena;
+use crate::save_restore::GdmaDriverSavedState;
+use crate::save_restore::InterruptSavedState;
 use anyhow::Context;
 use futures::FutureExt;
 use gdma_defs::Cqe;
@@ -67,6 +69,8 @@ use gdma_defs::Sge;
 use gdma_defs::SmcMessageType;
 use gdma_defs::SmcProtoHdr;
 use inspect::Inspect;
+use mana_save_restore::save_restore::DoorbellSavedState;
+use mana_save_restore::save_restore::SavedMemoryState;
 use pal_async::driver::Driver;
 use std::collections::HashMap;
 use std::mem::ManuallyDrop;
@@ -118,6 +122,13 @@ impl<T: DeviceRegisterIo + Inspect> Doorbell for Bar0<T> {
         safe_intrinsics::store_fence();
         self.mem.write_u64(offset as usize, value);
     }
+
+    fn save(&self, doorbell_id: Option<u64>) -> DoorbellSavedState {
+        DoorbellSavedState {
+            doorbell_id: doorbell_id.unwrap(),
+            page_count: self.page_count(),
+        }
+    }
 }
 
 #[derive(Inspect)]
@@ -148,6 +159,8 @@ pub struct GdmaDriver<T: DeviceBacking> {
     hwc_warning_time_in_ms: u32,
     hwc_timeout_in_ms: u32,
     hwc_failure: bool,
+    db_id: u32,
+    saving: bool,
 }
 
 const EQ_PAGE: usize = 0;
@@ -163,9 +176,17 @@ const RWQE_SIZE: u32 = 32;
 
 impl<T: DeviceBacking> Drop for GdmaDriver<T> {
     fn drop(&mut self) {
+        tracing::debug!(?self.saving, ?self.hwc_failure, "dropping gdma driver");
+
+        // Don't destroy anything if we're saving its state for restoration.
+        if self.saving {
+            return;
+        }
+
         if self.hwc_failure {
             return;
         }
+
         let data = self
             .bar0
             .mem
@@ -230,7 +251,12 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         self.bar0.clone() as _
     }
 
-    pub async fn new(driver: &impl Driver, mut device: T, num_vps: u32) -> anyhow::Result<Self> {
+    pub async fn new(
+        driver: &impl Driver,
+        mut device: T,
+        num_vps: u32,
+        dma_buffer: Option<MemoryBlock>,
+    ) -> anyhow::Result<Self> {
         let bar0_mapping = device.map_bar(0)?;
         let bar0_len = bar0_mapping.len();
         if bar0_len < size_of::<RegMap>() {
@@ -280,11 +306,14 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             );
         }
 
-        let dma_client = device.dma_client();
-
-        let dma_buffer = dma_client
-            .allocate_dma_buffer(NUM_PAGES * PAGE_SIZE)
-            .context("failed to allocate DMA buffer")?;
+        let dma_buffer = if let Some(dma_buffer) = dma_buffer {
+            dma_buffer
+        } else {
+            let dma_client = device.dma_client();
+            dma_client
+                .allocate_dma_buffer(NUM_PAGES * PAGE_SIZE)
+                .context("failed to allocate DMA buffer")?
+        };
 
         let pages = dma_buffer.pfns();
 
@@ -475,6 +504,8 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             hwc_warning_time_in_ms: HWC_WARNING_TIME_IN_MS,
             hwc_timeout_in_ms: HWC_TIMEOUT_DEFAULT_IN_MS,
             hwc_failure: false,
+            saving: false,
+            db_id,
         };
 
         this.push_rqe();
@@ -496,6 +527,183 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             .min(max_vf_resources.max_sq)
             .min(max_vf_resources.max_rq);
 
+        Ok(this)
+    }
+
+    #[allow(dead_code)]
+    pub async fn save(mut self) -> anyhow::Result<GdmaDriverSavedState> {
+        self.saving = true;
+
+        let doorbell = self.bar0.save(Some(self.db_id as u64));
+
+        let mut interrupt_config = Vec::new();
+        for (index, interrupt) in self.interrupts.iter().enumerate() {
+            if interrupt.is_some() {
+                interrupt_config.push(InterruptSavedState {
+                    msix_index: index as u32,
+                    cpu: index as u32,
+                });
+            }
+        }
+
+        Ok(GdmaDriverSavedState {
+            mem: SavedMemoryState {
+                base_pfn: self.dma_buffer.pfns()[0],
+                len: self.dma_buffer.len(),
+            },
+            eq: self.eq.save(),
+            cq: self.cq.save(),
+            rq: self.rq.save(),
+            sq: self.sq.save(),
+            db_id: doorbell.doorbell_id,
+            gpa_mkey: self.gpa_mkey,
+            pdid: self._pdid,
+            cq_armed: self.cq_armed,
+            eq_armed: self.eq_armed,
+            hwc_subscribed: self.hwc_subscribed,
+            eq_id_msix: self.eq_id_msix.clone(),
+            hwc_activity_id: self.hwc_activity_id,
+            num_msix: self.num_msix,
+            min_queue_avail: self.min_queue_avail,
+            link_toggle: self.link_toggle.clone(),
+            interrupt_config,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub async fn restore(
+        saved_state: GdmaDriverSavedState,
+        mut device: T,
+        dma_buffer: MemoryBlock,
+    ) -> anyhow::Result<Self> {
+        tracing::info!("restoring gdma driver");
+
+        let bar0_mapping = device.map_bar(0)?;
+        let bar0_len = bar0_mapping.len();
+        if bar0_len < size_of::<RegMap>() {
+            anyhow::bail!("bar0 ({} bytes) too small for reg map", bar0_mapping.len());
+        }
+
+        let mut map = RegMap::new_zeroed();
+        for i in 0..size_of_val(&map) / 4 {
+            let v = bar0_mapping.read_u32(i * 4);
+            // Unmapped device memory will return -1 on reads, so check the first 32
+            // bits for this condition to get a clear error message early.
+            if i == 0 && v == !0 {
+                anyhow::bail!("bar0 read returned -1, device is not present");
+            }
+            map.as_mut_bytes()[i * 4..(i + 1) * 4].copy_from_slice(&v.to_ne_bytes());
+        }
+
+        tracing::debug!(?map, "register map on restore");
+
+        // Log on unknown major version numbers. This is not necessarily an
+        // error, so continue.
+        if map.major_version_number != 0 && map.major_version_number != 1 {
+            tracing::warn!(
+                major = map.major_version_number,
+                minor = map.minor_version_number,
+                micro = map.micro_version_number,
+                "unrecognized major version"
+            );
+        }
+
+        if map.vf_gdma_sriov_shared_sz != 32 {
+            anyhow::bail!(
+                "unexpected shared memory size: {}",
+                map.vf_gdma_sriov_shared_sz
+            );
+        }
+
+        if (bar0_len as u64).saturating_sub(map.vf_gdma_sriov_shared_reg_start)
+            < map.vf_gdma_sriov_shared_sz as u64
+        {
+            anyhow::bail!(
+                "bar0 ({} bytes) too small for shared memory at {}",
+                bar0_mapping.len(),
+                map.vf_gdma_sriov_shared_reg_start
+            );
+        }
+
+        let doorbell_shift = map.vf_db_page_sz.trailing_zeros();
+        let bar0 = Arc::new(Bar0 {
+            mem: bar0_mapping,
+            map,
+            doorbell_shift,
+        });
+
+        let eq = Eq::restore(
+            dma_buffer.subblock(0, PAGE_SIZE),
+            saved_state.eq,
+            DoorbellPage::new(bar0.clone(), saved_state.db_id as u32)?,
+        )?;
+
+        let db_id = saved_state.db_id;
+        let cq = Cq::restore(
+            dma_buffer.subblock(CQ_PAGE * PAGE_SIZE, PAGE_SIZE),
+            saved_state.cq,
+            DoorbellPage::new(bar0.clone(), saved_state.db_id as u32)?,
+        )?;
+
+        let rq = Wq::restore_rq(
+            dma_buffer.subblock(RQ_PAGE * PAGE_SIZE, PAGE_SIZE),
+            saved_state.rq,
+            DoorbellPage::new(bar0.clone(), saved_state.db_id as u32)?,
+        )?;
+
+        let sq = Wq::restore_sq(
+            dma_buffer.subblock(SQ_PAGE * PAGE_SIZE, PAGE_SIZE),
+            saved_state.sq,
+            DoorbellPage::new(bar0.clone(), saved_state.db_id as u32)?,
+        )?;
+
+        let mut interrupts = vec![None; saved_state.num_msix as usize];
+        for int_state in &saved_state.interrupt_config {
+            let interrupt = device.map_interrupt(int_state.msix_index, int_state.cpu)?;
+
+            interrupts[int_state.msix_index as usize] = Some(interrupt);
+        }
+
+        let mut this = Self {
+            device: Some(device),
+            bar0,
+            dma_buffer,
+            interrupts,
+            eq,
+            cq,
+            rq,
+            sq,
+            test_events: 0,
+            eq_armed: saved_state.eq_armed,
+            cq_armed: saved_state.cq_armed,
+            gpa_mkey: saved_state.gpa_mkey,
+            _pdid: saved_state.pdid,
+            eq_id_msix: saved_state.eq_id_msix,
+            num_msix: saved_state.num_msix,
+            min_queue_avail: saved_state.min_queue_avail,
+            hwc_activity_id: saved_state.hwc_activity_id,
+            link_toggle: saved_state.link_toggle,
+            hwc_subscribed: saved_state.hwc_subscribed,
+            hwc_warning_time_in_ms: HWC_WARNING_TIME_IN_MS,
+            hwc_timeout_in_ms: HWC_TIMEOUT_DEFAULT_IN_MS,
+            hwc_failure: false,
+            saving: false,
+            db_id: db_id as u32,
+        };
+
+        if saved_state.hwc_subscribed {
+            this.hwc_subscribe();
+        }
+
+        if saved_state.eq_armed {
+            this.eq.arm();
+        }
+
+        if saved_state.cq_armed {
+            this.cq.arm();
+        }
+
+        tracing::info!("exiting restore");
         Ok(this)
     }
 
@@ -1017,6 +1225,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                 )
             })?;
         }
+
         Ok(())
     }
 
@@ -1061,11 +1270,13 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         &mut self,
         dev_id: GdmaDevId,
     ) -> anyhow::Result<GdmaRegisterDeviceResp> {
+        tracing::info!("registering device");
         self.request(GdmaRequestType::GDMA_REGISTER_DEVICE.0, dev_id, ())
             .await
     }
 
     pub async fn deregister_device(&mut self, dev_id: GdmaDevId) -> anyhow::Result<()> {
+        tracing::info!("deregistering device");
         self.hwc_timeout_in_ms = HWC_TIMEOUT_FOR_SHUTDOWN_IN_MS;
         self.request(GdmaRequestType::GDMA_DEREGISTER_DEVICE.0, dev_id, ())
             .await

--- a/vm/devices/net/mana_driver/src/lib.rs
+++ b/vm/devices/net/mana_driver/src/lib.rs
@@ -10,5 +10,6 @@ mod gdma_driver;
 pub mod mana;
 pub mod queues;
 mod resources;
+pub mod save_restore;
 #[cfg(test)]
 mod tests;

--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -77,7 +77,7 @@ impl<T: DeviceBacking> ManaDevice<T> {
         num_vps: u32,
         max_queues_per_vport: u16,
     ) -> anyhow::Result<Self> {
-        let mut gdma = GdmaDriver::new(driver, device, num_vps).await?;
+        let mut gdma = GdmaDriver::new(driver, device, num_vps, None).await?;
         gdma.test_eq().await?;
 
         gdma.verify_vf_driver_version().await?;

--- a/vm/devices/net/mana_driver/src/resources.rs
+++ b/vm/devices/net/mana_driver/src/resources.rs
@@ -5,6 +5,7 @@ use crate::bnic_driver::BnicDriver;
 use crate::gdma_driver::GdmaDriver;
 use gdma_defs::GdmaDevId;
 use gdma_defs::GdmaQueueType;
+use std::fmt::Debug;
 use std::mem::ManuallyDrop;
 use user_driver::DeviceBacking;
 use user_driver::memory::MemoryBlock;
@@ -36,6 +37,45 @@ pub(crate) enum Resource {
         wq_type: GdmaQueueType,
         wq_obj: u64,
     },
+}
+
+impl Debug for Resource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Resource::MemoryBlock(_) => f.debug_tuple("MemoryBlock").finish(),
+            Resource::DmaRegion {
+                dev_id,
+                gdma_region,
+            } => f
+                .debug_struct("DmaRegion")
+                .field("dev_id", dev_id)
+                .field("gdma_region", gdma_region)
+                .finish(),
+            Resource::Eq { dev_id, eq_id } => f
+                .debug_struct("Eq")
+                .field("dev_id", dev_id)
+                .field("eq_id", eq_id)
+                .finish(),
+            Resource::BnicQueue {
+                dev_id,
+                wq_type,
+                wq_obj,
+            } => f
+                .debug_struct("BnicQueue")
+                .field("dev_id", dev_id)
+                .field("wq_type", wq_type)
+                .field("wq_obj", wq_obj)
+                .finish(),
+        }
+    }
+}
+
+impl Debug for ResourceArena {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResourceArena")
+            .field("resources", &self.resources)
+            .finish()
+    }
 }
 
 impl ResourceArena {

--- a/vm/devices/net/mana_driver/src/save_restore.rs
+++ b/vm/devices/net/mana_driver/src/save_restore.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Types to save and restore the state of a MANA device.
+
+use mana_save_restore::save_restore::CqEqSavedState;
+use mana_save_restore::save_restore::SavedMemoryState;
+use mana_save_restore::save_restore::WqSavedState;
+use mesh::payload::Protobuf;
+use std::collections::HashMap;
+
+/// Top level saved state for the GDMA driver's saved state
+#[derive(Protobuf, Clone, Debug)]
+#[mesh(package = "mana_driver")]
+pub struct GdmaDriverSavedState {
+    /// Memory to be restored by a DMA client
+    #[mesh(1)]
+    pub mem: SavedMemoryState,
+
+    /// EQ to be restored
+    #[mesh(2)]
+    pub eq: CqEqSavedState,
+
+    /// CQ to be restored
+    #[mesh(3)]
+    pub cq: CqEqSavedState,
+
+    /// RQ to be restored
+    #[mesh(4)]
+    pub rq: WqSavedState,
+
+    /// SQ to be restored
+    #[mesh(5)]
+    pub sq: WqSavedState,
+
+    /// Doorbell id
+    #[mesh(6)]
+    pub db_id: u64,
+
+    /// Guest physical address memory key
+    #[mesh(7)]
+    pub gpa_mkey: u32,
+
+    /// Protection domain id
+    #[mesh(8)]
+    pub pdid: u32,
+
+    /// Whether the driver is subscribed to hwc
+    #[mesh(9)]
+    pub hwc_subscribed: bool,
+
+    /// Whether the eq is armed or not
+    #[mesh(10)]
+    pub eq_armed: bool,
+
+    /// Whether the cq is armed or not
+    #[mesh(11)]
+    pub cq_armed: bool,
+
+    /// Event queue id to msix mapping
+    #[mesh(12)]
+    pub eq_id_msix: HashMap<u32, u32>,
+
+    /// The id of the hwc activity
+    #[mesh(13)]
+    pub hwc_activity_id: u32,
+
+    /// How many msix vectors are available
+    #[mesh(14)]
+    pub num_msix: u32,
+
+    /// Minimum number of queues available
+    #[mesh(15)]
+    pub min_queue_avail: u32,
+
+    /// Saved interrupts for restoration
+    #[mesh(16)]
+    pub interrupt_config: Vec<InterruptSavedState>,
+
+    /// Link status by vport index
+    #[mesh(17)]
+    pub link_toggle: Vec<(u32, bool)>,
+}
+
+/// Saved state of an interrupt for restoration during servicing
+#[derive(Protobuf, Clone, Debug)]
+#[mesh(package = "mana_driver")]
+pub struct InterruptSavedState {
+    /// The index in the msix table for this interrupt
+    #[mesh(1)]
+    pub msix_index: u32,
+
+    /// Which CPU this interrupt is assigned to
+    #[mesh(2)]
+    pub cpu: u32,
+}

--- a/vm/devices/net/mana_save_restore/Cargo.toml
+++ b/vm/devices/net/mana_save_restore/Cargo.toml
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "mana_save_restore"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+mesh.workspace = true
+
+[lints]
+workspace = true

--- a/vm/devices/net/mana_save_restore/src/lib.rs
+++ b/vm/devices/net/mana_save_restore/src/lib.rs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Mana save/restore module
+
+/// Module containing structures for saving and restoring MANA device state
+pub mod save_restore {
+    use mesh::payload::Protobuf;
+
+    /// The saved state of a completion queue or event queue for restoration
+    /// during servicing
+    #[derive(Clone, Protobuf, Debug)]
+    #[mesh(package = "mana_driver")]
+    pub struct CqEqSavedState {
+        /// The doorbell state of the queue, which is how the device is notified
+        #[mesh(1)]
+        pub doorbell: DoorbellSavedState,
+
+        /// The address of the doorbell register
+        #[mesh(2)]
+        pub doorbell_addr: u32,
+
+        /// The id of the queue
+        #[mesh(3)]
+        pub id: u32,
+
+        /// The index of the next entry in the queue
+        #[mesh(4)]
+        pub next: u32,
+
+        /// The total size of the queue
+        #[mesh(5)]
+        pub size: u32,
+
+        /// The bit shift value for the queue
+        #[mesh(6)]
+        pub shift: u32,
+    }
+
+    /// Saved state of a doorbell for restoration during servicing
+    #[derive(Clone, Protobuf, Debug)]
+    #[mesh(package = "mana_driver")]
+    pub struct DoorbellSavedState {
+        /// The doorbell's id
+        #[mesh(1)]
+        pub doorbell_id: u64,
+
+        /// The number of pages allocated for the doorbell
+        #[mesh(2)]
+        pub page_count: u32,
+    }
+
+    /// Saved state of a work queue for restoration during servicing
+    #[derive(Debug, Protobuf, Clone)]
+    #[mesh(package = "mana_driver")]
+    pub struct WqSavedState {
+        /// The doorbell state of the queue, which is how the device is notified
+        #[mesh(1)]
+        pub doorbell: DoorbellSavedState,
+
+        /// The address of the doorbell
+        #[mesh(2)]
+        pub doorbell_addr: u32,
+
+        /// The id of the queue
+        #[mesh(3)]
+        pub id: u32,
+
+        /// The head of the queue
+        #[mesh(4)]
+        pub head: u32,
+
+        /// The tail of the queue
+        #[mesh(5)]
+        pub tail: u32,
+
+        /// The bitmask for wrapping queue indices
+        #[mesh(6)]
+        pub mask: u32,
+    }
+
+    /// Saved state for a memory region used by the driver
+    /// to be restored by a DMA client during servicing
+    #[derive(Debug, Protobuf, Clone)]
+    #[mesh(package = "mana_driver")]
+    pub struct SavedMemoryState {
+        /// The base page frame number of the memory region
+        #[mesh(1)]
+        pub base_pfn: u64,
+
+        /// How long the memory region is
+        #[mesh(2)]
+        pub len: usize,
+    }
+}

--- a/vm/devices/user_driver_emulated_mock/src/lib.rs
+++ b/vm/devices/user_driver_emulated_mock/src/lib.rs
@@ -39,7 +39,7 @@ use user_driver::memory::PAGE_SIZE64;
 /// allowing the user to control device behaviour to a certain extent. Can be used with devices such as the `NvmeController`
 pub struct EmulatedDevice<T, U> {
     device: Arc<Mutex<T>>,
-    controller: MsiController,
+    controller: Arc<MsiController>,
     dma_client: Arc<U>,
     bar0_len: usize,
 }
@@ -77,6 +77,17 @@ impl MsiInterruptTarget for MsiController {
     }
 }
 
+impl<T: PciConfigSpace + MmioIntercept, U: DmaClient> Clone for EmulatedDevice<T, U> {
+    fn clone(&self) -> Self {
+        Self {
+            device: self.device.clone(),
+            controller: self.controller.clone(),
+            dma_client: self.dma_client.clone(),
+            bar0_len: self.bar0_len,
+        }
+    }
+}
+
 impl<T: PciConfigSpace + MmioIntercept, U: DmaClient> EmulatedDevice<T, U> {
     /// Creates a new emulated device, wrapping `device` of type T, using the provided MSI Interrupt Set. Dma_client should point to memory
     /// shared with the device.
@@ -84,6 +95,7 @@ impl<T: PciConfigSpace + MmioIntercept, U: DmaClient> EmulatedDevice<T, U> {
         // Connect an interrupt controller.
         let controller = MsiController::new(msi_set.len());
         msi_set.connect(&controller);
+        let controller = Arc::new(controller);
 
         let bars = device.probe_bar_masks();
         let bar0_len = !(bars[0] & !0xf) as usize + 1;


### PR DESCRIPTION
First in a series of PRs implementing keepalive for mana devices. This is save/restore functionality for the GdmaDriver.

I've introduced a new crate, `mana_save_restore` for shared types that are needed across different crates (may not be necessary but was while I was prototyping to deal with a cyclic dependency). 