### PR TITLE
state_unit: remove PostRestore transition

### DIFF
--- a/openhcl/underhill_core/src/vmbus_relay_unit.rs
+++ b/openhcl/underhill_core/src/vmbus_relay_unit.rs
@@ -65,8 +65,4 @@ impl StateUnit for &'_ VmbusRelayUnit {
             .await
             .map_err(RestoreError::Other)
     }
-
-    async fn post_restore(&mut self) -> anyhow::Result<()> {
-        Ok(())
-    }
 }


### PR DESCRIPTION
Only `vmbus_server` was using this state transition, but refactoring has made it unnecessary.  Simplify the state machine model by removing it from all devices.