### PR TITLE
cvm: advertise translate gva flags as being available

### DIFF
--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -420,7 +420,8 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
             .with_guest_idle_available(true)
             .with_xmm_registers_for_fast_hypercall_available(true)
             .with_register_pat_available(true)
-            .with_fast_hypercall_output_available(true);
+            .with_fast_hypercall_output_available(true)
+            .with_translate_gva_flags_available(true);
 
         let enlightenments = hvdef::HvEnlightenmentInformation::new()
             .with_deprecate_auto_eoi(true)

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -283,7 +283,8 @@ impl CpuidArchInitializer for TdxCpuidInitializer<'_> {
             .with_guest_idle_available(true)
             .with_xmm_registers_for_fast_hypercall_available(true)
             .with_register_pat_available(true)
-            .with_fast_hypercall_output_available(true);
+            .with_fast_hypercall_output_available(true)
+            .with_translate_gva_flags_available(true);
 
         let use_apic_msrs = match self.topology.apic_mode() {
             vm_topology::processor::x86::ApicMode::XApic => {


### PR DESCRIPTION
Update cpuid bits to advertise the availability of translategvaflags, used by vtl 1.

Tested:
SNP + guest vsm boots