### PR TITLE
Add forbid(unsafe) to every library crate that can currently support it

### DIFF
--- a/flowey/flowey/src/lib.rs
+++ b/flowey/flowey/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 //! The user-facing flowey API.
 //!

--- a/flowey/flowey_cli/src/lib.rs
+++ b/flowey/flowey_cli/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use flowey_core::pipeline::IntoPipeline;
 use std::path::Path;

--- a/flowey/flowey_hvlite/src/lib.rs
+++ b/flowey/flowey_hvlite/src/lib.rs
@@ -9,6 +9,7 @@
 // consistent UX across open and closed-source).
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod pipelines;
 pub mod pipelines_shared;

--- a/flowey/flowey_lib_common/src/lib.rs
+++ b/flowey/flowey_lib_common/src/lib.rs
@@ -8,7 +8,6 @@
 
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
-// #![warn(missing_docs)] // TODO: lots to do here
 
 pub mod _util;
 pub mod ado_task_azure_key_vault;

--- a/flowey/flowey_lib_hvlite/src/lib.rs
+++ b/flowey/flowey_lib_hvlite/src/lib.rs
@@ -5,7 +5,6 @@
 
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
-// #![warn(missing_docs)] // TODO: lots to do here
 
 pub mod _jobs;
 pub mod artifact_openhcl_igvm_from_recipe;

--- a/flowey/schema_ado_yaml/src/lib.rs
+++ b/flowey/schema_ado_yaml/src/lib.rs
@@ -4,6 +4,7 @@
 //! Serde defs for ADO YAML
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/openhcl/azure_profiler_proto/src/lib.rs
+++ b/openhcl/azure_profiler_proto/src/lib.rs
@@ -4,6 +4,7 @@
 //! The Azure Profiler service protocol definitions.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 // Crates used by generated code. Reference them explicitly to ensure that
 // automated tools do not remove them.

--- a/openhcl/diag_client/src/lib.rs
+++ b/openhcl/diag_client/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! The client for connecting to the Underhill diagnostics server.
 
+#![forbid(unsafe_code)]
+
 pub mod kmsg_stream;
 
 use anyhow::Context;

--- a/openhcl/diag_proto/src/lib.rs
+++ b/openhcl/diag_proto/src/lib.rs
@@ -4,6 +4,7 @@
 //! The Underhill diagnostics server protocol definitions.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 // Crates used by generated code. Reference them explicitly to ensure that
 // automated tools do not remove them.

--- a/openhcl/hcl_mapper/src/lib.rs
+++ b/openhcl/hcl_mapper/src/lib.rs
@@ -5,6 +5,7 @@
 //! crate to map guest memory.
 
 #![cfg(target_os = "linux")]
+#![forbid(unsafe_code)]
 
 use anyhow::Context;
 use hcl::ioctl::MshvVtlLow;

--- a/openhcl/kmsg_defs/src/lib.rs
+++ b/openhcl/kmsg_defs/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Kmsg-related definitions shared by underhill_core and underhill_init.
 
+#![forbid(unsafe_code)]
+
 /// system is unusable
 pub const LOGLEVEL_EMERG: u8 = 0;
 /// action must be taken immediately

--- a/openhcl/minimal_rt_build/src/lib.rs
+++ b/openhcl/minimal_rt_build/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 /// Initializes compiler flags for building a minimal kernel using the
 /// `minimal_rt` crate.

--- a/openhcl/openhcl_attestation_protocol/src/lib.rs
+++ b/openhcl/openhcl_attestation_protocol/src/lib.rs
@@ -4,6 +4,7 @@
 //! Include modules the protocol used by the attestation process.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod igvm_attest;
 pub mod vmgs;

--- a/openhcl/underhill_dump/src/lib.rs
+++ b/openhcl/underhill_dump/src/lib.rs
@@ -16,6 +16,7 @@
 
 #![cfg(target_os = "linux")]
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use anyhow::Context;
 use std::fs::File;

--- a/openhcl/vmfirmwareigvm_dll/src/lib.rs
+++ b/openhcl/vmfirmwareigvm_dll/src/lib.rs
@@ -7,6 +7,7 @@
 //! The real magic is all in build.rs. See that file for more info.
 
 #![cfg_attr(not(any(test, feature = "ci")), no_std)]
+#![forbid(unsafe_code)]
 
 // required by the Rust compiler, even though we don't include any code
 #[cfg(not(any(test, feature = "ci")))]

--- a/openvmm/hvlite_defs/src/lib.rs
+++ b/openvmm/hvlite_defs/src/lib.rs
@@ -4,6 +4,7 @@
 //! Client-facing definitions for the VM worker.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod config;
 pub mod entrypoint;

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -5,6 +5,7 @@
 //! for the worker process.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 mod cli_args;
 mod crash_dump;

--- a/support/address_filter/src/lib.rs
+++ b/support/address_filter/src/lib.rs
@@ -9,6 +9,8 @@
 //! See [`AddressFilter`] for more information, including the syntax used to
 //! define the filter.
 
+#![forbid(unsafe_code)]
+
 use inspect::InspectMut;
 use std::fmt::Display;
 use std::fmt::LowerHex;

--- a/support/ci_logger/src/lib.rs
+++ b/support/ci_logger/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! A [`log::Log`] implementation translates log-levels to ADO logging commands.
 
+#![forbid(unsafe_code)]
+
 use env_logger::Logger;
 use log::Level;
 use log::Metadata;

--- a/support/console_relay/src/lib.rs
+++ b/support/console_relay/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Code to launch a terminal emulator for relaying input/output.
 
+#![forbid(unsafe_code)]
+
 mod unix;
 mod windows;
 

--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -14,6 +14,7 @@
 //! as this will automatically update the implementation as new fields are added.
 
 #![no_std]
+#![forbid(unsafe_code)]
 
 extern crate alloc;
 

--- a/support/inspect_counters/src/lib.rs
+++ b/support/inspect_counters/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Inspectable types for implementing performance counters.
 
+#![forbid(unsafe_code)]
+
 use inspect::Inspect;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;

--- a/support/inspect_derive/src/lib.rs
+++ b/support/inspect_derive/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use heck::ToSnakeCase;
 use proc_macro2::Ident;

--- a/support/inspect_proto/src/lib.rs
+++ b/support/inspect_proto/src/lib.rs
@@ -3,9 +3,11 @@
 
 //! A generic protobuf service for inspect.
 
+#![expect(missing_docs)]
+#![forbid(unsafe_code)]
+
 // Crates used by generated code. Reference them explicitly to ensure that
 // automated tools do not remove them.
-#![expect(missing_docs)]
 
 use mesh_rpc as _;
 use prost as _;

--- a/support/inspect_task/src/lib.rs
+++ b/support/inspect_task/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Logic for inspecting the task list.
 
+#![forbid(unsafe_code)]
+
 use inspect::Inspect;
 use pal_async::task::TaskData;
 use pal_async::task::TaskList;

--- a/support/kmsg/src/lib.rs
+++ b/support/kmsg/src/lib.rs
@@ -7,6 +7,7 @@
 //! documentation on the kmsg entry format.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use std::fmt::Display;
 use std::time::Duration;

--- a/support/local_clock/src/lib.rs
+++ b/support/local_clock/src/lib.rs
@@ -29,6 +29,8 @@
 //!
 //! [`Inspect`]: inspect::Inspect
 
+#![forbid(unsafe_code)]
+
 mod clock_impls;
 
 pub use clock_impls::MockLocalClock;

--- a/support/mesh/mesh_build/src/lib.rs
+++ b/support/mesh/mesh_build/src/lib.rs
@@ -5,6 +5,8 @@
 //!
 //! Used with the prost protobuf code generator.
 
+#![forbid(unsafe_code)]
+
 use heck::ToUpperCamelCase;
 use proc_macro2::Span;
 use syn::Ident;

--- a/support/mesh/mesh_derive/src/lib.rs
+++ b/support/mesh/mesh_derive/src/lib.rs
@@ -4,6 +4,7 @@
 //! Derive macro for `mesh::MeshPayload` and `mesh_protobuf::Protobuf`.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use heck::ToSnakeCase;
 use proc_macro2::Span;

--- a/support/mesh/mesh_rpc/src/lib.rs
+++ b/support/mesh/mesh_rpc/src/lib.rs
@@ -11,6 +11,8 @@
 //! Currently, the server supports the gRPC and ttrpc protocols, while the
 //! client only supports the ttrpc protocol.
 
+#![forbid(unsafe_code)]
+
 #[cfg(test)]
 extern crate self as mesh_rpc;
 

--- a/support/mesh/src/lib.rs
+++ b/support/mesh/src/lib.rs
@@ -6,6 +6,8 @@
 //! This crate provides cross-process message-based communication over channels.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
+
 #[allow(unused_extern_crates)]
 extern crate self as mesh;
 

--- a/support/mesh_tracing/src/lib.rs
+++ b/support/mesh_tracing/src/lib.rs
@@ -4,6 +4,7 @@
 //! Mesh tracing backend.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 mod bounded;
 

--- a/support/open_enum/src/lib.rs
+++ b/support/open_enum/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![no_std]
+#![forbid(unsafe_code)]
 
 //! Provides the [`open_enum`] macro.
 

--- a/support/pal/pal_async_test/src/lib.rs
+++ b/support/pal/pal_async_test/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Async test attribute macro for `pal_async` crate.
 
+#![forbid(unsafe_code)]
+
 use quote::quote;
 use syn::Error;
 use syn::ItemFn;

--- a/support/serde_helpers/src/lib.rs
+++ b/support/serde_helpers/src/lib.rs
@@ -5,6 +5,7 @@
 //! serde attribute: `#[serde(with = "serde_helpers::foo")]`
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 mod prelude {
     pub use serde::Deserialize;

--- a/support/test_with_tracing/src/lib.rs
+++ b/support/test_with_tracing/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Crate for defining tests that have tracing output.
 
+#![forbid(unsafe_code)]
+
 #[cfg(test)]
 extern crate self as test_with_tracing;
 

--- a/support/test_with_tracing/test_with_tracing_macro/src/lib.rs
+++ b/support/test_with_tracing/test_with_tracing_macro/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Test attribute macro for `test_with_tracing` crate.
 
+#![forbid(unsafe_code)]
+
 use quote::quote;
 use syn::Error;
 use syn::ItemFn;

--- a/support/tracing_helpers/src/lib.rs
+++ b/support/tracing_helpers/src/lib.rs
@@ -10,6 +10,8 @@
 //! Hopefully this crate will be short lived as `tracing` ergonomics continue
 //! to improve.
 
+#![forbid(unsafe_code)]
+
 pub mod formatter;
 
 /// Extension trait to make it easy to trace anyhow errors.

--- a/support/win_import_lib/src/lib.rs
+++ b/support/win_import_lib/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Support for building import libs from .def files.
 
+#![forbid(unsafe_code)]
+
 use anyhow::Context;
 use std::process::Command;
 

--- a/tmk/tmk_macros/src/lib.rs
+++ b/tmk/tmk_macros/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Procedural macros for TMK tests.
 
+#![forbid(unsafe_code)]
+
 use proc_macro::TokenStream;
 use quote::ToTokens;
 use quote::quote;

--- a/tmk/tmk_protocol/src/lib.rs
+++ b/tmk/tmk_protocol/src/lib.rs
@@ -4,6 +4,7 @@
 //! Definitions for the protocol between `tmk_vmm` and the test microkernel.
 
 #![no_std]
+#![forbid(unsafe_code)]
 
 use zerocopy::FromBytes;
 use zerocopy::Immutable;

--- a/vm/aarch64/aarch64defs/src/lib.rs
+++ b/vm/aarch64/aarch64defs/src/lib.rs
@@ -4,6 +4,7 @@
 //! ARM64 type and constant definitions.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
 
 pub mod gic;

--- a/vm/acpi/src/lib.rs
+++ b/vm/acpi/src/lib.rs
@@ -4,6 +4,7 @@
 //! Crate for dynamically creating ACPI tables.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod builder;
 pub mod dsdt;

--- a/vm/acpi_spec/src/lib.rs
+++ b/vm/acpi_spec/src/lib.rs
@@ -4,6 +4,7 @@
 //! ACPI types.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
 
 #[cfg(feature = "alloc")]

--- a/vm/chipset_arc_mutex_device/src/lib.rs
+++ b/vm/chipset_arc_mutex_device/src/lib.rs
@@ -8,6 +8,8 @@
 //! NOTE: this crate is no longer used by OpenVMM/OpenHCL, and only remains
 //! in-tree to support testing devices.
 
+#![forbid(unsafe_code)]
+
 pub mod device;
 pub mod services;
 

--- a/vm/chipset_device_fuzz/src/lib.rs
+++ b/vm/chipset_device_fuzz/src/lib.rs
@@ -4,6 +4,7 @@
 //! A chipset for fuzz-testing devices.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use chipset_arc_mutex_device::device::ArcMutexChipsetDeviceBuilder;
 use chipset_arc_mutex_device::device::ArcMutexChipsetServicesFinalize;

--- a/vm/devices/firmware/generation_id/src/lib.rs
+++ b/vm/devices/firmware/generation_id/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Implementation of Generation ID services (shared across both PCAT and UEFI)
 
+#![forbid(unsafe_code)]
+
 use guestmem::GuestMemory;
 use inspect::InspectMut;
 use mesh::RecvError;

--- a/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
+++ b/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
@@ -14,6 +14,8 @@
 //! which means it's invalid to reference it as a `&[u16]`, or any similar
 //! wrapper type (e.g: `widestring::U16CStr`).
 
+#![forbid(unsafe_code)]
+
 pub mod storage_backend;
 
 use guid::Guid;

--- a/vm/devices/firmware/uefi_nvram_specvars/src/lib.rs
+++ b/vm/devices/firmware/uefi_nvram_specvars/src/lib.rs
@@ -4,6 +4,7 @@
 //!  UEFI NVRAM structures.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use thiserror::Error;
 

--- a/vm/devices/firmware/uefi_nvram_storage/src/lib.rs
+++ b/vm/devices/firmware/uefi_nvram_storage/src/lib.rs
@@ -4,6 +4,7 @@
 //! Abstractions to support pluggable UEFI nvram storage backends (e.g: in memory, file backed, etc...)
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub use uefi_specs::uefi::time::EFI_TIME;
 

--- a/vm/devices/firmware/uefi_specs/src/lib.rs
+++ b/vm/devices/firmware/uefi_specs/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `linux`: types specific to UEFI on Linux
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
 
 // TODO: find a nice way to create const `Ucs2LeSlice` instances, and use proper

--- a/vm/devices/framebuffer/src/lib.rs
+++ b/vm/devices/framebuffer/src/lib.rs
@@ -19,6 +19,8 @@
 //! This is separate from the synthetic device because its lifetime is separate
 //! from that of the synthetic video VMBus channel.
 
+#![forbid(unsafe_code)]
+
 use anyhow::Context;
 use chipset_device::ChipsetDevice;
 use guestmem::GuestMemory;

--- a/vm/devices/hyperv_ic_protocol/src/lib.rs
+++ b/vm/devices/hyperv_ic_protocol/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! IC protocol definitions.
 
+#![forbid(unsafe_code)]
+
 pub mod heartbeat;
 pub mod kvp;
 pub mod shutdown;

--- a/vm/devices/mcr_resources/src/lib.rs
+++ b/vm/devices/mcr_resources/src/lib.rs
@@ -5,7 +5,6 @@
 
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
-// #![warn(missing_docs)] // TODO MCR
 
 use mesh::MeshPayload;
 use vm_resource::ResourceId;

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod resolver;
 

--- a/vm/devices/net/net_dio/src/lib.rs
+++ b/vm/devices/net/net_dio/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![cfg(windows)]
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod resolver;
 

--- a/vm/devices/net/net_packet_capture/src/lib.rs
+++ b/vm/devices/net/net_packet_capture/src/lib.rs
@@ -4,6 +4,7 @@
 //! `pcapng` compatible packet capture endpoint implementation.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use async_trait::async_trait;
 use futures::FutureExt;

--- a/vm/devices/pci/pci_bus/src/lib.rs
+++ b/vm/devices/pci/pci_bus/src/lib.rs
@@ -14,6 +14,8 @@
 //! Incoming config space accesses are then routed to connected
 //! [`GenericPciBusDevice`] devices.
 
+#![forbid(unsafe_code)]
+
 use bitfield_struct::bitfield;
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;

--- a/vm/devices/pci/pci_core/src/lib.rs
+++ b/vm/devices/pci/pci_core/src/lib.rs
@@ -6,6 +6,8 @@
 //! A collection of constants, types, and traits that are shared across all PCI
 //! implementations (i.e: vpci, pci_gen1, pcie).
 
+#![forbid(unsafe_code)]
+
 pub mod test_helpers;
 
 pub mod bar_mapping;

--- a/vm/devices/pci/vpci_protocol/src/lib.rs
+++ b/vm/devices/pci/vpci_protocol/src/lib.rs
@@ -10,6 +10,8 @@
 //! The VPCI protocol is used to create a virtual PCI bus over a vmbus transport, which allows
 //! for efficient and safe exposure of PCI devices to guest virtual machines.
 
+#![forbid(unsafe_code)]
+
 use bitfield_struct::bitfield;
 use guid::Guid;
 use open_enum::open_enum;

--- a/vm/devices/serial/serial_16550/src/lib.rs
+++ b/vm/devices/serial/serial_16550/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Emulator for 16550 serial UART.
 
+#![forbid(unsafe_code)]
+
 pub mod resolver;
 mod spec;
 

--- a/vm/devices/serial/serial_core/src/lib.rs
+++ b/vm/devices/serial/serial_core/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Core types shared by serial port implementations and users.
 
+#![forbid(unsafe_code)]
+
 pub mod disconnected;
 pub mod resources;
 pub mod serial_io;

--- a/vm/devices/serial/serial_debugcon/src/lib.rs
+++ b/vm/devices/serial/serial_debugcon/src/lib.rs
@@ -7,6 +7,8 @@
 //! be used for debugging (hence the name). It offers no flow control
 //! mechanisms, or any method of reading data into the Guest.
 
+#![forbid(unsafe_code)]
+
 pub mod resolver;
 
 use chipset_device::ChipsetDevice;

--- a/vm/devices/serial/serial_socket/src/lib.rs
+++ b/vm/devices/serial/serial_socket/src/lib.rs
@@ -4,6 +4,7 @@
 //! Serial port backends based on sockets and Windows named pipes.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod net;
 #[cfg(windows)]

--- a/vm/devices/serial/vmbus_serial_guest/src/lib.rs
+++ b/vm/devices/serial/vmbus_serial_guest/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Implements a UART backend that communicates with the host over a VMBUS pipe.
 
+#![forbid(unsafe_code)]
+
 pub use vmbus_serial_protocol::UART_INTERFACE_INSTANCE_COM1;
 pub use vmbus_serial_protocol::UART_INTERFACE_INSTANCE_COM2;
 pub use vmbus_serial_protocol::UART_INTERFACE_INSTANCE_COM3;

--- a/vm/devices/serial/vmbus_serial_host/src/lib.rs
+++ b/vm/devices/serial/vmbus_serial_host/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! The host (server) side implementation of a VMBUS based serial device.
 
+#![forbid(unsafe_code)]
+
 pub mod resolver;
 
 use async_trait::async_trait;

--- a/vm/devices/serial/vmbus_serial_protocol/src/lib.rs
+++ b/vm/devices/serial/vmbus_serial_protocol/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Protocol definitions for a VMBUS based serial device. Today this serial device is only offered to VTL2.
 
+#![forbid(unsafe_code)]
+
 use core::fmt::Debug;
 use guid::Guid;
 use open_enum::open_enum;

--- a/vm/devices/storage/disk_crypt/src/lib.rs
+++ b/vm/devices/storage/disk_crypt/src/lib.rs
@@ -4,6 +4,8 @@
 //! A disk device wrapper that provides confidentiality (but not authentication)
 //! via encryption.
 
+#![forbid(unsafe_code)]
+
 pub mod resolver;
 
 use block_crypto::XtsAes256;

--- a/vm/devices/storage/disk_crypt_resources/src/lib.rs
+++ b/vm/devices/storage/disk_crypt_resources/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Resources for the encrypted disk device.
 
+#![forbid(unsafe_code)]
+
 use mesh::MeshPayload;
 use vm_resource::Resource;
 use vm_resource::ResourceId;

--- a/vm/devices/storage/disk_get_vmgs/src/lib.rs
+++ b/vm/devices/storage/disk_get_vmgs/src/lib.rs
@@ -8,6 +8,7 @@
 //! device.
 
 #![cfg(target_os = "linux")]
+#![forbid(unsafe_code)]
 
 use disk_backend::DiskError;
 use disk_backend::DiskIo;

--- a/vm/devices/storage/disk_nvme/src/lib.rs
+++ b/vm/devices/storage/disk_nvme/src/lib.rs
@@ -4,6 +4,7 @@
 //! Disk backend implementation that uses a user-mode NVMe driver based on VFIO.
 
 #![cfg(target_os = "linux")]
+#![forbid(unsafe_code)]
 #![expect(missing_docs)]
 
 use async_trait::async_trait;

--- a/vm/devices/storage/disk_prwrap/src/lib.rs
+++ b/vm/devices/storage/disk_prwrap/src/lib.rs
@@ -8,6 +8,7 @@
 //! for actually sharing a disk between VMs. This is just useful for testing.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use async_trait::async_trait;
 use disk_backend::Disk;

--- a/vm/devices/storage/nvme_spec/src/lib.rs
+++ b/vm/devices/storage/nvme_spec/src/lib.rs
@@ -7,6 +7,7 @@
 //! PCIe transport 1.0c: <https://nvmexpress.org/wp-content/uploads/NVM-Express-PCIe-Transport-Specification-1.0c-2022.10.03-Ratified.pdf>
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
 
 pub mod nvm;

--- a/vm/devices/storage/scsi_defs/src/lib.rs
+++ b/vm/devices/storage/scsi_defs/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod srb;
 

--- a/vm/devices/support/device_emulators/src/lib.rs
+++ b/vm/devices/support/device_emulators/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Utilities for implementing device emulators.
 
+#![forbid(unsafe_code)]
+
 /// Performs a device register read as a series of 32-bit reads.
 pub fn read_as_u32_chunks<F, Num>(offset: Num, data: &mut [u8], mut read_u32: F)
 where

--- a/vm/devices/support/fs/fuse/src/lib.rs
+++ b/vm/devices/support/fs/fuse/src/lib.rs
@@ -5,6 +5,7 @@
 //! particular at virtio-fs.
 
 #![expect(missing_docs)]
+
 #[cfg(unix)]
 mod conn;
 pub mod protocol;

--- a/vm/devices/support/fs/lx/src/lib.rs
+++ b/vm/devices/support/fs/lx/src/lib.rs
@@ -4,6 +4,7 @@
 //! Provides constants and types derived from Linux without requiring libc.
 
 #![expect(missing_docs)]
+
 #[macro_use]
 mod macros;
 mod string;

--- a/vm/devices/support/fs/plan9/src/lib.rs
+++ b/vm/devices/support/fs/plan9/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 #![cfg(any(windows, target_os = "linux"))]
 
 mod fid;

--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![cfg(feature = "tpm")]
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod ak_cert;
 pub mod logger;

--- a/vm/devices/uidevices/src/lib.rs
+++ b/vm/devices/uidevices/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Vmbus UI devices (mouse, keyboard, video).
 
+#![forbid(unsafe_code)]
+
 pub mod keyboard;
 pub mod mouse;
 pub mod resolver;

--- a/vm/devices/user_driver_emulated_mock/src/lib.rs
+++ b/vm/devices/user_driver_emulated_mock/src/lib.rs
@@ -4,7 +4,6 @@
 //! This crate provides a collection of wrapper structs around things like devices and memory. Through the wrappers, it provides functionality to emulate devices such
 //! as Nvme and Mana and gives some additional control over things like [`GuestMemory`] to make testing devices easier.
 //! Everything in this crate is meant for TESTING PURPOSES ONLY and it should only ever be added as a dev-dependency (Few expceptions like using this for fuzzing)
-#![deny(missing_docs)]
 
 mod guest_memory_access_wrapper;
 

--- a/vm/devices/vga/src/lib.rs
+++ b/vm/devices/vga/src/lib.rs
@@ -15,6 +15,7 @@
 //! interface that SeaVGABios uses).
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 mod emu;
 mod non_linear;

--- a/vm/devices/vga_proxy/src/lib.rs
+++ b/vm/devices/vga_proxy/src/lib.rs
@@ -4,6 +4,7 @@
 //! A fake VGA device that proxies all PCI accesses to the emulated host device.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;

--- a/vm/devices/virtio/virtio_net/src/lib.rs
+++ b/vm/devices/virtio/virtio_net/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 mod buffers;
 pub mod resolver;

--- a/vm/devices/virtio/virtio_p9/src/lib.rs
+++ b/vm/devices/virtio/virtio_p9/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 #![cfg(any(windows, target_os = "linux"))]
 
 pub mod resolver;

--- a/vm/devices/virtio/virtio_pmem/src/lib.rs
+++ b/vm/devices/virtio/virtio_pmem/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod resolver;
 

--- a/vm/devices/virtio/virtio_serial/src/lib.rs
+++ b/vm/devices/virtio/virtio_serial/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use async_trait::async_trait;
 use guestmem::GuestMemory;

--- a/vm/devices/watchdog/guest_watchdog/src/lib.rs
+++ b/vm/devices/watchdog/guest_watchdog/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;

--- a/vm/devices/watchdog/watchdog_core/src/lib.rs
+++ b/vm/devices/watchdog/watchdog_core/src/lib.rs
@@ -9,6 +9,7 @@
 //! Guest Watchdog device.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod platform;
 use inspect::Inspect;

--- a/vm/hv1/hv1_structs/src/lib.rs
+++ b/vm/hv1/hv1_structs/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Data structures that may be useful when working with hv1_hypercall.
 
+#![forbid(unsafe_code)]
+
 mod proc_mask;
 mod vtl_array;
 

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -4,6 +4,7 @@
 //! Microsoft hypervisor definitions.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
 
 use bitfield_struct::bitfield;

--- a/vm/loader/igvmfilegen_config/src/lib.rs
+++ b/vm/loader/igvmfilegen_config/src/lib.rs
@@ -5,6 +5,7 @@
 //! manifest file used by the file builder.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use serde::Deserialize;
 use serde::Serialize;

--- a/vm/loader/loader_defs/src/lib.rs
+++ b/vm/loader/loader_defs/src/lib.rs
@@ -4,6 +4,7 @@
 //! Type definitions for loading guest firmware, available as no_std if no features are defined.
 
 #![no_std]
+#![forbid(unsafe_code)]
 
 pub mod linux;
 pub mod paravisor;

--- a/vm/loader/page_table/src/lib.rs
+++ b/vm/loader/page_table/src/lib.rs
@@ -4,6 +4,7 @@
 //! Methods to construct page tables.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod aarch64;
 pub mod x64;

--- a/vm/loader/src/lib.rs
+++ b/vm/loader/src/lib.rs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
+
 #[warn(missing_docs)]
 pub mod common;
 pub mod cpuid;

--- a/vm/vbs_defs/src/lib.rs
+++ b/vm/vbs_defs/src/lib.rs
@@ -4,6 +4,7 @@
 // Virtualization Based Security (VBS) platform definitions defined by Hyper-V
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 #![allow(non_camel_case_types)]
 
 use bitfield_struct::bitfield;

--- a/vm/vhd1_defs/src/lib.rs
+++ b/vm/vhd1_defs/src/lib.rs
@@ -6,6 +6,7 @@
 //! Currently incomplete (missing defs for non-fixed disks).
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
 
 use self::packed_nums::*;

--- a/vm/vmcore/build_rs_guest_arch/src/lib.rs
+++ b/vm/vmcore/build_rs_guest_arch/src/lib.rs
@@ -20,6 +20,8 @@
 //! appropriate CI coverage!).
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
+
 #[derive(Copy, Clone, PartialEq)]
 enum GuestArch {
     X86_64,

--- a/vm/vmcore/save_restore_derive/src/lib.rs
+++ b/vm/vmcore/save_restore_derive/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use quote::quote;
 use syn::DeriveInput;

--- a/vm/vmcore/vm_topology/src/lib.rs
+++ b/vm/vmcore/vm_topology/src/lib.rs
@@ -4,5 +4,7 @@
 //! Types for describing VM topology (processor packages and layout, memory
 //! layout).
 
+#![forbid(unsafe_code)]
+
 pub mod memory;
 pub mod processor;

--- a/vm/vmgs/vmgs_broker/src/lib.rs
+++ b/vm/vmgs/vmgs_broker/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! A task + RPC client for interacting with a shared VMGS instance.
 
+#![forbid(unsafe_code)]
+
 mod broker;
 mod client;
 pub mod non_volatile_store;

--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -4,6 +4,7 @@
 //! VMGS format definitions
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 #![no_std]
 
 use bitfield_struct::bitfield;

--- a/vm/x86/tdcall/src/lib.rs
+++ b/vm/x86/tdcall/src/lib.rs
@@ -4,6 +4,7 @@
 //! Common TDCALL handling for issuing tdcalls and functionality using tdcalls.
 
 #![no_std]
+#![forbid(unsafe_code)]
 
 use hvdef::HV_PAGE_SIZE;
 use memory_range::MemoryRange;

--- a/vmm_core/src/lib.rs
+++ b/vmm_core/src/lib.rs
@@ -5,6 +5,7 @@
 //! Used by both hvlite and underhill today.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 pub mod acpi_builder;
 pub mod cpuid;

--- a/vmm_core/state_unit/src/lib.rs
+++ b/vmm_core/state_unit/src/lib.rs
@@ -28,6 +28,8 @@
 //! This model allows for asynchronous, highly concurrent state changes, and it
 //! works across process boundaries thanks to `mesh`.
 
+#![forbid(unsafe_code)]
+
 use futures::FutureExt;
 use futures::StreamExt;
 use futures::future::join_all;

--- a/vmm_core/vm_loader/src/lib.rs
+++ b/vmm_core/vm_loader/src/lib.rs
@@ -6,6 +6,7 @@
 //! DEVNOTE: this organization isn't great, and should be reconsidered...
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use anyhow::Context;
 use guestmem::GuestMemory;

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -14,6 +14,8 @@
 //! devices. In the future, it will also build handles for PCI and VMBus
 //! devices.
 
+#![forbid(unsafe_code)]
+
 use chipset_resources::battery::BatteryDeviceHandleAArch64;
 use chipset_resources::battery::BatteryDeviceHandleX64;
 use chipset_resources::battery::HostBatteryUpdate;

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use petri_artifacts_common::tags::IsTestIso;
 use petri_artifacts_common::tags::IsTestVhd;

--- a/workers/debug_worker/src/lib.rs
+++ b/workers/debug_worker/src/lib.rs
@@ -8,6 +8,7 @@
 //! guest debugger is not available or practical.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 mod gdb;
 

--- a/workers/vnc_worker/src/lib.rs
+++ b/workers/vnc_worker/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! A worker for running a VNC server.
 
+#![forbid(unsafe_code)]
+
 use anyhow::Context;
 use anyhow::anyhow;
 use futures::FutureExt;

--- a/workers/vnc_worker/vnc/src/lib.rs
+++ b/workers/vnc_worker/vnc/src/lib.rs
@@ -4,6 +4,7 @@
 //! A VNC server implementation.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 mod rfb;
 mod scancode;

--- a/workers/vnc_worker_defs/src/lib.rs
+++ b/workers/vnc_worker_defs/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use mesh::MeshPayload;
 use mesh_worker::WorkerId;

--- a/xtask/xtask_fuzz/src/lib.rs
+++ b/xtask/xtask_fuzz/src/lib.rs
@@ -6,6 +6,8 @@
 //! Might end up getting deprecated, if/when
 //! <https://github.com/rust-fuzz/cargo-fuzz/issues/346> is resolved
 
+#![forbid(unsafe_code)]
+
 use std::sync::OnceLock;
 
 static IS_REPRO: OnceLock<bool> = OnceLock::new();


### PR DESCRIPTION
Just brute forcing this, there's almost certainly more cleanup that can be done to reduce unsafe code elsewhere. After this PR the following crates are the only ones that do not have `#![forbid(unsafe_code)]` or `#![expect(unsafe_code)]` at the top level in their lib.rs file:

flowey/flowey_core
openhcl/build_info
openhcl/diag_server
openhcl/lower_vtl_permissions_guard
openhcl/underhill_mem
openhcl/virt_mshv_vtl
openvmm/membacking
support/cache_topology
support/mesh/mesh_channel
support/mesh/mesh_channel_core
support/mesh/mesh_node
support/mesh/mesh_remote
support/mesh/mesh_worker
support/pal/pal_async
support/pal
support/sev_guest_device
support/tdx_guest_device
support/uevent
support/unix_socket
support/vmsocket
tmk/tmk_tests
vm/devices/get/get_protocol
vm/devices/net/net_consomme/consomme
vm/devices/net/net_tap
vm/devices/storage/block_crypto
vm/devices/support/fs/fuse
vm/devices/support/fs/lx
vm/devices/support/fs/lxutil
vm/devices/user_driver_emulated_mock
vm/devices/virtio/virtio
vm/devices/virtio/virtiofs
vm/page_pool_alloc
vm/vmgs/vmgs
vmm_core/virt