### PR TITLE
openhcl_boot: add sidecar command line options

### DIFF
--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -7,6 +7,7 @@ use super::PartitionInfo;
 use super::shim_params::IsolationType;
 use super::shim_params::ShimParams;
 use crate::boot_logger::log;
+use crate::cmdline::BootCommandLineOptions;
 use crate::host_params::COMMAND_LINE_SIZE;
 use crate::host_params::MAX_CPU_COUNT;
 use crate::host_params::MAX_ENTROPY_SIZE;
@@ -323,6 +324,7 @@ impl PartitionInfo {
     pub fn read_from_dt<'a>(
         params: &'a ShimParams,
         storage: &'a mut Self,
+        mut options: BootCommandLineOptions,
         can_trust_host: bool,
     ) -> Result<Option<&'a mut Self>, DtError> {
         let dt = params.device_tree();
@@ -350,6 +352,8 @@ impl PartitionInfo {
 
         // Depending on policy, write what the host specified in the chosen node.
         if can_trust_host && command_line.policy == CommandLinePolicy::APPEND_CHOSEN {
+            // Parse in extra options from the host provided command line.
+            options.parse(&parsed.command_line);
             write!(storage.cmdline, " {}", &parsed.command_line)
                 .map_err(|_| DtError::CommandLineSize)?;
         }
@@ -459,10 +463,7 @@ impl PartitionInfo {
         // from the final command line, or the host provided device tree value.
         let vtl2_gpa_pool_size = {
             let dt_page_count = parsed.device_dma_page_count;
-            let cmdline_page_count =
-                crate::cmdline::parse_boot_command_line(storage.cmdline.as_str())
-                    .enable_vtl2_gpa_pool;
-
+            let cmdline_page_count = options.enable_vtl2_gpa_pool;
             max(dt_page_count.unwrap_or(0), cmdline_page_count.unwrap_or(0))
         };
         if vtl2_gpa_pool_size != 0 {
@@ -528,6 +529,7 @@ impl PartitionInfo {
             entropy,
             vtl0_alias_map: _,
             nvme_keepalive,
+            boot_options,
         } = storage;
 
         assert!(!vtl2_used_ranges.is_empty());
@@ -550,6 +552,7 @@ impl PartitionInfo {
         *gic = parsed.gic.clone();
         *entropy = parsed.entropy.clone();
         *nvme_keepalive = parsed.nvme_keepalive;
+        *boot_options = options;
 
         Ok(Some(storage))
     }

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -4,6 +4,7 @@
 //! Module used to parse the host parameters used to setup Underhill. These are
 //! provided via a device tree IGVM parameter.
 
+use crate::cmdline::BootCommandLineOptions;
 use arrayvec::ArrayString;
 use arrayvec::ArrayVec;
 use host_fdt_parser::CpuEntry;
@@ -94,6 +95,8 @@ pub struct PartitionInfo {
     pub vtl0_alias_map: Option<u64>,
     /// Host is compatible with DMA preservation / NVMe keep-alive.
     pub nvme_keepalive: bool,
+    /// Parsed boot command line options.
+    pub boot_options: BootCommandLineOptions,
 }
 
 impl PartitionInfo {
@@ -125,6 +128,7 @@ impl PartitionInfo {
             entropy: None,
             vtl0_alias_map: None,
             nvme_keepalive: false,
+            boot_options: BootCommandLineOptions::new(),
         }
     }
 

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -31,6 +31,7 @@ use crate::single_threaded::off_stack;
 use arrayvec::ArrayString;
 use arrayvec::ArrayVec;
 use boot_logger::LoggerType;
+use cmdline::BootCommandLineOptions;
 use core::fmt::Write;
 use dt::BootTimes;
 use dt::write_dt;
@@ -605,8 +606,10 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
 
     // Enable early log output if requested in the static command line.
     // Also check for confidential debug mode if we're isolated.
-    let static_options =
-        cmdline::parse_boot_command_line(p.command_line().command_line().unwrap_or(""));
+    let mut static_options = BootCommandLineOptions::new();
+    if let Some(cmdline) = p.command_line().command_line() {
+        static_options.parse(cmdline);
+    }
     if let Some(typ) = static_options.logger {
         boot_logger_init(p.isolation_type, typ);
         log!("openhcl_boot: early debugging enabled");
@@ -618,11 +621,12 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
     let boot_reftime = get_ref_time(p.isolation_type);
 
     let mut dt_storage = off_stack!(PartitionInfo, PartitionInfo::new());
-    let partition_info = match PartitionInfo::read_from_dt(&p, &mut dt_storage, can_trust_host) {
-        Ok(Some(val)) => val,
-        Ok(None) => panic!("host did not provide a device tree"),
-        Err(e) => panic!("unable to read device tree params {}", e),
-    };
+    let partition_info =
+        match PartitionInfo::read_from_dt(&p, &mut dt_storage, static_options, can_trust_host) {
+            Ok(Some(val)) => val,
+            Ok(None) => panic!("host did not provide a device tree"),
+            Err(e) => panic!("unable to read device tree params {}", e),
+        };
 
     // Fill out the non-devicetree derived parts of PartitionInfo.
     if !p.isolation_type.is_hardware_isolated()
@@ -657,8 +661,7 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
     if can_trust_host {
         // Enable late log output if requested in the dynamic command line.
         // Confidential debug is only allowed in the static command line.
-        let dynamic_options = cmdline::parse_boot_command_line(&partition_info.cmdline);
-        if let Some(typ) = dynamic_options.logger {
+        if let Some(typ) = partition_info.boot_options.logger {
             boot_logger_init(p.isolation_type, typ);
         } else if partition_info.com3_serial_available && cfg!(target_arch = "x86_64") {
             // If COM3 is available and we can trust the host, enable log output even
@@ -891,6 +894,7 @@ mod test {
     use super::x86_boot::E820Ext;
     use super::x86_boot::build_e820_map;
     use crate::ReservedMemoryType;
+    use crate::cmdline::BootCommandLineOptions;
     use crate::dt::write_dt;
     use crate::host_params::MAX_CPU_COUNT;
     use crate::host_params::PartitionInfo;
@@ -956,6 +960,7 @@ mod test {
             entropy: None,
             vtl0_alias_map: None,
             nvme_keepalive: false,
+            boot_options: BootCommandLineOptions::new(),
         }
     }
 


### PR DESCRIPTION
Add `OPENHCL_SIDECAR` boot loader command-line option for controlling whether sidecar gets enabled:

* `OPENHCL_SIDECAR=off`: Disable sidecar support.
* `OPENHCL_SIDECAR=on`: Enable sidecar support, if possible.
* `OPENHCL_SIDECAR=log`: Enable sidecar logging.

This replaces the existing `SIDECAR_LOGGING` command line option.