### PR TITLE
mesh_remote: windows: fix messages near the small message limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,6 +4092,7 @@ dependencies = [
 name = "mesh_remote"
 version = "0.0.0"
 dependencies = [
+ "event-listener",
  "futures",
  "futures-concurrency",
  "libc",

--- a/support/mesh/mesh_remote/Cargo.toml
+++ b/support/mesh/mesh_remote/Cargo.toml
@@ -31,6 +31,7 @@ libc.workspace = true
 socket2.workspace = true
 
 [dev-dependencies]
+event-listener.workspace = true
 test_with_tracing.workspace = true
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/support/mesh/mesh_remote/src/alpc_node.rs
+++ b/support/mesh/mesh_remote/src/alpc_node.rs
@@ -741,6 +741,7 @@ impl Connection {
 
 impl SendEvent for Connection {
     fn event(&self, event: OutgoingEvent<'_>) {
+        let len = event.len();
         match self.send_event(event) {
             Ok(_) => (),
             Err(err) => {
@@ -748,6 +749,7 @@ impl SendEvent for Connection {
                     node = ?self.local_id,
                     remote_node = ?self.remote_id,
                     error = err.as_error(),
+                    len,
                     "error sending packet"
                 );
                 // Notify the connection task of the failure.
@@ -780,6 +782,7 @@ impl Deref for AlpcPort {
 #[cfg(test)]
 mod tests {
     use super::AlpcNode;
+    use crate::alpc_node::MAX_SMALL_EVENT_SIZE;
     use mesh_channel::RecvError;
     use mesh_channel::channel;
     use pal_async::DefaultDriver;
@@ -823,6 +826,17 @@ mod tests {
         drop(recv2);
         node1.shutdown().await;
         node2.shutdown().await;
+    }
+
+    #[async_test]
+    async fn test_message_sizes(driver: DefaultDriver) {
+        let (p1, p2) = mesh_node::local_node::Port::new_pair();
+        let (p3, p4) = mesh_node::local_node::Port::new_pair();
+        let node1 = AlpcNode::new(driver.clone()).unwrap();
+        let (invitation, _handle) = node1.invite(p2).unwrap();
+        let _node2 = AlpcNode::join(driver.clone(), invitation, p3).unwrap();
+
+        crate::test_common::test_message_sizes(p1, p4, 0..=MAX_SMALL_EVENT_SIZE + 0x1000).await;
     }
 
     #[async_test]

--- a/support/mesh/mesh_remote/src/alpc_node.rs
+++ b/support/mesh/mesh_remote/src/alpc_node.rs
@@ -835,12 +835,8 @@ mod tests {
         let (invitation, _handle) = node1.invite(p2).unwrap();
         let _node2 = AlpcNode::join(driver.clone(), invitation, p3).unwrap();
 
-        crate::test_common::test_message_sizes(
-            p1,
-            p4,
-            0..=crate::alpc_node::MAX_SMALL_EVENT_SIZE + 0x1000,
-        )
-        .await;
+        crate::test_common::test_message_sizes(p1, p4, 0..=super::MAX_SMALL_EVENT_SIZE + 0x1000)
+            .await;
     }
 
     #[async_test]

--- a/support/mesh/mesh_remote/src/alpc_node.rs
+++ b/support/mesh/mesh_remote/src/alpc_node.rs
@@ -782,7 +782,6 @@ impl Deref for AlpcPort {
 #[cfg(test)]
 mod tests {
     use super::AlpcNode;
-    use crate::alpc_node::MAX_SMALL_EVENT_SIZE;
     use mesh_channel::RecvError;
     use mesh_channel::channel;
     use pal_async::DefaultDriver;
@@ -836,7 +835,12 @@ mod tests {
         let (invitation, _handle) = node1.invite(p2).unwrap();
         let _node2 = AlpcNode::join(driver.clone(), invitation, p3).unwrap();
 
-        crate::test_common::test_message_sizes(p1, p4, 0..=MAX_SMALL_EVENT_SIZE + 0x1000).await;
+        crate::test_common::test_message_sizes(
+            p1,
+            p4,
+            0..=crate::alpc_node::MAX_SMALL_EVENT_SIZE + 0x1000,
+        )
+        .await;
     }
 
     #[async_test]

--- a/support/mesh/mesh_remote/src/lib.rs
+++ b/support/mesh/mesh_remote/src/lib.rs
@@ -7,6 +7,7 @@ mod alpc_node;
 mod common;
 mod point_to_point;
 mod protocol;
+mod test_common;
 mod unix_node;
 
 #[cfg(windows)]

--- a/support/mesh/mesh_remote/src/test_common.rs
+++ b/support/mesh/mesh_remote/src/test_common.rs
@@ -1,0 +1,65 @@
+#![cfg(test)]
+
+use mesh_node::local_node::HandlePortEvent;
+use mesh_node::local_node::Port;
+use mesh_node::message::Message;
+use std::ops::RangeInclusive;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::Relaxed;
+
+#[cfg_attr(not(any(windows, target_os = "linux")), expect(dead_code))]
+pub(crate) async fn test_message_sizes(left: Port, right: Port, range: RangeInclusive<usize>) {
+    let counter = Arc::new(Counter {
+        count: AtomicUsize::new(*range.start()),
+        event: event_listener::Event::new(),
+    });
+    let _right = right.set_handler(CountHandler(counter.clone()));
+    let buf = vec![0; *range.end()];
+    for i in range {
+        if i % 0x1000 == 0 {
+            tracing::info!(i, "at message");
+        }
+        left.send(Message::serialized(&buf[..i], Vec::new()));
+        loop {
+            let listener = counter.event.listen();
+            if counter.count.load(Relaxed) == i + 1 {
+                break;
+            }
+            listener.await;
+        }
+    }
+}
+
+struct Counter {
+    count: AtomicUsize,
+    event: event_listener::Event,
+}
+
+struct CountHandler(Arc<Counter>);
+
+impl HandlePortEvent for CountHandler {
+    fn message<'a>(
+        &mut self,
+        _control: &mut mesh_node::local_node::PortControl<'_, 'a>,
+        _message: Message<'a>,
+    ) -> Result<(), mesh_node::local_node::HandleMessageError> {
+        self.0.count.fetch_add(1, Relaxed);
+        self.0.event.notify(1);
+        Ok(())
+    }
+
+    fn close(&mut self, _control: &mut mesh_node::local_node::PortControl<'_, '_>) {}
+
+    fn fail(
+        &mut self,
+        _control: &mut mesh_node::local_node::PortControl<'_, '_>,
+        _err: mesh_node::local_node::NodeError,
+    ) {
+        panic!("failed after {} messages", self.0.count.load(Relaxed));
+    }
+
+    fn drain(&mut self) -> Vec<mesh_node::message::OwnedMessage> {
+        Vec::new()
+    }
+}

--- a/support/mesh/mesh_remote/src/test_common.rs
+++ b/support/mesh/mesh_remote/src/test_common.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #![cfg(test)]
 
 use mesh_node::local_node::HandlePortEvent;

--- a/support/mesh/mesh_remote/src/unix_node.rs
+++ b/support/mesh/mesh_remote/src/unix_node.rs
@@ -1291,7 +1291,6 @@ fn set_cloexec(fd: impl AsFd) {
 
 #[cfg(test)]
 mod tests {
-    use super::MAX_SMALL_EVENT_SIZE;
     use crate::unix::UnixNode;
     use mesh_channel::RecvError;
     use mesh_channel::channel;
@@ -1346,7 +1345,8 @@ mod tests {
             .await
             .unwrap();
 
-        crate::test_common::test_message_sizes(p1, p4, 0..=MAX_SMALL_EVENT_SIZE + 0x1000).await;
+        crate::test_common::test_message_sizes(p1, p4, 0..=super::MAX_SMALL_EVENT_SIZE + 0x1000)
+            .await;
     }
 
     #[async_test]

--- a/support/mesh/mesh_remote/src/unix_node.rs
+++ b/support/mesh/mesh_remote/src/unix_node.rs
@@ -1291,6 +1291,7 @@ fn set_cloexec(fd: impl AsFd) {
 
 #[cfg(test)]
 mod tests {
+    use super::MAX_SMALL_EVENT_SIZE;
     use crate::unix::UnixNode;
     use mesh_channel::RecvError;
     use mesh_channel::channel;
@@ -1332,6 +1333,20 @@ mod tests {
         assert_eq!(v, v2);
         follower.shutdown().await;
         leader.shutdown().await;
+    }
+
+    #[cfg(target_os = "linux")]
+    #[async_test]
+    async fn test_message_sizes(driver: DefaultDriver) {
+        let (p1, p2) = mesh_node::local_node::Port::new_pair();
+        let (p3, p4) = mesh_node::local_node::Port::new_pair();
+        let node1 = UnixNode::new(driver.clone());
+        let invitation = node1.invite(p2).await.unwrap();
+        let _node2 = UnixNode::join(driver.clone(), invitation, p3)
+            .await
+            .unwrap();
+
+        crate::test_common::test_message_sizes(p1, p4, 0..=MAX_SMALL_EVENT_SIZE + 0x1000).await;
     }
 
     #[async_test]

--- a/support/pal/src/windows/alpc.rs
+++ b/support/pal/src/windows/alpc.rs
@@ -139,7 +139,7 @@ impl PortConfig {
                 | ALPC_PORFLG_ACCEPT_INDIRECT_HANDLES
                 | ALPC_PORFLG_ACCEPT_REQUESTS,
             DupObjectTypes: OB_ALL_OBJECT_TYPE_CODES,
-            MaxMessageLength: self.max_message_len,
+            MaxMessageLength: self.max_message_len + size_of::<PORT_MESSAGE>(),
             MaxPoolUsage: usize::MAX,
             MaxSectionSize: usize::MAX,
             MaxTotalSectionSize: usize::MAX,


### PR DESCRIPTION
Messages on the Windows ALPC backend near the small message limit fail
to send due to a miscalculation of the maximum message size. Fix this
the maximum size calculation and add tests.
