### PR TITLE
flowey: add ADO trigger for tags

### DIFF
--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -572,6 +572,10 @@ EOF
                     batch,
                 } = t;
 
+                if branches.is_empty() && tags.is_empty() {
+                    anyhow::bail!("branches and tags cannot both be empty")
+                }
+
                 schema_ado_yaml::CiTrigger::Some {
                     batch,
                     branches: if branches.is_empty() {

--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -567,18 +567,44 @@ EOF
                 let flowey_core::pipeline::AdoCiTriggers {
                     branches,
                     exclude_branches,
+                    tags,
+                    exclude_tags,
                     batch,
                 } = t;
 
                 schema_ado_yaml::CiTrigger::Some {
                     batch,
-                    branches: schema_ado_yaml::TriggerBranches {
-                        include: branches,
-                        exclude: if exclude_branches.is_empty() {
-                            None
-                        } else {
-                            Some(exclude_branches)
-                        },
+                    branches: if branches.is_empty() {
+                        if !exclude_branches.is_empty() {
+                            anyhow::bail!("empty branch trigger with non-empty exclude")
+                        }
+
+                        None
+                    } else {
+                        Some(schema_ado_yaml::TriggerBranches {
+                            include: branches,
+                            exclude: if exclude_branches.is_empty() {
+                                None
+                            } else {
+                                Some(exclude_branches)
+                            },
+                        })
+                    },
+                    tags: if tags.is_empty() {
+                        if !exclude_tags.is_empty() {
+                            anyhow::bail!("empty tags trigger with non-empty exclude")
+                        }
+
+                        None
+                    } else {
+                        Some(schema_ado_yaml::TriggerTags {
+                            include: tags,
+                            exclude: if exclude_tags.is_empty() {
+                                None
+                            } else {
+                                Some(exclude_tags)
+                            },
+                        })
                     },
                 }
             }

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -157,12 +157,18 @@ pub struct AdoPrTriggers {
 /// Trigger ADO pipelines per PR
 #[derive(Debug, Default)]
 pub struct AdoCiTriggers {
-    /// Run the pipeline whenever there is a PR to these specified branches
+    /// Run the pipeline whenever there is a change to these specified branches
     /// (supports glob syntax)
     pub branches: Vec<String>,
     /// Specify any branches which should be filtered out from the list of
     /// `branches` (supports glob syntax)
     pub exclude_branches: Vec<String>,
+    /// Run the pipeline whenever a matching tag is created (supports glob
+    /// syntax)
+    pub tags: Vec<String>,
+    /// Specify any tags which should be filtered out from the list of `tags`
+    /// (supports glob syntax)
+    pub exclude_tags: Vec<String>,
     /// Whether to batch changes per branch.
     pub batch: bool,
 }
@@ -238,14 +244,14 @@ pub struct GhPrTriggers {
 /// Trigger Github Actions pipelines per PR
 #[derive(Debug, Default)]
 pub struct GhCiTriggers {
-    /// Run the pipeline whenever there is a PR to these specified branches
+    /// Run the pipeline whenever there is a change to these specified branches
     /// (supports glob syntax)
     pub branches: Vec<String>,
     /// Specify any branches which should be filtered out from the list of
     /// `branches` (supports glob syntax)
     pub exclude_branches: Vec<String>,
-    /// Run the pipeline whenever there is a PR to these specified tags
-    /// (supports glob syntax)
+    /// Run the pipeline whenever a matching tag is created (supports glob
+    /// syntax)
     pub tags: Vec<String>,
     /// Specify any tags which should be filtered out from the list of `tags`
     /// (supports glob syntax)

--- a/flowey/schema_ado_yaml/src/lib.rs
+++ b/flowey/schema_ado_yaml/src/lib.rs
@@ -66,6 +66,16 @@ pub struct TriggerBranches {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TriggerTags {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
+    // Wrapping this in an Option is necessary to prevent problems when deserializing and exclude isn't present
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclude: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 #[serde(rename_all = "camelCase")]
 pub enum PrTrigger {
@@ -88,7 +98,10 @@ pub enum CiTrigger {
     #[serde(rename_all = "camelCase")]
     Some {
         batch: bool,
-        branches: TriggerBranches,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        branches: Option<TriggerBranches>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tags: Option<TriggerTags>,
     },
     // serde has a bug with untagged and `with` during deserialization
     NoneWorkaround(String),


### PR DESCRIPTION
This change introduces the ability to trigger pipelines when tags are created. While developing this change I also noticed that the current ADO CI triggers functionality did not generate correct yaml when an empty vector of trigger branches is specified, so a fix for that issue is included as well.