### PR TITLE
vmm_core: Remove is_mmio from CpuIo

### DIFF
--- a/tmk/tmk_vmm/src/run.rs
+++ b/tmk/tmk_vmm/src/run.rs
@@ -247,10 +247,6 @@ fn widen(d: &[u8]) -> u64 {
 }
 
 impl CpuIo for IoHandler<'_> {
-    fn is_mmio(&self, _address: u64) -> bool {
-        false
-    }
-
     fn acknowledge_pic_interrupt(&self) -> Option<u8> {
         None
     }

--- a/vmm_core/src/vmotherboard_adapter.rs
+++ b/vmm_core/src/vmotherboard_adapter.rs
@@ -31,10 +31,6 @@ impl ChipsetPlusSynic {
 }
 
 impl CpuIo for ChipsetPlusSynic {
-    fn is_mmio(&self, address: u64) -> bool {
-        self.chipset.is_mmio(address)
-    }
-
     fn acknowledge_pic_interrupt(&self) -> Option<u8> {
         self.chipset.acknowledge_pic_interrupt()
     }

--- a/vmm_core/virt/src/io.rs
+++ b/vmm_core/virt/src/io.rs
@@ -8,9 +8,6 @@ use vm_topology::processor::VpIndex;
 /// This trait provides the operations between the VP dispatch loop and the
 /// platform's devices.
 pub trait CpuIo {
-    /// Check if a given address will be handled by a device.
-    fn is_mmio(&self, address: u64) -> bool;
-
     /// Gets the vector of the next interrupt to inject from the legacy
     /// interrupt controller (PIC) and sets the IRQ in service.
     fn acknowledge_pic_interrupt(&self) -> Option<u8>;

--- a/vmm_core/virt_support_x86emu/tests/tests/common.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/common.rs
@@ -49,10 +49,6 @@ pub fn long_protected_mode(user_mode: bool) -> CpuState {
 pub struct MockCpu;
 
 impl CpuIo for MockCpu {
-    fn is_mmio(&self, _address: u64) -> bool {
-        todo!()
-    }
-
     fn acknowledge_pic_interrupt(&self) -> Option<u8> {
         todo!()
     }

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -802,7 +802,6 @@ mod x86 {
 
             if self.intercept_state().is_some()
                 && self.state.active_vtl == Vtl::Vtl0
-                && !dev.is_mmio(access.Gpa)
                 && self
                     .state
                     .vtls

--- a/vmm_core/vmotherboard/src/chipset/io_ranges/mod.rs
+++ b/vmm_core/vmotherboard/src/chipset/io_ranges/mod.rs
@@ -195,10 +195,6 @@ impl<T: RangeKey> IoRanges<T> {
             .take()
             .expect("must only be called once")
     }
-
-    pub fn is_occupied(&self, addr: T) -> bool {
-        self.inner.read().map.contains(&addr)
-    }
 }
 
 pub struct LookupResult {

--- a/vmm_core/vmotherboard/src/chipset/mod.rs
+++ b/vmm_core/vmotherboard/src/chipset/mod.rs
@@ -207,11 +207,6 @@ impl Chipset {
         .await
     }
 
-    /// Check if a MMIO device exists at the given address
-    pub fn is_mmio(&self, addr: u64) -> bool {
-        self.mmio_ranges.is_occupied(addr)
-    }
-
     /// Dispatch a Port IO read to the given address.
     pub async fn io_read(&self, vp: u32, port: u16, data: &mut [u8]) {
         let lookup = self.pio_ranges.lookup(port, true);


### PR DESCRIPTION
This function is a footgun, as it doesn't capture MNF or MMIO ranges emulated elsewhere (like on the host for OpenHCL). It also only has one user. Just remove it. This will likely result in virt_whp sending more intercepts to OpenHCL instead of handling them locally, which may incur a perf penalty (hopefully not a big one), but it should not cause any functional issues (in theory 🤞).