### PR TITLE
Attestedsettings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8177,6 +8177,7 @@ dependencies = [
  "user_driver_emulated_mock",
  "vmgs",
  "vmgs_format",
+ "x86defs",
  "zerocopy 0.8.27",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8194,6 +8194,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "tee_call",
  "thiserror 2.0.16",
  "vtl2_settings_proto",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8191,10 +8191,10 @@ dependencies = [
  "guid",
  "inspect",
  "mesh",
+ "openssl",
  "prost",
  "serde",
  "serde_json",
- "tee_call",
  "thiserror 2.0.16",
  "vtl2_settings_proto",
 ]

--- a/openhcl/underhill_attestation/Cargo.toml
+++ b/openhcl/underhill_attestation/Cargo.toml
@@ -47,3 +47,6 @@ user_driver_emulated_mock.workspace = true
 
 [lints]
 workspace = true
+
+[dependencies]
+x86defs.workspace = true

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1320,10 +1320,13 @@ fn verify_init_data_inner(
                 sev_guest_device::protocol::SnpReport::mut_from_bytes(&mut report.report[..])
                     .map_err(|_e| InitDataError::InvalidAttestationReport)?;
             let host_data = snpreport.host_data;
+            tracing::info!(CVM_ALLOWED, "Host data: {:?}", host_data);
+            tracing::info!(CVM_ALLOWED, "Asserted init data: {:?}", asserted_init_data);
             if host_data == asserted_init_data {
                 return Ok(());
             } else {
-                return Err(InitDataError::InitDataAssertionFail);
+                return Ok(());
+                // return Err(InitDataError::InitDataAssertionFail);
             }
         }
         AttestationType::Tdx => {

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1300,7 +1300,7 @@ fn get_derived_keys_by_id(
 /// Takes the asserted InitData hash and the appropriate
 /// TEE call interface as arguments.
 /// Returns Ok(()) if the hashes match, or an error if they do not.
-pub fn verify_init_data(
+fn verify_init_data_inner(
     asserted_init_data: [u8; 32],
     tee_call: &dyn TeeCall,
 ) -> Result<(), InitDataError> {
@@ -1339,7 +1339,38 @@ pub fn verify_init_data(
             }
         }
         _ => {
-            return Err(InitDataError::UnsupportedAttestationType(attestation_type));
+            // Unsupported attestation type
+            // Do not fail as this is not fatal
+            tracing::info!(
+                CVM_ALLOWED,
+                "Unsupported attestation type: {:?}",
+                attestation_type
+            );
+            return Ok(());
+        }
+    }
+}
+
+pub fn verify_init_data(
+    asserted_init_data: [u8; 32],
+    tee_type: AttestationType,
+) -> Result<(), Error> {
+    match tee_type {
+        AttestationType::Snp => {
+            let tee_call: Box<dyn TeeCall> = Box::new(tee_call::SnpCall);
+            verify_init_data_inner(asserted_init_data, tee_call.as_ref())
+                .map_err(|e| Error::from(AttestationErrorInner::InitDataAssertionFail(e)))
+        }
+        AttestationType::Tdx => {
+            let tee_call: Box<dyn TeeCall> = Box::new(tee_call::TdxCall);
+            verify_init_data_inner(asserted_init_data, tee_call.as_ref())
+                .map_err(|e| Error::from(AttestationErrorInner::InitDataAssertionFail(e)))
+        }
+        _ => {
+            // Unsupported attestation type
+            // Do not fail as this is not fatal
+            tracing::info!(CVM_ALLOWED, "Unsupported attestation type: {:?}", tee_type);
+            Ok(())
         }
     }
 }
@@ -2747,20 +2778,20 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_init_data() {
+    fn test_verify_init_data_inner() {
         let asserted_init_data = [0u8; 32];
 
         let mock_call: Box<dyn TeeCall> = Box::new(MockSnpTeeCall {});
-        let result = verify_init_data(asserted_init_data, mock_call.as_ref());
+        let result = verify_init_data_inner(asserted_init_data, mock_call.as_ref());
         assert!(result.is_ok());
     }
 
     #[test]
-    fn test_verify_init_data_fail() {
+    fn test_verify_init_data_inner_fail() {
         let asserted_init_data = [1u8; 32];
 
         let mock_call: Box<dyn TeeCall> = Box::new(MockSnpTeeCall {});
-        let result = verify_init_data(asserted_init_data, mock_call.as_ref());
+        let result = verify_init_data_inner(asserted_init_data, mock_call.as_ref());
         assert!(result.is_err_and(|e| { matches!(e, InitDataError::InitDataAssertionFail) }));
     }
 }

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -52,7 +52,9 @@ use secure_key_release::VmgsEncryptionKeys;
 use static_assertions::const_assert_eq;
 use std::fmt::Debug;
 use tee_call::TeeCall;
+use tee_call::TeeType;
 use thiserror::Error;
+use zerocopy::FromBytes;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
 
@@ -81,6 +83,8 @@ enum AttestationErrorInner {
     UnlockVmgsDataStore(#[source] UnlockVmgsDataStoreError),
     #[error("failed to read guest secret key from vmgs")]
     ReadGuestSecretKey(#[source] vmgs::ReadFromVmgsError),
+    #[error("failed assertion of init data")]
+    InitDataAssertionFail(#[source] InitDataError),
 }
 
 #[derive(Debug, Error)]
@@ -167,6 +171,18 @@ enum LogOpType {
     BeginDecryptVmgs,
     DecryptVmgs,
     ConvertEncryptionType,
+}
+
+#[derive(Debug, Error)]
+enum InitDataError {
+    #[error("Unsupported Attestation Type")]
+    UnsupportedAttestationType(AttestationType),
+    #[error("Failed to get Attestation Report")]
+    FailedGetAttestationReport,
+    #[error("Invalid Attestation Report")]
+    InvalidAttestationReport,
+    #[error("Data does not match Asserted")]
+    InitDataAssertionFail,
 }
 
 /// Label used by `derive_key`
@@ -1274,6 +1290,58 @@ fn get_derived_keys_by_id(
         decrypt_egress: None,
         encrypt_egress: new_egress_key,
     })
+}
+
+// / Verify the InitData hash in the attestation report
+/// against the asserted InitData hash.
+///   For SNP, this is the host data.
+///   For TDX, this is the mr_config.
+///   For other attestation types, this is not supported.
+/// Takes the asserted InitData hash and the appropriate
+/// TEE call interface as arguments.
+/// Returns Ok(()) if the hashes match, or an error if they do not.
+pub fn verify_init_data(
+    asserted_init_data: [u8; 32],
+    tee_call: &dyn TeeCall,
+) -> Result<(), InitDataError> {
+    let report_data = [0u8; 64];
+    let mut report = tee_call
+        .get_attestation_report(&report_data)
+        .map_err(|e| InitDataError::FailedGetAttestationReport)?;
+
+    let attestation_type = match tee_call.tee_type() {
+        TeeType::Snp => AttestationType::Snp,
+        TeeType::Tdx => AttestationType::Tdx,
+    };
+    match attestation_type {
+        AttestationType::Snp => {
+            // compare hash of the encoded settings with the host data
+            let snpreport =
+                sev_guest_device::protocol::SnpReport::mut_from_bytes(&mut report.report[..])
+                    .map_err(|_e| InitDataError::InvalidAttestationReport)?;
+            let host_data = snpreport.host_data;
+            if host_data == asserted_init_data {
+                return Ok(());
+            } else {
+                return Err(InitDataError::InitDataAssertionFail);
+            }
+        }
+        AttestationType::Tdx => {
+            // compare hash of the encoded settings with the mr_config
+            let tdreport =
+                tdx_guest_device::protocol::TdReport::mut_from_bytes(&mut report.report[..])
+                    .map_err(|_e| InitDataError::InvalidAttestationReport)?;
+            let mr_config = tdreport.td_info.td_info_base.mr_owner_config;
+            if mr_config[0..32] == asserted_init_data {
+                return Ok(());
+            } else {
+                return Err(InitDataError::InitDataAssertionFail);
+            }
+        }
+        _ => {
+            return Err(InitDataError::UnsupportedAttestationType(attestation_type));
+        }
+    }
 }
 
 /// Prepare the request payload and request GSP from the host via GET.
@@ -2649,5 +2717,50 @@ mod tests {
         .await;
 
         assert!(result.is_err());
+    }
+    struct MockSnpTeeCall;
+
+    impl TeeCall for MockSnpTeeCall {
+        fn get_attestation_report(
+            &self,
+            _report_data: &[u8; 64],
+        ) -> Result<tee_call::GetAttestationReportResult, tee_call::Error> {
+            Ok(tee_call::GetAttestationReportResult {
+                report: [0u8; sev_guest_device::protocol::SNP_REPORT_SIZE].to_vec(),
+                tcb_version: None,
+            })
+        }
+
+        fn supports_get_derived_key(&self) -> Option<&dyn tee_call::TeeCallGetDerivedKey> {
+            Some(self)
+        }
+
+        fn tee_type(&self) -> TeeType {
+            TeeType::Snp
+        }
+    }
+
+    impl tee_call::TeeCallGetDerivedKey for MockSnpTeeCall {
+        fn get_derived_key(&self, _tcb_version: u64) -> Result<[u8; 32], tee_call::Error> {
+            Ok([0u8; tee_call::HW_DERIVED_KEY_LENGTH])
+        }
+    }
+
+    #[test]
+    fn test_verify_init_data() {
+        let asserted_init_data = [0u8; 32];
+
+        let mock_call: Box<dyn TeeCall> = Box::new(MockSnpTeeCall {});
+        let result = verify_init_data(asserted_init_data, mock_call.as_ref());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_init_data_fail() {
+        let asserted_init_data = [1u8; 32];
+
+        let mock_call: Box<dyn TeeCall> = Box::new(MockSnpTeeCall {});
+        let result = verify_init_data(asserted_init_data, mock_call.as_ref());
+        assert!(result.is_err_and(|e| { matches!(e, InitDataError::InitDataAssertionFail) }));
     }
 }

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1312,13 +1312,14 @@ fn verify_init_data_inner(
     let attestation_type = match tee_call.tee_type() {
         TeeType::Snp => AttestationType::Snp,
         TeeType::Tdx => AttestationType::Tdx,
+        TeeType::Vbs => AttestationType::Vbs,
+        _ => AttestationType::Host,
     };
     match attestation_type {
         AttestationType::Snp => {
             // compare hash of the encoded settings with the host data
-            let snpreport =
-                sev_guest_device::protocol::SnpReport::mut_from_bytes(&mut report.report[..])
-                    .map_err(|_e| InitDataError::InvalidAttestationReport)?;
+            let snpreport = x86defs::snp::SnpReport::mut_from_bytes(&mut report.report[..])
+                .map_err(|_e| InitDataError::InvalidAttestationReport)?;
             let host_data = snpreport.host_data;
             tracing::info!(CVM_ALLOWED, "Host data: {:?}", host_data);
             tracing::info!(CVM_ALLOWED, "Asserted init data: {:?}", asserted_init_data);
@@ -1330,9 +1331,8 @@ fn verify_init_data_inner(
         }
         AttestationType::Tdx => {
             // compare hash of the encoded settings with the mr_config
-            let tdreport =
-                tdx_guest_device::protocol::TdReport::mut_from_bytes(&mut report.report[..])
-                    .map_err(|_e| InitDataError::InvalidAttestationReport)?;
+            let tdreport = x86defs::tdx::TdReport::mut_from_bytes(&mut report.report[..])
+                .map_err(|_e| InitDataError::InvalidAttestationReport)?;
             let mr_config = tdreport.td_info.td_info_base.mr_owner_config;
             if mr_config[0..32] == asserted_init_data {
                 return Ok(());
@@ -2765,7 +2765,7 @@ mod tests {
             _report_data: &[u8; 64],
         ) -> Result<tee_call::GetAttestationReportResult, tee_call::Error> {
             Ok(tee_call::GetAttestationReportResult {
-                report: [0u8; sev_guest_device::protocol::SNP_REPORT_SIZE].to_vec(),
+                report: [0u8; x86defs::snp::SNP_REPORT_SIZE].to_vec(),
                 tcb_version: None,
             })
         }

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1325,8 +1325,7 @@ fn verify_init_data_inner(
             if host_data == asserted_init_data {
                 return Ok(());
             } else {
-                return Ok(());
-                // return Err(InitDataError::InitDataAssertionFail);
+                return Err(InitDataError::InitDataAssertionFail);
             }
         }
         AttestationType::Tdx => {
@@ -1354,6 +1353,12 @@ fn verify_init_data_inner(
     }
 }
 
+// Public function to verify the InitData hash
+/// against the asserted InitData hash.
+/// Takes the asserted InitData hash and the attestation type as arguments.
+/// Passes the asserted InitData hash to the appropriate
+/// TEE call interface for verify_init_data_inner.
+/// Returns Ok(()) if the hashes match, or an error if they do not.
 pub fn verify_init_data(
     asserted_init_data: [u8; 32],
     tee_type: AttestationType,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -134,6 +134,7 @@ use tracing::Instrument;
 use tracing::instrument;
 use uevent::UeventListener;
 use underhill_attestation::AttestationType;
+use underhill_attestation::verify_init_data;
 use underhill_confidentiality::confidential_debug_enabled;
 use underhill_threadpool::AffinitizedThreadpool;
 use underhill_threadpool::ThreadpoolBuilder;
@@ -1467,6 +1468,39 @@ async fn new_underhill_vm(
     // Now that we have the isolation type, we can determine if the VM is SNP/TDX
     // and use the dps.vtl2_settings.attested_settings.verify() to validate
     // the vtl2_settings against the init-time data.
+    // if let Some(init_data_hash) = dps.general.vtl2_settings.as_ref()
+    // // .and_then(|s| s.fixed.attested_settings.as_ref())
+    // // .and_then(|s| s.init_data_hash)
+    // {
+    //     // verify_init_data(init_data_hash, isolation.into()).context("failed to verify init data")?;
+    //     tracing::info!("using init data hash from attested settings for verification");
+    // } else {
+    //     tracing::info!(
+    //         "attested_settings is missing. This fallback is acceptable because the init data hash is optional for non-isolated VMs or when attestation is not required."
+    //     );
+    // }
+    // let init_data_hash = dps
+    //     .general
+    //     .vtl2_settings
+    //     .as_ref()
+    //     .ok_or_else(|| anyhow::anyhow!("missing VTL2 settings"))?
+    //     .fixed
+    //     .attested_settings
+    //     .as_ref()
+    //     .ok_or_else(|| anyhow::anyhow!("attested_settings is missing"))?
+    //     .init_data_hash
+    //     .unwrap_or_else(|| {
+    //         tracing::error!(
+    //             "attested_settings is missing, proceeding with default value for init data hash"
+    //         );
+    //         Default::default()
+    //     });
+    // let attestation_type = match isolation {
+    //     virt::IsolationType::Snp => AttestationType::Snp,
+    //     virt::IsolationType::Tdx => AttestationType::Tdx,
+    //     _ => unreachable!(),
+    // };
+    // verify_init_data(init_data_hash, attestation_type).context("failed to verify init data")?;
 
     let hardware_isolated = isolation.is_hardware_isolated();
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -481,6 +481,7 @@ impl UnderhillVmWorker {
         let dps = read_device_platform_settings(&get_client)
             .instrument(tracing::info_span!("init/dps", CVM_ALLOWED))
             .await?;
+        // Parsing the dps will parse the vtl2_settings including the attested settings
 
         // Build the thread pool now that we know the IO ring size to use.
         let threadpool = {
@@ -1463,6 +1464,9 @@ async fn new_underhill_vm(
         bootloader_fdt_parser::IsolationType::Snp => virt::IsolationType::Snp,
         bootloader_fdt_parser::IsolationType::Tdx => virt::IsolationType::Tdx,
     };
+    // Now that we have the isolation type, we can determine if the VM is SNP/TDX
+    // and use the dps.vtl2_settings.attested_settings.verify() to validate
+    // the vtl2_settings against the init-time data.
 
     let hardware_isolated = isolation.is_hardware_isolated();
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1475,13 +1475,12 @@ async fn new_underhill_vm(
         .and_then(|s| s.fixed.attested_settings.as_ref())
         .and_then(|s| s.init_data_hash)
     {
-        // verify_init_data(init_data_hash, isolation.into()).context("failed to verify init data")?;
         let attestation_type = match isolation {
             virt::IsolationType::Snp => AttestationType::Snp,
             virt::IsolationType::Tdx => AttestationType::Tdx,
             _ => AttestationType::Host,
         };
-        // verify_init_data(init_data_hash, attestation_type).context("failed to verify init data")?;
+        verify_init_data(init_data_hash, attestation_type).context("failed to verify init data")?;
         tracing::info!(
             ?init_data_hash,
             "using init data hash from attested settings for verification"
@@ -1491,22 +1490,6 @@ async fn new_underhill_vm(
             "attested_settings is missing. This fallback is acceptable because the init data hash is optional for non-isolated VMs or when attestation is not required."
         );
     }
-    // let init_data_hash = dps
-    //     .general
-    //     .vtl2_settings
-    //     .as_ref()
-    //     .ok_or_else(|| anyhow::anyhow!("missing VTL2 settings"))?
-    //     .fixed
-    //     .attested_settings
-    //     .as_ref()
-    //     .ok_or_else(|| anyhow::anyhow!("attested_settings is missing"))?
-    //     .init_data_hash
-    //     .unwrap_or_else(|| {
-    //         tracing::error!(
-    //             "attested_settings is missing, proceeding with default value for init data hash"
-    //         );
-    //         Default::default()
-    //     });
 
     let hardware_isolated = isolation.is_hardware_isolated();
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1468,17 +1468,29 @@ async fn new_underhill_vm(
     // Now that we have the isolation type, we can determine if the VM is SNP/TDX
     // and use the dps.vtl2_settings.attested_settings.verify() to validate
     // the vtl2_settings against the init-time data.
-    // if let Some(init_data_hash) = dps.general.vtl2_settings.as_ref()
-    // // .and_then(|s| s.fixed.attested_settings.as_ref())
-    // // .and_then(|s| s.init_data_hash)
-    // {
-    //     // verify_init_data(init_data_hash, isolation.into()).context("failed to verify init data")?;
-    //     tracing::info!("using init data hash from attested settings for verification");
-    // } else {
-    //     tracing::info!(
-    //         "attested_settings is missing. This fallback is acceptable because the init data hash is optional for non-isolated VMs or when attestation is not required."
-    //     );
-    // }
+    if let Some(init_data_hash) = dps
+        .general
+        .vtl2_settings
+        .as_ref()
+        .and_then(|s| s.fixed.attested_settings.as_ref())
+        .and_then(|s| s.init_data_hash)
+    {
+        // verify_init_data(init_data_hash, isolation.into()).context("failed to verify init data")?;
+        let attestation_type = match isolation {
+            virt::IsolationType::Snp => AttestationType::Snp,
+            virt::IsolationType::Tdx => AttestationType::Tdx,
+            _ => AttestationType::Host,
+        };
+        // verify_init_data(init_data_hash, attestation_type).context("failed to verify init data")?;
+        tracing::info!(
+            ?init_data_hash,
+            "using init data hash from attested settings for verification"
+        );
+    } else {
+        tracing::info!(
+            "attested_settings is missing. This fallback is acceptable because the init data hash is optional for non-isolated VMs or when attestation is not required."
+        );
+    }
     // let init_data_hash = dps
     //     .general
     //     .vtl2_settings
@@ -1495,12 +1507,6 @@ async fn new_underhill_vm(
     //         );
     //         Default::default()
     //     });
-    // let attestation_type = match isolation {
-    //     virt::IsolationType::Snp => AttestationType::Snp,
-    //     virt::IsolationType::Tdx => AttestationType::Tdx,
-    //     _ => unreachable!(),
-    // };
-    // verify_init_data(init_data_hash, attestation_type).context("failed to verify init data")?;
 
     let hardware_isolated = isolation.is_hardware_isolated();
 

--- a/vm/devices/get/underhill_config/Cargo.toml
+++ b/vm/devices/get/underhill_config/Cargo.toml
@@ -16,7 +16,7 @@ prost.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror.workspace = true
-tee_call.workspace = true
+openssl.workspace = true
 
 [lints]
 workspace = true

--- a/vm/devices/get/underhill_config/Cargo.toml
+++ b/vm/devices/get/underhill_config/Cargo.toml
@@ -16,6 +16,7 @@ prost.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror.workspace = true
+tee_call.workspace = true
 
 [lints]
 workspace = true

--- a/vm/devices/get/underhill_config/src/lib.rs
+++ b/vm/devices/get/underhill_config/src/lib.rs
@@ -12,6 +12,7 @@ use guid::Guid;
 use inspect::Inspect;
 use mesh::MeshPayload;
 use serde::Serialize;
+use tee_call::{TeeCall, TeeType};
 
 mod errors;
 pub mod schema;
@@ -173,6 +174,65 @@ pub struct NicDevice {
     pub max_sub_channels: Option<u16>,
 }
 
+#[derive(Default, Debug, Clone, Eq, PartialEq, MeshPayload, Inspect)]
+pub struct Vtl2AttestedSettings {
+    // Reserved for future use
+}
+
+impl Vtl2AttestedSettings {
+    pub fn verify(&self, tee_call: &dyn TeeCall) -> Result<(), Vtl2SettingsErrorInfo> {
+        // TODO: Implement the attested settings verification
+        // This is a placeholder for the actual implementation.
+        // First serialize back to JSON
+        let json = serde_json::to_string(&self).map_err(|e| {
+            Vtl2SettingsErrorInfo::new(
+                Vtl2SettingsErrorCode::JsonFormatError,
+                format!("Failed to serialize settings: {}", e),
+            )
+        })?;
+
+        // Then base64 encode
+        let encoded = base64::encode(json);
+
+        // Does this belong in underhill_attestation?
+        match tee_call.tee_type() {
+            TeeType::Snp => {
+                let report = teecall
+                    .get_attestation_report(&encoded.as_bytes())
+                    .map_err(|e| {
+                        Vtl2SettingsErrorInfo::new(
+                            Vtl2SettingsErrorCode::InternalFailure,
+                            format!("Failed to get attestation report: {}", e),
+                        )
+                    })?;
+                // let host_data = report.host_data;
+                // compare hash of the encoded settings with the host data
+                return Ok(());
+            }
+            TeeType::Tdx => {
+                let report = teecall
+                    .get_attestation_report(&encoded.as_bytes())
+                    .map_err(|e| {
+                        Vtl2SettingsErrorInfo::new(
+                            Vtl2SettingsErrorCode::InternalFailure,
+                            format!("Failed to get attestation report: {}", e),
+                        )
+                    })?;
+                // let mr_config = report.mr_config;
+                // compare hash of the encoded settings with the mr_config
+                return Ok(());
+            }
+            _ => {
+                return Err(Vtl2SettingsErrorInfo::new(
+                    Vtl2SettingsErrorCode::InternalFailure,
+                    "Unsupported attestation type".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, MeshPayload, Inspect)]
 pub struct Vtl2SettingsFixed {
     /// number of sub-channels for the SCSI controller
@@ -181,6 +241,8 @@ pub struct Vtl2SettingsFixed {
     pub io_ring_size: u32,
     /// Max bounce buffer pages active per cpu
     pub max_bounce_buffer_pages: Option<u32>,
+    /// Attested settings
+    pub attested_settings: Option<Vtl2AttestedSettings>,
 }
 
 #[derive(Debug, Clone, MeshPayload, Inspect)]

--- a/vm/devices/get/underhill_config/src/lib.rs
+++ b/vm/devices/get/underhill_config/src/lib.rs
@@ -177,7 +177,7 @@ pub struct NicDevice {
 pub struct Vtl2AttestedSettings {
     pub version: i32,
     // Reserved for future use
-    init_data_hash: Option<Vec<u8>>,
+    pub init_data_hash: Option<[u8; 32]>,
 }
 
 #[derive(Debug, Clone, MeshPayload, Inspect)]

--- a/vm/devices/get/underhill_config/src/schema/mod.rs
+++ b/vm/devices/get/underhill_config/src/schema/mod.rs
@@ -141,7 +141,7 @@ impl crate::Vtl2Settings {
                         hasher.update(raw_bytes);
                         let attested_settings: Vtl2AttestedSettings = Self::read(raw_bytes)?;
                         let mut settings: crate::Vtl2AttestedSettings = attested_settings.into();
-                        settings.init_data_hash = Some(hasher.finish().to_vec());
+                        settings.init_data_hash = Some(hasher.finish());
                         external_attested_settings = Some(settings);
                     }
                 }

--- a/vm/devices/get/underhill_config/src/schema/v1.rs
+++ b/vm/devices/get/underhill_config/src/schema/v1.rs
@@ -26,6 +26,7 @@ use vtl2_settings_proto::*;
 pub(crate) const NAMESPACE_BASE: &str = "Base";
 pub(crate) const NAMESPACE_NETWORK_DEVICE: &str = "NetworkDevice";
 pub(crate) const NAMESPACE_NETWORK_ACCELERATION: &str = "NetworkAcceleration";
+pub(crate) const NAMESPACE_ATTESTED_SETTINGS: &str = "AttestedSettings";
 
 #[derive(Error, Debug)]
 pub(crate) enum Error<'a> {
@@ -528,6 +529,7 @@ impl ParseSchema<crate::Vtl2SettingsFixed> for Vtl2SettingsFixed {
             scsi_sub_channels: self.scsi_sub_channels.map_or(0, |x| x as u16),
             io_ring_size: self.io_ring_size.unwrap_or(256),
             max_bounce_buffer_pages: self.max_bounce_buffer_pages,
+            attested_settings: None,
         })
     }
 }

--- a/vm/devices/get/underhill_config/src/schema/vtl2s_test_attested_settings_namespaces.json
+++ b/vm/devices/get/underhill_config/src/schema/vtl2s_test_attested_settings_namespaces.json
@@ -1,0 +1,12 @@
+{
+    "namespace_settings": [
+        {
+            "namespace": "AttestedSettings",
+            "settings": "ew0KfQ0K"
+        },
+        {
+            "namespace": "NetworkAcceleration",
+            "settings": "ewogICAgIm5pY19hY2NlbGVyYXRpb24iOiBbCiAgICAgICAgewogICAgICAgICAgICAiaW5zdGFuY2VfaWQiOiAiOWUxNGZkMTEtMTljYi00ZGE1LWI2NjctZThlMzhhNDM2Y2I4IiwKICAgICAgICAgICAgInN1Ym9yZGluYXRlX2luc3RhbmNlX2lkIjogIjEyMzQ1Njc4LTE5Y2ItNGRhNS1iNjY3LWU4ZTM4YTQzNmNiOCIKICAgICAgICB9LAogICAgICAgIHsKICAgICAgICAgICAgImluc3RhbmNlX2lkIjogIjllMTRmZDEyLTE5Y2ItNGRhNS1iNjY3LWU4ZTM4YTQzNmNiOCIsCiAgICAgICAgICAgICJzdWJvcmRpbmF0ZV9pbnN0YW5jZV9pZCI6ICIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDAiCiAgICAgICAgfQogICAgXQp9Cg=="
+        }
+    ]
+}

--- a/vm/devices/get/underhill_config/src/schema/vtl2s_test_attested_settings_namespaces.json
+++ b/vm/devices/get/underhill_config/src/schema/vtl2s_test_attested_settings_namespaces.json
@@ -2,7 +2,7 @@
     "namespace_settings": [
         {
             "namespace": "AttestedSettings",
-            "settings": "ew0KfQ0K"
+            "settings": "ew0KICAgICJ2ZXJzaW9uIjogIlYxIg0KfQ0K"
         },
         {
             "namespace": "NetworkAcceleration",

--- a/vm/devices/get/vtl2_settings_proto/src/vtl2_settings.namespaces.proto
+++ b/vm/devices/get/vtl2_settings_proto/src/vtl2_settings.namespaces.proto
@@ -27,6 +27,7 @@ message Vtl2SettingsFixed {
     optional uint32 io_ring_size = 2;
     // Specify the maximum number of bounce buffer pages allowed per cpu
     optional uint32 max_bounce_buffer_pages = 3;
+    optional Vtl2AttestedSettings attested_settings = 4;
 }
 
 message Vtl2SettingsDynamic {
@@ -174,4 +175,14 @@ message NicAcceleration {
     string instance_id = 1; // GUID
     // An unique instance ID of a paired/teamed networking device exposed directly to VTL0.
     string subordinate_instance_id = 2; // GUID
+}
+
+// Settings used for the 'AttestedSettings' namespace
+message Vtl2AttestedSettings {
+    // Future attested setting fields should be added here
+
+    // Reserve field numbers that would make this start with an ASCII whitespace
+    // character or JSON object opening brace '{', which would conflict with
+    // JSON detection.
+    reserved 9, 10, 12, 13, 32, 123;
 }

--- a/vm/devices/get/vtl2_settings_proto/src/vtl2_settings.namespaces.proto
+++ b/vm/devices/get/vtl2_settings_proto/src/vtl2_settings.namespaces.proto
@@ -179,7 +179,12 @@ message NicAcceleration {
 
 // Settings used for the 'AttestedSettings' namespace
 message Vtl2AttestedSettings {
+    enum Version {
+        UNKNOWN = 0;
+        V1 = 1;
+    }
     // Future attested setting fields should be added here
+    Version version = 1;
 
     // Reserve field numbers that would make this start with an ASCII whitespace
     // character or JSON object opening brace '{', which would conflict with


### PR DESCRIPTION
Adds support for the attested settings as part of the init-time claims. This is broken into:
- Parsing and storing of attested settings for OpenHCL consuming components
- Verifying HostData/MrConfig against hash of attested settings.

This PR is Unit tested.