### PR TITLE
vmgs: fix overflow in test_logger()

### DIFF
--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -2603,7 +2603,7 @@ mod tests {
         let fcb = vmgs.fcbs.get_mut(&FileId::BIOS_NVRAM).unwrap();
 
         // Manipulate the nonce and expect the read to fail.
-        fcb.nonce[0] += 1;
+        fcb.nonce[0] ^= 1;
 
         // read and expect to fail
         let result = vmgs.read_file(FileId::BIOS_NVRAM).await;


### PR DESCRIPTION
The test fails due to overflow 1/256 of the time. Fix this by changing
the nonce manipulation to avoid overflow.
