### PR TITLE
tpm: support AK cert retry if the boot-time request fails

### DIFF
--- a/openhcl/underhill_core/src/emuplat/tpm.rs
+++ b/openhcl/underhill_core/src/emuplat/tpm.rs
@@ -99,7 +99,12 @@ impl RequestAkCert for TpmRequestAkCertHelper {
             .get_client
             .igvm_attest(agent_data, request, AK_CERT_RESPONSE_BUFFER_SIZE)
             .await?;
-        let payload = underhill_attestation::parse_ak_cert_response(&result.response)?;
+        let payload = if !result.response.is_empty() {
+            underhill_attestation::parse_ak_cert_response(&result.response)?
+        } else {
+            // Let the caller to handle the empty response.
+            vec![]
+        };
 
         Ok(payload)
     }

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -948,6 +948,7 @@ fn vm_config_from_command_line(
                     },
                     enable_battery: opt.battery,
                     no_persistent_secrets: true,
+                    igvm_attest_test_config: None,
                 }
                 .into_resource(),
             ),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -859,6 +859,7 @@ impl PetriVmConfigSetupCore<'_> {
             secure_boot_template: get_resources::ged::GuestSecureBootTemplateType::None,
             enable_battery: false,
             no_persistent_secrets: true,
+            igvm_attest_test_config: None,
         };
 
         Ok((ged, guest_request_send))

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -196,7 +196,7 @@ impl PetriVmConfigOpenVmm {
     /// Set test config for the GED's IGVM attest request handler
     pub fn with_igvm_attest_test_config(mut self, config: IgvmAttestTestConfig) -> Self {
         if !self.firmware.is_openhcl() {
-            panic!("TPM state persistence is only supported for OpenHCL.")
+            panic!("IGVM Attest test config is only supported for OpenHCL.")
         };
 
         let ged = self.ged.as_mut().expect("No GED to configure TPM");

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -15,6 +15,7 @@ use disk_backend_resources::layer::RamDiskLayerHandle;
 use fs_err::File;
 use gdma_resources::GdmaDeviceHandle;
 use gdma_resources::VportDefinition;
+use get_resources::ged::IgvmAttestTestConfig;
 use hvlite_defs::config::Config;
 use hvlite_defs::config::DeviceVtl;
 use hvlite_defs::config::LoadMode;
@@ -188,6 +189,19 @@ impl PetriVmConfigOpenVmm {
         // Disable no_persistent_secrets implies preserving TPM states
         // across boots
         ged.no_persistent_secrets = false;
+
+        self
+    }
+
+    /// Set test config for the GED's IGVM attest request handler
+    pub fn with_igvm_attest_test_config(mut self, config: IgvmAttestTestConfig) -> Self {
+        if !self.firmware.is_openhcl() {
+            panic!("TPM state persistence is only supported for OpenHCL.")
+        };
+
+        let ged = self.ged.as_mut().expect("No GED to configure TPM");
+
+        ged.igvm_attest_test_config = Some(config);
 
         self
     }

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -88,6 +88,8 @@ pub mod ged {
         pub enable_battery: bool,
         /// Suppress attestation and disable TPM state persistence.
         pub no_persistent_secrets: bool,
+        /// Test configuration for IGVM Attest message.
+        pub igvm_attest_test_config: Option<IgvmAttestTestConfig>,
     }
 
     /// The firmware and chipset configuration for the guest.
@@ -219,5 +221,15 @@ pub mod ged {
         NoBootDevice,
         /// A boot attempt was made.
         BootAttempt,
+    }
+
+    /// Configuration to the GED's IGVM Attest request handler
+    /// for test scenarios.
+    #[derive(Debug, MeshPayload, Copy, Clone)]
+    pub enum IgvmAttestTestConfig {
+        /// Config for testing AK cert retry after failure.
+        AkCertRequestFailureAndRetry,
+        /// Config for testing AK cert persistency across boots.
+        AkCertPersistentAcrossBoot,
     }
 }

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -278,7 +278,9 @@ impl GuestEmulationDevice {
 
     fn update_igvm_attest_state(&mut self) -> Result<(), Error> {
         match (self.igvm_attest_state, self.igvm_attest_test_config) {
+            // No test config set, default to sending valid AK cert for now.
             (_, None) => self.igvm_attest_state = IgvmAttestState::SendValidAkCert,
+            // State machine for testing retrying AK cert request after failing attempt.
             (IgvmAttestState::Init, Some(IgvmAttestTestConfig::AkCertRequestFailureAndRetry)) => {
                 self.igvm_attest_state = IgvmAttestState::SendEmptyAkCert
             }
@@ -295,6 +297,7 @@ impl GuestEmulationDevice {
                 Some(IgvmAttestTestConfig::AkCertRequestFailureAndRetry),
             ) => self.igvm_attest_state = IgvmAttestState::Done,
 
+            // State machine for testing AK cert persistency across boots.
             (IgvmAttestState::Init, Some(IgvmAttestTestConfig::AkCertPersistentAcrossBoot)) => {
                 self.igvm_attest_state = IgvmAttestState::SendValidAkCert
             }

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -276,6 +276,7 @@ impl GuestEmulationDevice {
         }
     }
 
+    /// Update IGVM Attest state machine based on IGVM Attest test config.
     fn update_igvm_attest_state(&mut self) -> Result<(), Error> {
         match (self.igvm_attest_state, self.igvm_attest_test_config) {
             // No test config set, default to sending valid AK cert for now.
@@ -309,6 +310,8 @@ impl GuestEmulationDevice {
                 IgvmAttestState::SendEmptyAkCert,
                 Some(IgvmAttestTestConfig::AkCertPersistentAcrossBoot),
             ) => self.igvm_attest_state = IgvmAttestState::Done,
+
+            // Unhandled scenarios
             (_, _) => {
                 return Err(Error::InvalidIgvmAttestState {
                     state: self.igvm_attest_state,

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -151,6 +151,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
             resource.guest_request_recv,
             framebuffer_control,
             vmgs_disk,
+            resource.igvm_attest_test_config,
         );
         Ok(SimpleDeviceWrapper::new(input.driver_source.simple(), device).into())
     }

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -275,6 +275,7 @@ pub fn create_host_channel(
         recv,
         None,
         Some(disklayer_ram::ram_disk(TEST_VMGS_CAPACITY as u64, false).unwrap()),
+        None,
     );
 
     if let Some(ged_responses) = ged_responses {

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -42,7 +42,7 @@ async fn boot_alias_map(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 )]
 async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
-    let config = config.with_tpm().with_tpm_state_persistence();
+    let config = config.with_tpm();
 
     let (vm, agent) = match os_flavor {
         OsFlavor::Windows => {
@@ -52,64 +52,117 @@ async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
             config.run().await?
         }
         OsFlavor::Linux => {
-            // First boot - expect no AK cert from GED
             let mut vm = config.run_with_lazy_pipette().await?;
             // Workaround to https://github.com/microsoft/openvmm/issues/379
             assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
 
-            // Second boot - except get AK cert from GED on the second attempts
             vm.reset().await?;
             let agent = vm.wait_for_agent().await?;
             vm.wait_for_successful_boot_event().await?;
-
-            // Use the python script to read AK cert from TPM nv index
-            // and verify that the AK cert preserves across boot.
-            // TODO: Replace the script with tpm2-tools
-            const TEST_FILE: &str = "tpm.py";
-            const TEST_CONTENT: &str = include_str!("../../test_data/tpm.py");
-
-            agent.write_file(TEST_FILE, TEST_CONTENT.as_bytes()).await?;
-            assert_eq!(agent.read_file(TEST_FILE).await?, TEST_CONTENT.as_bytes());
-
-            // The first AK cert request made during boot is expected to
-            // get invalid response from GED such that no data is set
-            // to nv index. The script should return failure. Also, the nv
-            // read made by the script is expected to trigger another AK cert
-            // request.
-            let sh = agent.unix_shell();
-            let output = cmd!(sh, "python3 tpm.py").read().await?;
-
-            // Check if there is no content yet
-            assert!(!output.contains("succeeded"));
-
-            // Run the script again to test if the AK cert triggered by nv read
-            // succeeds and the data is written into the nv index.
-            let sh = agent.unix_shell();
-            let output = cmd!(sh, "python3 tpm.py").read().await?;
-
-            // Check if the content is now available
-            assert!(output.contains("succeeded"));
-
-            // Third boot - Ak cert request will be bypassed by GED
-            vm.reset().await?;
-            let agent = vm.wait_for_agent().await?;
-            vm.wait_for_successful_boot_event().await?;
-
-            agent.write_file(TEST_FILE, TEST_CONTENT.as_bytes()).await?;
-            assert_eq!(agent.read_file(TEST_FILE).await?, TEST_CONTENT.as_bytes());
-
-            // Run the script after boot to verify that the previous
-            // data in the nv index preserves.
-            let sh = agent.unix_shell();
-            let output = cmd!(sh, "python3 tpm.py").read().await?;
-
-            // Check if the content the same across boots
-            assert!(output.contains("succeeded"));
 
             (vm, agent)
         }
         _ => unreachable!(),
     };
+
+    agent.power_off().await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+    Ok(())
+}
+
+/// Test AK cert is persistent across boots on Linux.
+// TODO: Add in-guest TPM tests for Windows as we currently
+// do have an easy way to interact with TPM without a private
+// or custom tool.
+#[openvmm_test(openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)))]
+async fn tpm_ak_cert_persisted(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+    let config = config
+        .with_tpm()
+        .with_tpm_state_persistence()
+        .with_igvm_attest_test_config(
+            get_resources::ged::IgvmAttestTestConfig::AkCertPersistentAcrossBoot,
+        );
+
+    // First boot - AK cert request will be served by GED
+    let mut vm = config.run_with_lazy_pipette().await?;
+    // Workaround to https://github.com/microsoft/openvmm/issues/379
+    assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
+
+    // Second boot - Ak cert request will be bypassed by GED
+    vm.reset().await?;
+    let agent = vm.wait_for_agent().await?;
+    vm.wait_for_successful_boot_event().await?;
+
+    // Use the python script to read AK cert from TPM nv index
+    // and verify that the AK cert preserves across boot.
+    // TODO: Replace the script with tpm2-tools
+    const TEST_FILE: &str = "tpm.py";
+    const TEST_CONTENT: &str = include_str!("../../test_data/tpm.py");
+
+    agent.write_file(TEST_FILE, TEST_CONTENT.as_bytes()).await?;
+    assert_eq!(agent.read_file(TEST_FILE).await?, TEST_CONTENT.as_bytes());
+
+    let sh = agent.unix_shell();
+    let output = cmd!(sh, "python3 tpm.py").read().await?;
+
+    // Check if the content preserves as expected
+    assert!(output.contains("succeeded"));
+
+    agent.power_off().await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+    Ok(())
+}
+
+/// Test AK cert retry logic on Linux.
+// TODO: Add in-guest TPM tests for Windows as we currently
+// do have an easy way to interact with TPM without a private
+// or custom tool.
+#[openvmm_test(openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)))]
+async fn tpm_ak_cert_retry(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+    let config = config
+        .with_tpm()
+        .with_tpm_state_persistence()
+        .with_igvm_attest_test_config(
+            get_resources::ged::IgvmAttestTestConfig::AkCertRequestFailureAndRetry,
+        );
+
+    // First boot - expect no AK cert from GED
+    let mut vm = config.run_with_lazy_pipette().await?;
+    // Workaround to https://github.com/microsoft/openvmm/issues/379
+    assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
+
+    // Second boot - except get AK cert from GED on the second attempts
+    vm.reset().await?;
+    let agent = vm.wait_for_agent().await?;
+    vm.wait_for_successful_boot_event().await?;
+
+    // Use the python script to read AK cert from TPM nv index
+    // and verify that the AK cert preserves across boot.
+    // TODO: Replace the script with tpm2-tools
+    const TEST_FILE: &str = "tpm.py";
+    const TEST_CONTENT: &str = include_str!("../../test_data/tpm.py");
+
+    agent.write_file(TEST_FILE, TEST_CONTENT.as_bytes()).await?;
+    assert_eq!(agent.read_file(TEST_FILE).await?, TEST_CONTENT.as_bytes());
+
+    // The first AK cert request made during boot is expected to
+    // get invalid response from GED such that no data is set
+    // to nv index. The script should return failure. Also, the nv
+    // read made by the script is expected to trigger another AK cert
+    // request.
+    let sh = agent.unix_shell();
+    let output = cmd!(sh, "python3 tpm.py").read().await?;
+
+    // Check if there is no content yet
+    assert!(!output.contains("succeeded"));
+
+    // Run the script again to test if the AK cert triggered by nv read
+    // succeeds and the data is written into the nv index.
+    let sh = agent.unix_shell();
+    let output = cmd!(sh, "python3 tpm.py").read().await?;
+
+    // Check if the content is now available
+    assert!(output.contains("succeeded"));
 
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -45,12 +45,7 @@ async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     let config = config.with_tpm();
 
     let (vm, agent) = match os_flavor {
-        OsFlavor::Windows => {
-            // TODO: Add in-guest TPM tests for Windows as we currently
-            // do have an easy way to interact with TPM without a private
-            // or custom tool.
-            config.run().await?
-        }
+        OsFlavor::Windows => config.run().await?,
         OsFlavor::Linux => {
             let mut vm = config.run_with_lazy_pipette().await?;
             // Workaround to https://github.com/microsoft/openvmm/issues/379


### PR DESCRIPTION
This PR updates the TPM AK cert handling logic to allow the guest to trigger an AK cert request if the first request made during boot fails. Other changes include
* Update `request_ak_cert` to return empty vector, allowing TPM to distinguish between AK cert request failure and host agent unavailable. TPM only supports AK cert retry on the former case.
* Fix the bug for TVM that AK cert request triggered by NV read does not work correctly.
* Update vmm_tests  and the IgvmAttest state machine in test GED to test the code change.