### PR TITLE
TDX: Fix TLB flush waking by using new ioctl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2745,6 +2745,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bitfield-struct 0.10.1",
+ "bitvec",
  "build_rs_guest_arch",
  "fs-err",
  "getrandom 0.3.2",

--- a/openhcl/hcl/Cargo.toml
+++ b/openhcl/hcl/Cargo.toml
@@ -18,6 +18,7 @@ inspect.workspace = true
 user_driver.workspace = true
 
 anyhow.workspace = true
+bitvec.workspace = true
 parking_lot.workspace = true
 signal-hook.workspace = true
 thiserror.workspace = true

--- a/openhcl/hcl/src/protocol.rs
+++ b/openhcl/hcl/src/protocol.rs
@@ -275,3 +275,21 @@ pub struct tdx_vp_context {
 
 const _: () = assert!(core::mem::offset_of!(tdx_vp_context, gpr_list) + 272 == 512);
 const _: () = assert!(size_of::<tdx_vp_context>() == 1024);
+
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct hcl_kick_cpus_flags {
+    #[bits(1)]
+    pub wait_for_other_cpus: bool,
+    #[bits(1)]
+    pub cancel_run: bool,
+    #[bits(62)]
+    reserved: u64,
+}
+
+#[repr(C)]
+pub struct hcl_kick_cpus {
+    pub len: u64,
+    pub cpu_mask: *const u8,
+    pub flags: hcl_kick_cpus_flags,
+}


### PR DESCRIPTION
Part of #699. Tested that a 128 VP with Guest VSM still boots.

Depends on https://github.com/microsoft/OHCL-Linux-Kernel/pull/68, which came in through https://github.com/microsoft/openvmm/pull/1357