### PR TITLE
vmgstool: allow read/write to unencrypted file in encrypted vmgs

### DIFF
--- a/vm/vmgs/vmgs/src/vmgs_impl.rs
+++ b/vm/vmgs/vmgs/src/vmgs_impl.rs
@@ -44,6 +44,8 @@ pub struct VmgsFileInfo {
     pub allocated_bytes: u64,
     /// Number of valid bytes in the file.
     pub valid_bytes: u64,
+    /// Whether this file is encrypted.
+    pub encrypted: bool,
 }
 
 // Aggregates fully validated data from the FILE_TABLE and EXTENDED_FILE_TABLE
@@ -411,6 +413,7 @@ impl Vmgs {
         Ok(VmgsFileInfo {
             allocated_bytes: block_count_to_byte_count(fcb.allocated_blocks.get()),
             valid_bytes: fcb.valid_bytes,
+            encrypted: fcb.attributes.encrypted() || fcb.attributes.authenticated(),
         })
     }
 

--- a/vm/vmgs/vmgstool/src/uefi_nvram.rs
+++ b/vm/vmgs/vmgstool/src/uefi_nvram.rs
@@ -340,7 +340,7 @@ async fn vmgs_file_open_nvram(
     key_path: Option<impl AsRef<Path>>,
     open_mode: OpenMode,
 ) -> Result<HclCompatNvram<VmgsStorageBackend>, Error> {
-    let vmgs = vmgs_file_open(file_path, key_path, open_mode, false).await?;
+    let vmgs = vmgs_file_open(file_path, key_path, open_mode).await?;
     let encrypted = vmgs.is_encrypted();
 
     open_nvram(vmgs, encrypted)


### PR DESCRIPTION
Fixes an issue where vmgstool would return an error when trying to open an encrypted VMGS file without an encryption key, even if the file being accessed was not encrypted.