### PR TITLE
virt_mshv_vtl: Separate out CVM and non-CVM deliver_synic_messages

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -44,6 +44,7 @@ use guestmem::GuestMemory;
 use hcl::ioctl::Hcl;
 use hcl::ioctl::ProcessorRunner;
 use hv1_emulator::message_queues::MessageQueues;
+use hv1_emulator::synic::ProcessorSynic;
 use hv1_hypercall::HvRepResult;
 use hv1_structs::ProcessorSet;
 use hv1_structs::VtlArray;
@@ -186,7 +187,6 @@ mod private {
     use crate::GuestVtl;
     use crate::processor::UhProcessor;
     use hv1_emulator::hv::ProcessorVtlHv;
-    use hv1_emulator::synic::ProcessorSynic;
     use hv1_structs::VtlArray;
     use inspect::InspectMut;
     use std::future::Future;
@@ -259,8 +259,6 @@ mod private {
 
         fn hv(&self, vtl: GuestVtl) -> Option<&ProcessorVtlHv>;
         fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv>;
-
-        fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic>;
 
         fn vtl1_inspectable(this: &UhProcessor<'_, Self>) -> bool;
     }
@@ -477,6 +475,8 @@ trait HardwareIsolatedBacking: Backing {
         this: &mut UhProcessor<'_, Self>,
         intercept_control: HvRegisterCrInterceptControl,
     );
+
+    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic>;
 }
 
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
@@ -1124,49 +1124,6 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
             devices,
         )
         .await
-    }
-
-    fn deliver_synic_messages(&mut self, vtl: GuestVtl, sints: u16) {
-        let proxied_sints = self
-            .backing
-            .hv(vtl)
-            .as_ref()
-            .map_or(!0, |hv| hv.synic.proxied_sints());
-        let pending_sints =
-            self.inner.message_queues[vtl].post_pending_messages(sints, |sint, message| {
-                if proxied_sints & (1 << sint) != 0 {
-                    if let Some(synic) = self.backing.untrusted_synic_mut().as_mut() {
-                        synic.post_message(
-                            sint,
-                            message,
-                            &mut self
-                                .partition
-                                .synic_interrupt(self.inner.vp_info.base.vp_index, vtl),
-                        )
-                    } else {
-                        self.partition.hcl.post_message_direct(
-                            self.inner.vp_info.base.vp_index.index(),
-                            sint,
-                            message,
-                        )
-                    }
-                } else {
-                    self.backing
-                        .hv_mut(vtl)
-                        .as_mut()
-                        .unwrap()
-                        .synic
-                        .post_message(
-                            sint,
-                            message,
-                            &mut self
-                                .partition
-                                .synic_interrupt(self.inner.vp_info.base.vp_index, vtl),
-                        )
-                }
-            });
-
-        self.request_sint_notifications(vtl, pending_sints);
     }
 
     #[cfg(guest_arch = "x86_64")]

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -18,6 +18,7 @@ cfg_if::cfg_if! {
         use crate::VtlCrash;
         use bitvec::prelude::BitArray;
         use bitvec::prelude::Lsb0;
+        use hv1_emulator::synic::ProcessorSynic;
         use hvdef::HvX64RegisterName;
         use virt::vp::MpState;
         use virt::x86::MsrError;
@@ -44,7 +45,6 @@ use guestmem::GuestMemory;
 use hcl::ioctl::Hcl;
 use hcl::ioctl::ProcessorRunner;
 use hv1_emulator::message_queues::MessageQueues;
-use hv1_emulator::synic::ProcessorSynic;
 use hv1_hypercall::HvRepResult;
 use hv1_structs::ProcessorSet;
 use hv1_structs::VtlArray;

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -30,7 +30,6 @@ use hcl::UnsupportedGuestVtl;
 use hcl::ioctl;
 use hcl::ioctl::aarch64::MshvArm64;
 use hv1_emulator::hv::ProcessorVtlHv;
-use hv1_emulator::synic::ProcessorSynic;
 use hvdef::HvAarch64PendingEvent;
 use hvdef::HvArm64RegisterName;
 use hvdef::HvArm64ResetType;
@@ -236,10 +235,6 @@ impl BackingPrivate for HypervisorBackedArm64 {
     }
 
     fn hv_mut(&mut self, _vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
-        None
-    }
-
-    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
         None
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/mod.rs
@@ -3,6 +3,10 @@
 
 //! Processor support for Microsoft hypervisor-backed partitions.
 
+use crate::HypervisorBacked;
+use crate::UhProcessor;
+use hcl::GuestVtl;
+
 pub mod arm64;
 mod tlb_lock;
 pub mod x64;
@@ -12,4 +16,19 @@ pub(crate) struct VbsIsolatedVtl1State {
     #[inspect(hex, with = "|flags| flags.map(u32::from)")]
     default_vtl_protections: Option<hvdef::HvMapGpaFlags>,
     enable_vtl_protection: bool,
+}
+
+impl<'a> UhProcessor<'a, HypervisorBacked> {
+    fn deliver_synic_messages(&mut self, vtl: GuestVtl, sints: u16) {
+        let pending_sints =
+            self.inner.message_queues[vtl].post_pending_messages(sints, |sint, message| {
+                self.partition.hcl.post_message_direct(
+                    self.inner.vp_info.base.vp_index.index(),
+                    sint,
+                    message,
+                )
+            });
+
+        self.request_sint_notifications(vtl, pending_sints);
+    }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/mod.rs
@@ -18,7 +18,7 @@ pub(crate) struct VbsIsolatedVtl1State {
     enable_vtl_protection: bool,
 }
 
-impl<'a> UhProcessor<'a, HypervisorBacked> {
+impl UhProcessor<'_, HypervisorBacked> {
     fn deliver_synic_messages(&mut self, vtl: GuestVtl, sints: u16) {
         let pending_sints =
             self.inner.message_queues[vtl].post_pending_messages(sints, |sint, message| {

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -31,7 +31,6 @@ use hcl::ioctl::ApplyVtlProtectionsError;
 use hcl::ioctl::x64::MshvX64;
 use hcl::protocol;
 use hv1_emulator::hv::ProcessorVtlHv;
-use hv1_emulator::synic::ProcessorSynic;
 use hv1_hypercall::HvRepResult;
 use hv1_structs::VtlSet;
 use hvdef::HV_PAGE_SIZE;
@@ -350,10 +349,6 @@ impl BackingPrivate for HypervisorBackedX86 {
     }
 
     fn hv_mut(&mut self, _vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
-        None
-    }
-
-    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
         None
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -359,6 +359,10 @@ impl HardwareIsolatedBacking for SnpBacked {
             true
         })
     }
+
+    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
+        None
+    }
 }
 
 /// Partition-wide shared data for SNP VPs.
@@ -575,10 +579,6 @@ impl BackingPrivate for SnpBacked {
 
     fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
         Some(&mut self.cvm.hv[vtl])
-    }
-
-    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
-        None
     }
 
     fn handle_vp_start_enable_vtl_wake(

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -715,6 +715,10 @@ impl HardwareIsolatedBacking for TdxBacked {
             true
         })
     }
+
+    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
+        self.untrusted_synic.as_mut()
+    }
 }
 
 /// Partition-wide shared data for TDX VPs.
@@ -1101,10 +1105,6 @@ impl BackingPrivate for TdxBacked {
 
     fn hv_mut(&mut self, vtl: GuestVtl) -> Option<&mut ProcessorVtlHv> {
         Some(&mut self.cvm.hv[vtl])
-    }
-
-    fn untrusted_synic_mut(&mut self) -> Option<&mut ProcessorSynic> {
-        self.untrusted_synic.as_mut()
     }
 
     fn handle_vp_start_enable_vtl_wake(


### PR DESCRIPTION
Continuing on separating out these two, and removing the unwraps doing so allows for.