### PR TITLE
virt_mshv_vtl: Cleanup MSR accessing for all backends

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -1088,7 +1088,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn write_msr(&mut self, msr: u32, value: u64, vtl: GuestVtl) -> Result<(), MsrError> {
+    fn write_crash_msr(&mut self, msr: u32, value: u64, vtl: GuestVtl) -> Result<(), MsrError> {
         match msr {
             hvdef::HV_X64_MSR_GUEST_CRASH_CTL => {
                 self.crash_control = hvdef::GuestCrashCtl::from(value);
@@ -1115,16 +1115,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn read_msr(&mut self, msr: u32, vtl: GuestVtl) -> Result<u64, MsrError> {
-        if msr & 0xf0000000 == 0x40000000 {
-            if let Some(hv) = self.backing.hv(vtl).as_ref() {
-                let r = hv.msr_read(msr);
-                if !matches!(r, Err(MsrError::Unknown)) {
-                    return r;
-                }
-            }
-        }
-
+    fn read_crash_msr(&self, msr: u32, _vtl: GuestVtl) -> Result<u64, MsrError> {
         let v = match msr {
             hvdef::HV_X64_MSR_GUEST_CRASH_CTL => self.crash_control.into(),
             hvdef::HV_X64_MSR_GUEST_CRASH_P0 => self.crash_reg[0],

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -794,7 +794,8 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
         let msr = message.msr_number;
         match message.header.intercept_access_type {
             HvInterceptAccessType::READ => {
-                let value = match self.vp.read_msr(msr, self.intercepted_vtl) {
+                // Only supported MSRs are the crash MSRs.
+                let value = match self.vp.read_crash_msr(msr, self.intercepted_vtl) {
                     Ok(v) => v,
                     Err(MsrError::Unknown) => {
                         tracing::trace!(msr, "unknown msr read");
@@ -812,7 +813,8 @@ impl<'a, 'b> InterceptHandler<'a, 'b> {
             }
             HvInterceptAccessType::WRITE => {
                 let value = (message.rax & 0xffff_ffff) | (message.rdx << 32);
-                match self.vp.write_msr(msr, value, self.intercepted_vtl) {
+                // Only supported MSRs are the crash MSRs.
+                match self.vp.write_crash_msr(msr, value, self.intercepted_vtl) {
                     Ok(()) => {}
                     Err(MsrError::Unknown) => {
                         tracing::trace!(msr, value, "unknown msr write");

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1017,7 +1017,6 @@ impl UhProcessor<'_, SnpBacked> {
                 })
                 .msr_write(msr, value)
                 .or_else_if_unknown(|| self.write_msr_cvm(msr, value, entered_from_vtl))
-                .or_else_if_unknown(|| self.write_msr(msr, value, entered_from_vtl))
                 .or_else_if_unknown(|| self.write_msr_snp(dev, msr, value, entered_from_vtl));
 
             match r {
@@ -1039,7 +1038,7 @@ impl UhProcessor<'_, SnpBacked> {
                     vtl: entered_from_vtl,
                 })
                 .msr_read(msr)
-                .or_else_if_unknown(|| self.read_msr(msr, entered_from_vtl))
+                .or_else_if_unknown(|| self.read_msr_cvm(msr, entered_from_vtl))
                 .or_else_if_unknown(|| self.read_msr_snp(dev, msr, entered_from_vtl));
 
             let value = match r {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1809,7 +1809,7 @@ impl UhProcessor<'_, TdxBacked> {
                         vtl: intercepted_vtl,
                     })
                     .msr_read(msr)
-                    .or_else_if_unknown(|| self.read_msr(msr, intercepted_vtl))
+                    .or_else_if_unknown(|| self.read_msr_cvm(msr, intercepted_vtl))
                     .or_else_if_unknown(|| self.read_msr_tdx(msr, intercepted_vtl));
 
                 let value = match result {
@@ -1855,7 +1855,6 @@ impl UhProcessor<'_, TdxBacked> {
                         })
                         .msr_write(msr, value)
                         .or_else_if_unknown(|| self.write_msr_cvm(msr, value, intercepted_vtl))
-                        .or_else_if_unknown(|| self.write_msr(msr, value, intercepted_vtl))
                         .or_else_if_unknown(|| self.write_msr_tdx(msr, value, intercepted_vtl))
                         .or_else_if_unknown(|| {
                             // Sanity check


### PR DESCRIPTION
This removes one access of the annoying Backing::hv getter, and also makes it clearer what is happening when.