### PR TITLE
net_mana: adding explicit forbidding of unsafe code

### DIFF
--- a/vm/devices/net/net_mana/src/lib.rs
+++ b/vm/devices/net/net_mana/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![forbid(unsafe_code)]
 #![expect(missing_docs)]
 
 use anyhow::Context as _;


### PR DESCRIPTION
Unsafe code presents risks and should be carefully tested. First step is to be explicit about where we do and don't use unsafe code.

Adding forbid unsafe_code to networking libraries:
* net_mana