### PR TITLE
kernel: update dev / main kernels to latest available

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -29,8 +29,8 @@ pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.9.3";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.9.4";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.9.4";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.9.5";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 


### PR DESCRIPTION
This change updates the dev and main kernel to contain the below patches from the [OHCL Kernel repo](https://github.com/microsoft/OHCL-Linux-Kernel):
```
f22734c154c8 x86/tdx: Disable unnecessary virtualization exceptions
79eece374099 x86/tdx: Enable CPU topology enumeration
fa9c7ca9b63a drivers: hv: vtl: Don't allow register ioctl on HCVMs
```
