### PR TITLE
CVM: Set GuestCrashRegsAvailable in cpuid

### DIFF
--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/snp.rs
@@ -421,7 +421,8 @@ impl CpuidArchInitializer for SnpCpuidInitializer {
             .with_xmm_registers_for_fast_hypercall_available(true)
             .with_register_pat_available(true)
             .with_fast_hypercall_output_available(true)
-            .with_translate_gva_flags_available(true);
+            .with_translate_gva_flags_available(true)
+            .with_guest_crash_regs_available(true);
 
         let enlightenments = hvdef::HvEnlightenmentInformation::new()
             .with_deprecate_auto_eoi(true)

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -284,7 +284,8 @@ impl CpuidArchInitializer for TdxCpuidInitializer<'_> {
             .with_xmm_registers_for_fast_hypercall_available(true)
             .with_register_pat_available(true)
             .with_fast_hypercall_output_available(true)
-            .with_translate_gva_flags_available(true);
+            .with_translate_gva_flags_available(true)
+            .with_guest_crash_regs_available(true);
 
         let use_apic_msrs = match self.topology.apic_mode() {
             vm_topology::processor::x86::ApicMode::XApic => {


### PR DESCRIPTION
We support these regs on all backends, so no reason not to.