### PR TITLE
virt_mshv_vtl, snp: Log computed SEV features, too

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -642,7 +642,6 @@ fn init_vmsa(vmsa: &mut VmsaWrapper<'_, &mut SevVmsa>, vtl: GuestVtl, vtom: Opti
     // and use that to set btb_isolation, prevent_host_ibs, and VMSA register protection.
     let msr = devmsr::MsrDevice::new(0).expect("open msr");
     let sev_status = SevStatusMsr::from(msr.read_msr(x86defs::X86X_AMD_MSR_SEV).expect("read msr"));
-    tracing::info!(?vtl, ?sev_status, "VMSA creation");
 
     // BUGBUG: this isn't fully accurate--the hypervisor can try running
     // from this at any time, so we need to be careful to set the field
@@ -679,8 +678,8 @@ fn init_vmsa(vmsa: &mut VmsaWrapper<'_, &mut SevVmsa>, vtl: GuestVtl, vtom: Opti
     // must always have the SVME bit set).
     vmsa.set_efer(x86defs::X64_EFER_SVME);
 
-    let features = vmsa.sev_features();
-    tracing::info!(?vtl, ?features, "VMSA features");
+    let sev_features = vmsa.sev_features();
+    tracing::info!(?vtl, ?sev_status, ?sev_features, "VMSA features");
 }
 
 struct SnpApicClient<'a, T> {

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -642,7 +642,7 @@ fn init_vmsa(vmsa: &mut VmsaWrapper<'_, &mut SevVmsa>, vtl: GuestVtl, vtom: Opti
     // and use that to set btb_isolation, prevent_host_ibs, and VMSA register protection.
     let msr = devmsr::MsrDevice::new(0).expect("open msr");
     let sev_status = SevStatusMsr::from(msr.read_msr(x86defs::X86X_AMD_MSR_SEV).expect("read msr"));
-    tracing::info!("VMSA creation {:?} {:?}", vtl, sev_status);
+    tracing::info!(?vtl, ?sev_status, "VMSA creation");
 
     // BUGBUG: this isn't fully accurate--the hypervisor can try running
     // from this at any time, so we need to be careful to set the field
@@ -678,6 +678,9 @@ fn init_vmsa(vmsa: &mut VmsaWrapper<'_, &mut SevVmsa>, vtl: GuestVtl, vtom: Opti
     // Efer has a value that is different than the architectural default (for SNP, efer
     // must always have the SVME bit set).
     vmsa.set_efer(x86defs::X64_EFER_SVME);
+
+    let features = vmsa.sev_features();
+    tracing::info!(?vtl, ?features, "VMSA features");
 }
 
 struct SnpApicClient<'a, T> {


### PR DESCRIPTION
init_vmsa() logs only SEV status but not the SEV features it sets in the VMSA. Report that, too.

Also use the structured tracing throughout the function. Maybe could consider logging in this function at the debug level to produce less output on large VMs