### PR TITLE
Repo: Lock to our rust version for this release branch

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[toolchain]
+channel = "1.86.0"


### PR DESCRIPTION
This branch will be on 1.86.0 for the forseeable future. As per our internal support policy this is an even version.