### PR TITLE
hcl: move MMIO routines from Hcl to MshvHvcall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7396,6 +7396,7 @@ dependencies = [
  "guest_emulation_transport",
  "guestmem",
  "guid",
+ "hcl",
  "hcl_compat_uefi_nvram_storage",
  "hvdef",
  "hyperv_ic_guest",

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1489,6 +1489,60 @@ impl MshvHvcall {
 
         self.get_vp_register_for_vtl_inner(vtl, name.into())
     }
+
+    /// Invokes the HvCallMemoryMappedIoRead hypercall
+    pub fn mmio_read(&self, gpa: u64, data: &mut [u8]) -> Result<(), HvError> {
+        assert!(data.len() <= hvdef::hypercall::HV_HYPERCALL_MMIO_MAX_DATA_LENGTH);
+
+        let header = hvdef::hypercall::MemoryMappedIoRead {
+            gpa,
+            access_width: data.len() as u32,
+            reserved_z0: 0,
+        };
+
+        let mut output: hvdef::hypercall::MemoryMappedIoReadOutput = FromZeros::new_zeroed();
+
+        // SAFETY: The input header and slice are the correct types for this hypercall.
+        //         The hypercall output is validated right after the hypercall is issued.
+        let status = unsafe {
+            self.hvcall(
+                HypercallCode::HvCallMemoryMappedIoRead,
+                &header,
+                &mut output,
+            )
+            .expect("submitting hypercall should not fail")
+        };
+
+        // Only copy the data if the hypercall was successful
+        if status.result().is_ok() {
+            data.copy_from_slice(&output.data[..data.len()]);
+        };
+
+        status.result()
+    }
+
+    /// Invokes the HvCallMemoryMappedIoWrite hypercall
+    pub fn mmio_write(&self, gpa: u64, data: &[u8]) -> Result<(), HvError> {
+        assert!(data.len() <= hvdef::hypercall::HV_HYPERCALL_MMIO_MAX_DATA_LENGTH);
+
+        let mut header = hvdef::hypercall::MemoryMappedIoWrite {
+            gpa,
+            access_width: data.len() as u32,
+            reserved_z0: 0,
+            data: [0; hvdef::hypercall::HV_HYPERCALL_MMIO_MAX_DATA_LENGTH],
+        };
+
+        header.data[..data.len()].copy_from_slice(data);
+
+        // SAFETY: The input header and slice are the correct types for this hypercall.
+        //         The hypercall output is validated right after the hypercall is issued.
+        let status = unsafe {
+            self.hvcall(HypercallCode::HvCallMemoryMappedIoWrite, &header, &mut ())
+                .expect("submitting hypercall should not fail")
+        };
+
+        status.result()
+    }
 }
 
 /// The HCL device and collection of fds.
@@ -3060,62 +3114,6 @@ impl Hcl {
         }
 
         value
-    }
-
-    /// Invokes the HvCallMemoryMappedIoRead hypercall
-    pub fn memory_mapped_io_read(&self, gpa: u64, data: &mut [u8]) -> Result<(), HvError> {
-        assert!(data.len() <= hvdef::hypercall::HV_HYPERCALL_MMIO_MAX_DATA_LENGTH);
-
-        let header = hvdef::hypercall::MemoryMappedIoRead {
-            gpa,
-            access_width: data.len() as u32,
-            reserved_z0: 0,
-        };
-
-        let mut output: hvdef::hypercall::MemoryMappedIoReadOutput = FromZeros::new_zeroed();
-
-        // SAFETY: The input header and slice are the correct types for this hypercall.
-        //         The hypercall output is validated right after the hypercall is issued.
-        let status = unsafe {
-            self.mshv_hvcall
-                .hvcall(
-                    HypercallCode::HvCallMemoryMappedIoRead,
-                    &header,
-                    &mut output,
-                )
-                .expect("submitting hypercall should not fail")
-        };
-
-        // Only copy the data if the hypercall was successful
-        if status.result().is_ok() {
-            data.copy_from_slice(&output.data[..data.len()]);
-        };
-
-        status.result()
-    }
-
-    /// Invokes the HvCallMemoryMappedIoWrite hypercall
-    pub fn memory_mapped_io_write(&self, gpa: u64, data: &[u8]) -> Result<(), HvError> {
-        assert!(data.len() <= hvdef::hypercall::HV_HYPERCALL_MMIO_MAX_DATA_LENGTH);
-
-        let mut header = hvdef::hypercall::MemoryMappedIoWrite {
-            gpa,
-            access_width: data.len() as u32,
-            reserved_z0: 0,
-            data: [0; hvdef::hypercall::HV_HYPERCALL_MMIO_MAX_DATA_LENGTH],
-        };
-
-        header.data[..data.len()].copy_from_slice(data);
-
-        // SAFETY: The input header and slice are the correct types for this hypercall.
-        //         The hypercall output is validated right after the hypercall is issued.
-        let status = unsafe {
-            self.mshv_hvcall
-                .hvcall(HypercallCode::HvCallMemoryMappedIoWrite, &header, &mut ())
-                .expect("submitting hypercall should not fail")
-        };
-
-        status.result()
     }
 
     /// Invokes the HvCallRetargetDeviceInterrupt hypercall.

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -64,6 +64,7 @@ ide.workspace = true
 ide_resources.workspace = true
 input_core.workspace = true
 kmsg_defs.workspace = true
+hcl.workspace = true
 mana_driver.workspace = true
 mcr_resources.workspace = true
 net_backend.workspace = true

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3357,7 +3357,7 @@ impl FallbackMmioDevice {
 
 impl chipset_device::mmio::MmioIntercept for FallbackMmioDevice {
     fn mmio_read(&mut self, addr: u64, data: &mut [u8]) -> chipset_device::io::IoResult {
-            data.fill(!0);
+        data.fill(!0);
         if self.is_allowed(addr, data.len()) {
             if let Err(err) = self.mshv_hvcall.mmio_read(addr, data) {
                 tracelimit::error_ratelimited!(

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2496,7 +2496,14 @@ async fn new_underhill_vm(
         deps_winbond_super_io_and_floppy_full: None,
     };
 
-    let fallback_mmio_device = use_mmio_hypercalls.then(|| {
+    let fallback_mmio_device = if use_mmio_hypercalls {
+        let mshv_hvcall =
+            hcl::ioctl::MshvHvcall::new().context("failed to open mshv_hvcall device")?;
+        mshv_hvcall.set_allowed_hypercalls(&[
+            hvdef::HypercallCode::HvCallMemoryMappedIoRead,
+            hvdef::HypercallCode::HvCallMemoryMappedIoWrite,
+        ]);
+
         // If VTOM is present (CVM scenario), accesses to physical device and PCI config space may
         // occur below or above vTOM, but only within MMIO regions. Forward both to the host.
         let vtom = vtom.unwrap_or(0);
@@ -2514,11 +2521,13 @@ async fn new_underhill_vm(
                 Some(untrusted_mmio_ranges)
             };
 
-        Arc::new(CloseableMutex::new(FallbackMmioDevice {
-            partition: Arc::downgrade(&partition),
+        Some(Arc::new(CloseableMutex::new(FallbackMmioDevice {
             mmio_ranges: untrusted_mmio_ranges,
-        })) as Arc<CloseableMutex<dyn ChipsetDevice>>
-    });
+            mshv_hvcall,
+        })) as _)
+    } else {
+        None
+    };
 
     let BaseChipsetBuilderOutput {
         mut chipset_builder,
@@ -3332,43 +3341,43 @@ impl chipset::pm::PmTimerAssist for UnderhillPmTimerAssist {
 // forwarding them to the host. It needs to implement the ChipsetDevice and
 // MmioIntercept traits.
 struct FallbackMmioDevice {
-    partition: std::sync::Weak<UhPartition>,
     mmio_ranges: Option<Vec<MemoryRange>>,
+    mshv_hvcall: hcl::ioctl::MshvHvcall,
+}
+
+impl FallbackMmioDevice {
+    fn is_allowed(&self, addr: u64, data_len: usize) -> bool {
+        self.mmio_ranges.as_ref().is_none_or(|v| {
+            v.iter().any(|range| {
+                range.contains_addr(addr) && range.contains_addr(addr + data_len as u64 - 1)
+            })
+        })
+    }
 }
 
 impl chipset_device::mmio::MmioIntercept for FallbackMmioDevice {
     fn mmio_read(&mut self, addr: u64, data: &mut [u8]) -> chipset_device::io::IoResult {
-        let Some(partition) = self.partition.upgrade() else {
-            return chipset_device::io::IoResult::Ok;
-        };
-
-        if let Some(mmio_ranges) = &self.mmio_ranges {
             data.fill(!0);
-            if mmio_ranges.iter().any(|range| {
-                range.contains_addr(addr) && range.contains_addr(addr + data.len() as u64 - 1)
-            }) {
-                partition.host_mmio_read(addr, data);
+        if self.is_allowed(addr, data.len()) {
+            if let Err(err) = self.mshv_hvcall.mmio_read(addr, data) {
+                tracelimit::error_ratelimited!(
+                    error = &err as &dyn std::error::Error,
+                    "failed host MMIO read"
+                );
             }
-        } else {
-            partition.host_mmio_read(addr, data);
         }
 
         chipset_device::io::IoResult::Ok
     }
 
     fn mmio_write(&mut self, addr: u64, data: &[u8]) -> chipset_device::io::IoResult {
-        let Some(partition) = self.partition.upgrade() else {
-            return chipset_device::io::IoResult::Ok;
-        };
-
-        if let Some(mmio_ranges) = &self.mmio_ranges {
-            if mmio_ranges.iter().any(|range| {
-                range.contains_addr(addr) && range.contains_addr(addr + data.len() as u64 - 1)
-            }) {
-                partition.host_mmio_write(addr, data);
+        if self.is_allowed(addr, data.len()) {
+            if let Err(err) = self.mshv_hvcall.mmio_write(addr, data) {
+                tracelimit::error_ratelimited!(
+                    error = &err as &dyn std::error::Error,
+                    "failed host MMIO write"
+                );
             }
-        } else {
-            partition.host_mmio_write(addr, data);
         }
 
         chipset_device::io::IoResult::Ok

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -2063,34 +2063,6 @@ impl UhPartition {
 
         caps
     }
-
-    /// Forward a (virtual) MMIO read to the host for handling.
-    pub fn host_mmio_read(&self, addr: u64, data: &mut [u8]) {
-        if !self.inner.use_mmio_hypercalls {
-            return;
-        }
-        // There isn't anything reasonable that can be done in the face of errors from the host.
-        if let Err(err) = self.inner.hcl.memory_mapped_io_read(addr, data) {
-            tracelimit::error_ratelimited!(
-                error = &err as &dyn std::error::Error,
-                "Failed host MMIO read"
-            );
-        }
-    }
-
-    /// Forward a (virtual) MMIO write to the host for handling.
-    pub fn host_mmio_write(&self, addr: u64, data: &[u8]) {
-        if !self.inner.use_mmio_hypercalls {
-            return;
-        }
-        // There isn't anything reasonable that can be done in the face of errors from the host.
-        if let Err(err) = self.inner.hcl.memory_mapped_io_write(addr, data) {
-            tracelimit::error_ratelimited!(
-                error = &err as &dyn std::error::Error,
-                "Failed host MMIO write"
-            );
-        }
-    }
 }
 
 #[cfg(guest_arch = "x86_64")]


### PR DESCRIPTION
These routines are being used only by the fallback MMIO code in `underhill_core`, so make them available without needing a whole `Hcl` instance. This gets `virt_mshv_vtl` and `UhPartition` out of the path.