### PR TITLE
loader: bump ohcl minimum memory size for x64 release to 70 MB

### DIFF
--- a/vm/loader/manifests/openhcl-x64-release.json
+++ b/vm/loader/manifests/openhcl-x64-release.json
@@ -9,7 +9,7 @@
                 "openhcl": {
                     "initrd_path": "./underhill.cpio.gz",
                     "command_line": "",
-                    "memory_page_count": 16384,
+                    "memory_page_count": 17920,
                     "uefi": true
                 }
             }


### PR DESCRIPTION
The Linux kernel sizes tmpfs for rootfs based on half of the available ram. When OpenHCL is loaded at high memory addresses, for some reason the kernel reports different amounts of available memory, which results in tmpfs being a different size with no free space available, leading to issues writing the underhill_pid:
```
<6>[    1.552853] [U] Error: failed to write pid to /run/underhill.pid
<6>[    1.563864] [U] Caused by:
<6>[    1.565310] [U]     No space left on device (os error 28)
```

Bump the size up slightly to 70MB, which should allow these minimum memory tests to work when loaded at high GPAs. 

#1266 tracks investigating why the kernel does this behavior.