### PR TITLE
vmgs: conditionally reprovision based on dps setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,6 @@ dependencies = [
  "dirs",
  "disk_backend_resources",
  "disk_crypt_resources",
- "disk_vhd1",
  "firmware_uefi_custom_vars",
  "floppy_resources",
  "framebuffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ dependencies = [
  "mesh",
  "thiserror 2.0.12",
  "vm_resource",
+ "vmgs_resources",
 ]
 
 [[package]]
@@ -2576,6 +2577,7 @@ dependencies = [
  "vmbus_channel",
  "vmbus_ring",
  "vmcore",
+ "vmgs_resources",
  "zerocopy 0.8.24",
 ]
 
@@ -3013,6 +3015,7 @@ dependencies = [
  "vmcore",
  "vmgs",
  "vmgs_broker",
+ "vmgs_resources",
  "vmm_core",
  "vmm_core_defs",
  "vmotherboard",
@@ -3046,6 +3049,7 @@ dependencies = [
  "virt_whp",
  "vm_resource",
  "vmbus_proxy",
+ "vmgs_resources",
  "vmm_core_defs",
  "vmotherboard",
 ]
@@ -5413,6 +5417,7 @@ dependencies = [
  "vmbus_serial_resources",
  "vmcore",
  "vmgs_format",
+ "vmgs_resources",
  "vmm_core_defs",
  "vmotherboard",
  "vmsocket",

--- a/openhcl/underhill_core/src/vmgs_logger.rs
+++ b/openhcl/underhill_core/src/vmgs_logger.rs
@@ -24,6 +24,9 @@ impl VmgsLogger for GetVmgsLogger {
     async fn log_event_fatal(&self, event: VmgsLogEvent) {
         let event_id = match event {
             VmgsLogEvent::AccessFailed => EventLogId::VMGS_ACCESS_FAILED,
+            VmgsLogEvent::InvalidFormat => EventLogId::VMGS_INVALID_FORMAT,
+            VmgsLogEvent::CorruptFormat => EventLogId::VMGS_CORRUPT_FORMAT,
+            VmgsLogEvent::InitFailed => EventLogId::VMGS_INIT_FAILED,
         };
 
         self.get_client.event_log_fatal(event_id).await

--- a/openhcl/underhill_core/src/vmgs_logger.rs
+++ b/openhcl/underhill_core/src/vmgs_logger.rs
@@ -23,10 +23,10 @@ impl GetVmgsLogger {
 impl VmgsLogger for GetVmgsLogger {
     async fn log_event_fatal(&self, event: VmgsLogEvent) {
         let event_id = match event {
-            VmgsLogEvent::AccessFailed => EventLogId::VMGS_ACCESS_FAILED,
+            VmgsLogEvent::InitFailed => EventLogId::VMGS_INIT_FAILED,
             VmgsLogEvent::InvalidFormat => EventLogId::VMGS_INVALID_FORMAT,
             VmgsLogEvent::CorruptFormat => EventLogId::VMGS_CORRUPT_FORMAT,
-            VmgsLogEvent::InitFailed => EventLogId::VMGS_INIT_FAILED,
+            VmgsLogEvent::AccessFailed => EventLogId::VMGS_ACCESS_FAILED,
         };
 
         self.get_client.event_log_fatal(event_id).await

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -69,6 +69,7 @@ use futures_concurrency::future::Race;
 use get_protocol::EventLogId;
 use get_protocol::RegisterState;
 use get_protocol::TripleFaultType;
+use get_protocol::dps_json::GuestStateLifetime;
 use guest_emulation_transport::GuestEmulationTransportClient;
 use guest_emulation_transport::api::platform_settings::DevicePlatformSettings;
 use guest_emulation_transport::api::platform_settings::General;
@@ -1334,6 +1335,13 @@ async fn new_underhill_vm(
         with_vmbus_relay = !hide_isolation;
     }
 
+    if matches!(
+        dps.general.guest_state_lifetime,
+        GuestStateLifetime::Ephemeral
+    ) {
+        todo!("OpenHCL ephemeral guest state")
+    }
+
     // also construct the VMGS nice and early, as much like the GET, it also
     // plays an important role during initial bringup
     let (vmgs_disk_metadata, mut vmgs) = match servicing_state.vmgs {
@@ -1361,47 +1369,33 @@ async fn new_underhill_vm(
 
             let meta = disk.save_meta();
             let disk = Disk::new(disk).context("invalid vmgs disk")?;
+            let logger = Arc::new(GetVmgsLogger::new(get_client.clone()));
 
-            let vmgs = if !env_cfg.reformat_vmgs {
-                match Vmgs::open(
-                    disk.clone(),
-                    Some(Arc::new(GetVmgsLogger::new(get_client.clone()))),
-                )
-                .instrument(tracing::info_span!("vmgs_open"))
-                .await
-                {
-                    Ok(vmgs) => Some(vmgs),
-                    Err(vmgs::Error::EmptyFile) if !is_restoring => {
-                        tracing::info!("empty vmgs file, formatting");
-                        None
-                    }
-                    Err(err) => {
-                        let event_log_id = match err {
-                            // The data store format is invalid or not supported.
-                            vmgs::Error::InvalidFormat(_) => EventLogId::VMGS_INVALID_FORMAT,
-                            // The data store is corrupted.
-                            vmgs::Error::CorruptFormat(_) => EventLogId::VMGS_CORRUPT_FORMAT,
-                            // All other errors
-                            _ => EventLogId::VMGS_INIT_FAILED,
-                        };
-
-                        get_client.event_log_fatal(event_log_id).await;
-                        return Err(err).context("fatal VMGS initialization error")?;
-                    }
-                }
-            } else {
+            let vmgs = if env_cfg.reformat_vmgs
+                || matches!(
+                    dps.general.guest_state_lifetime,
+                    GuestStateLifetime::Reprovision
+                ) {
                 tracing::info!("formatting vmgs file on request");
-                None
-            };
-
-            let vmgs = if let Some(vmgs) = vmgs {
-                vmgs
-            } else {
-                Vmgs::format_new(disk, Some(Arc::new(GetVmgsLogger::new(get_client.clone()))))
+                Vmgs::format_new(disk, Some(logger))
                     .instrument(tracing::info_span!("vmgs_format"))
                     .await
                     .context("failed to format vmgs")?
+            } else {
+                Vmgs::try_open(
+                    disk,
+                    Some(logger),
+                    !is_restoring,
+                    matches!(
+                        dps.general.guest_state_lifetime,
+                        GuestStateLifetime::ReprovisionOnFailure
+                    ),
+                )
+                .instrument(tracing::info_span!("vmgs_open"))
+                .await
+                .context("failed to open vmgs")?
             };
+
             (meta, vmgs)
         }
     };
@@ -3065,6 +3059,7 @@ fn validate_isolated_configuration(dps: &DevicePlatformSettings) -> Result<(), a
         watchdog_enabled: _,
         vtl2_settings: _,
         cxl_memory_enabled: _,
+        guest_state_lifetime: _,
     } = &dps.general;
 
     if *hibernation_enabled {

--- a/openvmm/hvlite_core/Cargo.toml
+++ b/openvmm/hvlite_core/Cargo.toml
@@ -22,6 +22,7 @@ vm_topology = { workspace = true, features = ["mesh"] }
 guestmem.workspace = true
 vmcore.workspace = true
 vm_resource.workspace = true
+vmgs_resources.workspace = true
 
 aarch64defs.workspace = true
 acpi.workspace = true

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -123,6 +123,7 @@ use vmcore::vmtime::VmTime;
 use vmcore::vmtime::VmTimeKeeper;
 use vmcore::vmtime::VmTimeSource;
 use vmgs_broker::resolver::VmgsFileResolver;
+use vmgs_resources::VmgsResource;
 use vmm_core::acpi_builder::AcpiTablesBuilder;
 use vmm_core::input_distributor::InputDistributor;
 use vmm_core::partition_unit::Halt;
@@ -178,8 +179,7 @@ impl Manifest {
             vtl2_vmbus: config.vtl2_vmbus,
             #[cfg(all(windows, feature = "virt_whp"))]
             vpci_resources: config.vpci_resources,
-            format_vmgs: config.format_vmgs,
-            vmgs_disk: config.vmgs_disk,
+            vmgs: config.vmgs,
             secure_boot_enabled: config.secure_boot_enabled,
             custom_uefi_vars: config.custom_uefi_vars,
             firmware_event_send: config.firmware_event_send,
@@ -219,8 +219,7 @@ pub struct Manifest {
     vtl2_vmbus: Option<VmbusConfig>,
     #[cfg(all(windows, feature = "virt_whp"))]
     vpci_resources: Vec<virt_whp::device::DeviceHandle>,
-    format_vmgs: bool,
-    vmgs_disk: Option<Resource<DiskHandleKind>>,
+    vmgs: Option<VmgsResource>,
     secure_boot_enabled: bool,
     custom_uefi_vars: firmware_uefi_custom_vars::CustomVars,
     firmware_event_send: Option<mesh::Sender<get_resources::ged::FirmwareEvent>>,
@@ -966,18 +965,38 @@ impl InitializedVm {
             }
         }
 
-        let (vmgs_client, vmgs_task) = if let Some(vmgs_file) = cfg.vmgs_disk {
-            let disk = open_simple_disk(&resolver, vmgs_file, false).await?;
-            let vmgs = if cfg.format_vmgs {
-                vmgs::Vmgs::format_new(disk, None)
+        let vmgs = match cfg.vmgs {
+            Some(VmgsResource::Disk(disk)) => Some(
+                vmgs::Vmgs::try_open(
+                    open_simple_disk(&resolver, disk, false).await?,
+                    None,
+                    true,
+                    false,
+                )
+                .await
+                .context("failed to open vmgs file")?,
+            ),
+            Some(VmgsResource::ReprovisionOnFailure(disk)) => Some(
+                vmgs::Vmgs::try_open(
+                    open_simple_disk(&resolver, disk, false).await?,
+                    None,
+                    true,
+                    true,
+                )
+                .await
+                .context("failed to open vmgs file")?,
+            ),
+            Some(VmgsResource::Reprovision(disk)) => Some(
+                vmgs::Vmgs::format_new(open_simple_disk(&resolver, disk, false).await?, None)
                     .await
-                    .context("failed to format vmgs file")?
-            } else {
-                vmgs::Vmgs::open(disk, None)
-                    .await
-                    .context("failed to open vmgs file")?
-            };
+                    .context("failed to format vmgs file")?,
+            ),
+            Some(VmgsResource::Ephemeral) => None,
+            // TODO: make sure we don't need a VMGS
+            None => None,
+        };
 
+        let (vmgs_client, vmgs_task) = if let Some(vmgs) = vmgs {
             let (vmgs_client, vmgs_task) =
                 vmgs_broker::spawn_vmgs_broker(driver_source.builder().build("vmgs_broker"), vmgs);
             resolver.add_resolver(VmgsFileResolver::new(vmgs_client.clone()));
@@ -2853,8 +2872,7 @@ impl LoadedVm {
             virtio_devices: vec![], // TODO
             #[cfg(all(windows, feature = "virt_whp"))]
             vpci_resources: vec![], // TODO
-            vmgs_disk: None,        // TODO
-            format_vmgs: false,     // TODO
+            vmgs: None,             // TODO
             secure_boot_enabled: false, // TODO
             custom_uefi_vars: Default::default(), // TODO
             firmware_event_send: self.inner.firmware_event_send,

--- a/openvmm/hvlite_defs/Cargo.toml
+++ b/openvmm/hvlite_defs/Cargo.toml
@@ -12,6 +12,7 @@ hvlite_pcat_locator.workspace = true
 # vmcore
 memory_range.workspace = true
 vm_resource.workspace = true
+vmgs_resources.workspace = true
 
 vmotherboard.workspace = true
 firmware_uefi_custom_vars.workspace = true

--- a/openvmm/hvlite_defs/src/config.rs
+++ b/openvmm/hvlite_defs/src/config.rs
@@ -13,10 +13,10 @@ use net_backend_resources::mac_address::MacAddress;
 use std::fmt;
 use std::fs::File;
 use vm_resource::Resource;
-use vm_resource::kind::DiskHandleKind;
 use vm_resource::kind::PciDeviceHandleKind;
 use vm_resource::kind::VirtioDeviceHandle;
 use vm_resource::kind::VmbusDeviceHandleKind;
+use vmgs_resources::VmgsResource;
 use vmotherboard::ChipsetDeviceHandle;
 use vmotherboard::options::BaseChipsetManifest;
 
@@ -43,8 +43,7 @@ pub struct Config {
     pub virtio_devices: Vec<(VirtioBus, Resource<VirtioDeviceHandle>)>,
     #[cfg(windows)]
     pub vpci_resources: Vec<virt_whp::device::DeviceHandle>,
-    pub format_vmgs: bool,
-    pub vmgs_disk: Option<Resource<DiskHandleKind>>,
+    pub vmgs: Option<VmgsResource>,
     pub secure_boot_enabled: bool,
     pub custom_uefi_vars: firmware_uefi_custom_vars::CustomVars,
     // TODO: move FirmwareEvent somewhere not GED-specific.

--- a/openvmm/hvlite_helpers/src/disk.rs
+++ b/openvmm/hvlite_helpers/src/disk.rs
@@ -87,10 +87,10 @@ pub fn create_disk_type(path: &Path, size: u64) -> anyhow::Result<Resource<DiskH
             Resource::new(disk_backend_resources::FixedVhd1DiskHandle(file))
         }
         Some("vhdx") => {
-            anyhow::bail!("creating vhdx no supported")
+            anyhow::bail!("creating vhdx not supported")
         }
         Some("iso") => {
-            anyhow::bail!("creating iso no supported")
+            anyhow::bail!("creating iso not supported")
         }
         _ => {
             let file = std::fs::OpenOptions::new()

--- a/openvmm/hvlite_helpers/src/disk.rs
+++ b/openvmm/hvlite_helpers/src/disk.rs
@@ -70,3 +70,38 @@ pub fn open_disk_type(path: &Path, read_only: bool) -> anyhow::Result<Resource<D
         }
     })
 }
+
+/// Create and open the resources needed for using a disk from a file at `path`.
+pub fn create_disk_type(path: &Path, size: u64) -> anyhow::Result<Resource<DiskHandleKind>> {
+    Ok(match path.extension().and_then(|s| s.to_str()) {
+        Some("vhd") | Some("vmgs") => {
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .read(true)
+                .write(true)
+                .open(path)?;
+
+            file.set_len(size)?;
+            disk_vhd1::Vhd1Disk::make_fixed(&file)?;
+            Resource::new(disk_backend_resources::FixedVhd1DiskHandle(file))
+        }
+        Some("vhdx") => {
+            anyhow::bail!("creating vhdx no supported")
+        }
+        Some("iso") => {
+            anyhow::bail!("creating iso no supported")
+        }
+        _ => {
+            let file = std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .read(true)
+                .write(true)
+                .open(path)?;
+
+            file.set_len(size)?;
+            Resource::new(disk_backend_resources::FileDiskHandle(file))
+        }
+    })
+}

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -33,7 +33,6 @@ hvlite_pcat_locator.workspace = true
 hvlite_ttrpc_vmservice.workspace = true
 disk_backend_resources.workspace = true
 disk_crypt_resources.workspace = true
-disk_vhd1.workspace = true
 firmware_uefi_custom_vars.workspace = true
 hyperv_secure_boot_templates.workspace = true
 hyperv_uefi_custom_vars_json.workspace = true

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -887,6 +887,20 @@ fn vm_config_from_command_line(
         let (send, guest_request_recv) = mesh::channel();
         resources.ged_rpc = Some(send);
 
+        let vmgs = vmgs.take().unwrap();
+        // OpenHCL doesn't support ephemeral guest state yet,
+        // so give it a memory-backed VMGS
+        let vmgs = if matches!(vmgs, VmgsResource::Ephemeral) {
+            VmgsResource::Disk(
+                disk_backend_resources::LayeredDiskHandle::single_layer(RamDiskLayerHandle {
+                    len: Some(vmgs_format::VMGS_DEFAULT_CAPACITY),
+                })
+                .into_resource(),
+            )
+        } else {
+            vmgs
+        };
+
         vmbus_devices.extend([
             (
                 openhcl_vtl,
@@ -935,7 +949,7 @@ fn vm_config_from_command_line(
                     com2: with_vmbus_com2_serial,
                     vtl2_settings: Some(prost::Message::encode_to_vec(&vtl2_settings)),
                     vmbus_redirection: opt.vmbus_redirect,
-                    vmgs: vmgs.take().unwrap(),
+                    vmgs,
                     framebuffer: opt
                         .vtl2_gfx
                         .then(|| SharedFramebufferHandle.into_resource()),

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -30,9 +30,11 @@ use clap::Parser;
 use cli_args::DiskCliKind;
 use cli_args::EndpointConfigCli;
 use cli_args::NicConfigCli;
+use cli_args::ProvisionVmgs;
 use cli_args::SerialConfigCli;
 use cli_args::UefiConsoleModeCli;
 use cli_args::VirtioBusCli;
+use cli_args::VmgsCli;
 use crash_dump::spawn_dump_handler;
 use disk_backend_resources::DiskLayerDescription;
 use disk_backend_resources::layer::DiskLayerHandle;
@@ -76,6 +78,7 @@ use hvlite_defs::rpc::PulseSaveRestoreError;
 use hvlite_defs::rpc::VmRpc;
 use hvlite_defs::worker::VM_WORKER;
 use hvlite_defs::worker::VmWorkerParameters;
+use hvlite_helpers::disk::create_disk_type;
 use hvlite_helpers::disk::open_disk_type;
 use input_core::MultiplexedInputHandle;
 use inspect::InspectMut;
@@ -146,6 +149,7 @@ use vmbus_serial_resources::VmbusSerialDeviceHandle;
 use vmbus_serial_resources::VmbusSerialPort;
 use vmcore::non_volatile_store::resources::EphemeralNonVolatileStoreHandle;
 use vmgs_resources::VmgsFileHandle;
+use vmgs_resources::VmgsResource;
 use vmotherboard::ChipsetDeviceHandle;
 use vnc_worker_defs::VncParameters;
 
@@ -858,6 +862,17 @@ fn vm_config_from_command_line(
         };
     }
 
+    let mut vmgs = Some(if let Some(VmgsCli { kind, provision }) = &opt.vmgs {
+        let disk = disk_open(kind, false).context("failed to open vmgs disk")?;
+        match provision {
+            ProvisionVmgs::OnEmpty => VmgsResource::Disk(disk),
+            ProvisionVmgs::OnFailure => VmgsResource::ReprovisionOnFailure(disk),
+            ProvisionVmgs::True => VmgsResource::Reprovision(disk),
+        }
+    } else {
+        VmgsResource::Ephemeral
+    });
+
     if with_get && with_hv {
         let vtl2_settings = vtl2_settings_proto::Vtl2Settings {
             version: vtl2_settings_proto::vtl2_settings_base::Version::V1.into(),
@@ -871,14 +886,7 @@ fn vm_config_from_command_line(
 
         let (send, guest_request_recv) = mesh::channel();
         resources.ged_rpc = Some(send);
-        let vmgs_disk = if let Some(disk) = &opt.get_vmgs {
-            disk_open(disk, false).context("failed to open GET vmgs disk")?
-        } else {
-            disk_backend_resources::LayeredDiskHandle::single_layer(RamDiskLayerHandle {
-                len: Some(vmgs_format::VMGS_DEFAULT_CAPACITY),
-            })
-            .into_resource()
-        };
+
         vmbus_devices.extend([
             (
                 openhcl_vtl,
@@ -927,7 +935,7 @@ fn vm_config_from_command_line(
                     com2: with_vmbus_com2_serial,
                     vtl2_settings: Some(prost::Message::encode_to_vec(&vtl2_settings)),
                     vmbus_redirection: opt.vmbus_redirect,
-                    vmgs_disk: Some(vmgs_disk),
+                    vmgs: vmgs.take().unwrap(),
                     framebuffer: opt
                         .vtl2_gfx
                         .then(|| SharedFramebufferHandle.into_resource()),
@@ -962,7 +970,7 @@ fn vm_config_from_command_line(
             TpmRegisterLayout::Mmio
         };
 
-        let (ppi_store, nvram_store) = if opt.vmgs_file.is_some() {
+        let (ppi_store, nvram_store) = if opt.vmgs.is_some() {
             (
                 VmgsFileHandle::new(vmgs_format::FileId::TPM_PPI, true).into_resource(),
                 VmgsFileHandle::new(vmgs_format::FileId::TPM_NVRAM, true).into_resource(),
@@ -1265,27 +1273,6 @@ fn vm_config_from_command_line(
         );
     }
 
-    let (vmgs_disk, format_vmgs) = if let Some(path) = &opt.vmgs_file {
-        let file = fs_err::OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .open(path)
-            .context("failed to create or open vmgs file")?;
-        let format_vmgs = file.metadata()?.len() == 0;
-        if format_vmgs {
-            file.set_len(vmgs_format::VMGS_DEFAULT_CAPACITY)?;
-            disk_vhd1::Vhd1Disk::make_fixed(file.file())
-                .context("failed to format VHD1 file for VMGS")?;
-        }
-        (
-            Some(disk_backend_resources::FixedVhd1DiskHandle(file.into()).into_resource()),
-            format_vmgs,
-        )
-    } else {
-        (None, false)
-    };
-
     let mut cfg = Config {
         chipset,
         load_mode,
@@ -1350,8 +1337,7 @@ fn vm_config_from_command_line(
         chipset_devices,
         #[cfg(windows)]
         vpci_resources,
-        vmgs_disk,
-        format_vmgs,
+        vmgs,
         secure_boot_enabled: opt.secure_boot,
         custom_uefi_vars,
         firmware_event_send: None,
@@ -1537,10 +1523,16 @@ fn disk_open_inner(
         &DiskCliKind::Memory(len) => {
             layers.push(layer(RamDiskLayerHandle { len: Some(len) }));
         }
-        DiskCliKind::File(path) => layers.push(LayerOrDisk::Disk(
+        DiskCliKind::File {
+            path,
+            create_with_len,
+        } => layers.push(LayerOrDisk::Disk(if let Some(size) = create_with_len {
+            create_disk_type(path, *size)
+                .with_context(|| format!("failed to create {}", path.display()))?
+        } else {
             open_disk_type(path, read_only)
-                .with_context(|| format!("failed to open {}", path.display()))?,
-        )),
+                .with_context(|| format!("failed to open {}", path.display()))?
+        })),
         DiskCliKind::Blob { kind, url } => {
             layers.push(disk(disk_backend_resources::BlobDiskHandle {
                 url: url.to_owned(),

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -498,8 +498,7 @@ impl VmService {
             vmbus_devices: vec![],
             #[cfg(windows)]
             vpci_resources: vec![],
-            vmgs_disk: None,
-            format_vmgs: false,
+            vmgs: None,
             secure_boot_enabled: false,
             custom_uefi_vars: Default::default(),
             firmware_event_send: None,

--- a/petri/Cargo.toml
+++ b/petri/Cargo.toml
@@ -44,6 +44,7 @@ vmcore.workspace = true
 vm_manifest_builder.workspace = true
 vm_resource.workspace = true
 vmgs_format.workspace = true
+vmgs_resources.workspace = true
 vmm_core_defs.workspace = true
 vmotherboard.workspace = true
 vmsocket.workspace = true

--- a/petri/petri_artifacts_common/src/lib.rs
+++ b/petri/petri_artifacts_common/src/lib.rs
@@ -107,4 +107,7 @@ pub mod tags {
         /// What [`MachineArch`] this artifact supports.
         const ARCH: MachineArch;
     }
+
+    /// Artifact is a test VMGS file
+    pub trait IsTestVmgs: ArtifactId {}
 }

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -496,3 +496,13 @@ pub struct OpenHclServicingFlags {
     /// Preserve DMA memory for NVMe devices if supported.
     pub enable_nvme_keepalive: bool,
 }
+
+/// When to provision the VMGS file
+pub enum ProvisionVmgs {
+    /// If it is empty
+    OnEmpty,
+    /// If it is corrupt
+    OnFailure,
+    /// Reprovision, regardless
+    True,
+}

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -11,6 +11,7 @@ use crate::ShutdownKind;
 use async_trait::async_trait;
 use get_resources::ged::FirmwareEvent;
 use petri_artifacts_common::tags::GuestQuirks;
+use petri_artifacts_common::tags::IsTestVmgs;
 use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_common::tags::OsFlavor;
 use petri_artifacts_core::ArtifactResolver;
@@ -497,12 +498,14 @@ pub struct OpenHclServicingFlags {
     pub enable_nvme_keepalive: bool,
 }
 
-/// When to provision the VMGS file
-pub enum ProvisionVmgs {
-    /// If it is empty
-    OnEmpty,
-    /// If it is corrupt
-    OnFailure,
-    /// Reprovision, regardless
-    True,
+/// Virtual machine guest state resource
+pub enum PetriVmgsResource<T: IsTestVmgs> {
+    /// Use disk to store guest state
+    Disk(ResolvedArtifact<T>),
+    /// Use disk to store guest state, reformatting if corrupted.
+    ReprovisionOnFailure(ResolvedArtifact<T>),
+    /// Format and use disk to store guest state
+    Reprovision(ResolvedArtifact<T>),
+    /// Store guest state in memory
+    Ephemeral,
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -849,7 +849,12 @@ impl PetriVmConfigSetupCore<'_> {
             com2: true,
             vmbus_redirection: false,
             vtl2_settings: None, // Will be added at startup to allow tests to modify
-            vmgs: VmgsResource::Ephemeral,
+            vmgs: VmgsResource::Disk(
+                LayeredDiskHandle::single_layer(RamDiskLayerHandle {
+                    len: Some(vmgs_format::VMGS_DEFAULT_CAPACITY),
+                })
+                .into_resource(),
+            ),
             framebuffer: framebuffer.then(|| SharedFramebufferHandle.into_resource()),
             guest_request_recv,
             enable_tpm: false,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -85,6 +85,7 @@ use vm_resource::kind::SerialBackendHandle;
 use vm_resource::kind::VmbusDeviceHandleKind;
 use vmbus_serial_resources::VmbusSerialDeviceHandle;
 use vmbus_serial_resources::VmbusSerialPort;
+use vmgs_resources::VmgsResource;
 use vtl2_settings_proto::Vtl2Settings;
 
 impl PetriVmConfigOpenVmm {
@@ -347,8 +348,11 @@ impl PetriVmConfigOpenVmm {
             virtio_devices: vec![],
             #[cfg(windows)]
             vpci_resources: vec![],
-            vmgs_disk: None,
-            format_vmgs: false,
+            vmgs: if firmware.is_openhcl() {
+                None
+            } else {
+                Some(VmgsResource::Ephemeral)
+            },
             secure_boot_enabled: false,
             debugger_rpc: None,
             generation_id_recv: None,
@@ -845,12 +849,7 @@ impl PetriVmConfigSetupCore<'_> {
             com2: true,
             vmbus_redirection: false,
             vtl2_settings: None, // Will be added at startup to allow tests to modify
-            vmgs_disk: Some(
-                LayeredDiskHandle::single_layer(RamDiskLayerHandle {
-                    len: Some(vmgs_format::VMGS_DEFAULT_CAPACITY),
-                })
-                .into_resource(),
-            ),
+            vmgs: VmgsResource::Ephemeral,
             framebuffer: framebuffer.then(|| SharedFramebufferHandle.into_resource()),
             guest_request_recv,
             enable_tpm: false,

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -6,13 +6,11 @@
 use super::MANA_INSTANCE;
 use super::NIC_MAC_ADDRESS;
 use super::PetriVmConfigOpenVmm;
+use super::memdiff_disk_from_artifact;
+use crate::PetriVmgsResource;
 use crate::ProcessorTopology;
-use crate::ProvisionVmgs;
 use chipset_resources::battery::BatteryDeviceHandleX64;
 use chipset_resources::battery::HostBatteryUpdate;
-use disk_backend_resources::LayeredDiskHandle;
-use disk_backend_resources::layer::DiskLayerHandle;
-use disk_backend_resources::layer::RamDiskLayerHandle;
 use fs_err::File;
 use gdma_resources::GdmaDeviceHandle;
 use gdma_resources::VportDefinition;
@@ -22,10 +20,9 @@ use hvlite_defs::config::DeviceVtl;
 use hvlite_defs::config::LoadMode;
 use hvlite_defs::config::VpciDeviceConfig;
 use hvlite_defs::config::Vtl2BaseAddressType;
-use hvlite_helpers::disk::open_disk_type;
+use petri_artifacts_common::tags::IsTestVmgs;
 use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_core::ResolvedArtifact;
-use std::path::Path;
 use tpm_resources::TpmDeviceHandle;
 use tpm_resources::TpmRegisterLayout;
 use vm_resource::IntoResource;
@@ -316,23 +313,18 @@ impl PetriVmConfigOpenVmm {
     }
 
     /// Specifies an existing VMGS file to use
-    pub fn with_vmgs(mut self, vmgs_path: impl AsRef<Path>, provision: ProvisionVmgs) -> Self {
-        let disk = LayeredDiskHandle {
-            layers: vec![
-                RamDiskLayerHandle { len: None }.into_resource().into(),
-                DiskLayerHandle(
-                    open_disk_type(vmgs_path.as_ref(), true).expect("failed to open VMGS file"),
-                )
-                .into_resource()
-                .into(),
-            ],
-        }
-        .into_resource();
-
-        let vmgs = match provision {
-            ProvisionVmgs::OnEmpty => VmgsResource::Disk(disk),
-            ProvisionVmgs::OnFailure => VmgsResource::ReprovisionOnFailure(disk),
-            ProvisionVmgs::True => VmgsResource::Reprovision(disk),
+    pub fn with_vmgs<T: IsTestVmgs>(mut self, vmgs: PetriVmgsResource<T>) -> Self {
+        let vmgs = match vmgs {
+            PetriVmgsResource::Disk(disk) => {
+                VmgsResource::Disk(memdiff_disk_from_artifact(&disk.erase()).expect("open VMGS"))
+            }
+            PetriVmgsResource::ReprovisionOnFailure(disk) => VmgsResource::ReprovisionOnFailure(
+                memdiff_disk_from_artifact(&disk.erase()).expect("open VMGS"),
+            ),
+            PetriVmgsResource::Reprovision(disk) => VmgsResource::Reprovision(
+                memdiff_disk_from_artifact(&disk.erase()).expect("open VMGS"),
+            ),
+            PetriVmgsResource::Ephemeral => VmgsResource::Ephemeral,
         };
 
         if self.firmware.is_openhcl() {

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -90,6 +90,16 @@ pub enum PcatBootDevice {
     Network,
 }
 
+/// Guest state lifetime
+#[derive(Debug, Copy, Clone, Deserialize, Serialize, Default)]
+pub enum GuestStateLifetime {
+    #[default]
+    Default,
+    ReprovisionOnFailure,
+    Reprovision,
+    Ephemeral,
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct HclDevicePlatformSettingsV2Static {
@@ -138,6 +148,8 @@ pub struct HclDevicePlatformSettingsV2Static {
     pub imc_enabled: bool,
     #[serde(default)]
     pub cxl_memory_enabled: bool,
+    #[serde(default)]
+    pub guest_state_lifetime: GuestStateLifetime,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/vm/devices/get/get_resources/Cargo.toml
+++ b/vm/devices/get/get_resources/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 vm_resource.workspace = true
+vmgs_resources.workspace = true
 
 mesh.workspace = true
 

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -51,9 +51,9 @@ pub mod ged {
     use thiserror::Error;
     use vm_resource::Resource;
     use vm_resource::ResourceId;
-    use vm_resource::kind::DiskHandleKind;
     use vm_resource::kind::FramebufferHandleKind;
     use vm_resource::kind::VmbusDeviceHandleKind;
+    use vmgs_resources::VmgsResource;
 
     /// A resource handle for a guest emulation device.
     #[derive(MeshPayload)]
@@ -71,9 +71,7 @@ pub mod ged {
         /// Encoded VTL2 settings.
         pub vtl2_settings: Option<Vec<u8>>,
         /// The disk to back the GET's VMGS interface.
-        ///
-        /// If `None`, then VMGS services will not be provided to the guest.
-        pub vmgs_disk: Option<Resource<DiskHandleKind>>,
+        pub vmgs: VmgsResource,
         /// Framebuffer device control.
         pub framebuffer: Option<Resource<FramebufferHandleKind>>,
         /// Access to VTL2 functionality.

--- a/vm/devices/get/guest_emulation_device/Cargo.toml
+++ b/vm/devices/get/guest_emulation_device/Cargo.toml
@@ -25,6 +25,7 @@ vmbus_channel.workspace = true
 vmbus_ring.workspace = true
 vmcore.workspace = true
 vm_resource.workspace = true
+vmgs_resources.workspace = true
 
 async-trait.workspace = true
 inspect.workspace = true

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -36,6 +36,7 @@ use get_protocol::SecureBootTemplateType;
 use get_protocol::StartVtl0Status;
 use get_protocol::UefiConsoleMode;
 use get_protocol::VmgsIoStatus;
+use get_protocol::dps_json::GuestStateLifetime;
 use get_protocol::dps_json::HclSecureBootTemplateId;
 use get_protocol::dps_json::PcatBootDevice;
 use get_resources::ged::FirmwareEvent;
@@ -149,6 +150,9 @@ pub struct GuestConfig {
     pub enable_battery: bool,
     /// Suppress attestation.
     pub no_persistent_secrets: bool,
+    /// Guest state lifetime
+    #[inspect(debug)]
+    pub guest_state_lifetime: GuestStateLifetime,
 }
 
 #[derive(Debug, Clone, Inspect)]
@@ -1420,6 +1424,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     always_relay_host_mmio: false,
                     imc_enabled: false,
                     cxl_memory_enabled: false,
+                    guest_state_lifetime: state.config.guest_state_lifetime,
                 },
                 dynamic: get_protocol::dps_json::HclDevicePlatformSettingsV2Dynamic {
                     is_servicing_scenario: state.save_restore_buf.is_some(),

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -78,7 +78,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                 (Some(disk), GuestStateLifetime::ReprovisionOnFailure)
             }
             VmgsResource::Reprovision(disk) => (Some(disk), GuestStateLifetime::Reprovision),
-            VmgsResource::Ephemeral => (None, GuestStateLifetime::Default),
+            VmgsResource::Ephemeral => (None, GuestStateLifetime::Ephemeral),
         };
 
         let vmgs_disk = if let Some(disk) = vmgs_disk {

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -5,6 +5,7 @@ use crate::GuestEmulationDevice;
 use async_trait::async_trait;
 use disk_backend::resolve::ResolveDiskParameters;
 use get_protocol::SecureBootTemplateType;
+use get_protocol::dps_json::GuestStateLifetime;
 use get_resources::ged::GuestEmulationDeviceHandle;
 use get_resources::ged::GuestFirmwareConfig;
 use get_resources::ged::GuestSecureBootTemplateType;
@@ -22,6 +23,7 @@ use vm_resource::kind::VmbusDeviceHandleKind;
 use vmbus_channel::resources::ResolveVmbusDeviceHandleParams;
 use vmbus_channel::resources::ResolvedVmbusDevice;
 use vmbus_channel::simple::SimpleDeviceWrapper;
+use vmgs_resources::VmgsResource;
 
 pub struct GuestEmulationDeviceResolver;
 
@@ -70,7 +72,16 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
             .await
             .map_err(Error::Power)?;
 
-        let vmgs_disk = if let Some(disk) = resource.vmgs_disk {
+        let (vmgs_disk, guest_state_lifetime) = match resource.vmgs {
+            VmgsResource::Disk(disk) => (Some(disk), GuestStateLifetime::Default),
+            VmgsResource::ReprovisionOnFailure(disk) => {
+                (Some(disk), GuestStateLifetime::ReprovisionOnFailure)
+            }
+            VmgsResource::Reprovision(disk) => (Some(disk), GuestStateLifetime::Reprovision),
+            VmgsResource::Ephemeral => (None, GuestStateLifetime::Default),
+        };
+
+        let vmgs_disk = if let Some(disk) = vmgs_disk {
             Some(
                 resolver
                     .resolve(
@@ -145,6 +156,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                 },
                 enable_battery: resource.enable_battery,
                 no_persistent_secrets: resource.no_persistent_secrets,
+                guest_state_lifetime,
             },
             halt,
             resource.firmware_event_send,

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -253,6 +253,7 @@ pub fn create_host_channel(
         secure_boot_template: SecureBootTemplateType::SECURE_BOOT_DISABLED,
         enable_battery: false,
         no_persistent_secrets: true,
+        guest_state_lifetime: Default::default(),
     };
 
     let halt_reason = Arc::new(Mutex::new(None));

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -26,6 +26,7 @@ use guid::Guid;
 pub mod platform_settings {
     pub use get_protocol::dps_json::PcatBootDevice;
 
+    use get_protocol::dps_json::GuestStateLifetime;
     use guid::Guid;
     use inspect::Inspect;
 
@@ -119,6 +120,9 @@ pub mod platform_settings {
         pub firmware_mode_is_pcat: bool,
         pub imc_enabled: bool,
         pub cxl_memory_enabled: bool,
+
+        #[inspect(debug)]
+        pub guest_state_lifetime: GuestStateLifetime,
     }
 
     #[derive(Copy, Clone, Debug, Inspect)]

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -336,6 +336,7 @@ impl GuestEmulationTransportClient {
                 firmware_mode_is_pcat: json.v2.r#static.firmware_mode_is_pcat,
                 imc_enabled: json.v2.r#static.imc_enabled,
                 cxl_memory_enabled: json.v2.r#static.cxl_memory_enabled,
+                guest_state_lifetime: json.v2.r#static.guest_state_lifetime,
             },
             acpi_tables: json.v2.dynamic.acpi_tables,
         })

--- a/vm/vmgs/vmgs/src/logger.rs
+++ b/vm/vmgs/vmgs/src/logger.rs
@@ -10,6 +10,12 @@ use std::sync::Arc;
 pub enum VmgsLogEvent {
     /// Data store access failure.
     AccessFailed,
+    /// Invalid VMGS file format.
+    InvalidFormat,
+    /// Corrupt VMGS file format.
+    CorruptFormat,
+    /// VMGS initialization failed.
+    InitFailed,
 }
 
 /// A trait for sending log event to the host.

--- a/vm/vmgs/vmgs/src/logger.rs
+++ b/vm/vmgs/vmgs/src/logger.rs
@@ -8,14 +8,14 @@ use std::sync::Arc;
 
 /// List of events for `VmgsLogger`.
 pub enum VmgsLogEvent {
-    /// Data store access failure.
-    AccessFailed,
+    /// VMGS initialization failed.
+    InitFailed,
     /// Invalid VMGS file format.
     InvalidFormat,
     /// Corrupt VMGS file format.
     CorruptFormat,
-    /// VMGS initialization failed.
-    InitFailed,
+    /// Data store access failure.
+    AccessFailed,
 }
 
 /// A trait for sending log event to the host.

--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -138,6 +138,40 @@ mod vmgs_inspect {
 }
 
 impl Vmgs {
+    /// Attempt to open the VMGS file, optionally formatting if it is
+    /// empty or corrupted.
+    pub async fn try_open(
+        disk: Disk,
+        logger: Option<Arc<dyn VmgsLogger>>,
+        format_on_empty: bool,
+        format_on_failure: bool,
+    ) -> Result<Self, Error> {
+        match Vmgs::open(disk.clone(), logger.clone()).await {
+            Ok(vmgs) => Ok(vmgs),
+            Err(Error::EmptyFile) if format_on_empty => {
+                tracing::info!("empty vmgs file, formatting");
+                Vmgs::format_new(disk, logger).await
+            }
+            Err(err) if format_on_failure => {
+                tracing::warn!(?err, "vmgs initialization error, reformatting");
+                Vmgs::format_new(disk, logger).await
+            }
+            Err(err) => {
+                let event_log_id = match err {
+                    // The data store format is invalid or not supported.
+                    Error::InvalidFormat(_) => VmgsLogEvent::InvalidFormat,
+                    // The data store is corrupted.
+                    Error::CorruptFormat(_) => VmgsLogEvent::CorruptFormat,
+                    // All other errors
+                    _ => VmgsLogEvent::InitFailed,
+                };
+
+                logger.log_event_fatal(event_log_id).await;
+                Err(err)
+            }
+        }
+    }
+
     /// Format and open a new VMGS file.
     pub async fn format_new(
         disk: Disk,

--- a/vm/vmgs/vmgs_resources/src/lib.rs
+++ b/vm/vmgs/vmgs_resources/src/lib.rs
@@ -6,7 +6,9 @@
 #![forbid(unsafe_code)]
 
 use mesh::MeshPayload;
+use vm_resource::Resource;
 use vm_resource::ResourceId;
+use vm_resource::kind::DiskHandleKind;
 use vm_resource::kind::NonVolatileStoreKind;
 use vmgs_format::FileId;
 
@@ -33,4 +35,17 @@ impl VmgsFileHandle {
 
 impl ResourceId<NonVolatileStoreKind> for VmgsFileHandle {
     const ID: &'static str = "vmgs";
+}
+
+/// Virtual machine guest state resource
+#[derive(MeshPayload, Debug)]
+pub enum VmgsResource {
+    /// Use disk to store guest state
+    Disk(Resource<DiskHandleKind>),
+    /// Use disk to store guest state, reformatting if corrupted.
+    ReprovisionOnFailure(Resource<DiskHandleKind>),
+    /// Format and use disk to store guest state
+    Reprovision(Resource<DiskHandleKind>),
+    /// Store guest state in memory
+    Ephemeral,
 }

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -380,6 +380,7 @@ pub mod artifacts {
     /// Test VMGS artifacts
     pub mod test_vmgs {
         use crate::tags::IsHostedOnHvliteAzureBlobStore;
+        use petri_artifacts_common::tags::IsTestVmgs;
         use petri_artifacts_core::declare_artifacts;
 
         declare_artifacts! {
@@ -396,6 +397,8 @@ pub mod artifacts {
             const FILENAME: &'static str = "sample-vmgs.vhd";
             const SIZE: u64 = 4194816;
         }
+
+        impl IsTestVmgs for VMGS_WITH_BOOT_ENTRY {}
     }
 
     /// TMK-related artifacts

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -428,7 +428,7 @@ async fn default_boot(
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
-        .with_vmgs(initial_vmgs, petri::ProvisionVmgs::OnEmpty)
+        .with_vmgs(petri::PetriVmgsResource::Disk(initial_vmgs))
         .with_default_boot_always_attempt(true)
         .run()
         .await?;
@@ -454,7 +454,7 @@ async fn clear_vmgs(
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
-        .with_vmgs(initial_vmgs, petri::ProvisionVmgs::True)
+        .with_vmgs(petri::PetriVmgsResource::Reprovision(initial_vmgs))
         .run()
         .await?;
 
@@ -481,7 +481,7 @@ async fn boot_expect_fail(
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let mut vm = config
-        .with_vmgs(initial_vmgs, petri::ProvisionVmgs::OnEmpty)
+        .with_vmgs(petri::PetriVmgsResource::Disk(initial_vmgs))
         .run_without_agent()
         .await?;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -428,8 +428,33 @@ async fn default_boot(
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
-        .with_vmgs(initial_vmgs)
+        .with_vmgs(initial_vmgs, petri::ProvisionVmgs::OnEmpty)
         .with_default_boot_always_attempt(true)
+        .run()
+        .await?;
+
+    agent.power_off().await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+
+    Ok(())
+}
+
+/// Verify that UEFI successfully boots an operating system after reprovisioning
+/// the VMGS when invalid boot entries existed initially.
+#[openvmm_test(
+    // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))[VMGS_WITH_BOOT_ENTRY],
+    openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGS_WITH_BOOT_ENTRY],
+    openvmm_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
+    openvmm_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY],
+    openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
+    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY]
+)]
+async fn clear_vmgs(
+    config: PetriVmConfigOpenVmm,
+    (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
+) -> Result<(), anyhow::Error> {
+    let (vm, agent) = config
+        .with_vmgs(initial_vmgs, petri::ProvisionVmgs::True)
         .run()
         .await?;
 
@@ -442,7 +467,7 @@ async fn default_boot(
 /// Verify that UEFI fails to boot if invalid boot entries exist
 ///
 /// This test exists to ensure we are not getting a false positive for
-/// the `default_boot` test above.
+/// the `default_boot` and `clear_vmgs` test above.
 #[openvmm_test(
     // openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[VMGS_WITH_BOOT_ENTRY],
@@ -451,11 +476,14 @@ async fn default_boot(
     openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64))[VMGS_WITH_BOOT_ENTRY],
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY]
 )]
-async fn no_default_boot(
+async fn boot_expect_fail(
     config: PetriVmConfigOpenVmm,
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
-    let mut vm = config.with_vmgs(initial_vmgs).run_without_agent().await?;
+    let mut vm = config
+        .with_vmgs(initial_vmgs, petri::ProvisionVmgs::OnEmpty)
+        .run_without_agent()
+        .await?;
 
     assert_eq!(vm.wait_for_boot_event().await?, FirmwareEvent::BootFailed);
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);


### PR DESCRIPTION
Reprovision the VMGS file based on a DevicePlatformSettings property: either only on failure or always. Also plumbs a setting (yet to be implemented in OpenHCL) to use ephemeral, in-memory guest state.