### PR TITLE
kernel: update dev / main kernels to latest available

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -29,8 +29,8 @@ pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.9.2";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.9.3";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.9.3";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.9.4";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 


### PR DESCRIPTION
This change updates the Linux kernel to the latest version. The only difference between this and the previous kernel is that it contains two additional patches:

1. *drivers: hv: mshv_vtl: introduce ioctl for kicking a remote cpu* - https://github.com/microsoft/OHCL-Linux-Kernel/pull/68
2. *mshv_vtl: fix and optimize MSR context switching* - https://github.com/microsoft/OHCL-Linux-Kernel/pull/76