### PR TITLE
cvm_tracing: Allow untagged tracing statements by default

### DIFF
--- a/Guide/src/reference/openhcl/diag/cvm_restrictions.md
+++ b/Guide/src/reference/openhcl/diag/cvm_restrictions.md
@@ -22,14 +22,14 @@ behave as if it is running in a CVM for the purpose of diagnostics.
 ## Tracing
 
 Tracing statements and spans will still be sent to the host, and therefore will still show up in
-ETW traces and Kusto. However, individual statements must opt in to being logged inside a CVM, as a
-way of affirming that they do not leak any guest secrets.
+ETW traces and Kusto. However, individual statements may opt out of being logged inside a CVM, as a
+way of protecting guest secrets.
 
 ### For Developers:
 
-This is done by using the `CVM_ALLOWED`
-constant provided by the `cvm_tracing` crate. `cvm_tracing` also provides a `CVM_CONFIDENTIAL`
-constant, to mark statements that could contain secrets and should not be logged in a CVM.
+This is done by using the `CVM_CONFIDENTIAL` constant provided by the
+`cvm_tracing` crate. `cvm_tracing` also provides a `CVM_ALLOWED` constant, to
+mark statements that do not contain secrets and can be logged in a CVM.
 
 Examples:
 
@@ -37,26 +37,26 @@ Examples:
 use cvm_tracing::{CVM_ALLOWED, CVM_CONFIDENTIAL};
 
 tracing::info!(CVM_ALLOWED, foo, ?bar, "This statement will be logged in a CVM");
-tracing::info!(baz, "This statement will not be logged in a CVM");
-tracing::info!(CVM_CONFIDENTIAL, super_secret, "This statement will also not be logged in a CVM");
+tracing::info!(baz, "This statement will also be logged in a CVM");
+tracing::info!(CVM_CONFIDENTIAL, super_secret, "This statement will not be logged in a CVM");
 
 // This also works with spans.
-let span = tracing::info_span!("a span", CVM_ALLOWED);
+let span = tracing::info_span!("a span", CVM_CONFIDENTIAL);
 my_func.instrument(span).await;
 
 // And the #[instrument] macro.
-#[instrument(name = "foo", fields(CVM_ALLOWED))]
+#[instrument(name = "foo", fields(CVM_CONFIDENTIAL))]
 fn my_func() {
     // ...
 }
 ```
 
 ```admonish tip
-Some of the tracing macros will not accept `cvm_tracing::CVM_ALLOWED` as an
+Some of the tracing macros will not accept `cvm_tracing::CVM_CONFIDENTIAL` as an
 argument.
 
-Instead, you will need to `use cvm_tracing::CVM_ALLOWED`, and then use just
-`CVM_ALLOWED`.
+Instead, you will need to `use cvm_tracing::CVM_CONFIDENTIAL`, and then use just
+`CVM_CONFIDENTIAL`.
 ```
 
 ## ohcldiag-dev

--- a/vm/cvm_tracing/src/lib.rs
+++ b/vm/cvm_tracing/src/lib.rs
@@ -26,7 +26,7 @@ pub const CVM_CONFIDENTIAL: Empty = Empty;
 
 /// A tracing filter that will only allow events that are marked as [`CVM_ALLOWED`].
 pub fn confidential_event_filter<S: Subscriber>() -> impl Filter<S> {
-    FilterFn::new(move |m| m.fields().field("CVM_ALLOWED").is_some())
+    FilterFn::new(move |m| m.fields().field("CVM_CONFIDENTIAL").is_none())
 }
 
 #[cfg(test)]
@@ -96,6 +96,6 @@ mod test {
     fn it_works() {
         let (count, subscriber) = create_test_subscriber();
         log_test_events(subscriber);
-        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 5);
+        assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 10);
     }
 }

--- a/vm/cvm_tracing/src/lib.rs
+++ b/vm/cvm_tracing/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Implements a tracing filter to restrict logging of events to only those
-//! that are marked as [`CVM_ALLOWED`].
+//! Implements a tracing filter to restrict logging of events that are marked
+//! as [`CVM_CONFIDENTIAL`].
 
 // How it works:
 // The magic value [`tracing::field::Empty`] will cause that field to be omitted
@@ -24,7 +24,7 @@ pub const CVM_ALLOWED: Empty = Empty;
 /// not be logged out of a confidential environment.
 pub const CVM_CONFIDENTIAL: Empty = Empty;
 
-/// A tracing filter that will only allow events that are marked as [`CVM_ALLOWED`].
+/// A tracing filter that will block events that are marked as [`CVM_CONFIDENTIAL`].
 pub fn confidential_event_filter<S: Subscriber>() -> impl Filter<S> {
     FilterFn::new(move |m| m.fields().field("CVM_CONFIDENTIAL").is_none())
 }


### PR DESCRIPTION
After long discussions we have decided to flip the default of our tracing filter, and to allow untagged tracing statements by default. We believe that the risks and costs of being unable to debug incidents in production are too high, and that we can manually scrub our tracing statements to ensure that no sensitive information is leaked.

Part of #852.