### PR TITLE
virt_mshv_vtl: Be more spec-compliant with crash_ctl reads

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -97,8 +97,6 @@ pub struct UhProcessor<'a, T: Backing> {
     kernel_returns: u64,
     #[inspect(hex, iter_by_index)]
     crash_reg: [u64; hvdef::HV_X64_GUEST_CRASH_PARAMETER_MSRS],
-    #[inspect(hex, with = "|&x| u64::from(x)")]
-    crash_control: hvdef::GuestCrashCtl,
     vmtime: VmTimeAccess,
     #[inspect(skip)]
     timer: PollImpl<dyn PollTimer>,
@@ -928,7 +926,6 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
             idle_control,
             kernel_returns: 0,
             crash_reg: [0; hvdef::HV_X64_GUEST_CRASH_PARAMETER_MSRS],
-            crash_control: hvdef::GuestCrashCtl::new(),
             _not_send: PhantomData,
             backing,
             shared: backing_shared,
@@ -1040,11 +1037,10 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
     fn write_crash_msr(&mut self, msr: u32, value: u64, vtl: GuestVtl) -> Result<(), MsrError> {
         match msr {
             hvdef::HV_X64_MSR_GUEST_CRASH_CTL => {
-                self.crash_control = hvdef::GuestCrashCtl::from(value);
                 let crash = VtlCrash {
                     vp_index: self.vp_index(),
                     last_vtl: vtl,
-                    control: self.crash_control,
+                    control: hvdef::GuestCrashCtl::from(value),
                     parameters: self.crash_reg,
                 };
                 tracelimit::info_ratelimited!(?crash, "Guest has reported system crash");

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1887,7 +1887,7 @@ mod save_restore {
             #[mesh(24)]
             pub(super) crash_reg: Option<[u64; 5]>,
             #[mesh(25)]
-            pub(super) crash_control: u64,
+            pub(super) _crash_control: u64, // No longer needed
             #[mesh(26)]
             pub(super) msr_mtrr_def_type: u64,
             #[mesh(27)]
@@ -2005,7 +2005,6 @@ mod save_restore {
                     },
                 // Saved
                 crash_reg,
-                crash_control,
                 // Runtime glue
                 partition: _,
                 idle_control: _,
@@ -2058,7 +2057,7 @@ mod save_restore {
                 dr6: dr6_shared.then(|| values[4].as_u64()),
                 startup_suspend,
                 crash_reg: Some(*crash_reg),
-                crash_control: crash_control.into_bits(),
+                _crash_control: 0,
                 msr_mtrr_def_type,
                 fixed_mtrrs: Some(fixed_mtrrs),
                 variable_mtrrs: Some(variable_mtrrs),
@@ -2094,7 +2093,7 @@ mod save_restore {
                 dr6,
                 startup_suspend,
                 crash_reg,
-                crash_control,
+                _crash_control,
                 msr_mtrr_def_type,
                 fixed_mtrrs,
                 variable_mtrrs,
@@ -2138,7 +2137,6 @@ mod save_restore {
                 .copy_from_slice(&fx_state);
 
             self.crash_reg = crash_reg.unwrap_or_default();
-            self.crash_control = crash_control.into();
 
             // Previous versions of Underhill did not save the MTRRs.
             // If we get a restore state with them missing then assume they weren't

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/x64.rs
@@ -1815,6 +1815,7 @@ mod save_restore {
     use super::UhProcessor;
     use anyhow::Context;
     use hcl::GuestVtl;
+    use hvdef::HV_X64_MSR_GUEST_CRASH_CTL;
     use hvdef::HvInternalActivityRegister;
     use hvdef::HvX64RegisterName;
     use hvdef::Vtl;
@@ -1877,17 +1878,25 @@ mod save_restore {
             pub(super) dr2: u64,
             #[mesh(21)]
             pub(super) dr3: u64,
+
+            /// Only set when the DR6_SHARED capability is present
             #[mesh(22)]
-            pub(super) dr6: Option<u64>, // only set when the DR6_SHARED capability is present
+            pub(super) dr6: Option<u64>,
+
             /// If VTL0 should be in the startup suspend state. Older underhill
             /// versions do not save this property, so maintain the old buggy
             /// behavior for those cases its not present in the saved state.
             #[mesh(23)]
             pub(super) startup_suspend: Option<bool>,
+
             #[mesh(24)]
             pub(super) crash_reg: Option<[u64; 5]>,
+
+            /// This value is ignored going forward, but may still be read by downlevel
+            /// versions.
             #[mesh(25)]
-            pub(super) _crash_control: u64, // No longer needed
+            pub(super) crash_control: u64,
+
             #[mesh(26)]
             pub(super) msr_mtrr_def_type: u64,
             #[mesh(27)]
@@ -1987,6 +1996,12 @@ mod save_restore {
                 .context("failed to get MTRRs")
                 .map_err(SaveError::Other)?;
 
+            // This value is ignored during restore, but may still be read by downlevel
+            // versions. Set it to the correct hardcoded read value as a best effort for them.
+            let crash_control = self
+                .read_crash_msr(HV_X64_MSR_GUEST_CRASH_CTL, GuestVtl::Vtl0)
+                .unwrap();
+
             let UhProcessor {
                 _not_send,
                 inner:
@@ -2057,7 +2072,7 @@ mod save_restore {
                 dr6: dr6_shared.then(|| values[4].as_u64()),
                 startup_suspend,
                 crash_reg: Some(*crash_reg),
-                _crash_control: 0,
+                crash_control,
                 msr_mtrr_def_type,
                 fixed_mtrrs: Some(fixed_mtrrs),
                 variable_mtrrs: Some(variable_mtrrs),
@@ -2093,7 +2108,7 @@ mod save_restore {
                 dr6,
                 startup_suspend,
                 crash_reg,
-                _crash_control,
+                crash_control: _crash_control,
                 msr_mtrr_def_type,
                 fixed_mtrrs,
                 variable_mtrrs,


### PR DESCRIPTION
Technically a guest is allowed to report multiple crashes, for example if they reboot after a crash without resetting VTL 2 state. Currently the host will tear us down when we report a crash, but that's a host-side policy and not something we should depend on.