### PR TITLE
openhcl_boot: improve panic output

### DIFF
--- a/openhcl/openhcl_boot/src/arch/x86_64/hypercall.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/hypercall.rs
@@ -24,7 +24,11 @@ fn write_hypercall_msr(enable: bool) {
 
     let hypercall_page_num = addr_of!(HYPERCALL_PAGE) as u64 / HV_PAGE_SIZE;
 
-    assert!(!enable || !hypercall_contents.enable());
+    assert!(
+        !enable || !hypercall_contents.enable(),
+        "{:?}",
+        hypercall_contents
+    );
     let new_hv_contents = hypercall_contents.with_enable(enable).with_gpn(if enable {
         hypercall_page_num
     } else {

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -583,6 +583,9 @@ fn get_ref_time(isolation: IsolationType) -> Option<u64> {
 
 fn shim_main(shim_params_raw_offset: isize) -> ! {
     let p = shim_parameters(shim_params_raw_offset);
+    if p.isolation_type == IsolationType::None {
+        enable_enlightened_panic();
+    }
 
     // The support code for the fast hypercalls does not set
     // the Guest ID if it is not set yet as opposed to the slow
@@ -599,9 +602,6 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
     // provisions for the hardware-isolated case.
     if !p.isolation_type.is_hardware_isolated() {
         hvcall().initialize();
-        if p.isolation_type == IsolationType::None {
-            enable_enlightened_panic();
-        }
     }
 
     // Enable early log output if requested in the static command line.

--- a/openhcl/openhcl_boot/src/rt.rs
+++ b/openhcl/openhcl_boot/src/rt.rs
@@ -49,7 +49,7 @@ mod instead_of_builtins {
     fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
         crate::boot_logger::log!("{panic}");
         // The stack is identity mapped.
-        minimal_rt::enlightened_panic::report(panic, |va| Some(va as usize));
+        minimal_rt::enlightened_panic::report(*b"OHCLBOOT", panic, |va| Some(va as usize));
         minimal_rt::arch::fault();
     }
 }

--- a/openhcl/sidecar/src/arch/x86_64/mod.rs
+++ b/openhcl/sidecar/src/arch/x86_64/mod.rs
@@ -196,7 +196,7 @@ fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
             .offset_of(ptr as u64)
             .map(|offset| addr_space::stack_base_pa() + offset as usize)
     };
-    minimal_rt::enlightened_panic::report(panic, stack_va_to_pa);
+    minimal_rt::enlightened_panic::report(*b"SIDECARK", panic, stack_va_to_pa);
     if !AFTER_INIT.load(Acquire) {
         let _ = writeln!(Serial::new(InstrIoAccess), "{panic}");
     }


### PR DESCRIPTION
* Enable panic messages early in boot.
* Include the panicking component's identity in the panic message (openhcl-boot vs sidecar)
* Add more context for one of the possible early panics.
