### PR TITLE
flowey: publish hidden files in GitHub artifacts

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3019,31 +3019,37 @@ jobs:
       with:
         name: aarch64-windows-hypestv
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-hypestv/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-igvmfilegen
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-igvmfilegen/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-ohcldiag-dev
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-ohcldiag-dev/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-tmk_vmm
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-vmgstool
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
+        include-hidden-files: true
   job3:
     name: build artifacts (for VMM tests) [aarch64-windows]
     runs-on: windows-latest
@@ -3262,16 +3268,19 @@ jobs:
       with:
         name: aarch64-windows-openvmm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-pipette
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-pipette
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
+        include-hidden-files: true
   job4:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
@@ -3490,31 +3499,37 @@ jobs:
       with:
         name: x64-windows-hypestv
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-igvmfilegen
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-ohcldiag-dev
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-tmk_vmm
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-tmk_vmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-vmgstool
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgstool/
+        include-hidden-files: true
   job5:
     name: build artifacts (for VMM tests) [x64-windows]
     runs-on: windows-latest
@@ -3731,16 +3746,19 @@ jobs:
       with:
         name: x64-windows-openvmm
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-openvmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-pipette
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-pipette
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-vmm-tests-archive
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmm-tests-archive/
+        include-hidden-files: true
     - name: 🌼🧼 Redact bootstrap var db
       run: rm $AgentTempDirNormal/bootstrapped-flowey/job5.json
       shell: bash
@@ -4015,36 +4033,43 @@ jobs:
       with:
         name: aarch64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-openvmm
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-openvmm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-vmgstool
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-tmks
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-tmks
         path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
+        include-hidden-files: true
   job7:
     name: build artifacts [x64-linux]
     runs-on:
@@ -4355,41 +4380,49 @@ jobs:
       with:
         name: x64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-igvmfilegen
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-openvmm
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-openvmm
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmgstool
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmm-tests-archive
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-tmks
       uses: actions/upload-artifact@v4
       with:
         name: x64-tmks
         path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        include-hidden-files: true
   job8:
     name: build openhcl [aarch64-linux]
     runs-on:
@@ -4716,26 +4749,31 @@ jobs:
       with:
         name: aarch64-linux-musl-pipette
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-musl-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-baseline
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-openhcl-baseline
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-baseline/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        include-hidden-files: true
   job9:
     name: build openhcl [x64-linux]
     runs-on:
@@ -5156,26 +5194,31 @@ jobs:
       with:
         name: x64-linux-musl-pipette
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-musl-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-baseline
       uses: actions/upload-artifact@v4
       with:
         name: x64-openhcl-baseline
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-baseline/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm
       uses: actions/upload-artifact@v4
       with:
         name: x64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v4
       with:
         name: x64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        include-hidden-files: true
     - name: 🌼🧼 Redact bootstrap var db
       run: rm $AgentTempDirNormal/bootstrapped-flowey/job9.json
       shell: bash

--- a/.github/workflows/openvmm-docs-ci.yaml
+++ b/.github/workflows/openvmm-docs-ci.yaml
@@ -172,6 +172,7 @@ jobs:
       with:
         name: guide
         path: ${{ runner.temp }}/publish_artifacts/guide/
+        include-hidden-files: true
   job1:
     name: build and check docs [x64-windows]
     runs-on: windows-latest
@@ -336,6 +337,7 @@ jobs:
       with:
         name: x64-windows-rustdoc
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-rustdoc/
+        include-hidden-files: true
   job2:
     name: build and check docs [x64-linux]
     runs-on: ubuntu-latest
@@ -506,6 +508,7 @@ jobs:
       with:
         name: x64-linux-rustdoc
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-rustdoc/
+        include-hidden-files: true
     - name: 🌼🧼 Redact bootstrap var db
       run: rm $AgentTempDirNormal/bootstrapped-flowey/job2.json
       shell: bash

--- a/.github/workflows/openvmm-docs-pr.yaml
+++ b/.github/workflows/openvmm-docs-pr.yaml
@@ -180,6 +180,7 @@ jobs:
       with:
         name: guide
         path: ${{ runner.temp }}/publish_artifacts/guide/
+        include-hidden-files: true
   job1:
     name: build and check docs [x64-windows]
     runs-on: windows-latest
@@ -344,6 +345,7 @@ jobs:
       with:
         name: x64-windows-rustdoc
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-rustdoc/
+        include-hidden-files: true
   job2:
     name: build and check docs [x64-linux]
     runs-on: ubuntu-latest
@@ -514,6 +516,7 @@ jobs:
       with:
         name: x64-linux-rustdoc
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-rustdoc/
+        include-hidden-files: true
     - name: 🌼🧼 Redact bootstrap var db
       run: rm $AgentTempDirNormal/bootstrapped-flowey/job2.json
       shell: bash

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -3155,31 +3155,37 @@ jobs:
       with:
         name: aarch64-windows-hypestv
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-hypestv/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-igvmfilegen
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-igvmfilegen/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-ohcldiag-dev
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-ohcldiag-dev/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-tmk_vmm
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-tmk_vmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgs_lib/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-vmgstool
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmgstool/
+        include-hidden-files: true
   job20:
     name: test flowey local backend
     runs-on:
@@ -3569,16 +3575,19 @@ jobs:
       with:
         name: aarch64-windows-openvmm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-openvmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-pipette
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-pipette
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-pipette/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-windows-vmm-tests-archive
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-windows-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/aarch64-windows-vmm-tests-archive/
+        include-hidden-files: true
   job4:
     name: build artifacts (not for VMM tests) [x64-windows]
     runs-on:
@@ -3797,31 +3806,37 @@ jobs:
       with:
         name: x64-windows-hypestv
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-hypestv/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-igvmfilegen
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-igvmfilegen/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-ohcldiag-dev
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-ohcldiag-dev/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-tmk_vmm
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-tmk_vmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgs_lib/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-vmgstool
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmgstool/
+        include-hidden-files: true
   job5:
     name: build artifacts (for VMM tests) [x64-windows]
     runs-on: windows-latest
@@ -4038,16 +4053,19 @@ jobs:
       with:
         name: x64-windows-openvmm
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-openvmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-pipette
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-pipette
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-pipette/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-windows-vmm-tests-archive
       uses: actions/upload-artifact@v4
       with:
         name: x64-windows-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/x64-windows-vmm-tests-archive/
+        include-hidden-files: true
     - name: 🌼🧼 Redact bootstrap var db
       run: rm $AgentTempDirNormal/bootstrapped-flowey/job5.json
       shell: bash
@@ -4322,36 +4340,43 @@ jobs:
       with:
         name: aarch64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/aarch64-guest_test_uefi/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-igvmfilegen
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-igvmfilegen/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-ohcldiag-dev/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-openvmm
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-openvmm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-openvmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgs_lib/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-vmgstool
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-vmgstool/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-tmks
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-tmks
         path: ${{ runner.temp }}/publish_artifacts/aarch64-tmks/
+        include-hidden-files: true
   job7:
     name: build artifacts [x64-linux]
     runs-on:
@@ -4662,41 +4687,49 @@ jobs:
       with:
         name: x64-guest_test_uefi
         path: ${{ runner.temp }}/publish_artifacts/x64-guest_test_uefi/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-igvmfilegen
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-igvmfilegen
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-igvmfilegen/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-ohcldiag-dev
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-ohcldiag-dev
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-ohcldiag-dev/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-openvmm
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-openvmm
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-openvmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmgs_lib
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-vmgs_lib
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgs_lib/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmgstool
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-vmgstool
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmgstool/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-vmm-tests-archive
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-vmm-tests-archive
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-vmm-tests-archive/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-tmks
       uses: actions/upload-artifact@v4
       with:
         name: x64-tmks
         path: ${{ runner.temp }}/publish_artifacts/x64-tmks/
+        include-hidden-files: true
   job8:
     name: build openhcl [aarch64-linux]
     runs-on:
@@ -5002,21 +5035,25 @@ jobs:
       with:
         name: aarch64-linux-musl-pipette
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-pipette/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-linux-musl-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-linux-musl-tmk_vmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm/
+        include-hidden-files: true
     - name: 🌼📦 Publish aarch64-openhcl-igvm-extras
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/aarch64-openhcl-igvm-extras/
+        include-hidden-files: true
   job9:
     name: build openhcl [x64-linux]
     runs-on:
@@ -5419,21 +5456,25 @@ jobs:
       with:
         name: x64-linux-musl-pipette
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-pipette/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-linux-musl-tmk_vmm
       uses: actions/upload-artifact@v4
       with:
         name: x64-linux-musl-tmk_vmm
         path: ${{ runner.temp }}/publish_artifacts/x64-linux-musl-tmk_vmm/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm
       uses: actions/upload-artifact@v4
       with:
         name: x64-openhcl-igvm
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm/
+        include-hidden-files: true
     - name: 🌼📦 Publish x64-openhcl-igvm-extras
       uses: actions/upload-artifact@v4
       with:
         name: x64-openhcl-igvm-extras
         path: ${{ runner.temp }}/publish_artifacts/x64-openhcl-igvm-extras/
+        include-hidden-files: true
     - name: 🌼🧼 Redact bootstrap var db
       run: rm $AgentTempDirNormal/bootstrapped-flowey/job9.json
       shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,6 +1832,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
 ]
 
 [[package]]

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -444,6 +444,7 @@ EOF
                         with:
                             name: {name}
                             path: {RUNNER_TEMP}/publish_artifacts/{name}/
+                            include-hidden-files: true
                     "#
                 ))
                 .unwrap();

--- a/flowey/flowey_core/Cargo.toml
+++ b/flowey/flowey_core/Cargo.toml
@@ -14,5 +14,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true


### PR DESCRIPTION
We use hidden files to tag opaque directories in artifacts, but GitHub discards them out of an abundance of caution. Since we are generally quite careful about artifact construction, there is no security concern with including hidden files, so include away.

Also add some tests of the artifact parsing functionality, since originally I thought that might be the issue.