### PR TITLE
openhcl: disable nvme keepalive

### DIFF
--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -482,12 +482,13 @@ impl LoadedVm {
         &mut self,
         correlation_id: Guid,
         deadline: std::time::Instant,
-        capabilities_flags: SaveGuestVtl2StateFlags,
+        _capabilities_flags: SaveGuestVtl2StateFlags,
     ) -> anyhow::Result<ServicingState> {
         if self.isolation.is_isolated() {
             anyhow::bail!("Servicing is not yet supported for isolated VMs");
         }
-        let nvme_keepalive = !capabilities_flags.disable_nvme_keepalive();
+        let nvme_keepalive = false;
+
         // Do everything before the log flush under a span.
         let mut state = async {
             if !self.stop().await {

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -1184,12 +1184,8 @@ impl UpdateGenerationId {
 #[bitfield(u64)]
 #[derive(AsBytes, FromBytes, FromZeroes)]
 pub struct SaveGuestVtl2StateFlags {
-    /// Disable nvme_keepalive feature when servicing.
-    #[bits(1)]
-    pub disable_nvme_keepalive: bool,
-
-    /// Reserved
-    #[bits(63)]
+    /// Reserved, must be zero.
+    #[bits(64)]
     _rsvd1: u64,
 }
 

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -552,10 +552,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                             get_protocol::GuestNotifications::SAVE_GUEST_VTL2_STATE,
                         ),
                         correlation_id: Guid::ZERO,
-                        // TODO: disable nvme keep alive as it doesn't work with
-                        // openvmm yet.
-                        capabilities_flags: SaveGuestVtl2StateFlags::new()
-                            .with_disable_nvme_keepalive(true),
+                        capabilities_flags: SaveGuestVtl2StateFlags::new(),
                         timeout_hint_secs: 60,
                     };
 


### PR DESCRIPTION
The protocol definition for nvme keepalive changed but the old definition did not get removed from the release branch. Disable the feature altogether.

This is a partial cherry pick of #464 / 6236ceec3238ed2a68ed829c2b344e363c6dfe81.