### PR TITLE
flowey: make values secret, not variables

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -86,18 +86,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 0 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 0 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 0 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 0 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 0 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 0 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 0 flowey_lib_common::git_checkout 0
-        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 0 flowey_lib_common::git_checkout 3
@@ -135,8 +135,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 0 flowey_lib_common::cache 0
-        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -146,7 +146,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 0 flowey_lib_common::cache 2
@@ -245,18 +245,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 1 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 1 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 1 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 1 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 1 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 1 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 1 flowey_lib_common::git_checkout 0
-        flowey v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -268,7 +268,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 1 flowey_lib_common::git_checkout 3
@@ -294,8 +294,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 1 flowey_lib_common::cache 0
-        flowey v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -305,7 +305,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 1 flowey_lib_common::cache 2
@@ -414,10 +414,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 10 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 10 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 10 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 10 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 10 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
@@ -435,8 +435,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 10 flowey_lib_common::git_checkout 0
-        flowey.exe v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar6
+        flowey.exe v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -448,7 +448,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 10 flowey_lib_common::git_checkout 3
@@ -463,8 +463,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 10 flowey_lib_common::cache 4
-        flowey.exe v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -474,7 +474,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 10 flowey_lib_common::cache 6
@@ -533,8 +533,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 10 flowey_lib_common::cache 0
-        flowey.exe v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -544,7 +544,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 10 flowey_lib_common::cache 2
@@ -576,8 +576,8 @@ jobs:
         flowey.exe e 10 flowey_lib_common::publish_test_results 0
         flowey.exe e 10 flowey_lib_common::publish_test_results 1
         flowey.exe e 10 flowey_lib_common::publish_test_results 2
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 10 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 10 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 10 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -669,10 +669,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 11 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 11 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 11 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 11 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 11 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 11 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
@@ -699,8 +699,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 4
-        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -710,7 +710,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 6
@@ -725,8 +725,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 11 flowey_lib_common::git_checkout 0
-        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar6
+        flowey v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -738,7 +738,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 11 flowey_lib_common::git_checkout 3
@@ -822,8 +822,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 11 flowey_lib_common::cache 0
-        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -833,7 +833,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 11 flowey_lib_common::cache 2
@@ -870,8 +870,8 @@ jobs:
         flowey e 11 flowey_lib_common::publish_test_results 0
         flowey e 11 flowey_lib_common::publish_test_results 1
         flowey e 11 flowey_lib_common::publish_test_results 2
-        flowey v 11 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey v 11 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 11 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 11 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -963,10 +963,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 12 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 12 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 12 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
@@ -984,8 +984,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar6
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -997,7 +997,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 12 flowey_lib_common::git_checkout 3
@@ -1016,8 +1016,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 4
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -1027,7 +1027,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 6
@@ -1119,8 +1119,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1130,7 +1130,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1167,8 +1167,8 @@ jobs:
         flowey e 12 flowey_lib_common::publish_test_results 0
         flowey e 12 flowey_lib_common::publish_test_results 1
         flowey e 12 flowey_lib_common::publish_test_results 2
-        flowey v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -1261,10 +1261,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 13 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 13 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 13 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 13 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 13 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 13 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
@@ -1276,8 +1276,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 0
-        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1287,7 +1287,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 13 flowey_lib_common::cache 2
@@ -1309,8 +1309,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 13 flowey_lib_common::git_checkout 0
-        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar6
+        flowey.exe v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -1322,7 +1322,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 13 flowey_lib_common::git_checkout 3
@@ -1337,8 +1337,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 13 flowey_lib_common::cache 4
-        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -1348,7 +1348,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 13 flowey_lib_common::cache 6
@@ -1390,8 +1390,8 @@ jobs:
         flowey.exe e 13 flowey_lib_common::publish_test_results 0
         flowey.exe e 13 flowey_lib_common::publish_test_results 1
         flowey.exe e 13 flowey_lib_common::publish_test_results 2
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -1449,21 +1449,21 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10/flowey.exe
 
-        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 14 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 14 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 14 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 14 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 14 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 14 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 14 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 14 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 14 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 14 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 14 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 14 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 14 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 14 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 14 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 14 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 14 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 14 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 14 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 14 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
@@ -1485,8 +1485,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 0
-        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1496,7 +1496,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 2
@@ -1516,8 +1516,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 8
-        flowey.exe v 14 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 14 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 14 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -1527,7 +1527,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 10
@@ -1539,8 +1539,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 14 flowey_lib_common::git_checkout 0
-        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -1552,7 +1552,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 14 flowey_lib_common::git_checkout 3
@@ -1567,8 +1567,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 4
-        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -1578,7 +1578,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 6
@@ -1620,8 +1620,8 @@ jobs:
         flowey.exe e 14 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey.exe e 14 flowey_lib_common::publish_test_results 4
         flowey.exe e 14 flowey_lib_common::publish_test_results 5
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57 write-to-env github floweyvar2
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -1636,8 +1636,8 @@ jobs:
         flowey.exe e 14 flowey_lib_common::publish_test_results 0
         flowey.exe e 14 flowey_lib_common::publish_test_results 1
         flowey.exe e 14 flowey_lib_common::publish_test_results 2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -1697,21 +1697,21 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10/flowey.exe
 
-        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 15 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 15 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 15 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 15 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 15 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 15 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 15 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 15 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 15 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 15 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 15 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 15 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 15 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 15 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 15 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 15 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 15 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 15 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 15 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
@@ -1733,8 +1733,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1744,7 +1744,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 15 flowey_lib_common::cache 2
@@ -1764,8 +1764,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 8
-        flowey.exe v 15 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 15 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 15 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 15 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -1775,7 +1775,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 15 flowey_lib_common::cache 10
@@ -1787,8 +1787,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -1800,7 +1800,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 15 flowey_lib_common::git_checkout 3
@@ -1815,8 +1815,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -1826,7 +1826,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 15 flowey_lib_common::cache 6
@@ -1868,8 +1868,8 @@ jobs:
         flowey.exe e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey.exe e 15 flowey_lib_common::publish_test_results 4
         flowey.exe e 15 flowey_lib_common::publish_test_results 5
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57 write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -1884,8 +1884,8 @@ jobs:
         flowey.exe e 15 flowey_lib_common::publish_test_results 0
         flowey.exe e 15 flowey_lib_common::publish_test_results 1
         flowey.exe e 15 flowey_lib_common::publish_test_results 2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -1943,21 +1943,21 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-10/flowey.exe
 
-        echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 16 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 16 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 16 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 16 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 16 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 16 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 16 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 16 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 16 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 16 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 16 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 16 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 16 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
@@ -1979,8 +1979,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 0
-        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1990,7 +1990,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 2
@@ -2010,8 +2010,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 8
-        flowey.exe v 16 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 16 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 16 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 16 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -2021,7 +2021,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 10
@@ -2033,8 +2033,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -2046,7 +2046,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 16 flowey_lib_common::git_checkout 3
@@ -2061,8 +2061,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 4
-        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2072,7 +2072,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 6
@@ -2114,8 +2114,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey.exe e 16 flowey_lib_common::publish_test_results 4
         flowey.exe e 16 flowey_lib_common::publish_test_results 5
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57 write-to-env github floweyvar2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -2130,8 +2130,8 @@ jobs:
         flowey.exe e 16 flowey_lib_common::publish_test_results 0
         flowey.exe e 16 flowey_lib_common::publish_test_results 1
         flowey.exe e 16 flowey_lib_common::publish_test_results 2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -2187,19 +2187,19 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-6/flowey
 
-        echo '"debug"' | flowey v 17 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 17 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 17 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 17 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 17 'artifact_use_from_x64-linux-openvmm' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 17 'artifact_use_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 17 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 17 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 17 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 17 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 17 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 17 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 17 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
@@ -2217,8 +2217,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 0
-        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2228,7 +2228,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: checking if packages need to be installed
       run: |-
-        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 2
@@ -2254,8 +2254,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 8
-        flowey v 17 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey v 17 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 17 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 17 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -2265,7 +2265,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 17 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 17 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 10
@@ -2277,8 +2277,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 17 flowey_lib_common::git_checkout 0
-        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -2290,7 +2290,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 17 flowey_lib_common::git_checkout 3
@@ -2308,8 +2308,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 17 flowey_lib_common::cache 4
-        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2319,7 +2319,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 17 flowey_lib_common::cache 6
@@ -2358,8 +2358,8 @@ jobs:
         flowey e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 17 flowey_lib_common::publish_test_results 4
         flowey e 17 flowey_lib_common::publish_test_results 5
-        flowey v 17 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57 write-to-env github floweyvar2
+        flowey v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -2374,8 +2374,8 @@ jobs:
         flowey e 17 flowey_lib_common::publish_test_results 0
         flowey e 17 flowey_lib_common::publish_test_results 1
         flowey e 17 flowey_lib_common::publish_test_results 2
-        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -2483,21 +2483,21 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 18 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 18 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 18 'artifact_use_from_aarch64-tmks' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 18 'artifact_use_from_aarch64-windows-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_aarch64-windows-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 18 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 18 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 18 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 18 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 18 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 18 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 18 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 18 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 18 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
@@ -2519,8 +2519,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 0
-        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2530,7 +2530,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 2
@@ -2550,8 +2550,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 8
-        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -2561,7 +2561,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 10
@@ -2573,8 +2573,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 18 flowey_lib_common::git_checkout 0
-        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey.exe v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -2586,7 +2586,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 18 flowey_lib_common::git_checkout 3
@@ -2601,8 +2601,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 18 flowey_lib_common::cache 4
-        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2612,7 +2612,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 18 flowey_lib_common::cache 6
@@ -2654,8 +2654,8 @@ jobs:
         flowey.exe e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey.exe e 18 flowey_lib_common::publish_test_results 4
         flowey.exe e 18 flowey_lib_common::publish_test_results 5
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57 write-to-env github floweyvar2
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -2670,8 +2670,8 @@ jobs:
         flowey.exe e 18 flowey_lib_common::publish_test_results 0
         flowey.exe e 18 flowey_lib_common::publish_test_results 1
         flowey.exe e 18 flowey_lib_common::publish_test_results 2
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -2763,18 +2763,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 19 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 19 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 19 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 19 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 19 flowey_lib_common::git_checkout 0
-        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -2786,7 +2786,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 19 flowey_lib_common::git_checkout 3
@@ -2798,7 +2798,7 @@ jobs:
     - name: install Rust
       run: |-
         flowey e 19 flowey_lib_common::install_rust 1
-        flowey v 19 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
+        flowey v 19 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --is-secret --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -2875,24 +2875,24 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 2 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 2 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 2 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 2 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 2 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 2 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-hypestv' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-hypestv' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-igvmfilegen' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-igvmfilegen' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-tmk_vmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgs_lib' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgstool' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 2 flowey_lib_common::install_rust 0
@@ -2908,8 +2908,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -2921,7 +2921,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 2 flowey_lib_common::git_checkout 3
@@ -2936,8 +2936,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 2 flowey_lib_common::cache 0
-        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2947,7 +2947,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 2 flowey_lib_common::cache 2
@@ -3118,18 +3118,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 3 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 3 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 3 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 3 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 3 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 3 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 3 flowey_lib_common::install_rust 0
@@ -3145,8 +3145,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 3 flowey_lib_common::git_checkout 0
-        flowey.exe v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3158,7 +3158,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 3 flowey_lib_common::git_checkout 3
@@ -3173,8 +3173,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 3 flowey_lib_common::cache 4
-        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3184,7 +3184,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 3 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 3 flowey_lib_common::cache 6
@@ -3213,8 +3213,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 3 flowey_lib_common::cache 0
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3224,7 +3224,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 3 flowey_lib_common::cache 2
@@ -3351,24 +3351,24 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 4 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 4 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 4 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 4 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 4 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 4 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 4 'artifact_publish_from_x64-windows-hypestv' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 4 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_x64-windows-igvmfilegen' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_x64-windows-ohcldiag-dev' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 4 'artifact_publish_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 4 'artifact_publish_from_x64-windows-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgs_lib' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgstool' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
@@ -3384,8 +3384,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3397,7 +3397,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 4 flowey_lib_common::git_checkout 3
@@ -3412,8 +3412,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3423,7 +3423,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -3598,18 +3598,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 5 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 5 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 5 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 5 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 5 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 5 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 5 'artifact_publish_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 5 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
@@ -3628,8 +3628,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3639,7 +3639,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 6
@@ -3651,8 +3651,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3664,7 +3664,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 5 flowey_lib_common::git_checkout 3
@@ -3706,8 +3706,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3717,7 +3717,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -3838,26 +3838,26 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 6 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 6 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 6 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 6 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 6 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 6 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 6 'artifact_publish_from_aarch64-linux-igvmfilegen' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 6 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 6 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 6 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-openvmm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgs_lib' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 6 flowey_lib_common::install_rust 0
@@ -3882,8 +3882,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 6 flowey_lib_common::cache 0
-        flowey v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3893,7 +3893,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 6 flowey_lib_common::cache 2
@@ -3905,8 +3905,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 6 flowey_lib_common::git_checkout 0
-        flowey v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3918,7 +3918,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 6 flowey_lib_common::git_checkout 3
@@ -4141,28 +4141,28 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 7 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 7 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 7 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 7 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 7 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 7 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 7 'artifact_publish_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 7 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_x64-linux-igvmfilegen' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_x64-linux-ohcldiag-dev' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 7 'artifact_publish_from_x64-linux-openvmm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 7 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_x64-linux-vmgs_lib' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 7 'artifact_publish_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 7 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 7 'artifact_publish_from_x64-tmks' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 7 'artifact_publish_from_x64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 7 flowey_lib_common::install_rust 0
@@ -4187,8 +4187,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 7 flowey_lib_common::cache 4
-        flowey v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -4198,7 +4198,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 7 flowey_lib_common::cache 6
@@ -4210,8 +4210,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 7 flowey_lib_common::git_checkout 0
-        flowey v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -4223,7 +4223,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 7 flowey_lib_common::git_checkout 3
@@ -4340,8 +4340,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 7 flowey_lib_common::cache 0
-        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4351,7 +4351,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 7 flowey_lib_common::cache 2
@@ -4494,22 +4494,22 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 8 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 8 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 8 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 8 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 8 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 8 'artifact_publish_from_aarch64-openhcl-baseline' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-baseline" | flowey v 8 'artifact_publish_from_aarch64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm-extras' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 8 flowey_lib_common::install_dist_pkg 0
@@ -4523,8 +4523,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4534,7 +4534,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 2
@@ -4557,8 +4557,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -4570,7 +4570,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 8 flowey_lib_common::git_checkout 3
@@ -4845,22 +4845,22 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 9 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 9 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 9 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 9 'artifact_publish_from_x64-openhcl-baseline' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-baseline" | flowey v 9 'artifact_publish_from_x64-openhcl-baseline' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm-extras' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 9 flowey_lib_common::install_dist_pkg 0
@@ -4874,8 +4874,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4885,7 +4885,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2
@@ -4908,8 +4908,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -4921,7 +4921,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 9 flowey_lib_common::git_checkout 3

--- a/.github/workflows/openvmm-docs-ci.yaml
+++ b/.github/workflows/openvmm-docs-ci.yaml
@@ -83,14 +83,14 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 0 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 0 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 0 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 0 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 0 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 0 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/guide"
-        echo "$AgentTempDirNormal/publish_artifacts/guide" | flowey v 0 'artifact_publish_from_guide' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/guide" | flowey v 0 'artifact_publish_from_guide' --is-raw-string update
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 0 flowey_lib_common::download_gh_release 0
@@ -98,8 +98,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 0 flowey_lib_common::cache 0
-        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -109,7 +109,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -133,8 +133,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 0 flowey_lib_common::git_checkout 0
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 0 flowey_lib_common::git_checkout 3
@@ -241,20 +241,20 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 1 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 1 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 1 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 1 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 1 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 1 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-rustdoc"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-rustdoc" | flowey.exe v 1 'artifact_publish_from_x64-windows-rustdoc' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-rustdoc" | flowey.exe v 1 'artifact_publish_from_x64-windows-rustdoc' --is-raw-string update
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 1 flowey_lib_common::git_checkout 0
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -266,7 +266,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 1 flowey_lib_common::git_checkout 3
@@ -281,8 +281,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 1 flowey_lib_common::cache 0
-        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -292,7 +292,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -406,20 +406,20 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 2 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 2 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 2 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 2 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 2 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 2 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc" | flowey v 2 'artifact_publish_from_x64-linux-rustdoc' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc" | flowey v 2 'artifact_publish_from_x64-linux-rustdoc' --is-raw-string update
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 2 flowey_lib_common::git_checkout 0
-        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -431,7 +431,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 2 flowey_lib_common::git_checkout 3
@@ -446,8 +446,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 2 flowey_lib_common::cache 0
-        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -457,7 +457,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 2 flowey_lib_common::cache 2
@@ -546,15 +546,15 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 3 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 3 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 3 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 3 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 3 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 3 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/guide" | flowey v 3 'artifact_use_from_guide' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-rustdoc" | flowey v 3 'artifact_use_from_x64-linux-rustdoc' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-rustdoc" | flowey v 3 'artifact_use_from_x64-windows-rustdoc' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/guide" | flowey v 3 'artifact_use_from_guide' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-rustdoc" | flowey v 3 'artifact_use_from_x64-linux-rustdoc' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-rustdoc" | flowey v 3 'artifact_use_from_x64-windows-rustdoc' --is-raw-string update
       shell: bash
     - name: generate consolidated gh pages html
       run: |-
@@ -563,7 +563,7 @@ jobs:
         flowey e 3 flowey_core::pipeline::artifact::resolve 0
         flowey e 3 flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages 0
         flowey e 3 flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages 1
-        flowey v 3 'flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages:1:flowey_lib_hvlite/src/_jobs/consolidate_and_publish_gh_pages.rs:94:39' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 3 'flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages:1:flowey_lib_hvlite/src/_jobs/consolidate_and_publish_gh_pages.rs:94:39' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__consolidate_and_publish_gh_pages__2
       uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/openvmm-docs-pr.yaml
+++ b/.github/workflows/openvmm-docs-pr.yaml
@@ -91,14 +91,14 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 0 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 0 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 0 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 0 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 0 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 0 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/guide"
-        echo "$AgentTempDirNormal/publish_artifacts/guide" | flowey v 0 'artifact_publish_from_guide' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/guide" | flowey v 0 'artifact_publish_from_guide' --is-raw-string update
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 0 flowey_lib_common::download_gh_release 0
@@ -106,8 +106,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 0 flowey_lib_common::cache 0
-        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -117,7 +117,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 0 flowey_lib_common::cache 2
@@ -141,8 +141,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 0 flowey_lib_common::git_checkout 0
-        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -154,7 +154,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 0 flowey_lib_common::git_checkout 3
@@ -249,20 +249,20 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 1 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 1 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 1 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 1 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 1 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 1 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-rustdoc"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-rustdoc" | flowey.exe v 1 'artifact_publish_from_x64-windows-rustdoc' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-rustdoc" | flowey.exe v 1 'artifact_publish_from_x64-windows-rustdoc' --is-raw-string update
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 1 flowey_lib_common::git_checkout 0
-        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -274,7 +274,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 1 flowey_lib_common::git_checkout 3
@@ -289,8 +289,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 1 flowey_lib_common::cache 0
-        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -300,7 +300,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 1 flowey_lib_common::cache 2
@@ -414,20 +414,20 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 2 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 2 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 2 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 2 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 2 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 2 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc" | flowey v 2 'artifact_publish_from_x64-linux-rustdoc' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-rustdoc" | flowey v 2 'artifact_publish_from_x64-linux-rustdoc' --is-raw-string update
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 2 flowey_lib_common::git_checkout 0
-        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -439,7 +439,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 2 flowey_lib_common::git_checkout 3
@@ -454,8 +454,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 2 flowey_lib_common::cache 0
-        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -465,7 +465,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 2 flowey_lib_common::cache 2
@@ -555,10 +555,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-1/flowey
 
-        echo '"debug"' | flowey v 3 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 3 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 3 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 3 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 3 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 3 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -524,7 +524,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 10 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 2
-        flowey v 10 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_core/src/node.rs:1154:34' --is-raw-string write-to-env github floweyvar1
+        flowey v 10 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs:105:27' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__3
       uses: actions/upload-artifact@v4

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -94,18 +94,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 0 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 0 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 0 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 0 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 0 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 0 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 0 flowey_lib_common::git_checkout 0
-        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 0 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 0 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -117,7 +117,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 0 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 0 flowey_lib_common::git_checkout 3
@@ -143,8 +143,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 0 flowey_lib_common::cache 0
-        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 0 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 0 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -154,7 +154,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 0 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 0 flowey_lib_common::cache 2
@@ -253,18 +253,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 1 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 1 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 1 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 1 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 1 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 1 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 1 flowey_lib_common::git_checkout 0
-        flowey v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 1 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 1 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -276,7 +276,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 1 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 1 flowey_lib_common::git_checkout 3
@@ -302,8 +302,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 1 flowey_lib_common::cache 0
-        flowey v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 1 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 1 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -313,7 +313,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 1 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 1 flowey_lib_common::cache 2
@@ -423,10 +423,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 10 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 10 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 10 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 10 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 10 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 10 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
@@ -444,8 +444,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 10 flowey_lib_common::git_checkout 0
-        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 10 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar2
+        flowey v 10 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -457,7 +457,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 10 flowey_lib_common::git_checkout 3
@@ -476,8 +476,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 4
-        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar5 --is-raw-string
-        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar6 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar5
+        flowey v 10 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar6
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -487,7 +487,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 6
@@ -524,7 +524,7 @@ jobs:
     - name: collect openvmm_hcl files for analysis
       run: |-
         flowey e 10 flowey_lib_hvlite::_jobs::check_openvmm_hcl_size 2
-        flowey v 10 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_core/src/node.rs:1184:34' --write-to-gh-env floweyvar1 --is-raw-string
+        flowey v 10 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:9:flowey_core/src/node.rs:1154:34' --is-raw-string write-to-env github floweyvar1
       shell: bash
     - id: flowey_lib_hvlite___jobs__check_openvmm_hcl_size__3
       uses: actions/upload-artifact@v4
@@ -550,8 +550,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 10 flowey_lib_common::cache 0
-        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar3 --is-raw-string
-        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar4 --is-raw-string
+        flowey v 10 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar3
+        flowey v 10 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar4
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -561,12 +561,12 @@ jobs:
       name: 'Restore cache: gh-cli'
     - name: installing gh
       run: |-
-        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 10 flowey_lib_common::cache 2
         flowey e 10 flowey_lib_common::download_gh_cli 1
-        flowey v 10 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
+        flowey v 10 'flowey_lib_hvlite::_jobs::check_openvmm_hcl_size:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --is-secret --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -663,10 +663,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 11 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 11 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 11 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 11 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 11 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 11 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
@@ -684,8 +684,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 11 flowey_lib_common::git_checkout 0
-        flowey.exe v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 11 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar6
+        flowey.exe v 11 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -697,7 +697,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 11 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 11 flowey_lib_common::git_checkout 3
@@ -712,8 +712,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 11 flowey_lib_common::cache 4
-        flowey.exe v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 11 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 11 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -723,7 +723,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 11 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 11 flowey_lib_common::cache 6
@@ -782,8 +782,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 11 flowey_lib_common::cache 0
-        flowey.exe v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 11 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 11 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -793,7 +793,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 11 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 11 flowey_lib_common::cache 2
@@ -825,8 +825,8 @@ jobs:
         flowey.exe e 11 flowey_lib_common::publish_test_results 0
         flowey.exe e 11 flowey_lib_common::publish_test_results 1
         flowey.exe e 11 flowey_lib_common::publish_test_results 2
-        flowey.exe v 11 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 11 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 11 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 11 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -918,10 +918,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 12 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 12 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 12 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 12 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 12 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
@@ -948,8 +948,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 4
-        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 12 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -959,7 +959,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 6
@@ -974,8 +974,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 12 flowey_lib_common::git_checkout 0
-        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar6
+        flowey v 12 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -987,7 +987,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 12 flowey_lib_common::git_checkout 3
@@ -1071,8 +1071,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 12 flowey_lib_common::cache 0
-        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 12 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 12 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1082,7 +1082,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 12 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 12 flowey_lib_common::cache 2
@@ -1119,8 +1119,8 @@ jobs:
         flowey e 12 flowey_lib_common::publish_test_results 0
         flowey e 12 flowey_lib_common::publish_test_results 1
         flowey e 12 flowey_lib_common::publish_test_results 2
-        flowey v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 12 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 12 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -1212,10 +1212,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 13 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 13 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 13 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 13 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 13 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
@@ -1233,8 +1233,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 13 flowey_lib_common::git_checkout 0
-        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 13 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar6
+        flowey v 13 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -1246,7 +1246,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 13 flowey_lib_common::git_checkout 3
@@ -1265,8 +1265,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 4
-        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 13 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -1276,7 +1276,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 6
@@ -1368,8 +1368,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 13 flowey_lib_common::cache 0
-        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 13 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 13 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1379,7 +1379,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 13 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 13 flowey_lib_common::cache 2
@@ -1416,8 +1416,8 @@ jobs:
         flowey e 13 flowey_lib_common::publish_test_results 0
         flowey e 13 flowey_lib_common::publish_test_results 1
         flowey e 13 flowey_lib_common::publish_test_results 2
-        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 13 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 13 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -1510,10 +1510,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 14 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 14 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 14 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 14 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
@@ -1525,8 +1525,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 0
-        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 14 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1536,7 +1536,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 2
@@ -1558,8 +1558,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 14 flowey_lib_common::git_checkout 0
-        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar6 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 14 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar6
+        flowey.exe v 14 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -1571,7 +1571,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 14 flowey_lib_common::git_checkout 3
@@ -1586,8 +1586,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 14 flowey_lib_common::cache 4
-        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 14 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 14 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -1597,7 +1597,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 14 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 14 flowey_lib_common::cache 6
@@ -1639,8 +1639,8 @@ jobs:
         flowey.exe e 14 flowey_lib_common::publish_test_results 0
         flowey.exe e 14 flowey_lib_common::publish_test_results 1
         flowey.exe e 14 flowey_lib_common::publish_test_results 2
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 14 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -1698,21 +1698,21 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11/flowey.exe
 
-        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 15 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 15 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 15 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 15 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 15 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 15 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 15 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 15 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 15 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 15 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 15 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 15 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 15 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 15 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 15 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 15 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 15 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 15 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 15 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 15 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 15 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 15 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
@@ -1734,8 +1734,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 0
-        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 15 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 15 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1745,7 +1745,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 15 flowey_lib_common::cache 2
@@ -1765,8 +1765,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 8
-        flowey.exe v 15 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 15 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 15 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 15 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -1776,7 +1776,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 15 flowey_lib_common::cache 10
@@ -1788,8 +1788,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 15 flowey_lib_common::git_checkout 0
-        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey.exe v 15 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -1801,7 +1801,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 15 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 15 flowey_lib_common::git_checkout 3
@@ -1816,8 +1816,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 15 flowey_lib_common::cache 4
-        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 15 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 15 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -1827,7 +1827,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 15 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 15 flowey_lib_common::cache 6
@@ -1869,8 +1869,8 @@ jobs:
         flowey.exe e 15 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey.exe e 15 flowey_lib_common::publish_test_results 4
         flowey.exe e 15 flowey_lib_common::publish_test_results 5
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57 write-to-env github floweyvar2
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -1885,8 +1885,8 @@ jobs:
         flowey.exe e 15 flowey_lib_common::publish_test_results 0
         flowey.exe e 15 flowey_lib_common::publish_test_results 1
         flowey.exe e 15 flowey_lib_common::publish_test_results 2
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 15 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -1946,21 +1946,21 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11/flowey.exe
 
-        echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 16 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 16 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 16 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 16 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 16 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 16 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 16 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 16 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 16 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 16 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 16 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 16 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 16 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 16 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 16 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 16 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 16 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
@@ -1982,8 +1982,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 0
-        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 16 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 16 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -1993,7 +1993,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 2
@@ -2013,8 +2013,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 8
-        flowey.exe v 16 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 16 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 16 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 16 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -2024,7 +2024,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 10
@@ -2036,8 +2036,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 16 flowey_lib_common::git_checkout 0
-        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey.exe v 16 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -2049,7 +2049,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 16 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 16 flowey_lib_common::git_checkout 3
@@ -2064,8 +2064,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 16 flowey_lib_common::cache 4
-        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 16 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2075,7 +2075,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 16 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 16 flowey_lib_common::cache 6
@@ -2117,8 +2117,8 @@ jobs:
         flowey.exe e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey.exe e 16 flowey_lib_common::publish_test_results 4
         flowey.exe e 16 flowey_lib_common::publish_test_results 5
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57 write-to-env github floweyvar2
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -2133,8 +2133,8 @@ jobs:
         flowey.exe e 16 flowey_lib_common::publish_test_results 0
         flowey.exe e 16 flowey_lib_common::publish_test_results 1
         flowey.exe e 16 flowey_lib_common::publish_test_results 2
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -2192,21 +2192,21 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-windows-uid-11/flowey.exe
 
-        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 17 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 17 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 17 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 17 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 17 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 17 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 17 'artifact_use_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 17 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 17 'artifact_use_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 17 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 17 'artifact_use_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 17 'artifact_use_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\x64-guest_test_uefi" | flowey.exe v 17 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-pipette" | flowey.exe v 17 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-linux-musl-tmk_vmm" | flowey.exe v 17 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-openhcl-igvm" | flowey.exe v 17 'artifact_use_from_x64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-tmks" | flowey.exe v 17 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-openvmm" | flowey.exe v 17 'artifact_use_from_x64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-pipette" | flowey.exe v 17 'artifact_use_from_x64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 17 'artifact_use_from_x64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 17 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
@@ -2228,8 +2228,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 17 flowey_lib_common::cache 0
-        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 17 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2239,7 +2239,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 2
@@ -2259,8 +2259,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 17 flowey_lib_common::cache 8
-        flowey.exe v 17 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 17 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 17 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -2270,7 +2270,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 10
@@ -2282,8 +2282,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 17 flowey_lib_common::git_checkout 0
-        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 17 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey.exe v 17 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -2295,7 +2295,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 17 flowey_lib_common::git_checkout 3
@@ -2310,8 +2310,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 17 flowey_lib_common::cache 4
-        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 17 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2321,7 +2321,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 17 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 17 flowey_lib_common::cache 6
@@ -2363,8 +2363,8 @@ jobs:
         flowey.exe e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey.exe e 17 flowey_lib_common::publish_test_results 4
         flowey.exe e 17 flowey_lib_common::publish_test_results 5
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57 write-to-env github floweyvar2
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -2379,8 +2379,8 @@ jobs:
         flowey.exe e 17 flowey_lib_common::publish_test_results 0
         flowey.exe e 17 flowey_lib_common::publish_test_results 1
         flowey.exe e 17 flowey_lib_common::publish_test_results 2
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -2436,19 +2436,19 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-7/flowey
 
-        echo '"debug"' | flowey v 18 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 18 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 18 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 18 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 18 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 18 'artifact_use_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 18 'artifact_use_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 18 'artifact_use_from_x64-linux-openvmm' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 18 'artifact_use_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 18 'artifact_use_from_x64-tmks' --update-from-stdin --is-raw-string
-        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 18 'artifact_use_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/used_artifacts/x64-guest_test_uefi" | flowey v 18 'artifact_use_from_x64-guest_test_uefi' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-pipette" | flowey v 18 'artifact_use_from_x64-linux-musl-pipette' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-musl-tmk_vmm" | flowey v 18 'artifact_use_from_x64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-openvmm" | flowey v 18 'artifact_use_from_x64-linux-openvmm' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-linux-vmm-tests-archive" | flowey v 18 'artifact_use_from_x64-linux-vmm-tests-archive' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 18 'artifact_use_from_x64-tmks' --is-raw-string update
+        echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 18 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
@@ -2466,8 +2466,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 0
-        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 18 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 18 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2477,7 +2477,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: checking if packages need to be installed
       run: |-
-        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 18 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 18 flowey_lib_common::cache 2
@@ -2503,8 +2503,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 8
-        flowey v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey v 18 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey v 18 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -2514,7 +2514,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 18 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey e 18 flowey_lib_common::cache 10
@@ -2526,8 +2526,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 18 flowey_lib_common::git_checkout 0
-        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey v 18 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -2539,7 +2539,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 18 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 18 flowey_lib_common::git_checkout 3
@@ -2557,8 +2557,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 18 flowey_lib_common::cache 4
-        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey v 18 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2568,7 +2568,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 18 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 18 flowey_lib_common::cache 6
@@ -2607,8 +2607,8 @@ jobs:
         flowey e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey e 18 flowey_lib_common::publish_test_results 4
         flowey e 18 flowey_lib_common::publish_test_results 5
-        flowey v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57 write-to-env github floweyvar2
+        flowey v 18 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -2623,8 +2623,8 @@ jobs:
         flowey e 18 flowey_lib_common::publish_test_results 0
         flowey e 18 flowey_lib_common::publish_test_results 1
         flowey e 18 flowey_lib_common::publish_test_results 2
-        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 18 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -2732,21 +2732,21 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 19 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 19 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 19 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 19 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 19 'artifact_use_from_aarch64-tmks' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 19 'artifact_use_from_aarch64-windows-pipette' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_aarch64-windows-tmk_vmm' --update-from-stdin --is-raw-string
-        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-guest_test_uefi" | flowey.exe v 19 'artifact_use_from_aarch64-guest_test_uefi' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-pipette" | flowey.exe v 19 'artifact_use_from_aarch64-linux-musl-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-linux-musl-tmk_vmm" | flowey.exe v 19 'artifact_use_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-openhcl-igvm" | flowey.exe v 19 'artifact_use_from_aarch64-openhcl-igvm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-tmks" | flowey.exe v 19 'artifact_use_from_aarch64-tmks' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-openvmm" | flowey.exe v 19 'artifact_use_from_aarch64-windows-openvmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-pipette" | flowey.exe v 19 'artifact_use_from_aarch64-windows-pipette' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 19 'artifact_use_from_aarch64-windows-tmk_vmm' --is-raw-string update
+        echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 19 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: creating new test content dir
       run: |-
@@ -2768,8 +2768,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 0
-        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 19 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -2779,7 +2779,7 @@ jobs:
       name: 'Restore cache: azcopy'
     - name: installing azcopy
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 2
@@ -2799,8 +2799,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 8
-        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar8 --is-raw-string
-        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar9 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:18:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar8
+        flowey.exe v 19 'flowey_lib_common::cache:17:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar9
       shell: bash
     - id: flowey_lib_common__cache__9
       uses: actions/cache@v4
@@ -2810,7 +2810,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:20:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__9.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__9.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 10
@@ -2822,8 +2822,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 19 flowey_lib_common::git_checkout 0
-        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey.exe v 19 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -2835,7 +2835,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 19 flowey_lib_common::git_checkout 3
@@ -2850,8 +2850,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 19 flowey_lib_common::cache 4
-        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar6 --is-raw-string
-        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar7 --is-raw-string
+        flowey.exe v 19 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar6
+        flowey.exe v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar7
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -2861,7 +2861,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: add default cargo home to path
       run: |-
-        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 19 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 19 flowey_lib_common::cache 6
@@ -2903,8 +2903,8 @@ jobs:
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
         flowey.exe e 19 flowey_lib_common::publish_test_results 4
         flowey.exe e 19 flowey_lib_common::publish_test_results 5
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --write-to-gh-env floweyvar2 --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:9:flowey_lib_common/src/publish_test_results.rs:149:62' --is-raw-string --condvar flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57 write-to-env github floweyvar2
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:7:flowey_lib_common/src/publish_test_results.rs:141:57' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__6
       uses: actions/upload-artifact@v4
@@ -2919,8 +2919,8 @@ jobs:
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
         flowey.exe e 19 flowey_lib_common::publish_test_results 2
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43
-        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:4:flowey_lib_common/src/publish_test_results.rs:95:47' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43 write-to-env github floweyvar1
+        flowey.exe v 19 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs:77:43' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__publish_test_results__3
       uses: actions/upload-artifact@v4
@@ -3011,24 +3011,24 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 2 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 2 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 2 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 2 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 2 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 2 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-hypestv' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-hypestv" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-hypestv' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-igvmfilegen' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-igvmfilegen" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-igvmfilegen' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-ohcldiag-dev" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-tmk_vmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-tmk_vmm" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgs_lib' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgs_lib" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgstool' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmgstool" | flowey.exe v 2 'artifact_publish_from_aarch64-windows-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 2 flowey_lib_common::install_rust 0
@@ -3044,8 +3044,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 2 flowey_lib_common::git_checkout 0
-        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 2 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 2 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3057,7 +3057,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 2 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 2 flowey_lib_common::git_checkout 3
@@ -3072,8 +3072,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 2 flowey_lib_common::cache 0
-        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 2 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 2 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3083,7 +3083,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 2 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 2 flowey_lib_common::cache 2
@@ -3257,18 +3257,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 20 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 20 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 20 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 20 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 20 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 20 flowey_lib_common::git_checkout 0
-        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3280,7 +3280,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 20 flowey_lib_common::git_checkout 3
@@ -3292,7 +3292,7 @@ jobs:
     - name: install Rust
       run: |-
         flowey e 20 flowey_lib_common::install_rust 1
-        flowey v 20 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:42:41' --is-secret --update-from-stdin --is-raw-string <<EOF
+        flowey v 20 'flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm:2:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --is-secret --env-source github.token <<EOF
         ${{ github.token }}
         EOF
       shell: bash
@@ -3347,10 +3347,10 @@ jobs:
 
         chmod +x $AgentTempDirNormal/used_artifacts/_internal-flowey-bootstrap-x86_64-linux-uid-7/flowey
 
-        echo '"debug"' | flowey v 21 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 21 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 21 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 21 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 21 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
       shell: bash
@@ -3425,18 +3425,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 3 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 3 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 3 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 3 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 3 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 3 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-openvmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-openvmm" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-pipette" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 3 'artifact_publish_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 3 flowey_lib_common::install_rust 0
@@ -3452,8 +3452,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 3 flowey_lib_common::git_checkout 0
-        flowey.exe v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 3 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 3 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3465,7 +3465,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 3 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 3 flowey_lib_common::git_checkout 3
@@ -3480,8 +3480,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 3 flowey_lib_common::cache 4
-        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 3 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3491,7 +3491,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 3 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 3 flowey_lib_common::cache 6
@@ -3520,8 +3520,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 3 flowey_lib_common::cache 0
-        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 3 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 3 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3531,7 +3531,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 3 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 3 flowey_lib_common::cache 2
@@ -3658,24 +3658,24 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 4 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 4 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 4 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 4 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 4 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 4 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-hypestv"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 4 'artifact_publish_from_x64-windows-hypestv' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-hypestv" | flowey.exe v 4 'artifact_publish_from_x64-windows-hypestv' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-igvmfilegen"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_x64-windows-igvmfilegen' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-igvmfilegen" | flowey.exe v 4 'artifact_publish_from_x64-windows-igvmfilegen' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-ohcldiag-dev"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_x64-windows-ohcldiag-dev' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-ohcldiag-dev" | flowey.exe v 4 'artifact_publish_from_x64-windows-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-tmk_vmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 4 'artifact_publish_from_x64-windows-tmk_vmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-tmk_vmm" | flowey.exe v 4 'artifact_publish_from_x64-windows-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgs_lib"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgs_lib' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgs_lib" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmgstool"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgstool' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmgstool" | flowey.exe v 4 'artifact_publish_from_x64-windows-vmgstool' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 4 flowey_lib_common::install_rust 0
@@ -3691,8 +3691,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 4 flowey_lib_common::git_checkout 0
-        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 4 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 4 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3704,7 +3704,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 4 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 4 flowey_lib_common::git_checkout 3
@@ -3719,8 +3719,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 4 flowey_lib_common::cache 0
-        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 4 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 4 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -3730,7 +3730,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 4 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 4 flowey_lib_common::cache 2
@@ -3905,18 +3905,18 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey.exe
 
-        echo '"debug"' | flowey.exe v 5 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey.exe v 5 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey.exe v 5 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey.exe v 5 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey.exe v 5 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey.exe v 5 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-openvmm"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-openvmm' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-openvmm" | flowey.exe v 5 'artifact_publish_from_x64-windows-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-pipette"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 5 'artifact_publish_from_x64-windows-pipette' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-pipette" | flowey.exe v 5 'artifact_publish_from_x64-windows-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-windows-vmm-tests-archive"
-        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "${{ runner.temp }}\\publish_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 5 'artifact_publish_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey.exe e 5 flowey_lib_common::install_rust 0
@@ -3935,8 +3935,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 4
-        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 5 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -3946,7 +3946,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 6
@@ -3958,8 +3958,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey.exe e 5 flowey_lib_common::git_checkout 0
-        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey.exe v 5 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey.exe v 5 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -3971,7 +3971,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 5 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey.exe e 5 flowey_lib_common::git_checkout 3
@@ -4013,8 +4013,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey.exe e 5 flowey_lib_common::cache 0
-        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey.exe v 5 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey.exe v 5 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4024,7 +4024,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey.exe v 5 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey.exe e 5 flowey_lib_common::cache 2
@@ -4145,26 +4145,26 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 6 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 6 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 6 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 6 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 6 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 6 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-guest_test_uefi" | flowey v 6 'artifact_publish_from_aarch64-guest_test_uefi' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 6 'artifact_publish_from_aarch64-linux-igvmfilegen' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-igvmfilegen" | flowey v 6 'artifact_publish_from_aarch64-linux-igvmfilegen' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 6 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-ohcldiag-dev" | flowey v 6 'artifact_publish_from_aarch64-linux-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-openvmm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-openvmm" | flowey v 6 'artifact_publish_from_aarch64-linux-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgs_lib' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgs_lib" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-vmgstool" | flowey v 6 'artifact_publish_from_aarch64-linux-vmgstool' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-tmks" | flowey v 6 'artifact_publish_from_aarch64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 6 flowey_lib_common::install_rust 0
@@ -4189,8 +4189,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 6 flowey_lib_common::cache 0
-        flowey v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 6 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 6 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4200,7 +4200,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 6 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 6 flowey_lib_common::cache 2
@@ -4212,8 +4212,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 6 flowey_lib_common::git_checkout 0
-        flowey v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 6 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 6 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -4225,7 +4225,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 6 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 6 flowey_lib_common::git_checkout 3
@@ -4448,28 +4448,28 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 7 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 7 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 7 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 7 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 7 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 7 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 7 'artifact_publish_from_x64-guest_test_uefi' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-guest_test_uefi" | flowey v 7 'artifact_publish_from_x64-guest_test_uefi' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_x64-linux-igvmfilegen' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-igvmfilegen" | flowey v 7 'artifact_publish_from_x64-linux-igvmfilegen' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_x64-linux-ohcldiag-dev' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-ohcldiag-dev" | flowey v 7 'artifact_publish_from_x64-linux-ohcldiag-dev' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 7 'artifact_publish_from_x64-linux-openvmm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-openvmm" | flowey v 7 'artifact_publish_from_x64-linux-openvmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_x64-linux-vmgs_lib' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgs_lib" | flowey v 7 'artifact_publish_from_x64-linux-vmgs_lib' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmgstool" | flowey v 7 'artifact_publish_from_x64-linux-vmgstool' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 7 'artifact_publish_from_x64-linux-vmm-tests-archive' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-vmm-tests-archive" | flowey v 7 'artifact_publish_from_x64-linux-vmm-tests-archive' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-tmks"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 7 'artifact_publish_from_x64-tmks' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-tmks" | flowey v 7 'artifact_publish_from_x64-tmks' --is-raw-string update
       shell: bash
     - name: add default cargo home to path
       run: flowey e 7 flowey_lib_common::install_rust 0
@@ -4494,8 +4494,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 7 flowey_lib_common::cache 4
-        flowey v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar4 --is-raw-string
-        flowey v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar5 --is-raw-string
+        flowey v 7 'flowey_lib_common::cache:10:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar4
+        flowey v 7 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar5
       shell: bash
     - id: flowey_lib_common__cache__5
       uses: actions/cache@v4
@@ -4505,7 +4505,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 7 'flowey_lib_common::cache:12:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__5.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__5.outputs.cache-hit }}
         EOF
         flowey e 7 flowey_lib_common::cache 6
@@ -4517,8 +4517,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 7 flowey_lib_common::git_checkout 0
-        flowey v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar1 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 7 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar1
+        flowey v 7 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -4530,7 +4530,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 7 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 7 flowey_lib_common::git_checkout 3
@@ -4647,8 +4647,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 7 flowey_lib_common::cache 0
-        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar2 --is-raw-string
-        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar3 --is-raw-string
+        flowey v 7 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar2
+        flowey v 7 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar3
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4658,7 +4658,7 @@ jobs:
       name: 'Restore cache: cargo-nextest'
     - name: report $CARGO_HOME
       run: |-
-        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 7 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 7 flowey_lib_common::cache 2
@@ -4801,20 +4801,20 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 8 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 8 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 8 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 8 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 8 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 8 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-pipette" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-linux-musl-tmk_vmm" | flowey v 8 'artifact_publish_from_aarch64-linux-musl-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm-extras' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/aarch64-openhcl-igvm-extras" | flowey v 8 'artifact_publish_from_aarch64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 8 flowey_lib_common::install_dist_pkg 0
@@ -4828,8 +4828,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 8 flowey_lib_common::cache 0
-        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 8 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 8 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -4839,7 +4839,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 8 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 8 flowey_lib_common::cache 2
@@ -4862,8 +4862,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 8 flowey_lib_common::git_checkout 0
-        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 8 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey v 8 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -4875,7 +4875,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 8 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 8 flowey_lib_common::git_checkout 3
@@ -5125,20 +5125,20 @@ jobs:
 
         chmod +x $AgentTempDirNormal/bootstrapped-flowey/flowey
 
-        echo '"debug"' | flowey v 9 'FLOWEY_LOG' --update-from-stdin
-        echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --update-from-stdin --is-raw-string
+        echo '"debug"' | flowey v 9 'FLOWEY_LOG' update
+        echo "${{ runner.temp }}/work" | flowey v 9 '_internal_WORKING_DIR' --is-raw-string update
 
-        cat <<'EOF' | flowey v 9 'verbose' --update-from-stdin
+        cat <<'EOF' | flowey v 9 'verbose' update
         ${{ inputs.verbose != '' && inputs.verbose || 'false' }}
         EOF
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-pipette" | flowey v 9 'artifact_publish_from_x64-linux-musl-pipette' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-linux-musl-tmk_vmm" | flowey v 9 'artifact_publish_from_x64-linux-musl-tmk_vmm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm' --is-raw-string update
         mkdir -p "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras"
-        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm-extras' --update-from-stdin --is-raw-string
+        echo "$AgentTempDirNormal/publish_artifacts/x64-openhcl-igvm-extras" | flowey v 9 'artifact_publish_from_x64-openhcl-igvm-extras' --is-raw-string update
       shell: bash
     - name: checking if packages need to be installed
       run: flowey e 9 flowey_lib_common::install_dist_pkg 0
@@ -5152,8 +5152,8 @@ jobs:
     - name: Pre-processing cache vars
       run: |-
         flowey e 9 flowey_lib_common::cache 0
-        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --write-to-gh-env floweyvar1 --is-raw-string
-        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --write-to-gh-env floweyvar2 --is-raw-string
+        flowey v 9 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs:407:72' --is-raw-string write-to-env github floweyvar1
+        flowey v 9 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs:406:72' --is-raw-string write-to-env github floweyvar2
       shell: bash
     - id: flowey_lib_common__cache__1
       uses: actions/cache@v4
@@ -5163,7 +5163,7 @@ jobs:
       name: 'Restore cache: gh-release-download'
     - name: download artifacts from github releases
       run: |-
-        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --update-from-stdin --is-raw-string <<EOF
+        flowey v 9 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs:462:70' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
         ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
         EOF
         flowey e 9 flowey_lib_common::cache 2
@@ -5186,8 +5186,8 @@ jobs:
     - name: check if openvmm needs to be cloned
       run: |-
         flowey e 9 flowey_lib_common::git_checkout 0
-        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --write-to-gh-env floweyvar3 --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46
-        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' --write-to-gh-env FLOWEY_CONDITION
+        flowey v 9 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs:469:80' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46 write-to-env github floweyvar3
+        flowey v 9 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs:470:46' write-to-env github FLOWEY_CONDITION
       shell: bash
     - id: flowey_lib_common__git_checkout__1
       uses: actions/checkout@v4
@@ -5199,7 +5199,7 @@ jobs:
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report cloned repo directories
       run: |-
-        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:42:41' --update-from-stdin --is-raw-string <<EOF
+        flowey v 9 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs:55:41' --is-raw-string update --env-source github.workspace <<EOF
         ${{ github.workspace }}
         EOF
         flowey e 9 flowey_lib_common::git_checkout 3

--- a/flowey/flowey_cli/src/cli/debug/interrogate.rs
+++ b/flowey/flowey_cli/src/cli/debug/interrogate.rs
@@ -5,8 +5,10 @@ use crate::cli::FlowBackendCli;
 use flowey_core::node::FlowArch;
 use flowey_core::node::FlowBackend;
 use flowey_core::node::FlowPlatform;
-use flowey_core::node::GhVarState;
+use flowey_core::node::GhOutput;
+use flowey_core::node::GhToRust;
 use flowey_core::node::NodeHandle;
+use flowey_core::node::RustToGh;
 use flowey_core::node::steps::rust::RustRuntimeServices;
 use flowey_core::node::user_facing::ClaimedGhParam;
 use flowey_core::node::user_facing::GhPermission;
@@ -170,10 +172,10 @@ impl flowey_core::node::NodeCtxBackend for InterrogateCtx {
         _uses: &str,
         _with: BTreeMap<String, ClaimedGhParam>,
         _condvar: Option<String>,
-        _outputs: BTreeMap<String, Vec<GhVarState>>,
+        _outputs: BTreeMap<String, Vec<GhOutput>>,
         _permissions: BTreeMap<GhPermission, GhPermissionValue>,
-        _gh_to_rust: Vec<GhVarState>,
-        _rust_to_gh: Vec<GhVarState>,
+        _gh_to_rust: Vec<GhToRust>,
+        _rust_to_gh: Vec<RustToGh>,
     ) {
         println!("[step][yaml]    # {}", label);
         self.idx_tracker += 1;

--- a/flowey/flowey_cli/src/cli/exec_snippet.rs
+++ b/flowey/flowey_cli/src/cli/exec_snippet.rs
@@ -6,8 +6,10 @@ use anyhow::Context;
 use flowey_core::node::FlowArch;
 use flowey_core::node::FlowBackend;
 use flowey_core::node::FlowPlatform;
-use flowey_core::node::GhVarState;
+use flowey_core::node::GhOutput;
+use flowey_core::node::GhToRust;
 use flowey_core::node::NodeHandle;
+use flowey_core::node::RustToGh;
 use flowey_core::node::steps::rust::RustRuntimeServices;
 use flowey_core::node::user_facing::ClaimedGhParam;
 use flowey_core::node::user_facing::GhPermission;
@@ -58,7 +60,8 @@ impl ExecSnippet {
         let mut runtime_var_db = super::var_db::open_var_db(job_idx)?;
 
         let working_dir: PathBuf = {
-            let Some(working_dir) = runtime_var_db.try_get_var(VAR_DB_SEEDVAR_FLOWEY_WORKING_DIR)
+            let Some((working_dir, _)) =
+                runtime_var_db.try_get_var(VAR_DB_SEEDVAR_FLOWEY_WORKING_DIR)
             else {
                 anyhow::bail!("var db was not seeded with {VAR_DB_SEEDVAR_FLOWEY_WORKING_DIR}");
             };
@@ -290,10 +293,10 @@ impl flowey_core::node::NodeCtxBackend for ExecSnippetCtx<'_, '_> {
         _uses: &str,
         _with: BTreeMap<String, ClaimedGhParam>,
         _condvar: Option<String>,
-        _outputs: BTreeMap<String, Vec<GhVarState>>,
+        _outputs: BTreeMap<String, Vec<GhOutput>>,
         _permissions: BTreeMap<GhPermission, GhPermissionValue>,
-        _gh_to_rust: Vec<GhVarState>,
-        _rust_to_gh: Vec<GhVarState>,
+        _gh_to_rust: Vec<GhToRust>,
+        _rust_to_gh: Vec<RustToGh>,
     ) {
         self.idx_tracker += 1;
     }

--- a/flowey/flowey_cli/src/cli/mod.rs
+++ b/flowey/flowey_cli/src/cli/mod.rs
@@ -95,7 +95,7 @@ fn try_get_flowey_log(job_idx: usize) -> anyhow::Result<Option<String>> {
     if std::env::var("FLOWEY_LOG").is_err() {
         let log_level = var_db::open_var_db(job_idx)?
             .try_get_var("FLOWEY_LOG")
-            .map(|val| {
+            .map(|(val, _)| {
                 serde_json::from_slice::<String>(&val)
                     .expect("found FLOWEY_LOG in db, but it wasn't a json string!")
             });

--- a/flowey/flowey_cli/src/cli/var_db.rs
+++ b/flowey/flowey_cli/src/cli/var_db.rs
@@ -293,13 +293,7 @@ impl VarDb {
                         let mut gh_env_file = fs_err::OpenOptions::new()
                             .append(true)
                             .open(gh_env_file_path)?;
-                        let gh_env_var_assignment = format!(
-                            r#"{}<<EOF
-                            {}
-                            EOF
-                            "#,
-                            env, data_string
-                        );
+                        let gh_env_var_assignment = format!("{}<<EOF\n{}\nEOF\n", env, data_string);
                         gh_env_file.write_all(gh_env_var_assignment.as_bytes())?;
                     }
                 }

--- a/flowey/flowey_cli/src/cli/var_db.rs
+++ b/flowey/flowey_cli/src/cli/var_db.rs
@@ -115,7 +115,7 @@ impl<'a> VarDbRequest<'a> {
         }
     }
 
-    pub fn is_raw_string(self, is_raw_string: bool) -> Self {
+    pub fn raw_string(self, is_raw_string: bool) -> Self {
         Self {
             is_raw_string,
             ..self

--- a/flowey/flowey_cli/src/cli/var_db.rs
+++ b/flowey/flowey_cli/src/cli/var_db.rs
@@ -278,7 +278,7 @@ impl VarDb {
 
                 match backend {
                     EnvBackend::Ado => {
-                        println!("##vso[task.setvariable variable={env};issecret={is_secret}]");
+                        print!("##vso[task.setvariable variable={env};issecret={is_secret}]");
                         std::io::stdout().write_all(&data).unwrap();
                         println!();
                     }

--- a/flowey/flowey_cli/src/cli/var_db.rs
+++ b/flowey/flowey_cli/src/cli/var_db.rs
@@ -280,7 +280,7 @@ impl VarDb {
                     EnvBackend::Ado => {
                         println!("##vso[task.setvariable variable={env};issecret={is_secret}]");
                         std::io::stdout().write_all(&data).unwrap();
-                        println!("");
+                        println!();
                     }
                     EnvBackend::Github => {
                         let data_string = String::from_utf8(data)?;

--- a/flowey/flowey_cli/src/cli/var_db.rs
+++ b/flowey/flowey_cli/src/cli/var_db.rs
@@ -4,54 +4,187 @@
 use super::exec_snippet::FloweyPipelineStaticDb;
 use super::exec_snippet::VarDbBackendKind;
 use anyhow::Context;
+use clap::ValueEnum;
 use flowey_core::node::RuntimeVarDb;
-use std::fmt::Write as _;
 use std::io::Read;
 use std::io::Write;
+use std::path::Path;
 use std::path::PathBuf;
 
-pub fn construct_var_db_cli(
-    flowey_bin: &str,
+pub struct VarDbRequest<'a> {
+    flowey_bin: &'a str,
     job_idx: usize,
-    var: &str,
-    is_secret: bool,
-    update_from_stdin: bool,
-    update_from_file: Option<&str>,
+    var_name: &'a str,
+    action: RequestAction<'a>,
     is_raw_string: bool,
-    write_to_gh_env: Option<&str>,
-    condvar: Option<&str>,
-) -> String {
-    let mut base = format!(r#"{flowey_bin} v {job_idx} '{var}'"#);
+    condvar: Option<&'a str>,
+}
 
-    if update_from_stdin {
-        if is_secret {
-            base += " --is-secret"
+enum RequestAction<'a> {
+    WriteToEnv {
+        backend: EnvBackend,
+        env: &'a str,
+    },
+    Update {
+        file: Option<&'a Path>,
+        is_secret: bool,
+        env_source: Option<&'a str>,
+    },
+}
+
+pub struct VarDbRequestBuilder<'a> {
+    flowey_bin: &'a str,
+    job_idx: usize,
+}
+
+impl<'a> VarDbRequestBuilder<'a> {
+    pub fn new(flowey_bin: &'a str, job_idx: usize) -> Self {
+        Self {
+            flowey_bin,
+            job_idx,
         }
-
-        base += " --update-from-stdin"
-    } else if let Some(file) = update_from_file {
-        if is_secret {
-            base += " --is-secret"
-        }
-
-        write!(base, " --update-from-file {file}").unwrap();
-    } else if let Some(gh_var) = write_to_gh_env {
-        if is_secret {
-            base += " --is-secret"
-        }
-
-        write!(base, " --write-to-gh-env {gh_var}").unwrap();
     }
 
-    if is_raw_string {
-        base += " --is-raw-string"
+    fn req<'b>(&'b self, var_name: &'b str, action: RequestAction<'b>) -> VarDbRequest<'b> {
+        VarDbRequest::new(self.flowey_bin, self.job_idx, var_name, action)
     }
 
-    if let Some(condvar) = condvar {
-        write!(base, " --condvar {condvar}").unwrap();
+    pub fn write_to_ado_env<'b>(&'b self, var_name: &'b str, env: &'b str) -> VarDbRequest<'b> {
+        self.req(
+            var_name,
+            RequestAction::WriteToEnv {
+                backend: EnvBackend::Ado,
+                env,
+            },
+        )
     }
 
-    base
+    pub fn write_to_gh_env<'b>(&'b self, var_name: &'b str, env: &'b str) -> VarDbRequest<'b> {
+        self.req(
+            var_name,
+            RequestAction::WriteToEnv {
+                backend: EnvBackend::Github,
+                env,
+            },
+        )
+    }
+
+    pub fn update_from_stdin<'b>(&'b self, var_name: &'b str, is_secret: bool) -> VarDbRequest<'b> {
+        self.req(
+            var_name,
+            RequestAction::Update {
+                file: None,
+                is_secret,
+                env_source: None,
+            },
+        )
+    }
+
+    #[expect(dead_code)]
+    pub fn update_from_file<'b>(
+        &'b self,
+        var_name: &'b str,
+        file: &'b Path,
+        is_secret: bool,
+    ) -> VarDbRequest<'b> {
+        self.req(
+            var_name,
+            RequestAction::Update {
+                file: Some(file),
+                is_secret,
+                env_source: None,
+            },
+        )
+    }
+}
+
+impl<'a> VarDbRequest<'a> {
+    fn new(
+        flowey_bin: &'a str,
+        job_idx: usize,
+        var_name: &'a str,
+        action: RequestAction<'a>,
+    ) -> Self {
+        Self {
+            flowey_bin,
+            job_idx,
+            var_name,
+            action,
+            is_raw_string: false,
+            condvar: None,
+        }
+    }
+
+    pub fn is_raw_string(self, is_raw_string: bool) -> Self {
+        Self {
+            is_raw_string,
+            ..self
+        }
+    }
+
+    pub fn condvar(self, condvar: Option<&'a str>) -> Self {
+        Self { condvar, ..self }
+    }
+
+    #[track_caller]
+    pub fn env_source(mut self, source: Option<&'a str>) -> Self {
+        let RequestAction::Update { env_source, .. } = &mut self.action else {
+            panic!("env_source can only be set on Update actions");
+        };
+        *env_source = source;
+        self
+    }
+}
+
+impl std::fmt::Display for VarDbRequest<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            flowey_bin,
+            job_idx,
+            var_name,
+            ref action,
+            is_raw_string,
+            condvar,
+        } = *self;
+
+        write!(f, r#"{flowey_bin} v {job_idx} '{var_name}'"#)?;
+
+        if is_raw_string {
+            f.write_str(" --is-raw-string")?;
+        }
+
+        if let Some(condvar) = condvar {
+            write!(f, " --condvar {condvar}")?;
+        }
+
+        match *action {
+            RequestAction::WriteToEnv { backend, env } => {
+                write!(
+                    f,
+                    " write-to-env {backend} {env}",
+                    backend = backend.to_possible_value().unwrap().get_name()
+                )?;
+            }
+            RequestAction::Update {
+                file,
+                is_secret,
+                env_source,
+            } => {
+                write!(f, " update")?;
+                if is_secret {
+                    f.write_str(" --is-secret")?;
+                }
+                if let Some(env_source) = env_source {
+                    write!(f, " --env-source {env_source}")?;
+                }
+                if let Some(file) = file {
+                    write!(f, " {}", file.to_str().unwrap())?;
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 /// (internal) interact with the runtime variable database
@@ -63,30 +196,37 @@ pub struct VarDb {
     /// Runtime variable to access
     var_name: String,
 
-    /// Set the variable by reading from stdin
-    #[clap(long, group = "update")]
-    update_from_stdin: bool,
-
-    /// Set the variable by reading from a file
-    #[clap(long, group = "update")]
-    update_from_file: Option<PathBuf>,
-
     /// Variable is a raw string, and should be read/written as a plain string.
     #[clap(long)]
     is_raw_string: bool,
 
-    /// Whether or not the variable being set if a secret
-    #[clap(long, requires = "update")]
-    is_secret: bool,
-
-    /// Set the variable as a github environment variable with the given name
-    /// rather than printing to stdout.
-    #[clap(long, requires = "var_name", group = "update")]
-    write_to_gh_env: Option<String>,
-
     /// Only run if the given variable is true.
     #[clap(long)]
     condvar: Option<String>,
+
+    #[clap(subcommand)]
+    action: Option<VarDbAction>,
+}
+
+#[derive(clap::Subcommand)]
+enum VarDbAction {
+    WriteToEnv {
+        backend: EnvBackend,
+        env: String,
+    },
+    Update {
+        #[clap(long)]
+        env_source: Option<String>,
+        #[clap(long)]
+        is_secret: bool,
+        file: Option<PathBuf>,
+    },
+}
+
+#[derive(clap::ValueEnum, Copy, Clone)]
+enum EnvBackend {
+    Ado,
+    Github,
 }
 
 impl VarDb {
@@ -94,82 +234,115 @@ impl VarDb {
         let Self {
             job_idx,
             var_name,
-            update_from_stdin,
-            update_from_file,
-            is_secret,
             is_raw_string,
-            write_to_gh_env,
             condvar,
+            action,
         } = self;
 
         let mut runtime_var_db = open_var_db(job_idx)?;
 
         if let Some(condvar) = condvar {
-            let condvar_data = runtime_var_db.get_var(&condvar);
+            let (condvar_data, _) = runtime_var_db.get_var(&condvar);
             let set: bool = serde_json::from_slice(&condvar_data).unwrap();
             if !set {
                 return Ok(());
             }
         }
 
-        if update_from_stdin {
-            let mut data = Vec::new();
-            std::io::stdin().read_to_end(&mut data).unwrap();
-
-            // HACK: only one kind of db, so we know what routine to use
-            if is_raw_string {
-                // account for bash HEREDOCs including a trailing newline
-                // TODO: probably want this to be configurable.
-                if matches!(data.last(), Some(b'\n')) {
-                    data.pop();
-                }
-
-                let s = String::from_utf8(data).unwrap();
-                data = serde_json::to_vec(&s).unwrap();
-            }
-
-            runtime_var_db.set_var(&var_name, is_secret, data);
-        } else if let Some(file) = update_from_file {
-            let mut data = fs_err::read(file)?;
-
-            // HACK: only one kind of db, so we know what routine to use
-            if is_raw_string {
-                let s: String = String::from_utf8(data).unwrap();
-                data = serde_json::to_vec(&s).unwrap();
-            }
-
-            let var_name = var_name.trim_matches('\'');
-            runtime_var_db.set_var(var_name, is_secret, data);
-        } else {
-            let mut data = runtime_var_db.get_var(&var_name);
-
+        let get = |runtime_var_db: &mut Box<dyn RuntimeVarDb>, var_name: &str| {
+            let (mut data, data_is_secret) = runtime_var_db.get_var(var_name);
             // HACK: only one kind of db, so we know what routine to use
             if is_raw_string {
                 let s: String = serde_json::from_slice(&data).unwrap();
                 data = s.into();
             }
+            (data, data_is_secret)
+        };
 
-            if let Some(write_to_gh_env) = write_to_gh_env {
-                let data_string = String::from_utf8(data)?;
+        let env_source_name = |env_source| format!(".env.is_secret.{env_source}");
+
+        match action {
+            None => {
+                // Raw get.
+                let (data, _) = get(&mut runtime_var_db, &var_name);
+                std::io::stdout().write_all(&data).unwrap();
+            }
+            Some(VarDbAction::WriteToEnv { backend, env }) => {
+                let (data, is_secret) = get(&mut runtime_var_db, &var_name);
+
                 if is_secret {
-                    data_string.lines().for_each(|line| {
-                        println!("::add-mask::{}", line);
-                    });
+                    // Remember that this environment variable is secret so that
+                    // it cannot be easily laundered into a non-secret variable.
+                    runtime_var_db.set_var(&env_source_name(&env), false, Vec::new());
                 }
-                let gh_env_file_path = std::env::var("GITHUB_ENV")?;
-                let mut gh_env_file = fs_err::OpenOptions::new()
-                    .append(true)
-                    .open(gh_env_file_path)?;
-                let gh_env_var_assignment = format!(
-                    r#"{}<<EOF
-{}
-EOF
-"#,
-                    write_to_gh_env, data_string
-                );
-                gh_env_file.write_all(gh_env_var_assignment.as_bytes())?;
-            } else {
-                std::io::stdout().write_all(&data).unwrap()
+
+                match backend {
+                    EnvBackend::Ado => {
+                        println!("##vso[task.setvariable variable={env};issecret={is_secret}]");
+                        std::io::stdout().write_all(&data).unwrap();
+                        println!("");
+                    }
+                    EnvBackend::Github => {
+                        let data_string = String::from_utf8(data)?;
+                        if is_secret {
+                            data_string.lines().for_each(|line| {
+                                println!("::add-mask::{}", line);
+                            });
+                        }
+                        let gh_env_file_path = std::env::var("GITHUB_ENV")?;
+                        let mut gh_env_file = fs_err::OpenOptions::new()
+                            .append(true)
+                            .open(gh_env_file_path)?;
+                        let gh_env_var_assignment = format!(
+                            r#"{}<<EOF
+                            {}
+                            EOF
+                            "#,
+                            env, data_string
+                        );
+                        gh_env_file.write_all(gh_env_var_assignment.as_bytes())?;
+                    }
+                }
+            }
+            Some(VarDbAction::Update {
+                env_source,
+                mut is_secret,
+                file,
+            }) => {
+                if !is_secret {
+                    // If the source environment variable for this was known to
+                    // be a secret, then mark it secret.
+                    if let Some(env_source) = env_source {
+                        is_secret |= runtime_var_db
+                            .try_get_var(&env_source_name(&env_source))
+                            .is_some();
+                    }
+                }
+                let data = if let Some(file) = file {
+                    let mut data = fs_err::read(file)?;
+                    // HACK: only one kind of db, so we know what routine to use
+                    if is_raw_string {
+                        let s: String = String::from_utf8(data).unwrap();
+                        data = serde_json::to_vec(&s).unwrap();
+                    }
+                    data
+                } else {
+                    let mut data = Vec::new();
+                    std::io::stdin().read_to_end(&mut data).unwrap();
+                    // HACK: only one kind of db, so we know what routine to use
+                    if is_raw_string {
+                        // account for bash HEREDOCs including a trailing newline
+                        // TODO: probably want this to be configurable.
+                        if matches!(data.last(), Some(b'\n')) {
+                            data.pop();
+                        }
+
+                        let s = String::from_utf8(data).unwrap();
+                        data = serde_json::to_vec(&s).unwrap();
+                    }
+                    data
+                };
+                runtime_var_db.set_var(&var_name, is_secret, data);
             }
         }
 

--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -241,7 +241,7 @@ echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
         let bootstrap_bash_var_db_inject = |var, is_raw_string| {
             var_db
                 .update_from_stdin(var, false)
-                .is_raw_string(is_raw_string)
+                .raw_string(is_raw_string)
                 .to_string()
         };
 
@@ -843,7 +843,7 @@ pub(crate) fn resolve_flow_as_ado_yaml_steps(
                     // flowey considers all ADO vars to be typed as raw strings
                     let read_rust_var = var_db
                         .write_to_ado_env(&rust_var, &ado_var)
-                        .is_raw_string(true)
+                        .raw_string(true)
                         .condvar(condvar.as_deref());
 
                     bash_commands.push_minor(format!("{read_rust_var}\n"));
@@ -918,7 +918,7 @@ pub(crate) fn resolve_flow_as_ado_yaml_steps(
                     // flowey considers all ADO vars to be typed as raw strings
                     let write_rust_var = var_db
                         .update_from_stdin(&rust_var, is_secret)
-                        .is_raw_string(true)
+                        .raw_string(true)
                         .condvar(condvar.as_deref())
                         .env_source(Some(&ado_var));
 

--- a/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/ado_yaml.rs
@@ -11,6 +11,7 @@ use super::generic::ResolvedJobUseParameter;
 use crate::cli::exec_snippet::FloweyPipelineStaticDb;
 use crate::cli::exec_snippet::VAR_DB_SEEDVAR_FLOWEY_WORKING_DIR;
 use crate::cli::pipeline::CheckMode;
+use crate::cli::var_db::VarDbRequestBuilder;
 use crate::flow_resolver::stage1_dag::OutputGraphEntry;
 use crate::flow_resolver::stage1_dag::Step;
 use crate::pipeline_resolver::generic::ResolvedPipeline;
@@ -235,18 +236,13 @@ echo "##vso[task.setvariable variable=FLOWEY_BIN;]$FLOWEY_BIN"
 
         let mut flowey_bootstrap_bash = String::new();
 
+        let var_db = VarDbRequestBuilder::new("$FLOWEY_BIN", job_idx.index());
+
         let bootstrap_bash_var_db_inject = |var, is_raw_string| {
-            crate::cli::var_db::construct_var_db_cli(
-                "$FLOWEY_BIN",
-                job_idx.index(),
-                var,
-                false,
-                true,
-                None,
-                is_raw_string,
-                None,
-                None,
-            )
+            var_db
+                .update_from_stdin(var, false)
+                .is_raw_string(is_raw_string)
+                .to_string()
         };
 
         // and now use those vars to do some flowey bootstrap
@@ -807,6 +803,8 @@ pub(crate) fn resolve_flow_as_ado_yaml_steps(
     let output_order = petgraph::algo::toposort(&output_graph, None)
         .expect("runtime variables cannot introduce a DAG cycle");
 
+    let var_db = VarDbRequestBuilder::new("$FLOWEY_BIN", job_idx);
+
     let mut bash_commands = BashCommands::new_ado();
     for idx in output_order.into_iter().rev() {
         let OutputGraphEntry { node_handle, step } = output_graph[idx].1.take().unwrap();
@@ -841,50 +839,23 @@ pub(crate) fn resolve_flow_as_ado_yaml_steps(
                 code_idx,
                 code,
             } => {
-                let var_db_cmd =
-                    |var: &str, is_secret, update_from_stdin, is_raw_string, condvar| {
-                        crate::cli::var_db::construct_var_db_cli(
-                            "$(FLOWEY_BIN)",
-                            job_idx,
-                            var,
-                            is_secret,
-                            update_from_stdin,
-                            None,
-                            is_raw_string,
-                            None,
-                            condvar,
-                        )
-                    };
-
-                for (rust_var, ado_var, is_secret) in rust_to_ado {
-                    let mut cmd = String::new();
-
+                for (rust_var, ado_var) in rust_to_ado {
                     // flowey considers all ADO vars to be typed as raw strings
-                    let read_rust_var =
-                        var_db_cmd(&rust_var, is_secret, false, true, condvar.as_deref());
-                    writeln!(cmd, r#"rust_var=$({read_rust_var})"#)?;
-                    writeln!(
-                        cmd,
-                        r###"printf "##vso[task.setvariable variable={ado_var};issecret={is_secret}]%s\n" "$rust_var""###
-                    )?;
+                    let read_rust_var = var_db
+                        .write_to_ado_env(&rust_var, &ado_var)
+                        .is_raw_string(true)
+                        .condvar(condvar.as_deref());
 
-                    bash_commands.push_minor(cmd);
+                    bash_commands.push_minor(format!("{read_rust_var}\n"));
                 }
 
                 if !raw_yaml.is_empty() {
                     if let Some(condvar) = &condvar {
-                        let mut cmd = String::new();
-
                         // guaranteed to be a bare bool `true`/`false`, hence
                         // is_raw_string = false
-                        let read_condvar = var_db_cmd(condvar, false, false, false, None);
-                        writeln!(cmd, r#"rust_var=$({read_condvar})"#)?;
-                        writeln!(
-                            cmd,
-                            r###"echo "##vso[task.setvariable variable=FLOWEY_CONDITION;issecret=false]$rust_var""###
-                        )?;
+                        let read_condvar = var_db.write_to_ado_env(condvar, "FLOWEY_CONDITION");
 
-                        bash_commands.push_minor(cmd);
+                        bash_commands.push_minor(format!("{read_condvar}\n"));
                     }
 
                     let raw_yaml = if code.lock().is_some() {
@@ -945,8 +916,11 @@ pub(crate) fn resolve_flow_as_ado_yaml_steps(
 
                 for (ado_var, rust_var, is_secret) in ado_to_rust {
                     // flowey considers all ADO vars to be typed as raw strings
-                    let write_rust_var =
-                        var_db_cmd(&rust_var, is_secret, true, true, condvar.as_deref());
+                    let write_rust_var = var_db
+                        .update_from_stdin(&rust_var, is_secret)
+                        .is_raw_string(true)
+                        .condvar(condvar.as_deref())
+                        .env_source(Some(&ado_var));
 
                     let cmd = format!(
                         r#"

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -799,7 +799,7 @@ fn resolve_flow_as_github_yaml_steps(
                     if let Some(condvar) = &condvar {
                         // guaranteed to be a bare bool `true`/`false`, hence
                         // is_raw_string = false
-                        let set_condvar = var_db.write_to_gh_env(&condvar, "FLOWEY_CONDITION");
+                        let set_condvar = var_db.write_to_gh_env(condvar, "FLOWEY_CONDITION");
                         bash_commands.push_minor(format!("{set_condvar}\n"));
                     }
 

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -217,7 +217,7 @@ pub fn github_yaml(
         let bootstrap_bash_var_db_inject = |var, is_raw_string| {
             var_db
                 .update_from_stdin(var, false)
-                .is_raw_string(is_raw_string)
+                .raw_string(is_raw_string)
                 .to_string()
         };
 
@@ -789,7 +789,7 @@ fn resolve_flow_as_github_yaml_steps(
                 for gh_var_state in rust_to_gh {
                     let set_gh_env_var = var_db
                         .write_to_gh_env(&gh_var_state.backing_var, &gh_var_state.raw_name)
-                        .is_raw_string(!gh_var_state.is_object)
+                        .raw_string(!gh_var_state.is_object)
                         .condvar(condvar.as_deref());
 
                     bash_commands.push_minor(format!("{set_gh_env_var}\n"));
@@ -832,7 +832,7 @@ fn resolve_flow_as_github_yaml_steps(
 
                     let write_var = var_db
                         .update_from_stdin(&gh_var_state.backing_var, gh_var_state.is_secret)
-                        .is_raw_string(!gh_var_state.is_object)
+                        .raw_string(!gh_var_state.is_object)
                         .condvar(condvar.as_deref())
                         .env_source(Some(&gh_var_state.raw_name));
 

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -11,6 +11,7 @@ use super::generic::ResolvedJobUseParameter;
 use crate::cli::exec_snippet::FloweyPipelineStaticDb;
 use crate::cli::exec_snippet::VAR_DB_SEEDVAR_FLOWEY_WORKING_DIR;
 use crate::cli::pipeline::CheckMode;
+use crate::cli::var_db::VarDbRequestBuilder;
 use crate::flow_resolver::stage1_dag::OutputGraphEntry;
 use crate::flow_resolver::stage1_dag::Step;
 use crate::pipeline_resolver::common_yaml::FloweySource;
@@ -211,18 +212,13 @@ pub fn github_yaml(
             gh_steps.push(map.into());
         }
 
+        let var_db = VarDbRequestBuilder::new(&flowey_bin, job_idx.index());
+
         let bootstrap_bash_var_db_inject = |var, is_raw_string| {
-            crate::cli::var_db::construct_var_db_cli(
-                &flowey_bin,
-                job_idx.index(),
-                var,
-                false,
-                true,
-                None,
-                is_raw_string,
-                None,
-                None,
-            )
+            var_db
+                .update_from_stdin(var, false)
+                .is_raw_string(is_raw_string)
+                .to_string()
         };
 
         // if this was a bootstrap job, also take a moment to run a "self check"
@@ -730,6 +726,8 @@ fn resolve_flow_as_github_yaml_steps(
     let output_order = petgraph::algo::toposort(&output_graph, None)
         .expect("runtime variables cannot introduce a DAG cycle");
 
+    let var_db = VarDbRequestBuilder::new(flowey_bin, job_idx);
+
     for node_idx in output_order.into_iter().rev() {
         let OutputGraphEntry { node_handle, step } = output_graph[node_idx].1.take().unwrap();
 
@@ -767,25 +765,6 @@ fn resolve_flow_as_github_yaml_steps(
                 condvar,
                 permissions,
             } => {
-                let var_db_cmd = |var: &str,
-                                  is_secret,
-                                  update_from_stdin,
-                                  is_raw_string,
-                                  write_to_gh_env: Option<String>,
-                                  condvar: Option<String>| {
-                    crate::cli::var_db::construct_var_db_cli(
-                        flowey_bin,
-                        job_idx,
-                        var,
-                        is_secret,
-                        update_from_stdin,
-                        None,
-                        is_raw_string,
-                        write_to_gh_env.as_deref(),
-                        condvar.as_deref(),
-                    )
-                };
-
                 for permission in permissions {
                     if let Some(permission_map) = gh_permissions.get(&node_handle) {
                         if let Some(permission_value) = permission_map.get(&permission.0) {
@@ -808,38 +787,20 @@ fn resolve_flow_as_github_yaml_steps(
                 }
 
                 for gh_var_state in rust_to_gh {
-                    let mut cmd = String::new();
+                    let set_gh_env_var = var_db
+                        .write_to_gh_env(&gh_var_state.backing_var, &gh_var_state.raw_name)
+                        .is_raw_string(!gh_var_state.is_object)
+                        .condvar(condvar.as_deref());
 
-                    let set_gh_env_var = var_db_cmd(
-                        &gh_var_state.backing_var,
-                        gh_var_state.is_secret,
-                        false,
-                        !gh_var_state.is_object,
-                        gh_var_state.raw_name,
-                        condvar.clone(),
-                    );
-                    writeln!(cmd, r#"{set_gh_env_var}"#)?;
-
-                    bash_commands.push_minor(cmd);
+                    bash_commands.push_minor(format!("{set_gh_env_var}\n"));
                 }
 
                 if !uses.is_empty() {
                     if let Some(condvar) = &condvar {
-                        let mut cmd = String::new();
-
                         // guaranteed to be a bare bool `true`/`false`, hence
                         // is_raw_string = false
-                        let set_condvar = var_db_cmd(
-                            condvar,
-                            false,
-                            false,
-                            false,
-                            Some("FLOWEY_CONDITION".to_string()),
-                            None,
-                        );
-                        writeln!(cmd, r#"{set_condvar}"#)?;
-
-                        bash_commands.push_minor(cmd);
+                        let set_condvar = var_db.write_to_gh_env(&condvar, "FLOWEY_CONDITION");
+                        bash_commands.push_minor(format!("{set_condvar}\n"));
                     }
 
                     let mut map = serde_yaml::Mapping::new();
@@ -863,24 +824,17 @@ fn resolve_flow_as_github_yaml_steps(
                 }
 
                 for gh_var_state in gh_to_rust {
-                    let raw_name = gh_var_state
-                        .raw_name
-                        .expect("couldn't get raw name for variable");
-
                     let value = if gh_var_state.is_object {
-                        format!(r#"${{{{ toJSON({}) }}}}"#, raw_name)
+                        format!(r#"${{{{ toJSON({}) }}}}"#, gh_var_state.raw_name)
                     } else {
-                        format!(r#"${{{{ {} }}}}"#, raw_name)
+                        format!(r#"${{{{ {} }}}}"#, gh_var_state.raw_name)
                     };
 
-                    let write_var = var_db_cmd(
-                        &gh_var_state.backing_var,
-                        gh_var_state.is_secret,
-                        true,
-                        !gh_var_state.is_object,
-                        None,
-                        condvar.clone(),
-                    );
+                    let write_var = var_db
+                        .update_from_stdin(&gh_var_state.backing_var, gh_var_state.is_secret)
+                        .is_raw_string(!gh_var_state.is_object)
+                        .condvar(condvar.as_deref())
+                        .env_source(Some(&gh_var_state.raw_name));
 
                     let cmd = format!("{write_var} <<EOF\n{value}\nEOF",);
                     bash_commands.push_minor(cmd);

--- a/flowey/flowey_cli/src/var_db/in_memory.rs
+++ b/flowey/flowey_cli/src/var_db/in_memory.rs
@@ -19,9 +19,9 @@ impl InMemoryVarDb {
 }
 
 impl flowey_core::node::RuntimeVarDb for InMemoryVarDb {
-    fn try_get_var(&mut self, var_name: &str) -> Option<Vec<u8>> {
-        let (is_secret, val) = self.vars.get(var_name)?;
-        if *is_secret {
+    fn try_get_var(&mut self, var_name: &str) -> Option<(Vec<u8>, bool)> {
+        let (is_secret, ref val) = *self.vars.get(var_name)?;
+        if is_secret {
             log::debug!("[db] read var: {} = <secret>", var_name);
         } else {
             log::debug!(
@@ -30,7 +30,7 @@ impl flowey_core::node::RuntimeVarDb for InMemoryVarDb {
                 String::from_utf8_lossy(val)
             );
         }
-        Some(val.clone())
+        Some((val.clone(), is_secret))
     }
 
     fn set_var(&mut self, var_name: &str, is_secret: bool, value: Vec<u8>) {

--- a/flowey/flowey_cli/src/var_db/single_json_file.rs
+++ b/flowey/flowey_cli/src/var_db/single_json_file.rs
@@ -54,16 +54,16 @@ impl SingleJsonFileVarDb {
 }
 
 impl flowey_core::node::RuntimeVarDb for SingleJsonFileVarDb {
-    fn try_get_var(&mut self, var_name: &str) -> Option<Vec<u8>> {
+    fn try_get_var(&mut self, var_name: &str) -> Option<(Vec<u8>, bool)> {
         let db = self.load_db();
-        let (is_secret, val) = db.vars.get(var_name)?;
+        let (is_secret, ref val) = *db.vars.get(var_name)?;
         let val = val.to_string();
-        if *is_secret {
+        if is_secret {
             log::debug!("[db] read var: {} = <secret>", var_name);
         } else {
             log::debug!("[db] read var: {} = {}", var_name, val);
         }
-        Some(val.into())
+        Some((val.into(), is_secret))
     }
 
     fn set_var(&mut self, var_name: &str, is_secret: bool, value: Vec<u8>) {

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -6,7 +6,9 @@
 mod github_context;
 mod spec;
 
-pub use github_context::GhVarState;
+pub use github_context::GhOutput;
+pub use github_context::GhToRust;
+pub use github_context::RustToGh;
 
 use self::steps::ado::AdoRuntimeVar;
 use self::steps::ado::AdoStepServices;
@@ -136,7 +138,7 @@ where
     T: Serialize + DeserializeOwned,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.backing_var == other.backing_var && self.is_secret == other.is_secret
+        self.backing_var == other.backing_var
     }
 }
 
@@ -145,7 +147,7 @@ where
     T: Serialize + DeserializeOwned + PartialEq + Eq + Clone,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.backing_var == other.backing_var && self.is_secret == other.is_secret
+        self.backing_var == other.backing_var
     }
 }
 
@@ -200,7 +202,6 @@ pub enum VarClaimed {}
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WriteVar<T: Serialize + DeserializeOwned, C = VarNotClaimed> {
     backing_var: String,
-    is_secret: bool,
     /// If true, then readers on this var expect to read a side effect (`()`)
     /// and not `T`.
     is_side_effect: bool,
@@ -218,14 +219,12 @@ impl<T: Serialize + DeserializeOwned> WriteVar<T, VarNotClaimed> {
     fn into_claimed(self) -> WriteVar<T, VarClaimed> {
         let Self {
             backing_var,
-            is_secret,
             is_side_effect,
             _kind,
         } = self;
 
         WriteVar {
             backing_var,
-            is_secret,
             is_side_effect,
             _kind: std::marker::PhantomData,
         }
@@ -244,7 +243,6 @@ impl<T: Serialize + DeserializeOwned> WriteVar<T, VarNotClaimed> {
     pub(crate) fn into_json(self) -> WriteVar<serde_json::Value> {
         WriteVar {
             backing_var: self.backing_var,
-            is_secret: self.is_secret,
             is_side_effect: self.is_side_effect,
             _kind: std::marker::PhantomData,
         }
@@ -259,17 +257,9 @@ impl WriteVar<SideEffect, VarNotClaimed> {
     pub fn discard_result<T: Serialize + DeserializeOwned>(self) -> WriteVar<T> {
         WriteVar {
             backing_var: self.backing_var,
-            is_secret: self.is_secret,
             is_side_effect: true,
             _kind: std::marker::PhantomData,
         }
-    }
-}
-
-impl<T: Serialize + DeserializeOwned, C> WriteVar<T, C> {
-    /// Return whether the WriteVar is a secret.
-    pub fn is_secret(&self) -> bool {
-        self.is_secret
     }
 }
 
@@ -335,7 +325,7 @@ impl<T: Serialize + DeserializeOwned> ReadVarValue for ClaimedReadVar<T> {
                 is_side_effect,
             } => {
                 // Always get the data to validate that the variable is actually there.
-                let data = rt.get_var(&var);
+                let data = rt.get_var(&var, is_side_effect);
                 if is_side_effect {
                     // This was converted into a `ReadVar<SideEffect>` from
                     // another type, so parse the value that a
@@ -482,7 +472,6 @@ pub struct GhUserSecretVar(pub(crate) String);
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ReadVar<T, C = VarNotClaimed> {
     backing_var: ReadVarBacking<T>,
-    is_secret: bool,
     #[serde(skip)]
     _kind: std::marker::PhantomData<C>,
 }
@@ -496,7 +485,6 @@ impl<T: Serialize + DeserializeOwned, C> Clone for ReadVar<T, C> {
     fn clone(&self) -> Self {
         ReadVar {
             backing_var: self.backing_var.clone(),
-            is_secret: self.is_secret,
             _kind: std::marker::PhantomData,
         }
     }
@@ -538,15 +526,10 @@ impl<T: Serialize + DeserializeOwned> Clone for ReadVarBacking<T> {
 impl<T: Serialize + DeserializeOwned> ReadVar<T> {
     /// (Internal API) Switch the claim marker to "claimed".
     fn into_claimed(self) -> ReadVar<T, VarClaimed> {
-        let Self {
-            backing_var,
-            is_secret,
-            _kind,
-        } = self;
+        let Self { backing_var, _kind } = self;
 
         ReadVar {
             backing_var,
-            is_secret,
             _kind: std::marker::PhantomData,
         }
     }
@@ -572,7 +555,6 @@ impl<T: Serialize + DeserializeOwned> ReadVar<T> {
                 },
                 ReadVarBacking::Inline(_) => ReadVarBacking::Inline(()),
             },
-            is_secret: self.is_secret,
             _kind: std::marker::PhantomData,
         }
     }
@@ -587,7 +569,7 @@ impl<T: Serialize + DeserializeOwned> ReadVar<T> {
         U: Serialize + DeserializeOwned + 'static,
         F: FnOnce(T) -> U + 'static,
     {
-        let (read_from, write_into) = ctx.new_maybe_secret_var(self.is_secret, "");
+        let (read_from, write_into) = ctx.new_var();
         self.write_into(ctx, write_into, f);
         read_from
     }
@@ -621,8 +603,7 @@ impl<T: Serialize + DeserializeOwned> ReadVar<T> {
         T: 'static,
         U: Serialize + DeserializeOwned + 'static,
     {
-        let (read_from, write_into) =
-            ctx.new_maybe_secret_var(self.is_secret || other.is_secret, "");
+        let (read_from, write_into) = ctx.new_var();
         let this = self.clone();
         ctx.emit_minor_rust_step("🌼 Zip Vars", move |ctx| {
             let this = this.claim(ctx);
@@ -639,7 +620,7 @@ impl<T: Serialize + DeserializeOwned> ReadVar<T> {
 
     /// Create a new `ReadVar` from a static value.
     ///
-    /// **WARNING:** Static vars **CANNOT BE SECRETS**, as they are encoded as
+    /// **WARNING:** Static values **CANNOT BE SECRETS**, as they are encoded as
     /// plain-text in the output flow.
     #[track_caller]
     #[must_use]
@@ -649,7 +630,6 @@ impl<T: Serialize + DeserializeOwned> ReadVar<T> {
     {
         ReadVar {
             backing_var: ReadVarBacking::Inline(val),
-            is_secret: false,
             _kind: std::marker::PhantomData,
         }
     }
@@ -676,7 +656,7 @@ impl<T: Serialize + DeserializeOwned> ReadVar<T> {
     where
         T: 'static,
     {
-        let (read_from, write_into) = ctx.new_maybe_secret_var(vec.iter().any(|v| v.is_secret), "");
+        let (read_from, write_into) = ctx.new_var();
         ctx.emit_minor_rust_step("🌼 Transpose Vec<ReadVar<T>>", move |ctx| {
             let vec = vec.claim(ctx);
             let write_into = write_into.claim(ctx);
@@ -743,12 +723,10 @@ impl<T: Serialize + DeserializeOwned> ReadVar<T> {
                     var,
                     is_side_effect,
                 },
-                is_secret: self.is_secret,
                 _kind: std::marker::PhantomData,
             },
             ReadVarBacking::Inline(v) => ReadVar {
                 backing_var: ReadVarBacking::Inline(serde_json::to_value(v).unwrap()),
-                is_secret: self.is_secret,
                 _kind: std::marker::PhantomData,
             },
         }
@@ -761,7 +739,7 @@ impl<T: Serialize + DeserializeOwned> ReadVar<T> {
 /// and should only be used by code implementing flow / pipeline resolution
 /// logic.
 #[must_use]
-pub fn thin_air_read_runtime_var<T>(backing_var: String, is_secret: bool) -> ReadVar<T>
+pub fn thin_air_read_runtime_var<T>(backing_var: String) -> ReadVar<T>
 where
     T: Serialize + DeserializeOwned,
 {
@@ -770,7 +748,6 @@ where
             var: backing_var,
             is_side_effect: false,
         },
-        is_secret,
         _kind: std::marker::PhantomData,
     }
 }
@@ -781,32 +758,31 @@ where
 /// and should only be used by code implementing flow / pipeline resolution
 /// logic.
 #[must_use]
-pub fn thin_air_write_runtime_var<T>(backing_var: String, is_secret: bool) -> WriteVar<T>
+pub fn thin_air_write_runtime_var<T>(backing_var: String) -> WriteVar<T>
 where
     T: Serialize + DeserializeOwned,
 {
     WriteVar {
         backing_var,
-        is_secret,
         is_side_effect: false,
         _kind: std::marker::PhantomData,
     }
 }
 
-/// DANGER: obtain a [`ReadVar`] backing variable and secret status.
+/// DANGER: obtain a [`ReadVar`] backing variable and side effect status.
 ///
 /// This should NEVER be used from within a flowey node. This relies on
 /// flowey variable implementation details, and should only be used by code
 /// implementing flow / pipeline resolution logic.
 pub fn read_var_internals<T: Serialize + DeserializeOwned, C>(
     var: &ReadVar<T, C>,
-) -> (Option<String>, bool, bool) {
+) -> (Option<String>, bool) {
     match var.backing_var {
         ReadVarBacking::RuntimeVar {
             var: ref s,
             is_side_effect,
-        } => (Some(s.clone()), var.is_secret, is_side_effect),
-        ReadVarBacking::Inline(_) => (None, var.is_secret, false),
+        } => (Some(s.clone()), is_side_effect),
+        ReadVarBacking::Inline(_) => (None, false),
     }
 }
 
@@ -883,10 +859,10 @@ pub trait NodeCtxBackend {
         uses: &str,
         with: BTreeMap<String, ClaimedGhParam>,
         condvar: Option<String>,
-        outputs: BTreeMap<String, Vec<GhVarState>>,
+        outputs: BTreeMap<String, Vec<GhOutput>>,
         permissions: BTreeMap<GhPermission, GhPermissionValue>,
-        gh_to_rust: Vec<GhVarState>,
-        rust_to_gh: Vec<GhVarState>,
+        gh_to_rust: Vec<GhToRust>,
+        rust_to_gh: Vec<RustToGh>,
     );
 
     fn on_emit_side_effect_step(&mut self);
@@ -1076,9 +1052,6 @@ impl<'ctx> NodeCtx<'ctx> {
     /// Emit a Rust-based step, creating a new `ReadVar<T>` from the step's
     /// return value.
     ///
-    /// The var returned by this method is _not secret_. In order to create
-    /// secret variables, use the `ctx.new_var_secret()` method.
-    ///
     /// This is a convenience function that streamlines the following common
     /// flowey pattern:
     ///
@@ -1112,9 +1085,6 @@ impl<'ctx> NodeCtx<'ctx> {
     /// This is equivalent to `emit_rust_stepv`, but it is for steps that cannot
     /// fail and that do not need to be emitted as a separate step in a YAML
     /// pipeline. This simplifies the pipeline logs.
-    ///
-    /// The var returned by this method is _not secret_. In order to create
-    /// secret variables, use the `ctx.new_var_secret()` method.
     ///
     /// This is a convenience function that streamlines the following common
     /// flowey pattern:
@@ -1155,7 +1125,7 @@ impl<'ctx> NodeCtx<'ctx> {
         F: for<'a> FnOnce(&'a mut StepCtx<'_>) -> G,
         G: for<'a> FnOnce(&'a mut RustRuntimeServices<'_>) -> anyhow::Result<()> + 'static,
     {
-        let (read, write) = self.new_maybe_secret_var(false, "auto_se");
+        let (read, write) = self.new_prefixed_var("auto_se");
 
         let ctx = &mut StepCtx {
             backend: self.backend.clone(),
@@ -1205,7 +1175,7 @@ impl<'ctx> NodeCtx<'ctx> {
     #[track_caller]
     #[must_use]
     pub fn get_ado_variable(&mut self, ado_var: AdoRuntimeVar) -> ReadVar<String> {
-        let (var, write_var) = self.new_maybe_secret_var(ado_var.is_secret(), "");
+        let (var, write_var) = self.new_var();
         self.emit_ado_step(format!("🌼 read {}", ado_var.as_raw_var_name()), |ctx| {
             let write_var = write_var.claim(ctx);
             |rt| {
@@ -1427,10 +1397,9 @@ impl<'ctx> NodeCtx<'ctx> {
                             let var = var.claim(&mut StepCtx {
                                 backend: self.backend.clone(),
                             });
-                            GhVarState {
-                                raw_name: None,
+                            GhOutput {
                                 backing_var: var.backing_var,
-                                is_secret: var.is_secret,
+                                is_secret: false,
                                 is_object: false,
                             }
                         })
@@ -1542,38 +1511,18 @@ impl<'ctx> NodeCtx<'ctx> {
 
     /// Allocate a new flowey Var, returning two handles: one for reading the
     /// value, and another for writing the value.
-    ///
-    /// This will return a non-secret Var, and its value may be displayed in
-    /// logs and other output.
     #[track_caller]
     #[must_use]
     pub fn new_var<T>(&self) -> (ReadVar<T>, WriteVar<T>)
     where
         T: Serialize + DeserializeOwned,
     {
-        self.new_maybe_secret_var(false, "")
-    }
-
-    /// Allocate a new secret flowey Var, returning two handles: one for reading
-    /// the value, and another for writing the value.
-    ///
-    /// A secret Var must not be displayed in logs or other output.
-    #[track_caller]
-    #[must_use]
-    pub fn new_secret_var<T>(&self) -> (ReadVar<T>, WriteVar<T>)
-    where
-        T: Serialize + DeserializeOwned,
-    {
-        self.new_maybe_secret_var(true, "")
+        self.new_prefixed_var("")
     }
 
     #[track_caller]
     #[must_use]
-    fn new_maybe_secret_var<T>(
-        &self,
-        is_secret: bool,
-        prefix: &'static str,
-    ) -> (ReadVar<T>, WriteVar<T>)
+    fn new_prefixed_var<T>(&self, prefix: &'static str) -> (ReadVar<T>, WriteVar<T>)
     where
         T: Serialize + DeserializeOwned,
     {
@@ -1612,12 +1561,10 @@ impl<'ctx> NodeCtx<'ctx> {
                     var: backing_var.clone(),
                     is_side_effect: false,
                 },
-                is_secret,
                 _kind: std::marker::PhantomData,
             },
             WriteVar {
                 backing_var,
-                is_secret,
                 is_side_effect: false,
                 _kind: std::marker::PhantomData,
             },
@@ -1637,7 +1584,7 @@ impl<'ctx> NodeCtx<'ctx> {
     #[track_caller]
     #[must_use]
     pub fn new_post_job_side_effect(&self) -> (ReadVar<SideEffect>, WriteVar<SideEffect>) {
-        self.new_maybe_secret_var(false, "post_job")
+        self.new_prefixed_var("post_job")
     }
 
     /// Return a flowey Var pointing to a **node-specific** directory which
@@ -1660,7 +1607,6 @@ impl<'ctx> NodeCtx<'ctx> {
                 var: self.backend.borrow_mut().persistent_dir_path_var()?,
                 is_side_effect: false,
             },
-            is_secret: false,
             _kind: std::marker::PhantomData,
         };
 
@@ -1695,17 +1641,17 @@ impl<'ctx> NodeCtx<'ctx> {
 // FUTURE: explore using type-erased serde here, instead of relying on
 // `serde_json` in `flowey_core`.
 pub trait RuntimeVarDb {
-    fn get_var(&mut self, var_name: &str) -> Vec<u8> {
+    fn get_var(&mut self, var_name: &str) -> (Vec<u8>, bool) {
         self.try_get_var(var_name)
             .unwrap_or_else(|| panic!("db is missing var {}", var_name))
     }
 
-    fn try_get_var(&mut self, var_name: &str) -> Option<Vec<u8>>;
+    fn try_get_var(&mut self, var_name: &str) -> Option<(Vec<u8>, bool)>;
     fn set_var(&mut self, var_name: &str, is_secret: bool, value: Vec<u8>);
 }
 
 impl RuntimeVarDb for Box<dyn RuntimeVarDb> {
-    fn try_get_var(&mut self, var_name: &str) -> Option<Vec<u8>> {
+    fn try_get_var(&mut self, var_name: &str) -> Option<(Vec<u8>, bool)> {
         (**self).try_get_var(var_name)
     }
 
@@ -1850,7 +1796,7 @@ pub mod steps {
 
         pub struct CompletedAdoStepServices {
             pub ado_to_rust: Vec<(String, String, bool)>,
-            pub rust_to_ado: Vec<(String, String, bool)>,
+            pub rust_to_ado: Vec<(String, String)>,
         }
 
         impl CompletedAdoStepServices {
@@ -1871,7 +1817,7 @@ pub mod steps {
         pub struct AdoStepServices<'a> {
             fresh_ado_var: &'a mut dyn FnMut() -> String,
             ado_to_rust: Vec<(String, String, bool)>,
-            rust_to_ado: Vec<(String, String, bool)>,
+            rust_to_ado: Vec<(String, String)>,
         }
 
         impl AdoStepServices<'_> {
@@ -1887,8 +1833,11 @@ pub mod steps {
             // the fact that the ADO var to flowey bridge is handled by the ADO
             // backend, which itself needs to know type info...
             pub fn set_var(&mut self, var: ClaimedWriteVar<String>, from_ado_var: AdoRuntimeVar) {
-                self.ado_to_rust
-                    .push((from_ado_var.ado_var.into(), var.backing_var, var.is_secret))
+                self.ado_to_rust.push((
+                    from_ado_var.ado_var.into(),
+                    var.backing_var,
+                    from_ado_var.is_secret,
+                ))
             }
 
             /// Get the value of a flowey Var as a ADO runtime variable.
@@ -1906,12 +1855,9 @@ pub mod steps {
 
                 let new_ado_var_name = (self.fresh_ado_var)();
 
-                self.rust_to_ado.push((
-                    backing_var.clone(),
-                    new_ado_var_name.clone(),
-                    var.is_secret,
-                ));
-                AdoRuntimeVar::dangerous_from_global(new_ado_var_name, var.is_secret)
+                self.rust_to_ado
+                    .push((backing_var.clone(), new_ado_var_name.clone()));
+                AdoRuntimeVar::dangerous_from_global(new_ado_var_name, false)
             }
         }
     }
@@ -1980,9 +1926,9 @@ pub mod steps {
             /// to the param name and value. For example the following code generates the following yaml:
             ///
             /// ```rust,ignore
-            /// let (client_id, write_client_id) = ctx.new_secret_var();
-            /// let (tenant_id, write_tenant_id) = ctx.new_secret_var();
-            /// let (subscription_id, write_subscription_id) = ctx.new_secret_var();
+            /// let (client_id, write_client_id) = ctx.new_var();
+            /// let (tenant_id, write_tenant_id) = ctx.new_var();
+            /// let (subscription_id, write_subscription_id) = ctx.new_var();
             /// // ... insert rust step writing to each of those secrets ...
             /// GhStepBuilder::new("Azure Login", "Azure/login@v2")
             ///               .with("client-id", client_id)
@@ -2047,7 +1993,7 @@ pub mod steps {
             /// Finish building the step, emitting it to the backend and returning a side-effect.
             #[track_caller]
             pub fn finish(self, ctx: &mut NodeCtx<'_>) -> ReadVar<SideEffect> {
-                let (side_effect, claim_side_effect) = ctx.new_maybe_secret_var(false, "auto_se");
+                let (side_effect, claim_side_effect) = ctx.new_prefixed_var("auto_se");
                 ctx.backend
                     .borrow_mut()
                     .on_claimed_runtime_var(&claim_side_effect.backing_var, false);
@@ -2165,6 +2111,7 @@ pub mod steps {
                 backend,
                 platform,
                 arch,
+                has_read_secret: false,
             }
         }
 
@@ -2173,6 +2120,7 @@ pub mod steps {
             backend: FlowBackend,
             platform: FlowPlatform,
             arch: FlowArch,
+            has_read_secret: bool,
         }
 
         impl RustRuntimeServices<'_> {
@@ -2193,7 +2141,46 @@ pub mod steps {
                 self.arch
             }
 
+            /// Write a value.
+            ///
+            /// If this step has already read a secret value, then this will be
+            /// written as a secret value, as a conservative estimate to avoid
+            /// leaking secrets. Use [`write_secret`](Self::write_secret) or
+            /// [`write_not_secret`](Self::write_not_secret) to override this
+            /// behavior.
             pub fn write<T>(&mut self, var: ClaimedWriteVar<T>, val: &T)
+            where
+                T: Serialize + DeserializeOwned,
+            {
+                self.write_maybe_secret(var, val, self.has_read_secret)
+            }
+
+            /// Write a secret value, such as a key or token.
+            ///
+            /// Flowey will avoid logging this value, and if the value is
+            /// converted to a CI environment variable, the CI system will be
+            /// told not to print the value either.
+            pub fn write_secret<T>(&mut self, var: ClaimedWriteVar<T>, val: &T)
+            where
+                T: Serialize + DeserializeOwned,
+            {
+                self.write_maybe_secret(var, val, true)
+            }
+
+            /// Write a value that is not secret, even if this step has already
+            /// read secret values.
+            ///
+            /// Usually [`write`](Self::write) is preferred--use this only when
+            /// your step reads secret values and you explicitly want to write a
+            /// non-secret value.
+            pub fn write_not_secret<T>(&mut self, var: ClaimedWriteVar<T>, val: &T)
+            where
+                T: Serialize + DeserializeOwned,
+            {
+                self.write_maybe_secret(var, val, false)
+            }
+
+            fn write_maybe_secret<T>(&mut self, var: ClaimedWriteVar<T>, val: &T, is_secret: bool)
             where
                 T: Serialize + DeserializeOwned,
             {
@@ -2203,7 +2190,7 @@ pub mod steps {
                     serde_json::to_vec(val).expect("improve this error path")
                 };
                 self.runtime_var_db
-                    .set_var(&var.backing_var, var.is_secret, val);
+                    .set_var(&var.backing_var, is_secret, val);
             }
 
             pub fn write_all<T>(
@@ -2222,8 +2209,10 @@ pub mod steps {
                 var.read_value(self)
             }
 
-            pub(crate) fn get_var(&mut self, var: &str) -> Vec<u8> {
-                self.runtime_var_db.get_var(var)
+            pub(crate) fn get_var(&mut self, var: &str, is_side_effect: bool) -> Vec<u8> {
+                let (v, is_secret) = self.runtime_var_db.get_var(var);
+                self.has_read_secret |= is_secret && !is_side_effect;
+                v
             }
 
             /// DANGEROUS: Set the value of _Global_ Environment Variable (GitHub Actions only).

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -1070,6 +1070,7 @@ impl<'ctx> NodeCtx<'ctx> {
     /// let read_foo = ctx.emit_rust_stepv("foo", |ctx| |rt| Ok(get_foo()));
     /// ```
     #[must_use]
+    #[track_caller]
     pub fn emit_rust_stepv<T, F, G>(&mut self, label: impl AsRef<str>, code: F) -> ReadVar<T>
     where
         T: Serialize + DeserializeOwned + 'static,
@@ -1103,6 +1104,7 @@ impl<'ctx> NodeCtx<'ctx> {
     /// let read_foo = ctx.emit_minor_rust_stepv("foo", |ctx| |rt| get_foo());
     /// ```
     #[must_use]
+    #[track_caller]
     pub fn emit_minor_rust_stepv<T, F, G>(&mut self, label: impl AsRef<str>, code: F) -> ReadVar<T>
     where
         T: Serialize + DeserializeOwned + 'static,
@@ -1140,6 +1142,7 @@ impl<'ctx> NodeCtx<'ctx> {
     }
 
     #[must_use]
+    #[track_caller]
     fn emit_rust_stepv_inner<T, F, G>(
         &mut self,
         label: impl AsRef<str>,

--- a/flowey/flowey_core/src/node/github_context.rs
+++ b/flowey/flowey_core/src/node/github_context.rs
@@ -19,11 +19,24 @@ pub mod state {
     pub enum Event {}
 }
 
-#[derive(Clone)]
-pub struct GhVarState {
-    pub raw_name: Option<String>,
+pub struct GhOutput {
     pub backing_var: String,
     pub is_secret: bool,
+    pub is_object: bool,
+}
+
+#[derive(Clone)]
+pub struct GhToRust {
+    pub raw_name: String,
+    pub backing_var: String,
+    pub is_secret: bool,
+    pub is_object: bool,
+}
+
+#[derive(Clone)]
+pub struct RustToGh {
+    pub raw_name: String,
+    pub backing_var: String,
     pub is_object: bool,
 }
 
@@ -39,14 +52,14 @@ impl<S> GhContextVarReader<'_, S> {
         is_secret: bool,
         is_object: bool,
     ) -> ReadVar<T> {
-        let (var, write_var) = self.ctx.new_maybe_secret_var(is_secret, "");
+        let (var, write_var) = self.ctx.new_prefixed_var("");
         let write_var = write_var.claim(&mut StepCtx {
             backend: self.ctx.backend.clone(),
         });
-        let var_state = GhVarState {
-            raw_name: Some(var_name.as_ref().to_string()),
+        let var_state = GhToRust {
+            raw_name: var_name.as_ref().to_string(),
             backing_var: write_var.backing_var,
-            is_secret: write_var.is_secret,
+            is_secret,
             is_object,
         };
         let gh_to_rust = vec![var_state];

--- a/flowey/flowey_core/src/patch.rs
+++ b/flowey/flowey_core/src/patch.rs
@@ -83,10 +83,7 @@ where
         M: FlowNodeBase,
     {
         let backing_var = self.backend.new_side_effect_var();
-        let req = f(crate::node::thin_air_write_runtime_var(
-            backing_var.clone(),
-            false,
-        ));
+        let req = f(crate::node::thin_air_write_runtime_var(backing_var.clone()));
 
         self.backend.on_patch_event(PatchEvent::InjectSideEffect {
             from_old_node: NodeHandle::from_type::<N>(),

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -861,10 +861,7 @@ impl PipelineJobCtx<'_> {
     /// Create a new `WriteVar<SideEffect>` anchored to the pipeline job.
     pub fn new_done_handle(&mut self) -> WriteVar<crate::node::SideEffect> {
         self.pipeline.dummy_done_idx += 1;
-        crate::node::thin_air_write_runtime_var(
-            format!("start{}", self.pipeline.dummy_done_idx),
-            false,
-        )
+        crate::node::thin_air_write_runtime_var(format!("start{}", self.pipeline.dummy_done_idx))
     }
 
     /// Claim that this job will use this artifact, obtaining a path to a folder
@@ -874,10 +871,10 @@ impl PipelineJobCtx<'_> {
             .used_by_jobs
             .insert(self.job_idx);
 
-        crate::node::thin_air_read_runtime_var(
-            consistent_artifact_runtime_var_name(&self.pipeline.artifacts[artifact.idx].name, true),
-            false,
-        )
+        crate::node::thin_air_read_runtime_var(consistent_artifact_runtime_var_name(
+            &self.pipeline.artifacts[artifact.idx].name,
+            true,
+        ))
     }
 
     /// Claim that this job will publish this artifact, obtaining a path to a
@@ -889,13 +886,10 @@ impl PipelineJobCtx<'_> {
             .replace(self.job_idx);
         assert!(existing.is_none()); // PublishArtifact isn't cloneable
 
-        crate::node::thin_air_read_runtime_var(
-            consistent_artifact_runtime_var_name(
-                &self.pipeline.artifacts[artifact.idx].name,
-                false,
-            ),
+        crate::node::thin_air_read_runtime_var(consistent_artifact_runtime_var_name(
+            &self.pipeline.artifacts[artifact.idx].name,
             false,
-        )
+        ))
     }
 
     fn helper_request<R: IntoRequest>(&mut self, req: R)
@@ -914,8 +908,8 @@ impl PipelineJobCtx<'_> {
         self.pipeline.artifact_map_idx += 1;
 
         let backing_var = format!("artifact_map{}", artifact_map_idx);
-        let read_var = crate::node::thin_air_read_runtime_var(backing_var.clone(), false);
-        let write_var = crate::node::thin_air_write_runtime_var(backing_var, false);
+        let read_var = crate::node::thin_air_read_runtime_var(backing_var.clone());
+        let write_var = crate::node::thin_air_write_runtime_var(backing_var);
         (read_var, write_var)
     }
 
@@ -960,7 +954,6 @@ impl PipelineJobCtx<'_> {
                 .parameter
                 .name()
                 .to_string(),
-            false,
         )
     }
 

--- a/flowey/flowey_lib_common/src/gh_download_azure_key_vault_secret.rs
+++ b/flowey/flowey_lib_common/src/gh_download_azure_key_vault_secret.rs
@@ -63,15 +63,10 @@ impl FlowNode for Node {
                         let key_vault_name = key_vault_name;
                         let sh = xshell::Shell::new()?;
                         for (secret, vars) in secrets_and_vars {
-                            for var in &vars {
-                                if !var.is_secret() {
-                                    anyhow::bail!(
-                                        "WriteVar for downloaded secret must be marked as secret"
-                                    );
-                                }
-                            }
                             let secret_value = xshell::cmd!(sh, "{az_cli_bin} keyvault secret show --name {secret} --vault-name {key_vault_name} --query value --output tsv").read()?;
-                            rt.write_all(vars, &secret_value);
+                            for var in vars {
+                                rt.write_secret(var, &secret_value);
+                            }
                         }
 
                         Ok(())

--- a/flowey/flowey_lib_common/src/gh_task_azure_login.rs
+++ b/flowey/flowey_lib_common/src/gh_task_azure_login.rs
@@ -51,9 +51,9 @@ impl FlowNode for Node {
             return Ok(());
         }
 
-        let (client_id, write_client_id) = ctx.new_secret_var();
-        let (tenant_id, write_tenant_id) = ctx.new_secret_var();
-        let (subscription_id, write_subscription_id) = ctx.new_secret_var();
+        let (client_id, write_client_id) = ctx.new_var();
+        let (tenant_id, write_tenant_id) = ctx.new_var();
+        let (subscription_id, write_subscription_id) = ctx.new_var();
 
         ctx.emit_rust_step("Read Azure Login Credentials", |ctx| {
             let write_client_id = write_client_id.claim(ctx);

--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_gh_azure_login.rs
@@ -37,26 +37,20 @@ impl SimpleFlowNode for Node {
         let client_id = ctx.get_gh_context_var().secret(client_id);
         let tenant_id = ctx.get_gh_context_var().secret(tenant_id);
         let subscription_id = ctx.get_gh_context_var().secret(subscription_id);
-        let (open_id_connect, write_open_id_connect) = ctx.new_secret_var();
 
-        ctx.emit_rust_step("Create OpenIDConnect Credentials", |ctx| {
+        let open_id_connect = ctx.emit_rust_stepv("Create OpenIDConnect Credentials", |ctx| {
             let client_id = client_id.claim(ctx);
             let tenant_id = tenant_id.claim(ctx);
             let subscription_id = subscription_id.claim(ctx);
-            let write_open_id_connect = write_open_id_connect.claim(ctx);
             |rt| {
                 let client_id = rt.read(client_id);
                 let tenant_id = rt.read(tenant_id);
                 let subscription_id = rt.read(subscription_id);
-                rt.write(
-                    write_open_id_connect,
-                    &flowey_lib_common::gh_task_azure_login::OpenIDConnect {
-                        client_id,
-                        tenant_id,
-                        subscription_id,
-                    },
-                );
-                Ok(())
+                Ok(flowey_lib_common::gh_task_azure_login::OpenIDConnect {
+                    client_id,
+                    tenant_id,
+                    subscription_id,
+                })
             }
         });
 


### PR DESCRIPTION
Currently, a `ReadVar`/`WriteVar` pair can be marked as secret, in which case flowey is careful never to display its value in logs. To mark a variable as such, the user must remember to create the variable pair with `new_secret_var()`, and the user must ensure that users of the variable to do not rewrite its contents into some other, non-secret variable. This is hard to do accurately, especially as we change the code to create more variables implicitly (via `<foo>v`-style methods such as `reqv` and `emit_rust_stepv`).

Change the model so that _variables_ are not secret but their _values_ can be--when any variable is written to, the caller can specify that the value is secret. Propagate this to readers of the variable, even if this variable is converted into and back from a CI environment variable.

By default, be conservative in marking values as secret: once a Rust step reads a secret value from a variable, mark all future values written by that step as secret. Add specific `write_secret` and `write_non_secret` methods for overriding this default.