### PR TITLE
TDX: Pull TLB flush ringbuf struct into support/, add tests (#1387)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -29,6 +29,11 @@ path = "junit.xml"
 store-success-output = "true"
 
 [[profile.ci.overrides]]
+# allow loom based tests more time, as they take a while
+filter = 'test(loom)'
+slow-timeout = { period = "30s", terminate-after = 2 }
+
+[[profile.ci.overrides]]
 # use fuzzy-matching for the package() to allow out-of-tree tests to use the
 # same profile
 filter = 'package(~vmm_tests)'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic_ringbuf"
+version = "0.0.0"
+dependencies = [
+ "cfg-if",
+ "inspect",
+ "loom",
+ "parking_lot",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7949,6 +7959,7 @@ dependencies = [
  "aarch64defs",
  "aarch64emu",
  "anyhow",
+ "atomic_ringbuf",
  "bitfield-struct 0.10.1",
  "bitvec",
  "build_rs_guest_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ pipette_protocol = { path = "petri/pipette_protocol" }
 # support crates
 address_filter = { path = "support/address_filter" }
 arc_cyclic_builder = { path = "support/arc_cyclic_builder" }
+atomic_ringbuf = { path = "support/atomic_ringbuf" }
 cache_topology = { path = "support/cache_topology" }
 closeable_mutex = { path = "support/closeable_mutex" }
 ci_logger = { path = "support/ci_logger" }
@@ -462,6 +463,7 @@ libfuzzer-sys = "0.4"
 libtest-mimic = "0.8"
 linkme = "0.3.9"
 log = "0.4"
+loom = "0.7.2"
 macaddr = "1.0"
 mbrman = "0.5"
 mimalloc = { version = "0.1.39", default-features = false }
@@ -594,6 +596,10 @@ lto = 'fat'
 # FUTURE: rewrite relocator in asm to avoid depending on this.
 [profile.dev.package.minimal_rt]
 opt-level = 1
+
+# Optimize loom even in the dev profile, as otherwise tests just take too long.
+[profile.dev.package.loom]
+opt-level = 3
 
 [patch.crates-io]
 # Pending <https://github.com/ferrilab/bitvec/pull/273>

--- a/openhcl/virt_mshv_vtl/Cargo.toml
+++ b/openhcl/virt_mshv_vtl/Cargo.toml
@@ -30,6 +30,7 @@ vmcore.workspace = true
 x86defs.workspace = true
 x86emu.workspace = true
 
+atomic_ringbuf.workspace = true
 inspect_counters.workspace = true
 inspect = { workspace = true, features = ["std"] }
 mesh.workspace = true

--- a/support/atomic_ringbuf/Cargo.toml
+++ b/support/atomic_ringbuf/Cargo.toml
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "atomic_ringbuf"
+rust-version.workspace = true
+edition.workspace = true
+
+[dependencies]
+cfg-if.workspace = true
+inspect.workspace = true
+parking_lot.workspace = true
+
+[target.'cfg(target_arch = "x86_64")'.dev-dependencies]
+loom.workspace = true
+
+[lints]
+workspace = true

--- a/support/atomic_ringbuf/src/lib.rs
+++ b/support/atomic_ringbuf/src/lib.rs
@@ -1,0 +1,267 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! A fixed-size, multi-reader, seqlock-based, atomic ring buffer.
+//!
+//! This data structure is useful in situations where multiple writers are
+//! producing partial updates to a list of items and multiple readers are
+//! consuming these updates, so long as the readers have a fallback method
+//! for when they miss an update and the ring buffer wraps around. Writing
+//! is synchronized with a lock, but read attempts are never blocked.
+
+cfg_if::cfg_if! {
+    if #[cfg(all(target_arch = "x86_64", test))] { // xtask-fmt allow-target-arch dependency
+        use loom::sync::Mutex;
+        use loom::sync::MutexGuard;
+        use loom::sync::atomic::AtomicU64;
+        use loom::sync::atomic::AtomicUsize;
+        use loom::sync::atomic::Ordering;
+        use loom::sync::atomic::fence;
+    } else {
+        use parking_lot::Mutex;
+        use parking_lot::MutexGuard;
+        use std::sync::atomic::AtomicU64;
+        use std::sync::atomic::AtomicUsize;
+        use std::sync::atomic::Ordering;
+        use std::sync::atomic::fence;
+    }
+}
+
+use std::num::Wrapping;
+
+// TODO: Support data sizes other than u64.
+
+#[derive(Debug)]
+#[cfg_attr(not(test), derive(inspect::Inspect))]
+/// A fixed-size, multi-reader, seqlock-based, atomic ring buffer.
+pub struct AtomicRingBuffer<const N: usize, T: Copy + From<u64> + Into<u64>> {
+    /// The contents of the buffer.
+    #[cfg_attr(not(test), inspect(hex, with = "|x| inspect::iter_by_index(x.iter())"))]
+    buffer: Box<[AtomicU64; N]>,
+    /// The number of items that have been added over the lifetime of the struct.
+    list_count: AtomicUsize,
+    /// The number of items that have started being added over the lifetime of
+    /// the struct.
+    in_progress_count: AtomicUsize,
+    /// A guard to ensure that only one thread is writing at a time.
+    write_lock: Mutex<()>,
+    /// A marker to indicate the type of data stored in the buffer.
+    _datatype: std::marker::PhantomData<T>,
+}
+
+/// A guard that allows writing to the ring buffer.
+pub struct AtomicRingBufferWriteGuard<'a, const N: usize, T: Copy + From<u64> + Into<u64>> {
+    buf: &'a AtomicRingBuffer<N, T>,
+    _write_lock: MutexGuard<'a, ()>,
+}
+
+impl<const N: usize, T: Copy + From<u64> + Into<u64>> AtomicRingBuffer<N, T> {
+    /// Creates a new `AtomicRingBuffer`.
+    pub fn new() -> Self {
+        Self {
+            buffer: Box::new(std::array::from_fn(|_| AtomicU64::new(0))),
+            list_count: AtomicUsize::new(0),
+            in_progress_count: AtomicUsize::new(0),
+            write_lock: Mutex::new(()),
+            _datatype: std::marker::PhantomData,
+        }
+    }
+
+    /// Returns the number of items that have been added to the buffer over its
+    /// lifetime.
+    ///
+    /// This number only increases and is never reset, but it may wrap eventually.
+    pub fn count(&self) -> Wrapping<usize> {
+        Wrapping(self.list_count.load(Ordering::Acquire))
+    }
+
+    /// Obtain a write lock for the buffer.
+    pub fn write(&self) -> AtomicRingBufferWriteGuard<'_, N, T> {
+        let write_lock = self.write_lock.lock();
+        #[cfg(all(target_arch = "x86_64", test))] // xtask-fmt allow-target-arch dependency
+        let write_lock = write_lock.unwrap();
+        AtomicRingBufferWriteGuard {
+            buf: self,
+            _write_lock: write_lock,
+        }
+    }
+
+    /// Attempt to copy a portion of the buffer into the provided slice.
+    ///
+    /// This will copy `output.len()` items starting from `start_count` in the
+    /// buffer. `start_count` must be a previously observed value of `count()`.
+    /// If the buffer has wrapped around and items have been missed this will
+    /// return `false`, and readers should use their fallback method. If no
+    /// items have been missed it will return `true`, and readers may proceed
+    /// to consume the partial update.
+    pub fn try_copy(&self, start_count: usize, output: &mut [T]) -> bool {
+        if output.len() > N {
+            return false;
+        }
+        let mut index = start_count;
+        for slot in output.iter_mut() {
+            *slot = self.buffer[index % N].load(Ordering::Relaxed).into();
+            index = index.wrapping_add(1);
+        }
+        fence(Ordering::Acquire);
+
+        // Check to see whether any additional entries have been added
+        // that would have caused a wraparound. If so, the local list is
+        // incomplete and the copy has failed.
+        if (self
+            .in_progress_count
+            .load(Ordering::Acquire)
+            .wrapping_sub(start_count))
+            > N
+        {
+            return false;
+        }
+        true
+    }
+}
+
+impl<const N: usize, T: Copy + From<u64> + Into<u64>> AtomicRingBufferWriteGuard<'_, N, T> {
+    /// Add an item to the buffer.
+    ///
+    /// Note: using [`Self::extend`] is more efficient than using this method in a loop.
+    pub fn push(&self, item: T) {
+        self.extend(std::iter::once(item));
+    }
+
+    /// Add a range of items to the buffer.
+    pub fn extend(&self, items: impl ExactSizeIterator<Item = T>) {
+        debug_assert_eq!(
+            self.buf.in_progress_count.load(Ordering::Relaxed),
+            self.buf.list_count.load(Ordering::Relaxed)
+        );
+        // Adding a new item to the buffer must be done in three steps:
+        // 1. Indicate that an entry is about to be added so that any readers
+        //    code executing simultaneously will know that they might lose an
+        //    entry that they are expecting to see.
+        // 2. Add the entry.
+        // 3. Increment the valid entry count so that any readers executing
+        //    simultaneously will know it is valid.
+        let len = items.len();
+        let start_count = self.buf.in_progress_count.load(Ordering::Relaxed);
+        let end_count = start_count.wrapping_add(len);
+        self.buf
+            .in_progress_count
+            .store(end_count, Ordering::Release);
+        for (i, v) in items.enumerate() {
+            self.buf.buffer[(start_count.wrapping_add(i)) % N].store(v.into(), Ordering::Release);
+        }
+        self.buf.list_count.store(end_count, Ordering::Release);
+    }
+}
+
+#[cfg(all(target_arch = "x86_64", test))] // xtask-fmt allow-target-arch dependency
+mod loom_tests {
+    use super::*;
+    use loom::sync::Arc;
+    use loom::thread;
+
+    fn loom_test<F>(f: F)
+    where
+        F: Fn() + Sync + Send + 'static,
+    {
+        let mut model = loom::model::Builder::new();
+        // We need to set the preemption bound in order for any
+        // possibly-endless loops to complete in a reasonable time.
+        // Per loom's documentation: "In practice, setting the thread pre-emption
+        // bound to 2 or 3 is enough to catch most bugs".
+        model.preemption_bound = Some(2);
+        model.check(f);
+    }
+
+    #[test]
+    fn loom_basic() {
+        loom_test(|| {
+            const N: usize = 3;
+            let buf = Arc::new(AtomicRingBuffer::<N, u64>::new());
+
+            let buf_r = buf.clone();
+            let reader = thread::spawn(move || {
+                let mut out = [0u64; N];
+                let mut start = 0;
+
+                while start < N {
+                    let next_start = buf_r.count().0;
+                    if next_start == start {
+                        thread::yield_now();
+                        continue;
+                    }
+                    let ok = buf_r.try_copy(start, &mut out[start..next_start]);
+                    assert!(ok);
+                    start = next_start;
+                }
+                assert_eq!(out, [1, 2, 3]);
+            });
+
+            let buf_w = buf.clone();
+            let writer = thread::spawn(move || {
+                buf_w.write().push(1);
+                buf_w.write().push(2);
+                buf_w.write().push(3);
+            });
+
+            writer.join().unwrap();
+            reader.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn loom_multi_writer_wraparound() {
+        loom_test(|| {
+            let buf = Arc::new(AtomicRingBuffer::<3, u64>::new());
+
+            let buf_w = buf.clone();
+            let writer1 = thread::spawn(move || {
+                buf_w.write().push(1);
+                buf_w.write().push(2);
+            });
+
+            let buf_w = buf.clone();
+            let writer2 = thread::spawn(move || {
+                buf_w.write().push(3);
+                buf_w.write().push(4);
+            });
+
+            let buf_r = buf.clone();
+            let reader = thread::spawn(move || {
+                let mut out = [0u64; 4];
+                let mut start = 0;
+
+                while start < 4 {
+                    let next_start = buf_r.count().0;
+                    if next_start == start {
+                        thread::yield_now();
+                        continue;
+                    }
+                    let ok = buf_r.try_copy(start, &mut out[start..next_start]);
+                    if !ok {
+                        // A wrap around has occurred, at least one of the last
+                        // two items being written must be in the buffer. It is
+                        // possible the last one is still being added.
+                        assert!(buf_r.try_copy(1, &mut out[0..3]));
+                        out[3] = 0;
+                        assert!(out.contains(&2) || out.contains(&4));
+                        return;
+                    }
+                    start = next_start;
+                }
+                // The reader should have seen every item, but we don't know the order
+                assert!(out.contains(&1));
+                assert!(out.contains(&2));
+                assert!(out.contains(&3));
+                assert!(out.contains(&4));
+            });
+
+            writer1.join().unwrap();
+            writer2.join().unwrap();
+            reader.join().unwrap();
+
+            // Check that the ring buffer has wrapped around.
+            assert!(!buf.try_copy(0, &mut []));
+        });
+    }
+}

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -1817,6 +1817,18 @@ pub mod hypercall {
     #[repr(transparent)]
     pub struct HvGvaRange(pub u64);
 
+    impl From<u64> for HvGvaRange {
+        fn from(value: u64) -> Self {
+            Self(value)
+        }
+    }
+
+    impl From<HvGvaRange> for u64 {
+        fn from(value: HvGvaRange) -> Self {
+            value.0
+        }
+    }
+
     impl HvGvaRange {
         pub fn as_simple(self) -> HvGvaRangeSimple {
             HvGvaRangeSimple(self.0)

--- a/xtask/src/tasks/fmt/house_rules/cfg_target_arch.rs
+++ b/xtask/src/tasks/fmt/house_rules/cfg_target_arch.rs
@@ -14,6 +14,8 @@ const SUPPRESS_REASON_CPU_INTRINSIC: &str = "cpu-intrinsic";
 /// Using `target_arch` in order to implement a '*-sys'-like crate (where the
 /// structure changes depending on the host-arch)
 const SUPPRESS_REASON_SYS_CRATE: &str = "sys-crate";
+/// A dependency of this crate will not build on other target architectures
+const SUPPRESS_REASON_DEPENDENCY: &str = "dependency";
 /// One off - support for the auto-arch selection logic in
 /// `build_rs_guest_arch`.
 const SUPPRESS_REASON_ONEOFF_GUEST_ARCH_IMPL: &str = "oneoff-guest-arch-impl";
@@ -39,6 +41,7 @@ fn has_suppress(s: &str) -> bool {
         justification,
         SUPPRESS_REASON_CPU_INTRINSIC
             | SUPPRESS_REASON_SYS_CRATE
+            | SUPPRESS_REASON_DEPENDENCY
             | SUPPRESS_REASON_ONEOFF_GUEST_ARCH_IMPL
             | SUPPRESS_REASON_ONEOFF_VIRT_HVF
             | SUPPRESS_REASON_ONEOFF_FLOWEY


### PR DESCRIPTION
The added tests use [loom](https://docs.rs/loom/0.7.2/loom/) to ensure that all possible order of operations work correctly. This required tweaking the orderings we use.

Cherry-pick of #1387
