### PR TITLE
tmk: aarch64 test for the interrupt controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6454,6 +6454,8 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 name = "simple_tmk"
 version = "0.0.0"
 dependencies = [
+ "aarch64defs",
+ "bitfield-struct 0.10.1",
  "minimal_rt_build",
  "tmk_core",
  "tmk_macros",

--- a/tmk/simple_tmk/Cargo.toml
+++ b/tmk/simple_tmk/Cargo.toml
@@ -7,6 +7,8 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
+aarch64defs.workspace = true
+bitfield-struct.workspace = true
 tmk_core.workspace = true
 tmk_macros.workspace = true
 x86defs.workspace = true

--- a/tmk/simple_tmk/src/aarch64/device_register.rs
+++ b/tmk/simple_tmk/src/aarch64/device_register.rs
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Abstractions for memory-mapped device register(s) access.
+//!
+//! These lack an RMW implementation.
+
+use core::marker::PhantomData;
+use core::ops::Range;
+use core::sync::atomic::AtomicU32;
+use core::sync::atomic::AtomicU64;
+use core::sync::atomic::Ordering;
+
+/// Trait to describe atomic access.
+pub trait AtomicAccess<T: Copy> {
+    /// Loads the data from the address with the spcifies ordering.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn load(ptr: *mut T, order: Ordering) -> T;
+
+    /// Stores the data at the address with the spcifies ordering.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn store(ptr: *mut T, v: T, order: Ordering);
+
+    /// Bitwise "or" with the current value.
+    ///
+    /// Performs a bitwise "or" operation on the current value and the argument `v`, and
+    /// sets the new value to the result.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn fetch_or(ptr: *mut T, v: T, order: Ordering) -> T;
+
+    /// Bitwise "and" with the current value.
+    ///
+    /// Performs a bitwise "and" operation on the current value and the argument `v`, and
+    /// sets the new value to the result.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn fetch_and(ptr: *mut T, v: T, order: Ordering) -> T;
+}
+
+impl AtomicAccess<u64> for u64 {
+    /// Loads the data from the address with the spcifies ordering.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn load(ptr: *mut u64, order: Ordering) -> u64 {
+        // SAFETY: atomic access, the address is valid.
+        unsafe { AtomicU64::from_ptr(ptr).load(order) }
+    }
+
+    /// Stores the data at the address with the spcifies ordering.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn store(ptr: *mut u64, v: u64, order: Ordering) {
+        // SAFETY: atomic access, the address is valid.
+        unsafe { AtomicU64::from_ptr(ptr).store(v, order) };
+    }
+
+    /// Bitwise "or" with the current value.
+    ///
+    /// Performs a bitwise "or" operation on the current value and the argument `v`, and
+    /// sets the new value to the result.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn fetch_or(ptr: *mut u64, v: u64, order: Ordering) -> u64 {
+        // SAFETY: atomic access, the address is valid.
+        unsafe { AtomicU64::from_ptr(ptr).fetch_or(v, order) }
+    }
+
+    /// Bitwise "and" with the current value.
+    ///
+    /// Performs a bitwise "and" operation on the current value and the argument `v`, and
+    /// sets the new value to the result.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn fetch_and(ptr: *mut u64, v: u64, order: Ordering) -> u64 {
+        // SAFETY: atomic access, the address is valid.
+        unsafe { AtomicU64::from_ptr(ptr).fetch_and(v, order) }
+    }
+}
+
+impl AtomicAccess<u32> for u32 {
+    /// Loads the data from the address with the spcifies ordering.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn load(ptr: *mut u32, order: Ordering) -> u32 {
+        // SAFETY: atomic access, the address is valid.
+
+        unsafe { AtomicU32::from_ptr(ptr).load(order) }
+    }
+
+    /// Stores the data at the address with the spcifies ordering.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn store(ptr: *mut u32, v: u32, order: Ordering) {
+        // SAFETY: atomic access, the address is valid.
+        unsafe { AtomicU32::from_ptr(ptr).store(v, order) };
+    }
+
+    /// Bitwise "or" with the current value.
+    ///
+    /// Performs a bitwise "or" operation on the current value and the argument `v`, and
+    /// sets the new value to the result.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn fetch_or(ptr: *mut u32, v: u32, order: Ordering) -> u32 {
+        // SAFETY: atomic access, the address is valid.
+        unsafe { AtomicU32::from_ptr(ptr).fetch_or(v, order) }
+    }
+
+    /// Bitwise "and" with the current value.
+    ///
+    /// Performs a bitwise "and" operation on the current value and the argument `v`, and
+    /// sets the new value to the result.
+    ///
+    /// # Safety
+    /// The address is valid.
+    unsafe fn fetch_and(ptr: *mut u32, v: u32, order: Ordering) -> u32 {
+        // SAFETY: atomic access, the address is valid.
+        unsafe { AtomicU32::from_ptr(ptr).fetch_and(v, order) }
+    }
+}
+
+/// Trait to describe the register access.
+pub trait DeviceRegisterSpec {
+    /// The raw type used for memory representation.
+    type Raw: Copy + From<Self::Value> + AtomicAccess<Self::Raw>;
+    /// The value type used in the API.
+    type Value: Copy + From<Self::Raw>;
+    /// The register offset from the base address.
+    const OFFSET: usize;
+    /// Mmeory ordering when loading, deafults to the
+    /// sequential consistency.
+    const ORDERING_LOAD: Ordering = Ordering::SeqCst;
+    /// Mmeory ordering when loading, deafults to the
+    /// sequential consistency.
+    const ORDERING_STORE: Ordering = Ordering::SeqCst;
+}
+
+/// A memory-mapped device register.
+pub struct DeviceRegister<S: DeviceRegisterSpec> {
+    address: *mut S::Raw,
+    _spec: PhantomData<S>,
+}
+
+impl<S: DeviceRegisterSpec> DeviceRegister<S> {
+    /// Create a new MMIO register from a base address.
+    ///
+    /// Caller must ensure:
+    /// * the base address is valid and properly aligned,
+    /// * the resulting address (base + OFFSET) points to valid memory,
+    /// * the memory has the required access permissions, caching and
+    ///   attributes set.
+    pub const fn new(base_address: usize) -> Self {
+        Self {
+            address: (base_address + S::OFFSET) as *mut S::Raw,
+            _spec: PhantomData,
+        }
+    }
+
+    /// Read the register value. Might be reorderd by the CPU,
+    /// no compiler reordering.
+    pub fn read(&self) -> S::Value {
+        // SAFETY: volatile access ensures proper hardware interaction: no
+        // accesses  will be elided or reordered by the compiler, and the
+        // address comes from a trusted place.
+        unsafe { core::ptr::read_volatile(self.address).into() }
+    }
+
+    /// Write a value to the register. Might be reorderd by the CPU,
+    /// no compiler reordering.
+    pub fn write(&mut self, value: S::Value) {
+        // SAFETY: volatile access ensures proper hardware interaction: no
+        // accesses  will be elided or reordered by the compiler, and the
+        // address comes from a trusted place.
+        unsafe { core::ptr::write_volatile(self.address, value.into()) };
+    }
+
+    /// Atomically load the register value using memory ordering
+    /// from the specification.
+    pub fn load(&self) -> S::Value {
+        // SAFETY: atomic access provides a correct way to interact with the
+        // hardware, and the address comes from the trusted source.
+        unsafe { S::Raw::load(self.address, S::ORDERING_LOAD).into() }
+    }
+
+    /// Atoically store a value to the register using memory ordering
+    /// from the specification.
+    pub fn store(&mut self, value: S::Value) {
+        // SAFETY: atomic access provides a correct way to interact with the
+        // hardware, and the address comes from the trusted source.
+        unsafe {
+            S::Raw::store(self.address, value.into(), S::ORDERING_STORE);
+        }
+    }
+
+    /// Atomically bitise "or" load the register value using memory ordering
+    /// from the specification, and return the old value.
+    pub fn fetch_or(&mut self, value: S::Value) -> S::Value {
+        // SAFETY: atomic access provides a correct way to interact with the
+        // hardware, and the address comes from the trusted source.
+        unsafe { S::Raw::fetch_or(self.address, value.into(), S::ORDERING_LOAD).into() }
+    }
+
+    /// Atomically bitise "and" load the register value using memory ordering
+    /// from the specification, and return the old value.
+    pub fn fetch_and(&mut self, value: S::Value) -> S::Value {
+        // SAFETY: atomic access provides a correct way to interact with the
+        // hardware, and the address comes from the trusted source.
+        unsafe { S::Raw::fetch_and(self.address, value.into(), S::ORDERING_LOAD).into() }
+    }
+}
+
+/// Trait defining the specification for an array of device registers
+pub trait DeviceRegisterArraySpec: DeviceRegisterSpec {
+    /// The stride between consecutive registers in bytes
+    const STRIDE: usize = 0;
+    /// The number of registers in the array
+    const COUNT: usize;
+}
+
+/// An array of memory-mapped device registers
+pub struct DeviceRegisterArray<S: DeviceRegisterArraySpec> {
+    base_address: usize,
+    _spec: PhantomData<S>,
+}
+
+impl<S: DeviceRegisterArraySpec> DeviceRegisterArray<S> {
+    /// Create a new array of MMIO registers from a base address.
+    ///
+    /// The user must ensure that the base address and the offset are valid,
+    /// and that the memory is mapped as required for the device access.
+    pub const fn new(base_address: usize) -> Self {
+        Self {
+            base_address,
+            _spec: PhantomData,
+        }
+    }
+
+    /// Get a reference to a specific register in the array.
+    pub fn index(&self, index: usize) -> DeviceRegister<S> {
+        assert!(index < S::COUNT, "Register index out of bounds");
+
+        DeviceRegister::<S>::new(self.base_address + index * (S::STRIDE + size_of::<S::Raw>()))
+    }
+
+    /// Iterate over all registers in the array.
+    pub fn iter(&self) -> impl Iterator<Item = DeviceRegister<S>> + '_ {
+        (0..S::COUNT).map(move |i| self.index(i))
+    }
+
+    /// Fill the range with some value.
+    pub fn fill(&mut self, range: Range<usize>, value: S::Value) {
+        self.iter()
+            .skip(range.start)
+            .take(range.len())
+            .for_each(|mut r| r.store(value));
+    }
+}

--- a/tmk/simple_tmk/src/aarch64/gic.rs
+++ b/tmk/simple_tmk/src/aarch64/gic.rs
@@ -1,0 +1,760 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+///! GIC interface
+///!
+///! Enough functionality to send an SGI.
+// TODO: dedup with aarch64defs
+use super::device_register::DeviceRegister;
+use super::device_register::DeviceRegisterArray;
+use super::device_register::DeviceRegisterArraySpec;
+use super::device_register::DeviceRegisterSpec;
+use aarch64defs::gic::GICR_FRAME_SIZE;
+use aarch64defs::gic::GicdRegister;
+use aarch64defs::gic::GicrRdRegister;
+use aarch64defs::gic::GicrSgiRegister;
+use bitfield_struct::bitfield;
+
+const GICD_CTLR_OFFSET: usize = GicdRegister::CTLR.0 as usize;
+const GICD_TYPER_OFFSET: usize = GicdRegister::TYPER.0 as usize;
+const GICD_PIDR2_OFFSET: usize = GicdRegister::PIDR2.0 as usize;
+const GICD_ICENABLER_OFFSET: usize = GicdRegister::ICENABLER0.0 as usize;
+const GICD_ICPENDR_OFFSET: usize = GicdRegister::ICPENDR0.0 as usize;
+const GICD_IGROUPR_OFFSET: usize = GicdRegister::IGROUPR0.0 as usize;
+const GICD_IGRPMODR_OFFSET: usize = GicdRegister::IGRPMODR.0 as usize;
+const GICD_IROUTER_OFFSET: usize = GicdRegister::IROUTER0.0 as usize;
+
+const GICR_CTLR_OFFSET: usize = GicrRdRegister::CTLR.0 as usize;
+const GICR_IIDR_OFFSET: usize = GicrRdRegister::IIDR.0 as usize;
+const GICR_TYPER_OFFSET: usize = GicrRdRegister::TYPER.0 as usize;
+const GICR_WAKER_OFFSET: usize = GicrRdRegister::WAKER.0 as usize;
+const GICR_PIDR2_OFFSET: usize = GicrRdRegister::PIDR2.0 as usize;
+
+const GICR_IPRIORITYR_OFFSET: usize = GICR_FRAME_SIZE + GicrSgiRegister::IPRIORITYR0.0 as usize;
+const GICR_ISENABLER0_OFFSET: usize = GICR_FRAME_SIZE + GicrSgiRegister::ISENABLER0.0 as usize;
+const GICR_ICENABLER0_OFFSET: usize = GICR_FRAME_SIZE + GicrSgiRegister::ICENABLER0.0 as usize;
+const GICR_ISPENDR0_OFFSET: usize = GICR_FRAME_SIZE + GicrSgiRegister::ISPENDR0.0 as usize;
+const GICR_ICPENDR0_OFFSET: usize = GICR_FRAME_SIZE + GicrSgiRegister::ICPENDR0.0 as usize;
+const GICR_IGROUPR0_OFFSET: usize = GICR_FRAME_SIZE + GicrSgiRegister::IGROUPR0.0 as usize;
+
+/// Disributor control
+#[bitfield(u32)]
+pub struct GicdCtrl {
+    #[bits(1)]
+    pub enable_grp0: u32,
+    #[bits(1)]
+    pub enable_grp1_ns: u32,
+    #[bits(1)]
+    pub enable_grp1_s: u32,
+    #[bits(1)]
+    pub _res0: u32,
+    #[bits(1)]
+    pub are_s: u32,
+    #[bits(1)]
+    pub are_ns: u32,
+    #[bits(1)]
+    pub disable_secure: u32,
+    #[bits(1)]
+    pub e1_nwf: u32,
+    #[bits(23)]
+    pub _res1: u32,
+    #[bits(1)]
+    pub reg_write_pending: u32,
+}
+
+impl DeviceRegisterSpec for GicdCtrl {
+    type Raw = u32;
+    type Value = Self;
+    const OFFSET: usize = GICD_CTLR_OFFSET;
+}
+
+/// Identification register
+#[bitfield(u32)]
+pub struct GicdIidr {
+    #[bits(12)]
+    pub implementer: u32,
+    #[bits(4)]
+    pub revision: u32,
+    #[bits(4)]
+    pub variant: u32,
+    #[bits(4)]
+    pub _res0: u32,
+    #[bits(8)]
+    pub product_id: u32,
+}
+
+/// Distributor information
+#[bitfield(u32)]
+pub struct GicdTyper {
+    #[bits(5)]
+    pub it_lines: u32,
+    #[bits(3)]
+    pub cpu_number: u32,
+    #[bits(1)]
+    pub espi: u32,
+    #[bits(1)]
+    pub nmi: u32,
+    #[bits(1)]
+    pub security_extn: u32,
+    #[bits(5)]
+    pub lpi_lines: u32,
+    #[bits(1)]
+    pub mbis: u32,
+    #[bits(1)]
+    pub lpis: u32,
+    #[bits(1)]
+    pub dvis: u32,
+    #[bits(5)]
+    pub id_bits: u32,
+    #[bits(1)]
+    pub a3v: u32,
+    #[bits(1)]
+    pub no1n: u32,
+    #[bits(1)]
+    pub rss: u32,
+    #[bits(5)]
+    pub espi_range: u32,
+}
+
+impl DeviceRegisterSpec for GicdTyper {
+    type Raw = u32;
+    type Value = Self;
+    const OFFSET: usize = GICD_TYPER_OFFSET;
+}
+
+#[bitfield(u32)]
+/// Peripheral ID2 Register
+pub struct GicdPidr2 {
+    #[bits(4)]
+    pub _impl_def0: u32,
+    #[bits(4)]
+    pub gic_version: u32,
+    #[bits(24)]
+    pub _impl_def1: u32,
+}
+
+impl DeviceRegisterSpec for GicdPidr2 {
+    type Raw = u32;
+    type Value = Self;
+    const OFFSET: usize = GICD_PIDR2_OFFSET;
+}
+
+/// Clear enabled interrupts
+#[bitfield(u32)]
+pub struct GicdIcenabler {
+    pub icenable: u32,
+}
+
+impl DeviceRegisterSpec for GicdIcenabler {
+    type Raw = u32;
+    type Value = Self;
+    const OFFSET: usize = GICD_ICENABLER_OFFSET;
+}
+
+impl DeviceRegisterArraySpec for GicdIcenabler {
+    const COUNT: usize = 32;
+}
+
+/// Clear pending interrupts
+#[bitfield(u32)]
+pub struct GicdIcpendr {
+    pub icpend: u32,
+}
+
+impl DeviceRegisterSpec for GicdIcpendr {
+    type Raw = u32;
+    type Value = Self;
+    const OFFSET: usize = GICD_ICPENDR_OFFSET;
+}
+
+impl DeviceRegisterArraySpec for GicdIcpendr {
+    const COUNT: usize = 32;
+}
+
+/// Interrupt Group Registers
+#[bitfield(u32)]
+
+pub struct GicdIgroupr {
+    pub igroup: u32,
+}
+
+impl DeviceRegisterSpec for GicdIgroupr {
+    type Raw = u32;
+    type Value = Self;
+    const OFFSET: usize = GICD_IGROUPR_OFFSET;
+}
+
+impl DeviceRegisterArraySpec for GicdIgroupr {
+    const COUNT: usize = 32;
+}
+
+/// Interrupt Group Modifier Registers
+#[bitfield(u32)]
+pub struct GicdIgrpmodr {
+    pub igrpmod: u32,
+}
+
+impl DeviceRegisterSpec for GicdIgrpmodr {
+    type Raw = u32;
+    type Value = Self;
+    const OFFSET: usize = GICD_IGRPMODR_OFFSET;
+}
+
+impl DeviceRegisterArraySpec for GicdIgrpmodr {
+    const COUNT: usize = 32;
+}
+
+/// Interrupt Routing Registers
+#[bitfield(u32)]
+pub struct GicdIrouter {
+    pub iroute: u32,
+}
+
+impl DeviceRegisterSpec for GicdIrouter {
+    type Raw = u32;
+    type Value = Self;
+    const OFFSET: usize = GICD_IROUTER_OFFSET;
+}
+
+impl DeviceRegisterArraySpec for GicdIrouter {
+    const COUNT: usize = 1984;
+}
+
+/// GICR control
+#[bitfield(u32)]
+pub struct GicrCtlr {
+    #[bits(1)]
+    pub enable_lpis: u32,
+    #[bits(1)]
+    pub ces: u32,
+    #[bits(1)]
+    pub ir: u32,
+    #[bits(1)]
+    pub reg_write_pending: u32,
+    #[bits(20)]
+    _res0: u32,
+    #[bits(1)]
+    pub dpg0: u32,
+    #[bits(1)]
+    pub dpg1ns: u32,
+    #[bits(1)]
+    pub dpg1s: u32,
+    #[bits(4)]
+    _res1: u32,
+    #[bits(1)]
+    pub upstream_write_pending: u32,
+}
+
+impl DeviceRegisterSpec for GicrCtlr {
+    type Raw = u32;
+    type Value = GicrCtlr;
+    const OFFSET: usize = GICR_CTLR_OFFSET;
+}
+
+/// GICR Identification register
+#[bitfield(u32)]
+pub struct GicrIidr {
+    #[bits(12)]
+    pub implementer: u32,
+    #[bits(4)]
+    pub revision: u32,
+    #[bits(4)]
+    pub variant: u32,
+    #[bits(4)]
+    pub _res0: u32,
+    #[bits(8)]
+    pub product_id: u32,
+}
+
+impl DeviceRegisterSpec for GicrIidr {
+    type Raw = u32;
+    type Value = GicrIidr;
+    const OFFSET: usize = GICR_IIDR_OFFSET;
+}
+
+/// GICR Type register
+#[bitfield(u64)]
+pub struct GicrTyper {
+    #[bits(1)]
+    pub plpis: u64,
+    #[bits(1)]
+    pub vlpis: u64,
+    #[bits(1)]
+    pub dirty: u64,
+    #[bits(1)]
+    pub direct_lpi: u64,
+    #[bits(1)]
+    pub last: u64,
+    #[bits(1)]
+    pub dpgs: u64,
+    #[bits(1)]
+    pub mpam: u64,
+    #[bits(1)]
+    pub rvpeid: u64,
+    #[bits(16)]
+    pub processor_number: u64,
+    #[bits(2)]
+    pub common_lpi_aff: u64,
+    #[bits(1)]
+    pub vsgi: u64,
+    #[bits(5)]
+    pub ppi_num: u64,
+    #[bits(8)]
+    pub aff0: u64,
+    #[bits(8)]
+    pub aff1: u64,
+    #[bits(8)]
+    pub aff2: u64,
+    #[bits(8)]
+    pub aff3: u64,
+}
+
+impl DeviceRegisterSpec for GicrTyper {
+    type Raw = u64;
+    type Value = GicrTyper;
+    const OFFSET: usize = GICR_TYPER_OFFSET;
+}
+
+/// GICR Wake register
+#[bitfield(u32)]
+pub struct GicrWaker {
+    #[bits(1)]
+    pub _impl_def0: u32,
+    #[bits(1)]
+    pub processor_sleep: u32,
+    #[bits(1)]
+    pub children_asleep: u32,
+    #[bits(28)]
+    _res0: u32,
+    #[bits(1)]
+    pub _impl_def1: u32,
+}
+
+impl DeviceRegisterSpec for GicrWaker {
+    type Raw = u32;
+    type Value = GicrWaker;
+    const OFFSET: usize = GICR_WAKER_OFFSET;
+}
+
+#[bitfield(u32)]
+/// Peripheral ID2 Register
+pub struct GicrPidr2 {
+    #[bits(4)]
+    pub _impl_def0: u32,
+    #[bits(4)]
+    pub gic_version: u32,
+    #[bits(24)]
+    pub _impl_def1: u32,
+}
+
+impl DeviceRegisterSpec for GicrPidr2 {
+    type Raw = u32;
+    type Value = Self;
+    const OFFSET: usize = GICR_PIDR2_OFFSET;
+}
+
+#[bitfield(u32)]
+pub struct GicrIpriorityr {
+    p0: u8,
+    p1: u8,
+    p2: u8,
+    p3: u8,
+}
+
+impl DeviceRegisterSpec for GicrIpriorityr {
+    type Raw = u32;
+    type Value = GicrIpriorityr;
+    const OFFSET: usize = GICR_IPRIORITYR_OFFSET;
+}
+
+impl DeviceRegisterArraySpec for GicrIpriorityr {
+    const COUNT: usize = 8;
+}
+
+#[bitfield(u32)]
+pub struct GicrIsenabler {
+    sgis: u16,
+    ppis: u16,
+}
+
+impl DeviceRegisterSpec for GicrIsenabler {
+    type Raw = u32;
+    type Value = GicrIsenabler;
+    const OFFSET: usize = GICR_ISENABLER0_OFFSET;
+}
+
+#[bitfield(u32)]
+pub struct GicrIcenabler {
+    sgis: u16,
+    ppis: u16,
+}
+
+impl DeviceRegisterSpec for GicrIcenabler {
+    type Raw = u32;
+    type Value = GicrIcenabler;
+    const OFFSET: usize = GICR_ICENABLER0_OFFSET;
+}
+
+#[bitfield(u32)]
+pub struct GicrIspendr {
+    sgis: u16,
+    ppis: u16,
+}
+
+impl DeviceRegisterSpec for GicrIspendr {
+    type Raw = u32;
+    type Value = GicrIspendr;
+    const OFFSET: usize = GICR_ISPENDR0_OFFSET;
+}
+
+#[bitfield(u32)]
+pub struct GicrIcpendr {
+    sgis: u16,
+    ppis: u16,
+}
+
+impl DeviceRegisterSpec for GicrIcpendr {
+    type Raw = u32;
+    type Value = GicrIcpendr;
+    const OFFSET: usize = GICR_ICPENDR0_OFFSET;
+}
+
+#[bitfield(u32)]
+pub struct GicrIgroupr {
+    sgis: u16,
+    ppis: u16,
+}
+
+impl DeviceRegisterSpec for GicrIgroupr {
+    type Raw = u32;
+    type Value = GicrIgroupr;
+    const OFFSET: usize = GICR_IGROUPR0_OFFSET;
+}
+
+/// GIC version
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GicVersion {
+    /// Version 3: GICD and GICR with two frames per CPU.
+    GicV3,
+    /// Version 4: GICD and GICR with four frames per CPU.
+    GicV4,
+}
+
+/// GIC v3 or v4
+pub struct Gic {
+    gicd_base: usize,
+    gicr_base: usize,
+    version: GicVersion,
+    max_spi: usize,
+    num_cpus: usize,
+    redist_size: usize,
+}
+
+/// GIC
+///
+/// Initalization and configurations are described in "4. Configuring the GIC" of
+/// [GICv3 and GICv4 Software Overview](https://developer.arm.com/documentation/dai0492/b/)
+///
+/// Might be better to refactor to use type states.
+impl Gic {
+    /// Initialize the GIC interface
+    pub fn new(gicd_base: usize, gicr_base: usize, num_cpus: usize) -> Self {
+        // Run some basic (in)sanity checks
+
+        let gicd_pidr2 = DeviceRegister::<GicdPidr2>::new(gicd_base);
+        let gicd_ver = gicd_pidr2.load().gic_version();
+        assert!(
+            gicd_ver == 3 || gicd_ver == 4,
+            "Expected GIC v3 or GIC v4, got {gicd_ver}"
+        );
+
+        let (redist_size, version) = if gicd_ver == 3 {
+            // Got LPI and the SGI+PPI frames
+            (2 * GICR_FRAME_SIZE, GicVersion::GicV3)
+        } else if gicd_ver == 4 {
+            // The redistributor in GICv4 has two additional frames: VLPI and Reserved
+            (4 * GICR_FRAME_SIZE, GicVersion::GicV4)
+        } else {
+            unreachable!();
+        };
+
+        for i in 0..num_cpus {
+            let gicr_pidr2 = DeviceRegister::<GicrPidr2>::new(gicr_base + i * redist_size);
+            let gicr_ver = gicr_pidr2.load().gic_version();
+            assert!(
+                gicr_ver == 3 || gicr_ver == 4,
+                "Expected GIC v3 or GIC v4, got {gicr_ver}"
+            );
+
+            let gicr_typer = DeviceRegister::<GicrTyper>::new(gicr_base + i * redist_size);
+            let vlpis = gicr_typer.load().vlpis();
+            assert!(
+                vlpis == 0 || (gicr_ver == 4 && gicd_ver == 4),
+                "Expected VLPIs in GIC v4, CPU {i}"
+            );
+        }
+
+        // Initialize the instance
+
+        let gicd_typer = DeviceRegister::<GicdTyper>::new(gicd_base);
+        let max_spi = (32 * gicd_typer.load().it_lines() + 1) as usize;
+
+        Self {
+            gicd_base,
+            gicr_base,
+            version,
+            max_spi,
+            num_cpus,
+            redist_size,
+        }
+    }
+
+    /// Initialize the distributor, route all SPIs to the BSP.
+    pub fn init_gicd(&mut self) {
+        let mut gicd_ctrl = DeviceRegister::<GicdCtrl>::new(self.gicd_base);
+
+        // Reset
+        gicd_ctrl.store(GicdCtrl::new().with_disable_secure(0));
+        while gicd_ctrl.load().reg_write_pending() != 0 {
+            unsafe { core::arch::asm!("yield", options(nostack)) }
+        }
+
+        // Mask and clear all SPIs
+        let max_spi = self.max_spi;
+
+        DeviceRegisterArray::<GicdIcenabler>::new(self.gicd_base)
+            .fill(1..max_spi / 32, GicdIcenabler::from(!0));
+        DeviceRegisterArray::<GicdIcpendr>::new(self.gicd_base)
+            .fill(1..max_spi / 32, GicdIcpendr::from(!0));
+        DeviceRegisterArray::<GicdIgroupr>::new(self.gicd_base)
+            .fill(1..max_spi / 32, GicdIgroupr::from(!0));
+        DeviceRegisterArray::<GicdIgrpmodr>::new(self.gicd_base)
+            .fill(1..max_spi / 32, GicdIgrpmodr::from(!0));
+        while gicd_ctrl.load().reg_write_pending() != 0 {
+            unsafe { core::arch::asm!("yield", options(nostack)) }
+        }
+
+        gicd_ctrl.store(
+            GicdCtrl::new()
+                .with_enable_grp0(1)
+                .with_enable_grp1_ns(1)
+                .with_are_ns(1),
+        );
+        while gicd_ctrl.load().reg_write_pending() != 0 {
+            unsafe { core::arch::asm!("yield", options(nostack)) }
+        }
+
+        unsafe { core::arch::asm!("isb sy", options(nostack)) };
+
+        // CPU 0, affinity 0.0.0.0
+        DeviceRegisterArray::<GicdIrouter>::new(self.gicd_base)
+            .fill(32..max_spi, GicdIrouter::from(0));
+        while gicd_ctrl.load().reg_write_pending() != 0 {
+            unsafe { core::arch::asm!("yield", options(nostack)) }
+        }
+
+        unsafe { core::arch::asm!("isb sy", options(nostack)) };
+    }
+
+    /// Wake up the CPU and initialize its redistributor.
+    pub fn wakeup_cpu_and_init_gicr(&mut self, cpu: usize) {
+        let gicr_base = self.gicr_base + cpu * self.redist_size;
+
+        // Wake up the CPU
+
+        let mut waker = DeviceRegister::<GicrWaker>::new(gicr_base);
+        waker.store(waker.load().with_processor_sleep(0));
+        while waker.load().children_asleep() != 0 {
+            unsafe { core::arch::asm!("yield", options(nostack)) }
+        }
+
+        // Configure interrupts
+
+        let mut ipriorityr = DeviceRegisterArray::<GicrIpriorityr>::new(gicr_base);
+
+        // SGI priorities, implementation defined
+        let sgi_prio = GicrIpriorityr::new()
+            .with_p0(0x90)
+            .with_p1(0x90)
+            .with_p2(0x90)
+            .with_p3(0x90);
+        ipriorityr.fill(0..4, sgi_prio);
+
+        // PPI priorities, implementation defined
+        let ppi_prio = GicrIpriorityr::new()
+            .with_p0(0xa0)
+            .with_p1(0xa0)
+            .with_p2(0xa0)
+            .with_p3(0xa0);
+        ipriorityr.fill(4..8, ppi_prio);
+
+        // Disable forwarding all PPI and SGI to the CPU interface
+        DeviceRegister::<GicrIcenabler>::new(gicr_base).store(GicrIcenabler::new());
+        DeviceRegister::<GicrIsenabler>::new(gicr_base).store(GicrIsenabler::new());
+
+        // Set SGI and PPI as non-secure group 1 (set `GICD_CTLR.DS = 0` in GICD).
+        DeviceRegister::<GicrIgroupr>::new(gicr_base)
+            .store(GicrIgroupr::new().with_ppis(0xffff).with_sgis(0xffff));
+
+        let gicr_ctrl = DeviceRegister::<GicrCtlr>::new(gicr_base);
+        while gicr_ctrl.load().reg_write_pending() != 0 {
+            unsafe { core::arch::asm!("yield", options(nostack)) }
+        }
+
+        unsafe { core::arch::asm!("isb sy", options(nostack)) };
+    }
+
+    /// Enables a local (SGI or PPI interrupt).
+    fn enable_interrupt(&mut self, irq_num: u64, enable: bool, cpu: usize) {
+        let gicr_base = self.gicr_base + cpu * self.redist_size;
+
+        let mut icenable = DeviceRegister::<GicrIcenabler>::new(gicr_base);
+        let mut isenable = DeviceRegister::<GicrIsenabler>::new(gicr_base);
+        let mask = 1 << irq_num;
+
+        if enable {
+            icenable.fetch_and(GicrIcenabler::from(!mask));
+            isenable.fetch_or(GicrIsenabler::from(mask));
+        } else {
+            isenable.fetch_and(GicrIsenabler::from(!mask));
+            icenable.fetch_or(GicrIcenabler::from(mask));
+        }
+
+        let gicr_ctrl = DeviceRegister::<GicrCtlr>::new(gicr_base);
+        while gicr_ctrl.load().reg_write_pending() != 0 {
+            unsafe { core::arch::asm!("yield", options(nostack)) }
+        }
+    }
+
+    /// Pends a local (SGI or PPI interrupt).
+    fn pend_interrupt(&mut self, irq_num: u64, pend: bool, cpu: usize) {
+        let gicr_base = self.gicr_base + cpu * self.redist_size;
+
+        let mut icpend = DeviceRegister::<GicrIcpendr>::new(gicr_base);
+        let mut ispend = DeviceRegister::<GicrIspendr>::new(gicr_base);
+        let mask = 1 << irq_num;
+
+        if pend {
+            icpend.fetch_and(GicrIcpendr::from(!mask));
+            ispend.fetch_or(GicrIspendr::from(mask));
+        } else {
+            ispend.fetch_and(GicrIspendr::from(!mask));
+            icpend.fetch_or(GicrIcpendr::from(mask));
+        }
+
+        let gicr_ctrl = DeviceRegister::<GicrCtlr>::new(gicr_base);
+        while gicr_ctrl.load().reg_write_pending() != 0 {
+            unsafe { core::arch::asm!("yield", options(nostack)) }
+        }
+    }
+
+    /// Enables an SGI.
+    #[must_use]
+    pub fn enable_sgi(&mut self, irq_num: u64, enable: bool, cpu: usize) -> bool {
+        if !(0..16).contains(&irq_num) {
+            return false;
+        }
+
+        self.enable_interrupt(irq_num, enable, cpu);
+        true
+    }
+
+    /// Enables a PPI.
+    #[must_use]
+    pub fn enable_ppi(&mut self, irq_num: u64, enable: bool, cpu: usize) -> bool {
+        if !(16..32).contains(&irq_num) {
+            return false;
+        }
+
+        self.enable_interrupt(irq_num, enable, cpu);
+        true
+    }
+
+    /// Pends an SGI.
+    #[must_use]
+    pub fn pend_sgi(&mut self, irq_num: u64, pend: bool, cpu: usize) -> bool {
+        if !(0..16).contains(&irq_num) {
+            return false;
+        }
+
+        self.pend_interrupt(irq_num, pend, cpu);
+        true
+    }
+
+    /// Pends a PPI.
+    #[must_use]
+    pub fn pend_ppi(&mut self, irq_num: u64, pend: bool, cpu: usize) -> bool {
+        if !(16..32).contains(&irq_num) {
+            return false;
+        }
+
+        self.pend_interrupt(irq_num, pend, cpu);
+        true
+    }
+
+    /// Initialize the control interface to the CPU
+    /// through the ICC_* system registers.
+    ///
+    /// TODO: not hardcode the mask and the target.
+    pub fn init_icc(&mut self) {
+        // TODO: definitions for the registers
+        let enable = 1u64;
+        let disable = 0u64;
+        let mask: u64 = 0xffu64;
+
+        // SAFETY: not accesiing the memory.
+        unsafe {
+            core::arch::asm!(
+                // Enable access to the system regster interface
+                "msr ICC_SRE_EL1, {enable}",
+                // EOI will deactivate the interrupt so don't need
+                // to flip the bits in GICR separately
+                "msr ICC_CTLR_EL1, {disable}",
+                // Interrupt priority filter mask. Only interrupts with a higher priority than the value in this
+                // register are signaled
+                "msr ICC_PMR_EL1, {mask}",
+                // Enable group 1 (we're in the non-secure world)
+                "msr ICC_IGRPEN1_EL1, {enable}",
+                enable = in(reg) enable, disable = in(reg) disable, mask = in(reg) mask,
+                options(nostack, nomem))
+        };
+    }
+
+    #[must_use]
+    pub fn generate_sgi(&self, int_id: u64) -> bool {
+        if !(0..16).contains(&int_id) {
+            return false;
+        }
+
+        // Send to all (IRM aka Interrupt Routing Mode set to 1).
+        // TODO: define a struct and provide an ability to send to
+        // an individual CPU/PE.
+        let route_sgi = (1u64 << 40) | (int_id << 24);
+
+        // SAFETY: not accesiing the memory.
+        unsafe {
+            core::arch::asm!(
+                // Generates a software interrupt
+                "msr ICC_SGI1R_EL1, {route_sgi}",
+                route_sgi = in(reg) route_sgi,
+                options(nostack, nomem))
+        };
+
+        true
+    }
+
+    /// Get the GIC version.
+    pub fn version(&self) -> GicVersion {
+        self.version
+    }
+
+    /// Get the maximum SPI line.
+    pub fn max_spi_id(&self) -> usize {
+        self.max_spi
+    }
+
+    /// Number of CPUs
+    pub fn num_cpus(&self) -> usize {
+        self.num_cpus
+    }
+}

--- a/tmk/simple_tmk/src/aarch64/mod.rs
+++ b/tmk/simple_tmk/src/aarch64/mod.rs
@@ -1,0 +1,45 @@
+#![cfg(target_arch = "aarch64")]
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Tests for ARM64.
+
+use gic::Gic;
+use tmk_core::TestContext;
+use tmk_core::log;
+use tmk_macros::tmk_test;
+
+mod device_register;
+mod gic;
+
+const NUM_CPUS: usize = 1;
+
+// TODO: qemu specific
+const GICD_BASE: u64 = 0x08000000;
+const GICR_BASE: u64 = 0x080a0000;
+
+#[tmk_test]
+fn gic_test(_: TestContext<'_>) {
+    // Enable all exceptions.
+    // SAFETY: not touching memory, inteerupt handler is set up.
+    unsafe { core::arch::asm!("msr DAIFClr, #0xf", options(nomem, nostack)) };
+
+    let mut gic = Gic::new(GICD_BASE as usize, GICR_BASE as usize, NUM_CPUS);
+    gic.init_gicd();
+    gic.wakeup_cpu_and_init_gicr(0);
+    gic.init_icc();
+
+    log!(
+        "Initialized GIC, version {:?}, max SPI ID {}",
+        gic.version(),
+        gic.max_spi_id()
+    );
+
+    let irq_num = 4;
+    assert!(gic.enable_sgi(irq_num, true, 0));
+    assert!(gic.generate_sgi(irq_num));
+
+    // TODO: Chnage PMR, priorities, check on pending, etc.
+
+    unsafe { core::arch::asm!("1: wfi; b 1b") };
+}

--- a/tmk/simple_tmk/src/main.rs
+++ b/tmk/simple_tmk/src/main.rs
@@ -9,6 +9,7 @@
 
 mod prelude;
 
+mod aarch64;
 mod common;
 mod x86_64;
 

--- a/tmk/tmk_core/src/aarch64.rs
+++ b/tmk/tmk_core/src/aarch64.rs
@@ -13,6 +13,103 @@ mod entry {
         ".weak _DYNAMIC",
         ".hidden _DYNAMIC",
         ".globl _start",
+
+        // Good only for the EL1
+        " __exception_common:",
+
+        "str     x29, [sp, #-16]!",
+        "stp     x27, x28, [sp, #-16]!",
+        "stp     x25, x26, [sp, #-16]!",
+        "stp     x23, x24, [sp, #-16]!",
+        "stp     x21, x22, [sp, #-16]!",
+        "stp     x19, x20, [sp, #-16]!",
+        "stp     x17, x18, [sp, #-16]!",
+        "stp     x15, x16, [sp, #-16]!",
+        "stp     x13, x14, [sp, #-16]!",
+        "stp     x11, x12, [sp, #-16]!",
+        "stp     x9, x10, [sp, #-16]!",
+        "stp     x7, x8, [sp, #-16]!",
+        "stp     x5, x6, [sp, #-16]!",
+        "stp     x3, x4, [sp, #-16]!",
+        "stp     x1, x2, [sp, #-16]!",
+
+        "add     sp, sp, #-16",
+
+        "mrs     x2, spsr_el1",
+        "mrs     x1, elr_el1",
+        "stp     x1, x2, [sp, #-16]!",
+
+        "str     x0, [sp, #-16]!",
+
+        "mrs     x2, tpidr_el1",
+        "add     x1, sp, #38*8",
+        "stp     x1, x2, [sp, #32]",
+
+        "mov     x0, sp",
+        "bl      exception_handler",
+
+        "ldr     x1, [sp, #40]",
+        "msr     tpidr_el1, x1",
+
+        "add     sp, sp, #16",
+
+        "ldp     x1, x2, [sp], #16",
+        "msr     elr_el1, x1",
+        "msr     spsr_el1, x2",
+
+        "add     sp, sp, #16",
+
+        "ldp     x1, x2, [sp], #16",
+        "ldp     x3, x4, [sp], #16",
+        "ldp     x5, x6, [sp], #16",
+        "ldp     x7, x8, [sp], #16",
+        "ldp     x9, x10, [sp], #16",
+        "ldp     x11, x12, [sp], #16",
+        "ldp     x13, x14, [sp], #16",
+        "ldp     x15, x16, [sp], #16",
+        "ldp     x17, x18, [sp], #16",
+        "ldp     x19, x20, [sp], #16",
+        "ldp     x21, x22, [sp], #16",
+        "ldp     x23, x24, [sp], #16",
+        "ldp     x25, x26, [sp], #16",
+        "ldp     x27, x28, [sp], #16",
+        "ldr     x29, [sp], #16",
+        "ldp     lr, x0, [sp], #16",
+
+        "eret",
+
+        ".macro EXCEPTION_ENTRY source, kind",
+        ".align 7",
+        "	stp     lr, x0, [sp, #-16]!",
+        "	mov     x0, \\source",
+        "	movk    x0, \\kind, lsl #16",
+        "	b       __exception_common",
+        ".endm",
+
+        // Vector table must be aligned to a 2KB boundary
+        ".balign 0x800",
+        " _vector_table_el1:",
+        // Target and source at same exception level with source SP = SP_EL0
+        "     EXCEPTION_ENTRY #0x0, #0x0",  // Synchronous exception
+        "     EXCEPTION_ENTRY #0x0, #0x1",  // IRQ
+        "     EXCEPTION_ENTRY #0x0, #0x2",  // FIQ
+        "     EXCEPTION_ENTRY #0x0, #0x3",  // SError
+        // Target and source at same exception level with source SP = SP_ELx
+        "     EXCEPTION_ENTRY #0x1, #0x0  // Synchronous exception",
+        "     EXCEPTION_ENTRY #0x1, #0x1  // IRQ",
+        "     EXCEPTION_ENTRY #0x1, #0x2  // FIQ",
+        "     EXCEPTION_ENTRY #0x1, #0x3  // SError",
+        // Source is at lower exception level running on AArch64
+        "     EXCEPTION_ENTRY #0x2, #0x0",  // Synchronous exception
+        "     EXCEPTION_ENTRY #0x2, #0x1",  // IRQ
+        "     EXCEPTION_ENTRY #0x2, #0x2",  // FIQ
+        "     EXCEPTION_ENTRY #0x2, #0x3",  // SError
+        // Source is at lower exception level running on AArch32
+        "     EXCEPTION_ENTRY #0x3, #0x0",  // Synchronous exception
+        "     EXCEPTION_ENTRY #0x3, #0x1",  // IRQ
+        "     EXCEPTION_ENTRY #0x3, #0x2",  // FIQ
+        "     EXCEPTION_ENTRY #0x3, #0x3",  // SError
+
         "_start:",
         "mov x19, x0",
         "adrp x1, {stack}",
@@ -27,6 +124,12 @@ mod entry {
         "msr     CPACR_EL1, x0",
         "isb",
 
+        // Set up the vector table.
+        "adrp   x3, _vector_table_el1",
+        "add    x3, x3, :lo12:_vector_table_el1",
+        "msr    VBAR_EL1, x3",
+        "isb",
+
         "adrp x0, __ehdr_start",
         "add x0, x0, :lo12:__ehdr_start",
         "mov x1, x0",
@@ -35,6 +138,7 @@ mod entry {
         "bl {relocate}",
         "mov x0, x19",
         "b {entry}",
+
         relocate = sym minimal_rt::reloc::relocate,
         stack = sym STACK,
         entry = sym crate::entry,
@@ -55,3 +159,6 @@ impl Scope<'_, '_> {
     }
     pub(super) fn arch_reset(&mut self) {}
 }
+
+#[unsafe(no_mangle)]
+extern "C" fn exception_handler(_exception_frame: *const ()) {}

--- a/vm/aarch64/aarch64defs/src/gic.rs
+++ b/vm/aarch64/aarch64defs/src/gic.rs
@@ -2,40 +2,288 @@
 // Licensed under the MIT License.
 
 //! Definitions for the Generic Interrupt Controller (GIC) registers.
+//!
+//! GICv3 has two main components:
+//! 1. GICD (distributor) - the central hub for all interrupts
+//! 2. GICR (re-distributors) - per-CPU interrupt management
+//!
+//! GICD functions, most notably:
+//! - routes interrupts to correct CPU,
+//! - stores global interrupt state (enabled/pending),
+//! - handles interrupt prioritization,
+//! - broadcasts SGIs (Software Generated Interrupts)
+//!
+//! The distributor has the size of 64KiB.
+//!
+//! Crucial GICR functions (per CPU):
+//! - manages CPU-private interrupts (SGIs 0-15, PPIs 16-31),
+//! - handles interrupt signaling to individual cores,
+//! - provides wakeup control for power management
+//!
+//! Each redistributor defines two 64KiB frames in the physical address map:
+//! - RD_base for controlling the overall behavior of the Redistributor, for
+//!   controlling LPIs, and for generating LPIs in a system that does not
+//!   include at least one ITS,
+//! - SGI_base for controlling and generating PPIs and SGIs.
+//!
+//! For overview, refer to [GICv3 and GICv4 Software Overview](https://developer.arm.com/documentation/dai0492/b/)
+//! See [GIC architecture version 3 and version 4](https://developer.arm.com/documentation/ihi0069/latest/)
+//! for more details. That document is refernced below unless stated otherwise.
 
 use bitfield_struct::bitfield;
 use core::ops::Range;
 use open_enum::open_enum;
 
+// GIC registers, "12.9 The GIC Distributor register descriptions"
+
+pub const GICD_SIZE: usize = 0x10000;
+
 open_enum! {
+    /// GIC Distributor register map
+    ///
+    /// See "12.8 The GIC Distributor register map".
     pub enum GicdRegister: u16 {
-        CTLR = 0x0000,
-        TYPER = 0x0004,
-        IIDR = 0x0008,
-        TYPER2 = 0x000c,
-        STATUSR = 0x0010,
-        SETSPI_NSR = 0x0040,
-        CLRSPI_NSR = 0x0048,
-        SETSPI_SR = 0x0050,
-        CLRSPI_SR = 0x0058,
-        IGROUPR0 = 0x0080,       // 0x80
-        ISENABLER0 = 0x0100,     // 0x80
-        ICENABLER0 = 0x0180,     // 0x80
-        ISPENDR0 = 0x0200,       // 0x80
-        ICPENDR0 = 0x0280,       // 0x80
-        ISACTIVER0 = 0x0300,     // 0x80
-        ICACTIVER0 = 0x0380,     // 0x80
-        IPRIORITYR0 = 0x0400,    // 0x400
-        ITARGETSR0 = 0x0800,     // 0x400
-        ICFGR0 = 0x0c00,         // 0x100
-        IGRPMODR0 = 0x0d00,      // 0x100
-        NSACR0 = 0x0e00,         // 0x100
-        SGIR = 0x0f00,
-        CPENDSGIR0 = 0x0f10,     // 0x10
-        SPENDSGIR0 = 0x0f20,     // 0x10
-        INMIR0 = 0x0f80,         // 0x80
-        IROUTER0 = 0x6000,       // 0x2000, skip first 0x100,
-        PIDR2 = 0xffe8,
+        /// 0x0000 - Distributor Control Register (GICD_CTLR)
+        ///
+        /// Controls overall operation of the Distributor.
+        /// The reset value is implementation defined.
+        CTLR = 0x0000, // u32
+
+        /// 0x0004 - Interrupt Controller Type Register (GICD_TYPER)
+        ///
+        /// Provides information about the configuration of the GIC.
+        /// Read-only, implementation defined.
+        TYPER = 0x0004, // u32
+
+        /// 0x0008 - Distributor Implementer Identification Register (GICD_IIDR)
+        ///
+        /// Identifies the implementer of the GIC.
+        /// Read-only, implementation defined.
+        IIDR = 0x0008, // u32
+
+        /// 0x000C - Interrupt Controller Type Register 2 (GICD_TYPER2)
+        ///
+        /// Additional type information about the GIC.
+        /// Read-only, implementation defined.
+        TYPER2 = 0x000C, // u32
+
+        /// 0x0010 - Error Reporting Status Register (optional) (GICD_STATUSR)
+        ///
+        /// Reports error conditions in the Distributor.
+        /// Reset value: 0x00000000
+        STATUSR = 0x0010, // u32
+
+        /// 0x0040 - Set SPI Register (Non-secure) (GICD_SETSPI_NSR)
+        ///
+        /// Writing to this register sets the corresponding SPI interrupt
+        /// pending state in the non-secure state.
+        SETSPI_NSR = 0x0040, // u32
+
+        /// 0x0048 - Clear SPI Register (Non-secure) (GICD_CLRSPI_NSR)
+        ///
+        /// Writing to this register clears the corresponding SPI interrupt
+        /// pending state in the non-secure state.
+        CLRSPI_NSR = 0x0048, // u32
+
+        /// 0x0050 - Set SPI Register (Secure) (GICD_SETSPI_SR)
+        ///
+        /// Writing to this register sets the corresponding SPI interrupt
+        /// pending state in the secure state.
+        SETSPI_SR = 0x0050, // u32
+
+        /// 0x0058 - Clear SPI Register (Secure) (GICD_CLRSPI_SR)
+        ///
+        /// Writing to this register clears the corresponding SPI interrupt
+        /// pending state in the secure state.
+        CLRSPI_SR = 0x0058, // u32
+
+        /// 0x0080-0x00FC - Interrupt Group Registers (GICD_IGROUPR<n>)
+        ///
+        /// Configures interrupts as Group 0 or Group 1.
+        /// Reset value: implementation defined.
+        IGROUPR0 = 0x0080, // [u32; 32]
+
+        /// 0x0100-0x017C - Interrupt Set-Enable Registers (GICD_ISENABLER<n>)
+        ///
+        /// Enables forwarding of interrupts to CPU interfaces.
+        /// Reset value: implementation defined.
+        ISENABLER0 = 0x0100, // [u32; 32]
+
+        /// 0x0180-0x01FC - Interrupt Clear-Enable Registers (GICD_ICENABLER<n>)
+        ///
+        /// Disables forwarding of interrupts to CPU interfaces.
+        /// Reset value: implementation defined.
+        ICENABLER0 = 0x0180, // [u32; 32]
+
+        /// 0x0200-0x027C - Interrupt Set-Pending Registers (GICD_ISPENDR<n>)
+        ///
+        /// Sets the pending state of interrupts.
+        /// Reset value: 0x00000000
+        ISPENDR0 = 0x0200, // [u32; 32]
+
+        /// 0x0280-0x02FC - Interrupt Clear-Pending Registers (GICD_ICPENDR<n>)
+        ///
+        /// Clears the pending state of interrupts.
+        /// Reset value: 0x00000000
+        ICPENDR0 = 0x0280, // [u32; 32]
+
+        /// 0x0300-0x037C - Interrupt Set-Active Registers (GICD_ISACTIVER<n>)
+        ///
+        /// Sets the active state of interrupts.
+        /// Reset value: 0x00000000
+        ISACTIVER0 = 0x0300, // [u32; 32]
+
+        /// 0x0380-0x03FC - Interrupt Clear-Active Registers (GICD_ICACTIVER<n>)
+        ///
+        /// Clears the active state of interrupts.
+        /// Reset value: 0x00000000
+        ICACTIVER0 = 0x0380, // [u32; 32]
+
+        /// 0x0400-0x07F8 - Interrupt Priority Registers (GICD_IPRIORITYR<n>)
+        ///
+        /// Configures the priority of each interrupt.
+        /// Reset value: 0x00000000
+        IPRIORITYR0 = 0x0400, // [u32; 256]
+
+        /// 0x0800-0x081C - Interrupt Processor Targets Registers (GICD_ITARGETSR<n>)
+        ///
+        /// Configures which CPUs receive each interrupt. Read-only, implementation defined.
+        /// RES0 when affinity routing is enabled.
+        ITARGETSR = 0x0800, // [u32; 8]
+
+        /// 0x0C00-0x0CFC - Interrupt Configuration Registers (GICD_ICFGR<n>)
+        ///
+        /// Configures interrupts as level-sensitive or edge-triggered.
+        /// Reset value: implementation defined.
+        ICFGR0 = 0x0C00, // [u32; 64]
+
+        /// 0x0D00-0x0D7C - Interrupt Group Modifier Registers (GICD_IGRPMODR<n>)
+        ///
+        /// Modifies interrupt group behavior.
+        /// Reset value: 0x00000000
+        IGRPMODR = 0x0D00, // [u32; 32]
+
+        /// 0x0E00-0x0EFC - Non-secure Access Control Registers (GICD_NSACR<n>)
+        ///
+        /// Controls non-secure access to secure interrupts.
+        /// Reset value: 0x00000000
+        NSACR = 0x0E00, // [u32; 64]
+
+        /// 0x0F00 - Software Generated Interrupt Register (GICD_SGIR)
+        ///
+        /// Generates software interrupts.
+        /// RES0 when affinity routing is enabled.
+        SGIR = 0x0F00, // u32
+
+        /// 0x0F10-0x0F1C - SGI Clear-Pending Registers (GICD_CPENDSGIR<n>)
+        ///
+        /// Clears pending state of SGIs. Reset value: 0x00000000
+        /// RES0 when affinity routing is enabled.
+        CPENDSGIR = 0x0F10, // [u32; 4]
+
+        /// 0x0F20-0x0F2C - SGI Set-Pending Registers (GICD_SPENDSGIR<n>)
+        ///
+        /// Sets pending state of SGIs. Reset value: 0x00000000
+        /// RES0 when affinity routing is enabled.
+        SPENDSGIR = 0x0F20, // [u32; 4]
+
+        /// 0x0F80-0x0FFC - Non-maskable Interrupt Registers (GICD_INMIR<n>)
+        ///
+        /// Controls non-maskable interrupts.
+        /// Reset value: 0x00000000
+        INMIR = 0x0F80, // [u32; 32]
+
+        // Extended SPI registers (0x1000 onwards)
+
+        /// 0x1000-0x107C - Interrupt Group Registers for extended SPI range (GICD_IGROUPR<n>E)
+        ///
+        /// Configures extended SPIs as Group 0 or Group 1.
+        /// Reset value: 0x00000000
+        IGROUPR_E = 0x1000, // [u32; 32]
+
+        /// 0x1200-0x127C - Interrupt Set-Enable for extended SPI range (GICD_ISENABLER<n>E)
+        ///
+        /// Enables forwarding of extended SPI interrupts.
+        /// Reset value: implementation defined.
+        ISENABLER_E = 0x1200, // [u32; 32]
+
+        /// 0x1400-0x147C - Interrupt Clear-Enable for extended SPI range (GICD_ICENABLER<n>E)
+        ///
+        /// Disables forwarding of extended SPI interrupts.
+        /// Reset value: implementation defined.
+        ICENABLER_E = 0x1400, // [u32; 32]
+
+        /// 0x1600-0x167C - Interrupt Set-Pend for extended SPI range (GICD_ISPENDR<n>E)
+        ///
+        /// Sets the pending state of extended SPI interrupts.
+        /// Reset value: 0x00000000
+        ISPENDR_E = 0x1600, // [u32; 32]
+
+        /// 0x1800-0x187C - Interrupt Clear-Pend for extended SPI range (GICD_ICPENDR<n>E)
+        ///
+        /// Clears the pending state of extended SPI interrupts.
+        /// Reset value: 0x00000000
+        ICPENDR_E = 0x1800, // [u32; 32]
+
+        /// 0x1A00-0x1A7C - Interrupt Set-Active for extended SPI range (GICD_ISACTIVER<n>E)
+        ///
+        /// Sets the active state of extended SPI interrupts.
+        /// Reset value: 0x00000000
+        ISACTIVER_E = 0x1A00, // [u32; 32]
+
+        /// 0x1C00-0x1C7C - Interrupt Clear-Active for extended SPI range (GICD_ICACTIVER<n>E)
+        ///
+        /// Clears the active state of extended SPI interrupts.
+        /// Reset value: 0x00000000
+        ICACTIVER_E = 0x1C00, // [u32; 32]
+
+        /// 0x2000-0x23FC - Interrupt Priority for extended SPI range (GICD_IPRIORITYR<n>E)
+        ///
+        /// Configures the priority of extended SPI interrupts.
+        /// Reset value: 0x00000000
+        IPRIORITYR_E = 0x2000, // [u32; 256]
+
+        /// 0x3000-0x30FC - Extended SPI Configuration Register (GICD_ICFGR<n>E)
+        ///
+        /// Configures extended SPI interrupts as level-sensitive or edge-triggered.
+        /// Reset value: implementation defined.
+        ICFGR_E = 0x3000, // [u32; 64]
+
+        /// 0x3400-0x347C - Interrupt Group Modifier for extended SPI range (GICD_IGRPMODR<n>E)
+        ///
+        /// Modifies extended SPI interrupt group behavior.
+        /// Reset value: 0x00000000
+        IGRPMODR_E = 0x3400, // [u32; 32]
+
+        /// 0x3600-0x36FC - Non-secure Access Control Registers for extended SPI range (GICD_NSACR<n>E)
+        ///
+        /// Controls non-secure access to secure extended SPI interrupts.
+        /// Reset value: 0x00000000
+        NSACR_E = 0x3600, // [u32; 64]
+
+        /// 0x3B00-0x3B7C - Non-maskable Interrupt Registers for Extended SPIs (GICD_INMIR<n>Eg)
+        ///
+        /// Controls non-maskable extended SPI interrupts.
+        /// Reset value: 0x00000000
+        INMIR_E = 0x3B00, // [u32; 32]
+
+        /// 0x6100-0x7FD8 - Interrupt Routing Registers (GICD_IROUTER<n>)
+        ///
+        /// Configures interrupt routing for affinity-based systems.
+        /// Reset value: 0x00000000
+        IROUTER0 = 0x6100, // [u32; 1984]
+
+        /// 0x8000-0x9FFC - Interrupt Routing Registers for extended SPI range (GICD_IROUTER<n>E)
+        ///
+        /// Configures interrupt routing for extended SPI interrupts in affinity-based systems.
+        /// Reset value: 0x00000000
+        IROUTER_E = 0x8000, // [u32; 2048]
+
+        /// 0xFFE8 - Distributor Peripheral ID2 Register (GICD_PIDR2)
+        ///
+        /// Provides version data about the distributor.
+        ///
+        PIDR2 = 0xFFE8, // u32
     }
 }
 
@@ -103,38 +351,145 @@ pub struct GicdCtlr {
     pub rwp: bool,
 }
 
+// GICR registers, "12.11 The GIC Redistributor register descriptions"
+
+pub const GICR_SIZE: usize = 0x20000;
+pub const GICR_FRAME_SIZE: usize = 0x10000;
+
 open_enum! {
+    /// GIC physical LPI Redistributor register map
     pub enum GicrRdRegister: u16 {
+        /// 0x0000 - Redistributor Control Register (GICR_CTLR)
         CTLR = 0x0000,
+
+        /// 0x0004 - Implementer Identification Register (GICR_IIDR)
         IIDR = 0x0004,
-        TYPER = 0x0008,     // 64 bit
+
+        /// 0x0008 - Redistributor Type Register (GICR_TYPER)
+        TYPER = 0x0008,
+
+        /// 0x0010 - Error Reporting Status Register (optional) (GICR_STATUSR)
         STATUSR = 0x0010,
+
+        /// 0x0014 - Redistributor Wake Register (GICR_WAKER)
         WAKER = 0x0014,
+
+        /// 0x0018 - Report maximum PARTID and PMG Register (GICR_MPAMIDR)
         MPAMIDR = 0x0018,
-        PARTIDR = 0x001c,
-        SETLPIR = 0x0040,   // 64 bit
-        CLRLPIR = 0x0048,   // 64 bit
-        PROPBASER = 0x0070, // 64 bit
-        PENDBASER = 0x0078, // 64 bit
-        INVLPIR = 0x00A0,   // 64 bit
-        SYNCR = 0x00C0,     // 64 bit
-        PIDR2 = 0xffe8,
+
+        /// 0x001C - Set PARTID and PMG Register (GICR_PARTIDR)
+        PARTIDR = 0x001C,
+
+        /// 0x0040 - Set LPI Pending Register (GICR_SETLPIR)
+        SETLPIR = 0x0040,
+
+        /// 0x0048 - Clear LPI Pending Register (GICR_CLRLPIR)
+        CLRLPIR = 0x0048,
+
+        /// 0x0070 - Redistributor Properties Base Address Register (GICR_PROPBASER)
+        PROPBASER = 0x0070,
+
+        /// 0x0078 - Redistributor LPI Pending Table Base Address Register (GICR_PENDBASER)
+        PENDBASER = 0x0078,
+
+        /// 0x00A0 - Redistributor Invalidate LPI Register (GICR_INVLPIR)
+        INVLPIR = 0x00A0,
+
+        /// 0x00B0 - Redistributor Invalidate All Register (GICR_INVALLR)
+        INVALLR = 0x00B0,
+
+        /// 0x00C0 - Redistributor Synchronize Register (GICR_SYNCR)
+        SYNCR = 0x00C0,
+
+        /// Distributor Peripheral ID2 (GICR_PIDR2)
+        PIDR2 = 0xFFE8,
     }
 }
 
 open_enum! {
+    /// GIC SGI and PPI Redistributor register map
+    /// See "12.10 The GIC Redistributor register map"
     pub enum GicrSgiRegister: u16 {
-        IGROUPR0 = 0x0080,
-        ISENABLER0 = 0x0100,
-        ICENABLER0 = 0x0180,
-        ISPENDR0 = 0x0200,
-        ICPENDR0 = 0x0280,
-        ISACTIVER0 = 0x0300,
-        ICACTIVER0 = 0x0380,
-        IPRIORITYR0 = 0x0400, // 0x20
-        ICFGR0 = 0x0c00,
-        ICFGR1 = 0x0c04,
-        IGRPMODR0 = 0x0d00,
+        /// 0x0080 - Interrupt Group Register 0 (GICR_IGROUPR0)
+        ///
+        /// `1` means Group0, `0` means Secure if `GICD_CTRL.DS` == `1`.
+        IGROUPR0 = 0x0080, // u32
+
+        /// 0x0084-0x0088 - Interrupt Group Registers for extended PPI range (GICR_IGROUPR<n>E)
+        IGROUPR_E = 0x0084, // [u32; 2]
+
+        /// 0x0100 - Interrupt Set-Enable Register 0 (GICR_ISENABLER0)
+        ISENABLER0 = 0x0100, // u32
+
+        /// 0x0104-0x0108 - Interrupt Set-Enable for extended PPI range (GICR_ISENABLER<n>E)
+        ISENABLER_E = 0x0104, // [u32; 2]
+
+        /// 0x0180 - Interrupt Clear-Enable Register 0 (GICR_ICENABLER0)
+        ICENABLER0 = 0x0180, // u32
+
+        /// 0x0184-0x0188 - Interrupt Clear-Enable for extended PPI range (GICR_ICENABLER<n>E)
+        ICENABLER_E = 0x0184, // [u32; 2]
+
+        /// 0x0200 - Interrupt Set-Pend Register 0 (GICR_ISPENDR0)
+        ISPENDR0 = 0x0200, // u32
+
+        /// 0x0204-0x0208 - Interrupt Set-Pend for extended PPI range (GICR_ISPENDR<n>E)
+        ISPENDR0_E = 0x0204, // [u32; 2]
+
+        /// 0x0280 - Interrupt Clear-Pend Register 0 (GICR_ICPENDR0)
+        ICPENDR0 = 0x0280, // u32
+
+        /// 0x0284-0x0288 - Interrupt Clear-Pend for extended PPI range (GICR_ICPENDR<n>E)
+        ICPENDR_E = 0x0284, // [u32; 2]
+
+        /// 0x0300 - Interrupt Set-Active Register 0 (GICR_ISACTIVER0)
+        ISACTIVER0 = 0x0300, // u32
+
+        /// 0x0304-0x0308 - Interrupt Set-Active for extended PPI range (GICR_ISACTIVER<n>E)
+        ISACTIVER0_E = 0x0304, // [u32; 2]
+
+        /// 0x0380 - Interrupt Clear-Active Register 0 (GICR_ICACTIVER0)
+        ICACTIVER0 = 0x0380, // u32
+
+        /// 0x0384-0x0388 - Interrupt Clear-Active for extended PPI range (GICR_ICACTIVER<n>E)
+        ICACTIVER0_E = 0x0384, // [u32; 2]
+
+        /// 0x0400-0x041C - Interrupt Priority Registers (GICR_IPRIORITYR<n>)
+        ///
+        /// - GICR_IPRIORITYR0-GICR_IPRIORITYR3 store the priority of SGIs.
+        /// - GICR_IPRIORITYR4-GICR_IPRIORITYR7 store the priority of PPIs.
+        ///
+        /// Interrupt priority value from an IMPLEMENTATION DEFINED range,
+        /// takes 8 bits. Lower priority values correspond to greater priority
+        /// of the interrupt. For an INTID configured as non-maskable, this field is RES0.
+        IPRIORITYR0 = 0x0400, // [u32; 8]
+
+        /// 0x0420-0x045C - Interrupt Priority for extended PPI range (GICR_IPRIORITYR<n>E)
+        IPRIORITYR_E = 0x0420, // [u32; 16]
+
+        /// 0x0C00 - SGI Configuration Register (GICR_ICFGR0)
+        ICFGR0 = 0x0C00, // u32
+
+        /// 0x0C04 - PPI Configuration Register (GICR_ICFGR1)
+        ICFGR1 = 0x0C04, // u32
+
+        /// 0x0C08-0x0C14 - Extended PPI Configuration Register (GICR_ICFGR<n>E)
+        ICFGR_E = 0x0C08, // [u32; 4]
+
+        /// 0x0D00 - Interrupt Group Modifier Register 0 (GICR_IGRPMODR0)
+        IGRPMODR0 = 0x0D00, // u32
+
+        /// 0x0D04-0x0D08 - Interrupt Group Modifier for extended PPI range (GICR_IGRPMODR<n>E)
+        IGRPMODR_E = 0x0D04, // [u32; 2]
+
+        /// 0x0E00 - Non-Secure Access Control Register (GICR_NSACR)
+        NSACR = 0x0E00, // u32
+
+        /// 0x0F80 - Non-maskable Interrupt Register for PPIs and SGIs (GICR_INMIR0)
+        INMIR0 = 0x0F80, // u32
+
+        /// 0x0F84-0x0FFC - Non-maskable Interrupt Registers for Extended PPIs (GICR_INMIR<n>E)
+        INMIR_E = 0x0F84, // [u32; 31]
     }
 }
 


### PR DESCRIPTION
The code was first incubated outside of this repository, and the GIC initialization sequence follows what the Linux kernel does and what is recommended by ARM. Will need to improve/extend the definitions.

- [x] exception table and the exception frame
- [ ] rust exception handler code
- [x] initialize GICD
- [x] initialize GICR
- [x] initialize ICC
- [x] send an SGI
- [ ] check pending, acknowledge the interrupt, EOI
