### PR TITLE
Repo: Update to the 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ exclude = [
 
 [workspace.package]
 rust-version = "1.87"
-edition = "2021"
+edition = "2024"
 
 [workspace.dependencies]
 xtask_fuzz = { path = "xtask/xtask_fuzz" }
@@ -537,7 +537,6 @@ windows-sys = "0.59"
 xshell = "=0.2.2" # pin to 0.2.2 to work around https://github.com/matklad/xshell/issues/63
 xshell-macros = "0.2"
 # We add the derive feature here since the vast majority of our crates use it.
-#zerocopy = { version = "0.7.32", features = ["derive"]}
 zerocopy = { version = "0.8.14", features = ["derive"]}
 
 [workspace.metadata.xtask.unused-deps]
@@ -612,12 +611,6 @@ pbjson-build = { git = "https://github.com/jstarks/pbjson", branch = "aliases" }
 # Lint groups need a priority lower than individual lints so they get applied first.
 future_incompatible = { level = "deny", priority = -2 }
 rust_2018_idioms = { level = "warn", priority = -2 }
-
-rust-2024-compatibility = { level = "warn", priority = -1 }
-edition_2024_expr_fragment_specifier = "allow"
-# TODO: Fix all of the below, https://github.com/microsoft/openvmm/issues/288
-tail-expr-drop-order = "allow"
-if-let-rescope = "allow"
 
 unused_qualifications = "warn"
 missing_docs = "warn"

--- a/Guide/mdbook-openvmm-shim/Cargo.toml
+++ b/Guide/mdbook-openvmm-shim/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "mdbook-openvmm-shim"
-edition = "2021"
+edition = "2024"
 
 [package.metadata.xtask.house-rules]
 # emits a binary, where kebab-case is more natural

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -2393,7 +2393,7 @@ mod node_luts {
     pub(super) fn modpath_by_node_typeid() -> &'static HashMap<NodeHandle, &'static str> {
         static TYPEID_TO_MODPATH: OnceLock<HashMap<NodeHandle, &'static str>> = OnceLock::new();
 
-        let lookup = TYPEID_TO_MODPATH.get_or_init(|| {
+        TYPEID_TO_MODPATH.get_or_init(|| {
             let mut lookup = HashMap::new();
             for crate::node::private::FlowNodeMeta {
                 module_path,
@@ -2413,9 +2413,7 @@ mod node_luts {
             }
 
             lookup
-        });
-
-        lookup
+        })
     }
 
     pub(super) fn erased_node_by_typeid()
@@ -2424,7 +2422,7 @@ mod node_luts {
             HashMap<NodeHandle, fn() -> Box<dyn FlowNodeBase<Request = Box<[u8]>>>>,
         > = OnceLock::new();
 
-        let lookup = LOOKUP.get_or_init(|| {
+        LOOKUP.get_or_init(|| {
             let mut lookup = HashMap::new();
             for crate::node::private::FlowNodeMeta {
                 module_path: _,
@@ -2439,9 +2437,7 @@ mod node_luts {
             }
 
             lookup
-        });
-
-        lookup
+        })
     }
 
     pub(super) fn erased_node_by_modpath() -> &'static HashMap<
@@ -2461,7 +2457,7 @@ mod node_luts {
             >,
         > = OnceLock::new();
 
-        let lookup = MODPATH_LOOKUP.get_or_init(|| {
+        MODPATH_LOOKUP.get_or_init(|| {
             let mut lookup = HashMap::new();
             for crate::node::private::FlowNodeMeta { module_path, ctor, get_typeid } in crate::node::private::FLOW_NODES {
                 let existing = lookup.insert(module_path.strip_suffix("::_only_one_call_to_flowey_node_per_module").unwrap(), (NodeHandle(get_typeid()), *ctor));
@@ -2470,9 +2466,7 @@ mod node_luts {
                 }
             }
             lookup
-        });
-
-        lookup
+        })
     }
 }
 

--- a/flowey/flowey_core/src/patch.rs
+++ b/flowey/flowey_core/src/patch.rs
@@ -98,7 +98,7 @@ where
 pub fn patchfn_by_modpath() -> &'static BTreeMap<String, PatchFn> {
     static MODPATH_LOOKUP: OnceLock<BTreeMap<String, PatchFn>> = OnceLock::new();
 
-    let lookup = MODPATH_LOOKUP.get_or_init(|| {
+    MODPATH_LOOKUP.get_or_init(|| {
         let mut lookup = BTreeMap::new();
         for (f, module_path, fn_name) in private::PATCH_FNS {
             let existing = lookup.insert(format!("{}::{}", module_path, fn_name), *f);
@@ -106,9 +106,7 @@ pub fn patchfn_by_modpath() -> &'static BTreeMap<String, PatchFn> {
             assert!(existing.is_none());
         }
         lookup
-    });
-
-    lookup
+    })
 }
 
 /// [`PatchResolver`]

--- a/openhcl/ohcldiag-dev/src/main.rs
+++ b/openhcl/ohcldiag-dev/src/main.rs
@@ -895,7 +895,7 @@ fn create_or_stderr(path: &Option<PathBuf>) -> std::io::Result<fs_err::File> {
 
 async fn capture_packets(
     client: DiagClient,
-    streams: Vec<impl std::future::Future<Output = Result<u64, std::io::Error>>>,
+    streams: Vec<impl Future<Output = Result<u64, std::io::Error>>>,
     capture_duration: Duration,
 ) {
     let mut capture_streams = FuturesUnordered::from_iter(streams);

--- a/openhcl/openhcl_boot/src/arch/x86_64/address_space.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/address_space.rs
@@ -221,8 +221,7 @@ unsafe fn get_pde_for_va(va: u64) -> &'static mut PageTableEntry {
         let entry = pdpt.entry(va, 2);
         assert!(entry.is_present());
         let pd = page_table_at_address(entry.get_addr());
-        let entry = pd.entry(va, 1);
-        entry
+        pd.entry(va, 1)
     }
 }
 

--- a/openhcl/underhill_attestation/src/igvm_attest/wrapped_key.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/wrapped_key.rs
@@ -201,9 +201,7 @@ mod tests {
         let payload = result.unwrap();
 
         let header = openhcl_attestation_protocol::igvm_attest::get::IgvmAttestWrappedKeyResponseHeader::new_zeroed();
-        let response = [header.as_bytes(), payload.as_bytes()].concat();
-
-        response
+        [header.as_bytes(), payload.as_bytes()].concat()
     }
 
     #[test]

--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -986,7 +986,7 @@ impl HclNetworkVFManager {
     ) -> anyhow::Result<Box<dyn netvsp::VirtualFunction>>
     where
         F: Fn(bool) -> R + Sync + Send + 'static,
-        R: std::future::Future<Output = bool> + Send,
+        R: Future<Output = bool> + Send,
     {
         let (tx_update, rx_update) = mesh::channel();
         let guest_state = self
@@ -1095,7 +1095,7 @@ impl<F> HclNetworkVFManagerInstance<F> {
 impl<F, R> netvsp::VirtualFunction for HclNetworkVFManagerInstance<F>
 where
     F: Fn(bool) -> R + Sync + Send + 'static,
-    R: std::future::Future<Output = bool> + Send,
+    R: Future<Output = bool> + Send,
 {
     async fn id(&self) -> Option<u32> {
         self.guest_state.vtl0_vfid().await

--- a/support/clap_dyn_complete/src/lib.rs
+++ b/support/clap_dyn_complete/src/lib.rs
@@ -286,7 +286,7 @@ pub trait CustomCompleterFactory: Send + Sync {
     type CustomCompleter: CustomCompleter + 'static;
 
     /// Build a new [`CustomCompleter`].
-    fn build(&self, ctx: &RootCtx<'_>) -> impl std::future::Future<Output = Self::CustomCompleter>;
+    fn build(&self, ctx: &RootCtx<'_>) -> impl Future<Output = Self::CustomCompleter>;
 }
 
 /// A custom completer for a particular argument.
@@ -297,7 +297,7 @@ pub trait CustomCompleter: Send + Sync {
         ctx: &RootCtx<'_>,
         subcommand_path: &[&str],
         arg_id: &str,
-    ) -> impl Send + std::future::Future<Output = Vec<String>>;
+    ) -> impl Send + Future<Output = Vec<String>>;
 }
 
 #[async_trait::async_trait]

--- a/support/mesh/mesh_channel_core/src/oneshot.rs
+++ b/support/mesh/mesh_channel_core/src/oneshot.rs
@@ -368,14 +368,13 @@ impl OneshotReceiverCore {
             // avoid taking the lock here. A naive implementation would require
             // extra storage in `OneshotReceiverCore` to remember this, which is
             // probably undesirable.
-            let v = if let SlotState::Sent(value) =
+            if let SlotState::Sent(value) =
                 std::mem::replace(&mut *slot.state.lock(), SlotState::Done)
             {
                 Some(value)
             } else {
                 None
-            };
-            v
+            }
         }
         if let Some(v) = clear(self) {
             // SAFETY: the value is of type `T`.

--- a/support/mesh/mesh_node/src/local_node.rs
+++ b/support/mesh/mesh_node/src/local_node.rs
@@ -2168,7 +2168,7 @@ impl LocalNode {
     fn get_remote(&self, id: NodeId) -> Arc<RemoteNode> {
         assert!(id != self.id());
         let mut state = self.inner.state.lock();
-        let remote_node = match state.nodes.entry(id) {
+        match state.nodes.entry(id) {
             hash_map::Entry::Occupied(entry) => entry.get().clone(),
             hash_map::Entry::Vacant(entry) => {
                 let (remote_node, handle) = RemoteNode::new(self.inner.clone(), id);
@@ -2180,8 +2180,7 @@ impl LocalNode {
                 }
                 remote_node
             }
-        };
-        remote_node
+        }
     }
 
     /// Gets the local port with ID `port_id`.

--- a/support/mesh/mesh_process/src/lib.rs
+++ b/support/mesh/mesh_process/src/lib.rs
@@ -153,14 +153,17 @@ async fn node_from_environment() -> anyhow::Result<Option<NodeResult>> {
     // Clear the string to avoid leaking the invitation information into child
     // processes.
     //
-    // TODO: this function will become unsafe in a future Rust edition because
+    // TODO: this function is unsafe because
     // it can cause UB if non-Rust code is concurrently accessing the
-    // environment in another thread. To be completely sound (even in the
-    // current edition), either this function and its callers need to become
+    // environment in another thread. To be completely sound,
+    // either this function and its callers need to become
     // `unsafe`, or we need to avoid using the environment to propagate the
     // invitation so that we can avoid this call.
-    #[expect(deprecated_safe_2024)]
-    std::env::remove_var(INVITATION_ENV_NAME);
+    //
+    // SAFETY: Seems to work so far.
+    unsafe {
+        std::env::remove_var(INVITATION_ENV_NAME);
+    }
 
     let invitation: Invitation = mesh::payload::decode(
         &base64::engine::general_purpose::STANDARD

--- a/vm/devices/input_core/src/lib.rs
+++ b/vm/devices/input_core/src/lib.rs
@@ -47,10 +47,7 @@ pub struct KeyboardData {
 pub trait InputSource<T>: futures::Stream<Item = T> + Unpin + Send {
     /// Sets this input source active, so that the sending side can choose which
     /// device to send input to.
-    fn set_active(
-        &mut self,
-        active: bool,
-    ) -> Pin<Box<dyn '_ + std::future::Future<Output = ()> + Send>>;
+    fn set_active(&mut self, active: bool) -> Pin<Box<dyn '_ + Future<Output = ()> + Send>>;
 }
 
 /// A resolved [`InputSource`].

--- a/vm/devices/input_core/src/mesh_input.rs
+++ b/vm/devices/input_core/src/mesh_input.rs
@@ -17,10 +17,7 @@ pub struct MeshInputSource<T> {
 }
 
 impl<T: 'static + Send> InputSource<T> for MeshInputSource<T> {
-    fn set_active(
-        &mut self,
-        active: bool,
-    ) -> Pin<Box<dyn '_ + std::future::Future<Output = ()> + Send>> {
+    fn set_active(&mut self, active: bool) -> Pin<Box<dyn '_ + Future<Output = ()> + Send>> {
         Box::pin(async move {
             if *self.active.get() != active {
                 self.active.set(active).await;

--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -276,8 +276,7 @@ impl VportState {
 
     /// Get current filter setting if known.
     pub fn get_direction_to_vtl0(&self) -> Option<bool> {
-        let direction_to_vtl0 = *self.direction_to_vtl0.lock();
-        direction_to_vtl0
+        *self.direction_to_vtl0.lock()
     }
 }
 

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -1701,7 +1701,7 @@ impl Nic {
                         .iter()
                         .map(|worker| {
                             worker.state().map(|worker| {
-                                let channel = if let Some(ready) = worker.state.ready() {
+                                if let Some(ready) = worker.state.ready() {
                                     // In flight tx will be considered as dropped packets through save/restore, but need
                                     // to complete the requests back to the guest.
                                     let pending_tx_completions = ready
@@ -1735,8 +1735,7 @@ impl Nic {
                                         pending_tx_completions: Vec::new(),
                                         in_use_rx: Vec::new(),
                                     }
-                                };
-                                channel
+                                }
                             })
                         })
                         .collect();

--- a/vm/devices/storage/disk_crypt/src/lib.rs
+++ b/vm/devices/storage/disk_crypt/src/lib.rs
@@ -169,7 +169,7 @@ impl DiskIo for CryptDisk {
         sector: u64,
         count: u64,
         block_level_only: bool,
-    ) -> impl std::future::Future<Output = Result<(), DiskError>> + Send {
+    ) -> impl Future<Output = Result<(), DiskError>> + Send {
         self.inner.unmap(sector, count, block_level_only)
     }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -469,7 +469,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
         drop(self);
     }
 
-    fn reset(&mut self) -> impl Send + std::future::Future<Output = ()> + use<T> {
+    fn reset(&mut self) -> impl Send + Future<Output = ()> + use<T> {
         let driver = self.driver.clone();
         let mut task = std::mem::take(&mut self.task).unwrap();
         async move {

--- a/vm/devices/storage/disk_striped/src/lib.rs
+++ b/vm/devices/storage/disk_striped/src/lib.rs
@@ -549,7 +549,7 @@ impl DiskIo for StripedDisk {
 async fn await_all_and_check<T, E>(futures: T) -> Result<(), E>
 where
     T: IntoIterator,
-    T::Item: core::future::Future<Output = Result<(), E>>,
+    T::Item: Future<Output = Result<(), E>>,
 {
     // Use join_all to wait for all IOs even if one fails. This is necessary to
     // avoid dropping IOs while they are in flight.

--- a/vm/devices/storage/storvsp/benches/ioperf.rs
+++ b/vm/devices/storage/storvsp/benches/ioperf.rs
@@ -17,7 +17,7 @@ use std::cell::RefCell;
 struct WrappedExecutor(RefCell<DefaultPool>);
 
 impl AsyncExecutor for &'_ WrappedExecutor {
-    fn block_on<T>(&self, future: impl std::future::Future<Output = T>) -> T {
+    fn block_on<T>(&self, future: impl Future<Output = T>) -> T {
         self.0.borrow_mut().run_until(future)
     }
 }

--- a/vm/devices/vmbus/vmbus_server/src/hvsock.rs
+++ b/vm/devices/vmbus/vmbus_server/src/hvsock.rs
@@ -113,7 +113,7 @@ impl HvsockRelay {
         &self,
         ctx: &mut CancelContext,
         service_id: Guid,
-    ) -> impl std::future::Future<Output = anyhow::Result<UnixStream>> + Send + use<> {
+    ) -> impl Future<Output = anyhow::Result<UnixStream>> + Send + use<> {
         let inner = self.inner.clone();
         let host_send = self.host_send.clone();
         let (send, recv) = mesh::oneshot();

--- a/vm/loader/src/uefi/mod.rs
+++ b/vm/loader/src/uefi/mod.rs
@@ -499,12 +499,9 @@ pub mod x86_64 {
                     importer,
                     CONFIG_BLOB_GPA_BASE / HV_PAGE_SIZE,
                     match isolation.isolation_type {
-                        IsolationType::Snp => {
-                            let table = shared_vis_page_tables
-                                .as_ref()
-                                .expect("should be shared vis page tables");
-                            table
-                        }
+                        IsolationType::Snp => shared_vis_page_tables
+                            .as_ref()
+                            .expect("should be shared vis page tables"),
                         _ => &[],
                     },
                 )?

--- a/vm/vmcore/src/vm_task.rs
+++ b/vm/vmcore/src/vm_task.rs
@@ -78,7 +78,7 @@ pub trait TargetedDriver: 'static + Send + Sync + Inspect {
         true
     }
     /// Waits for this driver's target VP to be ready for tasks and IO.
-    fn wait_target_vp_ready(&self) -> impl std::future::Future<Output = ()> + Send {
+    fn wait_target_vp_ready(&self) -> impl Future<Output = ()> + Send {
         std::future::ready(())
     }
 }
@@ -88,7 +88,7 @@ trait DynTargetedDriver: 'static + Send + Sync + Inspect {
     fn driver(&self) -> &dyn Driver;
     fn retarget_vp(&self, target_vp: u32);
     fn is_ready(&self) -> bool;
-    fn wait_ready(&self) -> Pin<Box<dyn '_ + std::future::Future<Output = ()> + Send>>;
+    fn wait_ready(&self) -> Pin<Box<dyn '_ + Future<Output = ()> + Send>>;
 }
 
 impl<T: TargetedDriver> DynTargetedDriver for T {
@@ -108,7 +108,7 @@ impl<T: TargetedDriver> DynTargetedDriver for T {
         self.is_target_vp_ready()
     }
 
-    fn wait_ready(&self) -> Pin<Box<dyn '_ + std::future::Future<Output = ()> + Send>> {
+    fn wait_ready(&self) -> Pin<Box<dyn '_ + Future<Output = ()> + Send>> {
         Box::pin(self.wait_target_vp_ready())
     }
 }

--- a/vmm_core/src/vmotherboard_adapter.rs
+++ b/vmm_core/src/vmotherboard_adapter.rs
@@ -58,39 +58,19 @@ impl CpuIo for ChipsetPlusSynic {
             .on_post_message(vtl, connection_id, secure, message)
     }
 
-    fn read_mmio(
-        &self,
-        vp: VpIndex,
-        address: u64,
-        data: &mut [u8],
-    ) -> impl std::future::Future<Output = ()> {
+    fn read_mmio(&self, vp: VpIndex, address: u64, data: &mut [u8]) -> impl Future<Output = ()> {
         self.chipset.mmio_read(vp.index(), address, data)
     }
 
-    fn write_mmio(
-        &self,
-        vp: VpIndex,
-        address: u64,
-        data: &[u8],
-    ) -> impl std::future::Future<Output = ()> {
+    fn write_mmio(&self, vp: VpIndex, address: u64, data: &[u8]) -> impl Future<Output = ()> {
         self.chipset.mmio_write(vp.index(), address, data)
     }
 
-    fn read_io(
-        &self,
-        vp: VpIndex,
-        port: u16,
-        data: &mut [u8],
-    ) -> impl std::future::Future<Output = ()> {
+    fn read_io(&self, vp: VpIndex, port: u16, data: &mut [u8]) -> impl Future<Output = ()> {
         self.chipset.io_read(vp.index(), port, data)
     }
 
-    fn write_io(
-        &self,
-        vp: VpIndex,
-        port: u16,
-        data: &[u8],
-    ) -> impl std::future::Future<Output = ()> {
+    fn write_io(&self, vp: VpIndex, port: u16, data: &[u8]) -> impl Future<Output = ()> {
         self.chipset.io_write(vp.index(), port, data)
     }
 }

--- a/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/services.rs
+++ b/vmm_core/vmotherboard/src/chipset/backing/arc_mutex/services.rs
@@ -182,7 +182,7 @@ impl<'a, 'b> ArcMutexChipsetServices<'a, 'b> {
 
     pub fn new_line(&mut self, id: LineSetId, name: &str, vector: u32) -> LineInterrupt {
         let (line_set, _) = self.builder.line_set(id.clone());
-        let line = match line_set.new_line(vector, format!("{}:{}", self.dev_name, name)) {
+        match line_set.new_line(vector, format!("{}:{}", self.dev_name, name)) {
             Ok(line) => {
                 self.line_set_dependencies.push(id);
                 line
@@ -193,8 +193,7 @@ impl<'a, 'b> ArcMutexChipsetServices<'a, 'b> {
                 self.line_error.get_or_insert(err);
                 LineInterrupt::detached()
             }
-        };
-        line
+        }
     }
 
     pub fn add_line_target(

--- a/xsync/Cargo.toml
+++ b/xsync/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 
 [workspace.package]
 rust-version = "1.87"
-edition = "2021"
+edition = "2024"
 
 [workspace.dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
I have spot checked about 50 of the 300-ish hits the remaining lints have, as well as manually searching for known potentially problematic patterns, and am relatively certain that the drop order changes will not affect us. Thus the last blocker is removed, and we can update. This naturally introduced a few new minor lint issues, so those are fixed here.

Closes #288