### PR TITLE
virt_mshv_vtl: Add a vtl sanity check to mnf access

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -1260,8 +1260,9 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 }
 
-fn signal_mnf(dev: &impl CpuIo, connection_id: u32) {
-    if let Err(err) = dev.signal_synic_event(Vtl::Vtl0, connection_id, 0) {
+fn signal_mnf(vtl: GuestVtl, dev: &impl CpuIo, connection_id: u32) {
+    assert_eq!(vtl, GuestVtl::Vtl0);
+    if let Err(err) = dev.signal_synic_event(vtl.into(), connection_id, 0) {
         tracelimit::warn_ratelimited!(
             error = &err as &dyn std::error::Error,
             connection_id,

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -373,7 +373,7 @@ impl UhProcessor<'_, HypervisorBackedArm64> {
                     if let Some(connection_id) =
                         self.partition.monitor_page.write_bit(bit_offset + bit)
                     {
-                        signal_mnf(dev, connection_id);
+                        signal_mnf(intercepted_vtl, dev, connection_id);
                     }
                 }
                 return Ok(());
@@ -767,7 +767,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedA
             .partition
             .monitor_page
             .check_write(gpa, bytes, |connection_id| {
-                signal_mnf(self.devices, connection_id)
+                signal_mnf(self.vtl, self.devices, connection_id)
             })
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -671,7 +671,7 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
                 tlb_lock_held,
             )? {
                 if let Some(connection_id) = self.vp.partition.monitor_page.write_bit(bit) {
-                    signal_mnf(dev, connection_id);
+                    signal_mnf(self.intercepted_vtl, dev, connection_id);
                 }
                 return Ok(());
             }
@@ -1349,7 +1349,7 @@ impl<T: CpuIo> EmulatorSupport for UhEmulationState<'_, '_, T, HypervisorBackedX
             .partition
             .monitor_page
             .check_write(gpa, bytes, |connection_id| {
-                signal_mnf(self.devices, connection_id)
+                signal_mnf(self.vtl, self.devices, connection_id)
             })
     }
 


### PR DESCRIPTION
This is just to make sure we don't accidentally try to do mnf things on VTL 1. Following the pattern we've done elsewhere for VTL 0-only things.