### PR TITLE
flowey: change default concurrency group behavior

### DIFF
--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -21,7 +21,7 @@ on:
     - reopened
     - ready_for_review
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   job0:

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -631,8 +631,8 @@ EOF
             Some(gh_pr_triggers) => {
                 if gh_pr_triggers.auto_cancel {
                     concurrency = Some(github_yaml_defs::Concurrency {
-                        // only cancel in-progress jobs or runs for the same branch
-                        group: Some("${{ github.ref }}".to_string()),
+                        // only cancel in-progress jobs for the same workflow and branch
+                        group: Some("${{ github.workflow }}-${{ github.ref }}".to_string()),
                         cancel_in_progress: Some(true),
                     })
                 };


### PR DESCRIPTION
This change updates the default GitHub concurrency behavior to define a concurrency group that is workflow-specific rather than the current behavior of using the just the git reference (which prevents multiple unrelated workflows from running concurrently).

For more information, see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-using-concurrency-and-the-default-behavior.