### PR TITLE
vmbus_server: fix VTL2 shutdown for proxy integration.

### DIFF
--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -929,7 +929,7 @@ impl ProxyTask {
                     }
                     r = vtl2_saved_state_requests => {
                         if !self.handle_saved_state_request(r.unwrap(), 2).await {
-                            vtl2_hvsock_request_recv = None;
+                            vtl2_saved_state_recv = None;
                         }
                     }
                     complete => break 'outer,


### PR DESCRIPTION
The change made in #1361 did not correctly clear the VTL2 saved state request channel, preventing the kernel proxy from shutting down cleanly if the VM was using VTL2.