### PR TITLE
virt_support_apic: Add runtime configurable tracing filtering of vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "address_filter"
+version = "0.0.0"
+dependencies = [
+ "inspect",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7999,6 +8007,7 @@ dependencies = [
 name = "virt_support_apic"
 version = "0.0.0"
 dependencies = [
+ "address_filter",
  "bitfield-struct 0.10.1",
  "hvdef",
  "inspect",
@@ -8862,6 +8871,7 @@ dependencies = [
 name = "vmotherboard"
 version = "0.0.0"
 dependencies = [
+ "address_filter",
  "anyhow",
  "arc_cyclic_builder",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ pipette_client = { path = "petri/pipette_client" }
 pipette_protocol = { path = "petri/pipette_protocol" }
 
 # support crates
+address_filter = { path = "support/address_filter" }
 arc_cyclic_builder = { path = "support/arc_cyclic_builder" }
 cache_topology = { path = "support/cache_topology" }
 closeable_mutex = { path = "support/closeable_mutex" }

--- a/support/address_filter/Cargo.toml
+++ b/support/address_filter/Cargo.toml
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "address_filter"
+rust-version.workspace = true
+edition.workspace = true
+
+[dependencies]
+inspect.workspace = true
+
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/support/address_filter/src/lib.rs
+++ b/support/address_filter/src/lib.rs
@@ -4,7 +4,7 @@
 //! Types to manage a filter on addresses.
 //!
 //! This is used to track the conditions under which a given PIO/MMIO access
-//! should be traced.
+//! or interrupt vector should be traced.
 //!
 //! See [`AddressFilter`] for more information, including the syntax used to
 //! define the filter.
@@ -16,17 +16,37 @@ use std::num::ParseIntError;
 use std::str::FromStr;
 use thiserror::Error;
 
+/// A trait for types that can be used as a range value in an [`AddressFilter`].
 pub trait RangeKey: PartialOrd + Ord + PartialEq + Copy + LowerHex {
+    /// The zero value for this type.
     const ZERO: Self;
+    /// The maximum value for this type.
     const MAX: Self;
+    /// Parse a hex string into this type.
     fn parse_hex(s: &str) -> Result<Self, ParseIntError>;
+}
+
+impl RangeKey for u8 {
+    const ZERO: Self = 0;
+    const MAX: Self = Self::MAX;
+    fn parse_hex(s: &str) -> Result<Self, ParseIntError> {
+        Self::from_str_radix(s, 16)
+    }
 }
 
 impl RangeKey for u16 {
     const ZERO: Self = 0;
     const MAX: Self = Self::MAX;
     fn parse_hex(s: &str) -> Result<Self, ParseIntError> {
-        u16::from_str_radix(s, 16)
+        Self::from_str_radix(s, 16)
+    }
+}
+
+impl RangeKey for u32 {
+    const ZERO: Self = 0;
+    const MAX: Self = Self::MAX;
+    fn parse_hex(s: &str) -> Result<Self, ParseIntError> {
+        Self::from_str_radix(s, 16)
     }
 }
 
@@ -34,7 +54,7 @@ impl RangeKey for u64 {
     const ZERO: Self = 0;
     const MAX: Self = Self::MAX;
     fn parse_hex(s: &str) -> Result<Self, ParseIntError> {
-        u64::from_str_radix(s, 16)
+        Self::from_str_radix(s, 16)
     }
 }
 
@@ -47,6 +67,7 @@ impl RangeKey for u64 {
 ///
 /// For example: `0x40-0x4f,0x63,?` would filter addresses 0x40 through 0x4f, address
 /// 0x63, and any unknown addresses.
+#[derive(Debug)]
 pub struct AddressFilter<T> {
     unknown: bool,
     ranges: Vec<(T, T)>,
@@ -109,7 +130,9 @@ impl<T: RangeKey> Display for AddressFilter<T> {
     }
 }
 
+/// Errors returned when trying to parse a full filter string
 #[derive(Debug, Error)]
+#[expect(missing_docs)]
 pub enum InvalidRangeSet {
     #[error("invalid range value")]
     InvalidValue(#[from] InvalidRangeValue),
@@ -119,7 +142,9 @@ pub enum InvalidRangeSet {
     Overlapping,
 }
 
+/// Errors returned when trying to parse a single range value
 #[derive(Debug, Error)]
+#[expect(missing_docs)]
 pub enum InvalidRangeValue {
     #[error(transparent)]
     ParseInt(#[from] ParseIntError),

--- a/vmm_core/virt_support_apic/Cargo.toml
+++ b/vmm_core/virt_support_apic/Cargo.toml
@@ -13,6 +13,7 @@ vmcore.workspace = true
 virt.workspace = true
 x86defs.workspace = true
 
+address_filter.workspace = true
 inspect.workspace = true
 inspect_counters.workspace = true
 tracelimit.workspace = true

--- a/vmm_core/vmotherboard/Cargo.toml
+++ b/vmm_core/vmotherboard/Cargo.toml
@@ -43,6 +43,7 @@ vga_proxy = { optional = true, workspace = true }
 vga = { optional = true, workspace = true }
 watchdog_core.workspace = true
 
+address_filter.workspace = true
 arc_cyclic_builder.workspace = true
 closeable_mutex.workspace = true
 inspect_counters.workspace = true

--- a/vmm_core/vmotherboard/src/chipset/io_ranges/mod.rs
+++ b/vmm_core/vmotherboard/src/chipset/io_ranges/mod.rs
@@ -7,9 +7,8 @@
 //! - e.g: `IoRanges<u64>` can be used to model 64-bit MMIO.
 //! - e.g: `IoRanges<u16>` can be used to model 16-bit x86 port IO.
 
-mod address_filter;
-
-use self::address_filter::RangeKey;
+use address_filter::AddressFilter;
+use address_filter::RangeKey;
 use chipset_device::ChipsetDevice;
 use closeable_mutex::CloseableMutex;
 use inspect::Inspect;
@@ -23,8 +22,8 @@ use std::sync::Weak;
 
 struct IoRangesInner<T> {
     map: RangeMap<T, RangeEntry>,
-    trace_on: address_filter::AddressFilter<T>,
-    break_on: address_filter::AddressFilter<T>,
+    trace_on: AddressFilter<T>,
+    break_on: AddressFilter<T>,
     // Starts off a `Some(Vec::new())`, and then set to `None` as part of
     // Chipset finalization
     static_registration_conflicts: Option<Vec<IoRangeConflict<T>>>,
@@ -79,8 +78,8 @@ impl<T: RangeKey> IoRanges<T> {
         Self {
             inner: Arc::new(RwLock::new(IoRangesInner {
                 map: RangeMap::new(),
-                trace_on: address_filter::AddressFilter::new(trace_on_unknown),
-                break_on: address_filter::AddressFilter::new(false),
+                trace_on: AddressFilter::new(trace_on_unknown),
+                break_on: AddressFilter::new(false),
                 static_registration_conflicts: Some(Vec::new()),
                 fallback_device,
             })),


### PR DESCRIPTION
This allows us to filter out specific vectors from appearing in tracing output, such as timers or DPCs, allowing us to see only the interrupts we actually care about. The inspect path to get here is kinda gnarly though: `vm/partition/vp/{vp_index}/backing/lapics/{vtl}/lapic/vector_filter`