### PR TITLE
ci: fix trigger for upload petri test results

### DIFF
--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -2,7 +2,8 @@ name: Upload Petri Test Results
 
 on:
   workflow_run:
-    types: [completed]
+    types:
+      - completed
     workflows:
       - '[flowey] OpenVMM CI'
       - '[flowey] OpenVMM PR'


### PR DESCRIPTION
This didn't seem to trigger, so try changing up the inputs to see if it'll trigger now. 