### PR TITLE
vmm_tests: disable sidecar in keepalive servicing tests

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
@@ -66,7 +66,7 @@ async fn openhcl_servicing_keepalive(
 ) -> Result<(), anyhow::Error> {
     openhcl_servicing_core(
         config,
-        "OPENHCL_ENABLE_VTL2_GPA_POOL=512",
+        "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_SIDECAR=off", // disable sidecar until #1345 is fixed
         igvm_file,
         OpenHclServicingFlags {
             enable_nvme_keepalive: true,

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -102,7 +102,7 @@ async fn nvme_keepalive(
 ) -> Result<(), anyhow::Error> {
     nvme_relay_servicing_core(
         config,
-        "OPENHCL_ENABLE_VTL2_GPA_POOL=512",
+        "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_SIDECAR=off", // disable sidecar until #1345 is fixed
         igvm_file,
         OpenHclServicingFlags {
             enable_nvme_keepalive: true,


### PR DESCRIPTION
Works around #1345.