### PR TITLE
guestmem: add error kind for access failures

### DIFF
--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -331,7 +331,7 @@ unsafe impl GuestMemoryAccess for GuestMemoryMapping {
         if let Some(registrar) = &self.registrar {
             registrar
                 .register(address, len)
-                .map_err(|start| GuestMemoryBackingError::new(start, RegistrationError))
+                .map_err(|start| GuestMemoryBackingError::other(start, RegistrationError))
         } else {
             // TODO: fail this call once we have a way to avoid calling this for
             // user-mode-only accesses to locked memory (e.g., for vmbus ring

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -2416,7 +2416,10 @@ impl UhProcessor<'_, TdxBacked> {
                 // For now, we just check if the exit was suprious or if we
                 // should inject a machine check. An exit is considered spurious
                 // if the gpa is accessible.
-                if self.partition.gm[intercepted_vtl].check_gpa_readable(gpa) {
+                if self.partition.gm[intercepted_vtl]
+                    .probe_gpa_readable(gpa)
+                    .is_ok()
+                {
                     tracelimit::warn_ratelimited!(gpa, "possible spurious EPT violation, ignoring");
                 } else {
                     // TODO: It would be better to show what exact bitmap check

--- a/openvmm/membacking/src/mapping_manager/va_mapper.rs
+++ b/openvmm/membacking/src/mapping_manager/va_mapper.rs
@@ -31,6 +31,7 @@ use crate::RemoteProcess;
 use futures::executor::block_on;
 use guestmem::GuestMemoryAccess;
 use guestmem::PageFaultAction;
+use guestmem::PageFaultError;
 use memory_range::MemoryRange;
 use mesh::rpc::RpcError;
 use mesh::rpc::RpcSend;
@@ -295,7 +296,10 @@ unsafe impl GuestMemoryAccess for VaMapper {
             self.inner
                 .request_mapping(MemoryRange::bounding(address..address + len as u64), write),
         ) {
-            return PageFaultAction::Fail(err.into());
+            return PageFaultAction::Fail(PageFaultError::new(
+                guestmem::GuestMemoryErrorKind::OutOfRange,
+                err,
+            ));
         }
         PageFaultAction::Retry
     }


### PR DESCRIPTION
Allow the memory backing to provide an error kind, which the virt backends will later use to determine whether to attempt emulation, inject a machine fault, resume the VP, or terminate the VM.