### PR TITLE
Print error message on NVMe restore failure

### DIFF
--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -109,9 +109,17 @@ impl NvmeManager {
         let task = driver.spawn("nvme-manager", async move {
             // Restore saved data (if present) before async worker thread runs.
             if saved_state.is_some() {
-                let _ = NvmeManager::restore(&mut worker, saved_state.as_ref().unwrap())
+                match NvmeManager::restore(&mut worker, saved_state.as_ref().unwrap())
                     .instrument(tracing::info_span!("nvme_manager_restore"))
-                    .await;
+                    .await
+                {
+                    Ok(_) => {
+                        // Do nothing, the span above is good indicator.
+                    }
+                    Err(e) => {
+                        tracing::error!("failed to restore nvme manager: {}", e);
+                    }
+                }
             };
             worker.run(recv).await
         });

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -108,8 +108,8 @@ impl NvmeManager {
         };
         let task = driver.spawn("nvme-manager", async move {
             // Restore saved data (if present) before async worker thread runs.
-            if saved_state.is_some() {
-                if let Err(e) = NvmeManager::restore(&mut worker, saved_state.as_ref().unwrap())
+            if let Some(s) = saved_state.as_ref() {
+                if let Err(e) = NvmeManager::restore(&mut worker, s)
                     .instrument(tracing::info_span!("nvme_manager_restore"))
                     .await
                 {

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -109,16 +109,11 @@ impl NvmeManager {
         let task = driver.spawn("nvme-manager", async move {
             // Restore saved data (if present) before async worker thread runs.
             if saved_state.is_some() {
-                match NvmeManager::restore(&mut worker, saved_state.as_ref().unwrap())
+                if let Err(e) = NvmeManager::restore(&mut worker, saved_state.as_ref().unwrap())
                     .instrument(tracing::info_span!("nvme_manager_restore"))
                     .await
                 {
-                    Ok(_) => {
-                        // Do nothing, the span above is good indicator.
-                    }
-                    Err(e) => {
-                        tracing::error!("failed to restore nvme manager: {}", e);
-                    }
+                    tracing::error!("failed to restore nvme manager: {}", e);
                 }
             };
             worker.run(recv).await


### PR DESCRIPTION
Injected simulated errors and got the print in the log. Good for debugging in the fleet.
VTL2 servicing will fail and restart on error.