### PR TITLE
vmbus_server: include VTL when restoring proxy channels

### DIFF
--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -284,6 +284,7 @@ impl VmbusProxy {
         interface_type: GUID,
         interface_instance: GUID,
         subchannel_index: u16,
+        target_vtl: u8,
         open_params: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
         open: bool,
     ) -> Result<u64> {
@@ -294,6 +295,7 @@ impl VmbusProxy {
                     InterfaceType: interface_type,
                     InterfaceInstance: interface_instance,
                     SubchannelIndex: subchannel_index,
+                    TargetVtl: target_vtl,
                     OpenParameters: open_params,
                     Open: open.into(),
                 }),

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -296,6 +296,7 @@ impl VmbusProxy {
                     InterfaceInstance: interface_instance,
                     SubchannelIndex: subchannel_index,
                     TargetVtl: target_vtl,
+                    Padding: 0,
                     OpenParameters: open_params,
                     Open: open.into(),
                 }),

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -253,6 +253,7 @@ impl VmbusProxy {
                 proxyioctl::IOCTL_VMBUS_PROXY_OPEN_CHANNEL,
                 StaticIoctlBuffer(proxyioctl::VMBUS_PROXY_OPEN_CHANNEL_INPUT {
                     ProxyId: id,
+                    Padding: 0,
                     OpenParameters: *params,
                     VmmSignalEvent: handle,
                 }),
@@ -299,6 +300,7 @@ impl VmbusProxy {
                     Padding: 0,
                     OpenParameters: open_params,
                     Open: open.into(),
+                    Padding2: [0; 3],
                 }),
                 StaticIoctlBuffer(zeroed::<proxyioctl::VMBUS_PROXY_RESTORE_CHANNEL_OUTPUT>()),
             )
@@ -371,6 +373,7 @@ impl VmbusProxy {
                 StaticIoctlBuffer(proxyioctl::VMBUS_PROXY_DELETE_GPADL_INPUT {
                     ProxyId: id,
                     GpadlId: gpadl_id,
+                    Padding: 0,
                 }),
                 (),
             )
@@ -389,6 +392,7 @@ impl VmbusProxy {
                     Flags: proxyioctl::VMBUS_PROXY_TL_CONNECT_REQUEST_FLAGS::new()
                         .with_hosted_silo_unaware(request.hosted_silo_unaware),
                     Vtl: vtl,
+                    Padding: [0; 3],
                 }),
                 (),
             )

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -139,6 +139,7 @@ pub struct VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
     pub InterfaceInstance: GUID,
     pub SubchannelIndex: u16,
     pub TargetVtl: u8,
+    pub Padding: u8,
     pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
     pub Open: BOOLEAN,
 }

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -52,7 +52,7 @@ pub const IOCTL_VMBUS_PROXY_REVOKE_UNCLAIMED_CHANNELS: u32 = VMBUS_PROXY_IOCTL(0
 pub const IOCTL_VMBUS_PROXY_RESTORE_SET_INTERRUPT: u32 = VMBUS_PROXY_IOCTL(0xf);
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, zerocopy::IntoBytes)]
 pub struct VMBUS_PROXY_SET_VM_NAME_INPUT {
     pub VmId: [u8; 16],
     pub NameLength: u16,
@@ -60,7 +60,7 @@ pub struct VMBUS_PROXY_SET_VM_NAME_INPUT {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, zerocopy::IntoBytes)]
 pub struct VMBUS_PROXY_SET_TOPOLOGY_INPUT {
     pub NodeCount: u32,
     pub VpCount: u32,
@@ -68,7 +68,7 @@ pub struct VMBUS_PROXY_SET_TOPOLOGY_INPUT {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, zerocopy::IntoBytes)]
 pub struct VMBUS_PROXY_SET_MEMORY_INPUT {
     pub BaseAddress: u64,
     pub Size: u64,
@@ -83,6 +83,7 @@ pub const VmbusProxyActionTypeTlConnectResult: u32 = 4;
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_NEXT_ACTION_OUTPUT {
     pub Type: u32,
+    pub Padding: u32,
     pub ProxyId: u64,
     pub u: VMBUS_PROXY_NEXT_ACTION_OUTPUT_union,
 }
@@ -109,6 +110,7 @@ pub struct VMBUS_PROXY_NEXT_ACTION_OUTPUT_union_TlConnectResult {
     pub ServiceId: GUID,
     pub Status: NTSTATUS,
     pub Vtl: u8,
+    pub Padding: [u8; 3],
 }
 
 #[repr(C)]
@@ -116,6 +118,7 @@ pub struct VMBUS_PROXY_NEXT_ACTION_OUTPUT_union_TlConnectResult {
 pub struct VMBUS_PROXY_OPEN_CHANNEL_INPUT {
     pub ProxyId: u64,
     pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
+    pub Padding: u32,
     pub VmmSignalEvent: u64, // BUGBUG: HANDLE
 }
 
@@ -142,7 +145,9 @@ pub struct VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
     pub Padding: u8,
     pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
     pub Open: BOOLEAN,
+    pub Padding2: [u8; 3],
 }
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_RESTORE_CHANNEL_OUTPUT {
@@ -170,6 +175,7 @@ pub struct VMBUS_PROXY_CREATE_GPADL_INPUT {
 pub struct VMBUS_PROXY_DELETE_GPADL_INPUT {
     pub ProxyId: u64,
     pub GpadlId: u32,
+    pub Padding: u32,
 }
 
 #[repr(C)]
@@ -199,4 +205,5 @@ pub struct VMBUS_PROXY_TL_CONNECT_REQUEST_INPUT {
     pub SiloId: GUID,
     pub Flags: VMBUS_PROXY_TL_CONNECT_REQUEST_FLAGS,
     pub Vtl: u8,
+    pub Padding: [u8; 3],
 }

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -138,6 +138,7 @@ pub struct VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
     pub InterfaceType: GUID,
     pub InterfaceInstance: GUID,
     pub SubchannelIndex: u16,
+    pub TargetVtl: u8,
     pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
     pub Open: BOOLEAN,
 }

--- a/vm/devices/vmbus/vmbus_proxy/src/vmbusioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/vmbusioctl.rs
@@ -45,9 +45,10 @@ pub struct VmbusChannelOfferFlags {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, zerocopy::IntoBytes)]
 pub struct VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS {
     pub RingBufferGpadlHandle: u32,
     pub DownstreamRingBufferPageOffset: u32,
     pub NodeNumber: u16,
+    pub Padding: u16,
 }

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -219,6 +219,7 @@ impl ProxyTask {
                     RingBufferGpadlHandle: open_request.open_data.ring_gpadl_id.0,
                     DownstreamRingBufferPageOffset: open_request.open_data.ring_offset,
                     NodeNumber: 0, // BUGBUG: NUMA
+                    Padding: 0,
                 },
                 maybe_wrapped.event(),
             )
@@ -799,6 +800,7 @@ impl ProxyTask {
                                         DownstreamRingBufferPageOffset: open_params
                                             .downstream_ring_buffer_page_offset,
                                         NodeNumber: 0, // BUGBUG: NUMA
+                                        Padding: 0,
                                     },
                                     channel.saved_open(),
                                 )

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -793,6 +793,7 @@ impl ProxyTask {
                                     key.interface_id.into(),
                                     key.instance_id.into(),
                                     key.subchannel_index,
+                                    vtl,
                                     VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS {
                                         RingBufferGpadlHandle: open_params.ring_buffer_gpadl_id.0,
                                         DownstreamRingBufferPageOffset: open_params


### PR DESCRIPTION
This change updates proxyintegration to pass the channel's target VTL to the vmbusproxy driver when restoring channels. This allows the driver to mark the channels with the correct VTL immediately.