### PR TITLE
inspect: clean up field formatting

### DIFF
--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -515,7 +515,7 @@ pub struct TdxPrivateRegs {
     pub msr_xss: u64,
     pub msr_tsc_aux: u64,
     // VP Entry flags
-    #[inspect(with = "|x| inspect::AsHex(x.into_bits())")]
+    #[inspect(hex, with = "|x| x.into_bits()")]
     pub vp_entry_flags: TdxVmFlags,
 }
 

--- a/openhcl/host_fdt_parser/src/lib.rs
+++ b/openhcl/host_fdt_parser/src/lib.rs
@@ -1077,11 +1077,11 @@ mod inspect_helpers {
         // TODO: inspect::AsDebug would work here once
         // https://github.com/kupiakos/open-enum/pull/13 is merged.
         inspect::adhoc(|req| match *typ {
-            MemoryMapEntryType::MEMORY => req.value("MEMORY".into()),
-            MemoryMapEntryType::PERSISTENT => req.value("PERSISTENT".into()),
-            MemoryMapEntryType::PLATFORM_RESERVED => req.value("PLATFORM_RESERVED".into()),
-            MemoryMapEntryType::VTL2_PROTECTABLE => req.value("VTL2_PROTECTABLE".into()),
-            _ => req.value(typ.0.into()),
+            MemoryMapEntryType::MEMORY => req.value("MEMORY"),
+            MemoryMapEntryType::PERSISTENT => req.value("PERSISTENT"),
+            MemoryMapEntryType::PLATFORM_RESERVED => req.value("PLATFORM_RESERVED"),
+            MemoryMapEntryType::VTL2_PROTECTABLE => req.value("VTL2_PROTECTABLE"),
+            _ => req.value(typ.0),
         })
     }
 

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -24,7 +24,7 @@ use virt::VtlMemoryProtection;
 struct PagesAccessibleToLowerVtl {
     #[inspect(skip)]
     vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     pages: Vec<u64>,
 }
 

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -824,11 +824,11 @@ mod inspect_helpers {
         // TODO: inspect::AsDebug would work here once
         // https://github.com/kupiakos/open-enum/pull/15 is merged.
         inspect::adhoc(|req| match *typ {
-            MemoryMapEntryType::MEMORY => req.value("MEMORY".into()),
-            MemoryMapEntryType::PERSISTENT => req.value("PERSISTENT".into()),
-            MemoryMapEntryType::PLATFORM_RESERVED => req.value("PLATFORM_RESERVED".into()),
-            MemoryMapEntryType::VTL2_PROTECTABLE => req.value("VTL2_PROTECTABLE".into()),
-            _ => req.value(typ.0.into()),
+            MemoryMapEntryType::MEMORY => req.value("MEMORY"),
+            MemoryMapEntryType::PERSISTENT => req.value("PERSISTENT"),
+            MemoryMapEntryType::PLATFORM_RESERVED => req.value("PLATFORM_RESERVED"),
+            MemoryMapEntryType::VTL2_PROTECTABLE => req.value("VTL2_PROTECTABLE"),
+            _ => req.value(typ.0),
         })
     }
 
@@ -840,7 +840,7 @@ mod inspect_helpers {
                 entry.range,
                 inspect::adhoc(|req| {
                     req.respond()
-                        .field("length", inspect::AsHex(entry.range.len()))
+                        .hex("length", entry.range.len())
                         .field("type", inspect_memory_map_entry_type(typ))
                         .field("vnode", entry.vnode);
                 }),

--- a/openhcl/underhill_core/src/inspect_internal.rs
+++ b/openhcl/underhill_core/src/inspect_internal.rs
@@ -68,7 +68,7 @@ fn net(req: Request<'_>, reinspect: Sender<Deferred>, driver: DefaultDriver) {
             vm_inspection.resolve().await;
 
             let Node::Dir(nodes) = vm_inspection.results() else {
-                return defer.value("Error: No VM node.".into());
+                return defer.value("Error: No VM node.");
             };
 
             defer.respond(|resp| {
@@ -146,7 +146,7 @@ fn net_nic(req: Request<'_>, name: String, reinspect: Sender<Deferred>, driver: 
                     }
                 })
             } else {
-                defer.value(format!("Unexpected node when looking for NIC {name}.").into());
+                defer.value(format!("Unexpected node when looking for NIC {name}."));
             }
         })
         .detach();

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -78,7 +78,7 @@ impl Inspect for NvmeManager {
                     .sender
                     .send(Request::ForceLoadDriver(update.defer()));
             }
-            Err(req) => req.value("".into()),
+            Err(req) => req.value(""),
         });
         // Send the remaining fields directly to the worker.
         self.client
@@ -231,7 +231,7 @@ impl NvmeManagerWorker {
                 Request::ForceLoadDriver(update) => {
                     match self.get_driver(update.new_value().to_owned()).await {
                         Ok(_) => {
-                            let pci_id = update.new_value().into();
+                            let pci_id = update.new_value().to_string();
                             update.succeed(pci_id);
                         }
                         Err(err) => {

--- a/openhcl/underhill_core/src/threadpool_vm_task_backend.rs
+++ b/openhcl/underhill_core/src/threadpool_vm_task_backend.rs
@@ -44,11 +44,10 @@ enum Target {
 
 impl Inspect for Target {
     fn inspect(&self, req: inspect::Request<'_>) {
-        let v = match self {
-            Target::Untargeted(_) => "any".into(),
-            Target::Targeted(driver) => driver.current_target_cpu().into(),
-        };
-        req.value(v)
+        match self {
+            Target::Untargeted(_) => req.value("any"),
+            Target::Targeted(driver) => req.value(driver.current_target_cpu()),
+        }
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -223,7 +223,7 @@ struct UhPartitionInner {
     intercept_debug_exceptions: bool,
     #[cfg(guest_arch = "x86_64")]
     // N.B For now, only one device vector table i.e. for VTL0 only
-    #[inspect(with = "|x| inspect::iter_by_index(x.read().into_inner().map(inspect::AsHex))")]
+    #[inspect(hex, with = "|x| inspect::iter_by_index(x.read().into_inner())")]
     device_vector_table: RwLock<IrrBitmap>,
     vmbus_relay: bool,
 }
@@ -426,9 +426,10 @@ impl UhCvmVpState {
 
 #[cfg(guest_arch = "x86_64")]
 #[derive(Inspect, Default)]
+#[inspect(hex)]
 /// Configuration of VTL 1 registration for intercepts on certain registers
 pub struct SecureRegisterInterceptState {
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(with = "|&x| u64::from(x)")]
     intercept_control: hvdef::HvRegisterCrInterceptControl,
     cr0_mask: u64,
     cr4_mask: u64,

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -95,9 +95,9 @@ pub struct UhProcessor<'a, T: Backing> {
     idle_control: Option<&'a mut IdleControl>,
     #[inspect(skip)]
     kernel_returns: u64,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     crash_reg: [u64; hvdef::HV_X64_GUEST_CRASH_PARAMETER_MSRS],
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     crash_control: hvdef::GuestCrashCtl,
     vmtime: VmTimeAccess,
     #[inspect(skip)]
@@ -108,7 +108,7 @@ pub struct UhProcessor<'a, T: Backing> {
     vtls_tlb_locked: VtlsTlbLocked,
     #[inspect(skip)]
     shared: &'a T::Shared,
-    #[inspect(with = "|x| inspect::iter_by_index(x.iter()).map_value(|a| inspect::AsHex(a.0))")]
+    #[inspect(hex, with = "|x| inspect::iter_by_index(x.iter()).map_value(|a| a.0)")]
     exit_activities: VtlArray<ExitActivity, 2>,
 
     // Put the runner and backing at the end so that monomorphisms of functions

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -63,9 +63,9 @@ use zerocopy::IntoBytes;
 /// software-isolated).
 #[derive(InspectMut)]
 pub struct HypervisorBackedArm64 {
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     deliverability_notifications: HvDeliverabilityNotificationsRegister,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     next_deliverability_notifications: HvDeliverabilityNotificationsRegister,
     stats: ProcessorStatsArm64,
 }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/mod.rs
@@ -9,7 +9,7 @@ pub mod x64;
 
 #[derive(Default, inspect::Inspect)]
 pub(crate) struct VbsIsolatedVtl1State {
-    #[inspect(with = "|flags| flags.map(|f| inspect::AsHex(u32::from(f)))")]
+    #[inspect(hex, with = "|flags| flags.map(u32::from)")]
     default_vtl_protections: Option<hvdef::HvMapGpaFlags>,
     enable_vtl_protection: bool,
 }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -83,10 +83,10 @@ use zerocopy::KnownLayout;
 pub struct HypervisorBackedX86 {
     // VTL0 only, used for synic message and extint readiness notifications.
     // We do not currently support synic message ports or extint interrupts for VTL1.
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     deliverability_notifications: HvDeliverabilityNotificationsRegister,
     /// Next set of deliverability notifications. See register definition for details.
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     pub(super) next_deliverability_notifications: HvDeliverabilityNotificationsRegister,
     stats: ProcessorStatsX86,
 }

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -557,13 +557,10 @@ impl BackingPrivate for SnpBacked {
 
         let add_vmsa_inspect = |req: inspect::Request<'_>, vmsa: VmsaWrapper<'_, &SevVmsa>| {
             req.respond()
-                .field("guest_error_code", inspect::AsHex(vmsa.guest_error_code()))
-                .field("exit_info1", inspect::AsHex(vmsa.exit_info1()))
-                .field("exit_info2", inspect::AsHex(vmsa.exit_info2()))
-                .field(
-                    "v_intr_cntrl",
-                    inspect::AsHex(u64::from(vmsa.v_intr_cntrl())),
-                );
+                .hex("guest_error_code", vmsa.guest_error_code())
+                .hex("exit_info1", vmsa.exit_info1())
+                .hex("exit_info2", vmsa.exit_info2())
+                .hex("v_intr_cntrl", u64::from(vmsa.v_intr_cntrl()));
         };
 
         resp.child("vmsa_additional", |req| {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -355,7 +355,7 @@ pub struct TdxBacked {
     vtls: VtlArray<TdxVtl, 2>,
 
     untrusted_synic: Option<ProcessorSynic>,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     eoi_exit_bitmap: [u64; 4],
 
     /// A mapped page used for issuing INVGLA hypercalls.

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -24,7 +24,7 @@ pub(super) const FLUSH_GVA_LIST_SIZE: usize = 32;
 #[derive(Debug, Inspect)]
 pub(super) struct TdxPartitionFlushState {
     /// A fixed-size ring buffer of GVAs that need to be flushed.
-    #[inspect(with = "|vd| inspect::iter_by_index(vd).map_value(|g| inspect::AsHex(g.0))")]
+    #[inspect(hex, with = "|vd| inspect::iter_by_index(vd).map_value(|g| g.0)")]
     pub(super) gva_list: VecDeque<HvGvaRange>,
     pub(super) s: TdxFlushState,
 }

--- a/support/inspect/fuzz/fuzz_inspect.rs
+++ b/support/inspect/fuzz/fuzz_inspect.rs
@@ -14,7 +14,7 @@ use inspect::Node;
 use inspect::Request;
 use inspect::Response;
 use inspect::SensitivityLevel;
-use inspect::Value;
+use inspect::ValueKind;
 use xtask_fuzz::fuzz_eprintln;
 use xtask_fuzz::fuzz_target;
 
@@ -41,7 +41,7 @@ impl InspectNode<'_, '_> {
         match self.u.int_in_range(0..=5)? {
             0 => {
                 fuzz_eprintln!("value");
-                req.value(self.u.arbitrary()?)
+                req.value(self.u.arbitrary::<ValueKind>()?)
             }
             1 => {
                 fuzz_eprintln!("ignore");
@@ -57,7 +57,7 @@ impl InspectNode<'_, '_> {
                 match self.u.int_in_range(0..=6)? {
                     0 => {
                         fuzz_eprintln!("value");
-                        defer.value(self.u.arbitrary()?)
+                        defer.value(self.u.arbitrary::<ValueKind>()?)
                     }
                     1 => {
                         fuzz_eprintln!("ignore");
@@ -106,7 +106,7 @@ impl InspectNode<'_, '_> {
                         match parse_attempt {
                             Ok(new_val) => {
                                 fuzz_eprintln!("succeed");
-                                upd.succeed(new_val.into());
+                                upd.succeed(new_val);
                             }
                             Err(e) => {
                                 fuzz_eprintln!("fail");
@@ -134,23 +134,23 @@ impl InspectNode<'_, '_> {
                 }
                 1 => {
                     fuzz_eprintln!("hex");
-                    resp.hex(self.u.arbitrary()?, Value::arbitrary(self.u)?)
+                    resp.hex(self.u.arbitrary()?, ValueKind::arbitrary(self.u)?)
                 }
                 2 => {
                     fuzz_eprintln!("counter");
-                    resp.counter(self.u.arbitrary()?, Value::arbitrary(self.u)?)
+                    resp.counter(self.u.arbitrary()?, ValueKind::arbitrary(self.u)?)
                 }
                 3 => {
                     fuzz_eprintln!("sensitivity_counter");
                     resp.sensitivity_counter(
                         self.u.arbitrary()?,
                         self.u.arbitrary()?,
-                        Value::arbitrary(self.u)?,
+                        ValueKind::arbitrary(self.u)?,
                     )
                 }
                 4 => {
                     fuzz_eprintln!("binary");
-                    resp.binary(self.u.arbitrary()?, Value::arbitrary(self.u)?)
+                    resp.binary(self.u.arbitrary()?, ValueKind::arbitrary(self.u)?)
                 }
                 5 => {
                     fuzz_eprintln!("display");
@@ -226,7 +226,7 @@ fn do_defer_update(upd: DeferredUpdate) {
     match parse_attempt {
         Ok(new_val) => {
             fuzz_eprintln!("succeed");
-            upd.succeed(new_val.into());
+            upd.succeed(new_val);
         }
         Err(e) => {
             fuzz_eprintln!("fail");

--- a/support/inspect/src/initiate.rs
+++ b/support/inspect/src/initiate.rs
@@ -12,6 +12,7 @@ use super::RequestRoot;
 use super::SensitivityLevel;
 use super::Value;
 use super::ValueKind;
+use crate::NumberFormat;
 use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::string::ToString;
@@ -397,6 +398,7 @@ impl<'a> InspectionBuilder<'a> {
             depth_with_root,
             value,
             sensitivity.unwrap_or(SensitivityLevel::Sensitive),
+            NumberFormat::default(),
         );
         obj.inspect_mut(root.request());
         (root, path_node_count(path))

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -1065,25 +1065,29 @@ impl<'a> Request<'a> {
     }
 
     /// Sets numeric values to be displayed in decimal format.
-    pub fn as_decimal(mut self) -> Self {
+    #[must_use]
+    pub fn format_as_decimal(mut self) -> Self {
         self.number_format = NumberFormat::Decimal;
         self
     }
 
     /// Sets numeric values to be displayed in hexadecimal format.
-    pub fn as_hex(mut self) -> Self {
+    #[must_use]
+    pub fn format_as_hex(mut self) -> Self {
         self.number_format = NumberFormat::Hex;
         self
     }
 
     /// Sets numeric values to be displayed in binary format.
-    pub fn as_binary(mut self) -> Self {
+    #[must_use]
+    pub fn format_as_binary(mut self) -> Self {
         self.number_format = NumberFormat::Binary;
         self
     }
 
     /// Sets numeric values to be displayed as counters.
-    pub fn as_counter(mut self) -> Self {
+    #[must_use]
+    pub fn format_as_counter(mut self) -> Self {
         self.number_format = NumberFormat::Counter;
         self
     }
@@ -2122,13 +2126,13 @@ impl<T: ?Sized + Inspect + ToOwned> Inspect for Cow<'_, T> {
 
 impl<T> Inspect for *mut T {
     fn inspect(&self, req: Request<'_>) {
-        req.as_hex().value(*self as usize)
+        req.format_as_hex().value(*self as usize)
     }
 }
 
 impl<T> Inspect for *const T {
     fn inspect(&self, req: Request<'_>) {
-        req.as_hex().value(*self as usize)
+        req.format_as_hex().value(*self as usize)
     }
 }
 
@@ -2141,11 +2145,11 @@ impl Inspect for ValueKind {
 impl Inspect for Value {
     fn inspect(&self, req: Request<'_>) {
         let req = if self.flags.count() {
-            req.as_counter()
+            req.format_as_counter()
         } else if self.flags.hex() {
-            req.as_hex()
+            req.format_as_hex()
         } else if self.flags.binary() {
-            req.as_binary()
+            req.format_as_binary()
         } else {
             req
         };

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -2376,12 +2376,17 @@ mod tests {
         });
         inspect_sync_expect("a", None, &mut obj, expect!("1"));
         inspect_sync_expect("///a", None, &mut obj, expect!("1"));
-        inspect_sync_expect("b", None, &mut obj, expect!([r#"
+        inspect_sync_expect(
+            "b",
+            None,
+            &mut obj,
+            expect!([r#"
             {
                 c: 2,
                 d: 2,
                 e: {},
-            }"#]));
+            }"#]),
+        );
         inspect_sync_expect("b/c", None, &mut obj, expect!("2"));
         inspect_sync_expect("b////c", None, &mut obj, expect!("2"));
         inspect_sync_expect("b/c/", None, &mut obj, expect!("error (not a directory)"));
@@ -2421,11 +2426,16 @@ mod tests {
                 .field("b", 2);
         });
 
-        inspect_sync_expect("", None, &mut obj, expect!([r#"
+        inspect_sync_expect(
+            "",
+            None,
+            &mut obj,
+            expect!([r#"
             {
                 a: 1,
                 b: 2,
-            }"#]));
+            }"#]),
+        );
         inspect_sync_expect("a", None, &mut obj, expect!("1"));
         inspect_sync_expect("b", None, &mut obj, expect!("2"));
         inspect_sync_expect("c", None, &mut obj, expect!("error (not found)"));
@@ -2467,7 +2477,11 @@ mod tests {
                     },
                 }"#]),
         );
-        inspect_sync_expect("x", None, &mut obj, expect!([r#"
+        inspect_sync_expect(
+            "x",
+            None,
+            &mut obj,
+            expect!([r#"
             {
                 b: 4,
                 c: {
@@ -2476,7 +2490,8 @@ mod tests {
                 d: {
                     y: 5,
                 },
-            }"#]));
+            }"#]),
+        );
     }
 
     #[test]
@@ -2545,7 +2560,11 @@ mod tests {
             req.respond().field("x/a/b", 1).field("x/a/c", 2);
         });
 
-        inspect_sync_expect("", None, &mut obj, expect!([r#"
+        inspect_sync_expect(
+            "",
+            None,
+            &mut obj,
+            expect!([r#"
             {
                 x: {
                     a: {
@@ -2553,23 +2572,39 @@ mod tests {
                         c: 2,
                     },
                 },
-            }"#]));
-        inspect_sync_expect("x/a", None, &mut obj, expect!([r#"
+            }"#]),
+        );
+        inspect_sync_expect(
+            "x/a",
+            None,
+            &mut obj,
+            expect!([r#"
             {
                 b: 1,
                 c: 2,
-            }"#]));
-        inspect_sync_expect("x", Some(0), &mut obj, expect!([r#"
+            }"#]),
+        );
+        inspect_sync_expect(
+            "x",
+            Some(0),
+            &mut obj,
+            expect!([r#"
             {
                 a: _,
-            }"#]));
-        inspect_sync_expect("x", Some(2), &mut obj, expect!([r#"
+            }"#]),
+        );
+        inspect_sync_expect(
+            "x",
+            Some(2),
+            &mut obj,
+            expect!([r#"
             {
                 a: {
                     b: 1,
                     c: 2,
                 },
-            }"#]));
+            }"#]),
+        );
     }
 
     #[test]
@@ -2589,11 +2624,16 @@ mod tests {
                 .field("1d/2b/3b", 0);
         });
 
-        inspect_sync_expect("1d", Some(0), &mut obj, expect!([r#"
+        inspect_sync_expect(
+            "1d",
+            Some(0),
+            &mut obj,
+            expect!([r#"
             {
                 2a: 0,
                 2b: _,
-            }"#]));
+            }"#]),
+        );
         inspect_sync_expect(
             "",
             Some(0),
@@ -2628,10 +2668,15 @@ mod tests {
         let mut obj = adhoc(|req| {
             req.respond().hex("a", 0x1234);
         });
-        inspect_sync_expect("", Some(0), &mut obj, expect!([r#"
+        inspect_sync_expect(
+            "",
+            Some(0),
+            &mut obj,
+            expect!([r#"
             {
                 a: 0x1234,
-            }"#]));
+            }"#]),
+        );
     }
 
     #[test]
@@ -2639,10 +2684,15 @@ mod tests {
         let mut obj = adhoc(|req| {
             req.respond().binary("a", 0b1001000110100);
         });
-        inspect_sync_expect("", Some(0), &mut obj, expect!([r#"
+        inspect_sync_expect(
+            "",
+            Some(0),
+            &mut obj,
+            expect!([r#"
             {
                 a: 0b1001000110100,
-            }"#]));
+            }"#]),
+        );
     }
 
     #[test]
@@ -2864,7 +2914,6 @@ mod tests {
             inner_as_hex: Inner,
         }
 
-
         #[derive(Clone, Inspect)]
         struct Inner {
             val: u32,
@@ -3048,10 +3097,15 @@ mod tests {
                 }"#]),
         );
 
-        inspect_sync_expect("", None, &ExternallyTaggedEnum::C(5), expect!([r#"
+        inspect_sync_expect(
+            "",
+            None,
+            &ExternallyTaggedEnum::C(5),
+            expect!([r#"
             {
                 c: 5,
-            }"#]));
+            }"#]),
+        );
 
         #[expect(dead_code)]
         #[derive(Inspect)]
@@ -3061,10 +3115,15 @@ mod tests {
             B(#[inspect(rename = "y")] bool),
         }
 
-        inspect_sync_expect("", None, &UntaggedEnum::B(true), expect!([r#"
+        inspect_sync_expect(
+            "",
+            None,
+            &UntaggedEnum::B(true),
+            expect!([r#"
             {
                 y: true,
-            }"#]));
+            }"#]),
+        );
     }
 
     #[test]

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -133,6 +133,10 @@ pub use initiate::*;
 /// }
 /// ```
 ///
+/// ### `hex`
+///
+/// Use hexadecimal formatting by default for all fields, recursively.
+///
 /// ## Field attributes
 ///
 /// ### `rename = "custom_name"`
@@ -220,13 +224,13 @@ pub use initiate::*;
 ///
 /// ### `hex`
 ///
-/// Inspect the field as a hex-formatted numeric value. Calls [`Response::hex`]
-/// with `&field`.
+/// Inspect the field, including all children, recursively, with hexadecimal
+/// formatting.
 ///
 /// ### `binary`
 ///
-/// Inspect the field as a binary-formatted numeric value. Calls
-/// [`Response::hex`] with `&field`.
+/// Inspect the field, including all children, recursively, with binary
+/// formatting.
 ///
 /// ### `bytes`
 ///
@@ -467,6 +471,20 @@ pub struct Request<'a> {
     node: &'a mut InternalNode,
     value: Option<&'a str>,
     sensitivity: SensitivityLevel,
+    number_format: NumberFormat,
+}
+
+#[cfg_attr(
+    any(feature = "defer", feature = "initiate"),
+    derive(mesh::MeshPayload)
+)]
+#[derive(Debug, Default, Copy, Clone)]
+enum NumberFormat {
+    #[default]
+    Decimal,
+    Hex,
+    Binary,
+    Counter,
 }
 
 #[cfg(any(feature = "defer", feature = "initiate"))]
@@ -476,6 +494,7 @@ struct RequestRoot<'a> {
     depth: usize,
     value: Option<&'a str>,
     sensitivity: SensitivityLevel,
+    number_format: NumberFormat,
 }
 
 /// The sensitivity level for an inspection node or request.
@@ -514,6 +533,7 @@ impl<'a> RequestRoot<'a> {
         depth: usize,
         value: Option<&'a str>,
         sensitivity: SensitivityLevel,
+        number_format: NumberFormat,
     ) -> Self {
         Self {
             path,
@@ -521,6 +541,7 @@ impl<'a> RequestRoot<'a> {
             depth,
             value,
             sensitivity,
+            number_format,
         }
     }
 
@@ -531,6 +552,7 @@ impl<'a> RequestRoot<'a> {
             &mut self.node,
             self.value,
             self.sensitivity,
+            self.number_format,
         )
     }
 }
@@ -545,6 +567,7 @@ pub struct Response<'a> {
     cell: &'a mut InternalNode,
     value: Option<&'a str>,
     sensitivity: SensitivityLevel,
+    number_format: NumberFormat,
 }
 
 #[derive(Debug)]
@@ -663,23 +686,19 @@ impl Response<'_> {
     }
 
     /// Adds a hexadecimal field to the response.
-    ///
-    /// This is a convenience method for `field(name, Value::hex(value))`.
     pub fn hex<T>(&mut self, name: &str, value: T) -> &mut Self
     where
-        T: Into<Value>,
+        T: Inspect,
     {
-        self.field_with(name, || value.into().into_hex())
+        self.field(name, AsHex(value))
     }
 
     /// Adds a counter field to the response.
-    ///
-    /// This is a convenience method for `field(name, Value::counter(value))`.
     pub fn counter<T>(&mut self, name: &str, value: T) -> &mut Self
     where
-        T: Into<Value>,
+        T: Inspect,
     {
-        self.field_with(name, || value.into().into_counter())
+        self.field(name, AsCounter(value))
     }
 
     /// Adds a counter field to the response.
@@ -692,9 +711,9 @@ impl Response<'_> {
         value: T,
     ) -> &mut Self
     where
-        T: Into<Value>,
+        T: Inspect,
     {
-        self.sensitivity_field_with(name, sensitivity, || value.into().into_counter())
+        self.sensitivity_field(name, sensitivity, AsCounter(value))
     }
 
     /// Adds a binary field to the response.
@@ -702,9 +721,9 @@ impl Response<'_> {
     /// This is a convenience method for `field(name, Value::binary(value))`.
     pub fn binary<T>(&mut self, name: &str, value: T) -> &mut Self
     where
-        T: Into<Value>,
+        T: Inspect,
     {
-        self.field_with(name, || value.into().into_binary())
+        self.field(name, AsBinary(value))
     }
 
     /// Adds a string field that implements [`std::fmt::Display`].
@@ -789,15 +808,15 @@ impl Response<'_> {
     pub fn field_mut_with<F, V, E>(&mut self, name: &str, f: F) -> &mut Self
     where
         F: FnOnce(Option<&str>) -> Result<V, E>,
-        V: Into<Value>,
+        V: Into<ValueKind>,
         E: Into<Box<dyn core::error::Error + Send + Sync>>,
     {
         self.child(name, |req| match req.update() {
             Ok(req) => match (f)(Some(req.new_value())) {
-                Ok(v) => req.succeed(v.into()),
+                Ok(v) => req.succeed(v),
                 Err(err) => req.fail(err),
             },
-            Err(req) => req.value((f)(None).ok().unwrap().into()),
+            Err(req) => req.value((f)(None).ok().unwrap()),
         })
     }
 
@@ -826,6 +845,7 @@ impl Response<'_> {
                     &mut entry.node,
                     self.value,
                     self.sensitivity,
+                    self.number_format,
                 ))
             }
             Action::Skip => None,
@@ -1007,6 +1027,7 @@ assert_eq!(
             &mut entry.node,
             self.value,
             self.sensitivity,
+            self.number_format,
         )
     }
 }
@@ -1031,6 +1052,7 @@ impl<'a> Request<'a> {
         cell: &'a mut InternalNode,
         value: Option<&'a str>,
         sensitivity: SensitivityLevel,
+        number_format: NumberFormat,
     ) -> Self {
         Self {
             path,
@@ -1038,14 +1060,42 @@ impl<'a> Request<'a> {
             node: cell,
             value,
             sensitivity,
+            number_format,
         }
     }
 
+    /// Sets numeric values to be displayed in decimal format.
+    pub fn as_decimal(mut self) -> Self {
+        self.number_format = NumberFormat::Decimal;
+        self
+    }
+
+    /// Sets numeric values to be displayed in hexadecimal format.
+    pub fn as_hex(mut self) -> Self {
+        self.number_format = NumberFormat::Hex;
+        self
+    }
+
+    /// Sets numeric values to be displayed in binary format.
+    pub fn as_binary(mut self) -> Self {
+        self.number_format = NumberFormat::Binary;
+        self
+    }
+
+    /// Sets numeric values to be displayed as counters.
+    pub fn as_counter(mut self) -> Self {
+        self.number_format = NumberFormat::Counter;
+        self
+    }
+
     /// Responds to the request with a value.
-    pub fn value(self, value: Value) {
+    pub fn value(self, value: impl Into<ValueKind>) {
+        self.value_(value.into());
+    }
+    fn value_(self, value: ValueKind) {
         let node = if self.path.is_empty() {
             if self.value.is_none() {
-                InternalNode::Value(value)
+                InternalNode::Value(value.with_format(self.number_format))
             } else {
                 InternalNode::Failed(InternalError::Immutable)
             }
@@ -1066,6 +1116,7 @@ impl<'a> Request<'a> {
             Ok(UpdateRequest {
                 node: self.node,
                 value,
+                number_format: self.number_format,
             })
         } else {
             Err(self)
@@ -1083,6 +1134,7 @@ impl<'a> Request<'a> {
             cell: self.node,
             value: self.value,
             sensitivity: self.sensitivity,
+            number_format: self.number_format,
         }
     }
 
@@ -1106,6 +1158,7 @@ impl<'a> Request<'a> {
 pub struct UpdateRequest<'a> {
     node: &'a mut InternalNode,
     value: &'a str,
+    number_format: NumberFormat,
 }
 
 impl UpdateRequest<'_> {
@@ -1115,8 +1168,11 @@ impl UpdateRequest<'_> {
     }
 
     /// Report that the update succeeded, with a new value of `value`.
-    pub fn succeed(self, value: Value) {
-        *self.node = InternalNode::Value(value);
+    pub fn succeed(self, value: impl Into<ValueKind>) {
+        self.succeed_(value.into());
+    }
+    fn succeed_(self, value: ValueKind) {
+        *self.node = InternalNode::Value(value.with_format(self.number_format));
     }
 
     /// Report that the update failed, with the reason in `err`.
@@ -1222,6 +1278,20 @@ pub enum ValueKind {
     /// Opaque binary data.
     #[cfg_attr(any(feature = "defer", feature = "initiate"), mesh(7))]
     Bytes(Vec<u8>),
+}
+
+impl ValueKind {
+    fn with_format(self, format: NumberFormat) -> Value {
+        match self {
+            Self::Signed(_) | Self::Unsigned(_) => match format {
+                NumberFormat::Decimal => Value::new(self),
+                NumberFormat::Hex => Value::hex(self).into_hex(),
+                NumberFormat::Binary => Value::binary(self).into_binary(),
+                NumberFormat::Counter => Value::counter(self).into_counter(),
+            },
+            v => v.into(),
+        }
+    }
 }
 
 /// Flags specifying additional metadata on values.
@@ -1431,7 +1501,7 @@ macro_rules! inspect_value_immut {
         $(#[$attr])*
         impl Inspect for $ty {
             fn inspect(&self, req: Request<'_>) {
-                req.value(self.into())
+                req.value(self)
             }
         }
         )*
@@ -1449,11 +1519,11 @@ macro_rules! inspect_value {
                     Ok(req) => match req.new_value().parse::<Self>() {
                         Ok(v) => {
                             *self = v.clone();
-                            req.succeed(v.into());
+                            req.succeed(v);
                         }
                         Err(err) => req.fail(err),
                     }
-                    Err(req) => req.value((&*self).into()),
+                    Err(req) => req.value(&*self),
                 }
             }
         }
@@ -1515,7 +1585,7 @@ macro_rules! inspect_atomic_value {
 
         impl Inspect for core::sync::atomic::$ty {
             fn inspect(&self, req: Request<'_>) {
-                req.value(self.load(core::sync::atomic::Ordering::Relaxed).into())
+                req.value(self.load(core::sync::atomic::Ordering::Relaxed))
             }
         }
 
@@ -1569,7 +1639,7 @@ impl Inspect for std::fs::File {
     fn inspect(&self, req: Request<'_>) {
         use filepath::FilePath;
         if let Ok(path) = self.path() {
-            req.value(path.display().to_string().into());
+            req.value(path.display().to_string());
         } else {
             req.ignore();
         }
@@ -1582,7 +1652,7 @@ pub struct AsDisplay<T>(pub T);
 
 impl<T: Display> Inspect for AsDisplay<T> {
     fn inspect(&self, req: Request<'_>) {
-        req.value(self.0.to_string().into())
+        req.value(self.0.to_string())
     }
 }
 
@@ -1592,25 +1662,31 @@ pub struct AsDebug<T>(pub T);
 
 impl<T: Debug> InspectMut for AsDebug<T> {
     fn inspect_mut(&mut self, req: Request<'_>) {
-        req.value(format!("{:?}", self.0).into())
+        req.value(format!("{:?}", self.0))
     }
 }
 
 impl<T: Debug> Inspect for AsDebug<T> {
     fn inspect(&self, req: Request<'_>) {
-        req.value(format!("{:?}", self.0).into())
+        req.value(format!("{:?}", self.0))
     }
 }
 
 macro_rules! hexbincount {
-    ($tr:ident, $method:ident, $($ty:ty),* $(,)?) => {
-        $(
-            impl Inspect for $tr<$ty> {
-                fn inspect(&self, req: Request<'_>) {
-                    req.value(Value::from(self.0).$method());
-                }
+    ($tr:ident, $fmt:expr) => {
+        impl<T: Inspect> Inspect for $tr<T> {
+            fn inspect(&self, mut req: Request<'_>) {
+                req.number_format = $fmt;
+                self.0.inspect(req);
             }
-        )*
+        }
+
+        impl<T: InspectMut> InspectMut for $tr<T> {
+            fn inspect_mut(&mut self, mut req: Request<'_>) {
+                req.number_format = $fmt;
+                self.0.inspect_mut(req);
+            }
+        }
     };
 }
 
@@ -1619,73 +1695,19 @@ macro_rules! hexbincount {
 #[derive(Clone, Copy)]
 pub struct AsHex<T>(pub T);
 
-hexbincount!(AsHex, into_hex, u8, u16, u32, u64, usize);
-
-impl<T> Inspect for AsHex<Wrapping<T>>
-where
-    for<'a> AsHex<&'a T>: Inspect,
-{
-    fn inspect(&self, req: Request<'_>) {
-        Inspect::inspect(&AsHex(&self.0.0), req)
-    }
-}
-
-impl<T: Clone> Inspect for AsHex<&'_ T>
-where
-    AsHex<T>: Inspect,
-{
-    fn inspect(&self, req: Request<'_>) {
-        Inspect::inspect(&AsHex(self.0.clone()), req)
-    }
-}
-
-impl<T> Inspect for AsHex<Option<T>>
-where
-    for<'a> AsHex<&'a T>: Inspect,
-{
-    fn inspect(&self, req: Request<'_>) {
-        Inspect::inspect(&self.0.as_ref().map(AsHex), req);
-    }
-}
+hexbincount!(AsHex, NumberFormat::Hex);
 
 /// Wrapper around `T` that implements [`Inspect`] by writing a value with
 /// [`ValueFlags::binary`].
 pub struct AsBinary<T>(pub T);
 
-hexbincount!(AsBinary, into_binary, u8, u16, u32, u64, usize);
-
-impl<T: Clone> Inspect for AsBinary<&'_ T>
-where
-    AsBinary<T>: Inspect,
-{
-    fn inspect(&self, req: Request<'_>) {
-        Inspect::inspect(&AsBinary(self.0.clone()), req)
-    }
-}
-
-impl<T> Inspect for AsBinary<Option<T>>
-where
-    for<'a> AsBinary<&'a T>: Inspect,
-{
-    fn inspect(&self, req: Request<'_>) {
-        Inspect::inspect(&self.0.as_ref().map(AsBinary), req);
-    }
-}
+hexbincount!(AsBinary, NumberFormat::Binary);
 
 /// Wrapper around `T` that implements [`Inspect`] by writing a value with
 /// [`ValueFlags::count`].
 pub struct AsCounter<T>(pub T);
 
-hexbincount!(AsCounter, into_counter, u8, u16, u32, u64, usize);
-
-impl<T: Clone> Inspect for AsCounter<&'_ T>
-where
-    AsCounter<T>: Inspect,
-{
-    fn inspect(&self, req: Request<'_>) {
-        Inspect::inspect(&AsCounter(self.0.clone()), req)
-    }
-}
+hexbincount!(AsCounter, NumberFormat::Counter);
 
 /// Wrapper around `T` that implements [`Inspect`] by writing a
 /// [`ValueKind::Bytes`] value.
@@ -1701,7 +1723,7 @@ where
     fn inspect(&self, req: Request<'_>) {
         let mut v = Vec::new();
         v.extend(self.0.clone());
-        req.value(ValueKind::Bytes(v).into())
+        req.value(ValueKind::Bytes(v))
     }
 }
 
@@ -2100,19 +2122,34 @@ impl<T: ?Sized + Inspect + ToOwned> Inspect for Cow<'_, T> {
 
 impl<T> Inspect for *mut T {
     fn inspect(&self, req: Request<'_>) {
-        req.value(Value::hex(*self as usize))
+        req.as_hex().value(*self as usize)
     }
 }
 
 impl<T> Inspect for *const T {
     fn inspect(&self, req: Request<'_>) {
-        req.value(Value::hex(*self as usize))
+        req.as_hex().value(*self as usize)
+    }
+}
+
+impl Inspect for ValueKind {
+    fn inspect(&self, req: Request<'_>) {
+        req.value(self.clone());
     }
 }
 
 impl Inspect for Value {
     fn inspect(&self, req: Request<'_>) {
-        req.value(self.clone());
+        let req = if self.flags.count() {
+            req.as_counter()
+        } else if self.flags.hex() {
+            req.as_hex()
+        } else if self.flags.binary() {
+            req.as_binary()
+        } else {
+            req
+        };
+        req.value(self.kind.clone());
     }
 }
 
@@ -2186,7 +2223,7 @@ mod tests {
     use pal_async::timer::PolledTimer;
 
     fn expected_node(node: Node, expect: Expect) -> Node {
-        expect.assert_eq(&node.to_string());
+        expect.assert_eq(&std::format!("{node:#}"));
         node
     }
 
@@ -2274,7 +2311,19 @@ mod tests {
             "",
             None,
             &f,
-            expect!("{0: {xx: 3, xy: false}, 1: {xx: 5, xy: true}, xx: 1, xy: true}"),
+            expect!([r#"
+                {
+                    0: {
+                        xx: 3,
+                        xy: false,
+                    },
+                    1: {
+                        xx: 5,
+                        xy: true,
+                    },
+                    xx: 1,
+                    xy: true,
+                }"#]),
         );
         let expected_json =
             expect!([r#"{"0":{"xx":3,"xy":false},"1":{"xx":5,"xy":true},"xx":1,"xy":true}"#]);
@@ -2292,7 +2341,11 @@ mod tests {
                 let foo = req.defer();
                 std::thread::spawn(|| foo.inspect(&Foo::default()));
             }),
-            expect!("{xx: 0, xy: false}"),
+            expect!([r#"
+                {
+                    xx: 0,
+                    xy: false,
+                }"#]),
         )
         .await;
     }
@@ -2323,7 +2376,12 @@ mod tests {
         });
         inspect_sync_expect("a", None, &mut obj, expect!("1"));
         inspect_sync_expect("///a", None, &mut obj, expect!("1"));
-        inspect_sync_expect("b", None, &mut obj, expect!("{c: 2, d: 2, e: {}}"));
+        inspect_sync_expect("b", None, &mut obj, expect!([r#"
+            {
+                c: 2,
+                d: 2,
+                e: {},
+            }"#]));
         inspect_sync_expect("b/c", None, &mut obj, expect!("2"));
         inspect_sync_expect("b////c", None, &mut obj, expect!("2"));
         inspect_sync_expect("b/c/", None, &mut obj, expect!("error (not a directory)"));
@@ -2363,7 +2421,11 @@ mod tests {
                 .field("b", 2);
         });
 
-        inspect_sync_expect("", None, &mut obj, expect!("{a: 1, b: 2}"));
+        inspect_sync_expect("", None, &mut obj, expect!([r#"
+            {
+                a: 1,
+                b: 2,
+            }"#]));
         inspect_sync_expect("a", None, &mut obj, expect!("1"));
         inspect_sync_expect("b", None, &mut obj, expect!("2"));
         inspect_sync_expect("c", None, &mut obj, expect!("error (not found)"));
@@ -2391,9 +2453,30 @@ mod tests {
             "",
             None,
             &mut obj,
-            expect!("{a: 2, x: {b: 4, c: {y: 4}, d: {y: 5}}}"),
+            expect!([r#"
+                {
+                    a: 2,
+                    x: {
+                        b: 4,
+                        c: {
+                            y: 4,
+                        },
+                        d: {
+                            y: 5,
+                        },
+                    },
+                }"#]),
         );
-        inspect_sync_expect("x", None, &mut obj, expect!("{b: 4, c: {y: 4}, d: {y: 5}}"));
+        inspect_sync_expect("x", None, &mut obj, expect!([r#"
+            {
+                b: 4,
+                c: {
+                    y: 4,
+                },
+                d: {
+                    y: 5,
+                },
+            }"#]));
     }
 
     #[test]
@@ -2462,10 +2545,31 @@ mod tests {
             req.respond().field("x/a/b", 1).field("x/a/c", 2);
         });
 
-        inspect_sync_expect("", None, &mut obj, expect!("{x: {a: {b: 1, c: 2}}}"));
-        inspect_sync_expect("x/a", None, &mut obj, expect!("{b: 1, c: 2}"));
-        inspect_sync_expect("x", Some(0), &mut obj, expect!("{a: _}"));
-        inspect_sync_expect("x", Some(2), &mut obj, expect!("{a: {b: 1, c: 2}}"));
+        inspect_sync_expect("", None, &mut obj, expect!([r#"
+            {
+                x: {
+                    a: {
+                        b: 1,
+                        c: 2,
+                    },
+                },
+            }"#]));
+        inspect_sync_expect("x/a", None, &mut obj, expect!([r#"
+            {
+                b: 1,
+                c: 2,
+            }"#]));
+        inspect_sync_expect("x", Some(0), &mut obj, expect!([r#"
+            {
+                a: _,
+            }"#]));
+        inspect_sync_expect("x", Some(2), &mut obj, expect!([r#"
+            {
+                a: {
+                    b: 1,
+                    c: 2,
+                },
+            }"#]));
     }
 
     #[test]
@@ -2485,18 +2589,37 @@ mod tests {
                 .field("1d/2b/3b", 0);
         });
 
-        inspect_sync_expect("1d", Some(0), &mut obj, expect!("{2a: 0, 2b: _}"));
+        inspect_sync_expect("1d", Some(0), &mut obj, expect!([r#"
+            {
+                2a: 0,
+                2b: _,
+            }"#]));
         inspect_sync_expect(
             "",
             Some(0),
             &mut obj,
-            expect!("{1a: 0, 1b: 0, 1c: 0, 1d: _}"),
+            expect!([r#"
+                {
+                    1a: 0,
+                    1b: 0,
+                    1c: 0,
+                    1d: _,
+                }"#]),
         );
         inspect_sync_expect(
             "",
             Some(1),
             &mut obj,
-            expect!("{1a: 0, 1b: 0, 1c: 0, 1d: {2a: 0, 2b: _}}"),
+            expect!([r#"
+                {
+                    1a: 0,
+                    1b: 0,
+                    1c: 0,
+                    1d: {
+                        2a: 0,
+                        2b: _,
+                    },
+                }"#]),
         );
     }
 
@@ -2505,7 +2628,10 @@ mod tests {
         let mut obj = adhoc(|req| {
             req.respond().hex("a", 0x1234);
         });
-        inspect_sync_expect("", Some(0), &mut obj, expect!("{a: 0x1234}"));
+        inspect_sync_expect("", Some(0), &mut obj, expect!([r#"
+            {
+                a: 0x1234,
+            }"#]));
     }
 
     #[test]
@@ -2513,7 +2639,10 @@ mod tests {
         let mut obj = adhoc(|req| {
             req.respond().binary("a", 0b1001000110100);
         });
-        inspect_sync_expect("", Some(0), &mut obj, expect!("{a: 0b1001000110100}"));
+        inspect_sync_expect("", Some(0), &mut obj, expect!([r#"
+            {
+                a: 0b1001000110100,
+            }"#]));
     }
 
     #[test]
@@ -2548,7 +2677,18 @@ mod tests {
 
         expected_node(
             diff,
-            expect!("{c: 50, d: {1_c: true, 2: true, 3: 50, 4_b: true, 4_c: true}, f: 600}"),
+            expect!([r#"
+                {
+                    c: 50,
+                    d: {
+                        1_c: true,
+                        2: true,
+                        3: 50,
+                        4_b: true,
+                        4_c: true,
+                    },
+                    f: 600,
+                }"#]),
         );
     }
 
@@ -2607,23 +2747,83 @@ mod tests {
 
         expected_node(
             inspect_sync("", Some(SensitivityLevel::Safe), &mut obj),
-            expect!("{1a: 0, 1d: {2b: {}}}"),
+            expect!([r#"
+                {
+                    1a: 0,
+                    1d: {
+                        2b: {},
+                    },
+                }"#]),
         );
         expected_node(
             inspect_sync("", Some(SensitivityLevel::Unspecified), &mut obj),
-            expect!("{1a: 0, 1b: 0, 1d: {2b: {3b: 0}}}"),
+            expect!([r#"
+                {
+                    1a: 0,
+                    1b: 0,
+                    1d: {
+                        2b: {
+                            3b: 0,
+                        },
+                    },
+                }"#]),
         );
         expected_node(
             inspect_sync("", Some(SensitivityLevel::Sensitive), &mut obj),
-            expect!("{1a: 0, 1b: 0, 1c: 0, 1d: {2a: 0, 2b: {3a: {4a: 0}, 3b: 0}}, 1e: 0}"),
+            expect!([r#"
+                {
+                    1a: 0,
+                    1b: 0,
+                    1c: 0,
+                    1d: {
+                        2a: 0,
+                        2b: {
+                            3a: {
+                                4a: 0,
+                            },
+                            3b: 0,
+                        },
+                    },
+                    1e: 0,
+                }"#]),
         );
         expected_node(
             inspect_sync("", None, &mut obj),
-            expect!("{1a: 0, 1b: 0, 1c: 0, 1d: {2a: 0, 2b: {3a: {4a: 0}, 3b: 0}}, 1e: 0}"),
+            expect!([r#"
+                {
+                    1a: 0,
+                    1b: 0,
+                    1c: 0,
+                    1d: {
+                        2a: 0,
+                        2b: {
+                            3a: {
+                                4a: 0,
+                            },
+                            3b: 0,
+                        },
+                    },
+                    1e: 0,
+                }"#]),
         );
         expected_node(
             inspect_sync("", Some(SensitivityLevel::Sensitive), &mut obj),
-            expect!("{1a: 0, 1b: 0, 1c: 0, 1d: {2a: 0, 2b: {3a: {4a: 0}, 3b: 0}}, 1e: 0}"),
+            expect!([r#"
+                {
+                    1a: 0,
+                    1b: 0,
+                    1c: 0,
+                    1d: {
+                        2a: 0,
+                        2b: {
+                            3a: {
+                                4a: 0,
+                            },
+                            3b: 0,
+                        },
+                    },
+                    1e: 0,
+                }"#]),
         );
     }
 
@@ -2657,7 +2857,13 @@ mod tests {
             ignored: Ignored,
             tr1: Tr1,
             tr2: Tr2,
+            #[inspect(iter_by_index, hex)]
+            hex_array: [u8; 4],
+            hex_inner: HexInner,
+            #[inspect(hex)]
+            inner_as_hex: Inner,
         }
+
 
         #[derive(Clone, Inspect)]
         struct Inner {
@@ -2667,6 +2873,12 @@ mod tests {
         #[derive(InspectMut)]
         struct InnerMut {
             val: String,
+        }
+
+        #[derive(Inspect)]
+        #[inspect(hex)]
+        struct HexInner {
+            val: u32,
         }
 
         #[derive(Inspect)]
@@ -2723,15 +2935,52 @@ mod tests {
             ignored: Ignored { _x: || () },
             tr1: Tr1(10, PhantomData),
             tr2: Tr2(()),
+            hex_array: [100, 101, 102, 103],
+            hex_inner: HexInner { val: 100 },
+            inner_as_hex: Inner { val: 100 },
         };
 
         inspect_sync_expect(
             "",
             None,
             &mut obj,
-            expect!([
-                r#"{bin: 0b11, debug: "()", dec: 5, display: "10", hex: 0x4, inner: {val: 3}, inner_mut: {val: "hi"}, minute: "07", t: {val: 1}, t2: {val: 2}, tr1: 0xa, tr2: "()", val: 8, var: "bar_baz"}"#
-            ]),
+            expect!([r#"
+                {
+                    bin: 0b11,
+                    debug: "()",
+                    dec: 5,
+                    display: "10",
+                    hex: 0x4,
+                    hex_array: {
+                        0: 0x64,
+                        1: 0x65,
+                        2: 0x66,
+                        3: 0x67,
+                    },
+                    hex_inner: {
+                        val: 0x64,
+                    },
+                    inner: {
+                        val: 3,
+                    },
+                    inner_as_hex: {
+                        val: 0x64,
+                    },
+                    inner_mut: {
+                        val: "hi",
+                    },
+                    minute: "07",
+                    t: {
+                        val: 1,
+                    },
+                    t2: {
+                        val: 2,
+                    },
+                    tr1: 0xa,
+                    tr2: "()",
+                    val: 8,
+                    var: "bar_baz",
+                }"#]),
         );
     }
 
@@ -2768,7 +3017,11 @@ mod tests {
             "",
             None,
             &TaggedEnum::B(true),
-            expect!([r#"{tag: "b", y: true}"#]),
+            expect!([r#"
+                {
+                    tag: "b",
+                    y: true,
+                }"#]),
         );
 
         #[expect(dead_code)]
@@ -2787,10 +3040,18 @@ mod tests {
             "",
             None,
             &ExternallyTaggedEnum::B(true),
-            expect!("{b: {y: true}}"),
+            expect!([r#"
+                {
+                    b: {
+                        y: true,
+                    },
+                }"#]),
         );
 
-        inspect_sync_expect("", None, &ExternallyTaggedEnum::C(5), expect!("{c: 5}"));
+        inspect_sync_expect("", None, &ExternallyTaggedEnum::C(5), expect!([r#"
+            {
+                c: 5,
+            }"#]));
 
         #[expect(dead_code)]
         #[derive(Inspect)]
@@ -2800,7 +3061,10 @@ mod tests {
             B(#[inspect(rename = "y")] bool),
         }
 
-        inspect_sync_expect("", None, &UntaggedEnum::B(true), expect!("{y: true}"));
+        inspect_sync_expect("", None, &UntaggedEnum::B(true), expect!([r#"
+            {
+                y: true,
+            }"#]));
     }
 
     #[test]
@@ -2822,7 +3086,12 @@ mod tests {
             "",
             None,
             &Foo { x: 2, y: 5 },
-            expect!("{sum: 7, x: 2, y: 5}"),
+            expect!([r#"
+                {
+                    sum: 7,
+                    x: 2,
+                    y: 5,
+                }"#]),
         );
     }
 
@@ -2884,15 +3153,44 @@ mod tests {
 
         expected_node(
             inspect_sync("", Some(SensitivityLevel::Safe), &obj),
-            expect!("{a: 0, d: {b: {}}}"),
+            expect!([r#"
+                {
+                    a: 0,
+                    d: {
+                        b: {},
+                    },
+                }"#]),
         );
         expected_node(
             inspect_sync("", Some(SensitivityLevel::Unspecified), &obj),
-            expect!("{a: 0, b: 0, d: {b: {b: 0}}}"),
+            expect!([r#"
+                {
+                    a: 0,
+                    b: 0,
+                    d: {
+                        b: {
+                            b: 0,
+                        },
+                    },
+                }"#]),
         );
         let node = expected_node(
             inspect_sync("", Some(SensitivityLevel::Sensitive), &obj),
-            expect!("{a: 0, b: 0, c: 0, d: {a: 0, b: {a: {a: 0}, b: 0}}}"),
+            expect!([r#"
+                {
+                    a: 0,
+                    b: 0,
+                    c: 0,
+                    d: {
+                        a: 0,
+                        b: {
+                            a: {
+                                a: 0,
+                            },
+                            b: 0,
+                        },
+                    },
+                }"#]),
         );
         assert_eq!(
             node,

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -1066,28 +1066,28 @@ impl<'a> Request<'a> {
 
     /// Sets numeric values to be displayed in decimal format.
     #[must_use]
-    pub fn format_as_decimal(mut self) -> Self {
+    pub fn with_decimal_format(mut self) -> Self {
         self.number_format = NumberFormat::Decimal;
         self
     }
 
     /// Sets numeric values to be displayed in hexadecimal format.
     #[must_use]
-    pub fn format_as_hex(mut self) -> Self {
+    pub fn with_hex_format(mut self) -> Self {
         self.number_format = NumberFormat::Hex;
         self
     }
 
     /// Sets numeric values to be displayed in binary format.
     #[must_use]
-    pub fn format_as_binary(mut self) -> Self {
+    pub fn with_binary_format(mut self) -> Self {
         self.number_format = NumberFormat::Binary;
         self
     }
 
     /// Sets numeric values to be displayed as counters.
     #[must_use]
-    pub fn format_as_counter(mut self) -> Self {
+    pub fn with_counter_format(mut self) -> Self {
         self.number_format = NumberFormat::Counter;
         self
     }
@@ -2126,13 +2126,13 @@ impl<T: ?Sized + Inspect + ToOwned> Inspect for Cow<'_, T> {
 
 impl<T> Inspect for *mut T {
     fn inspect(&self, req: Request<'_>) {
-        req.format_as_hex().value(*self as usize)
+        req.with_hex_format().value(*self as usize)
     }
 }
 
 impl<T> Inspect for *const T {
     fn inspect(&self, req: Request<'_>) {
-        req.format_as_hex().value(*self as usize)
+        req.with_hex_format().value(*self as usize)
     }
 }
 
@@ -2145,11 +2145,11 @@ impl Inspect for ValueKind {
 impl Inspect for Value {
     fn inspect(&self, req: Request<'_>) {
         let req = if self.flags.count() {
-            req.format_as_counter()
+            req.with_counter_format()
         } else if self.flags.hex() {
-            req.format_as_hex()
+            req.with_hex_format()
         } else if self.flags.binary() {
-            req.format_as_binary()
+            req.with_binary_format()
         } else {
             req
         };

--- a/support/inspect_counters/src/lib.rs
+++ b/support/inspect_counters/src/lib.rs
@@ -35,7 +35,7 @@ impl Counter {
 
 impl Inspect for Counter {
     fn inspect(&self, req: inspect::Request<'_>) {
-        req.as_counter().value(self.0)
+        req.format_as_counter().value(self.0)
     }
 }
 
@@ -69,7 +69,8 @@ impl SharedCounter {
 
 impl Inspect for SharedCounter {
     fn inspect(&self, req: inspect::Request<'_>) {
-        req.as_counter().value(self.0.load(Ordering::Relaxed))
+        req.format_as_counter()
+            .value(self.0.load(Ordering::Relaxed))
     }
 }
 

--- a/support/inspect_counters/src/lib.rs
+++ b/support/inspect_counters/src/lib.rs
@@ -35,7 +35,7 @@ impl Counter {
 
 impl Inspect for Counter {
     fn inspect(&self, req: inspect::Request<'_>) {
-        req.format_as_counter().value(self.0)
+        req.with_counter_format().value(self.0)
     }
 }
 
@@ -69,7 +69,7 @@ impl SharedCounter {
 
 impl Inspect for SharedCounter {
     fn inspect(&self, req: inspect::Request<'_>) {
-        req.format_as_counter()
+        req.with_counter_format()
             .value(self.0.load(Ordering::Relaxed))
     }
 }

--- a/support/inspect_counters/src/lib.rs
+++ b/support/inspect_counters/src/lib.rs
@@ -4,7 +4,6 @@
 //! Inspectable types for implementing performance counters.
 
 use inspect::Inspect;
-use inspect::Value;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
@@ -36,7 +35,7 @@ impl Counter {
 
 impl Inspect for Counter {
     fn inspect(&self, req: inspect::Request<'_>) {
-        req.value(Value::counter(self.0))
+        req.as_counter().value(self.0)
     }
 }
 
@@ -70,7 +69,7 @@ impl SharedCounter {
 
 impl Inspect for SharedCounter {
     fn inspect(&self, req: inspect::Request<'_>) {
-        req.value(Value::counter(self.0.load(Ordering::Relaxed)))
+        req.as_counter().value(self.0.load(Ordering::Relaxed))
     }
 }
 

--- a/support/inspect_derive/src/lib.rs
+++ b/support/inspect_derive/src/lib.rs
@@ -377,7 +377,7 @@ fn impl_defs(
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
 
     let fmt = if hex {
-        quote!(let #req = #req.as_hex();)
+        quote!(let #req = #req.format_as_hex();)
     } else {
         quote!()
     };

--- a/support/inspect_derive/src/lib.rs
+++ b/support/inspect_derive/src/lib.rs
@@ -63,6 +63,7 @@ enum StructAttr {
     With(syn::Expr),
     Extra(syn::Expr),
     Bound(Punctuated<WherePredicate, Token![,]>),
+    Hex,
 }
 
 #[derive(Clone)]
@@ -74,6 +75,8 @@ enum FieldAttr {
     With(syn::Expr),
     Safe,
     Sensitive,
+    Hex,
+    Binary,
 }
 
 enum SensitivityLevel {
@@ -89,6 +92,7 @@ enum EnumAttr {
     Tag(LitStr),
     Extra(syn::Expr),
     Bound(Punctuated<WherePredicate, Token![,]>),
+    Hex,
 }
 
 enum VariantAttr {
@@ -144,6 +148,8 @@ impl Parse for StructAttr {
         } else if ident == "bound" {
             let val = parse_string_attr(input)?;
             Self::Bound(val.parse_with(Punctuated::parse_terminated)?)
+        } else if ident == "hex" {
+            Self::Hex
         } else {
             return Err(syn::Error::new(
                 ident.span(),
@@ -162,16 +168,16 @@ impl Parse for FieldAttr {
         } else if ident == "format" {
             let format = parse_string_attr(input)?;
             Self::With(parse_quote!(|x| ::inspect::adhoc(
-                move |req| req.value(::core::format_args!(#format, x).into())
+                move |req| req.value(::core::format_args!(#format, x))
             )))
         } else if ident == "display" {
             Self::With(parse_quote_spanned!(ident.span()=> ::inspect::AsDisplay))
         } else if ident == "debug" {
             Self::With(parse_quote_spanned!(ident.span()=> ::inspect::AsDebug))
         } else if ident == "hex" {
-            Self::With(parse_quote_spanned!(ident.span()=> ::inspect::AsHex))
+            Self::Hex
         } else if ident == "binary" {
-            Self::With(parse_quote_spanned!(ident.span()=> ::inspect::AsBinary))
+            Self::Binary
         } else if ident == "bytes" {
             Self::With(parse_quote_spanned!(ident.span()=> ::inspect::AsBytes))
         } else if ident == "iter_by_key" {
@@ -225,6 +231,8 @@ impl Parse for EnumAttr {
         } else if ident == "bound" {
             let val = parse_string_attr(input)?;
             Self::Bound(val.parse_with(Punctuated::parse_terminated)?)
+        } else if ident == "hex" {
+            Self::Hex
         } else {
             return Err(syn::Error::new(
                 ident.span(),
@@ -295,6 +303,7 @@ fn derive_struct(
     let mut struct_with = None;
     let mut extra = None;
     let mut bound = None;
+    let mut hex = false;
     let bitfield = parse_bitfield_attr(&input.attrs)?;
     for attr in parse_attrs(&input.attrs)? {
         match attr.kind {
@@ -307,6 +316,7 @@ fn derive_struct(
             StructAttr::With(with) => insert_or_fail(&mut struct_with, attr.span, with)?,
             StructAttr::Extra(x) => insert_or_fail(&mut extra, attr.span, x)?,
             StructAttr::Bound(x) => insert_or_fail(&mut bound, attr.span, x)?,
+            StructAttr::Hex => hex = true,
         }
     }
 
@@ -348,7 +358,7 @@ fn derive_struct(
         fields_response(&data.fields, &[], &req, bitfield, transparent, extra)?
     };
 
-    impl_defs(input, mutable, bound, &req, &respond)
+    impl_defs(input, mutable, bound, &req, &respond, hex)
 }
 
 fn impl_defs(
@@ -357,6 +367,7 @@ fn impl_defs(
     bound: Option<Punctuated<WherePredicate, Token![,]>>,
     req: &Ident,
     respond: &TokenStream,
+    hex: bool,
 ) -> Result<TokenStream, syn::Error> {
     let mut generics = input.generics.clone();
     if let Some(bound) = bound {
@@ -365,11 +376,18 @@ fn impl_defs(
 
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
 
+    let fmt = if hex {
+        quote!(let #req = #req.as_hex();)
+    } else {
+        quote!()
+    };
+
     let type_name = &input.ident;
     let tokens = if mutable {
         quote! {
             impl #impl_generics ::inspect::InspectMut for #type_name #type_generics #where_clause {
                 fn inspect_mut(&mut self, #req: ::inspect::Request<'_>) {
+                    #fmt
                     #respond
                 }
             }
@@ -378,6 +396,7 @@ fn impl_defs(
         quote! {
             impl #impl_generics ::inspect::Inspect for #type_name #type_generics #where_clause {
                 fn inspect(&self, #req: ::inspect::Request<'_>) {
+                    #fmt
                     #respond
                 }
             }
@@ -502,11 +521,19 @@ fn field_response(
         Transparent,
     }
 
+    #[derive(PartialEq, Eq)]
+    enum Format {
+        Default,
+        Hex,
+        Binary,
+    }
+
     let mut inspect_name = None;
     let mut sensitivity = None;
     let mut is_mut = false;
     let mut kind = None;
     let mut with = None;
+    let mut format = Format::Default;
     for attr in attrs {
         let mut new_with = None;
         let mut new_sen = None;
@@ -531,6 +558,20 @@ fn field_response(
             }
             FieldAttr::Sensitive => {
                 new_sen = Some(SensitivityLevel::Sensitive);
+                None
+            }
+            FieldAttr::Hex => {
+                if format != Format::Default {
+                    return Err(syn::Error::new(attr.span, "too many field formats"));
+                }
+                format = Format::Hex;
+                None
+            }
+            FieldAttr::Binary => {
+                if format != Format::Default {
+                    return Err(syn::Error::new(attr.span, "too many field formats"));
+                }
+                format = Format::Binary;
                 None
             }
         };
@@ -612,6 +653,16 @@ fn field_response(
         }
     }
 
+    match format {
+        Format::Hex => {
+            field_ref = quote!(#ref_ty ::inspect::AsHex(#field_ref));
+        }
+        Format::Binary => {
+            field_ref = quote!(#ref_ty ::inspect::AsBinary(#field_ref));
+        }
+        Format::Default => {}
+    }
+
     let tokens = match kind {
         Kind::Field => {
             let name = match inspect_name {
@@ -668,6 +719,7 @@ fn derive_enum(input: &DeriveInput, data: &DataEnum, mutable: bool) -> syn::Resu
     let mut tag = None;
     let mut extra = None;
     let mut bound = None;
+    let mut hex = false;
     for attr in parse_attrs(&input.attrs)? {
         match attr.kind {
             EnumAttr::Skip => {
@@ -681,6 +733,7 @@ fn derive_enum(input: &DeriveInput, data: &DataEnum, mutable: bool) -> syn::Resu
             EnumAttr::Untagged => insert_or_fail(&mut tag, attr.span, TagMode::Untagged)?,
             EnumAttr::Extra(x) => insert_or_fail(&mut extra, attr.span, x)?,
             EnumAttr::Bound(x) => insert_or_fail(&mut bound, attr.span, x)?,
+            EnumAttr::Hex => hex = true,
         }
     }
 
@@ -730,7 +783,7 @@ fn derive_enum(input: &DeriveInput, data: &DataEnum, mutable: bool) -> syn::Resu
         }
     };
 
-    impl_defs(input, mutable, bound, &req, &respond)
+    impl_defs(input, mutable, bound, &req, &respond, hex)
 }
 
 enum TagMode {
@@ -889,14 +942,14 @@ fn derive_unit_only_enum(data: &DataEnum, mutable: bool, req: &Ident) -> syn::Re
                         }
                     };
                     *self = v;
-                    let v = req.new_value().into();
+                    let v = req.new_value().to_string();
                     req.succeed(v);
                 }
                 Err(req) => {
                     let name = match self {
                         #(Self::#field_name2 => #inspect_name2,)*
                     };
-                    req.value(name.into());
+                    req.value(name);
                 }
             }
         }
@@ -905,7 +958,7 @@ fn derive_unit_only_enum(data: &DataEnum, mutable: bool, req: &Ident) -> syn::Re
             let name: &str = match self {
                 #(Self::#field_name => #inspect_name,)*
             };
-            #req.value(name.into());
+            #req.value(name);
         }
     };
     Ok(tokens)

--- a/support/inspect_derive/src/lib.rs
+++ b/support/inspect_derive/src/lib.rs
@@ -377,7 +377,7 @@ fn impl_defs(
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
 
     let fmt = if hex {
-        quote!(let #req = #req.format_as_hex();)
+        quote!(let #req = #req.with_hex_format();)
     } else {
         quote!()
     };

--- a/support/inspect_rlimit/src/lib.rs
+++ b/support/inspect_rlimit/src/lib.rs
@@ -11,7 +11,7 @@
 
 use cfg_if::cfg_if;
 use inspect::Inspect;
-use inspect::Value;
+use inspect::ValueKind;
 use libc::rlimit;
 use std::num::ParseIntError;
 use thiserror::Error;
@@ -103,7 +103,7 @@ impl Inspect for RlimitResource {
             libc::prlimit(pid, self.resource, std::ptr::null(), &mut rlimit)
         };
         if r != 0 {
-            req.value(std::io::Error::last_os_error().to_string().into());
+            req.value(std::io::Error::last_os_error().to_string());
             return;
         }
 
@@ -122,7 +122,7 @@ impl Inspect for RlimitResource {
             }
             let v = *sel(rlimit);
             let v = if v == !0 {
-                Value::from("unlimited")
+                ValueKind::from("unlimited")
             } else {
                 v.into()
             };

--- a/support/mesh_tracing/src/lib.rs
+++ b/support/mesh_tracing/src/lib.rs
@@ -112,10 +112,10 @@ impl InspectMut for MeshFilterUpdater {
     fn inspect_mut(&mut self, req: inspect::Request<'_>) {
         match req.update() {
             Ok(req) => match self.update(req.new_value()) {
-                Ok(()) => req.succeed(self.get().into()),
+                Ok(()) => req.succeed(self.get()),
                 Err(err) => req.fail(err),
             },
-            Err(req) => req.value(self.get().into()),
+            Err(req) => req.value(self.get()),
         }
     }
 }
@@ -150,11 +150,11 @@ impl InspectMut for MeshFlusher {
                 self.spawn
                     .spawn("trace-flush", async move {
                         let _ = join.await;
-                        req.succeed(true.into());
+                        req.succeed(true);
                     })
                     .detach();
             }
-            Err(req) => req.value(false.into()),
+            Err(req) => req.value(false),
         }
     }
 }

--- a/vm/aarch64/aarch64emu/src/emulator.rs
+++ b/vm/aarch64/aarch64emu/src/emulator.rs
@@ -34,7 +34,7 @@ pub struct InterceptState {
     pub instruction_bytes: [u8; 4],
     pub instruction_byte_count: u8,
     pub gpa: Option<u64>,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     pub syndrome: EsrEl2,
     pub interruption_pending: bool,
 }

--- a/vm/devices/chipset/src/cmos_rtc.rs
+++ b/vm/devices/chipset/src/cmos_rtc.rs
@@ -145,9 +145,7 @@ open_enum::open_enum! {
 /// Newtype around `[u8; 256]` that only supports indexing via [`CmosReg`]
 #[derive(Debug, Clone, Inspect)]
 #[inspect(transparent)]
-struct CmosData(
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")] [u8; 256],
-);
+struct CmosData(#[inspect(hex, iter_by_index)] [u8; 256]);
 
 impl CmosData {
     fn empty() -> CmosData {

--- a/vm/devices/chipset_legacy/src/piix4_pm.rs
+++ b/vm/devices/chipset_legacy/src/piix4_pm.rs
@@ -74,9 +74,9 @@ struct Piix4PmState {
     counter_info_a: u32,
     counter_info_b: u32,
     general_purpose_config_info: u32,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     device_resource_flags: [u32; 10],
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     device_activity_flags: [u32; 2],
 }
 

--- a/vm/devices/chipset_legacy/src/winbond83977_sio/super_io.rs
+++ b/vm/devices/chipset_legacy/src/winbond83977_sio/super_io.rs
@@ -127,7 +127,7 @@ open_enum! {
 #[derive(Debug, Default, Copy, Clone, Inspect)]
 struct LogicalDeviceData {
     enabled: bool,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     io_port_base: [u16; 2],
     #[inspect(bytes)]
     irq_vector: [u8; 2],

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -116,7 +116,7 @@ struct TcpConnection {
     #[inspect(hex)]
     rx_window_cap: usize,
     rx_window_scale: u8,
-    #[inspect(with = "|x| inspect::AsHex(x.0 as u32)")]
+    #[inspect(with = "inspect_seq")]
     rx_seq: TcpSeqNumber,
     needs_ack: bool,
     is_shutdown: bool,
@@ -124,20 +124,24 @@ struct TcpConnection {
 
     #[inspect(with = "|x| x.len()")]
     tx_buffer: ring::Ring,
-    #[inspect(with = "|x| inspect::AsHex(x.0 as u32)")]
+    #[inspect(with = "inspect_seq")]
     tx_acked: TcpSeqNumber,
-    #[inspect(with = "|x| inspect::AsHex(x.0 as u32)")]
+    #[inspect(with = "inspect_seq")]
     tx_send: TcpSeqNumber,
     tx_fin_buffered: bool,
     #[inspect(hex)]
     tx_window_len: u16,
     tx_window_scale: u8,
-    #[inspect(with = "|x| inspect::AsHex(x.0 as u32)")]
+    #[inspect(with = "inspect_seq")]
     tx_window_rx_seq: TcpSeqNumber,
-    #[inspect(with = "|x| inspect::AsHex(x.0 as u32)")]
+    #[inspect(with = "inspect_seq")]
     tx_window_tx_seq: TcpSeqNumber,
     #[inspect(hex)]
     tx_mss: usize,
+}
+
+fn inspect_seq(seq: &TcpSeqNumber) -> inspect::AsHex<u32> {
+    inspect::AsHex(seq.0 as u32)
 }
 
 #[derive(Inspect)]

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -563,7 +563,7 @@ impl std::fmt::Display for PrimaryChannelGuestVfState {
 
 impl Inspect for PrimaryChannelGuestVfState {
     fn inspect(&self, req: inspect::Request<'_>) {
-        req.value(format!("{}", self).into());
+        req.value(self.to_string());
     }
 }
 

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -148,9 +148,7 @@ mod inspect_helpers {
     use super::*;
 
     pub(crate) fn bars(bars: &[u32; 6]) -> impl Inspect + '_ {
-        inspect::iter_by_index(bars)
-            .prefix("bar")
-            .map_value(inspect::AsHex)
+        inspect::AsHex(inspect::iter_by_index(bars).prefix("bar"))
     }
 }
 

--- a/vm/devices/pci/vpci/src/device.rs
+++ b/vm/devices/pci/vpci/src/device.rs
@@ -1008,7 +1008,7 @@ pub struct VpciChannel {
     instance_id: Guid,
     serial_num: u32,
     hardware_ids: HardwareIds,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     bar_masks: [u32; 6],
 
     // The underlying device.

--- a/vm/devices/serial/serial_socket/src/windows.rs
+++ b/vm/devices/serial/serial_socket/src/windows.rs
@@ -54,14 +54,11 @@ enum PipeState {
 
 impl Inspect for PipeState {
     fn inspect(&self, req: inspect::Request<'_>) {
-        req.value(
-            match self {
-                PipeState::Done => "done",
-                PipeState::Listening(_) => "listening",
-                PipeState::Connected(_) => "connected",
-            }
-            .into(),
-        )
+        req.value(match self {
+            PipeState::Done => "done",
+            PipeState::Listening(_) => "listening",
+            PipeState::Connected(_) => "connected",
+        })
     }
 }
 

--- a/vm/devices/storage/nvme/src/queue.rs
+++ b/vm/devices/storage/nvme/src/queue.rs
@@ -18,7 +18,7 @@ pub const ILLEGAL_DOORBELL_VALUE: u32 = 0xffffffff;
 #[derive(Default, Inspect)]
 #[inspect(transparent)]
 pub struct DoorbellRegister {
-    #[inspect(with = "|x| inspect::AsHex(x.load(Ordering::Relaxed))")]
+    #[inspect(hex)]
     value: AtomicU32,
     #[inspect(skip)]
     event: event_listener::Event,

--- a/vm/devices/storage/storage_string/src/lib.rs
+++ b/vm/devices/storage/storage_string/src/lib.rs
@@ -34,9 +34,9 @@ impl<const N: usize> std::fmt::Debug for AsciiString<N> {
 impl<const N: usize> Inspect for AsciiString<N> {
     fn inspect(&self, req: inspect::Request<'_>) {
         if let Some(s) = self.as_str() {
-            req.value(s.into())
+            req.value(s)
         } else {
-            req.value(self.as_bytes().to_vec().into())
+            req.value(self.as_bytes().to_vec())
         }
     }
 }

--- a/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_relay_intercept_device/src/lib.rs
@@ -215,9 +215,7 @@ struct SimpleVmbusClientDeviceTaskState {
     offer: Option<OfferInfo>,
     #[inspect(skip)]
     recv_relay: mesh::Receiver<InterceptChannelRequest>,
-    #[inspect(
-        with = "|x| x.as_ref().map(|x| inspect::iter_by_index(x.pfns()).map_value(inspect::AsHex))"
-    )]
+    #[inspect(hex, with = "|x| x.as_ref().map(|x| inspect::iter_by_index(x.pfns()))")]
     vtl_pages: Option<MemoryBlock>,
 }
 

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -924,7 +924,7 @@ impl ServerTask {
                         .field("running", self.inner.running)
                         .field("hvsock_requests", self.inner.hvsock_requests)
                         .field_mut_with("unstick_channels", |v| {
-                            let v: inspect::Value = if let Some(v) = v {
+                            let v: inspect::ValueKind = if let Some(v) = v {
                                 if v == "force" {
                                     self.unstick_channels(true);
                                     v.into()

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -50,13 +50,13 @@ struct GlobalHvState {
 
 #[derive(Inspect)]
 struct MutableHvState {
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     hypercall_reg: hvdef::hypercall::MsrHypercallContents,
     #[inspect(with = "|x| x.is_some()")]
     hypercall_page: Option<LockedPage>,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     guest_os_id: hvdef::hypercall::HvGuestOsId,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     reference_tsc_reg: hvdef::HvRegisterReferenceTsc,
     #[inspect(with = "|x| x.is_some()")]
     reference_tsc_page: Option<LockedPage>,
@@ -174,7 +174,7 @@ pub struct ProcessorVtlHv {
     guest_memory: GuestMemory,
     /// The virtual processor's synic state.
     pub synic: ProcessorSynic,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     vp_assist_page_reg: HvRegisterVpAssistPage,
     vp_assist_page: OverlayPage,
 }

--- a/vm/hv1/hv1_emulator/src/synic.rs
+++ b/vm/hv1/hv1_emulator/src/synic.rs
@@ -48,14 +48,17 @@ pub struct ProcessorSynic {
 
 #[derive(Inspect)]
 struct SintState {
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     siefp: HvSynicSimpSiefp,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     simp: HvSynicSimpSiefp,
     simp_page: OverlayPage,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     scontrol: hvdef::HvSynicScontrol,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(|x| inspect::AsHex(u64::from(*x)))")]
+    #[inspect(
+        hex,
+        with = "|x| inspect::iter_by_index(x).map_value(|x| u64::from(*x))"
+    )]
     sint: [hvdef::HvSynicSint; NUM_SINTS],
     pending_sints: u16,
     ready_sints: u16,
@@ -77,7 +80,7 @@ impl Default for SintState {
 
 #[derive(Default, Inspect)]
 struct Timer {
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     config: HvSynicStimerConfig,
     count: u64,
     reevaluate: bool,
@@ -89,7 +92,10 @@ struct SharedProcessorState {
     online: bool,
     enabled: bool,
     siefp_page: OverlayPage,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(|x| inspect::AsHex(u64::from(*x)))")]
+    #[inspect(
+        hex,
+        with = "|x| inspect::iter_by_index(x).map_value(|x| u64::from(*x))"
+    )]
     sint: [hvdef::HvSynicSint; NUM_SINTS],
 }
 

--- a/vm/vmcore/vm_topology/src/processor/aarch64.rs
+++ b/vm/vmcore/vm_topology/src/processor/aarch64.rs
@@ -58,10 +58,7 @@ pub struct Aarch64VpInfo {
     #[cfg_attr(feature = "inspect", inspect(flatten))]
     pub base: VpInfo,
     /// The MPIDR_EL1 value of the processor.
-    #[cfg_attr(
-        feature = "inspect",
-        inspect(with = "|&x| inspect::AsHex(u64::from(x))")
-    )]
+    #[cfg_attr(feature = "inspect", inspect(hex, with = "|&x| u64::from(x)"))]
     pub mpidr: MpidrEl1,
     /// GIC Redistributor Address
     #[cfg_attr(feature = "inspect", inspect(hex))]

--- a/vmm_core/virt/src/aarch64/vp.rs
+++ b/vmm_core/virt/src/aarch64/vp.rs
@@ -15,110 +15,76 @@ use vm_topology::processor::aarch64::Aarch64VpInfo;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Protobuf, Inspect)]
 #[mesh(package = "virt.aarch64")]
+#[inspect(hex)]
 pub struct Registers {
-    #[inspect(hex)]
     #[mesh(1)]
     pub x0: u64,
-    #[inspect(hex)]
     #[mesh(2)]
     pub x1: u64,
-    #[inspect(hex)]
     #[mesh(3)]
     pub x2: u64,
-    #[inspect(hex)]
     #[mesh(4)]
     pub x3: u64,
-    #[inspect(hex)]
     #[mesh(5)]
     pub x4: u64,
-    #[inspect(hex)]
     #[mesh(6)]
     pub x5: u64,
-    #[inspect(hex)]
     #[mesh(7)]
     pub x6: u64,
-    #[inspect(hex)]
     #[mesh(8)]
     pub x7: u64,
-    #[inspect(hex)]
     #[mesh(9)]
     pub x8: u64,
-    #[inspect(hex)]
     #[mesh(10)]
     pub x9: u64,
-    #[inspect(hex)]
     #[mesh(11)]
     pub x10: u64,
-    #[inspect(hex)]
     #[mesh(12)]
     pub x11: u64,
-    #[inspect(hex)]
     #[mesh(13)]
     pub x12: u64,
-    #[inspect(hex)]
     #[mesh(14)]
     pub x13: u64,
-    #[inspect(hex)]
     #[mesh(15)]
     pub x14: u64,
-    #[inspect(hex)]
     #[mesh(16)]
     pub x15: u64,
-    #[inspect(hex)]
     #[mesh(17)]
     pub x16: u64,
-    #[inspect(hex)]
     #[mesh(18)]
     pub x17: u64,
-    #[inspect(hex)]
     #[mesh(19)]
     pub x18: u64,
-    #[inspect(hex)]
     #[mesh(20)]
     pub x19: u64,
-    #[inspect(hex)]
     #[mesh(21)]
     pub x20: u64,
-    #[inspect(hex)]
     #[mesh(22)]
     pub x21: u64,
-    #[inspect(hex)]
     #[mesh(23)]
     pub x22: u64,
-    #[inspect(hex)]
     #[mesh(24)]
     pub x23: u64,
-    #[inspect(hex)]
     #[mesh(25)]
     pub x24: u64,
-    #[inspect(hex)]
     #[mesh(26)]
     pub x25: u64,
-    #[inspect(hex)]
     #[mesh(27)]
     pub x26: u64,
-    #[inspect(hex)]
     #[mesh(28)]
     pub x27: u64,
-    #[inspect(hex)]
     #[mesh(29)]
     pub x28: u64,
-    #[inspect(hex)]
     #[mesh(30)]
     pub fp: u64,
-    #[inspect(hex)]
     #[mesh(31)]
     pub lr: u64,
-    #[inspect(hex)]
     #[mesh(32)]
     pub sp_el0: u64,
-    #[inspect(hex)]
     #[mesh(33)]
     pub sp_el1: u64,
-    #[inspect(hex)]
     #[mesh(34)]
     pub pc: u64,
-    #[inspect(hex)]
     #[mesh(35)]
     pub cpsr: u64,
 }

--- a/vmm_core/virt/src/x86/vp.rs
+++ b/vmm_core/virt/src/x86/vp.rs
@@ -967,14 +967,14 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for Xsave {
 
 #[derive(PartialEq, Eq, Clone, Protobuf, Inspect)]
 #[mesh(package = "virt.x86")]
+#[inspect(hex)]
 pub struct Apic {
-    #[inspect(hex)]
     #[mesh(1)]
     pub apic_base: u64,
     #[inspect(with = "ApicRegisters::from")]
     #[mesh(2)]
     pub registers: [u32; 64],
-    #[inspect(with = "|x| inspect::iter_by_index(x.iter().map(inspect::AsHex))")]
+    #[inspect(iter_by_index)]
     #[mesh(3)]
     pub auto_eoi: [u32; 8],
 }
@@ -996,64 +996,44 @@ impl Debug for Apic {
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes, Inspect)]
+#[inspect(hex)]
 pub struct ApicRegisters {
     #[inspect(skip)]
     pub reserved_0: [u32; 2],
-    #[inspect(hex)]
     pub id: u32,
-    #[inspect(hex)]
     pub version: u32,
     #[inspect(skip)]
     pub reserved_4: [u32; 4],
-    #[inspect(hex)]
     pub tpr: u32, // Task Priority Register
-    #[inspect(hex)]
     pub apr: u32, // Arbitration Priority Register
-    #[inspect(hex)]
     pub ppr: u32, // Processor Priority Register
-    #[inspect(hex)]
     pub eoi: u32, //
-    #[inspect(hex)]
     pub rrd: u32, // Remote Read Register
-    #[inspect(hex)]
     pub ldr: u32, // Logical Destination Register
-    #[inspect(hex)]
     pub dfr: u32, // Destination Format Register
-    #[inspect(hex)]
     pub svr: u32, // Spurious Interrupt Vector
-    #[inspect(with = "|x| inspect::iter_by_index(x.iter().map(inspect::AsHex))")]
+    #[inspect(iter_by_index)]
     pub isr: [u32; 8], // In-Service Register
-    #[inspect(with = "|x| inspect::iter_by_index(x.iter().map(inspect::AsHex))")]
+    #[inspect(iter_by_index)]
     pub tmr: [u32; 8], // Trigger Mode Register
-    #[inspect(with = "|x| inspect::iter_by_index(x.iter().map(inspect::AsHex))")]
+    #[inspect(iter_by_index)]
     pub irr: [u32; 8], // Interrupt Request Register
-    #[inspect(hex)]
     pub esr: u32, // Error Status Register
     #[inspect(skip)]
     pub reserved_29: [u32; 6],
-    #[inspect(hex)]
     pub lvt_cmci: u32,
-    #[inspect(with = "|x| inspect::iter_by_index(x.iter().map(inspect::AsHex))")]
+    #[inspect(iter_by_index)]
     pub icr: [u32; 2], // Interrupt Command Register
-    #[inspect(hex)]
     pub lvt_timer: u32,
-    #[inspect(hex)]
     pub lvt_thermal: u32,
-    #[inspect(hex)]
     pub lvt_pmc: u32,
-    #[inspect(hex)]
     pub lvt_lint0: u32,
-    #[inspect(hex)]
     pub lvt_lint1: u32,
-    #[inspect(hex)]
     pub lvt_error: u32,
-    #[inspect(hex)]
     pub timer_icr: u32, // Initial Count Register
-    #[inspect(hex)]
     pub timer_ccr: u32, // Current Count Register
     #[inspect(skip)]
     pub reserved_3a: [u32; 4],
-    #[inspect(hex)]
     pub timer_dcr: u32, // Divide Configuration Register
     #[inspect(skip)]
     pub reserved_3f: u32,
@@ -1287,15 +1267,16 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for Pat {
 #[repr(C)]
 #[derive(Default, Debug, PartialEq, Eq, Protobuf, Inspect)]
 #[mesh(package = "virt.x86")]
+#[inspect(hex)]
 pub struct Mtrrs {
     #[mesh(1)]
     #[inspect(hex)]
     pub msr_mtrr_def_type: u64,
     #[mesh(2)]
-    #[inspect(with = "|x| inspect::iter_by_index(x.iter().map(inspect::AsHex))")]
+    #[inspect(iter_by_index)]
     pub fixed: [u64; 11],
     #[mesh(3)]
-    #[inspect(with = "|x| inspect::iter_by_index(x.iter().map(inspect::AsHex))")]
+    #[inspect(iter_by_index)]
     pub variable: [u64; 16],
 }
 
@@ -1373,30 +1354,23 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for Mtrrs {
 #[repr(C)]
 #[derive(Default, Debug, PartialEq, Eq, Protobuf, Inspect)]
 #[mesh(package = "virt.x86")]
+#[inspect(hex)]
 pub struct VirtualMsrs {
     #[mesh(1)]
-    #[inspect(hex)]
     pub kernel_gs_base: u64,
     #[mesh(2)]
-    #[inspect(hex)]
     pub sysenter_cs: u64,
     #[mesh(3)]
-    #[inspect(hex)]
     pub sysenter_eip: u64,
     #[mesh(4)]
-    #[inspect(hex)]
     pub sysenter_esp: u64,
     #[mesh(5)]
-    #[inspect(hex)]
     pub star: u64,
     #[mesh(6)]
-    #[inspect(hex)]
     pub lstar: u64,
     #[mesh(7)]
-    #[inspect(hex)]
     pub cstar: u64,
     #[mesh(8)]
-    #[inspect(hex)]
     pub sfmask: u64,
 }
 
@@ -1583,12 +1557,11 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for Cet {
 #[repr(C)]
 #[derive(Default, Debug, PartialEq, Eq, Protobuf, Inspect)]
 #[mesh(package = "virt.x86")]
+#[inspect(hex)]
 pub struct CetSs {
     #[mesh(1)]
-    #[inspect(hex)]
     pub ssp: u64,
     #[mesh(2)]
-    #[inspect(hex)]
     pub interrupt_ssp_table_addr: u64,
     // Plx_ssp are part of xsave state.
 }
@@ -1627,21 +1600,18 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for CetSs {
 #[repr(C)]
 #[derive(Debug, Default, PartialEq, Eq, Protobuf, Inspect)]
 #[mesh(package = "virt.x86")]
+#[inspect(hex)]
 pub struct SyntheticMsrs {
     #[mesh(1)]
-    #[inspect(hex)]
     pub vp_assist_page: u64,
     #[mesh(2)]
-    #[inspect(hex)]
     pub scontrol: u64,
     #[mesh(3)]
-    #[inspect(hex)]
     pub siefp: u64,
     #[mesh(4)]
-    #[inspect(hex)]
     pub simp: u64,
     #[mesh(5)]
-    #[inspect(with = "|x| inspect::iter_by_index(x.iter().map(inspect::AsHex))")]
+    #[inspect(iter_by_index)]
     pub sint: [u64; 16],
 }
 
@@ -1714,18 +1684,15 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for SyntheticMsrs {
 
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq, Protobuf, Inspect)]
 #[mesh(package = "virt.x86")]
+#[inspect(hex)]
 pub struct SynicTimer {
     #[mesh(1)]
-    #[inspect(hex)]
     pub config: u64,
     #[mesh(2)]
-    #[inspect(hex)]
     pub count: u64,
     #[mesh(3)]
-    #[inspect(hex)]
     pub adjustment: u64,
     #[mesh(4)]
-    #[inspect(hex)]
     pub undelivered_message_expiration_time: Option<u64>,
 }
 

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -447,7 +447,7 @@ pub struct KvmVpInner {
     eval: AtomicBool,
     vp_info: X86VpInfo,
     synic_message_queue: MessageQueues,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x.read()))")]
+    #[inspect(hex, with = "|x| u64::from(*x.read())")]
     siefp: RwLock<HvSynicSimpSiefp>,
 }
 
@@ -634,11 +634,11 @@ pub struct KvmProcessor<'a> {
     vmtime: &'a mut VmTimeAccess,
     #[inspect(iter_by_index)]
     guest_debug_db: [u64; 4],
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     scontrol: HvSynicScontrol,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     siefp: HvSynicSimpSiefp,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     simp: HvSynicSimpSiefp,
 }
 

--- a/vmm_core/virt_support_apic/src/lib.rs
+++ b/vmm_core/virt_support_apic/src/lib.rs
@@ -78,13 +78,13 @@ pub struct LocalApic {
     cluster_mode: bool,
     #[inspect(hex)]
     svr: u32,
-    #[inspect(with = "|x| inspect::iter_by_index(x.to_bits()).map_value(inspect::AsHex)")]
+    #[inspect(hex, with = "|x| inspect::iter_by_index(x.to_bits())")]
     isr: IsrStack,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     irr: [u32; 8],
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     tmr: [u32; 8],
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     auto_eoi: [u32; 8],
     next_irr: Option<u8>,
     #[inspect(hex)]
@@ -97,7 +97,7 @@ pub struct LocalApic {
     lvt_thermal: u32,
     #[inspect(hex)]
     lvt_pmc: u32,
-    #[inspect(with = "|x| inspect::iter_by_index(x).map_value(inspect::AsHex)")]
+    #[inspect(hex, iter_by_index)]
     lvt_lint: [u32; 2],
     #[inspect(hex)]
     lvt_error: u32,
@@ -213,17 +213,11 @@ impl IsrStack {
 #[derive(Debug, Inspect)]
 struct SharedState {
     vp_index: VpIndex,
-    #[inspect(
-        with = "|x| inspect::iter_by_index(x).map_value(|x| inspect::AsHex(x.load(Ordering::Relaxed)))"
-    )]
+    #[inspect(hex, iter_by_index)]
     tmr: [AtomicU32; 8],
-    #[inspect(
-        with = "|x| inspect::iter_by_index(x).map_value(|x| inspect::AsHex(x.load(Ordering::Relaxed)))"
-    )]
+    #[inspect(hex, iter_by_index)]
     new_irr: [AtomicU32; 8],
-    #[inspect(
-        with = "|x| inspect::iter_by_index(x).map_value(|x| inspect::AsHex(x.load(Ordering::Relaxed)))"
-    )]
+    #[inspect(hex, iter_by_index)]
     auto_eoi: [AtomicU32; 8],
     work: AtomicU32,
     software_enabled_on_reset: bool,

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -174,7 +174,7 @@ struct RunState {
     active_vtl: Vtl,
     enabled_vtls: VtlSet,
     runnable_vtls: VtlSet,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     vtl2_deliverability_notifications: HvDeliverabilityNotificationsRegister,
     vtl2_wakeup_vmtime: Option<VmTimeAccess>,
     #[inspect(skip)]
@@ -202,7 +202,7 @@ struct PerVtlRunState {
     #[cfg(guest_arch = "x86_64")]
     lapic: Option<apic::ApicState>,
     hv: Option<ProcessorVtlHv>,
-    #[inspect(with = "|x| inspect::AsHex(u64::from(*x))")]
+    #[inspect(hex, with = "|&x| u64::from(x)")]
     deliverability_notifications: HvDeliverabilityNotificationsRegister,
     // Only used when `hv` is `None`.
     vp_assist_page: u64,

--- a/vmm_core/vmotherboard/src/chipset/io_ranges/address_filter.rs
+++ b/vmm_core/vmotherboard/src/chipset/io_ranges/address_filter.rs
@@ -176,13 +176,13 @@ impl<T: RangeKey> InspectMut for AddressFilter<T> {
             Ok(req) => match req.new_value().parse() {
                 Ok(v) => {
                     *self = v;
-                    req.succeed(self.to_string().into());
+                    req.succeed(self.to_string());
                 }
                 Err(err) => {
                     req.fail(err);
                 }
             },
-            Err(req) => req.value(self.to_string().into()),
+            Err(req) => req.value(self.to_string()),
         }
     }
 }


### PR DESCRIPTION
Make a field's formatting (currently hex, binary, and counter) easier to define. Instead of requiring the formatting to be specified on exactly the value to be formatted, specify it at any part of the node hierarchy, and inherit it on all child fields.

This and some other cleanups makes it possible to do a few things:

* You can specify `hex` on the derive of an entire struct in order to avoid having to specify it on each field.

* You can specify `hex` on fields that already have a `with` or `iter_by_index`, to avoid needing to manually apply `AsHex` in a `.map` call.

* You can specify `hex` on arbitrarily complicated numeric fields such as `Arc<RwLock<AtomicU32>>`, without needing explicit `Inspect` impls for `AsHex<T>`.

As part of this, simplify a bunch of inspect derives.