### PR TITLE
CI: Update docs pipeline to use GitHub hosted pools

### DIFF
--- a/.github/workflows/openvmm-docs-ci.yaml
+++ b/.github/workflows/openvmm-docs-ci.yaml
@@ -177,9 +177,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/guide/
   job1:
     name: build and check docs [x64-windows]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
+    runs-on: windows-latest
     permissions:
       contents: read
       id-token: write
@@ -349,10 +347,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-rustdoc/
   job2:
     name: build and check docs [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
-    - 1ES.ImageOverride=MMSUbuntu22.04-256GB
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/openvmm-docs-pr.yaml
+++ b/.github/workflows/openvmm-docs-pr.yaml
@@ -185,9 +185,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/guide/
   job1:
     name: build and check docs [x64-windows]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=OpenVMM-GitHub-Win-Pool-WestUS3
+    runs-on: windows-latest
     permissions:
       contents: read
       id-token: write
@@ -357,10 +355,7 @@ jobs:
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-rustdoc/
   job2:
     name: build and check docs [x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=OpenVMM-GitHub-Linux-Pool-WestUS3
-    - 1ES.ImageOverride=MMSUbuntu22.04-256GB
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/flowey/flowey_hvlite/src/pipelines/build_docs.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_docs.rs
@@ -154,7 +154,7 @@ impl IntoPipeline for BuildDocsCli {
                     FlowArch::X86_64,
                     format!("build and check docs [x64-{platform}]"),
                 )
-                .gh_set_pool(crate::pipelines_shared::gh_pools::default_x86_pool(
+                .gh_set_pool(crate::pipelines_shared::gh_pools::default_gh_hosted(
                     platform,
                 ))
                 .dep_on(


### PR DESCRIPTION
After merging #1299 I noticed that we are using our selfhosted pools for some of the jobs, which are a limited resource. This change moves all the docs jobs over to using GitHub hosted pools which will reduce contention on the selfhosted pools and reduce runtime.