### PR TITLE
Avoid NVRAM out-of-space issue

### DIFF
--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -461,6 +461,7 @@ impl TpmEngineHelper {
         preserve_ak_cert: bool,
         support_attestation_report: bool,
     ) -> Result<(), TpmHelperError> {
+        /* If the AKCert index exists and is not platform-defined, skip recreating it. */
         let ak_cert_non_platform = if let Some(res) = self.find_nv_index(TPM_NV_INDEX_AIK_CERT)? {
             let nv_bits = TpmaNvBits::from(res.nv_public.nv_public.attributes.0.get());
             !nv_bits.nv_platformcreate()

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -461,7 +461,7 @@ impl TpmEngineHelper {
         preserve_ak_cert: bool,
         support_attestation_report: bool,
     ) -> Result<(), TpmHelperError> {
-        /* If the AKCert index exists and is not platform-defined, skip recreating it. */
+        // If the AKCert index exists and is not platform-defined, skip recreating it.
         let ak_cert_non_platform = if let Some(res) = self.find_nv_index(TPM_NV_INDEX_AIK_CERT)? {
             let nv_bits = TpmaNvBits::from(res.nv_public.nv_public.attributes.0.get());
             !nv_bits.nv_platformcreate()


### PR DESCRIPTION
PR 1120 added a TPM NVRAM behavior where the AKCert NVRAM index is always undefined and redefined, with size 4kB and the platform-defined attribute. In some cases, existing VMs may have an NVRAM blob that is too small to accommodate a 4kB index. This change works around that by not modifying the existing index if it is not platform-defined. This change also keeps other behavior added in 1120, such as preserving any existing contents of that NVRAM index.