### PR TITLE
Add a few more forbid(unsafe)s

### DIFF
--- a/petri/src/test.rs
+++ b/petri/src/test.rs
@@ -39,8 +39,6 @@ macro_rules! multitest {
     ($tests:expr) => {
         const _: () = {
             use $crate::test_macro_support::linkme;
-            // UNSAFETY: linkme uses manual link sections, which are unsafe.
-            #[expect(unsafe_code)]
             #[linkme::distributed_slice($crate::test_macro_support::TESTS)]
             #[linkme(crate = linkme)]
             static TEST: fn() -> (&'static str, Vec<$crate::TestCase>) =

--- a/tmk/simple_tmk/src/main.rs
+++ b/tmk/simple_tmk/src/main.rs
@@ -5,7 +5,7 @@
 
 #![cfg_attr(minimal_rt, no_std, no_main)]
 // UNSAFETY: TMK tests are going to need to perform unsafe operations.
-#![allow(unsafe_code)]
+#![expect(unsafe_code)]
 
 mod prelude;
 

--- a/tmk/simple_tmk/src/main.rs
+++ b/tmk/simple_tmk/src/main.rs
@@ -5,7 +5,7 @@
 
 #![cfg_attr(minimal_rt, no_std, no_main)]
 // UNSAFETY: TMK tests are going to need to perform unsafe operations.
-#![expect(unsafe_code)]
+#![allow(unsafe_code)]
 
 mod prelude;
 

--- a/tmk/tmk_core/src/lib.rs
+++ b/tmk/tmk_core/src/lib.rs
@@ -156,7 +156,7 @@ macro_rules! define_tmk_test {
             };
 
             // UNSAFETY: needed to specify the link section for the test.
-            #[allow(unsafe_code)]
+            #[expect(unsafe_code)]
             #[unsafe(link_section = "tmk_tests")]
             #[used]
             static TEST: $crate::TestDescriptor = $crate::TestDescriptor {

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Test code for running TMK tests in different environments.
 
+#![forbid(unsafe_code)]
+
 use anyhow::Context as _;
 use pal_async::DefaultDriver;
 use pal_async::DefaultPool;

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -5,6 +5,7 @@
 //! GET (Guest Emulation Transport)
 
 #![expect(missing_docs)]
+#![forbid(unsafe_code)]
 
 use bitfield_struct::bitfield;
 use guid::Guid;
@@ -163,8 +164,6 @@ open_enum! {
 }
 
 pub use header::*;
-// UNSAFETY: The unsafe manual impl of IntoBytes for HeaderGeneric
-#[expect(unsafe_code)]
 pub mod header {
     use super::MessageTypes;
     use super::MessageVersions;
@@ -249,28 +248,16 @@ pub mod header {
         (HeaderHostRequest => HostRequest, HOST_REQUEST, HostRequests),
     }
 
-    #[repr(C)]
-    #[derive(Copy, Clone, Debug, FromBytes, Immutable, KnownLayout, PartialEq)]
+    // TODO: repr(packed) is only needed here to make zerocopy's IntoBytes
+    // derive happy. Ideally it wouldn't be needed. We know this type has no
+    // padding bytes because of the asserts inside `defn_header_meta!`, and
+    // HeaderMeta is sealed, but zerocopy can't see all of that yet.
+    #[repr(C, packed)]
+    #[derive(Copy, Clone, Debug, FromBytes, Immutable, KnownLayout, PartialEq, IntoBytes)]
     pub struct HeaderGeneric<Meta: HeaderMeta> {
         pub message_version: MessageVersions,
         pub message_type: MessageTypes,
-        pub message_id: Meta::MessageId,
-    }
-
-    // SAFETY:
-    // - `HeaderMeta::MessageId` includes a bound on `IntoBytes`
-    // - All other HeaderGeneric fields implement IntoBytes
-    // - HeaderGeneric is repr(C + Immutable + KnownLayout)
-    // - the `defn_header_meta!` macro includes calls to `static_assert!` which
-    // ensure that the `MessageId` type is the correct size + alignment
-    // - a sealed trait bound on `HeaderMeta` ensures that external consumers
-    // cannot construct instances of HeaderGeneric that have not been validated
-    unsafe impl<Meta: HeaderMeta> IntoBytes for HeaderGeneric<Meta> {
-        fn only_derive_is_allowed_to_implement_this_trait()
-        where
-            Self: Sized,
-        {
-        }
+        message_id: Meta::MessageId,
     }
 
     impl<Meta: HeaderMeta> HeaderGeneric<Meta> {
@@ -280,6 +267,15 @@ pub mod header {
                 message_type: Meta::MESSAGE_TYPE,
                 message_id,
             }
+        }
+
+        // This method is only needed to force a copy of the message_id field to
+        // avoid references to potentially unaligned packed fields. message_id
+        // will never actually be unaligned in practice, but the compiler can't
+        // prove that. This can go away and message_id can be made `pub` when
+        // repr(packed) goes away.
+        pub fn message_id(&self) -> Meta::MessageId {
+            self.message_id
         }
     }
 }

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -450,7 +450,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                         .await?
                         .map_err(Error::Vmbus)?;
 
-                    if version_request.message_header.message_id != HostRequests::VERSION {
+                    if version_request.message_header.message_id() != HostRequests::VERSION {
                         return Err(Error::InvalidSequence);
                     }
 
@@ -655,7 +655,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
         message_buf: &[u8],
         state: &mut GuestEmulationDevice,
     ) -> Result<(), Error> {
-        match header.message_id {
+        match header.message_id() {
             HostRequests::TIME => self.handle_time()?,
             HostRequests::BIOS_BOOT_FINALIZE => self.handle_bios_boot_finalize(message_buf)?,
             HostRequests::VMGS_GET_DEVICE_INFO => self.handle_vmgs_get_device_info(state)?,
@@ -683,7 +683,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
             HostRequests::CREATE_RAM_GPA_RANGE => self.handle_create_ram_gpa_range(message_buf)?,
             HostRequests::RESET_RAM_GPA_RANGE => self.handle_reset_ram_gpa_range(message_buf)?,
             _ => {
-                tracing::error!(message_id = ?header.message_id, "unexpected message");
+                tracing::error!(message_id = ?header.message_id(), "unexpected message");
                 return Err(Error::InvalidSequence);
             }
         };
@@ -1139,7 +1139,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
         message_buf: &[u8],
         state: &mut GuestEmulationDevice,
     ) -> Result<(), Error> {
-        match header.message_id {
+        match header.message_id() {
             HostNotifications::POWER_OFF => {
                 self.handle_power_off(state);
             }

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -99,7 +99,7 @@ impl<T: RingMem + Unpin> TestGedChannel<T> {
                 .await
                 .map_err(Error::Vmbus)?;
 
-            if version_request.message_header.message_id != HostRequests::VERSION {
+            if version_request.message_header.message_id() != HostRequests::VERSION {
                 return Err(Error::InvalidSequence);
             }
 
@@ -136,7 +136,7 @@ impl<T: RingMem + Unpin> TestGedChannel<T> {
             if header.message_type == get_protocol::MessageTypes::HOST_NOTIFICATION {
                 let header: get_protocol::HeaderHostNotification =
                     header.try_into().expect("valid host request");
-                match header.message_id {
+                match header.message_id() {
                     HostNotifications::EVENT_LOG => {
                         let notification = get_protocol::EventLogNotification::read_from_prefix(
                             &message_buf[..size_of::<get_protocol::EventLogNotification>()],
@@ -170,7 +170,7 @@ impl<T: RingMem + Unpin> TestGedChannel<T> {
                             get_protocol::MessageTypes::HOST_RESPONSE => {
                                 let header: get_protocol::HeaderHostRequest =
                                     header.try_into().expect("valid host request");
-                                match header.message_id {
+                                match header.message_id() {
                                     HostRequests::VMGS_READ => {
                                         let request_size =
                                             size_of::<get_protocol::VmgsReadRequest>();

--- a/vm/devices/get/guest_emulation_transport/src/lib.rs
+++ b/vm/devices/get/guest_emulation_transport/src/lib.rs
@@ -147,7 +147,7 @@ mod tests {
                 );
 
                 assert_eq!(
-                    version_request.message_header.message_id,
+                    version_request.message_header.message_id(),
                     get_protocol::HostRequests::VERSION
                 );
                 assert_eq!(version_request.version, protocol);

--- a/xtask/src/tasks/fmt/house_rules/unsafe_code_comment.rs
+++ b/xtask/src/tasks/fmt/house_rules/unsafe_code_comment.rs
@@ -36,7 +36,9 @@ pub fn check_unsafe_code_comment(path: &Path, _fix: bool) -> anyhow::Result<()> 
             continue;
         }
 
-        if line.contains("expect(unsafe_code)") && !in_comment {
+        if (line.contains("expect(unsafe_code)") || line.contains("allow(unsafe_code)"))
+            && !in_comment
+        {
             error = true;
             log::error!(
                 "unjustified `expect(unsafe_code)`: {}:{}",


### PR DESCRIPTION
1. Add forbid(unsafe) to tmk_tests by removing the expect inside the macro in petri.
2. Change some allows to expects in tmk crates
3. Add forbid to get_protocol with some zerocopy tweaks