### PR TITLE
virt_mshv_vtl, snp: report the SEV inject info in the debug assert

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1209,7 +1209,10 @@ impl UhProcessor<'_, SnpBacked> {
             //
             // TODO SNP: Handle ICEBP.
             let exit_int_info = SevEventInjectInfo::from(vmsa.exit_int_info());
-            debug_assert!(exit_int_info.valid());
+            debug_assert!(
+                exit_int_info.valid(),
+                "event inject info should be valid {exit_int_info:x?}"
+            );
 
             let inject = match exit_int_info.interruption_type() {
                 x86defs::snp::SEV_INTR_TYPE_EXCEPT => {


### PR DESCRIPTION
IMHO makes that debug assert more useful for debugging