### PR TITLE
openhcl, vm: Support loading static elf files into VTL0

### DIFF
--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -36,12 +36,13 @@ pub enum LoadKind {
     Uefi,
     Pcat,
     Linux,
+    StaticElf,
 }
 
 impl From<LoadKind> for FirmwareType {
     fn from(value: LoadKind) -> Self {
         match value {
-            LoadKind::None | LoadKind::Linux => FirmwareType::None,
+            LoadKind::None | LoadKind::Linux | LoadKind::StaticElf => FirmwareType::None,
             LoadKind::Uefi => FirmwareType::Uefi,
             LoadKind::Pcat => FirmwareType::Pcat,
         }
@@ -116,6 +117,16 @@ pub fn load(
         LoadKind::None => {
             tracing::info!("loading nothing into VTL0");
             VpContext::Vbs(Vec::new())
+        }
+        LoadKind::StaticElf => {
+            tracing::info!("loading static ELF into VTL0");
+
+            // Static ELF image is already loaded into guest memory.
+            let static_elf_info = vtl0_info
+                .supports_static_elf
+                .as_ref()
+                .ok_or(Error::LinuxSupport)?;
+            static_elf_info.vp_context.clone()
         }
         LoadKind::Uefi => {
             tracing::info!("loading UEFI into VTL0");

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -260,7 +260,7 @@ pub struct UnderhillEnvCfg {
     /// Force load the specified image in VTL0. The image must support the
     /// option specified.
     ///
-    /// Valid options are "pcat, uefi, linux".
+    /// Valid options are "pcat, uefi, linux, static_elf".
     pub force_load_vtl0_image: Option<String>,
     /// Use the user-mode NVMe driver.
     pub nvme_vfio: bool,
@@ -1674,6 +1674,7 @@ async fn new_underhill_vm(
                     "pcat" => LoadKind::Pcat,
                     "uefi" => LoadKind::Uefi,
                     "linux" => LoadKind::Linux,
+                    "static_elf" => LoadKind::StaticElf,
                     _ => anyhow::bail!("unexpected force load vtl0 type {kind}"),
                 }
             } else {

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -26,6 +26,7 @@ use igvmfilegen_config::LinuxImage;
 use igvmfilegen_config::ResourceType;
 use igvmfilegen_config::Resources;
 use igvmfilegen_config::SnpInjectionType;
+use igvmfilegen_config::StaticElfImage;
 use igvmfilegen_config::UefiConfigType;
 use loader::importer::Aarch64Register;
 use loader::importer::GuestArch;
@@ -33,6 +34,7 @@ use loader::importer::GuestArchKind;
 use loader::importer::ImageLoad;
 use loader::importer::X86Register;
 use loader::linux::InitrdConfig;
+use loader::linux::StaticElfLoadInfo;
 use loader::paravisor::CommandLineType;
 use loader::paravisor::Vtl0Config;
 use loader::paravisor::Vtl0Linux;
@@ -411,6 +413,17 @@ trait IgvmfilegenRegister: IgvmLoaderRegister + 'static {
         F: std::io::Read + std::io::Seek,
         Self: GuestArch;
 
+    fn load_static_elf<F>(
+        importer: &mut impl ImageLoad<Self>,
+        image: &mut F,
+        minimum_start_address: u64,
+        load_offset: u64,
+        assume_pic: bool,
+    ) -> Result<StaticElfLoadInfo, loader::linux::Error>
+    where
+        F: std::io::Read + std::io::Seek,
+        Self: GuestArch;
+
     fn load_openhcl<F>(
         importer: &mut dyn ImageLoad<Self>,
         kernel_image: &mut F,
@@ -450,6 +463,26 @@ impl IgvmfilegenRegister for X86Register {
             kernel_image,
             kernel_minimum_start_address,
             initrd,
+        )
+    }
+
+    fn load_static_elf<F>(
+        importer: &mut impl ImageLoad<Self>,
+        image: &mut F,
+        minimum_start_address: u64,
+        load_offset: u64,
+        assume_pic: bool,
+    ) -> Result<StaticElfLoadInfo, loader::linux::Error>
+    where
+        F: std::io::Read + std::io::Seek,
+        Self: GuestArch,
+    {
+        loader::linux::load_static_elf_x64(
+            importer,
+            image,
+            minimum_start_address,
+            load_offset,
+            assume_pic,
         )
     }
 
@@ -509,6 +542,26 @@ impl IgvmfilegenRegister for Aarch64Register {
         )
     }
 
+    fn load_static_elf<F>(
+        importer: &mut impl ImageLoad<Self>,
+        image: &mut F,
+        minimum_start_address: u64,
+        load_offset: u64,
+        assume_pic: bool,
+    ) -> Result<StaticElfLoadInfo, loader::linux::Error>
+    where
+        F: std::io::Read + std::io::Seek,
+        Self: GuestArch,
+    {
+        loader::linux::load_static_elf_arm64(
+            importer,
+            image,
+            minimum_start_address,
+            load_offset,
+            assume_pic,
+        )
+    }
+
     fn load_openhcl<F>(
         importer: &mut dyn ImageLoad<Self>,
         kernel_image: &mut F,
@@ -561,6 +614,7 @@ fn load_image<'a, R: IgvmfilegenRegister + GuestArch + 'static>(
             memory_page_count,
             uefi,
             ref linux,
+            ref static_elf,
         } => {
             if uefi && linux.is_some() {
                 anyhow::bail!("cannot include both UEFI and Linux images in OpenHCL image");
@@ -614,6 +668,7 @@ fn load_image<'a, R: IgvmfilegenRegister + GuestArch + 'static>(
                     supports_pcat: loader.loader().arch() == GuestArchKind::X86_64,
                     supports_uefi: Some((load_info, vp_context)),
                     supports_linux: None,
+                    supports_static_elf: None,
                 }
             } else if let Some(linux) = linux {
                 let load_info = load_linux(&mut loader.nested_loader(), linux, resources)?;
@@ -624,12 +679,29 @@ fn load_image<'a, R: IgvmfilegenRegister + GuestArch + 'static>(
                         command_line: &linux.command_line,
                         load_info,
                     }),
+                    supports_static_elf: None,
+                }
+            } else if let Some(static_elf) = static_elf {
+                let mut inner_loader = loader.nested_loader();
+                let StaticElfLoadInfo { gpa, size } =
+                    load_static_elf(&mut inner_loader, static_elf, resources)?;
+                let vp_context = inner_loader.take_vp_context();
+                Vtl0Config {
+                    supports_pcat: false,
+                    supports_uefi: None,
+                    supports_linux: None,
+                    supports_static_elf: Some(loader::paravisor::Vtl0StaticElf {
+                        gpa,
+                        size,
+                        vp_context,
+                    }),
                 }
             } else {
                 Vtl0Config {
                     supports_pcat: false,
                     supports_uefi: None,
                     supports_linux: None,
+                    supports_static_elf: None,
                 }
             };
 
@@ -720,5 +792,31 @@ fn load_linux<R: IgvmfilegenRegister + GuestArch + 'static>(
     };
     let load_info = R::load_linux_kernel_and_initrd(loader, &mut kernel, 0, initrd, None)
         .context("loading linux kernel and initrd")?;
+    Ok(load_info)
+}
+
+fn load_static_elf<R: IgvmfilegenRegister + GuestArch + 'static>(
+    loader: &mut IgvmVtlLoader<'_, R>,
+    static_elf: &StaticElfImage,
+    resources: &Resources,
+) -> Result<StaticElfLoadInfo, anyhow::Error> {
+    let path = resources
+        .get(ResourceType::StaticElf)
+        .expect("validated present");
+    let mut image = fs_err::File::open(path)
+        .context(format!("reading vtl0 kernel image at {}", path.display()))?;
+    let StaticElfImage {
+        start_address: minimum_start_address,
+        load_offset,
+        assume_pic,
+    } = *static_elf;
+    let load_info = R::load_static_elf(
+        loader,
+        &mut image,
+        minimum_start_address as u64,
+        load_offset as u64,
+        assume_pic,
+    )
+    .context("loading static elf")?;
     Ok(load_info)
 }

--- a/vm/loader/igvmfilegen_config/src/lib.rs
+++ b/vm/loader/igvmfilegen_config/src/lib.rs
@@ -95,6 +95,7 @@ pub enum Image {
         /// Include the Linux kernel for loading into the guest.
         #[serde(skip_serializing_if = "Option::is_none")]
         linux: Option<LinuxImage>,
+        static_elf: Option<StaticElfImage>,
     },
     /// Load the Linux kernel.
     /// TODO: Currently, this only works with underhill.
@@ -108,6 +109,17 @@ pub struct LinuxImage {
     pub use_initrd: bool,
     /// The command line to boot the kernel with.
     pub command_line: CString,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct StaticElfImage {
+    /// Load address.
+    pub start_address: usize,
+    /// Load offset.
+    pub load_offset: usize,
+    /// Whether the code is position independent or not.
+    pub assume_pic: bool,
 }
 
 impl Image {
@@ -194,6 +206,7 @@ impl Config {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum ResourceType {
+    StaticElf,
     Uefi,
     UnderhillKernel,
     OpenhclBoot,

--- a/vm/loader/loader_defs/src/paravisor.rs
+++ b/vm/loader/loader_defs/src/paravisor.rs
@@ -290,6 +290,17 @@ pub struct LinuxInfo {
     pub command_line: PageRegionDescriptor,
 }
 
+/// Measured config about ELF loaded into VTL0.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+#[cfg_attr(feature = "inspect", derive(Inspect))]
+pub struct ElfInfo {
+    /// The memory the image was loaded into.
+    pub region: PageRegionDescriptor,
+    /// The VP context for the image.
+    pub vp_context: PageRegionDescriptor,
+}
+
 /// Measured config about UEFI loaded into VTL0.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
@@ -315,8 +326,11 @@ pub struct SupportedVtl0LoadInfo {
     /// This image supports Linux Direct.
     #[bits(1)]
     pub linux_direct_supported: bool,
+    /// This image supports a static ELF.
+    #[bits(1)]
+    pub static_elf_supported: bool,
     /// Currently reserved.
-    #[bits(61)]
+    #[bits(60)]
     pub reserved: u64,
 }
 
@@ -336,6 +350,8 @@ pub struct ParavisorMeasuredVtl0Config {
     pub uefi_info: UefiInfo,
     /// If Linux is supported, information about Linux for VTL0.
     pub linux_info: LinuxInfo,
+    /// If a static ELF is supported, information about it for VTL0.
+    pub static_elf: ElfInfo,
 }
 
 impl ParavisorMeasuredVtl0Config {


### PR DESCRIPTION
Needed a way to run a test probe for the hardware-isolated VMs. TMKs wouldn't work in that scenario so coded up this.