### PR TITLE
kernel: update dev kernel to 6.12.9.2 release

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -29,7 +29,7 @@ pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.9.1";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.9.2";
 pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.9.2";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";


### PR DESCRIPTION
This change updates the dev kernel to a version which contains a fix for sidecar when using nested virtualization. For more information, see https://github.com/microsoft/OHCL-Linux-Kernel/pull/70.