### PR TITLE
virt_mshv_vtl: the VMSA PFN IOCTL takes a CPU number

### DIFF
--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -3025,8 +3025,8 @@ impl Hcl {
     }
 
     /// Gets the PFN for the VTL 1 VMSA
-    pub fn vtl1_vmsa_pfn(&self, vp_index: u32) -> u64 {
-        let mut vp_pfn = vp_index as u64; // input vp, output pfn
+    pub fn vtl1_vmsa_pfn(&self, cpu_index: u32) -> u64 {
+        let mut vp_pfn = cpu_index as u64; // input vp, output pfn
 
         // SAFETY: The ioctl requires no prerequisites other than the VTL 1 VMSA
         // should be mapped. This ioctl should never fail as long as the vtl 1

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1337,7 +1337,7 @@ impl<T, B: HardwareIsolatedBacking>
             virt::IsolationType::Snp => {
                 // For VTL 1, user mode needs to explicitly register the VMSA
                 // with the hypervisor via the EnableVpVtl hypercall.
-                let vmsa_pfn = self.vp.partition.hcl.vtl1_vmsa_pfn(vp_index);
+                let vmsa_pfn = self.vp.partition.hcl.vtl1_vmsa_pfn(self.vp.inner.cpu_index);
                 let sev_control = hvdef::HvX64RegisterSevControl::new()
                     .with_enable_encrypted_state(true)
                     .with_vmsa_gpa_page_number(vmsa_pfn);


### PR DESCRIPTION
Currently passing VP index, and the kernel might return the per-CPU data of another processor.

Should work. Out of abundance of caution, will do basic tests. 
