### PR TITLE
Ensure NVMe restore task finishes before worker runs

### DIFF
--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -109,11 +109,10 @@ impl NvmeManager {
         let task = driver.spawn("nvme-manager", async move {
             // Restore saved data (if present) before async worker thread runs.
             if saved_state.is_some() {
-                let mut state_vec = Vec::new();
-                state_vec.push(NvmeManager::restore(
+                let state_vec = vec![NvmeManager::restore(
                     &mut worker,
                     saved_state.as_ref().unwrap(),
-                ));
+                )];
                 // TODO: Move join_all into NvmeManagerWorker::restore instead?
                 join_all(state_vec)
                     .instrument(tracing::info_span!("nvme_manager_restore"))

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -109,7 +109,13 @@ impl NvmeManager {
         let task = driver.spawn("nvme-manager", async move {
             // Restore saved data (if present) before async worker thread runs.
             if saved_state.is_some() {
-                let _ = NvmeManager::restore(&mut worker, saved_state.as_ref().unwrap())
+                let mut state_vec = Vec::new();
+                state_vec.push(NvmeManager::restore(
+                    &mut worker,
+                    saved_state.as_ref().unwrap(),
+                ));
+                // TODO: Move join_all into NvmeManagerWorker::restore instead?
+                join_all(state_vec)
                     .instrument(tracing::info_span!("nvme_manager_restore"))
                     .await;
             };


### PR DESCRIPTION
Running real life scenarios shows failures which only can be explained by race conditions.
It appears that the original intent to wait for restore task to finish before worker runs, has a gap.
The fix is to add a proper wait for futures to complete.