### PR TITLE
cvm guest vsm: install intercept hypercall handling

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -519,7 +519,7 @@ impl<T: Inspect> GuestVsmState<T> {
 }
 
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-#[derive(Default, Inspect)]
+#[derive(Inspect)]
 struct CvmVtl1State {
     /// Whether VTL 1 has been enabled on any vp
     enabled_on_any_vp: bool,
@@ -531,7 +531,6 @@ struct CvmVtl1State {
     pub mbec_enabled: bool,
     /// Whether shadow supervisor stack is enabled.
     pub shadow_supervisor_stack_enabled: bool,
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     #[inspect(with = "|bb| inspect::iter_by_index(bb.iter().map(|v| *v))")]
     io_read_intercepts: BitBox<u64>,
     #[inspect(with = "|bb| inspect::iter_by_index(bb.iter().map(|v| *v))")]

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -518,7 +518,6 @@ impl<T: Inspect> GuestVsmState<T> {
     }
 }
 
-#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 #[derive(Inspect)]
 struct CvmVtl1State {
     /// Whether VTL 1 has been enabled on any vp

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -518,6 +518,7 @@ impl<T: Inspect> GuestVsmState<T> {
     }
 }
 
+#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 #[derive(Default, Inspect)]
 struct CvmVtl1State {
     /// Whether VTL 1 has been enabled on any vp
@@ -531,21 +532,23 @@ struct CvmVtl1State {
     /// Whether shadow supervisor stack is enabled.
     pub shadow_supervisor_stack_enabled: bool,
     #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-    #[inspect(skip)]
+    #[inspect(with = "|bb| inspect::iter_by_index(bb.iter().map(|v| *v))")]
     io_read_intercepts: BitBox<u64>,
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-    #[inspect(skip)]
+    #[inspect(with = "|bb| inspect::iter_by_index(bb.iter().map(|v| *v))")]
     io_write_intercepts: BitBox<u64>,
 }
 
+#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 impl CvmVtl1State {
-    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     fn new(mbec_enabled: bool) -> Self {
         Self {
+            enabled_on_any_vp: false,
+            zero_memory_on_reset: false,
+            deny_lower_vtl_startup: false,
             mbec_enabled,
+            shadow_supervisor_stack_enabled: false,
             io_read_intercepts: BitVec::repeat(false, u16::MAX as usize + 1).into_boxed_bitslice(),
             io_write_intercepts: BitVec::repeat(false, u16::MAX as usize + 1).into_boxed_bitslice(),
-            ..Default::default()
         }
     }
 }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -530,6 +530,24 @@ struct CvmVtl1State {
     pub mbec_enabled: bool,
     /// Whether shadow supervisor stack is enabled.
     pub shadow_supervisor_stack_enabled: bool,
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
+    #[inspect(skip)]
+    io_read_intercepts: BitBox<u64>,
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
+    #[inspect(skip)]
+    io_write_intercepts: BitBox<u64>,
+}
+
+impl CvmVtl1State {
+    #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
+    fn new(mbec_enabled: bool) -> Self {
+        Self {
+            mbec_enabled,
+            io_read_intercepts: BitVec::repeat(false, u16::MAX as usize + 1).into_boxed_bitslice(),
+            io_write_intercepts: BitVec::repeat(false, u16::MAX as usize + 1).into_boxed_bitslice(),
+            ..Default::default()
+        }
+    }
 }
 
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -2468,8 +2468,10 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::InstallIntercept
                     access_type_mask & HV_INTERCEPT_ACCESS_MASK_READ != 0,
                 );
 
-                vtl1.io_write_intercepts
-                    .set(io_port, HV_INTERCEPT_ACCESS_MASK_WRITE != 0);
+                vtl1.io_write_intercepts.set(
+                    io_port,
+                    access_type_mask & HV_INTERCEPT_ACCESS_MASK_WRITE != 0,
+                );
             }
             _ => return Err(HvError::InvalidParameter),
         }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -34,6 +34,8 @@ use hvdef::HvVtlEntryReason;
 use hvdef::HvX64PendingExceptionEvent;
 use hvdef::HvX64RegisterName;
 use hvdef::Vtl;
+use hvdef::hypercall::HV_INTERCEPT_ACCESS_MASK_READ;
+use hvdef::hypercall::HV_INTERCEPT_ACCESS_MASK_WRITE;
 use hvdef::hypercall::HostVisibilityType;
 use hvdef::hypercall::HvFlushFlags;
 use hvdef::hypercall::TranslateGvaResultCode;
@@ -1231,10 +1233,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::EnablePartitionVtl
         )?;
 
         *gvsm_state = GuestVsmState::Enabled {
-            vtl1: CvmVtl1State {
-                mbec_enabled: flags.enable_mbec(),
-                ..Default::default()
-            },
+            vtl1: CvmVtl1State::new(flags.enable_mbec()),
         };
 
         let protector = &self.vp.cvm_partition().isolated_memory_protector;
@@ -2059,12 +2058,12 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
     ) -> bool {
         let send_intercept = self.cvm_is_protected_register_write(vtl, reg, value);
         if send_intercept {
-            let message_state = B::intercept_message_state(self, vtl);
+            let message_state = B::intercept_message_state(self, vtl, false);
 
             self.send_intercept_message(
                 GuestVtl::Vtl1,
                 &crate::processor::InterceptMessageType::Register { reg, value }
-                    .generate_hv_message(self.vp_index(), vtl, message_state),
+                    .generate_hv_message(self.vp_index(), vtl, message_state, false),
             );
         }
 
@@ -2093,7 +2092,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             // Note: writes to X86X_IA32_MSR_MISC_ENABLE are dropped, so don't
             // need to check the mask.
 
-            let generate_intercept = match msr {
+            let send_intercept = match msr {
                 x86defs::X86X_MSR_LSTAR => configured_intercepts.msr_lstar_write(),
                 x86defs::X86X_MSR_STAR => configured_intercepts.msr_star_write(),
                 x86defs::X86X_MSR_CSTAR => configured_intercepts.msr_cstar_write(),
@@ -2115,8 +2114,8 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                 _ => false,
             };
 
-            if generate_intercept {
-                let message_state = B::intercept_message_state(self, vtl);
+            if send_intercept {
+                let message_state = B::intercept_message_state(self, vtl, false);
 
                 self.send_intercept_message(
                     GuestVtl::Vtl1,
@@ -2124,12 +2123,68 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                         self.vp_index(),
                         vtl,
                         message_state,
+                        false,
                     ),
                 );
 
                 return true;
             }
         }
+        false
+    }
+
+    /// Checks if a higher VTL registered for intercepts on io port and sends
+    /// the intercept as required.
+    ///
+    /// If an intercept message is posted then no further processing is
+    /// required. The instruction pointer should not be advanced, since the
+    /// instruction pointer must continue to point to the instruction that
+    /// generated the intercept.
+    pub(crate) fn cvm_try_protect_io_port_access(
+        &mut self,
+        vtl: GuestVtl,
+        port_number: u16,
+        is_read: bool,
+        access_size: u8,
+        string_access: bool,
+        rep_access: bool,
+    ) -> bool {
+        if vtl == GuestVtl::Vtl0 {
+            let send_intercept = {
+                if let GuestVsmState::Enabled { vtl1 } = &*self.cvm_partition().guest_vsm.read() {
+                    if is_read {
+                        vtl1.io_read_intercepts[port_number as usize]
+                    } else {
+                        vtl1.io_write_intercepts[port_number as usize]
+                    }
+                } else {
+                    false
+                }
+            };
+
+            if send_intercept {
+                let message_state = B::intercept_message_state(self, vtl, true);
+
+                self.send_intercept_message(
+                    GuestVtl::Vtl1,
+                    &crate::processor::InterceptMessageType::IoPort {
+                        port_number,
+                        access_size,
+                        string_access,
+                        rep_access,
+                    }
+                    .generate_hv_message(
+                        self.vp_index(),
+                        vtl,
+                        message_state,
+                        is_read,
+                    ),
+                );
+
+                return true;
+            }
+        }
+
         false
     }
 
@@ -2362,5 +2417,63 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::SendSyntheticClusterIpiEx
 
         self.vp
             .cvm_send_synthetic_cluster_ipi(target_vtl, vector, processor_set)
+    }
+}
+
+impl<T, B: HardwareIsolatedBacking> hv1_hypercall::InstallIntercept
+    for UhHypercallHandler<'_, '_, T, B>
+{
+    fn install_intercept(
+        &mut self,
+        partition_id: u64,
+        access_type_mask: u32,
+        intercept_type: hvdef::hypercall::HvInterceptType,
+        intercept_parameters: hvdef::hypercall::HvInterceptParameters,
+    ) -> HvResult<()> {
+        tracing::debug!(
+            vp_index = self.vp.vp_index().index(),
+            ?access_type_mask,
+            ?intercept_type,
+            ?intercept_parameters,
+            "HvInstallIntercept"
+        );
+
+        if partition_id != hvdef::HV_PARTITION_ID_SELF {
+            return Err(HvError::AccessDenied);
+        }
+
+        if self.intercepted_vtl == GuestVtl::Vtl0 {
+            return Err(HvError::AccessDenied);
+        }
+
+        match intercept_type {
+            hvdef::hypercall::HvInterceptType::HvInterceptTypeX64IoPort => {
+                if access_type_mask
+                    & !(HV_INTERCEPT_ACCESS_MASK_READ | HV_INTERCEPT_ACCESS_MASK_WRITE)
+                    != 0
+                {
+                    return Err(HvError::InvalidParameter);
+                }
+
+                let mut gvsm_lock = self.vp.cvm_partition().guest_vsm.write();
+
+                let GuestVsmState::Enabled { vtl1, .. } = &mut *gvsm_lock else {
+                    return Err(HvError::InvalidVtlState);
+                };
+
+                let io_port = intercept_parameters.io_port() as usize;
+
+                vtl1.io_read_intercepts.set(
+                    io_port,
+                    access_type_mask & HV_INTERCEPT_ACCESS_MASK_READ != 0,
+                );
+
+                vtl1.io_write_intercepts
+                    .set(io_port, HV_INTERCEPT_ACCESS_MASK_WRITE != 0);
+            }
+            _ => return Err(HvError::InvalidParameter),
+        }
+
+        Ok(())
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -2472,6 +2472,9 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::InstallIntercept
                     io_port,
                     access_type_mask & HV_INTERCEPT_ACCESS_MASK_WRITE != 0,
                 );
+
+                // TODO GUEST VSM: flush io port accesses on other VPs before
+                // returning back to VTL 0
             }
             _ => return Err(HvError::InvalidParameter),
         }

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -294,6 +294,13 @@ enum InterceptMessageType {
     Msr {
         msr: u32,
     },
+    #[cfg(guest_arch = "x86_64")]
+    IoPort {
+        port_number: u16,
+        access_size: u8,
+        string_access: bool,
+        rep_access: bool,
+    },
 }
 
 /// Per-arch state required to generate an intercept message.
@@ -302,11 +309,24 @@ struct InterceptMessageState {
     instruction_length_and_cr8: u8,
     cpl: u8,
     efer_lma: bool,
-    cs_segment: hvdef::HvX64SegmentRegister,
+    cs: hvdef::HvX64SegmentRegister,
     rip: u64,
     rflags: u64,
     rax: u64,
     rdx: u64,
+    rcx: u64,
+    rsi: u64,
+    rdi: u64,
+    optional: Option<InterceptMessageOptionalState>,
+}
+
+#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
+/// Additional per-arch state required to generate an intercept message. Used
+/// for state that is not common across the intercept message types and that
+/// might be slower to retrieve on certain architectures.
+struct InterceptMessageOptionalState {
+    ds: hvdef::HvX64SegmentRegister,
+    es: hvdef::HvX64SegmentRegister,
 }
 
 impl InterceptMessageType {
@@ -316,23 +336,28 @@ impl InterceptMessageType {
         vp_index: VpIndex,
         vtl: GuestVtl,
         state: InterceptMessageState,
+        is_read: bool,
     ) -> HvMessage {
-        let write_header = hvdef::HvX64InterceptMessageHeader {
+        let header = hvdef::HvX64InterceptMessageHeader {
             vp_index: vp_index.index(),
             instruction_length_and_cr8: state.instruction_length_and_cr8,
-            intercept_access_type: hvdef::HvInterceptAccessType::WRITE,
+            intercept_access_type: if is_read {
+                hvdef::HvInterceptAccessType::READ
+            } else {
+                hvdef::HvInterceptAccessType::WRITE
+            },
             execution_state: hvdef::HvX64VpExecutionState::new()
                 .with_cpl(state.cpl)
                 .with_vtl(vtl.into())
                 .with_efer_lma(state.efer_lma),
-            cs_segment: state.cs_segment,
+            cs_segment: state.cs,
             rip: state.rip,
             rflags: state.rflags,
         };
         match self {
             InterceptMessageType::Register { reg, value } => {
                 let intercept_message = hvdef::HvX64RegisterInterceptMessage {
-                    header: write_header,
+                    header,
                     flags: hvdef::HvX64RegisterInterceptMessageFlags::new(),
                     rsvd: 0,
                     rsvd2: 0,
@@ -349,7 +374,7 @@ impl InterceptMessageType {
             }
             InterceptMessageType::Msr { msr } => {
                 let intercept_message = hvdef::HvX64MsrInterceptMessage {
-                    header: write_header,
+                    header,
                     msr_number: *msr,
                     rax: state.rax,
                     rdx: state.rdx,
@@ -358,6 +383,35 @@ impl InterceptMessageType {
 
                 HvMessage::new(
                     hvdef::HvMessageType::HvMessageTypeMsrIntercept,
+                    0,
+                    intercept_message.as_bytes(),
+                )
+            }
+            InterceptMessageType::IoPort {
+                port_number,
+                access_size,
+                string_access,
+                rep_access,
+            } => {
+                let access_info =
+                    hvdef::HvX64IoPortAccessInfo::new(*access_size, *string_access, *rep_access);
+                let intercept_message = hvdef::HvX64IoPortInterceptMessage {
+                    header,
+                    port_number: *port_number,
+                    access_info,
+                    instruction_byte_count: 0,
+                    reserved: 0,
+                    rax: state.rax,
+                    instruction_bytes: [0u8; 16],
+                    ds_segment: state.optional.as_ref().unwrap().ds,
+                    es_segment: state.optional.as_ref().unwrap().es,
+                    rcx: state.rcx,
+                    rsi: state.rsi,
+                    rdi: state.rdi,
+                };
+
+                HvMessage::new(
+                    hvdef::HvMessageType::HvMessageTypeX64IoPortIntercept,
                     0,
                     intercept_message.as_bytes(),
                 )
@@ -407,6 +461,7 @@ trait HardwareIsolatedBacking: Backing {
     fn intercept_message_state(
         this: &UhProcessor<'_, Self>,
         vtl: GuestVtl,
+        include_optional_state: bool,
     ) -> InterceptMessageState;
 
     /// Individual register for CPUID and crx intercept handling, since

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1307,9 +1307,9 @@ impl UhProcessor<'_, SnpBacked> {
                         let interruption_pending = vmsa.event_inject().valid()
                             || SevEventInjectInfo::from(vmsa.exit_int_info()).valid();
 
-                        // TODO GUEST VSM: figure out whether emulation will
-                        // involve additional io port accesses that need to be
-                        // intercepted as well.
+                        // TODO GUEST VSM: consider changing the emulation path
+                        // to also check for io port installation, mainly for
+                        // handling rep instructions.
 
                         self.emulate(dev, interruption_pending, entered_from_vtl, ())
                             .await?;

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -7,6 +7,7 @@ use super::BackingParams;
 use super::BackingPrivate;
 use super::BackingSharedParams;
 use super::HardwareIsolatedBacking;
+use super::InterceptMessageOptionalState;
 use super::InterceptMessageState;
 use super::UhEmulationState;
 use super::UhRunVpError;
@@ -71,6 +72,7 @@ use x86defs::snp::SevExitCode;
 use x86defs::snp::SevInvlpgbEcx;
 use x86defs::snp::SevInvlpgbEdx;
 use x86defs::snp::SevInvlpgbRax;
+use x86defs::snp::SevIoAccessInfo;
 use x86defs::snp::SevSelector;
 use x86defs::snp::SevStatusMsr;
 use x86defs::snp::SevVmsa;
@@ -273,6 +275,7 @@ impl HardwareIsolatedBacking for SnpBacked {
     fn intercept_message_state(
         this: &UhProcessor<'_, Self>,
         vtl: GuestVtl,
+        include_optional_state: bool,
     ) -> InterceptMessageState {
         let vmsa = this.runner.vmsa(vtl);
 
@@ -280,11 +283,22 @@ impl HardwareIsolatedBacking for SnpBacked {
             instruction_length_and_cr8: (vmsa.next_rip() - vmsa.rip()) as u8,
             cpl: vmsa.cpl(),
             efer_lma: vmsa.efer() & x86defs::X64_EFER_LMA != 0,
-            cs_segment: virt_seg_from_snp(vmsa.cs()).into(),
+            cs: virt_seg_from_snp(vmsa.cs()).into(),
             rip: vmsa.rip(),
             rflags: vmsa.rflags(),
             rax: vmsa.rax(),
             rdx: vmsa.rdx(),
+            optional: if include_optional_state {
+                Some(InterceptMessageOptionalState {
+                    ds: virt_seg_from_snp(vmsa.ds()).into(),
+                    es: virt_seg_from_snp(vmsa.es()).into(),
+                })
+            } else {
+                None
+            },
+            rcx: vmsa.rcx(),
+            rsi: vmsa.rsi(),
+            rdi: vmsa.rdi(),
         }
     }
 
@@ -732,6 +746,7 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, SnpBacked> {
             hv1_hypercall::HvX64TranslateVirtualAddress,
             hv1_hypercall::HvSendSyntheticClusterIpi,
             hv1_hypercall::HvSendSyntheticClusterIpiEx,
+            hv1_hypercall::HvInstallIntercept,
         ],
     );
 
@@ -1266,35 +1281,54 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::IOIO => {
-                let io_info = x86defs::snp::SevIoAccessInfo::from(vmsa.exit_info1() as u32);
-                if io_info.string_access() || io_info.rep_access() {
-                    let interruption_pending = vmsa.event_inject().valid()
-                        || SevEventInjectInfo::from(vmsa.exit_int_info()).valid();
-                    self.emulate(dev, interruption_pending, entered_from_vtl, ())
-                        .await?;
+                let io_info =
+                    SevIoAccessInfo::from(self.runner.vmsa(entered_from_vtl).exit_info1() as u32);
+
+                let access_size = if io_info.access_size32() {
+                    4
+                } else if io_info.access_size16() {
+                    2
                 } else {
-                    let len = if io_info.access_size32() {
-                        4
-                    } else if io_info.access_size16() {
-                        2
+                    1
+                };
+
+                let port_access_protected = self.cvm_try_protect_io_port_access(
+                    entered_from_vtl,
+                    io_info.port(),
+                    io_info.read_access(),
+                    access_size,
+                    io_info.string_access(),
+                    io_info.rep_access(),
+                );
+
+                let vmsa = self.runner.vmsa(entered_from_vtl);
+                if !port_access_protected {
+                    if io_info.string_access() || io_info.rep_access() {
+                        let interruption_pending = vmsa.event_inject().valid()
+                            || SevEventInjectInfo::from(vmsa.exit_int_info()).valid();
+
+                        // TODO GUEST VSM: figure out whether emulation will
+                        // involve additional io port accesses that need to be
+                        // intercepted as well.
+
+                        self.emulate(dev, interruption_pending, entered_from_vtl, ())
+                            .await?;
                     } else {
-                        1
-                    };
+                        let mut rax = vmsa.rax();
+                        emulate_io(
+                            self.inner.vp_info.base.vp_index,
+                            !io_info.read_access(),
+                            io_info.port(),
+                            &mut rax,
+                            access_size,
+                            dev,
+                        )
+                        .await;
 
-                    let mut rax = vmsa.rax();
-                    emulate_io(
-                        self.inner.vp_info.base.vp_index,
-                        !io_info.read_access(),
-                        io_info.port(),
-                        &mut rax,
-                        len,
-                        dev,
-                    )
-                    .await;
-
-                    let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
-                    vmsa.set_rax(rax);
-                    advance_to_next_instruction(&mut vmsa);
+                        let mut vmsa = self.runner.vmsa_mut(entered_from_vtl);
+                        vmsa.set_rax(rax);
+                        advance_to_next_instruction(&mut vmsa);
+                    }
                 }
                 &mut self.backing.exit_stats[entered_from_vtl].ioio
             }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1747,6 +1747,10 @@ impl UhProcessor<'_, TdxBacked> {
 
                 if !port_access_protected {
                     if io_qual.is_string() || io_qual.rep_prefix() {
+                        // TODO GUEST VSM: consider changing the emulation path
+                        // to also check for io port installation, mainly for
+                        // handling rep instructions.
+
                         self.emulate(
                             dev,
                             self.backing.vtls[intercepted_vtl]

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1742,7 +1742,7 @@ impl UhProcessor<'_, TdxBacked> {
                     io_qual.is_in(),
                     len,
                     io_qual.is_string(),
-                    io_qual.is_string() && io_qual.rep_prefix(),
+                    io_qual.rep_prefix(),
                 );
 
                 if !port_access_protected {
@@ -3493,6 +3493,7 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
             hv1_hypercall::HvX64TranslateVirtualAddress,
             hv1_hypercall::HvSendSyntheticClusterIpi,
             hv1_hypercall::HvSendSyntheticClusterIpiEx,
+            hv1_hypercall::HvInstallIntercept,
         ]
     );
 

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -2647,7 +2647,7 @@ const_assert!(size_of::<HvArm64InterceptMessageHeader>() == 0x18);
 impl MessagePayload for HvArm64InterceptMessageHeader {}
 
 #[repr(transparent)]
-#[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[derive(Debug, Copy, Clone, IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct HvX64IoPortAccessInfo(pub u8);
 
 impl HvX64IoPortAccessInfo {


### PR DESCRIPTION
Handles the install intercept hypercall on io ports for guest vsm support in cvms.

Tested:
SNP +/- guest vsm boots