### PR TITLE
vmbusproxy: Support saved state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8431,6 +8431,7 @@ dependencies = [
  "vmbus_core",
  "widestring",
  "windows 0.59.0",
+ "windows-sys 0.59.0",
  "zerocopy 0.8.24",
 ]
 

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1672,7 +1672,7 @@ impl InitializedVm {
             let hvsock_channel = HvsockRelayChannel::new();
             let saved_state_channel = SavedStateRelayChannel::new();
 
-            let (vtl2_vmbus, vtl2_request_send, vtl2_saved_state_recv) =
+            let (vtl2_vmbus, vtl2_request_send, _vtl2_saved_state_recv) =
                 if let Some(vtl2_vmbus_cfg) = cfg.vtl2_vmbus {
                     let (server_request_send, server_request_recv) = mesh::channel();
                     let vtl2_hvsock_channel = HvsockRelayChannel::new();
@@ -1730,6 +1730,7 @@ impl InitializedVm {
                         .vmbus_max_version
                         .map(vmbus_core::MaxVersionInfo::new),
                 )
+                .proxy_saved_state_notify(Some(saved_state_channel.server_half))
                 .delay_max_version(matches!(cfg.load_mode, LoadMode::Uefi { .. }))
                 .enable_mnf(true)
                 .build()
@@ -1751,7 +1752,7 @@ impl InitializedVm {
                             vmbus_server::ProxyServerInfo::new(
                                 server.control().clone(),
                                 None,
-                                vtl2_saved_state_recv,
+                                _vtl2_saved_state_recv,
                             )
                         }),
                         Some(&gm),

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1745,13 +1745,13 @@ impl InitializedVm {
                         vmbus_server::ProxyServerInfo::new(
                             vmbus.control(),
                             None,
-                            saved_state_channel.relay_half,
+                            Some(saved_state_channel.relay_half),
                         ),
                         vtl2_vmbus.as_ref().map(|server| {
                             vmbus_server::ProxyServerInfo::new(
                                 server.control().clone(),
                                 None,
-                                vtl2_saved_state_recv.unwrap(),
+                                vtl2_saved_state_recv,
                             )
                         }),
                         Some(&gm),

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -114,7 +114,6 @@ use vm_topology::processor::x86::X2ApicState;
 use vm_topology::processor::x86::X86Topology;
 use vmbus_channel::channel::VmbusDevice;
 use vmbus_server::HvsockRelayChannel;
-use vmbus_server::SavedStateRelayChannel;
 use vmbus_server::VmbusServer;
 use vmbus_server::hvsock::HvsockRelay;
 use vmcore::save_restore::SavedStateRoot;
@@ -1670,55 +1669,47 @@ impl InitializedVm {
 
             vmbus_redirect = vmbus_cfg.vtl2_redirect;
             let hvsock_channel = HvsockRelayChannel::new();
-            let saved_state_channel = SavedStateRelayChannel::new();
 
-            let (vtl2_vmbus, vtl2_request_send, _vtl2_saved_state_recv) =
-                if let Some(vtl2_vmbus_cfg) = cfg.vtl2_vmbus {
-                    let (server_request_send, server_request_recv) = mesh::channel();
-                    let vtl2_hvsock_channel = HvsockRelayChannel::new();
-                    let vtl2_saved_state_channel = SavedStateRelayChannel::new();
+            let (vtl2_vmbus, vtl2_request_send) = if let Some(vtl2_vmbus_cfg) = cfg.vtl2_vmbus {
+                let (server_request_send, server_request_recv) = mesh::channel();
+                let vtl2_hvsock_channel = HvsockRelayChannel::new();
 
-                    let vmbus_driver = driver_source.simple();
-                    let vtl2_vmbus = VmbusServer::builder(&vmbus_driver, synic.clone(), gm.clone())
-                        .vtl(Vtl::Vtl2)
-                        .max_version(
-                            vtl2_vmbus_cfg
-                                .vmbus_max_version
-                                .map(vmbus_core::MaxVersionInfo::new),
-                        )
-                        .hvsock_notify(Some(vtl2_hvsock_channel.server_half))
-                        .proxy_saved_state_notify(Some(vtl2_saved_state_channel.server_half))
-                        .external_requests(Some(server_request_recv))
-                        .enable_mnf(true)
-                        .build()
-                        .context("failed to create VTL2 vmbus server")?;
-
-                    let vtl2_vmbus = VmbusServerHandle::new(
-                        &vmbus_driver,
-                        state_units.add("vtl2_vmbus"),
-                        vtl2_vmbus,
+                let vmbus_driver = driver_source.simple();
+                let vtl2_vmbus = VmbusServer::builder(&vmbus_driver, synic.clone(), gm.clone())
+                    .vtl(Vtl::Vtl2)
+                    .max_version(
+                        vtl2_vmbus_cfg
+                            .vmbus_max_version
+                            .map(vmbus_core::MaxVersionInfo::new),
                     )
-                    .context("failed to add vmbus state unit")?;
+                    .hvsock_notify(Some(vtl2_hvsock_channel.server_half))
+                    .external_requests(Some(server_request_recv))
+                    .enable_mnf(true)
+                    .build()
+                    .context("failed to create VTL2 vmbus server")?;
 
-                    let relay = HvsockRelay::new(
-                        vmbus_driver,
-                        vtl2_vmbus.control().clone(),
-                        vtl2_hvsock_channel.relay_half,
-                        vtl2_vmbus_cfg.vsock_path.map(Into::into),
-                        vtl2_vmbus_cfg.vsock_listener,
-                    )
-                    .context("failed to create vtl2 hvsock relay")?;
+                let vtl2_vmbus = VmbusServerHandle::new(
+                    &vmbus_driver,
+                    state_units.add("vtl2_vmbus"),
+                    vtl2_vmbus,
+                )
+                .context("failed to add vmbus state unit")?;
 
-                    vtl2_hvsock_relay = Some(relay);
+                let relay = HvsockRelay::new(
+                    vmbus_driver,
+                    vtl2_vmbus.control().clone(),
+                    vtl2_hvsock_channel.relay_half,
+                    vtl2_vmbus_cfg.vsock_path.map(Into::into),
+                    vtl2_vmbus_cfg.vsock_listener,
+                )
+                .context("failed to create vtl2 hvsock relay")?;
 
-                    (
-                        Some(vtl2_vmbus),
-                        Some(server_request_send),
-                        Some(vtl2_saved_state_channel.relay_half),
-                    )
-                } else {
-                    (None, None, None)
-                };
+                vtl2_hvsock_relay = Some(relay);
+
+                (Some(vtl2_vmbus), Some(server_request_send))
+            } else {
+                (None, None)
+            };
 
             let vmbus_driver = driver_source.simple();
             let vmbus = VmbusServer::builder(&vmbus_driver, synic.clone(), gm.clone())
@@ -1730,7 +1721,6 @@ impl InitializedVm {
                         .vmbus_max_version
                         .map(vmbus_core::MaxVersionInfo::new),
                 )
-                .proxy_saved_state_notify(Some(saved_state_channel.server_half))
                 .delay_max_version(matches!(cfg.load_mode, LoadMode::Uefi { .. }))
                 .enable_mnf(true)
                 .build()
@@ -1743,17 +1733,9 @@ impl InitializedVm {
                     vmbus_server::ProxyIntegration::start(
                         &vmbus_driver,
                         proxy_handle,
-                        vmbus_server::ProxyServerInfo::new(
-                            vmbus.control(),
-                            None,
-                            Some(saved_state_channel.relay_half),
-                        ),
+                        vmbus_server::ProxyServerInfo::new(vmbus.control(), None, None),
                         vtl2_vmbus.as_ref().map(|server| {
-                            vmbus_server::ProxyServerInfo::new(
-                                server.control().clone(),
-                                None,
-                                _vtl2_saved_state_recv,
-                            )
+                            vmbus_server::ProxyServerInfo::new(server.control().clone(), None, None)
                         }),
                         Some(&gm),
                     )

--- a/vm/devices/vmbus/vmbus_proxy/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_proxy/Cargo.toml
@@ -25,6 +25,7 @@ windows = { workspace = true, features = [
     "Win32_System_IO",
     "Win32_System_Ioctl"
 ] }
+windows-sys.workspace = true
 zerocopy.workspace = true
 [lints]
 workspace = true

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -266,6 +266,24 @@ impl VmbusProxy {
         NTSTATUS(output.Status).ok()
     }
 
+    pub async fn restore(
+        &self,
+        id: u64,
+        params: &VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
+    ) -> Result<()> {
+        unsafe {
+            self.ioctl(
+                proxyioctl::IOCTL_VMBUS_PROXY_RESTORE_CHANNEL,
+                StaticIoctlBuffer(proxyioctl::VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
+                    ChannelId: id,
+                    OpenParameters: *params,
+                }),
+                (),
+            )
+            .await
+        }
+    }
+
     pub async fn close(&self, id: u64) -> Result<()> {
         unsafe {
             self.ioctl(

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -267,37 +267,37 @@ impl VmbusProxy {
         NTSTATUS(output.Status).ok()
     }
 
-    pub async fn restore(&self, id: u64) -> Result<()> {
-        unsafe {
-            self.ioctl(
-                proxyioctl::IOCTL_VMBUS_PROXY_RESTORE_CHANNEL,
-                StaticIoctlBuffer(proxyioctl::VMBUS_PROXY_RESTORE_CHANNEL_INPUT { ChannelId: id }),
-                (),
-            )
-            .await
-        }
-    }
-
-    pub async fn restore_state(
+    pub async fn restore(
         &self,
-        id: u64,
         interface_type: GUID,
         interface_instance: GUID,
         subchannel_index: u16,
         open_params: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
         open: bool,
-    ) -> Result<()> {
-        unsafe {
+    ) -> Result<u64> {
+        Ok(unsafe {
             self.ioctl(
-                proxyioctl::IOCTL_VMBUS_PROXY_RESTORE_STATE,
-                StaticIoctlBuffer(proxyioctl::VMBUS_PROXY_RESTORE_STATE_INPUT {
-                    ChannelId: id,
+                proxyioctl::IOCTL_VMBUS_PROXY_RESTORE_CHANNEL,
+                StaticIoctlBuffer(proxyioctl::VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
                     InterfaceType: interface_type,
                     InterfaceInstance: interface_instance,
                     SubchannelIndex: subchannel_index,
                     OpenParameters: open_params,
                     Open: open,
                 }),
+                StaticIoctlBuffer(zeroed::<proxyioctl::VMBUS_PROXY_RESTORE_CHANNEL_OUTPUT>()),
+            )
+            .await?
+            .0
+            .ChannelId
+        })
+    }
+
+    pub async fn revoke_unclaimed_channels(&self) -> Result<()> {
+        unsafe {
+            self.ioctl(
+                proxyioctl::IOCTL_VMBUS_PROXY_REVOKE_UNCLAIMED_CHANNELS,
+                (),
                 (),
             )
             .await

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -266,6 +266,21 @@ impl VmbusProxy {
         };
         NTSTATUS(output.Status).ok()
     }
+    pub async fn set_interrupt(&self, id: u64, event: &Event) -> Result<()> {
+        unsafe {
+            let handle = event.as_handle().as_raw_handle() as usize as u64;
+            self.ioctl(
+                proxyioctl::IOCTL_VMBUS_PROXY_SET_INTERRUPT,
+                StaticIoctlBuffer(proxyioctl::VMBUS_PROXY_SET_INTERRUPT_INPUT {
+                    ChannelId: id,
+                    VmmSignalEvent: handle,
+                }),
+                (),
+            )
+            .await?
+        };
+        Ok(())
+    }
 
     pub async fn restore(
         &self,

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -18,6 +18,7 @@ use windows::Win32::System::Ioctl::FILE_READ_ACCESS;
 use windows::Win32::System::Ioctl::FILE_WRITE_ACCESS;
 use windows::Win32::System::Ioctl::METHOD_BUFFERED;
 use windows::core::GUID;
+use windows_sys::Win32::Foundation::BOOLEAN;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
 
@@ -48,7 +49,7 @@ pub const IOCTL_VMBUS_PROXY_SET_VID_HANDLE: u32 = VMBUS_PROXY_IOCTL(0xb);
 pub const IOCTL_VMBUS_PROXY_TL_CONNECT_REQUEST: u32 = VMBUS_PROXY_IOCTL(0xc);
 pub const IOCTL_VMBUS_PROXY_RESTORE_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0xd);
 pub const IOCTL_VMBUS_PROXY_REVOKE_UNCLAIMED_CHANNELS: u32 = VMBUS_PROXY_IOCTL(0xe);
-pub const IOCTL_VMBUS_PROXY_SET_INTERRUPT: u32 = VMBUS_PROXY_IOCTL(0xf);
+pub const IOCTL_VMBUS_PROXY_RESTORE_SET_INTERRUPT: u32 = VMBUS_PROXY_IOCTL(0xf);
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -82,7 +83,7 @@ pub const VmbusProxyActionTypeTlConnectResult: u32 = 4;
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_NEXT_ACTION_OUTPUT {
     pub Type: u32,
-    pub ChannelId: u64,
+    pub ProxyId: u64,
     pub u: VMBUS_PROXY_NEXT_ACTION_OUTPUT_union,
 }
 
@@ -113,7 +114,7 @@ pub struct VMBUS_PROXY_NEXT_ACTION_OUTPUT_union_TlConnectResult {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_OPEN_CHANNEL_INPUT {
-    pub ChannelId: u64,
+    pub ProxyId: u64,
     pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
     pub VmmSignalEvent: u64, // BUGBUG: HANDLE
 }
@@ -121,7 +122,7 @@ pub struct VMBUS_PROXY_OPEN_CHANNEL_INPUT {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_SET_INTERRUPT_INPUT {
-    pub ChannelId: u64,
+    pub ProxyId: u64,
     pub VmmSignalEvent: u64, // BUGBUG: HANDLE
 }
 
@@ -138,24 +139,24 @@ pub struct VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
     pub InterfaceInstance: GUID,
     pub SubchannelIndex: u16,
     pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
-    pub Open: bool,
+    pub Open: BOOLEAN,
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_RESTORE_CHANNEL_OUTPUT {
-    pub ChannelId: u64,
+    pub ProxyId: u64,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_CLOSE_CHANNEL_INPUT {
-    pub ChannelId: u64,
+    pub ProxyId: u64,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, IntoBytes, Immutable)]
 pub struct VMBUS_PROXY_CREATE_GPADL_INPUT {
-    pub ChannelId: u64,
+    pub ProxyId: u64,
     pub GpadlId: u32,
     pub RangeCount: u32,
     pub RangeBufferOffset: u32,
@@ -165,20 +166,20 @@ pub struct VMBUS_PROXY_CREATE_GPADL_INPUT {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_DELETE_GPADL_INPUT {
-    pub ChannelId: u64,
+    pub ProxyId: u64,
     pub GpadlId: u32,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_RELEASE_CHANNEL_INPUT {
-    pub ChannelId: u64,
+    pub ProxyId: u64,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_RUN_CHANNEL_INPUT {
-    pub ChannelId: u64,
+    pub ProxyId: u64,
 }
 
 #[bitfield(u32)]

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -46,6 +46,7 @@ pub const IOCTL_VMBUS_PROXY_RELEASE_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0x9);
 pub const IOCTL_VMBUS_PROXY_RUN_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0xa);
 pub const IOCTL_VMBUS_PROXY_SET_VID_HANDLE: u32 = VMBUS_PROXY_IOCTL(0xb);
 pub const IOCTL_VMBUS_PROXY_TL_CONNECT_REQUEST: u32 = VMBUS_PROXY_IOCTL(0xc);
+pub const IOCTL_VMBUS_PROXY_RESTORE_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0xd);
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -119,6 +120,13 @@ pub struct VMBUS_PROXY_OPEN_CHANNEL_INPUT {
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_OPEN_CHANNEL_OUTPUT {
     pub Status: i32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
+    pub ChannelId: u64,
+    pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
 }
 
 #[repr(C)]

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -48,6 +48,7 @@ pub const IOCTL_VMBUS_PROXY_SET_VID_HANDLE: u32 = VMBUS_PROXY_IOCTL(0xb);
 pub const IOCTL_VMBUS_PROXY_TL_CONNECT_REQUEST: u32 = VMBUS_PROXY_IOCTL(0xc);
 pub const IOCTL_VMBUS_PROXY_RESTORE_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0xd);
 pub const IOCTL_VMBUS_PROXY_REVOKE_UNCLAIMED_CHANNELS: u32 = VMBUS_PROXY_IOCTL(0xe);
+pub const IOCTL_VMBUS_PROXY_SET_INTERRUPT: u32 = VMBUS_PROXY_IOCTL(0xf);
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -114,6 +115,13 @@ pub struct VMBUS_PROXY_NEXT_ACTION_OUTPUT_union_TlConnectResult {
 pub struct VMBUS_PROXY_OPEN_CHANNEL_INPUT {
     pub ChannelId: u64,
     pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
+    pub VmmSignalEvent: u64, // BUGBUG: HANDLE
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_SET_INTERRUPT_INPUT {
+    pub ChannelId: u64,
     pub VmmSignalEvent: u64, // BUGBUG: HANDLE
 }
 

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -47,6 +47,7 @@ pub const IOCTL_VMBUS_PROXY_RUN_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0xa);
 pub const IOCTL_VMBUS_PROXY_SET_VID_HANDLE: u32 = VMBUS_PROXY_IOCTL(0xb);
 pub const IOCTL_VMBUS_PROXY_TL_CONNECT_REQUEST: u32 = VMBUS_PROXY_IOCTL(0xc);
 pub const IOCTL_VMBUS_PROXY_RESTORE_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0xd);
+pub const IOCTL_VMBUS_PROXY_RESTORE_STATE: u32 = VMBUS_PROXY_IOCTL(0xe);
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -126,7 +127,17 @@ pub struct VMBUS_PROXY_OPEN_CHANNEL_OUTPUT {
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
     pub ChannelId: u64,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_RESTORE_STATE_INPUT {
+    pub ChannelId: u64,
+    pub InterfaceType: GUID,
+    pub InterfaceInstance: GUID,
+    pub SubchannelIndex: u16,
     pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
+    pub Open: bool,
 }
 
 #[repr(C)]

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -47,7 +47,7 @@ pub const IOCTL_VMBUS_PROXY_RUN_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0xa);
 pub const IOCTL_VMBUS_PROXY_SET_VID_HANDLE: u32 = VMBUS_PROXY_IOCTL(0xb);
 pub const IOCTL_VMBUS_PROXY_TL_CONNECT_REQUEST: u32 = VMBUS_PROXY_IOCTL(0xc);
 pub const IOCTL_VMBUS_PROXY_RESTORE_CHANNEL: u32 = VMBUS_PROXY_IOCTL(0xd);
-pub const IOCTL_VMBUS_PROXY_RESTORE_STATE: u32 = VMBUS_PROXY_IOCTL(0xe);
+pub const IOCTL_VMBUS_PROXY_REVOKE_UNCLAIMED_CHANNELS: u32 = VMBUS_PROXY_IOCTL(0xe);
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -126,18 +126,16 @@ pub struct VMBUS_PROXY_OPEN_CHANNEL_OUTPUT {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
-    pub ChannelId: u64,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct VMBUS_PROXY_RESTORE_STATE_INPUT {
-    pub ChannelId: u64,
     pub InterfaceType: GUID,
     pub InterfaceInstance: GUID,
     pub SubchannelIndex: u16,
     pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
     pub Open: bool,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VMBUS_PROXY_RESTORE_CHANNEL_OUTPUT {
+    pub ChannelId: u64,
 }
 
 #[repr(C)]

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -321,7 +321,8 @@ pub struct SavedState {
 }
 
 impl SavedState {
-    pub fn contains_channel(
+    /// Returns true if the channel is in the SavedState and was not saved closed.
+    pub fn contains_channel_to_restore(
         &self,
         interface_id: Guid,
         instance_id: Guid,
@@ -336,7 +337,7 @@ impl SavedState {
                         && c.key.subchannel_index == subchannel_index
                 })
             })
-            .is_some()
+            .is_some_and(|c| !matches!(c.unwrap().state, ChannelState::Closed))
     }
 
     pub fn channels_iter(&self) -> Option<std::slice::Iter<'_, Channel>> {

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -641,10 +641,6 @@ impl Channel {
         matches!(self.state, ChannelState::Open { .. })
     }
 
-    pub fn saved_closed(&self) -> bool {
-        matches!(self.state, ChannelState::Closed)
-    }
-
     pub fn key(&self) -> OfferKey {
         self.key
     }

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -1092,6 +1092,7 @@ pub struct Gpadl {
 
 impl Gpadl {
     fn save(gpadl_id: GpadlId, channel_id: ChannelId, gpadl: &super::Gpadl) -> Option<Self> {
+        tracing::info!(id = %gpadl_id.0, channel_id = %channel_id.0, "gpadl saved");
         Some(Gpadl {
             id: gpadl_id.0,
             channel_id: channel_id.0,

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -320,6 +320,26 @@ pub struct SavedState {
     pending_messages: Vec<OutgoingMessage>,
 }
 
+impl SavedState {
+    pub fn contains_channel(
+        &self,
+        interface_id: Guid,
+        instance_id: Guid,
+        subchannel_index: u16,
+    ) -> bool {
+        self.state
+            .as_ref()
+            .map(|s| {
+                s.channels.iter().find(|c| {
+                    c.key.instance_id == instance_id
+                        && c.key.interface_id == interface_id
+                        && c.key.subchannel_index == subchannel_index
+                })
+            })
+            .is_some()
+    }
+}
+
 #[derive(Debug, Clone, Protobuf)]
 #[mesh(package = "vmbus.server.channels")]
 struct ConnectedState {

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -170,14 +170,17 @@ impl<'a, N: 'a + Notifier> super::ServerWithNotifier<'a, N> {
     /// Restores state.
     ///
     /// This may be called before or after channels have been offered. After
-    /// calling this routine, [`super::ServerWithNotifier::restore_channel`] should be
+    /// calling this routine, [`restore_channel`] should be
     /// called for each channel to be restored, possibly interleaved with
     /// additional calls to offer or revoke channels.
     ///
     /// Once all channels are in the appropriate state,
-    /// [`super::ServerWithNotifier::revoke_unclaimed_channels`] should be called. This will revoke
+    /// [`revoke_unclaimed_channels`] should be called. This will revoke
     /// any channels that were in the saved state but were not restored via
-    /// `restore_channel`.
+    /// [`restore_channel`].
+    ///
+    /// [`revoke_unclaimed_channels`]: super::ServerWithNotifier::revoke_unclaimed_channels
+    /// [`restore_channel`]: super::ServerWithNotifier::restore_channel
     pub fn restore(&mut self, saved: SavedState) -> Result<(), RestoreError> {
         tracing::trace!(?saved, "restoring channel state");
 

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -9,7 +9,7 @@ pub mod channels;
 pub mod event;
 pub mod hvsock;
 mod monitor;
-mod proxyintegration;
+pub mod proxyintegration;
 
 /// The GUID type used for vmbus channel identifiers.
 pub type Guid = guid::Guid;
@@ -122,7 +122,7 @@ pub struct VmbusServerBuilder<'a, T: Spawn> {
     vtl: Vtl,
     hvsock_notify: Option<HvsockServerChannelHalf>,
     server_relay: Option<VmbusServerChannelHalf>,
-    saved_state_notify: Option<mesh::Sender<Option<channels::SavedState>>>,
+    saved_state_notify: Option<mesh::Sender<proxyintegration::SavedStateRequest>>,
     external_server: Option<mesh::Sender<InitiateContactRequest>>,
     external_requests: Option<mesh::Receiver<InitiateContactRequest>>,
     use_message_redirect: bool,
@@ -305,7 +305,7 @@ impl<'a, T: Spawn> VmbusServerBuilder<'a, T> {
     /// Sets a send channel used to enlighten ProxyIntegration about saved channels.
     pub fn saved_state_notify(
         mut self,
-        saved_state_notify: Option<mesh::Sender<Option<channels::SavedState>>>,
+        saved_state_notify: Option<mesh::Sender<proxyintegration::SavedStateRequest>>,
     ) -> Self {
         self.saved_state_notify = saved_state_notify;
         self
@@ -650,7 +650,7 @@ struct ServerTaskInner {
     message_port: Box<dyn GuestMessagePort>,
     hvsock_requests: usize,
     hvsock_send: mesh::Sender<HvsockConnectRequest>,
-    saved_state_notify: Option<mesh::Sender<Option<channels::SavedState>>>,
+    saved_state_notify: Option<mesh::Sender<proxyintegration::SavedStateRequest>>,
     channels: HashMap<OfferId, Channel>,
     channel_responses: FuturesUnordered<
         Pin<Box<dyn Send + Future<Output = (OfferId, u64, Result<ChannelResponse, RpcError>)>>>,
@@ -927,7 +927,7 @@ impl ServerTask {
         Ok(result)
     }
 
-    fn handle_request(&mut self, request: VmbusRequest) {
+    async fn handle_request(&mut self, request: VmbusRequest) {
         tracing::debug!(?request, "handle_request");
         match request {
             VmbusRequest::Reset(rpc) => self.handle_reset(rpc),
@@ -961,17 +961,32 @@ impl ServerTask {
                 server: self.server.save(),
                 lost_synic_bug_fixed: true,
             }),
-            VmbusRequest::Restore(rpc) => rpc.handle_sync(|state| {
-                self.unstick_on_start = !state.lost_synic_bug_fixed;
-                if let Some(sender) = self.inner.saved_state_notify.as_ref() {
-                    tracing::trace!("sending saved state to proxy");
-                    sender.send(Some(state.server.clone()));
-                }
+            VmbusRequest::Restore(rpc) => {
+                rpc.handle(async |state: SavedState| {
+                    self.unstick_on_start = !state.lost_synic_bug_fixed;
+                    if let Some(sender) = &self.inner.saved_state_notify {
+                        tracing::trace!("sending saved state to proxy");
+                        if let Err(err) = sender
+                            .call_failable(
+                                proxyintegration::SavedStateRequest::Set,
+                                state.server.clone(),
+                            )
+                            .await
+                        {
+                            tracing::error!(
+                                err = &err as &dyn std::error::Error,
+                                "failed to restore proxy saved state"
+                            );
+                            return Err(RestoreError::ServerError(err.into()));
+                        }
+                    }
 
-                self.server
-                    .with_notifier(&mut self.inner)
-                    .restore(state.server)
-            }),
+                    self.server
+                        .with_notifier(&mut self.inner)
+                        .restore(state.server)
+                })
+                .await
+            }
             VmbusRequest::Stop(rpc) => rpc.handle_sync(|()| {
                 if self.inner.running {
                     self.inner.running = false;
@@ -984,7 +999,16 @@ impl ServerTask {
                         // Indicate to the proxy that the server is starting and that it should
                         // clear its saved state cache.
                         tracing::trace!("sending clear saved state message to proxy");
-                        sender.send(None);
+                        if let Err(err) = sender
+                            .call(proxyintegration::SavedStateRequest::Clear, ())
+                            .await
+                        {
+                            tracing::warn!(
+                                err = &err as &dyn std::error::Error,
+                                "failed to clear proxy saved state"
+                            );
+                            self.inner.saved_state_notify = None;
+                        }
                     }
 
                     self.server
@@ -1111,7 +1135,7 @@ impl ServerTask {
             futures::select! { // merge semantics
                 r = self.task_recv.recv().fuse() => {
                     if let Ok(request) = r {
-                        self.handle_request(request);
+                        self.handle_request(request).await;
                     } else {
                         break;
                     }

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1003,13 +1003,10 @@ impl ServerTask {
                         // Indicate to the proxy that the server is starting and that it should
                         // clear its saved state cache.
                         tracing::trace!("sending clear saved state message to proxy");
-                        if let Err(err) = sender.call(SavedStateRequest::Clear, ()).await {
-                            tracing::warn!(
-                                err = &err as &dyn std::error::Error,
-                                "failed to clear proxy saved state"
-                            );
-                            self.inner.saved_state_notify = None;
-                        }
+                        sender
+                            .call(SavedStateRequest::Clear, ())
+                            .await
+                            .expect("failed to clear proxy saved state");
                     }
 
                     self.server

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1007,9 +1007,9 @@ impl ServerTask {
                         sender.send(None);
                     }
 
-                    // self.server
-                    //     .with_notifier(&mut self.inner)
-                    //     .revoke_unclaimed_channels();
+                    self.server
+                        .with_notifier(&mut self.inner)
+                        .revoke_unclaimed_channels();
                     if self.unstick_on_start {
                         tracing::info!(
                             "lost synic bug fix is not in yet, call unstick_channels to mitigate the issue."

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -984,6 +984,7 @@ impl ServerTask {
             VmbusRequest::Restore(rpc) => rpc.handle_sync(|state| {
                 self.unstick_on_start = !state.lost_synic_bug_fixed;
                 if let Some(sender) = self.inner.saved_state_send.as_ref() {
+                    tracing::trace!("sending saved state to proxy");
                     sender.send(Some(state.server.clone()));
                 }
 
@@ -1002,12 +1003,13 @@ impl ServerTask {
                     if let Some(sender) = self.inner.saved_state_send.as_ref() {
                         // Indicate to the proxy that the server is starting and that it should
                         // clear its saved state cache.
+                        tracing::trace!("sending clear saved state message to proxy");
                         sender.send(None);
                     }
 
-                    self.server
-                        .with_notifier(&mut self.inner)
-                        .revoke_unclaimed_channels();
+                    // self.server
+                    //     .with_notifier(&mut self.inner)
+                    //     .revoke_unclaimed_channels();
                     if self.unstick_on_start {
                         tracing::info!(
                             "lost synic bug fix is not in yet, call unstick_channels to mitigate the issue."


### PR DESCRIPTION
This PR integrates the `vmbus_server` saved state support with `proxyintegration`. Previously, `proxyintegration` and vmbusproxy had no concept of save and restore, and their respective states were completely reconstructed from scratch on each start.

On start, if using the proxy, the server sends its saved state to the proxy integration, which in turn repopulates the saved channels and GPADLs in vmbusproxy. On start, the saved state is cleared.

- Create a new mesh channel in `vmbus_server` and `proxyintegration` which allows the server to send and clear saved state to the proxy.
- On receive of the saved state, create skeleton channels in vmbusproxy with their GPADLs to be later claimed by a device.
- On receiving an offer from vmbusproxy, send `ChannelServerRequest::Restore  to the server to restore that channel with the interrupt received from vmbusproxy.
- On start, tell vmbusproxy to revoke all the unclaimed channels it has in its list.
- Introduce various new IOCTLs to accomplish the above.
- Introduce new functions in vmbus `SavedState` to allow the proxy to inspect the `SavedState`.

This PR also fixes a panic related to the Cancel changes in proxyintegration.