### PR TITLE
openhcl_boot: provide stronger safety guarantees in the hypercall fra…

### DIFF
--- a/openhcl/openhcl_boot/src/arch/aarch64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/aarch64/memory.rs
@@ -5,10 +5,14 @@
 
 use crate::PartitionInfo;
 use crate::ShimParams;
-use crate::hvcall;
+use crate::hypercall::HvCall;
 use aarch64defs::IntermPhysAddrSize;
 
-pub fn setup_vtl2_memory(_shim_params: &ShimParams, _partition_info: &PartitionInfo) {
+pub fn setup_vtl2_memory(
+    hvcall: &mut HvCall,
+    _shim_params: &ShimParams,
+    _partition_info: &PartitionInfo,
+) {
     // TODO: memory acceptance isn't currently supported in the boot shim for aarch64.
     let _ = _shim_params.bounce_buffer;
 
@@ -18,7 +22,7 @@ pub fn setup_vtl2_memory(_shim_params: &ShimParams, _partition_info: &PartitionI
         .with_default_vtl_protection_mask(0xF)
         .with_enable_vtl_protection(true);
 
-    hvcall()
+    hvcall
         .set_register(
             hvdef::HvArm64RegisterName::VsmPartitionConfig.into(),
             hvdef::HvRegisterValue::from(u64::from(vsm_config)),

--- a/openhcl/openhcl_boot/src/arch/aarch64/vp.rs
+++ b/openhcl/openhcl_boot/src/arch/aarch64/vp.rs
@@ -4,16 +4,16 @@
 //! Setting up VTL2 VPs
 
 use crate::PartitionInfo;
-use crate::hypercall::hvcall;
+use crate::hypercall::HvCall;
 
-pub fn setup_vtl2_vp(partition_info: &PartitionInfo) {
+pub fn setup_vtl2_vp(hvcall: &mut HvCall, partition_info: &PartitionInfo) {
     // VTL2 kernel boot processor will try to remote read the GICR before AP's are
     // brought up. But, the hypervisor doesn't set the GICR overlay pages until the
     // Enable VP VTL hypercall has been made. Without the VP VTLs setup, accessing
     // GICR will cause the VTL2 kernel to panic.
     // BSP already has the VP VTL enabled at this time, so skip the BSP.
     for cpu in 1..partition_info.cpus.len() {
-        hvcall()
+        hvcall
             .enable_vp_vtl(cpu as u32)
             .expect("Enabling VP VTL should not fail");
     }

--- a/openhcl/openhcl_boot/src/arch/x86_64/vp.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/vp.rs
@@ -4,8 +4,8 @@
 //! Setting up VTL2 VPs
 
 use crate::host_params::PartitionInfo;
-
-pub fn setup_vtl2_vp(_partition_info: &PartitionInfo) {
+use crate::hypercall::HvCall;
+pub fn setup_vtl2_vp(_: &mut HvCall, _partition_info: &PartitionInfo) {
     // X64 doesn't require any special VTL2 VP setup in the boot loader at the
     // moment.
 }

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -107,7 +107,7 @@ mod details {
             // of the functions that use it are such that they cannot be
             // called concurrently.
             unsafe { HVCALL_OUTPUT.get().as_mut() }
-                .expect("input page")
+                .expect("output page")
                 .0
                 .as_slice()
         }

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -134,9 +134,10 @@ mod details {
     }
 }
 
+pub use details::HvCall;
 pub use details::hvcall;
 
-impl details::HvCall {
+impl HvCall {
     /// Returns the address of the hypercall page, mapping it first if
     /// necessary.
     #[cfg(target_arch = "x86_64")]

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -245,7 +245,7 @@ impl HvCallNoHardIsolation {
             let count = remaining_pages.min(MAX_INPUT_ELEMENTS as u64) as usize;
 
             // PANIC: Infallable, since the hypercall header is less than the size of a page
-            header.write_to_prefix(&mut self.input_page_mut()).unwrap();
+            header.write_to_prefix(self.input_page_mut()).unwrap();
 
             let mut input_offset = HEADER_SIZE;
             for i in 0..count {
@@ -284,7 +284,7 @@ impl HvCallNoHardIsolation {
         };
 
         // PANIC: Infallable, since the hypercall header is less than the size of a page
-        header.write_to_prefix(&mut self.input_page_mut()).unwrap();
+        header.write_to_prefix(self.input_page_mut()).unwrap();
 
         let output = self.dispatch_hvcall(hvdef::HypercallCode::HvCallEnableVpVtl, None);
         match output.result() {
@@ -321,7 +321,7 @@ impl HvCallNoHardIsolation {
             let count = remaining_pages.min(MAX_INPUT_ELEMENTS as u64) as usize;
 
             // PANIC: Infallable, since the hypercall header is less than the size of a page
-            header.write_to_prefix(&mut self.input_page_mut()).unwrap();
+            header.write_to_prefix(self.input_page_mut()).unwrap();
 
             let output =
                 self.dispatch_hvcall(hvdef::HypercallCode::HvCallAcceptGpaPages, Some(count));

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -3,153 +3,92 @@
 
 //! Hypercall infrastructure.
 
+use crate::PageAlign;
+use crate::host_params::shim_params::IsolationType;
+use crate::off_stack;
+use crate::single_threaded::OffStackRef;
+use crate::zeroed;
 use arrayvec::ArrayVec;
+use core::mem::MaybeUninit;
 use core::mem::size_of;
 use hvdef::HV_PAGE_SIZE;
+use hvdef::Vtl;
 use hvdef::hypercall::HvInputVtl;
 use memory_range::MemoryRange;
 use minimal_rt::arch::hypercall::invoke_hypercall;
 use zerocopy::FromBytes;
+use zerocopy::Immutable;
 use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
 
-mod details {
-    use crate::PageAlign;
-    use crate::single_threaded::SingleThreaded;
-    use crate::zeroed;
-    use core::cell::RefCell;
-    use core::cell::RefMut;
-    use core::cell::UnsafeCell;
-    use hvdef::HV_PAGE_SIZE;
-    use hvdef::Vtl;
-
-    /// Static, reusable page for hypercall input
-    static HVCALL_INPUT: SingleThreaded<UnsafeCell<PageAlign<[u8; HV_PAGE_SIZE as usize]>>> =
-        SingleThreaded(zeroed());
-
-    /// Static, reusable page for hypercall output
-    static HVCALL_OUTPUT: SingleThreaded<UnsafeCell<PageAlign<[u8; HV_PAGE_SIZE as usize]>>> =
-        SingleThreaded(zeroed());
-
-    static HVCALL: SingleThreaded<RefCell<HvCall>> = SingleThreaded(RefCell::new(HvCall {
-        initialized: false,
-        vtl: Vtl::Vtl0,
-    }));
-
-    /// Provides mechanisms to invoke hypercalls within the boot shim.
-    /// Internally uses static buffers for the hypercall page, the input
-    /// page, and the output page, so this should not be used in any
-    /// multi-threaded capacity (which the boot shim currently is not).
-    pub struct HvCall {
-        initialized: bool,
-        vtl: Vtl,
-    }
-
-    /// Returns an [`HvCall`] instance.
-    ///
-    /// Panics if another instance is already in use.
-    #[track_caller]
-    pub fn hvcall() -> RefMut<'static, HvCall> {
-        HVCALL.borrow_mut()
-    }
-
-    impl HvCall {
-        pub fn initialized(&self) -> bool {
-            self.initialized
-        }
-
-        pub fn initialize(&mut self) {
-            assert!(!self.initialized());
-            assert!(HVCALL_INPUT.get() as u64 & (HV_PAGE_SIZE - 1) == 0);
-            assert!(HVCALL_OUTPUT.get() as u64 & (HV_PAGE_SIZE - 1) == 0);
-
-            // TODO: revisit os id value. For now, use 1 (which is what UEFI does)
-            let guest_os_id = hvdef::hypercall::HvGuestOsMicrosoft::new().with_os_id(1);
-            crate::arch::hypercall::initialize(guest_os_id.into());
-
-            self.initialized = true;
-
-            self.vtl = self
-                .get_register(hvdef::HvAllArchRegisterName::VsmVpStatus.into())
-                .map_or(Vtl::Vtl0, |status| {
-                    hvdef::HvRegisterVsmVpStatus::from(status.as_u64())
-                        .active_vtl()
-                        .try_into()
-                        .unwrap()
-                });
-        }
-
-        /// Call before jumping to kernel.
-        pub fn uninitialize(&mut self) {
-            if self.initialized {
-                crate::arch::hypercall::uninitialize();
-                self.initialized = false;
-            }
-        }
-
-        /// Returns the environment's VTL.
-        pub fn vtl(&self) -> Vtl {
-            assert!(self.initialized);
-            self.vtl
-        }
-
-        pub fn input_page(&self) -> &[u8] {
-            // SAFETY: The input page is a static buffer, and the signatures
-            // of the functions that use it are such that they cannot be
-            // called concurrently.
-            unsafe { HVCALL_INPUT.get().as_mut() }
-                .expect("input page")
-                .0
-                .as_slice()
-        }
-
-        pub fn output_page(&self) -> &[u8] {
-            // SAFETY: The output page is a static buffer, and the signatures
-            // of the functions that use it are such that they cannot be
-            // called concurrently.
-            unsafe { HVCALL_OUTPUT.get().as_mut() }
-                .expect("output page")
-                .0
-                .as_slice()
-        }
-
-        pub fn input_page_mut(&mut self) -> &mut [u8] {
-            // SAFETY: The input page is a static buffer, and the signatures
-            // of the functions that use it are such that they cannot be
-            // called concurrently.
-            unsafe { HVCALL_INPUT.get().as_mut() }
-                .expect("input page")
-                .0
-                .as_mut_slice()
-        }
-
-        pub fn output_page_mut(&mut self) -> &mut [u8] {
-            // SAFETY: The output page is a static buffer, and the signatures
-            // of the functions that use it are such that they cannot be
-            // called concurrently.
-            unsafe { HVCALL_OUTPUT.get().as_mut() }
-                .expect("output page")
-                .0
-                .as_mut_slice()
-        }
-    }
+/// Provides mechanisms to invoke hypercalls within the boot shim.
+/// Internally uses static buffers for the hypercall page, the input
+/// page, and the output page, so this should not be used in any
+/// multi-threaded capacity (which the boot shim currently is not).
+struct HvCallNoHardIsolation {
+    input: OffStackRef<'static, PageAlign<[u8; HV_PAGE_SIZE as usize]>>,
+    output: OffStackRef<'static, PageAlign<[u8; HV_PAGE_SIZE as usize]>>,
+    vtl: Vtl,
 }
 
-pub use details::HvCall;
-pub use details::hvcall;
+impl HvCallNoHardIsolation {
+    pub fn new() -> Self {
+        // TODO: revisit os id value. For now, use 1 (which is what UEFI does)
+        let guest_os_id = hvdef::hypercall::HvGuestOsMicrosoft::new().with_os_id(1);
+        crate::arch::hypercall::initialize(guest_os_id.into());
 
-impl HvCall {
-    /// Returns the address of the hypercall page, mapping it first if
-    /// necessary.
-    #[cfg(target_arch = "x86_64")]
-    pub fn hypercall_page(&mut self) -> u64 {
-        self.init_if_needed();
-        core::ptr::addr_of!(minimal_rt::arch::hypercall::HYPERCALL_PAGE) as u64
+        // Use the internal function to bootstrap.
+        let vtl = Self::get_register_internal(hvdef::HvAllArchRegisterName::VsmVpStatus.into())
+            .map_or(Vtl::Vtl0, |status| {
+                hvdef::HvRegisterVsmVpStatus::from(status.as_u64())
+                    .active_vtl()
+                    .try_into()
+                    .unwrap()
+            });
+
+        Self {
+            input: off_stack!(PageAlign<[u8; HV_PAGE_SIZE as usize]>, zeroed()),
+            output: off_stack!(PageAlign<[u8; HV_PAGE_SIZE as usize]>, zeroed()),
+            vtl,
+        }
     }
 
-    fn init_if_needed(&mut self) {
-        if !self.initialized() {
-            self.initialize();
+    /// Returns the address of the hypercall page.
+    pub fn hypercall_page(&mut self) -> Option<u64> {
+        #[cfg(target_arch = "x86_64")]
+        {
+            Some(core::ptr::addr_of!(minimal_rt::arch::hypercall::HYPERCALL_PAGE) as u64)
         }
+        #[cfg(target_arch = "aarch64")]
+        {
+            None
+        }
+    }
+
+    /// Call before jumping to kernel.
+    pub fn uninitialize(self) {
+        crate::arch::hypercall::uninitialize();
+    }
+
+    /// Returns the environment's VTL.
+    pub fn vtl(&self) -> Vtl {
+        self.vtl
+    }
+
+    pub fn input_page(&self) -> &[u8] {
+        self.input.0.as_slice()
+    }
+
+    pub fn output_page(&self) -> &[u8] {
+        self.output.0.as_slice()
+    }
+
+    pub fn input_page_mut(&mut self) -> &mut [u8] {
+        self.input.0.as_mut_slice()
+    }
+
+    pub fn output_page_mut(&mut self) -> &mut [u8] {
+        self.input.0.as_mut_slice()
     }
 
     /// Makes a hypercall.
@@ -159,8 +98,6 @@ impl HvCall {
         code: hvdef::HypercallCode,
         rep_count: Option<usize>,
     ) -> hvdef::hypercall::HypercallOutput {
-        self.init_if_needed();
-
         let control = hvdef::hypercall::Control::new()
             .with_code(code.0)
             .with_rep_count(rep_count.unwrap_or_default());
@@ -176,68 +113,121 @@ impl HvCall {
     }
 
     /// Hypercall for setting a register to a value.
+    ///
+    /// The implementatio takes advantage of the fact that just one register
+    /// is set so a fixed on-stack buffer is used. Make sure the hypercall
+    /// interface with the hypervisor is established before calling this
+    /// function.
+    fn set_register_internal(
+        name: hvdef::HvRegisterName,
+        value: hvdef::HvRegisterValue,
+    ) -> Result<(), hvdef::HvError> {
+        #[repr(C, align(8))]
+        #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+        struct Input {
+            header: hvdef::hypercall::GetSetVpRegisters,
+            assoc: hvdef::hypercall::HvRegisterAssoc,
+        }
+
+        let input = Input {
+            header: hvdef::hypercall::GetSetVpRegisters {
+                partition_id: hvdef::HV_PARTITION_ID_SELF,
+                vp_index: hvdef::HV_VP_INDEX_SELF,
+                target_vtl: HvInputVtl::CURRENT_VTL,
+                rsvd: [0; 3],
+            },
+            assoc: hvdef::hypercall::HvRegisterAssoc {
+                name,
+                pad: Default::default(),
+                value,
+            },
+        };
+
+        // SAFETY: Invoking hypercall per TLFS spec
+        unsafe {
+            invoke_hypercall(
+                hvdef::hypercall::Control::new()
+                    .with_code(hvdef::HypercallCode::HvCallSetVpRegisters.0)
+                    .with_rep_count(1),
+                input.as_bytes().as_ptr() as u64,
+                0,
+            )
+        }
+        .result()
+    }
+
+    /// Hypercall for setting a register to a value.
     pub fn set_register(
         &mut self,
         name: hvdef::HvRegisterName,
         value: hvdef::HvRegisterValue,
     ) -> Result<(), hvdef::HvError> {
-        const HEADER_SIZE: usize = size_of::<hvdef::hypercall::GetSetVpRegisters>();
-
-        let header = hvdef::hypercall::GetSetVpRegisters {
-            partition_id: hvdef::HV_PARTITION_ID_SELF,
-            vp_index: hvdef::HV_VP_INDEX_SELF,
-            target_vtl: HvInputVtl::CURRENT_VTL,
-            rsvd: [0; 3],
-        };
-
-        // PANIC: Infallable, since the hypercall header is less than the size of a page
-        header.write_to_prefix(self.input_page_mut()).unwrap();
-
-        let reg = hvdef::hypercall::HvRegisterAssoc {
-            name,
-            pad: Default::default(),
-            value,
-        };
-
-        // PANIC: Infallable, since the hypercall parameter (plus size of header above) is less than the size of a page
-        reg.write_to_prefix(&mut self.input_page_mut()[HEADER_SIZE..])
-            .unwrap();
-
-        let output = self.dispatch_hvcall(hvdef::HypercallCode::HvCallSetVpRegisters, Some(1));
-
-        output.result()
+        Self::set_register_internal(name, value)
     }
 
-    /// Hypercall for setting a register to a value.
+    /// Hypercall for getting a value of a register.
+    ///
+    /// The implementatio takes advantage of the fact that just one register
+    /// is gotten so a fixed on-stack buffer is used. Make sure the hypercall
+    /// interface with the hypervisor is established before calling this
+    /// function.
+    fn get_register_internal(
+        name: hvdef::HvRegisterName,
+    ) -> Result<hvdef::HvRegisterValue, hvdef::HvError> {
+        #[repr(C, align(8))]
+        #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+        struct Input {
+            header: hvdef::hypercall::GetSetVpRegisters,
+            name: hvdef::HvRegisterName,
+            pad: u32,
+        }
+
+        let input = Input {
+            header: hvdef::hypercall::GetSetVpRegisters {
+                partition_id: hvdef::HV_PARTITION_ID_SELF,
+                vp_index: hvdef::HV_VP_INDEX_SELF,
+                target_vtl: HvInputVtl::CURRENT_VTL,
+                rsvd: [0; 3],
+            },
+            name,
+            pad: 0,
+        };
+
+        #[repr(C, align(8))]
+        #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+        struct Output {
+            value: hvdef::HvRegisterValue,
+        }
+
+        let mut output: MaybeUninit<Output> = MaybeUninit::uninit();
+
+        // SAFETY: Invoking hypercall per TLFS spec
+        unsafe {
+            invoke_hypercall(
+                hvdef::hypercall::Control::new()
+                    .with_code(hvdef::HypercallCode::HvCallSetVpRegisters.0)
+                    .with_rep_count(1),
+                input.as_bytes().as_ptr() as u64,
+                output.as_mut_ptr() as u64,
+            )
+        }
+        .result()?;
+
+        // SAFETY: The output must be a valid bit pattern for the type as the hypercall
+        // succeeded.
+        let output = unsafe { output.assume_init() };
+        Ok(output.value)
+    }
+
+    /// Hypercall for getting a register value.
     pub fn get_register(
         &mut self,
         name: hvdef::HvRegisterName,
     ) -> Result<hvdef::HvRegisterValue, hvdef::HvError> {
-        const HEADER_SIZE: usize = size_of::<hvdef::hypercall::GetSetVpRegisters>();
-
-        let header = hvdef::hypercall::GetSetVpRegisters {
-            partition_id: hvdef::HV_PARTITION_ID_SELF,
-            vp_index: hvdef::HV_VP_INDEX_SELF,
-            target_vtl: HvInputVtl::CURRENT_VTL,
-            rsvd: [0; 3],
-        };
-
-        // PANIC: Infallable, since the hypercall header is less than the size of a page
-        header.write_to_prefix(&mut self.input_page_mut()).unwrap();
-        // PANIC: Infallable, since the hypercall parameter (plus size of header above) is less than the size of a page
-        name.write_to_prefix(&mut self.input_page_mut()[HEADER_SIZE..])
-            .unwrap();
-
-        let output = self.dispatch_hvcall(hvdef::HypercallCode::HvCallGetVpRegisters, Some(1));
-        output.result()?;
-        let value = hvdef::HvRegisterValue::read_from_prefix(self.output_page())
-            .unwrap()
-            .0; // TODO: zerocopy: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
-        Ok(value)
+        Self::get_register_internal(name)
     }
 
     /// Hypercall to apply vtl protections to the pages from address start to end
-    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     pub fn apply_vtl2_protections(&mut self, range: MemoryRange) -> Result<(), hvdef::HvError> {
         const HEADER_SIZE: usize = size_of::<hvdef::hypercall::ModifyVtlProtectionMask>();
         const MAX_INPUT_ELEMENTS: usize = (HV_PAGE_SIZE as usize - HEADER_SIZE) / size_of::<u64>();
@@ -305,7 +295,6 @@ impl HvCall {
 
     /// Hypercall to accept vtl2 pages from address start to end with VTL 2
     /// protections and no host visibility
-    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     pub fn accept_vtl2_pages(
         &mut self,
         range: MemoryRange,
@@ -407,3 +396,124 @@ pub type HwId = u32;
 /// MPIDR on ARM64.
 #[cfg(target_arch = "aarch64")]
 pub type HwId = u64;
+
+struct HvCallHardIsolation;
+
+enum HvCallRoute {
+    NoHardIsolation(HvCallNoHardIsolation),
+    HardIsolation(HvCallHardIsolation),
+}
+
+/// The main entry point for hypercalls in the boot shim.
+///
+/// Performs the dynamic dispatch to the correct hypercall implementation
+/// manually as without the heap using dyn traits is cumbersome.
+pub struct HvCall {
+    route: HvCallRoute,
+}
+
+impl HvCall {
+    pub fn new(isolation: IsolationType) -> Self {
+        Self {
+            route: if isolation.is_hardware_isolated() {
+                HvCallRoute::HardIsolation(HvCallHardIsolation)
+            } else {
+                HvCallRoute::NoHardIsolation(HvCallNoHardIsolation::new())
+            },
+        }
+    }
+
+    /// Returns the address of the hypercall page, mapping it first if
+    /// necessary.
+    pub fn hypercall_page(&mut self) -> Option<u64> {
+        match self.route {
+            HvCallRoute::NoHardIsolation(ref mut hvcall) => hvcall.hypercall_page(),
+            HvCallRoute::HardIsolation(_) => {
+                panic!("Hypercall page not available in hardware isolation")
+            }
+        }
+    }
+
+    pub fn uninitialize(self) {
+        match self.route {
+            HvCallRoute::NoHardIsolation(hvcall) => hvcall.uninitialize(),
+            HvCallRoute::HardIsolation(_) => {}
+        }
+    }
+
+    pub fn get_vp_index_from_hw_id<const N: usize>(
+        &mut self,
+        hw_ids: &[HwId],
+        output: &mut ArrayVec<u32, N>,
+    ) -> Result<(), hvdef::HvError> {
+        match self.route {
+            HvCallRoute::NoHardIsolation(ref mut hvcall) => {
+                hvcall.get_vp_index_from_hw_id(hw_ids, output)
+            }
+            HvCallRoute::HardIsolation(_) => unimplemented!(),
+        }
+    }
+
+    pub fn set_register(
+        &mut self,
+        name: hvdef::HvRegisterName,
+        value: hvdef::HvRegisterValue,
+    ) -> Result<(), hvdef::HvError> {
+        match self.route {
+            HvCallRoute::NoHardIsolation(ref mut hvcall) => hvcall.set_register(name, value),
+            HvCallRoute::HardIsolation(_) => unimplemented!(),
+        }
+    }
+    pub fn get_register(
+        &mut self,
+        name: hvdef::HvRegisterName,
+    ) -> Result<hvdef::HvRegisterValue, hvdef::HvError> {
+        match self.route {
+            HvCallRoute::NoHardIsolation(ref mut hvcall) => hvcall.get_register(name),
+            HvCallRoute::HardIsolation(_) => unimplemented!(),
+        }
+    }
+
+    /// Get VTL.
+    pub fn vtl(&self) -> Vtl {
+        match self.route {
+            HvCallRoute::NoHardIsolation(ref hvcall) => hvcall.vtl(),
+            HvCallRoute::HardIsolation(_) => unimplemented!(),
+        }
+    }
+
+    /// Hypercall to enable VP VTL for the given VP index.
+    #[cfg(target_arch = "aarch64")]
+    pub fn enable_vp_vtl(&mut self, vp_index: u32) -> Result<(), hvdef::HvError> {
+        match self.route {
+            HvCallRoute::NoHardIsolation(ref mut hvcall) => hvcall.enable_vp_vtl(vp_index),
+            HvCallRoute::HardIsolation(_) => unimplemented!(),
+        }
+    }
+
+    /// Hypercall to accept vtl2 pages from address start to end with VTL 2
+    /// protections and no host visibility
+    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
+    pub fn accept_vtl2_pages(
+        &mut self,
+        range: MemoryRange,
+        memory_type: hvdef::hypercall::AcceptMemoryType,
+    ) -> Result<(), hvdef::HvError> {
+        match self.route {
+            HvCallRoute::NoHardIsolation(ref mut hvcall) => {
+                hvcall.accept_vtl2_pages(range, memory_type)
+            }
+            HvCallRoute::HardIsolation(_) => unimplemented!(),
+        }
+    }
+
+    /// Hypercall to apply vtl2 protections to the pages from address start to end
+    /// with VTL 2 protections and no host visibility
+    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
+    pub fn apply_vtl2_protections(&mut self, range: MemoryRange) -> Result<(), hvdef::HvError> {
+        match self.route {
+            HvCallRoute::NoHardIsolation(ref mut hvcall) => hvcall.apply_vtl2_protections(range),
+            HvCallRoute::HardIsolation(_) => unimplemented!(),
+        }
+    }
+}

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -127,7 +127,7 @@ mod details {
             // of the functions that use it are such that they cannot be
             // called concurrently.
             unsafe { HVCALL_OUTPUT.get().as_mut() }
-                .expect("input page")
+                .expect("output page")
                 .0
                 .as_mut_slice()
         }

--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -356,7 +356,7 @@ impl HvCallNoHardIsolation {
 
         for hw_ids in hw_ids.chunks(MAX_PER_CALL) {
             // PANIC: Infallable, since the hypercall header is less than the size of a page
-            header.write_to_prefix(&mut self.input_page_mut()).unwrap();
+            header.write_to_prefix(self.input_page_mut()).unwrap();
             // PANIC: Infallable, since the hypercall parameters are chunked to be less
             // than the remaining size (after the header) of the input page.
             // todo: This is *not true* for aarch64, where the hw_ids are u64s. Tracked via

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -673,7 +673,7 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
         partition_info,
         &mut sidecar_params.0,
         &mut sidecar_output.0,
-        hvcall.hypercall_page().expect("hypercall page"),
+        hvcall.hypercall_page().unwrap_or(0),
     );
 
     let mut cmdline = off_stack!(ArrayString<COMMAND_LINE_SIZE>, ArrayString::new_const());

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -63,6 +63,7 @@ pub fn start_sidecar<'a>(
     partition_info: &PartitionInfo,
     sidecar_params: &'a mut SidecarParams,
     sidecar_output: &'a mut SidecarOutput,
+    hypercall_page_address: u64,
 ) -> Option<SidecarConfig<'a>> {
     if !cfg!(target_arch = "x86_64") || p.isolation_type != IsolationType::None {
         return None;
@@ -150,11 +151,7 @@ pub fn start_sidecar<'a>(
             nodes,
         } = sidecar_params;
 
-        *hypercall_page = 0;
-        #[cfg(target_arch = "x86_64")]
-        {
-            *hypercall_page = crate::hypercall::hvcall().hypercall_page();
-        }
+        *hypercall_page = hypercall_page_address;
         *enable_logging = partition_info.boot_options.sidecar_logging;
 
         let mut base_vp = 0;


### PR DESCRIPTION
…mework

* The statics are hidden into a nested module to prevent bare access.
* The input and output pages are now associated functions with signatures that ensure exclusive mutable access at compile-time
* The associates functions absorb the patterns used in the code