### PR TITLE
CVM: Don't recommend TLB flush hypercalls in cpuid without VSM

### DIFF
--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -306,9 +306,8 @@ impl CpuidArchInitializer for TdxCpuidInitializer<'_> {
             .with_use_ex_processor_masks(true)
             .with_use_apic_msrs(use_apic_msrs)
             .with_long_spin_wait_count(!0)
-            .with_use_synthetic_cluster_ipi(true);
-        // TODO TDX
-        //  .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
+            .with_use_synthetic_cluster_ipi(true)
+            .with_use_hypercall_for_remote_flush_and_local_flush_entire(true);
 
         let hardware_features = hvdef::HvHardwareFeatures::new()
             .with_apic_overlay_assist_in_use(true)

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1635,6 +1635,8 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     *self.cvm_partition().guest_vsm.read(),
                     GuestVsmState::NotPlatformSupported
                 ) {
+                    // The only bit we care about here is within the first 32 bits,
+                    // so just truncating is fine.
                     let eax_bit = hvdef::HvEnlightenmentInformation::new()
                         .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
                         .into_bits() as u32;

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1626,6 +1626,18 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                 ecx = 0;
                 edx = 0;
             }
+            CpuidFunction(hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION) => {
+                // If VSM has been revoked (or just isn't available) then don't
+                // recommend the use of TLB flush hypercalls. They are only needed
+                // for synchronization between VTLs, and the non-hypercall direct
+                // path is always more efficient.
+                if matches!(
+                    *self.cvm_partition().guest_vsm.read(),
+                    GuestVsmState::NotPlatformSupported
+                ) {
+                    eax &= !0b100;
+                }
+            }
 
             _ => {}
         }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1635,7 +1635,10 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     *self.cvm_partition().guest_vsm.read(),
                     GuestVsmState::NotPlatformSupported
                 ) {
-                    eax &= !0b100;
+                    let eax_bit = hvdef::HvEnlightenmentInformation::new()
+                        .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
+                        .into_bits() as u32;
+                    eax &= !eax_bit;
                 }
             }
 


### PR DESCRIPTION
The TLB flush hypercalls are necessary when multiple VTLs are being run in order to synchronize our TLB locks, but when there's no VSM going on we don't need them. They're also slower than just not using them. Add some runtime cpuid fixup code that removes our normal cpuid recommendation of them when VSM is disabled or revoked. Then enable them for TDX just like SNP. We know the TDX implementation still has a race condition, but since VSM is still a WIP that's fine.

Tested that a non-VSM TDX VM issues these hypercalls with only the enablement change, then doesn't issue them with the full change.

Part of #699