### PR TITLE
virt_mshv_vtl: Flatten some more CVM-related inspects

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -229,7 +229,7 @@ struct UhPartitionInner {
 }
 
 #[derive(Inspect)]
-#[inspect(external_tag)]
+#[inspect(untagged)]
 enum BackingShared {
     Hypervisor(#[inspect(flatten)] HypervisorBackedShared),
     #[cfg(guest_arch = "x86_64")]
@@ -506,7 +506,10 @@ struct UhCvmVpInner {
 enum GuestVsmState<T: Inspect> {
     NotPlatformSupported,
     NotGuestEnabled,
-    Enabled { vtl1: T },
+    Enabled {
+        #[inspect(flatten)]
+        vtl1: T,
+    },
 }
 
 impl<T: Inspect> GuestVsmState<T> {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -325,6 +325,7 @@ impl HardwareIsolatedBacking for SnpBacked {
 /// Partition-wide shared data for SNP VPs.
 #[derive(Inspect)]
 pub struct SnpBackedShared {
+    #[inspect(flatten)]
     pub(crate) cvm: UhCvmPartitionState,
     invlpgb_count_max: u16,
     tsc_aux_virtualized: bool,

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -665,6 +665,7 @@ impl HardwareIsolatedBacking for TdxBacked {
 /// Partition-wide shared data for TDX VPs.
 #[derive(Inspect)]
 pub struct TdxBackedShared {
+    #[inspect(flatten)]
     pub(crate) cvm: UhCvmPartitionState,
     /// The synic state used for untrusted SINTs, that is, the SINTs for which
     /// the guest thinks it is interacting directly with the untrusted


### PR DESCRIPTION
Makes things a bit nicer. Found while poking around yesterday debugging cstar.