### PR TITLE
openhcl, initramfs: print stats on the uncompressed and compresed si…

### DIFF
--- a/openhcl/gen_init_ramfs.py
+++ b/openhcl/gen_init_ramfs.py
@@ -110,7 +110,7 @@ class CpioEntry(object):
     def __repr__(self) -> str:
         return None
 
-    def write(self, buffer: BinaryIO) -> None:
+    def write(self, buffer: BinaryIO) -> int:
         def align_on_dword(buffer):
             while buffer.tell() & 3 != 0:
                 buffer.write(b'\x00')
@@ -156,6 +156,9 @@ class CpioEntry(object):
             buffer.write(data)
 
         align_on_dword(buffer)
+
+        # Return the number of bytes written to the buffer
+        return buffer.tell()
 
 class FileEntry(CpioEntry):
     def __init__(self, inode, name, location, mode, uid, gid, hard_links) -> None:
@@ -341,6 +344,7 @@ class TrailerEntry(CpioEntry):
 
 class CpioRamFs:
     def __init__(self, buffer_obj: BinaryIO):
+        self.written = 0
         self.buffer_obj = buffer_obj
         self.opened = False
 
@@ -350,7 +354,11 @@ class CpioRamFs:
 
     def write(self, cpio_entry: CpioEntry):
         assert(self.opened)
-        cpio_entry.write(self.buffer_obj)
+        self.written += cpio_entry.write(self.buffer_obj)
+
+    def written_bytes(self) -> int:
+        assert(self.opened)
+        return self.written
 
     def __exit__(self, type, value, traceback):
         trailer = TrailerEntry()
@@ -632,16 +640,32 @@ def __open_output_stream(file_name: str, compression: str):
     else:
         raise Exception("Unknown compression algorithm")
 
+class CpioStat:
+    def __init__(self, uncompressed, compressed):
+        self.uncompressed = uncompressed
+        self.compressed = compressed
 
-def create_cpio_from_config(config_files: List[str], output_file: str, compression: str):
+    def __repr__(self):
+        return f"uncompressed: {self.uncompressed}, compressed: {self.compressed}"
+
+def create_cpio_from_config(config_files: List[str], output_file: str, compression: str) -> CpioStat:
+    written_uncompressed = 0
+    written_compressed = 0
+
     with __open_output_stream(output_file, compression) as ostream:
         with CpioRamFs(ostream) as cpio:
             config = InitRamFsConfig(config_files)
             for entry in config.entries():
                 cpio.write(entry)
+            written_uncompressed = cpio.written_bytes()
+            written_compressed = ostream.tell()
 
+    return CpioStat(written_uncompressed, written_compressed)
 
 def create_cpio_from_dir(top_dir: str, output_file: str, compression: str):
+    written_uncompressed = 0
+    written_compressed = 0
+
     if not os.path.isdir(top_dir):
         raise Exception(f"{top_dir} is not a directory")
     with __open_output_stream(output_file, compression) as ostream:
@@ -668,6 +692,11 @@ def create_cpio_from_dir(top_dir: str, output_file: str, compression: str):
                     file_entry = FileEntry(name, location, mode=stat_info.st_mode, uid=0, gid=0, hard_links=[])
                     # print(file_entry)
                     cpio.write(file_entry)
+            written_uncompressed = cpio.written_bytes()
+            written_compressed = ostream.tell()
+
+    return CpioStat(written_uncompressed, written_compressed)
+
 
 if __name__ == '__main__':
     import argparse

--- a/openhcl/gen_init_ramfs.py
+++ b/openhcl/gen_init_ramfs.py
@@ -706,7 +706,9 @@ def create_cpio_from_dir(top_dir: str, output_file: str, compression: str):
                     # print(file_entry)
                     cpio.write(file_entry)
             written_uncompressed = cpio.written_bytes()
-            written_compressed = ostream.tell()
+    # tell() is not reliable for the compressed stream
+    # so we need to use the size of the file
+    written_compressed = os.path.getsize(output_file)
 
     return CpioStat(written_uncompressed, written_compressed)
 

--- a/openhcl/update-rootfs.py
+++ b/openhcl/update-rootfs.py
@@ -109,7 +109,8 @@ def process(temp_dir: str, underhill_path: str, kernel_path: str,
     os.environ["OPENHCL_KERNEL_PATH"] = kernel_path
     os.environ["OPENHCL_BUILD_INFO"] = build_info
 
-    create_cpio_from_config(rootfs_config_path, underhill_cpio_gz_file_name, 'gzip')
+    stat = create_cpio_from_config(rootfs_config_path, underhill_cpio_gz_file_name, 'gzip')
+    eprint(f"The initial root fs size, bytes: {stat}")
 
     for dir_name in additional_dirs:
         temp_file_name = os.path.join(temp_dir, "add_dir.cpio.gz")
@@ -118,6 +119,8 @@ def process(temp_dir: str, underhill_path: str, kernel_path: str,
         os.unlink(temp_file_name)
 
     for layer in additional_layers:
+        layer_size = os.path.getsize(layer)
+        eprint(f"Adding layer {layer}, size: {layer_size} bytes")
         append_file(underhill_cpio_gz_file_name, layer)
 
     if Config.VERBOSE: subprocess.run(f'binwalk -eM {underhill_cpio_gz_file_name}', shell=True, check=True)


### PR DESCRIPTION
…ze, and on added layers

Came up during an OOM investigations.

Example output:

```console
The initial root fs size, bytes: uncompressed: 14905188, compressed: 6472016
Adding layer /home/krom/src/openvmm/flowey-persist/flowey_lib_hvlite__download_openvmm_deps/extracted/openvmm-deps.x86_64.0.1.0-20250403.3.tar.bz2/shell.cpio.gz, size: 1707144 bytes
Size of the updated initial RAM FS 8179160 bytes
```
