### PR TITLE
vmgs: reformat via dps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,7 +4901,6 @@ dependencies = [
  "dirs",
  "disk_backend_resources",
  "disk_crypt_resources",
- "disk_vhd1",
  "firmware_uefi_custom_vars",
  "floppy_resources",
  "framebuffer",

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1362,7 +1362,9 @@ async fn new_underhill_vm(
             let meta = disk.save_meta();
             let disk = Disk::new(disk).context("invalid vmgs disk")?;
 
-            let vmgs = if !env_cfg.reformat_vmgs {
+            let reformat_vmgs = env_cfg.reformat_vmgs || dps.general.reformat_vmgs;
+
+            let vmgs = if !reformat_vmgs {
                 match Vmgs::open(
                     disk.clone(),
                     Some(Arc::new(GetVmgsLogger::new(get_client.clone()))),
@@ -3064,6 +3066,7 @@ fn validate_isolated_configuration(dps: &DevicePlatformSettings) -> Result<(), a
         watchdog_enabled: _,
         vtl2_settings: _,
         cxl_memory_enabled: _,
+        reformat_vmgs: _,
     } = &dps.general;
 
     if *hibernation_enabled {

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -178,7 +178,7 @@ impl Manifest {
             vtl2_vmbus: config.vtl2_vmbus,
             #[cfg(all(windows, feature = "virt_whp"))]
             vpci_resources: config.vpci_resources,
-            format_vmgs: config.format_vmgs,
+            reformat_vmgs: config.reformat_vmgs,
             vmgs_disk: config.vmgs_disk,
             secure_boot_enabled: config.secure_boot_enabled,
             custom_uefi_vars: config.custom_uefi_vars,
@@ -219,7 +219,7 @@ pub struct Manifest {
     vtl2_vmbus: Option<VmbusConfig>,
     #[cfg(all(windows, feature = "virt_whp"))]
     vpci_resources: Vec<virt_whp::device::DeviceHandle>,
-    format_vmgs: bool,
+    reformat_vmgs: bool,
     vmgs_disk: Option<Resource<DiskHandleKind>>,
     secure_boot_enabled: bool,
     custom_uefi_vars: firmware_uefi_custom_vars::CustomVars,
@@ -968,7 +968,7 @@ impl InitializedVm {
 
         let (vmgs_client, vmgs_task) = if let Some(vmgs_file) = cfg.vmgs_disk {
             let disk = open_simple_disk(&resolver, vmgs_file, false).await?;
-            let vmgs = if cfg.format_vmgs {
+            let vmgs = if cfg.reformat_vmgs {
                 vmgs::Vmgs::format_new(disk, None)
                     .await
                     .context("failed to format vmgs file")?
@@ -2854,7 +2854,7 @@ impl LoadedVm {
             #[cfg(all(windows, feature = "virt_whp"))]
             vpci_resources: vec![], // TODO
             vmgs_disk: None,        // TODO
-            format_vmgs: false,     // TODO
+            reformat_vmgs: false,   // TODO
             secure_boot_enabled: false, // TODO
             custom_uefi_vars: Default::default(), // TODO
             firmware_event_send: self.inner.firmware_event_send,

--- a/openvmm/hvlite_defs/src/config.rs
+++ b/openvmm/hvlite_defs/src/config.rs
@@ -43,7 +43,7 @@ pub struct Config {
     pub virtio_devices: Vec<(VirtioBus, Resource<VirtioDeviceHandle>)>,
     #[cfg(windows)]
     pub vpci_resources: Vec<virt_whp::device::DeviceHandle>,
-    pub format_vmgs: bool,
+    pub reformat_vmgs: bool,
     pub vmgs_disk: Option<Resource<DiskHandleKind>>,
     pub secure_boot_enabled: bool,
     pub custom_uefi_vars: firmware_uefi_custom_vars::CustomVars,

--- a/openvmm/hvlite_helpers/src/disk.rs
+++ b/openvmm/hvlite_helpers/src/disk.rs
@@ -12,50 +12,34 @@ use vm_resource::kind::DiskHandleKind;
 /// If the file ends with .vhd and is a fixed VHD1, it will be opened using
 /// the user-mode VHD parser. Otherwise, if the file ends with .vhd or
 /// .vhdx, the file will be opened using the kernel-mode VHD parser.
-pub fn open_disk_type(
-    path: &Path,
-    read_only: bool,
-    create_with_len: Option<u64>,
-) -> anyhow::Result<Resource<DiskHandleKind>> {
+pub fn open_disk_type(path: &Path, read_only: bool) -> anyhow::Result<Resource<DiskHandleKind>> {
     Ok(match path.extension().and_then(|s| s.to_str()) {
         Some("vhd") => {
-            let overwrite = create_with_len.is_some();
             let file = std::fs::OpenOptions::new()
-                .create(overwrite)
-                .truncate(overwrite)
                 .read(true)
                 .write(!read_only)
                 .open(path)?;
 
-            if let Some(size) = create_with_len {
-                file.set_len(size)?;
-                disk_vhd1::Vhd1Disk::make_fixed(&file)?;
-                Resource::new(disk_backend_resources::FixedVhd1DiskHandle(file))
-            } else {
-                match disk_vhd1::Vhd1Disk::open_fixed(file, read_only) {
-                    Ok(vhd) => Resource::new(disk_backend_resources::FixedVhd1DiskHandle(
-                        vhd.into_inner(),
-                    )),
-                    Err(disk_vhd1::OpenError::NotFixed) => {
-                        #[cfg(windows)]
-                        {
-                            Resource::new(disk_vhdmp::OpenVhdmpDiskConfig(
-                                disk_vhdmp::VhdmpDisk::open_vhd(path, read_only)?,
-                            ))
-                        }
-                        #[cfg(not(windows))]
-                        anyhow::bail!("non-fixed VHD not supported on Linux");
+            match disk_vhd1::Vhd1Disk::open_fixed(file, read_only) {
+                Ok(vhd) => Resource::new(disk_backend_resources::FixedVhd1DiskHandle(
+                    vhd.into_inner(),
+                )),
+                Err(disk_vhd1::OpenError::NotFixed) => {
+                    #[cfg(windows)]
+                    {
+                        Resource::new(disk_vhdmp::OpenVhdmpDiskConfig(
+                            disk_vhdmp::VhdmpDisk::open_vhd(path, read_only)?,
+                        ))
                     }
-                    Err(err) => return Err(err.into()),
+                    #[cfg(not(windows))]
+                    anyhow::bail!("non-fixed VHD not supported on Linux");
                 }
+                Err(err) => return Err(err.into()),
             }
         }
         Some("vhdx") => {
             #[cfg(windows)]
             {
-                if create_with_len.is_some() {
-                    anyhow::bail!("Creating VHDX not supported")
-                }
                 Resource::new(disk_vhdmp::OpenVhdmpDiskConfig(
                     disk_vhdmp::VhdmpDisk::open_vhd(path, read_only)?,
                 ))
@@ -69,18 +53,10 @@ pub fn open_disk_type(
         Some("vmgs") => {
             // VMGS files are fixed VHD1s. Don't bother to validate the footer
             // here; let the resource resolver do that later.
-            let overwrite = create_with_len.is_some();
             let file = std::fs::OpenOptions::new()
-                .create(overwrite)
-                .truncate(overwrite)
                 .read(true)
                 .write(!read_only)
                 .open(path)?;
-
-            if let Some(size) = create_with_len {
-                file.set_len(size)?;
-                disk_vhd1::Vhd1Disk::make_fixed(&file)?;
-            }
 
             Resource::new(disk_backend_resources::FixedVhd1DiskHandle(file))
         }
@@ -90,6 +66,41 @@ pub fn open_disk_type(
                 .write(!read_only)
                 .open(path)?;
 
+            Resource::new(disk_backend_resources::FileDiskHandle(file))
+        }
+    })
+}
+
+/// Create and open the resources needed for using a disk from a file at `path`.
+pub fn create_disk_type(path: &Path, size: u64) -> anyhow::Result<Resource<DiskHandleKind>> {
+    Ok(match path.extension().and_then(|s| s.to_str()) {
+        Some("vhd") | Some("vmgs") => {
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .read(true)
+                .write(true)
+                .open(path)?;
+
+            file.set_len(size)?;
+            disk_vhd1::Vhd1Disk::make_fixed(&file)?;
+            Resource::new(disk_backend_resources::FixedVhd1DiskHandle(file))
+        }
+        Some("vhdx") => {
+            anyhow::bail!("creating vhdx no supported")
+        }
+        Some("iso") => {
+            anyhow::bail!("creating iso no supported")
+        }
+        _ => {
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .read(true)
+                .write(true)
+                .open(path)?;
+
+            file.set_len(size)?;
             Resource::new(disk_backend_resources::FileDiskHandle(file))
         }
     })

--- a/openvmm/hvlite_helpers/src/disk.rs
+++ b/openvmm/hvlite_helpers/src/disk.rs
@@ -12,34 +12,50 @@ use vm_resource::kind::DiskHandleKind;
 /// If the file ends with .vhd and is a fixed VHD1, it will be opened using
 /// the user-mode VHD parser. Otherwise, if the file ends with .vhd or
 /// .vhdx, the file will be opened using the kernel-mode VHD parser.
-pub fn open_disk_type(path: &Path, read_only: bool) -> anyhow::Result<Resource<DiskHandleKind>> {
+pub fn open_disk_type(
+    path: &Path,
+    read_only: bool,
+    create_with_len: Option<u64>,
+) -> anyhow::Result<Resource<DiskHandleKind>> {
     Ok(match path.extension().and_then(|s| s.to_str()) {
         Some("vhd") => {
+            let overwrite = create_with_len.is_some();
             let file = std::fs::OpenOptions::new()
+                .create(overwrite)
+                .truncate(overwrite)
                 .read(true)
                 .write(!read_only)
                 .open(path)?;
 
-            match disk_vhd1::Vhd1Disk::open_fixed(file, read_only) {
-                Ok(vhd) => Resource::new(disk_backend_resources::FixedVhd1DiskHandle(
-                    vhd.into_inner(),
-                )),
-                Err(disk_vhd1::OpenError::NotFixed) => {
-                    #[cfg(windows)]
-                    {
-                        Resource::new(disk_vhdmp::OpenVhdmpDiskConfig(
-                            disk_vhdmp::VhdmpDisk::open_vhd(path, read_only)?,
-                        ))
+            if let Some(size) = create_with_len {
+                file.set_len(size)?;
+                disk_vhd1::Vhd1Disk::make_fixed(&file)?;
+                Resource::new(disk_backend_resources::FixedVhd1DiskHandle(file))
+            } else {
+                match disk_vhd1::Vhd1Disk::open_fixed(file, read_only) {
+                    Ok(vhd) => Resource::new(disk_backend_resources::FixedVhd1DiskHandle(
+                        vhd.into_inner(),
+                    )),
+                    Err(disk_vhd1::OpenError::NotFixed) => {
+                        #[cfg(windows)]
+                        {
+                            Resource::new(disk_vhdmp::OpenVhdmpDiskConfig(
+                                disk_vhdmp::VhdmpDisk::open_vhd(path, read_only)?,
+                            ))
+                        }
+                        #[cfg(not(windows))]
+                        anyhow::bail!("non-fixed VHD not supported on Linux");
                     }
-                    #[cfg(not(windows))]
-                    anyhow::bail!("non-fixed VHD not supported on Linux");
+                    Err(err) => return Err(err.into()),
                 }
-                Err(err) => return Err(err.into()),
             }
         }
         Some("vhdx") => {
             #[cfg(windows)]
             {
+                if create_with_len.is_some() {
+                    anyhow::bail!("Creating VHDX not supported")
+                }
                 Resource::new(disk_vhdmp::OpenVhdmpDiskConfig(
                     disk_vhdmp::VhdmpDisk::open_vhd(path, read_only)?,
                 ))
@@ -53,10 +69,18 @@ pub fn open_disk_type(path: &Path, read_only: bool) -> anyhow::Result<Resource<D
         Some("vmgs") => {
             // VMGS files are fixed VHD1s. Don't bother to validate the footer
             // here; let the resource resolver do that later.
+            let overwrite = create_with_len.is_some();
             let file = std::fs::OpenOptions::new()
+                .create(overwrite)
+                .truncate(overwrite)
                 .read(true)
                 .write(!read_only)
                 .open(path)?;
+
+            if let Some(size) = create_with_len {
+                file.set_len(size)?;
+                disk_vhd1::Vhd1Disk::make_fixed(&file)?;
+            }
 
             Resource::new(disk_backend_resources::FixedVhd1DiskHandle(file))
         }

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -33,7 +33,6 @@ hvlite_pcat_locator.workspace = true
 hvlite_ttrpc_vmservice.workspace = true
 disk_backend_resources.workspace = true
 disk_crypt_resources.workspace = true
-disk_vhd1.workspace = true
 firmware_uefi_custom_vars.workspace = true
 hyperv_secure_boot_templates.workspace = true
 hyperv_uefi_custom_vars_json.workspace = true

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -97,12 +97,6 @@ pub struct Options {
     #[clap(long, conflicts_with("get"))]
     pub no_get: bool,
 
-    /// The disk to use for the GET VMGS.
-    ///
-    /// If this is not provided, then a 4MB RAM disk will be used.
-    #[clap(long)]
-    pub get_vmgs: Option<DiskCliKind>,
-
     /// disable the VTL0 alias map presented to VTL2 by default
     #[clap(long, requires("vtl2"))]
     pub no_alias_map: bool,
@@ -392,9 +386,15 @@ flags:
     #[clap(long, value_parser = vmbus_core::parse_vmbus_version)]
     pub vmbus_max_version: Option<u32>,
 
-    /// path to vmgs file. if no file is provided, fallback to in-memory vmgs implementation
-    #[clap(long, value_name = "PATH")]
-    pub vmgs_file: Option<PathBuf>,
+    /// The disk to use for the VMGS.
+    ///
+    /// If this is not provided, then fallback to using in-memory VMGS storage.
+    #[clap(long)]
+    pub vmgs: Option<DiskCliKind>,
+
+    /// Reformat the VMGS disk
+    #[clap(long)]
+    pub reformat_vmgs: bool,
 
     /// VGA firmware file
     #[clap(long, requires("pcat"), value_name = "FILE")]
@@ -656,7 +656,10 @@ pub enum DiskCliKind {
     // prwrap:<kind>
     PersistentReservationsWrapper(Box<DiskCliKind>),
     // file:<path>
-    File(PathBuf),
+    File {
+        path: PathBuf,
+        create_with_len: Option<u64>,
+    },
     // blob:<type>:<url>
     Blob {
         kind: BlobKind,
@@ -682,32 +685,48 @@ pub enum BlobKind {
     Vhd1,
 }
 
+fn parse_path_and_len(arg: &str) -> anyhow::Result<(PathBuf, Option<u64>)> {
+    Ok(match arg.split_once(';') {
+        Some((path, len)) => {
+            let Some(len) = len.strip_prefix("create=") else {
+                anyhow::bail!("invalid syntax after ';', expected 'create=<len>'")
+            };
+
+            let len: u64 = if len == "VMGS_DEFAULT" {
+                vmgs_format::VMGS_DEFAULT_CAPACITY
+            } else {
+                parse_memory(len)?
+            };
+
+            (path.into(), Some(len))
+        }
+        None => (arg.into(), None),
+    })
+}
+
 impl FromStr for DiskCliKind {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
         let disk = match s.split_once(':') {
             // convenience support for passing bare paths as file disks
-            None => DiskCliKind::File(PathBuf::from(s)),
+            None => {
+                let (path, create_with_len) = parse_path_and_len(s)?;
+                DiskCliKind::File {
+                    path,
+                    create_with_len,
+                }
+            }
             Some((kind, arg)) => match kind {
                 "mem" => DiskCliKind::Memory(parse_memory(arg)?),
                 "memdiff" => DiskCliKind::MemoryDiff(Box::new(arg.parse()?)),
-                "sql" => match arg.split_once(';') {
-                    Some((path, len)) => {
-                        let Some(len) = len.strip_prefix("create=") else {
-                            anyhow::bail!("invalid syntax after ';', expected 'create=<len>'")
-                        };
-
-                        DiskCliKind::Sqlite {
-                            path: path.into(),
-                            create_with_len: Some(parse_memory(len)?),
-                        }
+                "sql" => {
+                    let (path, create_with_len) = parse_path_and_len(arg)?;
+                    DiskCliKind::Sqlite {
+                        path,
+                        create_with_len,
                     }
-                    None => DiskCliKind::Sqlite {
-                        path: arg.into(),
-                        create_with_len: None,
-                    },
-                },
+                }
                 "sqldiff" => {
                     let (path_and_opts, kind) =
                         arg.split_once(':').context("expected path[;opts]:kind")?;
@@ -742,7 +761,13 @@ impl FromStr for DiskCliKind {
                     }
                 }
                 "prwrap" => DiskCliKind::PersistentReservationsWrapper(Box::new(arg.parse()?)),
-                "file" => DiskCliKind::File(PathBuf::from(arg)),
+                "file" => {
+                    let (path, create_with_len) = parse_path_and_len(s)?;
+                    DiskCliKind::File {
+                        path,
+                        create_with_len,
+                    }
+                }
                 "blob" => {
                     let (blob_kind, url) = arg.split_once(':').context("expected kind:url")?;
                     let blob_kind = match blob_kind {
@@ -772,9 +797,12 @@ impl FromStr for DiskCliKind {
                     //
                     // in this case, we actually want to treat that leading `d:` as part of the
                     // path, rather than as a disk with `kind == 'd'`
-                    let path_buf = PathBuf::from(s);
-                    if path_buf.has_root() {
-                        DiskCliKind::File(path_buf)
+                    let (path, create_with_len) = parse_path_and_len(s)?;
+                    if path.has_root() {
+                        DiskCliKind::File {
+                            path,
+                            create_with_len,
+                        }
                     } else {
                         anyhow::bail!("invalid disk kind {kind}");
                     }
@@ -782,6 +810,26 @@ impl FromStr for DiskCliKind {
             },
         };
         Ok(disk)
+    }
+}
+
+impl DiskCliKind {
+    pub fn is_new(&self) -> bool {
+        match self {
+            DiskCliKind::Memory(_) => true,
+            DiskCliKind::MemoryDiff(disk) => disk.is_new(),
+            DiskCliKind::Sqlite {
+                create_with_len, ..
+            } => create_with_len.is_some(),
+            DiskCliKind::SqliteDiff { disk, .. } => disk.is_new(),
+            DiskCliKind::AutoCacheSqlite { disk, .. } => disk.is_new(),
+            DiskCliKind::PersistentReservationsWrapper(disk) => disk.is_new(),
+            DiskCliKind::File {
+                create_with_len, ..
+            } => create_with_len.is_some(),
+            DiskCliKind::Blob { .. } => false,
+            DiskCliKind::Crypt { disk, .. } => disk.is_new(),
+        }
     }
 }
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -655,7 +655,7 @@ pub enum DiskCliKind {
     },
     // prwrap:<kind>
     PersistentReservationsWrapper(Box<DiskCliKind>),
-    // file:<path>
+    // file:<path>[;create=<len>]
     File {
         path: PathBuf,
         create_with_len: Option<u64>,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -858,6 +858,15 @@ fn vm_config_from_command_line(
         };
     }
 
+    let (mut vmgs_disk, reformat_vmgs) = if let Some(disk) = &opt.vmgs {
+        (
+            Some(disk_open(disk, false).context("failed to open vmgs disk")?),
+            disk.is_new() || opt.reformat_vmgs,
+        )
+    } else {
+        (None, false)
+    };
+
     if with_get && with_hv {
         let vtl2_settings = vtl2_settings_proto::Vtl2Settings {
             version: vtl2_settings_proto::vtl2_settings_base::Version::V1.into(),
@@ -871,14 +880,7 @@ fn vm_config_from_command_line(
 
         let (send, guest_request_recv) = mesh::channel();
         resources.ged_rpc = Some(send);
-        let vmgs_disk = if let Some(disk) = &opt.get_vmgs {
-            disk_open(disk, false).context("failed to open GET vmgs disk")?
-        } else {
-            disk_backend_resources::LayeredDiskHandle::single_layer(RamDiskLayerHandle {
-                len: Some(vmgs_format::VMGS_DEFAULT_CAPACITY),
-            })
-            .into_resource()
-        };
+
         vmbus_devices.extend([
             (
                 openhcl_vtl,
@@ -927,7 +929,7 @@ fn vm_config_from_command_line(
                     com2: with_vmbus_com2_serial,
                     vtl2_settings: Some(prost::Message::encode_to_vec(&vtl2_settings)),
                     vmbus_redirection: opt.vmbus_redirect,
-                    vmgs_disk: Some(vmgs_disk),
+                    vmgs_disk: vmgs_disk.take(),
                     framebuffer: opt
                         .vtl2_gfx
                         .then(|| SharedFramebufferHandle.into_resource()),
@@ -948,7 +950,7 @@ fn vm_config_from_command_line(
                     },
                     enable_battery: opt.battery,
                     no_persistent_secrets: true,
-                    reformat_vmgs: false,
+                    reformat_vmgs,
                 }
                 .into_resource(),
             ),
@@ -962,7 +964,7 @@ fn vm_config_from_command_line(
             TpmRegisterLayout::Mmio
         };
 
-        let (ppi_store, nvram_store) = if opt.vmgs_file.is_some() {
+        let (ppi_store, nvram_store) = if opt.vmgs.is_some() {
             (
                 VmgsFileHandle::new(vmgs_format::FileId::TPM_PPI, true).into_resource(),
                 VmgsFileHandle::new(vmgs_format::FileId::TPM_NVRAM, true).into_resource(),
@@ -1265,27 +1267,6 @@ fn vm_config_from_command_line(
         );
     }
 
-    let (vmgs_disk, format_vmgs) = if let Some(path) = &opt.vmgs_file {
-        let file = fs_err::OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .open(path)
-            .context("failed to create or open vmgs file")?;
-        let format_vmgs = file.metadata()?.len() == 0;
-        if format_vmgs {
-            file.set_len(vmgs_format::VMGS_DEFAULT_CAPACITY)?;
-            disk_vhd1::Vhd1Disk::make_fixed(file.file())
-                .context("failed to format VHD1 file for VMGS")?;
-        }
-        (
-            Some(disk_backend_resources::FixedVhd1DiskHandle(file.into()).into_resource()),
-            format_vmgs,
-        )
-    } else {
-        (None, false)
-    };
-
     let mut cfg = Config {
         chipset,
         load_mode,
@@ -1351,7 +1332,7 @@ fn vm_config_from_command_line(
         #[cfg(windows)]
         vpci_resources,
         vmgs_disk,
-        format_vmgs,
+        reformat_vmgs,
         secure_boot_enabled: opt.secure_boot,
         custom_uefi_vars,
         firmware_event_send: None,
@@ -1537,8 +1518,11 @@ fn disk_open_inner(
         &DiskCliKind::Memory(len) => {
             layers.push(layer(RamDiskLayerHandle { len: Some(len) }));
         }
-        DiskCliKind::File(path) => layers.push(LayerOrDisk::Disk(
-            open_disk_type(path, read_only)
+        DiskCliKind::File {
+            path,
+            create_with_len,
+        } => layers.push(LayerOrDisk::Disk(
+            open_disk_type(path, read_only, *create_with_len)
                 .with_context(|| format!("failed to open {}", path.display()))?,
         )),
         DiskCliKind::Blob { kind, url } => {
@@ -2563,7 +2547,7 @@ async fn run_control(driver: &DefaultDriver, mesh: &VmmMesh, opt: Options) -> an
                     let disk_type = match ram {
                         None => {
                             let path = file_path.context("no filename passed")?;
-                            open_disk_type(path.as_ref(), read_only)
+                            open_disk_type(path.as_ref(), read_only, None)
                                 .with_context(|| format!("failed to open {}", path.display()))?
                         }
                         Some(size) => {

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -948,6 +948,7 @@ fn vm_config_from_command_line(
                     },
                     enable_battery: opt.battery,
                     no_persistent_secrets: true,
+                    reformat_vmgs: false,
                 }
                 .into_resource(),
             ),

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -499,7 +499,7 @@ impl VmService {
             #[cfg(windows)]
             vpci_resources: vec![],
             vmgs_disk: None,
-            format_vmgs: false,
+            reformat_vmgs: false,
             secure_boot_enabled: false,
             custom_uefi_vars: Default::default(),
             firmware_event_send: None,
@@ -740,7 +740,7 @@ fn make_disk_config(disk: vmservice::ScsiDisk) -> anyhow::Result<ScsiDeviceAndPa
             lun: disk.lun.try_into().ok().context("lun value out of range")?,
         },
         device: SimpleScsiDiskHandle {
-            disk: open_disk_type(disk.host_path.as_ref(), disk.read_only)
+            disk: open_disk_type(disk.host_path.as_ref(), disk.read_only, None)
                 .with_context(|| format!("failed to open {}", disk.host_path))?,
             read_only: disk.read_only,
             parameters: Default::default(),

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -740,7 +740,7 @@ fn make_disk_config(disk: vmservice::ScsiDisk) -> anyhow::Result<ScsiDeviceAndPa
             lun: disk.lun.try_into().ok().context("lun value out of range")?,
         },
         device: SimpleScsiDiskHandle {
-            disk: open_disk_type(disk.host_path.as_ref(), disk.read_only, None)
+            disk: open_disk_type(disk.host_path.as_ref(), disk.read_only)
                 .with_context(|| format!("failed to open {}", disk.host_path))?,
             read_only: disk.read_only,
             parameters: Default::default(),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -859,6 +859,7 @@ impl PetriVmConfigSetupCore<'_> {
             secure_boot_template: get_resources::ged::GuestSecureBootTemplateType::None,
             enable_battery: false,
             no_persistent_secrets: true,
+            reformat_vmgs: false,
         };
 
         Ok((ged, guest_request_send))

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -348,7 +348,7 @@ impl PetriVmConfigOpenVmm {
             #[cfg(windows)]
             vpci_resources: vec![],
             vmgs_disk: None,
-            format_vmgs: false,
+            reformat_vmgs: false,
             secure_boot_enabled: false,
             debugger_rpc: None,
             generation_id_recv: None,
@@ -649,7 +649,7 @@ impl PetriVmConfigSetupCore<'_> {
             }
             Firmware::Pcat { guest, .. } => {
                 let disk_path = guest.artifact();
-                let inner_disk = open_disk_type(disk_path.as_ref(), true)?;
+                let inner_disk = open_disk_type(disk_path.as_ref(), true, None)?;
                 let guest_media = match guest {
                     PcatGuest::Vhd(_) => GuestMedia::Disk {
                         read_only: false,
@@ -706,6 +706,7 @@ impl PetriVmConfigSetupCore<'_> {
                                         DiskLayerHandle(open_disk_type(
                                             disk_path.expect("not uefi guest none").as_ref(),
                                             true,
+                                            None,
                                         )?)
                                         .into_resource()
                                         .into(),
@@ -741,6 +742,7 @@ impl PetriVmConfigSetupCore<'_> {
                                     DiskLayerHandle(open_disk_type(
                                         disk_path.expect("not uefi guest none").as_ref(),
                                         true,
+                                        None,
                                     )?)
                                     .into_resource()
                                     .into(),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -649,7 +649,7 @@ impl PetriVmConfigSetupCore<'_> {
             }
             Firmware::Pcat { guest, .. } => {
                 let disk_path = guest.artifact();
-                let inner_disk = open_disk_type(disk_path.as_ref(), true, None)?;
+                let inner_disk = open_disk_type(disk_path.as_ref(), true)?;
                 let guest_media = match guest {
                     PcatGuest::Vhd(_) => GuestMedia::Disk {
                         read_only: false,
@@ -706,7 +706,6 @@ impl PetriVmConfigSetupCore<'_> {
                                         DiskLayerHandle(open_disk_type(
                                             disk_path.expect("not uefi guest none").as_ref(),
                                             true,
-                                            None,
                                         )?)
                                         .into_resource()
                                         .into(),
@@ -742,7 +741,6 @@ impl PetriVmConfigSetupCore<'_> {
                                     DiskLayerHandle(open_disk_type(
                                         disk_path.expect("not uefi guest none").as_ref(),
                                         true,
-                                        None,
                                     )?)
                                     .into_resource()
                                     .into(),

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -299,13 +299,24 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
+    /// Specifies whether the UEFI will always attempt a default boot
+    pub fn with_reformat_vmgs(mut self, val: bool) -> Self {
+        if self.firmware.is_openhcl() {
+            self.ged.as_mut().unwrap().reformat_vmgs = val;
+        } else {
+            self.config.reformat_vmgs = val;
+        }
+        self
+    }
+
     /// Specifies an existing VMGS file to use
     pub fn with_vmgs(mut self, vmgs_path: impl AsRef<Path>) -> Self {
         let vmgs_disk = LayeredDiskHandle {
             layers: vec![
                 RamDiskLayerHandle { len: None }.into_resource().into(),
                 DiskLayerHandle(
-                    open_disk_type(vmgs_path.as_ref(), true).expect("failed to open VMGS file"),
+                    open_disk_type(vmgs_path.as_ref(), true, None)
+                        .expect("failed to open VMGS file"),
                 )
                 .into_resource()
                 .into(),

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -299,7 +299,7 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
-    /// Specifies whether the UEFI will always attempt a default boot
+    /// Specifies whether to reformat the VMGS file at boot
     pub fn with_reformat_vmgs(mut self, val: bool) -> Self {
         if self.firmware.is_openhcl() {
             self.ged.as_mut().unwrap().reformat_vmgs = val;
@@ -315,8 +315,7 @@ impl PetriVmConfigOpenVmm {
             layers: vec![
                 RamDiskLayerHandle { len: None }.into_resource().into(),
                 DiskLayerHandle(
-                    open_disk_type(vmgs_path.as_ref(), true, None)
-                        .expect("failed to open VMGS file"),
+                    open_disk_type(vmgs_path.as_ref(), true).expect("failed to open VMGS file"),
                 )
                 .into_resource()
                 .into(),

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -104,6 +104,11 @@ pub struct HclDevicePlatformSettingsV2Static {
     pub memory_protection_mode: u8,
     #[serde(default)]
     pub default_boot_always_attempt: bool,
+    pub watchdog_enabled: bool,
+    #[serde(default)]
+    pub imc_enabled: bool,
+    #[serde(default)]
+    pub cxl_memory_enabled: bool,
 
     // UEFI info
     pub vpci_boot_enabled: bool,
@@ -126,18 +131,19 @@ pub struct HclDevicePlatformSettingsV2Static {
     pub vtl2_settings: Option<Vec<u8>>,
 
     pub vmbus_redirection_enabled: bool,
-    pub no_persistent_secrets: bool,
-    pub watchdog_enabled: bool,
+
     // this `#[serde(default)]` shouldn't have been necessary, but we let a
     // `[OmitEmpty]` marker slip past in code review...
     #[serde(default)]
     pub firmware_mode_is_pcat: bool,
+
     #[serde(default)]
     pub always_relay_host_mmio: bool,
+
+    // guest state settings
+    pub no_persistent_secrets: bool,
     #[serde(default)]
-    pub imc_enabled: bool,
-    #[serde(default)]
-    pub cxl_memory_enabled: bool,
+    pub reformat_vmgs: bool,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -88,6 +88,8 @@ pub mod ged {
         pub enable_battery: bool,
         /// Suppress attestation and disable TPM state persistence.
         pub no_persistent_secrets: bool,
+        /// Clear the VMGS file on launch.
+        pub reformat_vmgs: bool,
     }
 
     /// The firmware and chipset configuration for the guest.

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -143,6 +143,8 @@ pub struct GuestConfig {
     pub enable_battery: bool,
     /// Suppress attestation.
     pub no_persistent_secrets: bool,
+    /// Clear the VMGS file on launch.
+    pub reformat_vmgs: bool,
 }
 
 #[derive(Debug, Clone, Inspect)]
@@ -1241,7 +1243,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
         &mut self,
         state: &mut GuestEmulationDevice,
     ) -> Result<(), Error> {
-        let vpci_boot_enabled;
+        let vpci_boot_enabled: bool;
         let enable_firmware_debugging;
         let disable_frontpage;
         let firmware_mode_is_pcat;
@@ -1328,6 +1330,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     always_relay_host_mmio: false,
                     imc_enabled: false,
                     cxl_memory_enabled: false,
+                    reformat_vmgs: state.config.reformat_vmgs,
                 },
                 dynamic: get_protocol::dps_json::HclDevicePlatformSettingsV2Dynamic {
                     is_servicing_scenario: state.save_restore_buf.is_some(),

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -1243,7 +1243,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
         &mut self,
         state: &mut GuestEmulationDevice,
     ) -> Result<(), Error> {
-        let vpci_boot_enabled: bool;
+        let vpci_boot_enabled;
         let enable_firmware_debugging;
         let disable_frontpage;
         let firmware_mode_is_pcat;

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -145,6 +145,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                 },
                 enable_battery: resource.enable_battery,
                 no_persistent_secrets: resource.no_persistent_secrets,
+                reformat_vmgs: resource.reformat_vmgs,
             },
             halt,
             resource.firmware_event_send,

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -253,6 +253,7 @@ pub fn create_host_channel(
         secure_boot_template: SecureBootTemplateType::SECURE_BOOT_DISABLED,
         enable_battery: false,
         no_persistent_secrets: true,
+        reformat_vmgs: false,
     };
 
     let halt_reason = Arc::new(Mutex::new(None));

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -119,6 +119,8 @@ pub mod platform_settings {
         pub firmware_mode_is_pcat: bool,
         pub imc_enabled: bool,
         pub cxl_memory_enabled: bool,
+
+        pub reformat_vmgs: bool,
     }
 
     #[derive(Copy, Clone, Debug, Inspect)]

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -336,6 +336,7 @@ impl GuestEmulationTransportClient {
                 firmware_mode_is_pcat: json.v2.r#static.firmware_mode_is_pcat,
                 imc_enabled: json.v2.r#static.imc_enabled,
                 cxl_memory_enabled: json.v2.r#static.cxl_memory_enabled,
+                reformat_vmgs: json.v2.r#static.reformat_vmgs,
             },
             acpi_tables: json.v2.dynamic.acpi_tables,
         })


### PR DESCRIPTION
Provide the option to reformat the VMGS file via DPS in addition to the OpenHCL command line. 

Refactors the OpenVMM command line settings and adds a test to make sure the VMGS is cleared properly.