### PR TITLE
hypestv: add nmi command

### DIFF
--- a/hyperv/tools/hypestv/src/windows/mod.rs
+++ b/hyperv/tools/hypestv/src/windows/mod.rs
@@ -95,6 +95,13 @@ pub(crate) enum VmCommand {
         /// The serial output mode.
         mode: Option<SerialMode>,
     },
+
+    /// Injects an NMI.
+    Nmi {
+        /// The target VTL.
+        #[clap(long, default_value = "0")]
+        vtl: u32,
+    },
 }
 
 #[derive(Parser)]

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -210,6 +210,17 @@ impl Vm {
                 }
             }
             VmCommand::Paravisor(cmd) => self.handle_paravisor_command(cmd).await?,
+            VmCommand::Nmi { vtl } => {
+                let r = powershell_script(
+                    r#"
+                    param([string]$id, [int]$vtl)
+                    $ErrorActionPreference = "Stop"
+                    $vm = Get-CimInstance -namespace "root\virtualization\v2" -query "select * from Msvm_ComputerSystem where Name = '$id'"
+                    $vm | Invoke-CimMethod -Name "InjectNonMaskableInterruptEx" -Arguments @{"Vtl" = $vtl}
+                    "#,
+                    &[&self.inner.id.to_string(), &vtl.to_string()],
+                )?;
+            }
         }
         Ok(())
     }

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -211,7 +211,7 @@ impl Vm {
             }
             VmCommand::Paravisor(cmd) => self.handle_paravisor_command(cmd).await?,
             VmCommand::Nmi { vtl } => {
-                let r = powershell_script(
+                powershell_script(
                     r#"
                     param([string]$id, [int]$vtl)
                     $ErrorActionPreference = "Stop"


### PR DESCRIPTION
Add an `nmi` command to inject a non-maskable interrupt into the VM.

This is useful to force a panic when the VM appears to be completely unresponsive.