### PR TITLE
hvdef: fix spacing around hypervisor errors

### DIFF
--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -468,7 +468,7 @@ macro_rules! hv_error {
             fn doc_str(&self) -> Option<&'static str> {
                 Some(match self.0.get() {
                     $(
-                        $val => $doc,
+                        $val => const { $doc.trim_ascii() },
                     )*
                     _ => return None,
                 })


### PR DESCRIPTION
There are some extra leading spaces in the `HvError` messages due to the way the macro works. Trim them.