### PR TITLE
[WIP] petri: OpenVMM tests have secure boot by default

### DIFF
--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -37,6 +37,8 @@ pub trait PetriVmConfig: Send {
 
     /// Inject Windows secure boot templates into the VM's UEFI.
     fn with_windows_secure_boot_template(self: Box<Self>) -> Box<dyn PetriVmConfig>;
+    /// Inject UEFI certificate authority boot template into the VM's UEFI.
+    fn with_uefi_ca_template(self: Box<Self>) -> Box<dyn PetriVmConfig>;
     /// Set the VM to use the specified processor topology.
     fn with_processor_topology(
         self: Box<Self>,

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -156,6 +156,10 @@ impl PetriVmConfig for PetriVmConfigOpenVmm {
         Box::new(Self::with_windows_secure_boot_template(*self))
     }
 
+    fn with_uefi_ca_template(self: Box<Self>) -> Box<dyn PetriVmConfig> {
+        Box::new(Self::with_uefi_ca_template(*self))
+    }
+
     fn with_processor_topology(
         self: Box<Self>,
         topology: ProcessorTopology,

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -26,6 +26,7 @@ use crate::linux_direct_serial_agent::LinuxDirectSerialAgent;
 use crate::openhcl_diag::OpenHclDiagHandler;
 use anyhow::Context;
 use async_trait::async_trait;
+use construct::OpenVmmSecureBootTemplate;
 use disk_backend_resources::LayeredDiskHandle;
 use disk_backend_resources::layer::DiskLayerHandle;
 use disk_backend_resources::layer::RamDiskLayerHandle;
@@ -135,6 +136,9 @@ pub struct PetriVmConfigOpenVmm {
     ged: Option<get_resources::ged::GuestEmulationDeviceHandle>,
     vtl2_settings: Option<Vtl2Settings>,
     framebuffer_access: Option<FramebufferAccess>,
+
+    // Secure boot
+    secure_boot_template: Option<OpenVmmSecureBootTemplate>,
 }
 
 #[async_trait]

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -140,6 +140,19 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
+    /// Disable secure boot for the VM.
+    pub fn without_secure_boot(mut self) -> Self {
+        if !self.firmware.is_uefi() {
+            panic!("Secure boot is only supported for UEFI firmware.");
+        }
+        if self.firmware.is_openhcl() {
+            self.ged.as_mut().unwrap().secure_boot_enabled = false;
+        } else {
+            self.config.secure_boot_enabled = false;
+        }
+        self
+    }
+
     /// Inject Windows secure boot templates into the VM's UEFI.
     pub fn with_windows_secure_boot_template(mut self) -> Self {
         if !self.firmware.is_uefi() {
@@ -150,6 +163,20 @@ impl PetriVmConfigOpenVmm {
                 get_resources::ged::GuestSecureBootTemplateType::MicrosoftWindows;
         } else {
             self.config.custom_uefi_vars = hyperv_secure_boot_templates::x64::microsoft_windows();
+        }
+        self
+    }
+
+    /// Inject UEFI certificate authority templates into the VM's UEFI
+    pub fn with_uefi_ca_template(mut self) -> Self {
+        if !self.firmware.is_uefi() {
+            panic!("Secure boot templates are only supported for UEFI firmware.");
+        }
+        if self.firmware.is_openhcl() {
+            self.ged.as_mut().unwrap().secure_boot_template =
+                get_resources::ged::GuestSecureBootTemplateType::MicrosoftUefiCertificateAuthoritiy;
+        } else {
+            self.config.custom_uefi_vars = hyperv_secure_boot_templates::x64::microsoft_uefi_ca();
         }
         self
     }

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -44,6 +44,7 @@ impl PetriVmConfigOpenVmm {
             firmware,
             arch,
             mut config,
+            secure_boot_template,
 
             mut resources,
 


### PR DESCRIPTION
This PR is currently a work in progress.

This PR focuses on:

- enabling secure boot for OpenVMM tests by default
- allow test functions to disable secure boot in the config
- plumbing to add a secure boot template field