### PR TITLE
tmk_tests: wait for modules to load before trying to launch VTL2 pipette

### DIFF
--- a/openhcl/underhill_init/src/lib.rs
+++ b/openhcl/underhill_init/src/lib.rs
@@ -576,11 +576,14 @@ fn do_main() -> anyhow::Result<()> {
     }
 
     // Start loading modules in parallel.
-    std::thread::spawn(|| {
+    let thread = std::thread::spawn(|| {
         if let Err(err) = load_modules("/lib/modules") {
             panic!("failed to load modules: {:#}", err);
         }
     });
+    if std::env::var("OPENHCL_WAIT_FOR_MODULES").as_deref() == Ok("1") {
+        thread.join().unwrap();
+    }
 
     run(&options, new_env)
 }


### PR DESCRIPTION
This should fix (or at least make less likely) a race that causes VTL2 pipette to sometimes fail to load.