### PR TITLE
vpci: make interrupt mapping async

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2738,6 +2738,7 @@ async fn new_underhill_vm(
     #[cfg(feature = "vpci")]
     {
         use virt::Hv1;
+        use vmcore::vpci_msi::VpciInterruptMapper;
 
         for crate::dispatch::vtl2_settings_worker::UhVpciDeviceConfig {
             instance_id,
@@ -2764,7 +2765,7 @@ async fn new_underhill_vm(
                         .context("vpci is not supported by this hypervisor")?
                         .build(Vtl::Vtl0, device_id)?;
                     let device = Arc::new(device);
-                    Ok((device.clone(), device))
+                    Ok((device.clone(), VpciInterruptMapper::new(device)))
                 },
             )
             .await?;

--- a/openvmm/hvlite_core/src/partition.rs
+++ b/openvmm/hvlite_core/src/partition.rs
@@ -48,6 +48,7 @@ use vmcore::reference_time::ReferenceTimeSource;
 use vmcore::save_restore::RestoreError;
 use vmcore::save_restore::SaveError;
 use vmcore::save_restore::SaveRestore;
+use vmcore::vpci_msi::MapVpciInterrupt;
 use vmcore::vpci_msi::VpciInterruptMapper;
 use vmm_core::partition_unit::RequestYield;
 use vmm_core::partition_unit::RunCancelled;
@@ -268,15 +269,15 @@ impl SaveRestore for WrappedPartition {
 pub trait VpciDevice {
     /// Gets the [`VpciInterruptMapper`] interface to create interrupt mapping
     /// table entries.
-    fn interrupt_mapper(self: Arc<Self>) -> Arc<dyn VpciInterruptMapper>;
+    fn interrupt_mapper(self: Arc<Self>) -> VpciInterruptMapper;
 
-    /// Gets the [`VpciInterruptMapper`] interface to signal interrupts.
+    /// Gets the [`MsiInterruptTarget`] interface to signal interrupts.
     fn target(self: Arc<Self>) -> Arc<dyn MsiInterruptTarget>;
 }
 
-impl<T: 'static + VpciInterruptMapper + MsiInterruptTarget> VpciDevice for T {
-    fn interrupt_mapper(self: Arc<Self>) -> Arc<dyn VpciInterruptMapper> {
-        self
+impl<T: 'static + MapVpciInterrupt + MsiInterruptTarget> VpciDevice for T {
+    fn interrupt_mapper(self: Arc<Self>) -> VpciInterruptMapper {
+        VpciInterruptMapper::new(self)
     }
 
     fn target(self: Arc<Self>) -> Arc<dyn MsiInterruptTarget> {

--- a/vm/devices/pci/vpci/src/bus.rs
+++ b/vm/devices/pci/vpci/src/bus.rs
@@ -77,7 +77,7 @@ impl VpciBusDevice {
         instance_id: Guid,
         device: Arc<CloseableMutex<dyn ChipsetDevice>>,
         register_mmio: &mut dyn RegisterMmioIntercept,
-        msi_controller: Arc<dyn VpciInterruptMapper>,
+        msi_controller: VpciInterruptMapper,
     ) -> Result<(Self, VpciChannel), NotPciDevice> {
         let config_space = VpciConfigSpace::new(
             register_mmio.new_io_region(&format!("vpci-{instance_id}-config"), 2 * HV_PAGE_SIZE),
@@ -103,7 +103,7 @@ impl VpciBus {
         device: Arc<CloseableMutex<dyn ChipsetDevice>>,
         register_mmio: &mut dyn RegisterMmioIntercept,
         vmbus: &dyn vmbus_channel::bus::ParentBus,
-        msi_controller: Arc<dyn VpciInterruptMapper>,
+        msi_controller: VpciInterruptMapper,
     ) -> Result<Self, CreateBusError> {
         let (bus, channel) = VpciBusDevice::new(
             instance_id,

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -1220,11 +1220,10 @@ mod tests {
     use vmbus_async::queue::Queue;
     use vmbus_async::queue::connected_queues;
     use vmbus_ring as ring;
+    use vmcore::vpci_msi::VpciInterruptMapper;
     use vpci_protocol as protocol;
     use vpci_protocol::SlotNumber;
     use zerocopy::FromBytes;
-
-    use vmcore::vpci_msi::VpciInterruptMapper;
     use zerocopy::Immutable;
     use zerocopy::IntoBytes;
     use zerocopy::KnownLayout;

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -37,6 +37,7 @@ use vmbus_channel::simple::SimpleVmbusDevice;
 use vmbus_ring as ring;
 use vmbus_ring::RingMem;
 use vmcore::save_restore::NoSavedState;
+use vmcore::vpci_msi::MapVpciInterrupt;
 use vmcore::vpci_msi::MsiAddressData;
 use vmcore::vpci_msi::RegisterInterruptError;
 use vmcore::vpci_msi::VpciInterruptMapper;
@@ -648,7 +649,7 @@ impl ReadyState {
             let r = match packet {
                 Ok(packet) => {
                     tracing::trace!(?packet, "vpci packet");
-                    match self.handle_packet(packet, dev, conn, transaction_id) {
+                    match self.handle_packet(packet, dev, conn, transaction_id).await {
                         Ok(()) => Ok(()),
                         Err(WorkerError::Packet(err)) => Err(err),
                         Err(err) => return Err(err),
@@ -668,7 +669,7 @@ impl ReadyState {
         }
     }
 
-    fn handle_packet(
+    async fn handle_packet(
         &mut self,
         packet: PacketData,
         dev: &mut VpciChannel,
@@ -717,7 +718,8 @@ impl ReadyState {
                             AssignedResourcesReplyType::V2 => {
                                 v2.push(r.into());
                             }
-                        })?;
+                        })
+                        .await?;
 
                         let translated = protocol::DeviceTranslateReply {
                             status: protocol::Status::SUCCESS,
@@ -735,12 +737,13 @@ impl ReadyState {
                         conn.send_completion(transaction_id, &translated, extra)?;
                     }
                     DeviceRequest::ReleaseResources => {
-                        dev.release_all();
+                        dev.release_all().await;
                         conn.send_completion(transaction_id, &protocol::Status::SUCCESS, &[])?;
                     }
                     DeviceRequest::CreateInterrupt { interrupt } => {
                         let mut resource = FromZeros::new_zeroed();
-                        dev.map_interrupts(&[interrupt], &mut |r| resource = r)?;
+                        dev.map_interrupts(&[interrupt], &mut |r| resource = r)
+                            .await?;
                         conn.send_completion(
                             transaction_id,
                             &(protocol::CreateInterruptReply {
@@ -755,7 +758,8 @@ impl ReadyState {
                         dev.unmap_interrupt(MsiAddressData {
                             address: interrupt.address,
                             data: interrupt.data_payload,
-                        })?;
+                        })
+                        .await?;
                     }
                     DeviceRequest::QueryResources => {
                         let reply = protocol::QueryResourceRequirementsReply {
@@ -922,10 +926,10 @@ impl VpciChannel {
         // TODO: set power cap, too, on devices that support it.
     }
 
-    fn map_interrupts(
+    async fn map_interrupts(
         &mut self,
         interrupts: &[InterruptResourceRequest],
-        add_resource: &mut dyn FnMut(protocol::MsiResourceRemapped),
+        add_resource: &mut (dyn FnMut(protocol::MsiResourceRemapped) + Send),
     ) -> Result<(), PacketError> {
         let interrupts = interrupts.iter().filter(|r| r.vector_count != 0);
         let count = interrupts.clone().count();
@@ -945,6 +949,7 @@ impl VpciChannel {
             let address_data = self
                 .msi_mapper
                 .register_interrupt(interrupt.vector_count.into(), &params)
+                .await
                 .map_err(PacketError::RegisterInterrupt)?;
 
             add_resource(protocol::MsiResourceRemapped {
@@ -960,7 +965,7 @@ impl VpciChannel {
         Ok(())
     }
 
-    fn unmap_interrupt(&mut self, interrupt: MsiAddressData) -> Result<(), PacketError> {
+    async fn unmap_interrupt(&mut self, interrupt: MsiAddressData) -> Result<(), PacketError> {
         let i = self
             .interrupts
             .iter()
@@ -968,18 +973,19 @@ impl VpciChannel {
             .ok_or(PacketError::UnknownInterrupt)?;
 
         self.msi_mapper
-            .unregister_interrupt(interrupt.address, interrupt.data);
+            .unregister_interrupt(interrupt.address, interrupt.data)
+            .await;
         self.interrupts.swap_remove(i);
         Ok(())
     }
 
-    fn release_all(&mut self) {
+    async fn release_all(&mut self) {
         // Power off the device.
         self.set_power(false);
 
         // Unmap all interrupts.
         for MsiAddressData { address, data } in self.interrupts.drain(..) {
-            self.msi_mapper.unregister_interrupt(address, data);
+            self.msi_mapper.unregister_interrupt(address, data).await;
         }
 
         // Clear the BARs.
@@ -993,7 +999,7 @@ impl VpciChannel {
 pub struct VpciChannel {
     // Runtime services.
     #[inspect(skip)]
-    msi_mapper: Arc<dyn VpciInterruptMapper>,
+    msi_mapper: VpciInterruptMapper,
     #[inspect(skip)]
     config_space: VpciConfigSpace,
 
@@ -1078,7 +1084,7 @@ impl VpciChannel {
         device: &Arc<CloseableMutex<dyn ChipsetDevice>>,
         instance_id: Guid,
         config_space: VpciConfigSpace,
-        msi_mapper: Arc<dyn VpciInterruptMapper>,
+        msi_mapper: VpciInterruptMapper,
     ) -> Result<Self, NotPciDevice> {
         let (hardware_ids, bar_masks);
         {
@@ -1135,7 +1141,7 @@ impl<M: 'static + Send + Sync + RingMem> SimpleVmbusDevice<M> for VpciChannel {
     }
 
     async fn close(&mut self) {
-        self.release_all();
+        self.release_all().await;
     }
 
     async fn run(
@@ -1214,11 +1220,11 @@ mod tests {
     use vmbus_async::queue::Queue;
     use vmbus_async::queue::connected_queues;
     use vmbus_ring as ring;
-    use vmcore::vpci_msi::VpciInterruptMapper;
     use vpci_protocol as protocol;
     use vpci_protocol::SlotNumber;
     use zerocopy::FromBytes;
 
+    use vmcore::vpci_msi::VpciInterruptMapper;
     use zerocopy::Immutable;
     use zerocopy::IntoBytes;
     use zerocopy::KnownLayout;
@@ -1239,7 +1245,7 @@ mod tests {
     fn connected_device(
         driver: &impl SpawnDriver,
         device: Arc<CloseableMutex<dyn ChipsetDevice>>,
-        msi_mapper: Arc<dyn VpciInterruptMapper>,
+        msi_mapper: Arc<TestVpciInterruptController>,
     ) -> MockVpciGuestDevice {
         let (host, guest) = connected_queues(16384);
         let (hardware_ids, bar_masks);
@@ -1253,7 +1259,7 @@ mod tests {
             ExternallyManagedMmioIntercepts.new_io_region("test", 2 * HV_PAGE_SIZE),
         );
         let mut state = VpciChannel {
-            msi_mapper,
+            msi_mapper: VpciInterruptMapper::new(msi_mapper),
             config_space,
             instance_id: Guid::new_random(),
             serial_num: 0x1234,

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -34,7 +34,7 @@ pub async fn build_vpci_device(
         u64,
     ) -> anyhow::Result<(
         Arc<dyn MsiInterruptTarget>,
-        Arc<dyn VpciInterruptMapper>,
+        VpciInterruptMapper,
     )>,
 ) -> anyhow::Result<()> {
     let device_name = format!("{}:vpci-{instance_id}", resource.id());

--- a/vmm_core/virt/src/aarch64/gic_software_device.rs
+++ b/vmm_core/virt/src/aarch64/gic_software_device.rs
@@ -9,9 +9,9 @@ use pci_core::msi::MsiInterruptTarget;
 use std::ops::Range;
 use std::sync::Arc;
 use thiserror::Error;
+use vmcore::vpci_msi::MapVpciInterrupt;
 use vmcore::vpci_msi::MsiAddressData;
 use vmcore::vpci_msi::RegisterInterruptError;
-use vmcore::vpci_msi::VpciInterruptMapper;
 
 pub struct GicSoftwareDevice {
     irqcon: Arc<dyn ControlGic>,
@@ -33,8 +33,8 @@ enum GicInterruptError {
 
 const SPI_RANGE: Range<u32> = 32..1020;
 
-impl VpciInterruptMapper for GicSoftwareDevice {
-    fn register_interrupt(
+impl MapVpciInterrupt for GicSoftwareDevice {
+    async fn register_interrupt(
         &self,
         vector_count: u32,
         params: &vmcore::vpci_msi::VpciInterruptParameters<'_>,
@@ -57,7 +57,7 @@ impl VpciInterruptMapper for GicSoftwareDevice {
         })
     }
 
-    fn unregister_interrupt(&self, address: u64, data: u32) {
+    async fn unregister_interrupt(&self, address: u64, data: u32) {
         let _ = (address, data);
     }
 }

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -38,9 +38,9 @@ use vmcore::monitor::MonitorId;
 use vmcore::reference_time::ReferenceTimeSource;
 use vmcore::synic::GuestEventPort;
 use vmcore::vmtime::VmTimeSource;
+use vmcore::vpci_msi::MapVpciInterrupt;
 use vmcore::vpci_msi::MsiAddressData;
 use vmcore::vpci_msi::RegisterInterruptError;
-use vmcore::vpci_msi::VpciInterruptMapper;
 use vmcore::vpci_msi::VpciInterruptParameters;
 
 pub type Error = anyhow::Error;
@@ -588,7 +588,7 @@ pub trait PartitionMemoryMapper {
 
 pub trait Hv1 {
     type Error: std::error::Error + Send + Sync + 'static;
-    type Device: VpciInterruptMapper + MsiInterruptTarget;
+    type Device: MapVpciInterrupt + MsiInterruptTarget;
 
     fn reference_time_source(&self) -> Option<ReferenceTimeSource>;
 
@@ -603,8 +603,8 @@ pub trait DeviceBuilder: Hv1 {
 
 pub enum UnimplementedDevice {}
 
-impl VpciInterruptMapper for UnimplementedDevice {
-    fn register_interrupt(
+impl MapVpciInterrupt for UnimplementedDevice {
+    async fn register_interrupt(
         &self,
         _vector_count: u32,
         _params: &VpciInterruptParameters<'_>,
@@ -612,7 +612,7 @@ impl VpciInterruptMapper for UnimplementedDevice {
         match *self {}
     }
 
-    fn unregister_interrupt(&self, _address: u64, _data: u32) {
+    async fn unregister_interrupt(&self, _address: u64, _data: u32) {
         match *self {}
     }
 }

--- a/vmm_core/virt/src/x86/apic_software_device.rs
+++ b/vmm_core/virt/src/x86/apic_software_device.rs
@@ -15,9 +15,9 @@ use std::collections::HashMap;
 use std::collections::hash_map;
 use std::sync::Arc;
 use thiserror::Error;
+use vmcore::vpci_msi::MapVpciInterrupt;
 use vmcore::vpci_msi::MsiAddressData;
 use vmcore::vpci_msi::RegisterInterruptError;
-use vmcore::vpci_msi::VpciInterruptMapper;
 use vmcore::vpci_msi::VpciInterruptParameters;
 use x86defs::msi::MSI_ADDRESS;
 use x86defs::msi::MsiAddress;
@@ -347,8 +347,8 @@ impl MsiInterruptTarget for ApicSoftwareDevice {
     }
 }
 
-impl VpciInterruptMapper for ApicSoftwareDevice {
-    fn register_interrupt(
+impl MapVpciInterrupt for ApicSoftwareDevice {
+    async fn register_interrupt(
         &self,
         vector_count: u32,
         params: &VpciInterruptParameters<'_>,
@@ -359,7 +359,7 @@ impl VpciInterruptMapper for ApicSoftwareDevice {
             .map_err(RegisterInterruptError::new)
     }
 
-    fn unregister_interrupt(&self, address: u64, data: u32) {
+    async fn unregister_interrupt(&self, address: u64, data: u32) {
         self.table.lock().unregister_interrupt(address, data)
     }
 }

--- a/vmm_core/virt_whp/src/device.rs
+++ b/vmm_core/virt_whp/src/device.rs
@@ -21,9 +21,9 @@ use vmcore::save_restore::RestoreError;
 use vmcore::save_restore::SaveError;
 use vmcore::save_restore::SaveRestore;
 use vmcore::save_restore::SavedStateNotSupported;
+use vmcore::vpci_msi::MapVpciInterrupt;
 use vmcore::vpci_msi::MsiAddressData;
 use vmcore::vpci_msi::RegisterInterruptError;
-use vmcore::vpci_msi::VpciInterruptMapper;
 use vmcore::vpci_msi::VpciInterruptParameters;
 use whp::VpciInterruptTarget;
 use winapi::um::winnt;
@@ -109,8 +109,8 @@ impl MsiInterruptTarget for Device {
     }
 }
 
-impl VpciInterruptMapper for Device {
-    fn register_interrupt(
+impl MapVpciInterrupt for Device {
+    async fn register_interrupt(
         &self,
         vector_count: u32,
         params: &VpciInterruptParameters<'_>,
@@ -138,7 +138,7 @@ impl VpciInterruptMapper for Device {
         Ok(r)
     }
 
-    fn unregister_interrupt(&self, address: u64, data: u32) {
+    async fn unregister_interrupt(&self, address: u64, data: u32) {
         let mut interrupts = self.interrupts.lock();
         let (index, m) = interrupts
             .iter_mut()


### PR DESCRIPTION
The OpenHCL VPCI relay will need to make asynchronous vmbus requests to the host to map/unmap interrupts on behalf of the guest. Make the underlying trait async in anticipation of that.