### PR TITLE
Avoid NVRAM out-of-space issue

### DIFF
--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -461,28 +461,37 @@ impl TpmEngineHelper {
         preserve_ak_cert: bool,
         support_attestation_report: bool,
     ) -> Result<(), TpmHelperError> {
-        let previous_ak_cert = {
+        let (define_index, previous_ak_cert) = {
             let mut output = [0u8; MAX_NV_INDEX_SIZE as usize];
 
-            // Attempt to remove previous `TPM_NV_INDEX_AIK_CERT` regardless it is pre-provisioned
-            // (non-platform-created) or platform-created. Doing so ensures that we always recreate
-            // the nv index with newly-created auth_value (which does not persist across boots) and
-            // consistent index size for each boot.
+            // If the existing TPM_NV_INDEX_AIK_CERT is platform-defined, delete and recreate it.
+            // Doing so ensures that the NV index is created with the newly-created auth_value (which
+            // does not persist across boots) and consistent index size.
+            //
+            // If the existing TPM_NV_INDEX_AIK_CERT is not platform-defined, the vTPM blob may not
+            // have enough space to recreate the index with a larger size. In that case, don't
+            // change anything.
             match self.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output)? {
                 NvIndexState::Available => {
                     tracing::info!("AK cert nv index with available data");
 
-                    self.nv_undefine_space(TPM20_RH_PLATFORM, TPM_NV_INDEX_AIK_CERT)
-                        .map_err(|error| TpmHelperError::TpmCommandError {
-                            command_debug_info: CommandDebugInfo {
-                                command_code: CommandCodeEnum::NV_UndefineSpace,
-                                auth_handle: Some(TPM20_RH_PLATFORM),
-                                nv_index: Some(TPM_NV_INDEX_AIK_CERT),
-                            },
-                            error,
-                        })?;
+                    let res = self.find_nv_index(TPM_NV_INDEX_AIK_CERT)?.unwrap();
+                    let nv_bits = TpmaNvBits::from(res.nv_public.nv_public.attributes.0.get());
 
-                    Some(output)
+                    if nv_bits.nv_platformcreate() {
+                        self.nv_undefine_space(TPM20_RH_PLATFORM, TPM_NV_INDEX_AIK_CERT)
+                            .map_err(|error| TpmHelperError::TpmCommandError {
+                                command_debug_info: CommandDebugInfo {
+                                    command_code: CommandCodeEnum::NV_UndefineSpace,
+                                    auth_handle: Some(TPM20_RH_PLATFORM),
+                                    nv_index: Some(TPM_NV_INDEX_AIK_CERT),
+                                },
+                                error,
+                            })?;
+                        (true, Some(output))
+                    } else {
+                        (false, Some(output))
+                    }
                 }
                 NvIndexState::Uninitialized => {
                     tracing::info!("AK cert nv index allocated but uninitialized");
@@ -497,43 +506,45 @@ impl TpmEngineHelper {
                             error,
                         })?;
 
-                    None
+                    (true, None)
                 }
                 NvIndexState::Unallocated => {
                     tracing::info!("AK cert nv index not allocated yet");
-                    None
+                    (true, None)
                 }
             }
         };
 
-        tracing::info!(
-            nv_index = format!("{:x}", TPM_NV_INDEX_AIK_CERT),
-            size = MAX_NV_INDEX_SIZE,
-            "Allocate nv index for AK cert"
-        );
+        if define_index {
+            tracing::info!(
+                nv_index = format!("{:x}", TPM_NV_INDEX_AIK_CERT),
+                size = MAX_NV_INDEX_SIZE,
+                "Allocate nv index for AK cert"
+            );
 
-        self.nv_define_space(
-            TPM20_RH_PLATFORM,
-            auth_value,
-            TPM_NV_INDEX_AIK_CERT,
-            MAX_NV_INDEX_SIZE,
-        )
-        .map_err(|error| TpmHelperError::TpmCommandError {
-            command_debug_info: CommandDebugInfo {
-                command_code: CommandCodeEnum::NV_DefineSpace,
-                auth_handle: Some(TPM20_RH_PLATFORM),
-                nv_index: Some(TPM_NV_INDEX_AIK_CERT),
-            },
-            error,
-        })?;
+            self.nv_define_space(
+                TPM20_RH_PLATFORM,
+                auth_value,
+                TPM_NV_INDEX_AIK_CERT,
+                MAX_NV_INDEX_SIZE,
+            )
+            .map_err(|error| TpmHelperError::TpmCommandError {
+                command_debug_info: CommandDebugInfo {
+                    command_code: CommandCodeEnum::NV_DefineSpace,
+                    auth_handle: Some(TPM20_RH_PLATFORM),
+                    nv_index: Some(TPM_NV_INDEX_AIK_CERT),
+                },
+                error,
+            })?;
 
-        if preserve_ak_cert {
-            if let Some(data) = previous_ak_cert {
-                // For resiliency, write the previous AK cert to the newly created nv index
-                // in case the following boot-time AK cert request fails.
-                tracing::info!("Preserve previous AK cert across boot");
+            if preserve_ak_cert {
+                if let Some(data) = previous_ak_cert {
+                    // For resiliency, write the previous AK cert to the newly created nv index
+                    // in case the following boot-time AK cert request fails.
+                    tracing::info!("Preserve previous AK cert across boot");
 
-                self.write_to_nv_index(auth_value, TPM_NV_INDEX_AIK_CERT, &data)?;
+                    self.write_to_nv_index(auth_value, TPM_NV_INDEX_AIK_CERT, &data)?;
+                }
             }
         }
 
@@ -2431,7 +2442,8 @@ mod tests {
         let nv_read_public_reply = result.unwrap();
 
         // The provisioned nv size is less than the created one
-        assert!(nv_read_public_reply.nv_public.nv_public.data_size.get() < MAX_NV_INDEX_SIZE);
+        let nv_size = nv_read_public_reply.nv_public.nv_public.data_size.get();
+        assert!(nv_size < MAX_NV_INDEX_SIZE);
 
         // Ensure AK is provisioned
         assert!(tpm_engine_helper
@@ -2449,38 +2461,17 @@ mod tests {
             tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
         assert!(result.is_ok());
 
-        // Ensure nv index is re-created with new size
+        // Ensure nv index has the same size
         let result = tpm_engine_helper.nv_read_public(TPM_NV_INDEX_AIK_CERT);
         assert!(result.is_ok());
         let nv_read_public_reply = result.unwrap();
-        assert!(nv_read_public_reply.nv_public.nv_public.data_size.get() == MAX_NV_INDEX_SIZE);
+        assert!(nv_read_public_reply.nv_public.nv_public.data_size.get() == nv_size);
 
         let mut provisioned_ak_cert_after_call = [0u8; MAX_NV_INDEX_SIZE as usize];
         let result = tpm_engine_helper
             .read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut provisioned_ak_cert_after_call);
         assert!(matches!(result.unwrap(), NvIndexState::Available));
         assert_eq!(provisioned_ak_cert_after_call, provisioned_ak_cert);
-
-        // Test updating the provisioned nv index (with ownerwrite permission)
-        let ak_cert_input = [7u8; 1024];
-        let result =
-            tpm_engine_helper.write_to_nv_index(AUTH_VALUE, TPM_NV_INDEX_AIK_CERT, &ak_cert_input);
-        assert!(result.is_ok());
-
-        // Read the data and ensure it is zero-padded
-        let mut ak_cert_output = [0u8; MAX_NV_INDEX_SIZE as usize];
-        let result =
-            tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
-        assert!(matches!(result.unwrap(), NvIndexState::Available));
-        let input_with_padding = {
-            let mut input = ak_cert_input.to_vec();
-            input.resize(MAX_NV_INDEX_SIZE.into(), 0);
-            input
-        };
-        assert_eq!(&ak_cert_output, input_with_padding.as_slice());
-
-        // Ensure the data is overwritten
-        assert_ne!(&ak_cert_output, &provisioned_ak_cert);
     }
 
     #[test]

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -2472,6 +2472,34 @@ mod tests {
             .read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut provisioned_ak_cert_after_call);
         assert!(matches!(result.unwrap(), NvIndexState::Available));
         assert_eq!(provisioned_ak_cert_after_call, provisioned_ak_cert);
+
+        // Test updating the provisioned nv index (with ownerwrite permission)
+        // Write a very short AKCert that will definitely fit in the already-provisioned space.
+        let ak_cert_input = [7u8; 10];
+        let result =
+            tpm_engine_helper.nv_write(TPM20_RH_OWNER, None, TPM_NV_INDEX_AIK_CERT, &ak_cert_input);
+        assert!(result.is_ok());
+
+        // Ensure the data is overwritten
+        let mut ak_cert_output = [0u8; MAX_NV_INDEX_SIZE as usize];
+        let result =
+            tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+        assert!(matches!(result.unwrap(), NvIndexState::Available));
+
+        assert_ne!(&ak_cert_output, &provisioned_ak_cert);
+
+        // Ensure that write_to_nv_index fails because the nv index is not platform-defined
+        let ak_cert_input = [8u8; 10];
+        let result =
+            tpm_engine_helper.write_to_nv_index(AUTH_VALUE, TPM_NV_INDEX_AIK_CERT, &ak_cert_input);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            TpmHelperError::InvalidPermission {
+                platform_created: false,
+                ..
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Backport of PR 1276 and PR 1288 to 1.5.

PR 1120 added a TPM NVRAM behavior where the AKCert NVRAM index is always undefined and redefined, with size 4kB and the platform-defined attribute. In some cases, existing VMs may have an NVRAM blob that is too small to accommodate a 4kB index. This change works around that by not modifying the existing index if it is not platform-defined. This change also keeps other behavior added in 1120, such as preserving any existing contents of that NVRAM index.