### PR TITLE
devices: make vpci easier to use in tests

### DIFF
--- a/vm/devices/pci/vpci/src/bus.rs
+++ b/vm/devices/pci/vpci/src/bus.rs
@@ -40,10 +40,20 @@ use vmcore::vpci_msi::VpciInterruptMapper;
 /// In practice, this is the only used and well-tested configuration in Hyper-V.
 #[derive(InspectMut)]
 pub struct VpciBus {
-    #[inspect(skip)]
-    device: Arc<CloseableMutex<dyn ChipsetDevice>>,
+    #[inspect(mut, flatten)]
+    bus_device: VpciBusDevice,
     #[inspect(flatten)]
     channel: SimpleDeviceHandle<VpciChannel>,
+}
+
+/// The chipset device portion of the VPCI bus.
+///
+/// This is primarily used for testing. You should use [`VpciBus`] in
+/// product code to get a single device/state unit.
+#[derive(InspectMut)]
+pub struct VpciBusDevice {
+    #[inspect(skip)]
+    device: Arc<CloseableMutex<dyn ChipsetDevice>>,
     config_space_offset: VpciConfigSpaceOffset,
     #[inspect(with = "|&x| u32::from(x)")]
     current_slot: SlotNumber,
@@ -60,6 +70,31 @@ pub enum CreateBusError {
     Offer(#[source] anyhow::Error),
 }
 
+impl VpciBusDevice {
+    /// Returns a new VPCI bus device, along with the vmbus channel used for bus
+    /// communications.
+    pub fn new(
+        instance_id: Guid,
+        device: Arc<CloseableMutex<dyn ChipsetDevice>>,
+        register_mmio: &mut dyn RegisterMmioIntercept,
+        msi_controller: Arc<dyn VpciInterruptMapper>,
+    ) -> Result<(Self, VpciChannel), NotPciDevice> {
+        let config_space = VpciConfigSpace::new(
+            register_mmio.new_io_region(&format!("vpci-{instance_id}-config"), 2 * HV_PAGE_SIZE),
+        );
+        let config_space_offset = config_space.offset().clone();
+        let channel = VpciChannel::new(&device, instance_id, config_space, msi_controller)?;
+
+        let this = Self {
+            device,
+            config_space_offset,
+            current_slot: SlotNumber::from(0),
+        };
+
+        Ok((this, channel))
+    }
+}
+
 impl VpciBus {
     /// Creates a new VPCI bus.
     pub async fn new(
@@ -70,21 +105,20 @@ impl VpciBus {
         vmbus: &dyn vmbus_channel::bus::ParentBus,
         msi_controller: Arc<dyn VpciInterruptMapper>,
     ) -> Result<Self, CreateBusError> {
-        let config_space = VpciConfigSpace::new(
-            register_mmio.new_io_region(&format!("vpci-{instance_id}-config"), 2 * HV_PAGE_SIZE),
-        );
-        let config_space_offset = config_space.offset().clone();
-        let channel = VpciChannel::new(&device, instance_id, config_space, msi_controller)
-            .map_err(CreateBusError::NotPci)?;
+        let (bus, channel) = VpciBusDevice::new(
+            instance_id,
+            device.clone(),
+            register_mmio,
+            msi_controller.clone(),
+        )
+        .map_err(CreateBusError::NotPci)?;
         let channel = offer_simple_device(driver_source, vmbus, channel)
             .await
             .map_err(CreateBusError::Offer)?;
 
         Ok(Self {
-            device,
+            bus_device: bus,
             channel,
-            config_space_offset,
-            current_slot: SlotNumber::from(0),
         })
     }
 }
@@ -118,11 +152,17 @@ impl SaveRestore for VpciBus {
 
 impl ChipsetDevice for VpciBus {
     fn supports_mmio(&mut self) -> Option<&mut dyn MmioIntercept> {
+        self.bus_device.supports_mmio()
+    }
+}
+
+impl ChipsetDevice for VpciBusDevice {
+    fn supports_mmio(&mut self) -> Option<&mut dyn MmioIntercept> {
         Some(self)
     }
 }
 
-impl MmioIntercept for VpciBus {
+impl MmioIntercept for VpciBusDevice {
     fn mmio_read(&mut self, addr: u64, data: &mut [u8]) -> IoResult {
         let reg = match self.register(addr, data.len()) {
             Ok(reg) => reg,
@@ -195,7 +235,7 @@ enum Register {
     ConfigSpace(u16),
 }
 
-impl VpciBus {
+impl VpciBusDevice {
     fn register(&self, addr: u64, len: usize) -> Result<Register, IoError> {
         // Note that this base address might be concurrently changing. We can
         // ignore accesses that are to addresses that don't make sense.

--- a/vm/devices/vmbus/vmbus_channel/src/simple.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/simple.rs
@@ -34,6 +34,7 @@ use task_control::Cancelled;
 use task_control::InspectTaskMut;
 use task_control::StopTask;
 use task_control::TaskControl;
+use vmbus_ring::RingMem;
 use vmcore::save_restore::RestoreError;
 use vmcore::save_restore::SaveError;
 use vmcore::save_restore::SavedStateBlob;
@@ -43,7 +44,7 @@ use vmcore::vm_task::VmTaskDriverSource;
 
 /// A trait implemented by a simple vmbus device with no subchannels.
 #[async_trait]
-pub trait SimpleVmbusDevice: 'static + Send {
+pub trait SimpleVmbusDevice<M: RingMem = GpadlRingMem>: 'static + Send {
     /// The saved state type.
     type SavedState: SavedStateRoot + Send;
 
@@ -61,7 +62,7 @@ pub trait SimpleVmbusDevice: 'static + Send {
     /// When the channel is closed, the runner will be dropped.
     fn open(
         &mut self,
-        channel: RawAsyncChannel<GpadlRingMem>,
+        channel: RawAsyncChannel<M>,
         guest_memory: GuestMemory,
     ) -> Result<Self::Runner, ChannelOpenError>;
 
@@ -88,7 +89,7 @@ pub trait SimpleVmbusDevice: 'static + Send {
 /// Trait implemented by simple vmbus devices that support save/restore.
 ///
 /// If you implement this, make sure to return `Some(self)` from [`SimpleVmbusDevice::supports_save_restore`].
-pub trait SaveRestoreSimpleVmbusDevice: SimpleVmbusDevice {
+pub trait SaveRestoreSimpleVmbusDevice<M: RingMem = GpadlRingMem>: SimpleVmbusDevice {
     /// Saves the channel.
     ///
     /// Will only be called if the channel is open. If there is state to save on
@@ -102,7 +103,7 @@ pub trait SaveRestoreSimpleVmbusDevice: SimpleVmbusDevice {
     fn restore_open(
         &mut self,
         state: Self::SavedState,
-        channel: RawAsyncChannel<GpadlRingMem>,
+        channel: RawAsyncChannel<M>,
     ) -> Result<Self::Runner, ChannelOpenError>;
 }
 


### PR DESCRIPTION
As I work on the VPCI client driver, it will be nice to use the VPCI
server implementation in tests. Make this easier:

* Split the VPCI chipset device from the channel (keeping them together
  for product code).

* Allow simple vmbus devices to be used with generic ring buffer
  memories, not just with GPADL-backed ring buffers.

* Make it easy to construct a `StopTask` needed to run the simple
  vmbus channel.
