### PR TITLE
CVM: Don't recommend synthetic cluster ipis in cpuid

### DIFF
--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -436,8 +436,7 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
             // Hyper-V MSRs to function. Enable it here always.
             .with_use_apic_msrs(true)
             .with_long_spin_wait_count(!0)
-            .with_use_hypercall_for_remote_flush_and_local_flush_entire(true)
-            .with_use_synthetic_cluster_ipi(true);
+            .with_use_hypercall_for_remote_flush_and_local_flush_entire(true);
 
         let hardware_features = hvdef::HvHardwareFeatures::new()
             .with_apic_overlay_assist_in_use(true)

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -307,7 +307,6 @@ impl CpuidArchInitializer for TdxCpuidInitializer<'_> {
             .with_use_ex_processor_masks(true)
             .with_use_apic_msrs(use_apic_msrs)
             .with_long_spin_wait_count(!0)
-            .with_use_synthetic_cluster_ipi(true)
             .with_use_hypercall_for_remote_flush_and_local_flush_entire(true);
 
         let hardware_features = hvdef::HvHardwareFeatures::new()


### PR DESCRIPTION
We think the synthetic cluster ipi path is less efficient for us as it requires a switch into usermode, while other interrupt activity can be handled purely in kernel mode. We still support the hypercall in case it's made unconditionally in places.