### PR TITLE
igvm: add sidecar to all non-CVM x64 recipes

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -4951,7 +4951,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
@@ -4985,7 +4985,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
@@ -5010,7 +5010,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
@@ -5036,7 +5036,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
@@ -5058,7 +5058,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -5230,7 +5230,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 27
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 28
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 31
@@ -5264,7 +5264,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 4
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 39
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 40
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 43
@@ -5289,7 +5289,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 51
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 52
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 55
@@ -5315,7 +5315,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 2
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 3
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 15
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 16
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 19
@@ -5337,7 +5337,7 @@ jobs:
       shell: bash
     - name: split debug symbols
       run: |-
-        flowey e 9 flowey_lib_hvlite::run_split_debug_info 0
+        flowey e 9 flowey_lib_hvlite::run_split_debug_info 1
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 3
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 4
         flowey e 9 flowey_lib_hvlite::build_openhcl_igvm_from_recipe 7

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -30,7 +30,7 @@ pub const NODEJS: &str = "18.x";
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
 pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.9.2";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.9.2";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.9.3";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -129,7 +129,7 @@ impl OpenhclIgvmRecipe {
                 vtl0_kernel_type: None,
                 with_uefi: true,
                 with_interactive,
-                with_sidecar: false,
+                with_sidecar: true,
             },
             Self::X64Devkern => OpenhclIgvmRecipeDetails {
                 local_only: None,
@@ -168,7 +168,7 @@ impl OpenhclIgvmRecipe {
                 vtl0_kernel_type: Some(Vtl0KernelType::Example),
                 with_uefi: false,
                 with_interactive,
-                with_sidecar: false,
+                with_sidecar: true,
             },
             Self::X64TestLinuxDirectDevkern => OpenhclIgvmRecipeDetails {
                 local_only: None,
@@ -182,7 +182,7 @@ impl OpenhclIgvmRecipe {
                 vtl0_kernel_type: Some(Vtl0KernelType::Example),
                 with_uefi: false,
                 with_interactive,
-                with_sidecar: false,
+                with_sidecar: true,
             },
             Self::X64Cvm => OpenhclIgvmRecipeDetails {
                 local_only: None,

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -16,7 +16,6 @@ use petri::ShutdownKind;
 use petri::openvmm::PetriVmConfigOpenVmm;
 use petri::pipette::cmd;
 use petri_artifacts_common::tags::OsFlavor;
-use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_STANDARD_DEV_KERNEL_X64;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;
@@ -305,40 +304,32 @@ async fn battery_capacity(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Er
 
 fn configure_for_sidecar(
     config: Box<dyn PetriVmConfig>,
-    igvm: ResolvedArtifact<LATEST_STANDARD_DEV_KERNEL_X64>,
     proc_count: u32,
 ) -> Box<dyn PetriVmConfig> {
-    config
-        .with_custom_openhcl(igvm.erase())
-        .with_processor_topology({
-            ProcessorTopology {
-                vp_count: proc_count,
-                // Sidecar will start one VP per socket. For this test, use just one
-                // socket.
-                vps_per_socket: Some(proc_count),
-                enable_smt: Some(false),
-                // Sidecar currently requires x2APIC.
-                apic_mode: Some(ApicMode::X2apicSupported),
-            }
-        })
+    config.with_processor_topology({
+        ProcessorTopology {
+            vp_count: proc_count,
+            // Sidecar will start one VP per socket. For this test, use just one
+            // socket.
+            vps_per_socket: Some(proc_count),
+            enable_smt: Some(false),
+            // Sidecar currently requires x2APIC.
+            apic_mode: Some(ApicMode::X2apicSupported),
+        }
+    })
 }
 
-// Sidecar currently requires the dev kernel build.
-//
 // Use UEFI so that the guest doesn't access the other APs, causing hot adds
 // into VTL2 Linux.
 //
 // Sidecar isn't supported on aarch64 yet.
 #[vmm_test(
-    openvmm_openhcl_uefi_x64(none) [LATEST_STANDARD_DEV_KERNEL_X64],
-    // TODO: debug why boot is failing  hyperv_openhcl_uefi_x64(none) [LATEST_STANDARD_DEV_KERNEL_X64],
+    openvmm_openhcl_uefi_x64(none),
+    // TODO: debug why boot is failing hyperv_openhcl_uefi_x64(none),
 )]
-async fn sidecar_aps_unused(
-    config: Box<dyn PetriVmConfig>,
-    (igvm,): (ResolvedArtifact<LATEST_STANDARD_DEV_KERNEL_X64>,),
-) -> Result<(), anyhow::Error> {
+async fn sidecar_aps_unused(config: Box<dyn PetriVmConfig>) -> Result<(), anyhow::Error> {
     let proc_count = 4;
-    let mut vm = configure_for_sidecar(config, igvm, proc_count)
+    let mut vm = configure_for_sidecar(config, proc_count)
         .with_uefi_frontpage(true)
         .run_without_agent()
         .await?;
@@ -367,14 +358,11 @@ async fn sidecar_aps_unused(
 }
 
 #[vmm_test(
-    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)) [LATEST_STANDARD_DEV_KERNEL_X64],
-    // TODO: debug why boot is failing hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)) [LATEST_STANDARD_DEV_KERNEL_X64],
+    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
+    // TODO: debug why boot is failing hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
 )]
-async fn sidecar_boot(
-    config: Box<dyn PetriVmConfig>,
-    (igvm,): (ResolvedArtifact<LATEST_STANDARD_DEV_KERNEL_X64>,),
-) -> Result<(), anyhow::Error> {
-    let (vm, agent) = configure_for_sidecar(config, igvm, 4).run().await?;
+async fn sidecar_boot(config: Box<dyn PetriVmConfig>) -> Result<(), anyhow::Error> {
+    let (vm, agent) = configure_for_sidecar(config, 4).run().await?;
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
     Ok(())

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -11,7 +11,6 @@ use anyhow::Context;
 use petri::ApicMode;
 use petri::PetriVmConfig;
 use petri::ProcessorTopology;
-use petri::ResolvedArtifact;
 use petri::ShutdownKind;
 use petri::openvmm::PetriVmConfigOpenVmm;
 use petri::pipette::cmd;


### PR DESCRIPTION
This change updates the main kernel version and adds sidecar to all x64 non-CVM recipes. The only difference between this version of the kernel and the previous version, the new version contains sidecar patches which were previously only in the dev kernel. With this update, there is currently no delta between dev and main kernel versions.

https://github.com/microsoft/OHCL-Linux-Kernel/releases/tag/rolling-lts%2Fhcl-main%2F6.12.9.3