### PR TITLE
ci: escape special characters in workflow names

### DIFF
--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -5,8 +5,8 @@ on:
     types:
       - completed
     workflows:
-      - '[flowey] OpenVMM CI'
-      - '[flowey] OpenVMM PR'
+      - '\[flowey\] OpenVMM CI'
+      - '\[flowey\] OpenVMM PR'
 
 permissions:
   id-token: write


### PR DESCRIPTION
This should do the trick.