### PR TITLE
vmbusproxy: add code to flush pending actions

### DIFF
--- a/support/mesh/mesh_channel/src/cancel.rs
+++ b/support/mesh/mesh_channel/src/cancel.rs
@@ -175,6 +175,13 @@ impl CancelContext {
             Err(reason) => Err(ErrorOrCancelled::Cancelled(reason)),
         }
     }
+
+    /// Returns true if the context has been cancelled.
+    pub fn is_cancelled(&mut self) -> bool {
+        Pin::new(&mut self.cancelled())
+            .poll(&mut Context::from_waker(std::task::Waker::noop()))
+            .is_ready()
+    }
 }
 
 impl Default for CancelContext {

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -27,7 +27,7 @@ use vmbusioctl::VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS;
 use widestring::Utf16Str;
 use widestring::utf16str;
 use windows::Wdk::Storage::FileSystem::NtOpenFile;
-use windows::Win32::Foundation::ERROR_CANCELLED;
+use windows::Win32::Foundation::ERROR_OPERATION_ABORTED;
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::Foundation::NTSTATUS;
 use windows::Win32::Storage::FileSystem::FILE_ALL_ACCESS;
@@ -147,7 +147,7 @@ impl VmbusProxy {
         let mut cancel = self.cancel.clone();
         if cancel.is_cancelled() {
             tracing::trace!("ioctl cancelled before issued");
-            return Err(Error::from_hresult(ERROR_CANCELLED.into()));
+            return Err(ERROR_OPERATION_ABORTED.into());
         }
 
         // SAFETY: guaranteed by caller.

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -9,6 +9,7 @@
 
 use futures::poll;
 use guestmem::GuestMemory;
+use mesh::CancelContext;
 use mesh::MeshPayload;
 use pal::windows::ObjectAttributes;
 use pal::windows::UnicodeStringRef;
@@ -19,8 +20,6 @@ use pal_async::windows::overlapped::OverlappedFile;
 use pal_event::Event;
 use std::mem::zeroed;
 use std::os::windows::prelude::*;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 use vmbus_core::HvsockConnectRequest;
 use vmbus_core::HvsockConnectResult;
 use vmbusioctl::VMBUS_CHANNEL_OFFER;
@@ -83,7 +82,7 @@ pub struct VmbusProxy {
     // NOTE: This must come after `file` so that it is not released until `file`
     // is closed.
     guest_memory: Option<GuestMemory>,
-    cancelled: AtomicBool,
+    cancel: CancelContext,
 }
 
 #[derive(Debug)]
@@ -127,17 +126,12 @@ unsafe impl<T> IoBufMut for StaticIoctlBuffer<T> {
 }
 
 impl VmbusProxy {
-    pub fn new(driver: &dyn Driver, handle: ProxyHandle) -> Result<Self> {
+    pub fn new(driver: &dyn Driver, handle: ProxyHandle, ctx: CancelContext) -> Result<Self> {
         Ok(Self {
             file: OverlappedFile::new(driver, handle.0)?,
             guest_memory: None,
-            cancelled: AtomicBool::new(false),
+            cancel: ctx,
         })
-    }
-
-    pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Release);
-        self.file.cancel();
     }
 
     pub fn handle(&self) -> BorrowedHandle<'_> {
@@ -149,8 +143,9 @@ impl VmbusProxy {
         In: IoBufMut,
         Out: IoBufMut,
     {
-        // Don't issue new IO if the cancel() method has been called.
-        if self.cancelled.load(Ordering::Acquire) {
+        // Don't issue new IO if the cancel context has already been cancelled.
+        let mut cancel = self.cancel.clone();
+        if cancel.is_cancelled() {
             tracing::trace!("ioctl cancelled before issued");
             return Err(Error::from_hresult(ERROR_CANCELLED.into()));
         }
@@ -160,17 +155,16 @@ impl VmbusProxy {
         let (r, (_, output)) = match poll!(&mut ioctl) {
             std::task::Poll::Ready(result) => result,
             std::task::Poll::Pending => {
-                // Cancellation may have happened after the check above but before the IO was
-                // issued, in which case it was not actually cancelled. Cancel it again now just in
-                // case.
-                if self.cancelled.load(Ordering::Acquire) {
-                    tracing::trace!("ioctl cancelled during issue");
-                    ioctl.cancel();
+                match cancel.until_cancelled(&mut ioctl).await {
+                    Ok(r) => r,
+                    Err(_) => {
+                        tracing::trace!("ioctl cancelled after issued");
+                        ioctl.cancel();
+                        // Even when cancelled, we must wait to complete the IO so buffers aren't released
+                        // while still in use.
+                        ioctl.await
+                    }
                 }
-
-                // Even when cancelled, we must wait to complete the IO so buffers aren't released
-                // while still in use.
-                ioctl.await
             }
         };
 

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -24,6 +24,7 @@ use futures::stream::SelectAll;
 use guestmem::GuestMemory;
 use mesh::Cancel;
 use mesh::CancelContext;
+use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use pal_async::driver::SpawnDriver;
 use pal_async::task::Spawn;
@@ -32,9 +33,13 @@ use pal_event::Event;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::future::Future;
+use std::future::poll_fn;
 use std::io;
 use std::os::windows::prelude::*;
+use std::pin::pin;
 use std::sync::Arc;
+use std::task::Poll;
 use std::time::Duration;
 use vmbus_channel::bus::ChannelServerRequest;
 use vmbus_channel::bus::ChannelType;
@@ -75,12 +80,20 @@ impl ProxyServerInfo {
 pub struct ProxyIntegration {
     cancel: Cancel,
     handle: OwnedHandle,
+    flush_send: mesh::Sender<Rpc<(), ()>>,
 }
 
 impl ProxyIntegration {
     /// Cancels the vmbus proxy.
     pub fn cancel(&mut self) {
         self.cancel.cancel();
+    }
+
+    /// Wait for all currently ready pending actions to complete. E.g., wait for
+    /// all channels that have been offered to the kernel driver to have been
+    /// processed.
+    pub async fn flush_actions(&mut self) {
+        self.flush_send.call(|v| v, ()).await.ok();
     }
 
     /// Returns the handle to the vmbus proxy driver.
@@ -96,21 +109,26 @@ impl ProxyIntegration {
         vtl2_server: Option<ProxyServerInfo>,
         mem: Option<&GuestMemory>,
     ) -> io::Result<Self> {
-        let mut proxy = VmbusProxy::new(driver, handle)?;
+        let (cancel_ctx, cancel) = CancelContext::new().with_cancel();
+        let mut proxy = VmbusProxy::new(driver, handle, cancel_ctx)?;
         let handle = proxy.handle().try_clone_to_owned()?;
         if let Some(mem) = mem {
             proxy.set_memory(mem).await?;
         }
 
-        let (cancel_ctx, cancel) = CancelContext::new().with_cancel();
+        let (flush_send, flush_recv) = mesh::channel();
         driver
             .spawn(
                 "vmbus_proxy",
-                proxy_thread(driver.clone(), proxy, server, vtl2_server, cancel_ctx),
+                proxy_thread(driver.clone(), proxy, server, vtl2_server, flush_recv),
             )
             .detach();
 
-        Ok(Self { cancel, handle })
+        Ok(Self {
+            cancel,
+            handle,
+            flush_send,
+        })
     }
 }
 
@@ -388,8 +406,50 @@ impl ProxyTask {
     async fn run_proxy_actions(
         &self,
         send: mesh::Sender<TaggedStream<u64, mesh::Receiver<ChannelRequest>>>,
+        flush_recv: mesh::Receiver<Rpc<(), ()>>,
     ) {
-        while let Ok(action) = self.proxy.next_action().await {
+        let mut pending_flush = None::<Rpc<(), ()>>;
+        let mut flush_recv = Some(flush_recv);
+        loop {
+            let mut action_fut = pin!(self.proxy.next_action());
+            let action = poll_fn(|cx| {
+                loop {
+                    if let r @ Poll::Ready(_) = action_fut.as_mut().poll(cx) {
+                        break r;
+                    }
+                    if let Some(pending_flush) = pending_flush.take() {
+                        // The next action future was polled after this flush
+                        // was received, and it has returned pending. This
+                        // definitively means there are currently no more
+                        // actions pending, because the action future will check
+                        // if the pending IOCTL completed (via its IO status
+                        // block) when the future is polled.
+                        pending_flush.complete(());
+                    }
+                    if let Some(recv) = &mut flush_recv {
+                        match recv.poll_next_unpin(cx) {
+                            Poll::Ready(Some(rpc)) => {
+                                // We received a flush request from the client. Save
+                                // this request and loop around to poll the action
+                                // again.
+                                pending_flush = Some(rpc);
+                            }
+                            Poll::Ready(None) => {
+                                // The flush channel was closed, so we can stop
+                                // waiting for flushes.
+                                flush_recv = None;
+                            }
+                            Poll::Pending => {}
+                        }
+                    } else {
+                        break Poll::Pending;
+                    }
+                }
+            })
+            .await;
+
+            let Ok(action) = action else { break };
+
             tracing::debug!(action = ?action, "action");
             match action {
                 ProxyAction::Offer {
@@ -598,7 +658,7 @@ async fn proxy_thread(
     proxy: VmbusProxy,
     server: ProxyServerInfo,
     vtl2_server: Option<ProxyServerInfo>,
-    mut cancel: CancelContext,
+    flush_recv: mesh::Receiver<Rpc<(), ()>>,
 ) {
     // Separate the hvsocket relay channels.
     let (hvsock_request_recv, hvsock_response_send) = server
@@ -631,16 +691,11 @@ async fn proxy_thread(
         vtl2_hvsock_response_send,
         Arc::clone(&proxy),
     ));
-    let offers = task.run_proxy_actions(send);
+    let offers = task.run_proxy_actions(send, flush_recv);
     let requests =
         task.run_server_requests(spawner, recv, hvsock_request_recv, vtl2_hvsock_request_recv);
-    let cancellation = async {
-        cancel.cancelled().await;
-        tracing::debug!("proxy thread cancelling");
-        proxy.cancel();
-    };
 
-    futures::future::join3(offers, requests, cancellation).await;
+    futures::future::join(offers, requests).await;
     tracing::debug!("proxy thread finished");
     // BUGBUG: cancel all IO if something goes wrong?
 }

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -444,7 +444,20 @@ impl ProxyTask {
             })
             .await;
 
-            let Ok(action) = action else { break };
+            let action = match action {
+                Ok(action) => action,
+                Err(e) => {
+                    if e == windows::Win32::Foundation::ERROR_OPERATION_ABORTED.into() {
+                        tracing::debug!("proxy cancelled");
+                    } else {
+                        tracing::error!(
+                            error = &e as &dyn std::error::Error,
+                            "failed to get action",
+                        );
+                    }
+                    break;
+                }
+            };
 
             tracing::debug!(action = ?action, "action");
             match action {


### PR DESCRIPTION
This still needs to be wired up to vmbus server start.