### PR TITLE
Networking tracing improvements

### DIFF
--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -114,7 +114,7 @@ impl NvmeManager {
                     .await
                 {
                     tracing::error!(
-                        e = &err as &dyn std::error::Error,
+                        error = e.as_ref() as &dyn std::error::Error,
                         "failed to restore nvme manager"
                     );
                 }

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -113,7 +113,10 @@ impl NvmeManager {
                     .instrument(tracing::info_span!("nvme_manager_restore"))
                     .await
                 {
-                    tracing::error!("failed to restore nvme manager: {}", e);
+                    tracing::error!(
+                        e = &err as &dyn std::error::Error,
+                        "failed to restore nvme manager"
+                    );
                 }
             };
             worker.run(recv).await

--- a/vm/devices/net/gdma/src/queues.rs
+++ b/vm/devices/net/gdma/src/queues.rs
@@ -101,13 +101,16 @@ impl<T: IntoBytes + Immutable + KnownLayout> CqEq<T> {
         let mut writer = range.writer(gm);
         let (entry, last) = entry.as_bytes().split_at(entry.as_bytes().len() - 1);
         if let Err(err) = writer.write(entry) {
-            tracing::warn!(err = &err as &dyn std::error::Error, "failed to write");
+            tracing::warn!(
+                err = &err as &dyn std::error::Error,
+                "failed to write entry"
+            );
         }
         // Write the final byte last after a release fence to ensure that the
         // guest sees the entire entry before the owner count is updated.
         std::sync::atomic::fence(Release);
         if let Err(err) = writer.write(last) {
-            tracing::warn!(err = &err as &dyn std::error::Error, "failed to write");
+            tracing::warn!(err = &err as &dyn std::error::Error, "failed to write last");
         }
         // Ensure the write is flushed before sending the interrupt.
         std::sync::atomic::fence(Release);

--- a/vm/devices/net/mana_driver/src/gdma_driver.rs
+++ b/vm/devices/net/mana_driver/src/gdma_driver.rs
@@ -211,7 +211,7 @@ impl<T: DeviceBacking> Drop for GdmaDriver<T> {
             tracing::error!("expected response");
         }
         if header.status() != 0 {
-            tracing::error!("DESTROY_HWC failed: {}", header.status());
+            tracing::error!(header_status = header.status(), "DESTROY_HWC failed");
         }
     }
 }
@@ -420,7 +420,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
         // available.
         let mut eq_id_msix = HashMap::new();
         eq_id_msix.insert(eq.id(), 0);
-        tracing::info!("Created HWC with eq id: {}, msix: 0", eq.id());
+        tracing::info!(eq_id = eq.id(), msix = 0, "created HWC");
 
         let db_id = db_id.context("db id not provided")? as u32;
         let gpa_mkey = gpa_mkey.context("gpa mem key not provided")?;
@@ -591,7 +591,7 @@ impl<T: DeviceBacking> GdmaDriver<T> {
             tracing::error!(msg_type, "expected shmem response");
         }
         if header.status() != 0 {
-            tracing::error!(msg_type, "response failed status={}", header.status());
+            tracing::error!(msg_type, header_status = header.status(), "response failed");
         }
     }
 
@@ -830,10 +830,10 @@ impl<T: DeviceBacking> GdmaDriver<T> {
                                 "HWC timeout value"
                             );
                         }
-                        unknown => tracing::error!(unknown, "unknown reconfig data type."),
+                        unknown => tracing::error!(unknown, "unknown reconfig data type"),
                     }
                 }
-                ty => tracing::error!("unknown eq event {}", ty),
+                ty => tracing::error!(ty, "unknown eq event"),
             }
             self.eq.ack();
         }

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -3984,7 +3984,11 @@ impl Coordinator {
                     }
                     let result = c_state.endpoint.set_data_path_to_guest_vf(to_guest).await;
                     let result = if let Err(err) = result {
-                        tracing::error!(err = %err, to_guest, "Failed to switch guest VF data path");
+                        tracing::error!(
+                            err = err.as_ref() as &dyn std::error::Error,
+                            to_guest,
+                            "Failed to switch guest VF data path"
+                        );
                         false
                     } else {
                         primary.is_data_path_switched = Some(to_guest);
@@ -4041,7 +4045,10 @@ impl Coordinator {
                 ) => {
                     if !to_guest {
                         if let Err(err) = c_state.endpoint.set_data_path_to_guest_vf(false).await {
-                            tracing::warn!(err = %err, "Failed setting data path back to synthetic after guest VF was removed.");
+                            tracing::warn!(
+                                err = err.as_ref() as &dyn std::error::Error,
+                                "Failed setting data path back to synthetic after guest VF was removed."
+                            );
                         }
                         primary.is_data_path_switched = Some(false);
                     }
@@ -4051,7 +4058,10 @@ impl Coordinator {
                     saved_state::GuestVfState::DataPathSwitched,
                 ) => {
                     if let Err(err) = c_state.endpoint.set_data_path_to_guest_vf(false).await {
-                        tracing::warn!(err = %err, "Failed setting data path back to synthetic after guest VF was removed.");
+                        tracing::warn!(
+                            err = err.as_ref() as &dyn std::error::Error,
+                            "Failed setting data path back to synthetic after guest VF was removed."
+                        );
                     }
                     primary.is_data_path_switched = Some(false);
                 }
@@ -4393,14 +4403,14 @@ impl<T: RingMem + 'static> Worker<T> {
                         }
                         Err(WorkerError::EndpointRequiresQueueRestart(err)) => {
                             tracelimit::warn_ratelimited!(
-                                err = %err,
+                                err = err.as_ref() as &dyn std::error::Error,
                                 "Endpoint requires queues to restart",
                             );
                             if let Err(try_send_err) =
                                 self.coordinator_send.try_send(CoordinatorMessage::Restart)
                             {
                                 tracing::error!(
-                                    try_send_err = %try_send_err,
+                                    try_send_err = &try_send_err as &dyn std::error::Error,
                                     "failed to restart queues"
                                 );
                                 return Err(WorkerError::Endpoint(err));


### PR DESCRIPTION
Had to review all networking traces for a security review. In the process, found a number of tracing statements that did not align with our usual practices/style.

* Errors traced as %err instead of being cast to std::error::Error.
* Variables formatted into string text instead of being traced directly.