### PR TITLE
openhcl servicing: decrease flush logs timeout (#1385)

### DIFF
--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -559,10 +559,10 @@ impl LoadedVm {
         // Tell the initial process to flush all logs. Any logs
         // emitted after this point may be lost.
         state.init_state.flush_logs_result = Some({
-            // Only wait up to a second (which is still
+            // Only wait up to a half second (which is still
             // a long time!) to prevent delays from
             // introducing longer blackouts.
-            let ctx = CancelContext::new().with_timeout(Duration::from_secs(1));
+            let ctx = CancelContext::new().with_timeout(Duration::from_millis(500));
 
             let now = std::time::Instant::now();
             let call = self


### PR DESCRIPTION
Reduces the timeout for flushing logs during servicing to reduce blackout time if there is some issue with flushing the logs.