### PR TITLE
openhcl/tdx: inject machine check on ept exits caused by bad guest addresses

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1370,6 +1370,11 @@ impl UhProcessor<'_, SnpBacked> {
             }
 
             SevExitCode::NPF if has_intercept => {
+                // TODO SNP: This code needs to be fixed to not rely on the
+                // hypervisor message to check the validity of the NPF, rather
+                // we should look at the SNP hardware exit info only like we do
+                // with TDX.
+                //
                 // Determine whether an NPF needs to be handled. If not, assume this fault is spurious
                 // and that the instruction can be retried. The intercept itself may be presented by the
                 // hypervisor as either a GPA intercept or an exception intercept.

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1375,11 +1375,18 @@ impl UhProcessor<'_, SnpBacked> {
                 // we should look at the SNP hardware exit info only like we do
                 // with TDX.
                 //
-                // Determine whether an NPF needs to be handled. If not, assume this fault is spurious
-                // and that the instruction can be retried. The intercept itself may be presented by the
-                // hypervisor as either a GPA intercept or an exception intercept.
-                // The hypervisor configures the NPT to generate a #VC inside the guest for accesses to
-                // unmapped memory. This means that accesses to unmapped memory for lower VTLs will be
+                // TODO SNP: This code should be fixed so we do not attempt to
+                // emulate a NPF with an address that has the wrong shared bit,
+                // as this will cause the emulator to raise an internal error,
+                // and instead inject a machine check like TDX.
+                //
+                // Determine whether an NPF needs to be handled. If not, assume
+                // this fault is spurious and that the instruction can be
+                // retried. The intercept itself may be presented by the
+                // hypervisor as either a GPA intercept or an exception
+                // intercept. The hypervisor configures the NPT to generate a
+                // #VC inside the guest for accesses to unmapped memory. This
+                // means that accesses to unmapped memory for lower VTLs will be
                 // forwarded to underhill as a #VC exception.
                 let exit_info2 = vmsa.exit_info2();
                 let interruption_pending = vmsa.event_inject().valid()

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -2375,8 +2375,9 @@ impl UhProcessor<'_, TdxBacked> {
         gpa: u64,
         ept_info: VmxEptExitQualification,
     ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let vtom = self.partition.caps.vtom.expect("vtom always set on tdx");
-        let is_shared = (gpa & vtom) == vtom;
+        // vtom may be 0 if we are hiding isolation
+        let vtom = self.partition.caps.vtom.unwrap_or(0);
+        let is_shared = (gpa & vtom) == vtom && vtom != 0;
         let canonical_gpa = gpa & !vtom;
 
         // Only emulate the access if the gpa is expected to be accessible. This

--- a/vm/vmcore/vm_topology/src/memory.rs
+++ b/vm/vmcore/vm_topology/src/memory.rs
@@ -100,6 +100,15 @@ fn validate_ranges_core<T>(ranges: &[T], getter: impl Fn(&T) -> &MemoryRange) ->
     Ok(())
 }
 
+/// The type backing an address.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AddressType {
+    /// The address describes ram.
+    Ram,
+    /// The address describes mmio.
+    Mmio,
+}
+
 impl MemoryLayout {
     /// Makes a new memory layout for a guest with `ram_size` bytes of memory
     /// and MMIO gaps at the locations specified by `gaps`.
@@ -282,6 +291,27 @@ impl MemoryLayout {
     pub fn end_of_ram_or_mmio(&self) -> u64 {
         std::cmp::max(self.mmio.last().expect("mmio set").end(), self.end_of_ram())
     }
+
+    /// Probe a given address to see if it is in the memory layout described by
+    /// `self`. Returns the [`AddressType`] of the address if it is in the
+    /// layout.
+    ///
+    /// This does not check the vtl2_range.
+    fn probe_address(&self, address: u64) -> Option<AddressType> {
+        let ranges = self
+            .ram
+            .iter()
+            .map(|r| (&r.range, AddressType::Ram))
+            .chain(self.mmio.iter().map(|r| (r, AddressType::Mmio)));
+
+        for (range, address_type) in ranges {
+            if range.contains_addr(address) {
+                return Some(address_type);
+            }
+        }
+
+        None
+    }
 }
 
 #[cfg(test)]
@@ -385,5 +415,44 @@ mod tests {
             MemoryRange::new(3 * GB..4 * GB),
         ];
         MemoryLayout::new_from_ranges(ram, mmio).unwrap_err();
+    }
+
+    #[test]
+    fn probe_address() {
+        let mmio = &[
+            MemoryRange::new(GB..2 * GB),
+            MemoryRange::new(3 * GB..4 * GB),
+        ];
+        let ram = &[
+            MemoryRangeWithNode {
+                range: MemoryRange::new(0..GB),
+                vnode: 0,
+            },
+            MemoryRangeWithNode {
+                range: MemoryRange::new(2 * GB..3 * GB),
+                vnode: 0,
+            },
+            MemoryRangeWithNode {
+                range: MemoryRange::new(4 * GB..TB + 2 * GB),
+                vnode: 0,
+            },
+        ];
+
+        let layout = MemoryLayout::new_from_ranges(ram, mmio).unwrap();
+
+        assert_eq!(layout.probe_address(0), Some(AddressType::Ram));
+        assert_eq!(layout.probe_address(256), Some(AddressType::Ram));
+        assert_eq!(layout.probe_address(2 * GB), Some(AddressType::Ram));
+        assert_eq!(layout.probe_address(4 * GB), Some(AddressType::Ram));
+        assert_eq!(layout.probe_address(TB), Some(AddressType::Ram));
+        assert_eq!(layout.probe_address(TB + 1), Some(AddressType::Ram));
+
+        assert_eq!(layout.probe_address(GB), Some(AddressType::Mmio));
+        assert_eq!(layout.probe_address(GB + 123), Some(AddressType::Mmio));
+        assert_eq!(layout.probe_address(3 * GB), Some(AddressType::Mmio));
+
+        assert_eq!(layout.probe_address(TB + 2 * GB), None);
+        assert_eq!(layout.probe_address(TB + 3 * GB), None);
+        assert_eq!(layout.probe_address(4 * TB), None);
     }
 }

--- a/vm/vmcore/vm_topology/src/memory.rs
+++ b/vm/vmcore/vm_topology/src/memory.rs
@@ -297,7 +297,7 @@ impl MemoryLayout {
     /// layout.
     ///
     /// This does not check the vtl2_range.
-    fn probe_address(&self, address: u64) -> Option<AddressType> {
+    pub fn probe_address(&self, address: u64) -> Option<AddressType> {
         let ranges = self
             .ram
             .iter()


### PR DESCRIPTION
On TDX, we see some cases where the guest attempts to access an address with an incorrect shared bit. It's unclear if this is an issue in OpenHCL, the guest, or the host, but fix OpenHCL crashing with an emulation failure due to a `GuestMemory` access failure, and instead inject a machine check into the guest. 

For addresses outside of mmio and ram, continue to emulate but log that the guest did something strange. In the future, we may also inject a machine check on that path. 

Tested via a uefi app that attempts to access a shared page at a private gpa (see https://github.com/chris-oo/openvmm/blob/uefi-tmk-write-to-shared/tmk/tmk_launch/src/main.rs) with the following crash:

```
[kmsg]: [3.058450] virt_mshv_vtl::processor::tdx: WARN  guest accessed inaccessible gpa, injecting MC gpa=0x666d9000 is_shared=false
[kmsg]: [3.061137] virt_mshv_vtl::processor: WARN  Guest has reported system crash crash=VtlCrash { vp_index: VpIndex(0), last_vtl: Vtl0, control: GuestCrashCtl { pre_os_id: 0, no_crash_dump: false, crash_message: true, crash_notify: true }, parameters: [12, 0, 0, 6790a820, 4d7] }
[kmsg]: [3.061758] virt_mshv_vtl::processor:
WARN  Guest has reported a system crash message "!!!! X64 Exception Type - 12(#MC - Machine-Check)  CPU Apic ID - 00000000 !!!!<5c>r<5c>nRIP  - 00000000666DB030, CS  - 0000000000000038, RFLAGS - 0000000000010202<5c>r<5c>nRAX  - 00000000666D9000, RCX - 0000000000000042, RDX - 3333333333333333<5c>r<5c>nRBX  - 0000000066E00018, RSP - 0000000033D99150, RBP - 0000000033D99190<5c>r<5c>nRSI  - 0000000066E54718, RDI - 0000000033DB8160<5c>r<5c>nR8   - 0000000000000000, R9  - 00000000666ED508, R10 - 00000000666ED5EE<5c>r<5c>nR11  - 000000000000000A, R12 - 0000000000000000, R13 - 0000000000000000<5c>r<5c>nR14  - 0000000033D99AA0, R15 - 0000000033D99A98<5c>r<5c>nDS   - 0000000000000030, ES  - 0000000000000030, FS  - 0000000000000030<5c>r<5c>nGS   - 0000000000000030, SS  - 0000000000000030<5c>r<5c>nCR0  - 0000000080010073, CR2 - 0000000000000000, CR3 - 0000000033801000<5c>r<5c>nCR4  - 0000000000000668, CR8 - 0000000000000000<5c>r<5c>nDR0  - 0000000000000000, DR1 - 0000000000000000, DR2 - 0000000000000000<5c>r<5c>nDR3  -     
```

#1426 tracks implementing this for SNP.