### PR TITLE
openhcl: log vtl2 memory allocation mode and memory allocation size

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1168,6 +1168,19 @@ async fn new_underhill_vm(
     let (runtime_params, measured_vtl2_info) =
         crate::loader::vtl2_config::read_vtl2_params().context("failed to read load parameters")?;
 
+    // Log information about VTL2 memory
+    let memory_allocation_mode = runtime_params.parsed_openhcl_boot().memory_allocation_mode;
+    tracing::info!(?memory_allocation_mode, "memory allocation mode");
+    tracing::info!(
+        vtl2_ram = runtime_params
+            .vtl2_memory_map()
+            .iter()
+            .map(|r| r.range.to_string())
+            .collect::<Vec<String>>()
+            .join(", "),
+        "vtl2 ram"
+    );
+
     let isolation = match runtime_params.parsed_openhcl_boot().isolation {
         bootloader_fdt_parser::IsolationType::None => virt::IsolationType::None,
         bootloader_fdt_parser::IsolationType::Vbs => virt::IsolationType::Vbs,


### PR DESCRIPTION
OpenHCL has the ability to allocate it's own memory from the partition memory map, but that information is only available via inspect today. Log the memory allocation mode and what vtl2 ranges were chosen. You can technically back-calculate this somewhat from the e820 map, but it's annoying so just log it like we do vtl0 memory. 

The output now looks like this:
```
<30>[    2.582076] underhill_core::worker:  INFO worker_new{ name="UnderhillWorker" action="new"}:init:init/new_underhill_vm:  memory allocation mode memory_allocation_mode=Vtl2 { memory_size: Some(20000000), mmio_size: Some(8000000) }
<30>[    2.592587] underhill_core::worker:  INFO worker_new{ name="UnderhillWorker" action="new"}:init:init/new_underhill_vm:  vtl2 ram vtl2_ram="0x8000000-0x27000000, 0x107000000-0x108000000"
<30>[    2.603018] underhill_core::worker:  INFO worker_new{ name="UnderhillWorker" action="new"}:init:init/new_underhill_vm:  vtl0 ram vtl0_ram="0x0-0x8000000, 0x27000000-0xf8000000, 0x100000000-0x107000000"
<30>[    2.612254] underhill_core::worker:  INFO worker_new{ name="UnderhillWorker" action="new"}:init:init/new_underhill_vm:  vtl0 mmio vtl0_mmio="0xf8000000-0x100000000, 0xfe0000000-0xff8000000"
```