### PR TITLE
flowey: simplify some variable patterns

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -99,8 +99,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 0 flowey_lib_common::cache 0
-        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -110,7 +110,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -286,8 +286,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 1 flowey_lib_common::cache 0
-        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -297,7 +297,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -463,8 +463,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -474,7 +474,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
@@ -761,8 +761,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -772,7 +772,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 6
@@ -914,8 +914,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -925,7 +925,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
@@ -1089,8 +1089,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1100,7 +1100,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1435,8 +1435,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1446,7 +1446,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 2
@@ -1902,8 +1902,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 4
-        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -1913,7 +1913,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 6
@@ -1972,8 +1972,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 0
-        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1983,7 +1983,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 2
@@ -2138,8 +2138,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2149,7 +2149,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 6
@@ -2261,8 +2261,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2272,7 +2272,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 2
@@ -2455,8 +2455,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2466,7 +2466,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 6
@@ -2558,8 +2558,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2569,7 +2569,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 2
@@ -2715,8 +2715,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 17 flowey_lib_common::cache 0
-        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2726,7 +2726,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 2
@@ -2776,8 +2776,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 17 flowey_lib_common::cache 4
-        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2787,7 +2787,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 6
@@ -2924,8 +2924,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 0
-        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2935,7 +2935,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 2
@@ -2955,8 +2955,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 8
-        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -2966,7 +2966,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 10
@@ -3006,8 +3006,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 4
-        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3017,7 +3017,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 6
@@ -3172,8 +3172,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3183,7 +3183,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -3203,8 +3203,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 8
-        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -3214,7 +3214,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -3254,8 +3254,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3265,7 +3265,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
@@ -3456,8 +3456,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 2 flowey_lib_common::cache 0
-        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3467,7 +3467,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 2 flowey_lib_common::cache 2
@@ -3605,8 +3605,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 0
-        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3616,7 +3616,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 2
@@ -3636,8 +3636,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 8
-        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -3647,7 +3647,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 10
@@ -3687,8 +3687,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 4
-        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3698,7 +3698,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 6
@@ -3843,8 +3843,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 21 flowey_lib_common::cache 0
-        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3854,7 +3854,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: checking if packages need to be installed
       run: |-
-        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 21 flowey_lib_common::cache 2
@@ -3880,8 +3880,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 21 flowey_lib_common::cache 8
-        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -3891,7 +3891,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 21 flowey_lib_common::cache 10
@@ -3934,8 +3934,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 21 flowey_lib_common::cache 4
-        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3945,7 +3945,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 21 flowey_lib_common::cache 6
@@ -4145,8 +4145,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4156,7 +4156,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 2
@@ -4176,8 +4176,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -4187,7 +4187,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 10
@@ -4227,8 +4227,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -4238,7 +4238,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 6
@@ -4612,8 +4612,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4623,7 +4623,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -4771,8 +4771,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 5 flowey_lib_common::cache 0
-        flowey v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4782,7 +4782,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 5 flowey_lib_common::cache 2
@@ -4952,8 +4952,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 6 flowey_lib_common::cache 0
-        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4963,7 +4963,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
@@ -5158,8 +5158,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 4
-        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -5169,7 +5169,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 6
@@ -5236,8 +5236,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 0
-        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -5247,7 +5247,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
@@ -5417,8 +5417,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 8 flowey_lib_common::cache 0
-        flowey.exe v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -5428,7 +5428,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 8 flowey_lib_common::cache 2
@@ -5627,8 +5627,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 9 flowey_lib_common::cache 4
-        flowey.exe v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 9 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 9 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -5638,7 +5638,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 9 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 9 flowey_lib_common::cache 6
@@ -5705,8 +5705,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 9 flowey_lib_common::cache 0
-        flowey.exe v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -5716,7 +5716,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 9 flowey_lib_common::cache 2

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -107,8 +107,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 0 flowey_lib_common::cache 0
-        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -118,7 +118,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -294,8 +294,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 1 flowey_lib_common::cache 0
-        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -305,7 +305,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -473,8 +473,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 4
-        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -484,7 +484,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 6
@@ -626,8 +626,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -637,7 +637,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
@@ -799,8 +799,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -810,7 +810,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
@@ -1119,8 +1119,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1130,7 +1130,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1570,8 +1570,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar6 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -1581,7 +1581,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 6
@@ -1618,7 +1618,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 2
-        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_core/src/node.rs:1054:34' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_core/src/node.rs:1180:34' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__3
       uses: actions/upload-artifact@v4
@@ -1644,8 +1644,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar4 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1655,7 +1655,7 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 2
@@ -1806,8 +1806,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 4
-        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -1817,7 +1817,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 6
@@ -1876,8 +1876,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 0
-        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1887,7 +1887,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 2
@@ -2042,8 +2042,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 4
-        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2053,7 +2053,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 6
@@ -2165,8 +2165,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 15 flowey_lib_common::cache 0
-        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2176,7 +2176,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 15 flowey_lib_common::cache 2
@@ -2359,8 +2359,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 4
-        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2370,7 +2370,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 6
@@ -2462,8 +2462,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 16 flowey_lib_common::cache 0
-        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2473,7 +2473,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 16 flowey_lib_common::cache 2
@@ -2619,8 +2619,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 17 flowey_lib_common::cache 0
-        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2630,7 +2630,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 2
@@ -2680,8 +2680,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 17 flowey_lib_common::cache 4
-        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2691,7 +2691,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 6
@@ -2828,8 +2828,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 0
-        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2839,7 +2839,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 2
@@ -2859,8 +2859,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 8
-        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -2870,7 +2870,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 10
@@ -2910,8 +2910,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 4
-        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2921,7 +2921,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 6
@@ -3076,8 +3076,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3087,7 +3087,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -3107,8 +3107,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 8
-        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -3118,7 +3118,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -3158,8 +3158,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3169,7 +3169,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
@@ -3360,8 +3360,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 2 flowey_lib_common::cache 0
-        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3371,7 +3371,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 2 flowey_lib_common::cache 2
@@ -3501,8 +3501,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 0
-        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3512,7 +3512,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 2
@@ -3532,8 +3532,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 8
-        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -3543,7 +3543,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 10
@@ -3583,8 +3583,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 20 flowey_lib_common::cache 4
-        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 20 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3594,7 +3594,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 20 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 20 flowey_lib_common::cache 6
@@ -3739,8 +3739,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 21 flowey_lib_common::cache 0
-        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3750,7 +3750,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: checking if packages need to be installed
       run: |-
-        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 21 flowey_lib_common::cache 2
@@ -3776,8 +3776,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 21 flowey_lib_common::cache 8
-        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -3787,7 +3787,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 21 flowey_lib_common::cache 10
@@ -3830,8 +3830,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 21 flowey_lib_common::cache 4
-        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 21 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3841,7 +3841,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 21 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 21 flowey_lib_common::cache 6
@@ -4041,8 +4041,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4052,7 +4052,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 2
@@ -4072,8 +4072,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 8
-        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -4083,7 +4083,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 10
@@ -4123,8 +4123,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 22 flowey_lib_common::cache 4
-        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey.exe v 22 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -4134,7 +4134,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 22 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 22 flowey_lib_common::cache 6
@@ -4507,8 +4507,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 3 flowey_lib_common::cache 0
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4518,7 +4518,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 3 flowey_lib_common::cache 2
@@ -4666,8 +4666,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 4 flowey_lib_common::cache 0
-        flowey v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4677,7 +4677,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 4 flowey_lib_common::cache 2
@@ -4847,8 +4847,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4858,7 +4858,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -5053,8 +5053,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 6 flowey_lib_common::cache 4
-        flowey.exe v 6 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 6 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -5064,7 +5064,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 6
@@ -5131,8 +5131,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 6 flowey_lib_common::cache 0
-        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -5142,7 +5142,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 6 flowey_lib_common::cache 2
@@ -5312,8 +5312,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 7 flowey_lib_common::cache 0
-        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -5323,7 +5323,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 7 flowey_lib_common::cache 2
@@ -5522,8 +5522,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 8 flowey_lib_common::cache 4
-        flowey.exe v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -5533,7 +5533,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 8 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 8 flowey_lib_common::cache 6
@@ -5600,8 +5600,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 8 flowey_lib_common::cache 0
-        flowey.exe v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey.exe v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -5611,7 +5611,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 8 flowey_lib_common::cache 2
@@ -5773,8 +5773,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -5784,7 +5784,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:514:46' --update-from-stdin --is-raw-string <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1618,7 +1618,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 2
-        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_core/src/node.rs:1180:34' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_core/src/node.rs:1184:34' --write-to-gh-env floweyvar1 --is-raw-string
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__3
       uses: actions/upload-artifact@v4

--- a/flowey/flowey_cli/src/flow_resolver/stage1_dag.rs
+++ b/flowey/flowey_cli/src/flow_resolver/stage1_dag.rs
@@ -808,7 +808,8 @@ impl flowey_core::node::NodeCtxBackend for EmitFlowCtx<'_> {
             .map(|(k, v)| match v {
                 ClaimedGhParam::Static(v) => (k, v),
                 ClaimedGhParam::FloweyVar(v) => {
-                    let (backing_var, is_secret) = read_var_internals(&v);
+                    let (backing_var, is_secret, is_side_effect) = read_var_internals(&v);
+                    assert!(!is_side_effect);
                     let backing_var = backing_var.unwrap();
                     let new_gh_var_name = fresh_yaml_var();
                     rust_to_gh.push(GhVarState {

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -160,14 +160,13 @@ where
     }
 }
 
-/// Uninhabited type corresponding to a step which performs a side-effect,
+/// Type corresponding to a step which performs a side-effect,
 /// without returning a specific value.
 ///
 /// e.g: A step responsible for installing a package from `apt` might claim a
 /// `WriteVar<SideEffect>`, with any step requiring the package to have been
 /// installed prior being able to claim the corresponding `ReadVar<SideEffect>.`
-#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
-pub enum SideEffect {}
+pub type SideEffect = ();
 
 /// Uninhabited type used to denote that a particular [`WriteVar`] / [`ReadVar`]
 /// is not currently claimed by any step, and cannot be directly accessed.
@@ -202,6 +201,9 @@ pub enum VarClaimed {}
 pub struct WriteVar<T: Serialize + DeserializeOwned, C = VarNotClaimed> {
     backing_var: String,
     is_secret: bool,
+    /// If true, then readers on this var expect to read a side effect (`()`)
+    /// and not `T`.
+    is_side_effect: bool,
 
     #[serde(skip)]
     _kind: core::marker::PhantomData<(T, C)>,
@@ -217,22 +219,14 @@ impl<T: Serialize + DeserializeOwned> WriteVar<T, VarNotClaimed> {
         let Self {
             backing_var,
             is_secret,
+            is_side_effect,
             _kind,
         } = self;
 
         WriteVar {
             backing_var,
             is_secret,
-            _kind: std::marker::PhantomData,
-        }
-    }
-
-    /// Create a new [`ReadVar`] from this [`WriteVar`] handle.
-    #[must_use]
-    pub fn new_reader(&self) -> ReadVar<T> {
-        ReadVar {
-            backing_var: ReadVarBacking::RuntimeVar(self.backing_var.clone()),
-            is_secret: self.is_secret,
+            is_side_effect,
             _kind: std::marker::PhantomData,
         }
     }
@@ -251,6 +245,22 @@ impl<T: Serialize + DeserializeOwned> WriteVar<T, VarNotClaimed> {
         WriteVar {
             backing_var: self.backing_var,
             is_secret: self.is_secret,
+            is_side_effect: self.is_side_effect,
+            _kind: std::marker::PhantomData,
+        }
+    }
+}
+
+impl WriteVar<SideEffect, VarNotClaimed> {
+    /// Transforms this writer into one that can be used to write a `T`.
+    ///
+    /// This is useful when a reader only cares about the side effect of an
+    /// operation, but the writer wants to provide output as well.
+    pub fn discard_result<T: Serialize + DeserializeOwned>(self) -> WriteVar<T> {
+        WriteVar {
+            backing_var: self.backing_var,
+            is_secret: self.is_secret,
+            is_side_effect: true,
             _kind: std::marker::PhantomData,
         }
     }
@@ -277,11 +287,27 @@ pub trait ClaimVar {
     fn claim(self, ctx: &mut StepCtx<'_>) -> Self::Claimed;
 }
 
+/// Read the value of one or more flowey Vars.
+///
+/// By having this be a trait, it is possible to `read` both single
+/// instances of `ReadVar` / `WriteVar`, as well as whole _collections_ of
+/// Vars.
+pub trait ReadVarValue {
+    /// The read value of Self.
+    type Value;
+    /// Read the value of the Var at runtime.
+    fn read_value(self, rt: &mut RustRuntimeServices<'_>) -> Self::Value;
+}
+
 impl<T: Serialize + DeserializeOwned> ClaimVar for ReadVar<T> {
     type Claimed = ClaimedReadVar<T>;
 
     fn claim(self, ctx: &mut StepCtx<'_>) -> ClaimedReadVar<T> {
-        if let ReadVarBacking::RuntimeVar(var) = &self.backing_var {
+        if let ReadVarBacking::RuntimeVar {
+            var,
+            is_side_effect: _,
+        } = &self.backing_var
+        {
             ctx.backend.borrow_mut().on_claimed_runtime_var(var, true);
         }
         self.into_claimed()
@@ -299,11 +325,41 @@ impl<T: Serialize + DeserializeOwned> ClaimVar for WriteVar<T> {
     }
 }
 
+impl<T: Serialize + DeserializeOwned> ReadVarValue for ClaimedReadVar<T> {
+    type Value = T;
+
+    fn read_value(self, rt: &mut RustRuntimeServices<'_>) -> Self::Value {
+        match self.backing_var {
+            ReadVarBacking::RuntimeVar {
+                var,
+                is_side_effect: side_effect,
+            } => {
+                // Always get the data to validate that the variable is actually there.
+                let data = rt.get_var(&var);
+                if side_effect {
+                    serde_json::from_slice(b"null").expect("should be deserializing into ()")
+                } else {
+                    serde_json::from_slice(&data).expect("improve this error path")
+                }
+            }
+            ReadVarBacking::Inline(val) => val,
+        }
+    }
+}
+
 impl<T: ClaimVar> ClaimVar for Vec<T> {
     type Claimed = Vec<T::Claimed>;
 
     fn claim(self, ctx: &mut StepCtx<'_>) -> Vec<T::Claimed> {
         self.into_iter().map(|v| v.claim(ctx)).collect()
+    }
+}
+
+impl<T: ReadVarValue> ReadVarValue for Vec<T> {
+    type Value = Vec<T::Value>;
+
+    fn read_value(self, rt: &mut RustRuntimeServices<'_>) -> Self::Value {
+        self.into_iter().map(|v| v.read_value(rt)).collect()
     }
 }
 
@@ -315,11 +371,29 @@ impl<T: ClaimVar> ClaimVar for Option<T> {
     }
 }
 
+impl<T: ReadVarValue> ReadVarValue for Option<T> {
+    type Value = Option<T::Value>;
+
+    fn read_value(self, rt: &mut RustRuntimeServices<'_>) -> Self::Value {
+        self.map(|x| x.read_value(rt))
+    }
+}
+
 impl<U: Ord, T: ClaimVar> ClaimVar for BTreeMap<U, T> {
     type Claimed = BTreeMap<U, T::Claimed>;
 
     fn claim(self, ctx: &mut StepCtx<'_>) -> BTreeMap<U, T::Claimed> {
         self.into_iter().map(|(k, v)| (k, v.claim(ctx))).collect()
+    }
+}
+
+impl<U: Ord, T: ReadVarValue> ReadVarValue for BTreeMap<U, T> {
+    type Value = BTreeMap<U, T::Value>;
+
+    fn read_value(self, rt: &mut RustRuntimeServices<'_>) -> Self::Value {
+        self.into_iter()
+            .map(|(k, v)| (k, v.read_value(rt)))
+            .collect()
     }
 }
 
@@ -337,6 +411,19 @@ macro_rules! impl_tuple_claim {
                 ($($T.claim(ctx),)*)
             }
         }
+
+        impl<$($T,)*> $crate::node::ReadVarValue for ($($T,)*)
+        where
+            $($T: $crate::node::ReadVarValue,)*
+        {
+            type Value = ($($T::Value,)*);
+
+            #[expect(non_snake_case)]
+            fn read_value(self, rt: &mut $crate::node::RustRuntimeServices<'_>) -> Self::Value {
+                let ($($T,)*) = self;
+                ($($T.read_value(rt),)*)
+            }
+        }
     };
 }
 
@@ -350,6 +437,18 @@ impl_tuple_claim!(A B C D);
 impl_tuple_claim!(A B C);
 impl_tuple_claim!(A B);
 impl_tuple_claim!(A);
+
+impl ClaimVar for () {
+    type Claimed = ();
+
+    fn claim(self, _ctx: &mut StepCtx<'_>) -> Self::Claimed {}
+}
+
+impl ReadVarValue for () {
+    type Value = ();
+
+    fn read_value(self, _rt: &mut RustRuntimeServices<'_>) -> Self::Value {}
+}
 
 /// Read a custom, user-defined secret by passing in the secret name.
 ///
@@ -401,20 +500,33 @@ impl<T: Serialize + DeserializeOwned, C> Clone for ReadVar<T, C> {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 enum ReadVarBacking<T> {
-    RuntimeVar(String),
+    RuntimeVar {
+        var: String,
+        /// If true, then don't try to parse this variable--it was converted
+        /// into a side effect (of type `()`) from another type, so the
+        /// serialization will not match.
+        ///
+        /// If false, it may still be a "side effect" variable, but type `T`
+        /// matches its serialization.
+        is_side_effect: bool,
+    },
     Inline(T),
-    InlineSideEffect,
 }
 
 // avoid requiring types to include an explicit clone bound
 impl<T: Serialize + DeserializeOwned> Clone for ReadVarBacking<T> {
     fn clone(&self) -> Self {
         match self {
-            Self::RuntimeVar(v) => Self::RuntimeVar(v.clone()),
+            Self::RuntimeVar {
+                var,
+                is_side_effect: side_effect,
+            } => Self::RuntimeVar {
+                var: var.clone(),
+                is_side_effect: *side_effect,
+            },
             Self::Inline(v) => {
                 Self::Inline(serde_json::from_value(serde_json::to_value(v).unwrap()).unwrap())
             }
-            Self::InlineSideEffect => Self::InlineSideEffect,
         }
     }
 }
@@ -447,9 +559,14 @@ impl<T: Serialize + DeserializeOwned> ReadVar<T> {
     pub fn into_side_effect(self) -> ReadVar<SideEffect> {
         ReadVar {
             backing_var: match self.backing_var {
-                ReadVarBacking::RuntimeVar(var) => ReadVarBacking::RuntimeVar(var),
-                ReadVarBacking::Inline(_) => ReadVarBacking::InlineSideEffect,
-                ReadVarBacking::InlineSideEffect => ReadVarBacking::InlineSideEffect,
+                ReadVarBacking::RuntimeVar {
+                    var,
+                    is_side_effect: _,
+                } => ReadVarBacking::RuntimeVar {
+                    var,
+                    is_side_effect: true,
+                },
+                ReadVarBacking::Inline(_) => ReadVarBacking::Inline(()),
             },
             is_secret: self.is_secret,
             _kind: std::marker::PhantomData,
@@ -604,26 +721,29 @@ impl<T: Serialize + DeserializeOwned> ReadVar<T> {
     /// won't be used.
     pub fn claim_unused(self, ctx: &mut NodeCtx<'_>) {
         match self.backing_var {
-            ReadVarBacking::RuntimeVar(s) => ctx.backend.borrow_mut().on_unused_read_var(&s),
+            ReadVarBacking::RuntimeVar {
+                var,
+                is_side_effect: _,
+            } => ctx.backend.borrow_mut().on_unused_read_var(&var),
             ReadVarBacking::Inline(_) => {}
-            ReadVarBacking::InlineSideEffect => {}
         }
     }
 
     pub(crate) fn into_json(self) -> ReadVar<serde_json::Value> {
         match self.backing_var {
-            ReadVarBacking::RuntimeVar(s) => ReadVar {
-                backing_var: ReadVarBacking::RuntimeVar(s),
+            ReadVarBacking::RuntimeVar {
+                var,
+                is_side_effect: side_effect,
+            } => ReadVar {
+                backing_var: ReadVarBacking::RuntimeVar {
+                    var,
+                    is_side_effect: side_effect,
+                },
                 is_secret: self.is_secret,
                 _kind: std::marker::PhantomData,
             },
             ReadVarBacking::Inline(v) => ReadVar {
                 backing_var: ReadVarBacking::Inline(serde_json::to_value(v).unwrap()),
-                is_secret: self.is_secret,
-                _kind: std::marker::PhantomData,
-            },
-            ReadVarBacking::InlineSideEffect => ReadVar {
-                backing_var: ReadVarBacking::InlineSideEffect,
                 is_secret: self.is_secret,
                 _kind: std::marker::PhantomData,
             },
@@ -642,7 +762,10 @@ where
     T: Serialize + DeserializeOwned,
 {
     ReadVar {
-        backing_var: ReadVarBacking::RuntimeVar(backing_var),
+        backing_var: ReadVarBacking::RuntimeVar {
+            var: backing_var,
+            is_side_effect: false,
+        },
         is_secret,
         _kind: std::marker::PhantomData,
     }
@@ -661,6 +784,7 @@ where
     WriteVar {
         backing_var,
         is_secret,
+        is_side_effect: false,
         _kind: std::marker::PhantomData,
     }
 }
@@ -672,11 +796,13 @@ where
 /// implementing flow / pipeline resolution logic.
 pub fn read_var_internals<T: Serialize + DeserializeOwned, C>(
     var: &ReadVar<T, C>,
-) -> (Option<String>, bool) {
-    match &var.backing_var {
-        ReadVarBacking::RuntimeVar(s) => (Some(s.clone()), var.is_secret),
-        ReadVarBacking::Inline(_) => (None, var.is_secret),
-        ReadVarBacking::InlineSideEffect => (None, var.is_secret),
+) -> (Option<String>, bool, bool) {
+    match var.backing_var {
+        ReadVarBacking::RuntimeVar {
+            var: ref s,
+            is_side_effect: side_effect,
+        } => (Some(s.clone()), var.is_secret, side_effect),
+        ReadVarBacking::Inline(_) => (None, var.is_secret, false),
     }
 }
 
@@ -1191,11 +1317,14 @@ impl<'ctx> NodeCtx<'ctx> {
                     None
                 }
             }
-            Some(ReadVarBacking::RuntimeVar(var)) => {
+            Some(ReadVarBacking::RuntimeVar {
+                var,
+                is_side_effect: side_effect,
+            }) => {
+                assert!(!side_effect);
                 self.backend.borrow_mut().on_claimed_runtime_var(&var, true);
                 Some(var)
             }
-            Some(ReadVarBacking::InlineSideEffect) => unreachable!(),
             None => None,
         };
 
@@ -1254,11 +1383,14 @@ impl<'ctx> NodeCtx<'ctx> {
                     None
                 }
             }
-            Some(ReadVarBacking::RuntimeVar(var)) => {
+            Some(ReadVarBacking::RuntimeVar {
+                var,
+                is_side_effect: side_effect,
+            }) => {
+                assert!(!side_effect);
                 self.backend.borrow_mut().on_claimed_runtime_var(&var, true);
                 Some(var)
             }
-            Some(ReadVarBacking::InlineSideEffect) => unreachable!(),
             None => None,
         };
 
@@ -1329,7 +1461,11 @@ impl<'ctx> NodeCtx<'ctx> {
     ) {
         let mut backend = self.backend.borrow_mut();
         for var in use_side_effects.into_iter() {
-            if let ReadVarBacking::RuntimeVar(var) = &var.backing_var {
+            if let ReadVarBacking::RuntimeVar {
+                var,
+                is_side_effect: _,
+            } = &var.backing_var
+            {
                 backend.on_claimed_runtime_var(var, true);
             }
         }
@@ -1468,13 +1604,17 @@ impl<'ctx> NodeCtx<'ctx> {
 
         (
             ReadVar {
-                backing_var: ReadVarBacking::RuntimeVar(backing_var.clone()),
+                backing_var: ReadVarBacking::RuntimeVar {
+                    var: backing_var.clone(),
+                    is_side_effect: false,
+                },
                 is_secret,
                 _kind: std::marker::PhantomData,
             },
             WriteVar {
                 backing_var,
                 is_secret,
+                is_side_effect: false,
                 _kind: std::marker::PhantomData,
             },
         )
@@ -1512,9 +1652,10 @@ impl<'ctx> NodeCtx<'ctx> {
     #[must_use]
     pub fn persistent_dir(&mut self) -> Option<ReadVar<PathBuf>> {
         let path: ReadVar<PathBuf> = ReadVar {
-            backing_var: ReadVarBacking::RuntimeVar(
-                self.backend.borrow_mut().persistent_dir_path_var()?,
-            ),
+            backing_var: ReadVarBacking::RuntimeVar {
+                var: self.backend.borrow_mut().persistent_dir_path_var()?,
+                is_side_effect: false,
+            },
             is_secret: false,
             _kind: std::marker::PhantomData,
         };
@@ -1748,7 +1889,12 @@ pub mod steps {
 
             /// Get the value of a flowey Var as a ADO runtime variable.
             pub fn get_var(&mut self, var: ClaimedReadVar<String>) -> AdoRuntimeVar {
-                let backing_var = if let ReadVarBacking::RuntimeVar(var) = &var.backing_var {
+                let backing_var = if let ReadVarBacking::RuntimeVar {
+                    var,
+                    is_side_effect: side_effect,
+                } = &var.backing_var
+                {
+                    assert!(!side_effect);
                     var
                 } else {
                     todo!("support inline ado read vars")
@@ -1949,11 +2095,14 @@ pub mod steps {
                 match self {
                     GhParam::Static(s) => ClaimedGhParam::Static(s),
                     GhParam::FloweyVar(var) => match &var.backing_var {
-                        ReadVarBacking::RuntimeVar(_) => ClaimedGhParam::FloweyVar(var.claim(ctx)),
-                        ReadVarBacking::Inline(var) => ClaimedGhParam::Static(var.clone()),
-                        ReadVarBacking::InlineSideEffect => {
-                            panic!("inline side-effect vars are not supported")
+                        ReadVarBacking::RuntimeVar {
+                            is_side_effect: side_effect,
+                            ..
+                        } => {
+                            assert!(!side_effect);
+                            ClaimedGhParam::FloweyVar(var.claim(ctx))
                         }
+                        ReadVarBacking::Inline(var) => ClaimedGhParam::Static(var.clone()),
                     },
                 }
             }
@@ -1995,11 +2144,11 @@ pub mod steps {
     }
 
     pub mod rust {
-        use crate::node::ClaimedReadVar;
         use crate::node::ClaimedWriteVar;
         use crate::node::FlowArch;
         use crate::node::FlowBackend;
         use crate::node::FlowPlatform;
+        use crate::node::ReadVarValue;
         use crate::node::RuntimeVarDb;
         use serde::Serialize;
         use serde::de::DeserializeOwned;
@@ -2047,11 +2196,13 @@ pub mod steps {
             where
                 T: Serialize + DeserializeOwned,
             {
-                self.runtime_var_db.set_var(
-                    &var.backing_var,
-                    var.is_secret,
-                    serde_json::to_vec(val).expect("improve this error path"),
-                );
+                let val = if var.is_side_effect {
+                    b"null".to_vec()
+                } else {
+                    serde_json::to_vec(val).expect("improve this error path")
+                };
+                self.runtime_var_db
+                    .set_var(&var.backing_var, var.is_secret, val);
             }
 
             pub fn write_all<T>(
@@ -2066,18 +2217,12 @@ pub mod steps {
                 }
             }
 
-            pub fn read<T>(&mut self, var: ClaimedReadVar<T>) -> T
-            where
-                T: Serialize + DeserializeOwned,
-            {
-                match var.backing_var {
-                    crate::node::ReadVarBacking::RuntimeVar(var) => {
-                        let data = self.runtime_var_db.get_var(&var);
-                        serde_json::from_slice(&data).expect("improve this error path")
-                    }
-                    crate::node::ReadVarBacking::Inline(val) => val,
-                    crate::node::ReadVarBacking::InlineSideEffect => unreachable!(),
-                }
+            pub fn read<T: ReadVarValue>(&mut self, var: T) -> T::Value {
+                var.read_value(self)
+            }
+
+            pub(crate) fn get_var(&mut self, var: &str) -> Vec<u8> {
+                self.runtime_var_db.get_var(var)
             }
 
             /// DANGEROUS: Set the value of _Global_ Environment Variable (GitHub Actions only).

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -337,8 +337,12 @@ impl<T: Serialize + DeserializeOwned> ReadVarValue for ClaimedReadVar<T> {
                 // Always get the data to validate that the variable is actually there.
                 let data = rt.get_var(&var);
                 if is_side_effect {
+                    // This was converted into a `ReadVar<SideEffect>` from
+                    // another type, so parse the value that a
+                    // `WriteVar<SideEffect>` would have written.
                     serde_json::from_slice(b"null").expect("should be deserializing into ()")
                 } else {
+                    // This is a normal variable.
                     serde_json::from_slice(&data).expect("improve this error path")
                 }
             }

--- a/flowey/flowey_lib_common/src/cfg_persistent_dir_cargo_install.rs
+++ b/flowey/flowey_lib_common/src/cfg_persistent_dir_cargo_install.rs
@@ -27,7 +27,7 @@ impl FlowNode for Node {
                 .map(|x| x.0.claim(ctx))
                 .collect::<Vec<_>>();
             |rt| {
-                let persistent_dir = persistent_dir.map(|x| rt.read(x));
+                let persistent_dir = rt.read(persistent_dir);
                 for var in requests {
                     rt.write(var, &persistent_dir)
                 }

--- a/flowey/flowey_lib_common/src/download_azcopy.rs
+++ b/flowey/flowey_lib_common/src/download_azcopy.rs
@@ -4,7 +4,6 @@
 //! Download a copy of `azcopy`
 
 use crate::cache::CacheHit;
-use crate::cache::CacheResult;
 use flowey::node::prelude::*;
 
 flowey_request! {
@@ -60,7 +59,7 @@ impl FlowNode for Node {
             dir: cache_dir.clone(),
             key: cache_key,
             restore_keys: None,
-            hitvar: CacheResult::HitVar(hitvar),
+            hitvar,
         });
 
         // in case we need to unzip the thing we downloaded

--- a/flowey/flowey_lib_common/src/download_cargo_fuzz.rs
+++ b/flowey/flowey_lib_common/src/download_cargo_fuzz.rs
@@ -4,7 +4,6 @@
 //! Download (and optionally, install) a copy of `cargo-fuzz`.
 
 use crate::cache::CacheHit;
-use crate::cache::CacheResult;
 use flowey::node::prelude::*;
 
 flowey_request! {
@@ -60,7 +59,7 @@ impl FlowNode for Node {
                 dir: cache_dir.clone(),
                 key: cache_key,
                 restore_keys: None, // we want an exact hit
-                hitvar: CacheResult::HitVar(v),
+                hitvar: v,
             }
         });
 

--- a/flowey/flowey_lib_common/src/download_cargo_nextest.rs
+++ b/flowey/flowey_lib_common/src/download_cargo_nextest.rs
@@ -4,7 +4,6 @@
 //! Download (and optionally, install) a copy of `cargo-nextest`.
 
 use crate::cache::CacheHit;
-use crate::cache::CacheResult;
 use flowey::node::prelude::*;
 
 flowey_request! {
@@ -69,7 +68,7 @@ impl FlowNode for Node {
                 dir: cache_dir.clone(),
                 key: cache_key,
                 restore_keys: None, // we want an exact hit
-                hitvar: CacheResult::HitVar(v),
+                hitvar: v,
             }
         });
 

--- a/flowey/flowey_lib_common/src/download_gh_cli.rs
+++ b/flowey/flowey_lib_common/src/download_gh_cli.rs
@@ -7,7 +7,6 @@
 //! downloaded CLI binary!
 
 use crate::cache::CacheHit;
-use crate::cache::CacheResult;
 use flowey::node::prelude::*;
 
 flowey_request! {
@@ -67,7 +66,7 @@ impl FlowNode for Node {
             dir: cache_dir.clone(),
             key: cache_key,
             restore_keys: None,
-            hitvar: CacheResult::HitVar(hitvar),
+            hitvar,
         });
 
         ctx.emit_rust_step("installing gh", |ctx| {

--- a/flowey/flowey_lib_common/src/download_gh_release.rs
+++ b/flowey/flowey_lib_common/src/download_gh_release.rs
@@ -180,7 +180,7 @@ impl Node {
                 dir: cache_dir.clone(),
                 key: cache_key,
                 restore_keys: None, // OK if not exact - better than nothing
-                hitvar: crate::cache::CacheResult::HitVar(v),
+                hitvar: v,
             }
         });
 
@@ -224,7 +224,7 @@ fn download_all_reqs(
 ) -> anyhow::Result<()> {
     let sh = xshell::Shell::new()?;
 
-    let gh_cli = gh_cli.map(|x| rt.read(x));
+    let gh_cli = rt.read(gh_cli);
 
     for ((repo_owner, repo_name, tag), files) in download_reqs {
         let repo = format!("{repo_owner}/{repo_name}");

--- a/flowey/flowey_lib_common/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_build.rs
@@ -144,7 +144,7 @@ impl FlowNode for Node {
                     let rust_toolchain = rt.read(rust_toolchain);
                     let flags = rt.read(flags);
                     let in_folder = rt.read(in_folder);
-                    let with_env = extra_env.map(|x| rt.read(x)).unwrap_or_default();
+                    let with_env = rt.read(extra_env).unwrap_or_default();
 
                     let crate::cfg_cargo_common_flags::Flags { locked, verbose } = flags;
 

--- a/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
@@ -231,7 +231,7 @@ impl FlowNode for Node {
                 move |rt| {
                     let working_dir = rt.read(working_dir);
                     let config_file = rt.read(config_file);
-                    let mut with_env = extra_env.map(|x| rt.read(x)).unwrap_or_default();
+                    let mut with_env = rt.read(extra_env).unwrap_or_default();
 
                     // first things first - determine if junit is supported by
                     // the profile, and if so, where the output if going to be.

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_initrd.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_initrd.rs
@@ -116,11 +116,8 @@ impl FlowNode for Node {
                 let initrd = initrd.claim(ctx);
                 move |rt| {
                     let interactive_dep = rt.read(interactive_dep);
-                    let rootfs_config = rootfs_config
-                        .into_iter()
-                        .map(|x| rt.read(x))
-                        .collect::<Vec<_>>();
-                    let extra_env = extra_env.map(|x| rt.read(x));
+                    let rootfs_config = rt.read(rootfs_config);
+                    let extra_env = rt.read(extra_env);
                     let bin_openhcl = rt.read(bin_openhcl);
                     let openvmm_repo_path = rt.read(openvmm_repo_path);
                     let kernel_package_root = rt.read(kernel_package_root);


### PR DESCRIPTION
* Add a method for turning a `WriteVar<SideEffect>` into a `WriteVar<T>`, for throwing away the results of an operation but retaining the side effect.

* Allow collections (tuples, vecs, maps) of `ClaimedReadVar` to be read as one, like we allow collections of `ReadVar` to be claimed as one.

* Make `SideEffect` an alias for `()` rather than an uninhabited type so that it can be read and returned from Rust step functions. This is not yet used for anything useful, but future cleanup will leverage this.