### PR TITLE
vmm_tests: remove uses of guest_arch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6887,7 +6887,6 @@ name = "tmk_tests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "build_rs_guest_arch",
  "pal_async",
  "petri",
  "petri_artifacts_common",
@@ -8821,7 +8820,6 @@ name = "vmm_tests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "build_rs_guest_arch",
  "disk_backend_resources",
  "futures",
  "get_resources",

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1006,11 +1006,8 @@ impl IntoPipeline for CheckinGatesCli {
                 label: "x64-linux",
                 target: CommonTriple::X86_64_LINUX_GNU,
                 resolve_vmm_tests_artifacts: vmm_tests_artifacts_linux_x86,
-                // - OpenHCL is not supported on KVM
                 // - No legal way to obtain gen1 pcat blobs on non-msft linux machines
-                nextest_filter_expr: format!(
-                    "{standard_filter} & !test(openhcl) & !test(pcat_x64)"
-                ),
+                nextest_filter_expr: format!("{standard_filter} & !test(pcat_x64)"),
                 test_artifacts: standard_x64_test_artifacts,
             },
             VmmTestJobParams {

--- a/petri/petri_artifacts_common/src/lib.rs
+++ b/petri/petri_artifacts_common/src/lib.rs
@@ -47,6 +47,22 @@ pub mod tags {
         Aarch64,
     }
 
+    impl MachineArch {
+        /// Returns the host's architecture.
+        pub fn host() -> Self {
+            // xtask-fmt allow-target-arch oneoff-petri-host-arch
+            if cfg!(target_arch = "x86_64") {
+                Self::X86_64
+            }
+            // xtask-fmt allow-target-arch oneoff-petri-host-arch
+            else if cfg!(target_arch = "aarch64") {
+                Self::Aarch64
+            } else {
+                panic!("unsupported host architecture")
+            }
+        }
+    }
+
     /// Quirks needed to boot a guest.
     #[derive(Default, Copy, Clone, Debug)]
     pub struct GuestQuirks {

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -99,6 +99,8 @@ pub enum ApicMode {
 /// A running VM that tests can interact with.
 #[async_trait]
 pub trait PetriVm: Send {
+    /// Returns the guest architecture.
+    fn arch(&self) -> MachineArch;
     /// Wait for the VM to halt, returning the reason for the halt.
     async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason>;
     /// Wait for the VM to halt, returning the reason for the halt,

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -28,6 +28,7 @@ use pal_async::socket::PolledSocket;
 use pal_async::task::Task;
 use pal_async::timer::PolledTimer;
 use petri_artifacts_common::tags::GuestQuirks;
+use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_core::ResolvedArtifact;
 use pipette_client::PipetteClient;
 use std::future::Future;
@@ -48,6 +49,10 @@ pub struct PetriVmOpenVmm {
 
 #[async_trait]
 impl PetriVm for PetriVmOpenVmm {
+    fn arch(&self) -> MachineArch {
+        self.inner.arch
+    }
+
     async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason> {
         Self::wait_for_halt(self).await
     }
@@ -86,6 +91,7 @@ impl PetriVm for PetriVmOpenVmm {
 }
 
 pub(super) struct PetriVmInner {
+    pub(super) arch: MachineArch,
     pub(super) resources: PetriVmResourcesOpenVmm,
     pub(super) mesh: Mesh,
     pub(super) worker: Arc<Worker>,

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -126,6 +126,7 @@ impl PetriVmConfigOpenVmm {
 
         let mut vm = PetriVmOpenVmm::new(
             super::runtime::PetriVmInner {
+                arch,
                 resources,
                 mesh,
                 worker,

--- a/tmk/tmk_tests/Cargo.toml
+++ b/tmk/tmk_tests/Cargo.toml
@@ -16,8 +16,5 @@ pal_async.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 
-[build-dependencies]
-build_rs_guest_arch.workspace = true
-
 [lints]
 workspace = true

--- a/tmk/tmk_tests/build.rs
+++ b/tmk/tmk_tests/build.rs
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-//! Build script for TMK tests.
-
-fn main() {
-    build_rs_guest_arch::emit_guest_arch();
-}

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -9,8 +9,9 @@ use pal_async::DefaultPool;
 use pal_async::task::Spawn as _;
 use petri::ProcessorTopology;
 use petri::ResolvedArtifact;
+use petri_artifacts_common::tags::MachineArch;
 
-petri::test!(host_tmks, resolve_host_tmks);
+petri::test!(host_tmks, |resolver| resolve_host_tmks(resolver, false));
 
 fn host_tmks(
     params: petri::PetriTestParams<'_>,
@@ -19,10 +20,10 @@ fn host_tmks(
     host_tmks_core(params, false, artifacts)
 }
 
-#[cfg(windows)] // only useful on virt_whp for now
-petri::test!(host_tmks_emulated_apic, resolve_host_tmks);
+petri::test!(host_tmks_emulated_apic, |resolver| resolve_host_tmks(
+    resolver, true
+));
 
-#[cfg(windows)] // only useful on virt_whp for now
 fn host_tmks_emulated_apic(
     params: petri::PetriTestParams<'_>,
     artifacts: (ResolvedArtifact, ResolvedArtifact),
@@ -30,24 +31,32 @@ fn host_tmks_emulated_apic(
     host_tmks_core(params, true, artifacts)
 }
 
+fn resolve_simple_tmk(
+    resolver: &petri::ArtifactResolver<'_>,
+    arch: MachineArch,
+) -> ResolvedArtifact {
+    match arch {
+        MachineArch::X86_64 => resolver
+            .require(petri_artifacts_vmm_test::artifacts::tmks::SIMPLE_TMK_X64)
+            .erase(),
+        MachineArch::Aarch64 => resolver
+            .require(petri_artifacts_vmm_test::artifacts::tmks::SIMPLE_TMK_AARCH64)
+            .erase(),
+    }
+}
+
 fn resolve_host_tmks(
     resolver: &petri::ArtifactResolver<'_>,
-) -> (ResolvedArtifact, ResolvedArtifact) {
+    emulated_apic: bool,
+) -> Option<(ResolvedArtifact, ResolvedArtifact)> {
+    // Only useful on virt_whp x64 for now.
+    if emulated_apic && (MachineArch::host() != MachineArch::X86_64 || !cfg!(windows)) {
+        return None;
+    }
     let tmk_vmm = resolver
         .require(petri_artifacts_vmm_test::artifacts::tmks::TMK_VMM_NATIVE)
         .erase();
-    let tmk = if cfg!(guest_arch = "x86_64") {
-        resolver
-            .require(petri_artifacts_vmm_test::artifacts::tmks::SIMPLE_TMK_X64)
-            .erase()
-    } else if cfg!(guest_arch = "aarch64") {
-        resolver
-            .require(petri_artifacts_vmm_test::artifacts::tmks::SIMPLE_TMK_AARCH64)
-            .erase()
-    } else {
-        panic!("Unsupported guest architecture");
-    };
-    (tmk_vmm, tmk)
+    Some((tmk_vmm, resolve_simple_tmk(resolver, MachineArch::host())))
 }
 
 fn host_tmks_core(
@@ -90,36 +99,31 @@ fn host_tmks_core(
 
 fn resolve_paravisor_tmk_artifacts(
     resolver: &petri::ArtifactResolver<'_>,
+    arch: MachineArch,
 ) -> (ResolvedArtifact, ResolvedArtifact, ResolvedArtifact) {
     let igvm_path;
     let tmk_vmm;
-    let tmk;
 
-    if cfg!(guest_arch = "x86_64") {
-        igvm_path = resolver
-            .require(petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64)
-            .erase();
-        tmk_vmm = resolver
-            .require(petri_artifacts_vmm_test::artifacts::tmks::TMK_VMM_LINUX_X64_MUSL)
-            .erase();
-        tmk = resolver
-            .require(petri_artifacts_vmm_test::artifacts::tmks::SIMPLE_TMK_X64)
-            .erase();
-    } else if cfg!(guest_arch = "aarch64") {
-        igvm_path = resolver
-            .require(petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_AARCH64)
-            .erase();
-        tmk_vmm = resolver
-            .require(petri_artifacts_vmm_test::artifacts::tmks::TMK_VMM_LINUX_AARCH64_MUSL)
-            .erase();
-        tmk = resolver
-            .require(petri_artifacts_vmm_test::artifacts::tmks::SIMPLE_TMK_AARCH64)
-            .erase();
-    } else {
-        panic!("Unsupported guest architecture");
-    };
+    match arch {
+        MachineArch::X86_64 => {
+            igvm_path = resolver
+                .require(petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64)
+                .erase();
+            tmk_vmm = resolver
+                .require(petri_artifacts_vmm_test::artifacts::tmks::TMK_VMM_LINUX_X64_MUSL)
+                .erase();
+        }
+        MachineArch::Aarch64 => {
+            igvm_path = resolver
+                .require(petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_AARCH64)
+                .erase();
+            tmk_vmm = resolver
+                .require(petri_artifacts_vmm_test::artifacts::tmks::TMK_VMM_LINUX_AARCH64_MUSL)
+                .erase();
+        }
+    }
 
-    (igvm_path, tmk_vmm, tmk)
+    (igvm_path, tmk_vmm, resolve_simple_tmk(resolver, arch))
 }
 
 async fn openhcl_tmks(
@@ -161,7 +165,6 @@ async fn openhcl_tmks(
     Ok(())
 }
 
-#[cfg(guest_arch = "x86_64")] // We don't support openvmm+openhcl tests on aarch64 yet
 petri::test!(openvmm_openhcl_tmks, resolve_openvmm_openhcl_tmks);
 
 struct OpenvmmOpenhclArtifacts {
@@ -170,17 +173,11 @@ struct OpenvmmOpenhclArtifacts {
     tmk: ResolvedArtifact,
 }
 
-#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
-fn resolve_openvmm_openhcl_tmks(resolver: &petri::ArtifactResolver<'_>) -> OpenvmmOpenhclArtifacts {
-    let (igvm_path, tmk_vmm, tmk) = resolve_paravisor_tmk_artifacts(resolver);
-
-    let arch = if cfg!(guest_arch = "x86_64") {
-        petri_artifacts_common::tags::MachineArch::X86_64
-    } else if cfg!(guest_arch = "aarch64") {
-        petri_artifacts_common::tags::MachineArch::Aarch64
-    } else {
-        panic!("Unsupported guest architecture");
-    };
+fn resolve_openvmm_openhcl_tmks(
+    resolver: &petri::ArtifactResolver<'_>,
+) -> Option<OpenvmmOpenhclArtifacts> {
+    let arch = MachineArch::host();
+    let (igvm_path, tmk_vmm, tmk) = resolve_paravisor_tmk_artifacts(resolver, arch);
 
     let vm = petri::openvmm::PetriVmArtifactsOpenVmm::new(
         resolver,
@@ -191,11 +188,10 @@ fn resolve_openvmm_openhcl_tmks(resolver: &petri::ArtifactResolver<'_>) -> Openv
             igvm_path,
         },
         arch,
-    );
-    OpenvmmOpenhclArtifacts { vm, tmk_vmm, tmk }
+    )?;
+    Some(OpenvmmOpenhclArtifacts { vm, tmk_vmm, tmk })
 }
 
-#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 fn openvmm_openhcl_tmks(
     params: petri::PetriTestParams<'_>,
     artifacts: OpenvmmOpenhclArtifacts,
@@ -220,13 +216,13 @@ fn openvmm_openhcl_tmks(
 }
 
 #[cfg(windows)]
-#[cfg(guest_arch = "x86_64")] // TODO: aarch64 currently hangs, fix
 mod hyperv {
     use crate::openhcl_tmks;
     use crate::resolve_paravisor_tmk_artifacts;
     use pal_async::DefaultPool;
     use petri::ProcessorTopology;
     use petri::ResolvedArtifact;
+    use petri_artifacts_common::tags::MachineArch;
 
     petri::test!(hyperv_openhcl_tmks, resolve_hyperv_openhcl_tmks);
 
@@ -238,16 +234,14 @@ mod hyperv {
 
     fn resolve_hyperv_openhcl_tmks(
         resolver: &petri::ArtifactResolver<'_>,
-    ) -> HypervOpenhclArtifacts {
-        let (igvm_path, tmk_vmm, tmk) = resolve_paravisor_tmk_artifacts(resolver);
+    ) -> Option<HypervOpenhclArtifacts> {
+        let arch = MachineArch::host();
+        if MachineArch::host() != MachineArch::X86_64 {
+            // TODO: aarch64 currently hangs, fix
+            return None;
+        }
 
-        let arch = if cfg!(guest_arch = "x86_64") {
-            petri_artifacts_common::tags::MachineArch::X86_64
-        } else if cfg!(guest_arch = "aarch64") {
-            petri_artifacts_common::tags::MachineArch::Aarch64
-        } else {
-            panic!("Unsupported guest architecture");
-        };
+        let (igvm_path, tmk_vmm, tmk) = resolve_paravisor_tmk_artifacts(resolver, arch);
 
         let vm = petri::hyperv::PetriVmArtifactsHyperV::new(
             resolver,
@@ -258,8 +252,8 @@ mod hyperv {
                 igvm_path,
             },
             arch,
-        );
-        HypervOpenhclArtifacts { vm, tmk_vmm, tmk }
+        )?;
+        Some(HypervOpenhclArtifacts { vm, tmk_vmm, tmk })
     }
 
     fn hyperv_openhcl_tmks(

--- a/vmm_tests/vmm_tests/Cargo.toml
+++ b/vmm_tests/vmm_tests/Cargo.toml
@@ -52,8 +52,5 @@ mesh_rpc.workspace = true
 
 tempfile.workspace = true
 
-[build-dependencies]
-build_rs_guest_arch.workspace = true
-
 [lints]
 workspace = true

--- a/vmm_tests/vmm_tests/build.rs
+++ b/vmm_tests/vmm_tests/build.rs
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
-#![expect(missing_docs)]
-
-fn main() {
-    build_rs_guest_arch::emit_guest_arch()
-}

--- a/vmm_tests/vmm_tests/tests/tests/main.rs
+++ b/vmm_tests/vmm_tests/tests/tests/main.rs
@@ -25,8 +25,7 @@ mod ttrpc;
 // any architecture. As our ARM64 support improves these tests should be able to
 // someday run on both x86-64 and ARM64, and be moved into a multi-arch module.
 mod x86_64;
-// Tests that will only ever compile and run when targeting x86-64.
-#[cfg(guest_arch = "x86_64")]
+// Tests that will only ever run when targeting x86-64.
 mod x86_64_exclusive;
 
 pub fn main() {

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -3,8 +3,6 @@
 
 //! Integration tests for hvlite's TTRPC interface.
 
-#![cfg(guest_arch = "x86_64")]
-
 use anyhow::Context;
 use guid::Guid;
 use hvlite_ttrpc_vmservice as vmservice;
@@ -19,10 +17,16 @@ use std::process::Stdio;
 use unix_socket::UnixStream;
 
 petri::test!(test_ttrpc_interface, |resolver| {
+    // Only supported on x86_64 for now.
+    if petri_artifacts_common::tags::MachineArch::host()
+        != petri_artifacts_common::tags::MachineArch::X86_64
+    {
+        return None;
+    }
     let openvmm = resolver.require(artifacts::OPENVMM_NATIVE);
     let kernel = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_KERNEL_NATIVE);
     let initrd = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_INITRD_NATIVE);
-    [openvmm.erase(), kernel.erase(), initrd.erase()]
+    Some([openvmm.erase(), kernel.erase(), initrd.erase()])
 });
 
 fn test_ttrpc_interface(

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -241,11 +241,7 @@ fn configure_for_sidecar(
                 vps_per_socket: Some(proc_count),
                 enable_smt: Some(false),
                 // Sidecar currently requires x2APIC.
-                apic_mode: if cfg!(guest_arch = "x86_64") {
-                    Some(ApicMode::X2apicSupported)
-                } else {
-                    None
-                },
+                apic_mode: Some(ApicMode::X2apicSupported),
             }
         })
 }

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
@@ -10,7 +10,6 @@ use petri::OpenHclServicingFlags;
 use petri::ResolvedArtifact;
 use petri::openvmm::PetriVmConfigOpenVmm;
 use petri::pipette::cmd;
-#[cfg(guest_arch = "x86_64")]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_LINUX_DIRECT_TEST_X64;
 use scsidisk_resources::SimpleScsiDiskHandle;
 use storvsp_resources::ScsiControllerHandle;

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -9,7 +9,6 @@ use petri::OpenHclServicingFlags;
 use petri::ProcessorTopology;
 use petri::ResolvedArtifact;
 use petri::openvmm::PetriVmConfigOpenVmm;
-#[cfg(guest_arch = "x86_64")]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_X64;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;

--- a/xtask/src/tasks/fmt/house_rules/cfg_target_arch.rs
+++ b/xtask/src/tasks/fmt/house_rules/cfg_target_arch.rs
@@ -24,6 +24,8 @@ const SUPPRESS_REASON_ONEOFF_VIRT_HVF: &str = "oneoff-virt-hvf";
 const SUPPRESS_REASON_ONEOFF_FLOWEY: &str = "oneoff-flowey";
 /// One off - used by petri to select native test dependencies
 const SUPPRESS_REASON_ONEOFF_PETRI_NATIVE_TEST_DEPS: &str = "oneoff-petri-native-test-deps";
+/// Onee off - used by petri to return the host architecture for test filtering
+const SUPPRESS_REASON_ONEOFF_PETRI_HOST_ARCH: &str = "oneoff-petri-host-arch";
 
 fn has_suppress(s: &str) -> bool {
     let Some((_, after)) = s.split_once(SUPPRESS) else {
@@ -41,6 +43,7 @@ fn has_suppress(s: &str) -> bool {
             | SUPPRESS_REASON_ONEOFF_VIRT_HVF
             | SUPPRESS_REASON_ONEOFF_FLOWEY
             | SUPPRESS_REASON_ONEOFF_PETRI_NATIVE_TEST_DEPS
+            | SUPPRESS_REASON_ONEOFF_PETRI_HOST_ARCH
     );
 
     if !ok {


### PR DESCRIPTION
Stop using `cfg(guest_arch = ...)` for filtering out arch-specific tests. Instead, add a mechanism to skip a test from being reported in the test list.

Also use this mechanism to filter out openvmm+openhcl tests on platforms that don't support this combination, rather than have flowey explicitly filter out such tests.