### PR TITLE
tmk_vmm: drain paravisor partition before starting next test

### DIFF
--- a/support/pal/pal_uring/src/threadpool.rs
+++ b/support/pal/pal_uring/src/threadpool.rs
@@ -73,10 +73,10 @@ impl IoUringPool {
         &self.client
     }
 
-    /// Runs the pool until it is shut down.
-    ///
-    /// Typically this is called on a dedicated thread.
+    /// Runs the pool until all clients have been dropped and any registered idle
+    /// tasks have completed.
     pub fn run(mut self) {
+        drop(self.client);
         self.worker.run(self.completion_ring, self.queue.run())
     }
 }
@@ -99,9 +99,16 @@ impl PoolClient {
     where
         F: 'static + Send + AsyncFnOnce(IdleControl),
     {
-        let f =
-            Box::new(|fd| Box::pin(async move { f(fd).await }) as Pin<Box<dyn Future<Output = _>>>)
-                as Box<dyn Send + FnOnce(IdleControl) -> Pin<Box<dyn Future<Output = ()>>>>;
+        // Keep the pool alive as long as the idle task is running by keeping a
+        // clone of this client.
+        let keep_pool_alive = self.clone();
+        let f = Box::new(|fd| {
+            Box::pin(async move {
+                let _keep_pool_alive = keep_pool_alive;
+                f(fd).await
+            }) as Pin<Box<dyn Future<Output = _>>>
+        })
+            as Box<dyn Send + FnOnce(IdleControl) -> Pin<Box<dyn Future<Output = ()>>>>;
 
         // Spawn a short-lived task to update the idle task.
         let worker_id = Arc::as_ptr(&self.0.client.worker) as usize; // cast because pointers are not Send
@@ -623,6 +630,7 @@ impl<T, Init: Borrow<IoInitiator>> Drop for Io<T, Init> {
 mod tests {
     use super::Io;
     use super::IoRing;
+    use crate::IoUringPool;
     use crate::uring::tests::SingleThreadPool;
     use futures::executor::block_on;
     use io_uring::opcode;
@@ -633,6 +641,8 @@ mod tests {
     use std::os::unix::prelude::*;
     use std::pin::Pin;
     use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
     use std::task::Context;
     use std::task::Poll;
     use std::task::Waker;
@@ -978,5 +988,33 @@ mod tests {
                 assert_eq!(&write_buf[..], &read_buf[..]);
             })
             .detach();
+    }
+
+    #[test]
+    fn test_run_until_none() {
+        skip_if_no_io_uring_support!();
+        let (send, recv) = futures::channel::oneshot::channel();
+        let (send2, recv2) = futures::channel::oneshot::channel();
+        let pool = IoUringPool::new("test", 16).unwrap();
+        let done = Arc::new(AtomicBool::new(false));
+        pool.client()
+            .initiator()
+            .spawn("hmm", {
+                async move {
+                    recv.await.unwrap();
+                    send2.send(()).unwrap();
+                }
+            })
+            .detach();
+        pool.client().set_idle_task({
+            let done = done.clone();
+            |_ctl| async move {
+                send.send(()).unwrap();
+                recv2.await.unwrap();
+                done.store(true, Ordering::SeqCst);
+            }
+        });
+        pool.run();
+        assert!(done.load(Ordering::SeqCst));
     }
 }

--- a/support/pal/pal_uring/src/threadpool.rs
+++ b/support/pal/pal_uring/src/threadpool.rs
@@ -628,6 +628,11 @@ impl<T, Init: Borrow<IoInitiator>> Drop for Io<T, Init> {
 
 #[cfg(test)]
 mod tests {
+    #![expect(
+        clippy::disallowed_methods,
+        reason = "test code using futures channels"
+    )]
+
     use super::Io;
     use super::IoRing;
     use crate::IoUringPool;

--- a/tmk/tmk_vmm/src/paravisor_vmm.rs
+++ b/tmk/tmk_vmm/src/paravisor_vmm.rs
@@ -67,17 +67,31 @@ impl RunContext<'_> {
 
         let partition = Arc::new(partition);
 
-        self.run(m.vtl0(), partition.caps(), test, async |_this, runner| {
-            let [vp] = vps.try_into().ok().unwrap();
-            start_vp(vp, runner).await?;
-            Ok(())
-        })
-        .await
+        let mut threads = Vec::new();
+        let r = self
+            .run(m.vtl0(), partition.caps(), test, async |_this, runner| {
+                let [vp] = vps.try_into().ok().unwrap();
+                threads.push(start_vp(vp, runner).await?);
+                Ok(())
+            })
+            .await?;
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        // Ensure the partition has not leaked.
+        Arc::into_inner(partition).expect("partition is no longer referenced");
+
+        Ok(r)
     }
 }
 
-async fn start_vp(mut vp: UhProcessorBox, mut runner: RunnerBuilder) -> anyhow::Result<()> {
-    std::thread::spawn(move || {
+async fn start_vp(
+    mut vp: UhProcessorBox,
+    mut runner: RunnerBuilder,
+) -> anyhow::Result<std::thread::JoinHandle<()>> {
+    let vp_thread = std::thread::spawn(move || {
         let pool = pal_uring::IoUringPool::new("vp", 256).unwrap();
         let driver = pool.client().initiator().clone();
         pool.client().set_idle_task(async move |mut control| {
@@ -89,5 +103,5 @@ async fn start_vp(mut vp: UhProcessorBox, mut runner: RunnerBuilder) -> anyhow::
         });
         pool.run()
     });
-    Ok(())
+    Ok(vp_thread)
 }


### PR DESCRIPTION
Ensure the paravisor partition has been fully dropped before proceeding to the next test. This should fix some race conditions causing VTL0 triple faults.