### PR TITLE
partition_unit: consistently scrub VTL2 during VTL2 servicing

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -492,7 +492,7 @@ pub enum IsolationType {
 }
 
 /// Flags controlling servicing behavior.
-#[derive(Default)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct OpenHclServicingFlags {
     /// Preserve DMA memory for NVMe devices if supported.
     pub enable_nvme_keepalive: bool,

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -213,7 +213,7 @@ impl PetriVmOpenVmm {
         /// Restarts OpenHCL.
         pub async fn restart_openhcl(
             &mut self,
-            new_openhcl: ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
+            new_openhcl: &ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
             flags: OpenHclServicingFlags
         ) -> anyhow::Result<()>
     );
@@ -425,7 +425,7 @@ impl PetriVmInner {
 
     async fn restart_openhcl(
         &self,
-        new_openhcl: ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
+        new_openhcl: &ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
         flags: OpenHclServicingFlags,
     ) -> anyhow::Result<()> {
         let ged_send = self

--- a/vmm_core/src/partition_unit.rs
+++ b/vmm_core/src/partition_unit.rs
@@ -473,6 +473,7 @@ impl PartitionUnitRunner {
 
     fn try_start(&mut self) {
         if self.unit_started && self.halt_reason.is_none() && self.vp_stop_count == 0 {
+            self.needs_reset = true;
             self.vp_set.start();
         }
     }
@@ -490,7 +491,6 @@ impl Drop for StopGuard {
 impl StateUnit for PartitionUnitRunner {
     async fn start(&mut self) {
         self.unit_started = true;
-        self.needs_reset = true;
         self.try_start();
     }
 

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -138,12 +138,12 @@ where
             VpHaltReason::TripleFault { vtl } => {
                 let registers = self.vp.access_state(vtl).registers().ok().map(Arc::new);
 
+                tracing::error!(?vtl, vp = self.vp_index.index(), "triple fault");
                 self.trace_fault(
                     vtl,
                     vtl_guest_memory[vtl as usize].as_ref(),
                     registers.as_deref(),
                 );
-                tracing::error!(?vtl, "triple fault");
                 Err(HaltReason::TripleFault {
                     vp: self.vp_index.index(),
                     registers,
@@ -337,10 +337,31 @@ where
             efer,
         } = *registers;
         tracing::error!(
-            rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi, r8, r9, r10, r11, r12, r13, r14, r15, rip,
+            vp = self.vp_index.index(),
+            ?vtl,
+            rax,
+            rcx,
+            rdx,
+            rbx,
+            rsp,
+            rbp,
+            rsi,
+            rdi,
+            r8,
+            r9,
+            r10,
+            r11,
+            r12,
+            r13,
+            r14,
+            r15,
+            rip,
             rflags,
+            "triple fault register state",
         );
         tracing::error!(
+            ?vtl,
+            vp = self.vp_index.index(),
             ?cs,
             ?ds,
             ?es,
@@ -357,6 +378,7 @@ where
             cr4,
             cr8,
             efer,
+            "triple fault system register state",
         );
 
         #[cfg(feature = "gdb")]

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -464,6 +464,8 @@ impl virt::ScrubVtl for WhpPartition {
         assert!(!self.inner.isolation.is_isolated());
         assert_eq!(vtl, Vtl::Vtl2);
 
+        tracing::info!(?vtl, "scrubbing partition");
+
         let vtl2 = self.inner.vtl2.as_ref().ok_or(Error::NoVtl2)?;
 
         // Preserve VTL2 reference time across the scrub to match hypervisor

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -102,7 +102,7 @@ async fn mana_nic_servicing(
 
     validate_mana_nic(&agent).await?;
 
-    vm.restart_openhcl(igvm_file, OpenHclServicingFlags::default())
+    vm.restart_openhcl(&igvm_file, OpenHclServicingFlags::default())
         .await?;
 
     validate_mana_nic(&agent).await?;

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
@@ -36,7 +36,7 @@ async fn openhcl_servicing_core(
         // Test that inspect serialization works with the old version.
         vm.test_inspect_openhcl().await?;
 
-        vm.restart_openhcl(new_openhcl, flags).await?;
+        vm.restart_openhcl(&new_openhcl, flags).await?;
 
         agent.ping().await?;
 
@@ -123,7 +123,7 @@ async fn openhcl_servicing_shutdown_ic(
     cmd!(sh, "ls /dev/sda").run().await?;
 
     let shutdown_ic = vm.wait_for_enlightened_shutdown_ready().await?;
-    vm.restart_openhcl(igvm_file, OpenHclServicingFlags::default())
+    vm.restart_openhcl(&igvm_file, OpenHclServicingFlags::default())
         .await?;
     // VTL2 will disconnect and then reconnect the shutdown IC across a servicing event.
     tracing::info!("waiting for shutdown IC to close");

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_servicing.rs
@@ -30,17 +30,19 @@ async fn openhcl_servicing_core(
         .run()
         .await?;
 
-    agent.ping().await?;
+    for _ in 0..3 {
+        agent.ping().await?;
 
-    // Test that inspect serialization works with the old version.
-    vm.test_inspect_openhcl().await?;
+        // Test that inspect serialization works with the old version.
+        vm.test_inspect_openhcl().await?;
 
-    vm.restart_openhcl(new_openhcl, flags).await?;
+        vm.restart_openhcl(new_openhcl, flags).await?;
 
-    agent.ping().await?;
+        agent.ping().await?;
 
-    // Test that inspect serialization works with the new version.
-    vm.test_inspect_openhcl().await?;
+        // Test that inspect serialization works with the new version.
+        vm.test_inspect_openhcl().await?;
+    }
 
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_uefi.rs
@@ -52,7 +52,7 @@ async fn nvme_relay_servicing_core(
     // Test that inspect serialization works with the old version.
     vm.test_inspect_openhcl().await?;
 
-    vm.restart_openhcl(new_openhcl, flags).await?;
+    vm.restart_openhcl(&new_openhcl, flags).await?;
 
     agent.ping().await?;
 


### PR DESCRIPTION
Ensure that the VTL2 state of the partition gets scrubbed after every
servicing operation, not just the first one.

Also, update the servicing test to loop a few times, and add or improve
tracing in a couple of places.
