### PR TITLE
openhcl_boot: Account for control bits in CR3

### DIFF
--- a/openhcl/openhcl_boot/src/arch/x86_64/address_space.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/address_space.rs
@@ -214,8 +214,8 @@ unsafe fn get_pde_for_va(va: u64) -> &'static mut PageTableEntry {
 
     // SAFETY: See function comment.
     unsafe {
-        asm!("mov {0}, cr3", out(reg) page_table_base);
-        page_table_base &= !(HV_PAGE_SIZE - 1) as u64;
+        asm!("mov {0}, cr3", out(reg) page_table_base, options(nostack));
+        page_table_base &= !(HV_PAGE_SIZE - 1);
         let pml4 = page_table_at_address(page_table_base);
         let entry = pml4.entry(va, 3);
         assert!(entry.is_present());

--- a/openhcl/openhcl_boot/src/arch/x86_64/address_space.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/address_space.rs
@@ -17,6 +17,7 @@ use core::marker::PhantomData;
 use core::sync::atomic::AtomicU64;
 use core::sync::atomic::Ordering;
 use core::sync::atomic::compiler_fence;
+use hvdef::HV_PAGE_SIZE;
 use memory_range::MemoryRange;
 use x86defs::X64_LARGE_PAGE_SIZE;
 use zerocopy::FromBytes;
@@ -214,6 +215,7 @@ unsafe fn get_pde_for_va(va: u64) -> &'static mut PageTableEntry {
     // SAFETY: See function comment.
     unsafe {
         asm!("mov {0}, cr3", out(reg) page_table_base);
+        page_table_base &= !(HV_PAGE_SIZE - 1) as u64;
         let pml4 = page_table_at_address(page_table_base);
         let entry = pml4.entry(va, 3);
         assert!(entry.is_present());


### PR DESCRIPTION
```
The CR3 register isn't just a page root base address: its 12 LSBs may contain
control bits. See
* AMD PPR Vol 2 "Syetem Programming", "3.1.2 CR2 and CR3 Registers"
* Intel SDM Vol 3 "System Programming", "4.5.2 Use of CR3 ..."
for details.

Clear out the 12 LSBs to be follow the letter of the processor manuals.
```