### PR TITLE
flowey: don't log minor steps

### DIFF
--- a/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/direct_run.rs
@@ -21,13 +21,12 @@ use std::collections::BTreeSet;
 use std::path::Path;
 use std::path::PathBuf;
 
-pub struct ResolvedRunnableNode {
-    pub node_handle: NodeHandle,
-    pub steps: Vec<(
-        usize,
-        String,
-        Box<dyn for<'a> FnOnce(&'a mut RustRuntimeServices<'_>) -> anyhow::Result<()> + 'static>,
-    )>,
+struct ResolvedRunnableStep {
+    node_handle: NodeHandle,
+    label: String,
+    code: Box<dyn for<'a> FnOnce(&'a mut RustRuntimeServices<'_>) -> anyhow::Result<()> + 'static>,
+    idx: usize,
+    can_merge: bool,
 }
 
 /// Directly run the pipeline using flowey
@@ -160,7 +159,7 @@ fn direct_run_do_work(
         }
 
         let nodes = {
-            let mut resolved_local_nodes = Vec::new();
+            let mut resolved_local_steps = Vec::new();
 
             let (mut output_graph, _, err_unreachable_nodes) =
                 crate::flow_resolver::stage1_dag::stage1_dag(
@@ -193,15 +192,14 @@ fn direct_run_do_work(
             for idx in output_order.into_iter().rev() {
                 let OutputGraphEntry { node_handle, step } = output_graph[idx].1.take().unwrap();
 
-                let mut steps = Vec::new();
-                let (label, code, idx) = match step {
+                let (label, code, idx, can_merge) = match step {
                     Step::Anchor { .. } => continue,
                     Step::Rust {
                         label,
                         code,
                         idx,
-                        can_merge: _,
-                    } => (label, code, idx),
+                        can_merge,
+                    } => (label, code, idx, can_merge),
                     Step::AdoYaml { .. } => {
                         anyhow::bail!(
                             "{} emitted ADO YAML. Fix the node by checking `ctx.backend()` appropriately",
@@ -215,12 +213,17 @@ fn direct_run_do_work(
                         )
                     }
                 };
-                steps.push((idx, label, code.lock().take().unwrap()));
 
-                resolved_local_nodes.push(ResolvedRunnableNode { node_handle, steps })
+                resolved_local_steps.push(ResolvedRunnableStep {
+                    node_handle,
+                    label,
+                    code: code.lock().take().unwrap(),
+                    idx,
+                    can_merge,
+                });
             }
 
-            resolved_local_nodes
+            resolved_local_steps
         };
 
         let mut in_mem_var_db = crate::var_db::in_memory::InMemoryVarDb::new();
@@ -340,25 +343,39 @@ fn direct_run_do_work(
             }
         }
 
-        for ResolvedRunnableNode { node_handle, steps } in nodes {
-            for (idx, label, code) in steps {
-                let node_working_dir = out_dir.join(".work").join(format!(
-                    "{}_{}",
-                    node_handle.modpath().replace("::", "__"),
-                    idx
-                ));
-                if !node_working_dir.exists() {
-                    fs_err::create_dir(&node_working_dir)?;
-                }
-                std::env::set_current_dir(node_working_dir)?;
+        for ResolvedRunnableStep {
+            node_handle,
+            label,
+            code,
+            idx,
+            can_merge,
+        } in nodes
+        {
+            let node_working_dir = out_dir.join(".work").join(format!(
+                "{}_{}",
+                node_handle.modpath().replace("::", "__"),
+                idx
+            ));
+            if !node_working_dir.exists() {
+                fs_err::create_dir(&node_working_dir)?;
+            }
+            std::env::set_current_dir(node_working_dir)?;
 
+            if can_merge {
+                log::debug!("minor step: {} ({})", label, node_handle.modpath(),);
+            } else {
                 log::info!(
                     // green color
                     "\x1B[0;32m=== {} ({}) ===\x1B[0m",
                     label,
                     node_handle.modpath(),
                 );
-                code(&mut runtime_services)?;
+            }
+            code(&mut runtime_services)?;
+            if can_merge {
+                log::debug!("done!");
+                log::debug!(""); // log a newline, for the pretty
+            } else {
                 log::info!("\x1B[0;32m=== done! ===\x1B[0m");
                 log::info!(""); // log a newline, for the pretty
             }


### PR DESCRIPTION
Reduce clutter in local `cargo xflowey build-igvm` output--skip writing minor step output, since those steps cannot fail and are not doing anything interesting.