### PR TITLE
openhcl/cvm: correctly handle partial success on page visibility requests

### DIFF
--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -276,6 +276,7 @@ impl GuestMemoryMapping {
         }
     }
 
+    /// Read the bitmap for `gpn`.
     pub(crate) fn check_bitmap(&self, gpn: u64) -> bool {
         let bitmap = self.bitmap.as_ref().unwrap();
         let mut b = 0;


### PR DESCRIPTION
A page visibility change in the guest may partially succeed. This was `todo!`-ed before, so implement it.

Most guests will probably crash right after this, but openhcl itself should not crash. This way we can attribute the failure correctly. 

Fixes #1312 