### PR TITLE
EXPERIMENT: Switch a number of cases from using size_of_val to size_of

### DIFF
--- a/support/mesh/mesh_remote/src/unix_node.rs
+++ b/support/mesh/mesh_remote/src/unix_node.rs
@@ -651,7 +651,11 @@ async fn run_receive(
             .0; // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
         match header.packet_type {
             protocol::PacketType::EVENT => {
-                local_node.event(remote_id, &buf[size_of_val(&header)..], &mut fds);
+                local_node.event(
+                    remote_id,
+                    &buf[size_of::<protocol::PacketHeader>()..],
+                    &mut fds,
+                );
                 fds.clear();
             }
             protocol::PacketType::RELEASE_FDS => {

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/mod.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/mod.rs
@@ -436,7 +436,8 @@ impl UefiDevice {
         use uefi_specs::hyperv::nvram::NvramCommand;
         use uefi_specs::hyperv::nvram::NvramVariableCommand;
 
-        let command_addr = desc_addr + size_of_val(&desc) as u64;
+        let command_addr =
+            desc_addr + size_of::<uefi_specs::hyperv::nvram::NvramCommandDescriptor>() as u64;
 
         let (status, err) = match desc.command {
             NvramCommand::GET_VARIABLE => {

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/mod.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/mod.rs
@@ -728,7 +728,7 @@ impl<S: InspectableNvramStorage> NvramSpecServices<S> {
                 // split off the variable-length WIN_CERTIFICATE_UEFI_GUID cert
                 // data from the variable length payload
                 let (pkcs7_data, var_data) = {
-                    let auth_info_offset = size_of_val(&auth_hdr.timestamp);
+                    let auth_info_offset = size_of::<EFI_VARIABLE_AUTHENTICATION_2>();
 
                     // use the header's length value to extract the
                     // WIN_CERTIFICATE_UEFI_GUID struct + variable length payload
@@ -948,7 +948,7 @@ impl<S: InspectableNvramStorage> NvramSpecServices<S> {
                 // auth header and go on to actually performing the requested
                 // operation of the remaining payload.
                 let total_auth_hdr_len =
-                    size_of_val(&auth_hdr.timestamp) + (auth_info.header.length as usize);
+                    size_of::<EFI_VARIABLE_AUTHENTICATION_2>() + (auth_info.header.length as usize);
 
                 (
                     in_data_size - total_auth_hdr_len as u32,

--- a/vm/devices/hyperv_ic/src/common.rs
+++ b/vm/devices/hyperv_ic/src/common.rs
@@ -71,7 +71,7 @@ impl IcPipe {
 
                 let header = hyperv_ic_protocol::Header {
                     message_type: MessageType::VERSION_NEGOTIATION,
-                    message_size: (size_of_val(&message)
+                    message_size: (size_of::<hyperv_ic_protocol::NegotiateMessage>()
                         + size_of_val(FRAMEWORK_VERSIONS)
                         + size_of_val(message_versions)) as u16,
                     status: Status::SUCCESS,

--- a/vm/devices/hyperv_ic_guest/src/shutdown.rs
+++ b/vm/devices/hyperv_ic_guest/src/shutdown.rs
@@ -25,7 +25,6 @@ use inspect::InspectMut;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcSend;
 use std::io::IoSlice;
-use std::mem::size_of_val;
 use task_control::Cancelled;
 use task_control::StopTask;
 use thiserror::Error;
@@ -245,9 +244,8 @@ impl ShutdownGuestChannel {
         };
         let response = hyperv_ic_protocol::Header {
             message_type: hyperv_ic_protocol::MessageType::VERSION_NEGOTIATION,
-            message_size: (size_of_val(&message)
-                + size_of_val(&framework_version)
-                + size_of_val(&message_version)) as u16,
+            message_size: (size_of::<hyperv_ic_protocol::NegotiateMessage>()
+                + (2 * size_of::<hyperv_ic_protocol::Version>())) as u16,
             status: Status::SUCCESS,
             transaction_id: header.transaction_id,
             flags: hyperv_ic_protocol::HeaderFlags::new()

--- a/vm/devices/net/gdma/src/bnic.rs
+++ b/vm/devices/net/gdma/src/bnic.rs
@@ -32,6 +32,7 @@ use gdma_defs::Wqe;
 use gdma_defs::access::WqeAccess;
 use gdma_defs::bnic as bnic_defs;
 use gdma_defs::bnic::ManaDestroyWqobjReq;
+use gdma_defs::bnic::ManaQueryFilterStateResponse;
 use gdma_defs::bnic::ManaTxShortOob;
 use gdma_defs::bnic::Tristate;
 use guestmem::GuestMemory;
@@ -242,7 +243,7 @@ impl BasicNic {
                 };
 
                 write.write(resp.as_bytes())?;
-                size_of_val(&resp)
+                size_of::<ManaQueryDeviceCfgResp>()
             }
             ManaCommandCode::MANA_CONFIG_VPORT_TX => {
                 let req: ManaConfigVportReq = read
@@ -259,7 +260,7 @@ impl BasicNic {
                     reserved: 0,
                 };
                 write.write(resp.as_bytes())?;
-                size_of_val(&resp)
+                size_of::<ManaConfigVportResp>()
             }
             ManaCommandCode::MANA_CREATE_WQ_OBJ => {
                 let req: ManaCreateWqobjReq =
@@ -311,7 +312,7 @@ impl BasicNic {
                 // Take ownership of the DMA regions.
                 state.remove_dma_region(req.wq_gdma_region).unwrap();
                 state.remove_dma_region(req.cq_gdma_region).unwrap();
-                size_of_val(&resp)
+                size_of::<ManaCreateWqobjResp>()
             }
             ManaCommandCode::MANA_DESTROY_WQ_OBJ => {
                 let req: ManaDestroyWqobjReq = read
@@ -411,13 +412,13 @@ impl BasicNic {
                     .get_mut(req.vport as usize)
                     .context("invalid vport")?;
 
-                let resp = gdma_defs::bnic::ManaQueryFilterStateResponse {
+                let resp = ManaQueryFilterStateResponse {
                     direction_to_vtl0: 0,
                     reserved: [0; 7],
                 };
 
                 write.write(resp.as_bytes())?;
-                size_of_val(&resp)
+                size_of::<ManaQueryFilterStateResponse>()
             }
             ManaCommandCode::MANA_QUERY_VPORT_CONFIG => {
                 let req: ManaQueryVportCfgReq = read
@@ -439,7 +440,7 @@ impl BasicNic {
                 };
 
                 write.write(resp.as_bytes())?;
-                size_of_val(&resp)
+                size_of::<ManaQueryVportCfgResp>()
             }
             ManaCommandCode::MANA_VTL2_ASSIGN_SERIAL_NUMBER => {
                 let req: ManaSetVportSerialNo =

--- a/vm/devices/net/gdma/src/hwc.rs
+++ b/vm/devices/net/gdma/src/hwc.rs
@@ -226,7 +226,7 @@ impl HwControl {
                 .context("reading request message header")?;
 
             let mut read = MemoryRead::limit(read, hdr.req.msg_size as usize);
-            read.skip(size_of_val(&hdr))
+            read.skip(size_of::<GdmaReqHdr>())
                 .context("message size too small")?;
 
             let mut write = MemoryWrite::limit(rqe.access(&queues.gm), hdr.resp.msg_size as usize);
@@ -274,7 +274,7 @@ impl HwControl {
 
             let rx_oob = HwcRxOob {
                 wqe_addr_low_or_offset: rqe_offset,
-                tx_oob_data_size: (size_of_val(&resp) + response_len) as u32,
+                tx_oob_data_size: (size_of::<GdmaRespHdr>() + response_len) as u32,
                 ..FromZeros::new_zeroed()
             };
 
@@ -317,7 +317,7 @@ impl HwControl {
                 write
                     .write(resp.as_bytes())
                     .context("writing verify vf driver response")?;
-                size_of_val(&resp)
+                size_of::<GdmaVerifyVerResp>()
             }
             GdmaRequestType::GDMA_QUERY_MAX_RESOURCES => {
                 let resp = GdmaQueryMaxResourcesResp {
@@ -336,7 +336,7 @@ impl HwControl {
                 write
                     .write(resp.as_bytes())
                     .context("writing query max response")?;
-                size_of_val(&resp)
+                size_of::<GdmaQueryMaxResourcesResp>()
             }
             GdmaRequestType::GDMA_LIST_DEVICES => {
                 let mut resp = GdmaListDevicesResp {
@@ -349,7 +349,7 @@ impl HwControl {
                 write
                     .write(resp.as_bytes())
                     .context("writing gdma list response")?;
-                size_of_val(&resp)
+                size_of::<GdmaListDevicesResp>()
             }
             GdmaRequestType::GDMA_REGISTER_DEVICE => {
                 if hdr.dev_id != BNIC_DEV_ID {
@@ -371,7 +371,7 @@ impl HwControl {
                 write
                     .write(resp.as_bytes())
                     .context("writing register device response")?;
-                size_of_val(&resp)
+                size_of::<GdmaRegisterDeviceResp>()
             }
             GdmaRequestType::GDMA_CREATE_DMA_REGION => {
                 let req: GdmaCreateDmaRegionReq =
@@ -391,7 +391,7 @@ impl HwControl {
                 write
                     .write(resp.as_bytes())
                     .context("writing dma region response")?;
-                size_of_val(&resp)
+                size_of::<GdmaCreateDmaRegionResp>()
             }
             GdmaRequestType::GDMA_CREATE_QUEUE => {
                 let req: GdmaCreateQueueReq = read.read_plain().context("reading queue request")?;
@@ -414,7 +414,7 @@ impl HwControl {
 
                 // Take ownership of the DMA region.
                 self.state.remove_dma_region(req.gdma_region).unwrap();
-                size_of_val(&resp)
+                size_of::<GdmaCreateQueueResp>()
             }
             GdmaRequestType::GDMA_DISABLE_QUEUE => {
                 let req: GdmaDisableQueueReq = read

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -240,7 +240,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         let num_msix = 1;
         let mut interrupt0 = device.map_interrupt(0, 0)?;
         let mut map = RegMap::new_zeroed();
-        for i in 0..size_of_val(&map) / 4 {
+        for i in 0..size_of::<RegMap>() / 4 {
             let v = bar0_mapping.read_u32(i * 4);
             // Unmapped device memory will return -1 on reads, so check the first 32
             // bits for this condition to get a clear error message early.
@@ -661,7 +661,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             msg_type: req_msg_type,
             msg_version: req_msg_version,
             hwc_msg_id: 0,
-            msg_size: (size_of::<GdmaReqHdr>() + size_of_val(&req)) as u32,
+            msg_size: (size_of::<GdmaReqHdr>() + size_of::<Req>()) as u32,
         };
         let expected_resp_hdr = GdmaMsgHdr {
             msg_type: resp_msg_type,
@@ -684,7 +684,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         );
         self.dma_buffer.write_obj(REQUEST_PAGE * PAGE_SIZE, &hdr);
         self.dma_buffer
-            .write_obj(REQUEST_PAGE * PAGE_SIZE + size_of_val(&hdr), &req);
+            .write_obj(REQUEST_PAGE * PAGE_SIZE + size_of::<GdmaReqHdr>(), &req);
 
         let oob = HwcTxOob {
             flags3: HwcTxOobFlags3::new().with_vscq_id(self.cq.id()),
@@ -700,7 +700,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                     [Sge {
                         address: self.dma_buffer.pfns()[REQUEST_PAGE] * PAGE_SIZE64,
                         mem_key: self.gpa_mkey,
-                        size: (size_of_val(&hdr) + size_of_val(&req)) as u32,
+                        size: (size_of::<GdmaReqHdr>() + size_of::<Req>()) as u32,
                     }],
                     None,
                     0,
@@ -718,7 +718,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                     hdr.activity_id,
                     sgl_phys_addr,
                     req_phys_addr,
-                    size_of_val(&hdr) + size_of_val(&req),
+                    size_of::<GdmaReqHdr>() + size_of::<Req>(),
                     mem_key,
                 )
             };
@@ -750,7 +750,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
 
             let resp = self
                 .dma_buffer
-                .read_obj::<Resp>(RESPONSE_PAGE * PAGE_SIZE + size_of_val(&resp_hdr));
+                .read_obj::<Resp>(RESPONSE_PAGE * PAGE_SIZE + size_of::<GdmaRespHdr>());
             Ok(resp)
         };
         let resp = match hw_access.await {

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/namespace.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/namespace.rs
@@ -407,7 +407,7 @@ impl Namespace {
             let header = nvm::ReservationReportExtended::read_from_prefix(&data[..])
                 .unwrap()
                 .0; // TODO: zerocopy: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
-            let len = size_of_val(&header)
+            let len = size_of::<nvm::ReservationReportExtended>()
                 + header.report.regctl.get() as usize
                     * size_of::<nvm::RegisteredControllerExtended>();
 
@@ -423,7 +423,7 @@ impl Namespace {
 
             controllers
                 .as_mut_bytes()
-                .copy_from_slice(&data[size_of_val(&header)..len]);
+                .copy_from_slice(&data[size_of::<nvm::ReservationReportExtended>()..len]);
 
             break Ok((header, controllers));
         }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queues.rs
@@ -61,7 +61,7 @@ impl SubmissionQueue {
             return Err(QueueFull);
         }
         self.mem
-            .write_obj(self.tail as usize * size_of_val(&command), &command);
+            .write_obj(self.tail as usize * size_of::<spec::Command>(), &command);
         self.tail = next_tail;
         Ok(())
     }

--- a/vm/devices/storage/nvme/src/namespace.rs
+++ b/vm/devices/storage/nvme/src/namespace.rs
@@ -78,7 +78,7 @@ impl Namespace {
         }
         *id = nvm::NamespaceIdentificationDescriptor {
             nidt: nvm::NamespaceIdentifierType::NSGUID.0,
-            nidl: size_of_val(&nid) as u8,
+            nidl: 0x10,
             rsvd: [0, 0],
             nid,
         };
@@ -183,11 +183,10 @@ impl Namespace {
                 let cdw10 = nvm::Cdw10Dsm::from(command.cdw10);
                 let cdw11 = nvm::Cdw11Dsm::from(command.cdw11);
                 // TODO: zerocopy: manual: review carefully! (https://github.com/microsoft/openvmm/issues/759)
-                let mut dsm_ranges =
-                    <[nvm::DsmRange]>::new_box_zeroed_with_elems(cdw10.nr_z() as usize + 1)
-                        .unwrap();
+                let count = cdw10.nr_z() as usize + 1;
+                let mut dsm_ranges = <[nvm::DsmRange]>::new_box_zeroed_with_elems(count).unwrap();
                 let prp =
-                    PrpRange::parse(&self.mem, size_of_val(dsm_ranges.as_ref()), command.dptr)?;
+                    PrpRange::parse(&self.mem, count * size_of::<nvm::DsmRange>(), command.dptr)?;
                 prp.read(&self.mem, dsm_ranges.as_mut_bytes())?;
                 tracing::debug!(nsid = self.nsid, ?cdw11, ?dsm_ranges, "dsm");
                 if cdw11.ad() {

--- a/vm/devices/storage/nvme/src/namespace/reservations.rs
+++ b/vm/devices/storage/nvme/src/namespace/reservations.rs
@@ -22,7 +22,11 @@ impl Namespace {
     ) -> Result<(), NvmeError> {
         let cdw10 = nvm::Cdw10ReservationRegister::from(command.cdw10);
         let mut data = nvm::ReservationRegister::new_zeroed();
-        let range = PrpRange::parse(&self.mem, size_of_val(&data), command.dptr)?;
+        let range = PrpRange::parse(
+            &self.mem,
+            size_of::<nvm::ReservationRegister>(),
+            command.dptr,
+        )?;
         range.read(&self.mem, data.as_mut_bytes())?;
 
         let current_key = (!cdw10.iekey()).then_some(data.crkey);
@@ -134,7 +138,11 @@ impl Namespace {
     ) -> Result<(), NvmeError> {
         let cdw10 = nvm::Cdw10ReservationAcquire::from(command.cdw10);
         let mut data = nvm::ReservationAcquire::new_zeroed();
-        let range = PrpRange::parse(&self.mem, size_of_val(&data), command.dptr)?;
+        let range = PrpRange::parse(
+            &self.mem,
+            size_of::<nvm::ReservationAcquire>(),
+            command.dptr,
+        )?;
         range.read(&self.mem, data.as_mut_bytes())?;
 
         // According to the spec, this is never to be set.
@@ -175,7 +183,11 @@ impl Namespace {
     ) -> Result<(), NvmeError> {
         let cdw10 = nvm::Cdw10ReservationRelease::from(command.cdw10);
         let mut data = nvm::ReservationRelease::new_zeroed();
-        let range = PrpRange::parse(&self.mem, size_of_val(&data), command.dptr)?;
+        let range = PrpRange::parse(
+            &self.mem,
+            size_of::<nvm::ReservationRelease>(),
+            command.dptr,
+        )?;
         range.read(&self.mem, data.as_mut_bytes())?;
 
         // According to the spec, this is never to be set.

--- a/vm/devices/storage/scsidisk/src/getlbastatus.rs
+++ b/vm/devices/storage/scsidisk/src/getlbastatus.rs
@@ -284,10 +284,9 @@ impl SimpleScsiDisk {
         let lba_status_descriptors_length =
             lba_descriptors_used * size_of::<scsi::LbaStatusDescriptor>();
         let mut lba_status_list_header = scsi::LbaStatusListHeader::new_zeroed();
-        lba_status_list_header.parameter_length = ((lba_status_descriptors_length
-            + size_of_val(&lba_status_list_header.reserved))
-            as u32)
-            .into();
+        // Add a u32 for reserved header space
+        lba_status_list_header.parameter_length =
+            ((lba_status_descriptors_length + size_of::<u32>()) as u32).into();
 
         buffer[0..size_of::<scsi::LbaStatusListHeader>()]
             .copy_from_slice(lba_status_list_header.as_bytes());

--- a/vm/devices/storage/scsidisk/src/unmap.rs
+++ b/vm/devices/storage/scsidisk/src/unmap.rs
@@ -33,7 +33,7 @@ fn validate_unmap_list_header(
             .unwrap()
             .0; // TODO: zerocopy: from-prefix (read_from_prefix): use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
     let unmap_list_header_length = unmap_list_header.data_length.get() as usize; // TODO: zerocopy: from-prefix (read_from_prefix): use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
-    let expected = allocation_length - size_of_val(&unmap_list_header.data_length);
+    let expected = allocation_length - 2; // 2 bytes for the header length field itself
     if unmap_list_header_length != expected {
         tracelimit::error_ratelimited!(unmap_list_header_length, expected, "validate_unmap_error");
         return Err(ScsiError::IllegalRequest(AdditionalSenseCode::INVALID_CDB));

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1657,7 +1657,7 @@ impl GuestMemory {
         current: T,
         new: T,
     ) -> Result<Result<T, T>, GuestMemoryError> {
-        let len = size_of_val(&new);
+        let len = size_of::<T>();
         self.with_op(
             Some((gpa, len as u64)),
             GuestMemoryOperation::CompareExchange,


### PR DESCRIPTION
I stumbled on https://github.com/rust-lang/rust/issues/62321 the other day which points out how `size_of_val` currently can result in unfortunate binary size costs when compared to `size_of`, especially in async code. This PR switches a bunch of cases from `size_of_val` to `size_of` to see if it produces any interesting binary size changes. I'm not a fan of this code, as it feels more fragile to me, but if the binary size changes end up being significant it may be worthwhile. Let's see what CI says.