### PR TITLE
Revert "Build musl binaries with RELR relocations (#965)"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -89,8 +89,6 @@ rustflags = [
 rustflags = [
   # Use the musl from the sysroot, not from the Rust distribution.
   "-Clink-self-contained=n",
-  # Use RELR relocation format, which is considerably smaller.
-  "-Clink-arg=-Wl,-z,pack-relative-relocs",
 ]
 
 [target.'cfg(all(target_arch = "aarch64", target_env = "musl"))']

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1538,7 +1538,7 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
         flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
@@ -1546,7 +1546,7 @@ jobs:
       with:
         fetch-depth: '1'
         path: repo0
-        persist-credentials: ${{ env.floweyvar2 }}
+        persist-credentials: ${{ env.floweyvar1 }}
       name: checkout repo openvmm
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
@@ -1556,13 +1556,9 @@ jobs:
         EOF
         flowey e 13 flowey_lib_common::git_checkout 3
         flowey e 13 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
       shell: bash
-    - name: checking if packages need to be installed
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
-      shell: bash
-    - name: installing packages
-      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
+    - name: set '-Dwarnings' in .cargo/config.toml
+      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 13 flowey_lib_common::download_gh_release 0
@@ -1570,14 +1566,14 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar5 --is-raw-string
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar5 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar5 }}
-        path: ${{ env.floweyvar6 }}
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
@@ -1587,21 +1583,38 @@ jobs:
         flowey e 13 flowey_lib_common::cache 6
         flowey e 13 flowey_lib_common::download_gh_release 1
       shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: installing packages
+      run: flowey e 13 flowey_lib_common::install_dist_pkg 1
+      shell: bash
+    - name: unpack protoc
+      run: |-
+        flowey e 13 flowey_lib_common::download_protoc 0
+        flowey e 13 flowey_lib_hvlite::cfg_openvmm_magicpath 0
+      shell: bash
+    - name: symlink protoc
+      run: flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+      shell: bash
     - name: unpack openvmm-deps archive
       run: flowey e 13 flowey_lib_hvlite::download_openvmm_deps 0
       shell: bash
     - name: extract X64 sysroot.tar.gz
-      run: flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
-      shell: bash
-    - name: set '-Dwarnings' in .cargo/config.toml
-      run: flowey e 13 flowey_lib_hvlite::init_openvmm_cargo_config_deny_warnings 0
-      shell: bash
-    - name: unpack protoc
-      run: flowey e 13 flowey_lib_common::download_protoc 0
-      shell: bash
-    - name: symlink protoc
       run: |-
-        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_protoc 0
+        flowey e 13 flowey_lib_hvlite::init_openvmm_magicpath_openhcl_sysroot 0
+        flowey e 13 flowey_lib_hvlite::init_cross_build 0
+      shell: bash
+    - name: cargo build xtask
+      run: |-
+        flowey e 13 flowey_lib_common::run_cargo_build 1
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
+      shell: bash
+    - name: split debug symbols
+      run: |-
+        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
+        flowey e 13 flowey_lib_hvlite::build_xtask 0
         flowey e 13 flowey_lib_hvlite::init_cross_build 1
       shell: bash
     - name: cargo build openvmm_hcl
@@ -1615,43 +1628,20 @@ jobs:
         flowey e 13 flowey_lib_hvlite::run_cargo_build 1
         flowey e 13 flowey_lib_hvlite::build_openvmm_hcl 0
       shell: bash
-    - name: collect openvmm_hcl files for analysis
-      run: |-
-        flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 2
-        flowey v 13 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_core/src/node.rs:1054:34' --write-to-gh-env floweyvar1 --is-raw-string
-      shell: bash
-    - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__3
-      uses: actions/upload-artifact@v4
-      with:
-        name: x86_64_openvmm_hcl_for_size_analysis
-        path: ${{ env.floweyvar1 }}
-      name: publish openvmm_hcl for analysis
-    - name: cargo build xtask
-      run: |-
-        flowey e 13 flowey_lib_hvlite::init_cross_build 0
-        flowey e 13 flowey_lib_common::run_cargo_build 1
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 2
-      shell: bash
-    - name: split debug symbols
-      run: |-
-        flowey e 13 flowey_lib_hvlite::run_split_debug_info 0
-        flowey e 13 flowey_lib_hvlite::run_cargo_build 3
-        flowey e 13 flowey_lib_hvlite::build_xtask 0
-      shell: bash
     - name: create gh cache dir
       run: flowey e 13 flowey_lib_common::download_gh_cli 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar3 --is-raw-string
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:457:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:456:72' --write-to-gh-env floweyvar3 --is-raw-string
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
       with:
-        key: ${{ env.floweyvar3 }}
-        path: ${{ env.floweyvar4 }}
+        key: ${{ env.floweyvar2 }}
+        path: ${{ env.floweyvar3 }}
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
@@ -1679,7 +1669,7 @@ jobs:
       run: flowey e 13 flowey_lib_common::download_gh_artifact 0
       shell: bash
     - name: binary size comparison
-      run: flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 4
+      run: flowey e 13 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 2
       shell: bash
     - name: 'validate cache entry: gh-cli'
       run: flowey e 13 flowey_lib_common::cache 3

--- a/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
@@ -96,50 +96,7 @@ impl SimpleFlowNode for Node {
             gh_token: gh_token.clone(),
         });
 
-        // Publish the built binary as an artifact for offline analysis.
-        //
-        // FUTURE: Flowey should have a general mechanism for this. We cannot
-        // use the existing artifact support because all artifacts are only
-        // published at the end of the job, if everything else succeeds.
-        let publish_artifact = if ctx.backend() == FlowBackend::Github {
-            let dir = ctx.emit_rust_stepv("collect openvmm_hcl files for analysis", |ctx| {
-                let built_openvmm_hcl = built_openvmm_hcl.clone().claim(ctx);
-                move |rt| {
-                    let built_openvmm_hcl = rt.read(built_openvmm_hcl);
-                    let path = Path::new("artifact");
-                    fs_err::create_dir_all(path)?;
-                    fs_err::copy(built_openvmm_hcl.bin, path.join("openvmm_hcl"))?;
-                    if let Some(dbg) = built_openvmm_hcl.dbg {
-                        fs_err::copy(dbg, path.join("openvmm_hcl.dbg"))?;
-                    }
-                    Ok(path
-                        .absolute()?
-                        .into_os_string()
-                        .into_string()
-                        .ok()
-                        .unwrap())
-                }
-            });
-            let name = format!(
-                "{}_openvmm_hcl_for_size_analysis",
-                target.common_arch().unwrap().as_arch()
-            );
-            Some(
-                ctx.emit_gh_step(
-                    "publish openvmm_hcl for analysis",
-                    "actions/upload-artifact@v4",
-                )
-                .with("name", name)
-                .with("path", dir)
-                .finish(ctx),
-            )
-        } else {
-            None
-        };
-
         let comparison = ctx.emit_rust_step("binary size comparison", |ctx| {
-            // Ensure the artifact is published before the analysis since this step may fail.
-            let _publish_artifact = publish_artifact.claim(ctx);
             let xtask = xtask.claim(ctx);
             let openvmm_repo_path = openvmm_repo_path.claim(ctx);
             let old_openhcl = merge_head_artifact.claim(ctx);


### PR DESCRIPTION
This reverts commit fd5e1a482bb25403b59d9176a5c1b9fa1393bcd6.

I'm in the process of stabilizing the 6.12 kernel release and at first, I thought it would make sense for this to go in at the same time, to offset some of the size increase from 6.12. However, some new test failures that need to be debugged have popped up, so I think it makes sense to get 6.12 stable first.