### PR TITLE
gdma: adding explicit forbidding of unsafe code

### DIFF
--- a/vm/devices/net/gdma/src/lib.rs
+++ b/vm/devices/net/gdma/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![forbid(unsafe_code)]
 #![expect(missing_docs)]
 
 mod bnic;

--- a/vm/devices/net/gdma_defs/src/lib.rs
+++ b/vm/devices/net/gdma_defs/src/lib.rs
@@ -4,6 +4,7 @@
 //! Hardware definitions for the GDMA/MANA device, which is the NIC exposed by
 //! new Azure hardware SKUs.
 
+#![forbid(unsafe_code)]
 #![expect(missing_docs)]
 
 pub mod access;


### PR DESCRIPTION
Unsafe code presents risks and should be carefully tested. First step is to be explicit about where we do and don't use unsafe code.

Adding forbid unsafe_code to networking libraries:

* gdma
* gdma_defs