### PR TITLE
TDX: Remove RwLock on tlb flush state tracking to allow reads to interleave with a single write

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -228,6 +228,7 @@ struct UhPartitionInner {
     vmbus_relay: bool,
 }
 
+#[expect(clippy::large_enum_variant)]
 #[derive(Inspect)]
 #[inspect(untagged)]
 enum BackingShared {

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -228,7 +228,6 @@ struct UhPartitionInner {
     vmbus_relay: bool,
 }
 
-#[expect(clippy::large_enum_variant)]
 #[derive(Inspect)]
 #[inspect(untagged)]
 enum BackingShared {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -47,7 +47,6 @@ use hvdef::hypercall::HvGvaRange;
 use inspect::Inspect;
 use inspect::InspectMut;
 use inspect_counters::Counter;
-use parking_lot::RwLock;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering;
 use tlb_flush::FLUSH_GVA_LIST_SIZE;
@@ -727,7 +726,7 @@ pub struct TdxBackedShared {
     /// the guest thinks it is interacting directly with the untrusted
     /// hypervisor via an architecture-specific interface.
     pub(crate) untrusted_synic: Option<GlobalSynic>,
-    flush_state: VtlArray<RwLock<TdxPartitionFlushState>, 2>,
+    flush_state: VtlArray<TdxPartitionFlushState, 2>,
     #[inspect(iter_by_index)]
     active_vtl: Vec<AtomicU8>,
     /// CR4 bits that the guest is allowed to set to 1.
@@ -759,7 +758,7 @@ impl TdxBackedShared {
 
         Ok(Self {
             untrusted_synic,
-            flush_state: VtlArray::from_fn(|_| RwLock::new(TdxPartitionFlushState::new())),
+            flush_state: VtlArray::from_fn(|_| TdxPartitionFlushState::new()),
             cvm: params.cvm_state.unwrap(),
             // VPs start in VTL 2.
             active_vtl: std::iter::repeat_n(2, partition_params.topology.vp_count() as usize)
@@ -4156,20 +4155,22 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressListEx
             .map_err(|e| (e, 0))?;
 
         let vtl = self.intercepted_vtl;
-        {
-            let mut flush_state = self.vp.shared.flush_state[vtl].write();
+        let flush_state = &self.vp.shared.flush_state[vtl];
 
-            // If we fail to add ranges to the list for any reason then promote this request to a flush entire.
-            if let Err(()) = Self::add_ranges_to_tlb_flush_list(
-                &mut flush_state,
-                gva_ranges,
-                flags.use_extended_range_format(),
-            ) {
-                if flags.non_global_mappings_only() {
-                    flush_state.s.flush_entire_non_global_counter += 1;
-                } else {
-                    flush_state.s.flush_entire_counter += 1;
-                }
+        // If we fail to add ranges to the list for any reason then promote this request to a flush entire.
+        if let Err(()) = Self::add_ranges_to_tlb_flush_list(
+            flush_state,
+            gva_ranges,
+            flags.use_extended_range_format(),
+        ) {
+            if flags.non_global_mappings_only() {
+                flush_state
+                    .flush_entire_non_global_counter
+                    .fetch_add(1, Ordering::Relaxed);
+            } else {
+                flush_state
+                    .flush_entire_counter
+                    .fetch_add(1, Ordering::Relaxed);
             }
         }
 
@@ -4215,15 +4216,17 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressSpaceEx
         self.hcvm_validate_flush_inputs(processor_set, flags, false)?;
         let vtl = self.intercepted_vtl;
 
-        {
-            let mut flush_state = self.vp.shared.flush_state[vtl].write();
+        let flush_state = &self.vp.shared.flush_state[vtl];
 
-            // Set flush entire.
-            if flags.non_global_mappings_only() {
-                flush_state.s.flush_entire_non_global_counter += 1;
-            } else {
-                flush_state.s.flush_entire_counter += 1;
-            }
+        // Set flush entire.
+        if flags.non_global_mappings_only() {
+            flush_state
+                .flush_entire_non_global_counter
+                .fetch_add(1, Ordering::Relaxed);
+        } else {
+            flush_state
+                .flush_entire_counter
+                .fetch_add(1, Ordering::Relaxed);
         }
 
         // Send flush IPIs to the specified VPs.
@@ -4243,7 +4246,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressSpaceEx
 
 impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
     fn add_ranges_to_tlb_flush_list(
-        flush_state: &mut TdxPartitionFlushState,
+        flush_state: &TdxPartitionFlushState,
         gva_ranges: &[HvGvaRange],
         use_extended_range_format: bool,
     ) -> Result<(), ()> {
@@ -4252,17 +4255,14 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
             return Err(());
         }
 
+        let gva_list = flush_state.gva_list.write();
         for range in gva_ranges {
             if use_extended_range_format && range.as_extended().large_page() {
                 // TDX does not provide a way to flush large page ranges,
                 // we have to promote this request to a flush entire.
                 return Err(());
             }
-            if flush_state.gva_list.len() == FLUSH_GVA_LIST_SIZE {
-                flush_state.gva_list.pop_front();
-            }
-            flush_state.gva_list.push_back(*range);
-            flush_state.s.gva_list_count += 1;
+            gva_list.push(range.0);
         }
 
         Ok(())
@@ -4319,16 +4319,19 @@ struct TdxTlbLockFlushAccess<'a> {
 
 impl TlbFlushLockAccess for TdxTlbLockFlushAccess<'_> {
     fn flush(&mut self, vtl: GuestVtl) {
-        {
-            self.shared.flush_state[vtl].write().s.flush_entire_counter += 1;
-        }
+        self.shared.flush_state[vtl]
+            .flush_entire_counter
+            .fetch_add(1, Ordering::Relaxed);
+
         self.wake_processors_for_tlb_flush(vtl, None);
         self.set_wait_for_tlb_locks(vtl);
     }
 
     fn flush_entire(&mut self) {
         for vtl in [GuestVtl::Vtl0, GuestVtl::Vtl1] {
-            self.shared.flush_state[vtl].write().s.flush_entire_counter += 1;
+            self.shared.flush_state[vtl]
+                .flush_entire_counter
+                .fetch_add(1, Ordering::Relaxed);
         }
         for vtl in [GuestVtl::Vtl0, GuestVtl::Vtl1] {
             self.wake_processors_for_tlb_flush(vtl, None);

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -4262,8 +4262,8 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
                 // we have to promote this request to a flush entire.
                 return Err(());
             }
-            gva_list.push(range.0);
         }
+        gva_list.extend(gva_ranges.iter().map(|range| range.0));
 
         Ok(())
     }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -4255,13 +4255,14 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
             return Err(());
         }
 
+        let gva_list = flush_state.gva_list.write();
         for range in gva_ranges {
             if use_extended_range_format && range.as_extended().large_page() {
                 // TDX does not provide a way to flush large page ranges,
                 // we have to promote this request to a flush entire.
                 return Err(());
             }
-            flush_state.gva_list.push(range.0);
+            gva_list.push(range.0);
         }
 
         Ok(())

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -4255,14 +4255,13 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, TdxBacked> {
             return Err(());
         }
 
-        let gva_list = flush_state.gva_list.write();
         for range in gva_ranges {
             if use_extended_range_format && range.as_extended().large_page() {
                 // TDX does not provide a way to flush large page ranges,
                 // we have to promote this request to a flush entire.
                 return Err(());
             }
-            gva_list.push(range.0);
+            flush_state.gva_list.push(range.0);
         }
 
         Ok(())

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -272,9 +272,8 @@ impl AtomicTlbRingBufferWriteGuard<'_> {
         // 2. Add the entry.
         // 3. Increment the valid entry count so that any flush code executing
         //    simultaneously will know it is valid.
-        self.buf.in_progress_count.fetch_add(1, Ordering::Relaxed);
-        let count = self.buf.gva_list_count.load(Ordering::Relaxed);
+        let count = self.buf.in_progress_count.fetch_add(1, Ordering::Relaxed);
         self.buf.buffer[count % FLUSH_GVA_LIST_SIZE].store(v, Ordering::Relaxed);
-        self.buf.gva_list_count.store(count + 1, Ordering::Relaxed);
+        self.buf.gva_list_count.fetch_add(1, Ordering::Relaxed);
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -10,8 +10,6 @@ use hcl::ioctl::ProcessorRunner;
 use hcl::ioctl::tdx::Tdx;
 use hvdef::hypercall::HvGvaRange;
 use inspect::Inspect;
-use parking_lot::Mutex;
-use parking_lot::MutexGuard;
 use safeatomic::AtomicSliceOps;
 use std::num::Wrapping;
 use std::sync::atomic::AtomicU32;
@@ -209,13 +207,6 @@ pub(super) struct AtomicTlbRingBuffer {
     /// The number of GVAs that have started being added to the list over the
     /// lifetime of the VM.
     in_progress_count: AtomicUsize,
-    /// A guard to ensure that only one thread is writing to the list at a time.
-    write_lock: Mutex<()>,
-}
-
-pub(super) struct AtomicTlbRingBufferWriteGuard<'a> {
-    buf: &'a AtomicTlbRingBuffer,
-    _write_lock: MutexGuard<'a, ()>,
 }
 
 impl AtomicTlbRingBuffer {
@@ -224,20 +215,11 @@ impl AtomicTlbRingBuffer {
             buffer: std::array::from_fn(|_| AtomicU64::new(0)),
             gva_list_count: AtomicUsize::new(0),
             in_progress_count: AtomicUsize::new(0),
-            write_lock: Mutex::new(()),
         }
     }
 
     fn count(&self) -> usize {
         self.gva_list_count.load(Ordering::Relaxed)
-    }
-
-    pub fn write(&self) -> AtomicTlbRingBufferWriteGuard<'_> {
-        let write_lock = self.write_lock.lock();
-        AtomicTlbRingBufferWriteGuard {
-            buf: self,
-            _write_lock: write_lock,
-        }
     }
 
     fn try_copy(&self, start_count: Wrapping<usize>, flush_addrs: &mut [u64]) -> bool {
@@ -257,14 +239,8 @@ impl AtomicTlbRingBuffer {
         }
         true
     }
-}
 
-impl AtomicTlbRingBufferWriteGuard<'_> {
     pub fn push(&self, v: u64) {
-        debug_assert_eq!(
-            self.buf.in_progress_count.load(Ordering::Relaxed),
-            self.buf.gva_list_count.load(Ordering::Relaxed)
-        );
         // Adding a new item to the buffer must be done in three steps:
         // 1. Indicate that an entry is about to be added so that any flush
         //    code executing simultaneously will know that it might lose an
@@ -272,9 +248,8 @@ impl AtomicTlbRingBufferWriteGuard<'_> {
         // 2. Add the entry.
         // 3. Increment the valid entry count so that any flush code executing
         //    simultaneously will know it is valid.
-        self.buf.in_progress_count.fetch_add(1, Ordering::Relaxed);
-        let count = self.buf.gva_list_count.load(Ordering::Relaxed);
-        self.buf.buffer[count % FLUSH_GVA_LIST_SIZE].store(v, Ordering::Relaxed);
-        self.buf.gva_list_count.store(count + 1, Ordering::Relaxed);
+        let index = self.in_progress_count.fetch_add(1, Ordering::Relaxed);
+        self.buffer[index % FLUSH_GVA_LIST_SIZE].store(v, Ordering::Relaxed);
+        self.gva_list_count.fetch_add(1, Ordering::Relaxed);
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -262,8 +262,8 @@ impl AtomicTlbRingBuffer {
 impl AtomicTlbRingBufferWriteGuard<'_> {
     pub fn extend(&self, items: impl ExactSizeIterator<Item = HvGvaRange>) {
         debug_assert_eq!(
-            self.buf.in_progress_count.load(Ordering::Acquire),
-            self.buf.gva_list_count.load(Ordering::Acquire)
+            self.buf.in_progress_count.load(Ordering::Relaxed),
+            self.buf.gva_list_count.load(Ordering::Relaxed)
         );
         // Adding a new item to the buffer must be done in three steps:
         // 1. Indicate that an entry is about to be added so that any flush

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -260,7 +260,7 @@ impl AtomicTlbRingBuffer {
 }
 
 impl AtomicTlbRingBufferWriteGuard<'_> {
-    pub fn extend(&self, items: impl ExactSizeIterator<Item = u64>) {
+    pub fn extend(&self, items: impl ExactSizeIterator<Item = HvGvaRange>) {
         debug_assert_eq!(
             self.buf.in_progress_count.load(Ordering::Relaxed),
             self.buf.gva_list_count.load(Ordering::Relaxed)
@@ -275,7 +275,7 @@ impl AtomicTlbRingBufferWriteGuard<'_> {
         let len = items.len();
         let count = self.buf.in_progress_count.fetch_add(len, Ordering::Relaxed);
         for (i, v) in items.enumerate() {
-            self.buf.buffer[(count + i) % FLUSH_GVA_LIST_SIZE].store(v, Ordering::Relaxed);
+            self.buf.buffer[(count + i) % FLUSH_GVA_LIST_SIZE].store(v.0, Ordering::Relaxed);
         }
         self.buf.gva_list_count.fetch_add(len, Ordering::Relaxed);
     }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -200,8 +200,8 @@ impl UhProcessor<'_, TdxBacked> {
 #[derive(Debug, Inspect)]
 pub(super) struct AtomicTlbRingBuffer {
     /// The contents of the buffer.
-    #[inspect(hex, iter_by_index)]
-    buffer: [AtomicU64; FLUSH_GVA_LIST_SIZE],
+    #[inspect(hex, with = "|x| inspect::iter_by_index(x.iter())")]
+    buffer: Box<[AtomicU64; FLUSH_GVA_LIST_SIZE]>,
     /// The number of GVAs that have been added over the lifetime of the VM.
     gva_list_count: AtomicUsize,
     /// The number of GVAs that have started being added to the list over the
@@ -212,7 +212,7 @@ pub(super) struct AtomicTlbRingBuffer {
 impl AtomicTlbRingBuffer {
     fn new() -> Self {
         Self {
-            buffer: std::array::from_fn(|_| AtomicU64::new(0)),
+            buffer: Box::new(std::array::from_fn(|_| AtomicU64::new(0))),
             gva_list_count: AtomicUsize::new(0),
             in_progress_count: AtomicUsize::new(0),
         }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/tlb_flush.rs
@@ -10,9 +10,14 @@ use hcl::ioctl::ProcessorRunner;
 use hcl::ioctl::tdx::Tdx;
 use hvdef::hypercall::HvGvaRange;
 use inspect::Inspect;
+use parking_lot::Mutex;
+use parking_lot::MutexGuard;
 use safeatomic::AtomicSliceOps;
-use std::collections::VecDeque;
 use std::num::Wrapping;
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use x86defs::tdx::TdGlaVmAndFlags;
 use x86defs::tdx::TdxGlaListInfo;
 use x86defs::tdx::TdxVmFlags;
@@ -24,38 +29,38 @@ pub(super) const FLUSH_GVA_LIST_SIZE: usize = 32;
 #[derive(Debug, Inspect)]
 pub(super) struct TdxPartitionFlushState {
     /// A fixed-size ring buffer of GVAs that need to be flushed.
-    #[inspect(hex, with = "|vd| inspect::iter_by_index(vd).map_value(|g| g.0)")]
-    pub(super) gva_list: VecDeque<HvGvaRange>,
-    pub(super) s: TdxFlushState,
+    pub(super) gva_list: AtomicTlbRingBuffer,
+    /// The number of times an entire TLB flush has been requested.
+    pub(super) flush_entire_counter: AtomicU32,
+    /// The number of times a non-global TLB flush has been requested.
+    pub(super) flush_entire_non_global_counter: AtomicU32,
 }
 
 #[cfg(guest_arch = "x86_64")]
 impl TdxPartitionFlushState {
     pub(super) fn new() -> Self {
         Self {
-            gva_list: VecDeque::with_capacity(FLUSH_GVA_LIST_SIZE),
-            s: TdxFlushState::new(),
+            gva_list: AtomicTlbRingBuffer::new(),
+            flush_entire_counter: AtomicU32::new(0),
+            flush_entire_non_global_counter: AtomicU32::new(0),
         }
     }
 }
 
 #[cfg(guest_arch = "x86_64")]
-#[derive(Debug, Clone, Inspect)]
+#[derive(Debug, Inspect)]
 pub(super) struct TdxFlushState {
-    /// On the partition, the number of GVAs that have been added over the lifetime of the VM.
-    /// On a VP, the last observed value of the partition's counter.
+    /// The last observed value of the partition's counter.
     /// If the difference between the partition's value and a VP's value is greater
-    /// than FLUSH_GVA_LIST_SIZE, then the VP has missed some GVAs and must flush
+    /// than [`FLUSH_GVA_LIST_SIZE`]`, then the VP has missed some GVAs and must flush
     /// the entire TLB.
-    pub(super) gva_list_count: Wrapping<usize>,
-    /// On the partition, the number of times an entire TLB flush has been requested.
-    /// On a VP, the last observed value of the partition's counter.
+    gva_list_count: Wrapping<usize>,
+    /// The last observed value of the partition's counter.
     /// If the values differ, the VP must flush the entire TLB.
-    pub(super) flush_entire_counter: Wrapping<u32>,
-    /// On the partition, the number of times a non-global TLB flush has been requested.
-    /// On a VP, the last observed value of the partition's counter.
+    flush_entire_counter: Wrapping<u32>,
+    /// The last observed value of the partition's counter.
     /// If the values differ, the VP must flush the non-global portion of the TLB.
-    pub(super) flush_entire_non_global_counter: Wrapping<u32>,
+    flush_entire_non_global_counter: Wrapping<u32>,
 }
 
 #[cfg(guest_arch = "x86_64")]
@@ -72,7 +77,7 @@ impl TdxFlushState {
 impl UhProcessor<'_, TdxBacked> {
     /// Completes any pending TLB flush activity on the current VP.
     pub(super) fn do_tlb_flush(&mut self, target_vtl: GuestVtl) {
-        let partition_flush_state = self.shared.flush_state[target_vtl].read();
+        let partition_flush_state = &self.shared.flush_state[target_vtl];
         let self_flush_state = &mut self.backing.vtls[target_vtl].flush_state;
 
         // NOTE: It is theoretically possible that we haven't run in so long
@@ -81,26 +86,33 @@ impl UhProcessor<'_, TdxBacked> {
         // unlikely that we don't bother to worry about it.
 
         // Check first to see whether a full flush is required.
-        let flush_entire_required = if self_flush_state.flush_entire_counter
-            != partition_flush_state.s.flush_entire_counter
-        {
-            true
-        }
-        // Attempt to perform a flush by list and promote to flush entire if required.
-        else {
-            !Self::try_flush_list(
-                target_vtl,
-                &partition_flush_state,
-                &mut self_flush_state.gva_list_count,
-                &mut self.runner,
-                &self.backing.flush_page,
-            )
-        };
+        let partition_flush_entire = partition_flush_state
+            .flush_entire_counter
+            .load(Ordering::Relaxed);
+        let flush_entire_required =
+            if partition_flush_entire != self_flush_state.flush_entire_counter.0 {
+                true
+            }
+            // Attempt to perform a flush by list and promote to flush entire if required.
+            else {
+                !Self::try_flush_list(
+                    target_vtl,
+                    partition_flush_state,
+                    &mut self_flush_state.gva_list_count,
+                    &mut self.runner,
+                    &self.backing.flush_page,
+                )
+            };
 
         // If a flush entire is required, then complete the flush and update the
         // flush counters to indicate that a complete flush has been accomplished.
+        let partition_flush_non_global = partition_flush_state
+            .flush_entire_non_global_counter
+            .load(Ordering::Relaxed);
         if flush_entire_required {
-            *self_flush_state = partition_flush_state.s.clone();
+            self_flush_state.flush_entire_counter = Wrapping(partition_flush_entire);
+            self_flush_state.flush_entire_non_global_counter = Wrapping(partition_flush_non_global);
+            self_flush_state.gva_list_count = Wrapping(partition_flush_state.gva_list.count());
             Self::set_flush_entire(
                 true,
                 &mut self.backing.vtls[target_vtl].private_regs.vp_entry_flags,
@@ -108,11 +120,8 @@ impl UhProcessor<'_, TdxBacked> {
         }
         // If no flush entire is required, then check to see whether a full
         // non-global flush is required.
-        else if self_flush_state.flush_entire_non_global_counter
-            != partition_flush_state.s.flush_entire_non_global_counter
-        {
-            self_flush_state.flush_entire_non_global_counter =
-                partition_flush_state.s.flush_entire_non_global_counter;
+        else if self_flush_state.flush_entire_non_global_counter.0 != partition_flush_non_global {
+            self_flush_state.flush_entire_non_global_counter = Wrapping(partition_flush_non_global);
             Self::set_flush_entire(
                 false,
                 &mut self.backing.vtls[target_vtl].private_regs.vp_entry_flags,
@@ -130,29 +139,33 @@ impl UhProcessor<'_, TdxBacked> {
         flush_page: &user_driver::memory::MemoryBlock,
     ) -> bool {
         // Check quickly to see whether any new addresses are in the list.
-        if partition_flush_state.s.gva_list_count == *gva_list_count {
+        let partition_list_count = Wrapping(partition_flush_state.gva_list.count());
+        if partition_list_count == *gva_list_count {
             return true;
         }
 
         // If the list has overflowed, then a flush entire is required.
-        let count_diff = (partition_flush_state.s.gva_list_count - *gva_list_count).0;
+        let count_diff = (partition_list_count - *gva_list_count).0;
         if count_diff > FLUSH_GVA_LIST_SIZE {
             return false;
         }
 
-        // The last `count_diff` addresses are the new ones.
-        let mut flush_addrs = partition_flush_state
+        // The last `count_diff` addresses are the new ones, copy them locally.
+        let flush_addrs = &mut [0; FLUSH_GVA_LIST_SIZE][..count_diff];
+        if !partition_flush_state
             .gva_list
-            .range(partition_flush_state.gva_list.len() - count_diff..);
+            .try_copy(*gva_list_count, flush_addrs)
+        {
+            return false;
+        }
 
         // Now we can build the TDX structs and actually call INVGLA.
         tracing::trace!(count = count_diff, ?target_vtl, "flushing TLB by list");
         let mut gla_flags = TdGlaVmAndFlags::new().with_vm_index(target_vtl as u64 + 1);
 
         if count_diff == 1 {
-            let gva_range = flush_addrs.next().unwrap();
             runner
-                .invgla(gla_flags, TdxGlaListInfo::from(gva_range.0))
+                .invgla(gla_flags, TdxGlaListInfo::from(flush_addrs[0]))
                 .unwrap();
         } else {
             gla_flags.set_list(true);
@@ -172,16 +185,96 @@ impl UhProcessor<'_, TdxBacked> {
             runner.invgla(gla_flags, gla_list).unwrap();
         };
 
-        *gva_list_count = partition_flush_state.s.gva_list_count;
+        *gva_list_count = partition_list_count;
         true
     }
 
     fn set_flush_entire(global: bool, vp_flags: &mut TdxVmFlags) {
         if global {
-            // TODO: Track EPT invalidations separately.
+            // TODO TDX: Track EPT invalidations separately.
             vp_flags.set_invd_translations(x86defs::tdx::TDX_VP_ENTER_INVD_INVEPT);
         } else if !global && vp_flags.invd_translations() == 0 {
             vp_flags.set_invd_translations(x86defs::tdx::TDX_VP_ENTER_INVD_INVVPID_NON_GLOBAL);
         }
+    }
+}
+
+#[derive(Debug, Inspect)]
+pub(super) struct AtomicTlbRingBuffer {
+    /// The contents of the buffer.
+    #[inspect(hex, iter_by_index)]
+    buffer: [AtomicU64; FLUSH_GVA_LIST_SIZE],
+    /// The number of GVAs that have been added over the lifetime of the VM.
+    gva_list_count: AtomicUsize,
+    /// The number of GVAs that have started being added to the list over the
+    /// lifetime of the VM.
+    in_progress_count: AtomicUsize,
+    /// A guard to ensure that only one thread is writing to the list at a time.
+    write_lock: Mutex<()>,
+}
+
+pub(super) struct AtomicTlbRingBufferWriteGuard<'a> {
+    buf: &'a AtomicTlbRingBuffer,
+    _write_lock: MutexGuard<'a, ()>,
+}
+
+impl AtomicTlbRingBuffer {
+    fn new() -> Self {
+        Self {
+            buffer: std::array::from_fn(|_| AtomicU64::new(0)),
+            gva_list_count: AtomicUsize::new(0),
+            in_progress_count: AtomicUsize::new(0),
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    fn count(&self) -> usize {
+        self.gva_list_count.load(Ordering::Relaxed)
+    }
+
+    pub fn write(&self) -> AtomicTlbRingBufferWriteGuard<'_> {
+        let write_lock = self.write_lock.lock();
+        AtomicTlbRingBufferWriteGuard {
+            buf: self,
+            _write_lock: write_lock,
+        }
+    }
+
+    fn try_copy(&self, start_count: Wrapping<usize>, flush_addrs: &mut [u64]) -> bool {
+        let mut index = start_count;
+        for flush_addr in flush_addrs.iter_mut() {
+            *flush_addr = self.buffer[index.0 % FLUSH_GVA_LIST_SIZE].load(Ordering::Relaxed);
+            index += 1;
+        }
+
+        // Check to see whether any additional entries have been added
+        // that would have caused a wraparound. If so, the local list is
+        // incomplete and the copy has failed.
+        if (Wrapping(self.in_progress_count.load(Ordering::Relaxed)) - start_count).0
+            > FLUSH_GVA_LIST_SIZE
+        {
+            return false;
+        }
+        true
+    }
+}
+
+impl AtomicTlbRingBufferWriteGuard<'_> {
+    pub fn push(&self, v: u64) {
+        debug_assert_eq!(
+            self.buf.in_progress_count.load(Ordering::Relaxed),
+            self.buf.gva_list_count.load(Ordering::Relaxed)
+        );
+        // Adding a new item to the buffer must be done in three steps:
+        // 1. Indicate that an entry is about to be added so that any flush
+        //    code executing simultaneously will know that it might lose an
+        //    entry that it is expecting to see.
+        // 2. Add the entry.
+        // 3. Increment the valid entry count so that any flush code executing
+        //    simultaneously will know it is valid.
+        self.buf.in_progress_count.fetch_add(1, Ordering::Relaxed);
+        let count = self.buf.gva_list_count.load(Ordering::Relaxed);
+        self.buf.buffer[count % FLUSH_GVA_LIST_SIZE].store(v, Ordering::Relaxed);
+        self.buf.gva_list_count.store(count + 1, Ordering::Relaxed);
     }
 }


### PR DESCRIPTION
This is based on the legacy HCL's, but slightly modified to fit our slightly different organization. Tested that a 128 VP TDX VM with VSM still boots and shuts down cleanly.

Closes #699 together with #1325.