### PR TITLE
openvmm: add ability to route serial output to a file

### DIFF
--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -232,35 +232,35 @@ flags:
     #[clap(long, conflicts_with("virtio_console"))]
     pub virtio_console_pci: bool,
 
-    /// COM1 binding (console | stderr | listen=\<path\> | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
+    /// COM1 binding (console | stderr | listen=\<path\> | file=\<path\> (overwrites) | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
     #[clap(long, value_name = "SERIAL")]
     pub com1: Option<SerialConfigCli>,
 
-    /// COM2 binding (console | stderr | listen=\<path\> | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
+    /// COM2 binding (console | stderr | listen=\<path\> | file=\<path\> (overwrites) | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
     #[clap(long, value_name = "SERIAL")]
     pub com2: Option<SerialConfigCli>,
 
-    /// COM3 binding (console | stderr | listen=\<path\> | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
+    /// COM3 binding (console | stderr | listen=\<path\> | file=\<path\> (overwrites) | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
     #[clap(long, value_name = "SERIAL")]
     pub com3: Option<SerialConfigCli>,
 
-    /// COM4 binding (console | stderr | listen=\<path\> | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
+    /// COM4 binding (console | stderr | listen=\<path\> | file=\<path\> (overwrites) | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
     #[clap(long, value_name = "SERIAL")]
     pub com4: Option<SerialConfigCli>,
 
-    /// virtio serial binding (console | stderr | listen=\<path\> | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
+    /// virtio serial binding (console | stderr | listen=\<path\> | file=\<path\> (overwrites) | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
     #[clap(long, value_name = "SERIAL")]
     pub virtio_serial: Option<SerialConfigCli>,
 
-    /// vmbus com1 serial binding (console | stderr | listen=\<path\> | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
+    /// vmbus com1 serial binding (console | stderr | listen=\<path\> | file=\<path\> (overwrites) | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
     #[structopt(long, value_name = "SERIAL")]
     pub vmbus_com1_serial: Option<SerialConfigCli>,
 
-    /// vmbus com2 serial binding (console | stderr | listen=\<path\> | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
+    /// vmbus com2 serial binding (console | stderr | listen=\<path\> | file=\<path\> (overwrites) | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none)
     #[structopt(long, value_name = "SERIAL")]
     pub vmbus_com2_serial: Option<SerialConfigCli>,
 
-    /// debugcon binding (port:serial, where port is a u16, and serial is (console | stderr | listen=\<path\> | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none))
+    /// debugcon binding (port:serial, where port is a u16, and serial is (console | stderr | listen=\<path\> | file=\<path\> (overwrites) | listen=tcp:\<ip\>:\<port\> | term[=\<program\>][,name=<windowtitle>] | none))
     #[clap(long, value_name = "SERIAL")]
     pub debugcon: Option<DebugconSerialConfigCli>,
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1018,7 +1018,7 @@ impl FromStr for DebugconSerialConfigCli {
     }
 }
 
-/// (console | stderr | listen=\<path\> | listen=tcp:\<ip\>:\<port\> | none)
+/// (console | stderr | listen=\<path\> | listen=tcp:\<ip\>:\<port\> | file=\<path\> | none)
 #[derive(Clone)]
 pub enum SerialConfigCli {
     None,
@@ -1027,6 +1027,7 @@ pub enum SerialConfigCli {
     Stderr,
     Pipe(PathBuf),
     Tcp(SocketAddr),
+    File(PathBuf),
 }
 
 impl FromStr for SerialConfigCli {
@@ -1045,6 +1046,10 @@ impl FromStr for SerialConfigCli {
             "none" => SerialConfigCli::None,
             "console" => SerialConfigCli::Console,
             "stderr" => SerialConfigCli::Stderr,
+            "file" => match first_value {
+                Some(path) => SerialConfigCli::File(path.into()),
+                None => Err("invalid serial configuration: file requires a value")?,
+            },
             "term" => match first_value {
                 Some(path) => {
                     // If user supplies a name key, use it to title the window

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -251,6 +251,20 @@ fn vm_config_from_command_line(
                     .unwrap();
                 Some(config)
             }
+            SerialConfigCli::File(path) => {
+                let (config, serial) = serial_io::anonymous_serial_pair(&serial_driver)?;
+                thread::Builder::new()
+                    .name(name.to_owned())
+                    .spawn(move || {
+                        let file = fs_err::File::create(path)
+                            .context("failed to create file")
+                            .unwrap();
+
+                        let _ = block_on(futures::io::copy(serial, &mut AllowStdIo::new(file)));
+                    })
+                    .unwrap();
+                Some(config)
+            }
             SerialConfigCli::None => None,
             SerialConfigCli::Pipe(path) => {
                 Some(serial_io::bind_serial(&path).context("failed to bind serial")?)
@@ -297,6 +311,17 @@ fn vm_config_from_command_line(
             SerialConfigCli::Stderr => {
                 let mut io = SerialIo::new().context("creating serial IO")?;
                 io.spawn_copy_out(name, term::raw_stderr());
+                // Ensure there is no input so that the serial devices don't see
+                // EOF and think the port is disconnected.
+                io.config.input = None;
+                Some(io.config)
+            }
+            SerialConfigCli::File(path) => {
+                let mut io = SerialIo::new().context("creating serial IO")?;
+                let file = fs_err::File::create(path)
+                    .context("failed to create file")
+                    .unwrap();
+                io.spawn_copy_out(name, file);
                 // Ensure there is no input so that the serial devices don't see
                 // EOF and think the port is disconnected.
                 io.config.input = None;

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -253,13 +253,11 @@ fn vm_config_from_command_line(
             }
             SerialConfigCli::File(path) => {
                 let (config, serial) = serial_io::anonymous_serial_pair(&serial_driver)?;
+                let file = fs_err::File::create(path).context("failed to create file")?;
+
                 thread::Builder::new()
                     .name(name.to_owned())
                     .spawn(move || {
-                        let file = fs_err::File::create(path)
-                            .context("failed to create file")
-                            .unwrap();
-
                         let _ = block_on(futures::io::copy(serial, &mut AllowStdIo::new(file)));
                     })
                     .unwrap();
@@ -318,9 +316,7 @@ fn vm_config_from_command_line(
             }
             SerialConfigCli::File(path) => {
                 let mut io = SerialIo::new().context("creating serial IO")?;
-                let file = fs_err::File::create(path)
-                    .context("failed to create file")
-                    .unwrap();
+                let file = fs_err::File::create(path).context("failed to create file")?;
                 io.spawn_copy_out(name, file);
                 // Ensure there is no input so that the serial devices don't see
                 // EOF and think the port is disconnected.


### PR DESCRIPTION
This PR enables routing serial output to a file. Example usage: 
```
openvmm.exe ... --com3 file="./path/to/file"
```
