### PR TITLE
storage: Tag CVM_CONFIDENTIAL tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,7 @@ dependencies = [
  "async-trait",
  "bitfield-struct 0.10.1",
  "blocking",
+ "cvm_tracing",
  "disk_backend",
  "event-listener",
  "fs-err",
@@ -1774,6 +1775,7 @@ dependencies = [
  "arrayvec",
  "bitfield-struct 0.10.1",
  "chipset_device",
+ "cvm_tracing",
  "disk_backend",
  "guestmem",
  "inspect",
@@ -1793,6 +1795,7 @@ dependencies = [
  "arrayvec",
  "bitfield-struct 0.10.1",
  "chipset_device",
+ "cvm_tracing",
  "inspect",
  "mesh",
  "open_enum",
@@ -3295,6 +3298,7 @@ version = "0.0.0"
 dependencies = [
  "bitfield-struct 0.10.1",
  "chipset_device",
+ "cvm_tracing",
  "disk_backend",
  "disk_file",
  "guestmem",
@@ -4629,6 +4633,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "chipset_device",
+ "cvm_tracing",
  "device_emulators",
  "disk_backend",
  "event-listener",
@@ -4672,6 +4677,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chipset_device",
+ "cvm_tracing",
  "disklayer_ram",
  "event-listener",
  "futures",
@@ -6109,6 +6115,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "cvm_tracing",
  "disk_backend",
  "disk_prwrap",
  "futures",
@@ -6609,6 +6616,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "criterion",
+ "cvm_tracing",
  "disklayer_ram",
  "event-listener",
  "fast_select",

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -9,6 +9,7 @@ use crate::nvme_manager::save_restore::NvmeSavedDiskConfig;
 use crate::servicing::NvmeSavedState;
 use anyhow::Context;
 use async_trait::async_trait;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use disk_backend::resolve::ResolveDiskParameters;
 use disk_backend::resolve::ResolvedDisk;
 use futures::StreamExt;
@@ -113,7 +114,7 @@ impl NvmeManager {
                     .instrument(tracing::info_span!("nvme_manager_restore"))
                     .await
                 {
-                    tracing::error!("failed to restore nvme manager: {}", e);
+                    tracing::error!(CVM_CONFIDENTIAL, "failed to restore nvme manager: {}", e);
                 }
             };
             worker.run(recv).await

--- a/vm/devices/storage/disk_blockdevice/Cargo.toml
+++ b/vm/devices/storage/disk_blockdevice/Cargo.toml
@@ -12,6 +12,7 @@ nvme_common.workspace = true
 nvme_spec.workspace = true
 scsi_buffers.workspace = true
 
+cvm_tracing.workspace = true
 hvdef.workspace = true
 mesh.workspace = true
 guestmem.workspace = true

--- a/vm/devices/storage/disk_blockdevice/src/lib.rs
+++ b/vm/devices/storage/disk_blockdevice/src/lib.rs
@@ -16,6 +16,7 @@ mod nvme;
 use anyhow::Context;
 use async_trait::async_trait;
 use blocking::unblock;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use disk_backend::DiskError;
 use disk_backend::DiskIo;
 use disk_backend::UnmapBehavior;
@@ -326,6 +327,7 @@ impl BlockDevice {
     fn handle_resize(&self) {
         if let Err(err) = self.handle_resize_inner() {
             tracing::error!(
+                CVM_CONFIDENTIAL,
                 error = &err as &dyn std::error::Error,
                 "failed to update disk size"
             );

--- a/vm/devices/storage/disk_blockdevice/src/nvme.rs
+++ b/vm/devices/storage/disk_blockdevice/src/nvme.rs
@@ -7,6 +7,7 @@ use super::BlockDevice;
 use super::DeviceType;
 use bitfield_struct::bitfield;
 use blocking::unblock;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use disk_backend::pr::ReservationReport;
 use nvme_common::from_nvme_reservation_report;
 use nvme_spec::nvm;
@@ -213,7 +214,7 @@ fn nvme_reservation_report(
                     nvm::RegisteredControllerExtended::read_from_prefix(&buffer[source..])
                         .unwrap()
                         .0; // TODO: zerocopy: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
-                tracing::debug!(controller = ?controller, "nvme_reservation_report");
+                tracing::debug!(CVM_CONFIDENTIAL, controller = ?controller, "nvme_reservation_report");
                 controllers.push(controller);
                 source += source_step;
             }
@@ -269,7 +270,7 @@ pub fn nvme_identify_namespace_data(
     )?;
 
     let data = nvm::IdentifyNamespace::read_from_prefix(buffer).unwrap().0; // TODO: zerocopy: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
-    tracing::trace!(?data, "nvme_identify_namespace_data");
+    tracing::trace!(CVM_CONFIDENTIAL, ?data, "nvme_identify_namespace_data");
     Ok(data)
 }
 
@@ -294,7 +295,7 @@ pub fn nvme_identify_controller_data(file: &fs::File) -> io::Result<nvme_spec::I
     let data = nvme_spec::IdentifyController::read_from_prefix(buffer)
         .unwrap()
         .0; // TODO: zerocopy: use-rest-of-range (https://github.com/microsoft/openvmm/issues/759)
-    tracing::trace!(?data, "nvme_identify_controller_data");
+    tracing::trace!(CVM_CONFIDENTIAL, ?data, "nvme_identify_controller_data");
     Ok(data)
 }
 

--- a/vm/devices/storage/disk_nvme/nvme_driver/Cargo.toml
+++ b/vm/devices/storage/disk_nvme/nvme_driver/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+cvm_tracing.workspace = true
 guestmem.workspace = true
 inspect = { workspace = true, features = ["defer"] }
 inspect_counters.workspace = true

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -16,6 +16,7 @@ use crate::queue_pair::admin_cmd;
 use crate::registers::Bar0;
 use crate::registers::DeviceRegisters;
 use anyhow::Context as _;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use futures::StreamExt;
 use futures::future::join_all;
 use inspect::Inspect;
@@ -32,7 +33,6 @@ use task_control::InspectTask;
 use task_control::TaskControl;
 use thiserror::Error;
 use tracing::Instrument;
-use tracing::info_span;
 use user_driver::DeviceBacking;
 use user_driver::backoff::Backoff;
 use user_driver::interrupt::DeviceInterrupt;
@@ -192,6 +192,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
             Ok(()) => Ok(this),
             Err(err) => {
                 tracing::error!(
+                    CVM_CONFIDENTIAL,
                     error = err.as_ref() as &dyn std::error::Error,
                     "device initialization failed, shutting down"
                 );
@@ -430,6 +431,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
             async move {
                 if let Err(err) = handle_asynchronous_events(&admin, &rescan_event).await {
                     tracing::error!(
+                        CVM_CONFIDENTIAL,
                         error = err.as_ref() as &dyn std::error::Error,
                         "asynchronous event failure, not processing any more"
                     );
@@ -648,6 +650,7 @@ impl<T: DeviceBacking> NvmeDriver<T> {
             async move {
                 if let Err(err) = handle_asynchronous_events(&admin, &rescan_event).await {
                     tracing::error!(
+                        CVM_CONFIDENTIAL,
                         error = err.as_ref() as &dyn std::error::Error,
                         "asynchronous event failure, not processing any more"
                     );
@@ -839,7 +842,7 @@ impl<T: DeviceBacking> DriverWorkerTask<T> {
 
         let issuer = match self
             .create_io_queue(state, cpu)
-            .instrument(info_span!("create_nvme_io_queue", cpu))
+            .instrument(tracing::info_span!("create_nvme_io_queue", cpu))
             .await
         {
             Ok(issuer) => issuer,
@@ -853,6 +856,7 @@ impl<T: DeviceBacking> DriverWorkerTask<T> {
                     .unwrap();
 
                 tracing::error!(
+                    CVM_CONFIDENTIAL,
                     cpu,
                     fallback_cpu,
                     error = err.as_ref() as &dyn std::error::Error,
@@ -960,6 +964,7 @@ impl<T: DeviceBacking> DriverWorkerTask<T> {
                     .await
                 {
                     tracing::error!(
+                        CVM_CONFIDENTIAL,
                         error = &err as &dyn std::error::Error,
                         "failed to delete completion queue in teardown path"
                     );

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/namespace.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/namespace.rs
@@ -11,6 +11,7 @@ use crate::driver::save_restore::SavedNamespaceData;
 use crate::queue_pair::Issuer;
 use crate::queue_pair::RequestError;
 use crate::queue_pair::admin_cmd;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use guestmem::GuestMemory;
 use guestmem::ranges::PagedRange;
 use inspect::Inspect;
@@ -596,6 +597,7 @@ impl DynamicState {
                 }
                 Err(err) => {
                     tracing::warn!(
+                        CVM_CONFIDENTIAL,
                         nsid,
                         error = &err as &dyn std::error::Error,
                         "failed to query namespace during rescan"

--- a/vm/devices/storage/floppy/Cargo.toml
+++ b/vm/devices/storage/floppy/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+cvm_tracing.workspace = true
 chipset_device.workspace = true
 disk_backend.workspace = true
 guestmem.workspace = true

--- a/vm/devices/storage/floppy/src/lib.rs
+++ b/vm/devices/storage/floppy/src/lib.rs
@@ -43,6 +43,7 @@ use chipset_device::pio::PortIoIntercept;
 use chipset_device::pio::RegisterPortIoIntercept;
 use chipset_device::poll_device::PollDevice;
 use core::sync::atomic::Ordering;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use disk_backend::Disk;
 use guestmem::AlignedHeapMemory;
 use guestmem::GuestMemory;
@@ -684,7 +685,7 @@ impl PortIoIntercept for FloppyDiskController {
             _ => return IoResult::Err(IoError::InvalidRegister),
         };
 
-        tracing::trace!(?offset, ?data, "floppy pio read");
+        tracing::trace!(CVM_CONFIDENTIAL, ?offset, ?data, "floppy pio read");
 
         IoResult::Ok
     }
@@ -696,7 +697,7 @@ impl PortIoIntercept for FloppyDiskController {
 
         let data = data[0];
         let offset = RegisterOffset(io_port % 0x10);
-        tracing::trace!(?offset, ?data, "floppy pio write");
+        tracing::trace!(CVM_CONFIDENTIAL, ?offset, ?data, "floppy pio write");
         match offset {
             RegisterOffset::STATUS_A | RegisterOffset::STATUS_B => {
                 tracelimit::warn_ratelimited!(
@@ -706,12 +707,16 @@ impl PortIoIntercept for FloppyDiskController {
                 );
             }
             RegisterOffset::TAPE_DRIVE => {
-                tracing::debug!(?data, "write to obsolete tape drive register");
+                tracing::debug!(
+                    CVM_CONFIDENTIAL,
+                    ?data,
+                    "write to obsolete tape drive register"
+                );
             } // Do nothing. This port is obsolete.
             RegisterOffset::CONFIG_CONTROL => {
                 // This controls the data transfer rate which is not
                 // interesting to us. We will just ignore it.
-                tracing::debug!(?data, "write to control register");
+                tracing::debug!(CVM_CONFIDENTIAL, ?data, "write to control register");
             }
             RegisterOffset::DATA_RATE => {
                 const FLOPPY_DSR_DISK_RESET_MASK: u8 = 0x80; // DSR = Data-rate Select Register ("software" reset)
@@ -1046,7 +1051,7 @@ impl FloppyDiskController {
 
     fn handle_io_completion(&mut self, result: Result<(), disk_backend::DiskError>) {
         let command = self.state.pending_command;
-        tracing::trace!(?command, ?result, "io completion");
+        tracing::trace!(CVM_CONFIDENTIAL, ?command, ?result, "io completion");
 
         let result = match command {
             FloppyCommand::READ_NORMAL_DATA
@@ -1371,7 +1376,7 @@ impl FloppyDiskController {
         // we want this to be below update of input buffer so that we
         // don't otherwise misreport what the command byte is
         // side effect is multiple trace lines of one command issue
-        tracing::trace!(
+        tracing::trace!(CVM_CONFIDENTIAL,
             ?data,
             ?self.state.input_bytes,
             "floppy byte (cmd or param)"
@@ -1399,7 +1404,7 @@ impl FloppyDiskController {
             return;
         }
 
-        tracing::trace!(
+        tracing::trace!(CVM_CONFIDENTIAL,
             ?command,
             input_bytes = ?self.state.input_bytes,
             "executing floppy command"
@@ -1518,7 +1523,7 @@ impl FloppyDiskController {
             command
         };
 
-        tracing::trace!(
+        tracing::trace!(CVM_CONFIDENTIAL,
             main_status = ?self.state.main_status,
             digital_output = ?self.state.digital_output,
             sense_output = ?self.state.sense_output,
@@ -1807,7 +1812,14 @@ impl FloppyDiskController {
 
         let lba = (cylinder * 2 + head) * self.state.internals.sectors_per_track as u64;
 
-        tracing::trace!(?cylinder, ?head, ?lba, ?buffer_ptr, "Format: ");
+        tracing::trace!(
+            CVM_CONFIDENTIAL,
+            ?cylinder,
+            ?head,
+            ?lba,
+            ?buffer_ptr,
+            "Format: "
+        );
 
         self.set_io(async move |disk| {
             let buffers = command_buffer.buffers(0, size, false);

--- a/vm/devices/storage/floppy_pcat_stub/Cargo.toml
+++ b/vm/devices/storage/floppy_pcat_stub/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true
+cvm_tracing.workspace = true
 vmcore.workspace = true
 
 inspect.workspace = true

--- a/vm/devices/storage/floppy_pcat_stub/src/lib.rs
+++ b/vm/devices/storage/floppy_pcat_stub/src/lib.rs
@@ -17,6 +17,7 @@ use chipset_device::pio::ControlPortIoIntercept;
 use chipset_device::pio::PortIoIntercept;
 use chipset_device::pio::RegisterPortIoIntercept;
 use chipset_device::poll_device::PollDevice;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use inspect::Inspect;
 use inspect::InspectMut;
 use open_enum::open_enum;
@@ -203,7 +204,7 @@ impl PortIoIntercept for StubFloppyDiskController {
             }
         };
 
-        tracing::trace!(?io_port, ?offset, ?data, "io port read");
+        tracing::trace!(CVM_CONFIDENTIAL, ?io_port, ?offset, ?data, "io port read");
         io_result
     }
 
@@ -214,7 +215,7 @@ impl PortIoIntercept for StubFloppyDiskController {
 
         let data = data[0];
         let offset = RegisterOffset(io_port % 0x10);
-        tracing::trace!(?io_port, ?offset, ?data, "io port write");
+        tracing::trace!(CVM_CONFIDENTIAL, ?io_port, ?offset, ?data, "io port write");
 
         match offset {
             RegisterOffset::STATUS_A | RegisterOffset::STATUS_B => {
@@ -264,7 +265,7 @@ impl PortIoIntercept for StubFloppyDiskController {
                     return IoResult::Ok;
                 }
 
-                tracing::trace!(
+                tracing::trace!(CVM_CONFIDENTIAL,
                     ?data,
                     ?self.state.input_bytes,
                     "floppy command byte"
@@ -278,7 +279,7 @@ impl PortIoIntercept for StubFloppyDiskController {
                     return IoResult::Ok;
                 }
 
-                tracing::trace!(
+                tracing::trace!(CVM_CONFIDENTIAL,
                     ?command,
                     input_bytes = ?self.state.input_bytes,
                     "executing floppy command"

--- a/vm/devices/storage/ide/Cargo.toml
+++ b/vm/devices/storage/ide/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 chipset_device.workspace = true
+cvm_tracing.workspace = true
 disk_backend.workspace = true
 ide_resources.workspace = true
 inspect.workspace = true

--- a/vm/devices/storage/ide/src/drive/hard_drive.rs
+++ b/vm/devices/storage/ide/src/drive/hard_drive.rs
@@ -13,6 +13,7 @@ use crate::protocol::DeviceHeadReg;
 use crate::protocol::ErrorReg;
 use crate::protocol::IdeCommand;
 use crate::protocol::Status;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use disk_backend::Disk;
 use disk_backend::DiskError;
 use guestmem::AlignedHeapMemory;
@@ -723,7 +724,7 @@ impl HardDrive {
 
     fn handle_io_completion(&mut self, result: Result<(), DiskError>) {
         let command = self.state.command.as_ref().unwrap();
-        tracing::trace!(io_type = ?command.io_type, path = %self.disk_path, ?result, "io completion");
+        tracing::trace!(CVM_CONFIDENTIAL, io_type = ?command.io_type, path = %self.disk_path, ?result, "io completion");
 
         let result = match command.io_type {
             IoType::Read => match result {
@@ -1136,7 +1137,7 @@ impl HardDrive {
         match io_type {
             IoPortData::Read(ref mut data) => {
                 current_buffer[..length as usize].atomic_read(&mut data[..length as usize]);
-                tracing::trace!(?data, "data payload");
+                tracing::trace!(CVM_CONFIDENTIAL, ?data, "data payload");
             }
             IoPortData::Write(data) => {
                 current_buffer[..length as usize].atomic_write(&data[..length as usize]);

--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -23,6 +23,7 @@ use chipset_device::pio::ControlPortIoIntercept;
 use chipset_device::pio::PortIoIntercept;
 use chipset_device::pio::RegisterPortIoIntercept;
 use chipset_device::poll_device::PollDevice;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use disk_backend::Disk;
 use drive::DiskDrive;
 use drive::DriveRegister;
@@ -940,14 +941,24 @@ impl PciConfigSpace for IdeDevice {
             }
         };
 
-        tracing::trace!(?offset, value, "ide pci config space read");
+        tracing::trace!(
+            CVM_CONFIDENTIAL,
+            ?offset,
+            value,
+            "ide pci config space read"
+        );
         IoResult::Ok
     }
 
     fn pci_cfg_write(&mut self, offset: u16, value: u32) -> IoResult {
         if offset < HEADER_TYPE_00_SIZE {
             let offset = HeaderType00(offset);
-            tracing::trace!(?offset, value, "ide pci config space write");
+            tracing::trace!(
+                CVM_CONFIDENTIAL,
+                ?offset,
+                value,
+                "ide pci config space write"
+            );
 
             const BUS_MASTER_IO_ENABLE_MASK: u32 = Command::new()
                 .with_pio_enabled(true)
@@ -990,7 +1001,12 @@ impl PciConfigSpace for IdeDevice {
             }
         } else {
             let offset = IdeConfigSpace(offset);
-            tracing::trace!(?offset, value, "ide pci config space write");
+            tracing::trace!(
+                CVM_CONFIDENTIAL,
+                ?offset,
+                value,
+                "ide pci config space write"
+            );
 
             match offset {
                 IdeConfigSpace::PRIMARY_TIMING_REG_ADDR => self.bus_master_state.timing_reg = value,
@@ -1226,7 +1242,13 @@ impl Channel {
             0x7f
         };
 
-        tracing::trace!(?port, ?data, channel = self.channel, "io port read");
+        tracing::trace!(
+            CVM_CONFIDENTIAL,
+            ?port,
+            ?data,
+            channel = self.channel,
+            "io port read"
+        );
         self.post_drive_access(bus_master_state);
         data
     }
@@ -1240,7 +1262,13 @@ impl Channel {
         data: u8,
         bus_master_state: &BusMasterState,
     ) {
-        tracing::trace!(?port, ?data, channel = self.channel, "io port write");
+        tracing::trace!(
+            CVM_CONFIDENTIAL,
+            ?port,
+            ?data,
+            channel = self.channel,
+            "io port write"
+        );
 
         match port {
             DriveRegister::DeviceHead => {
@@ -1348,7 +1376,12 @@ impl Channel {
             _ => return IoResult::Err(IoError::InvalidRegister),
         }
 
-        tracing::trace!(?bus_master_reg, ?data, "bus master register read");
+        tracing::trace!(
+            CVM_CONFIDENTIAL,
+            ?bus_master_reg,
+            ?data,
+            "bus master register read"
+        );
         IoResult::Ok
     }
 
@@ -1365,7 +1398,12 @@ impl Channel {
             _ => return IoResult::Err(IoError::InvalidAccessSize),
         };
 
-        tracing::trace!(?bus_master_reg, value, "bus master register write");
+        tracing::trace!(
+            CVM_CONFIDENTIAL,
+            ?bus_master_reg,
+            value,
+            "bus master register write"
+        );
 
         match bus_master_reg {
             BusMasterReg::COMMAND => {
@@ -1410,7 +1448,12 @@ impl Channel {
                     new_value.set_dma_error(false);
                 }
 
-                tracing::trace!(?old_value, ?new_value, "set bus master status");
+                tracing::trace!(
+                    CVM_CONFIDENTIAL,
+                    ?old_value,
+                    ?new_value,
+                    "set bus master status"
+                );
                 self.bus_master_state.status_reg = new_value;
             }
             BusMasterReg::TABLE_PTR => {

--- a/vm/devices/storage/nvme/Cargo.toml
+++ b/vm/devices/storage/nvme/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+cvm_tracing.workspace = true
 disk_backend.workspace = true
 nvme_common.workspace = true
 nvme_resources.workspace = true

--- a/vm/devices/storage/nvme/src/workers/admin.rs
+++ b/vm/devices/storage/nvme/src/workers/admin.rs
@@ -23,6 +23,7 @@ use crate::queue::QueueError;
 use crate::queue::ShadowDoorbell;
 use crate::queue::SubmissionQueue;
 use crate::spec;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use disk_backend::Disk;
 use futures::FutureExt;
 use futures::SinkExt;
@@ -1079,6 +1080,7 @@ impl AsyncRun<AdminState> for AdminHandler {
             let event = stop.until_stopped(self.next_event(state)).await?;
             if let Err(err) = self.process_event(state, event).await {
                 tracing::error!(
+                    CVM_CONFIDENTIAL,
                     error = &err as &dyn std::error::Error,
                     "admin queue failure"
                 );

--- a/vm/devices/storage/nvme/src/workers/io.rs
+++ b/vm/devices/storage/nvme/src/workers/io.rs
@@ -14,6 +14,7 @@ use crate::queue::SubmissionQueue;
 use crate::spec;
 use crate::spec::nvm;
 use crate::workers::MAX_DATA_TRANSFER_SIZE;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use futures_concurrency::future::Race;
 use guestmem::GuestMemory;
 use inspect::Inspect;
@@ -111,7 +112,11 @@ impl AsyncRun<IoState> for IoHandler {
         let mem = self.mem.clone();
         stop.until_stopped(async {
             if let Err(err) = self.process(state, &mem).await {
-                tracing::error!(error = &err as &dyn std::error::Error, "io handler failed");
+                tracing::error!(
+                    CVM_CONFIDENTIAL,
+                    error = &err as &dyn std::error::Error,
+                    "io handler failed"
+                );
             }
         })
         .await

--- a/vm/devices/storage/scsidisk/Cargo.toml
+++ b/vm/devices/storage/scsidisk/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+cvm_tracing.workspace = true
 disk_backend.workspace = true
 scsi_buffers.workspace = true
 scsi_core.workspace = true

--- a/vm/devices/storage/scsidisk/src/lib.rs
+++ b/vm/devices/storage/scsidisk/src/lib.rs
@@ -17,6 +17,7 @@ mod tests;
 
 pub use inquiry::INQUIRY_DATA_TEMPLATE;
 
+use cvm_tracing::CVM_CONFIDENTIAL;
 use disk_backend::Disk;
 use disk_backend::DiskError;
 use disk_backend::UnmapBehavior;
@@ -940,8 +941,8 @@ impl SimpleScsiDisk {
             match err {
                 ScsiError::UnsupportedModePageCode(..)
                 | ScsiError::UnsupportedServiceAction(_)
-                | ScsiError::UnsupportedVpdPageCode(_) => tracing::debug!(disk = ?self.scsi_parameters.disk_id, error = err.as_error(), ?op, "scsi_error"),
-                | ScsiError::IllegalRequest(_) => tracing::debug!(disk = ?self.scsi_parameters.disk_id, error = err.as_error(), ?op, "scsi_error"),
+                | ScsiError::UnsupportedVpdPageCode(_) => tracing::debug!(CVM_CONFIDENTIAL, disk = ?self.scsi_parameters.disk_id, error = err.as_error(), ?op, "scsi_error"),
+                | ScsiError::IllegalRequest(_) => tracing::debug!(CVM_CONFIDENTIAL, disk = ?self.scsi_parameters.disk_id, error = err.as_error(), ?op, "scsi_error"),
                 _ => tracelimit::warn_ratelimited!(disk = ?self.scsi_parameters.disk_id, error = err.as_error(), ?op, "scsi_error"),
             }
             err

--- a/vm/devices/storage/scsidisk/src/unmap.rs
+++ b/vm/devices/storage/scsidisk/src/unmap.rs
@@ -5,6 +5,7 @@ use super::ScsiError;
 use super::SimpleScsiDisk;
 use crate::UNMAP_RANGE_DESCRIPTOR_COUNT_MAX;
 use crate::scsi;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use guestmem::MemoryRead;
 use scsi::AdditionalSenseCode;
 use scsi_buffers::RequestBuffers;
@@ -218,7 +219,7 @@ impl SimpleScsiDisk {
                 .unmap(start_lba, lba_count, block_level_only)
                 .await
             {
-                tracing::debug!(error = ?e, "Unmap failures ignored")
+                tracing::debug!(CVM_CONFIDENTIAL, error = ?e, "Unmap failures ignored")
             }
         }
     }

--- a/vm/devices/storage/storvsp/Cargo.toml
+++ b/vm/devices/storage/storvsp/Cargo.toml
@@ -17,6 +17,7 @@ fuzz_helpers = []
 
 [dependencies]
 
+cvm_tracing.workspace = true
 disklayer_ram = { workspace = true, optional = true } # For `ioperf` modules
 scsi_buffers.workspace = true
 scsi_core.workspace = true

--- a/vm/devices/storage/storvsp/src/lib.rs
+++ b/vm/devices/storage/storvsp/src/lib.rs
@@ -20,6 +20,7 @@ use crate::ring::gparange::GpnList;
 use crate::ring::gparange::MultiPagedRangeBuf;
 use anyhow::Context as _;
 use async_trait::async_trait;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use fast_select::FastSelect;
 use futures::FutureExt;
 use futures::StreamExt;
@@ -423,9 +424,9 @@ fn parse_packet<T: RingMem>(
     };
 
     if let PacketData::ExecuteScsi(_) = data {
-        tracing::trace!(transaction_id, ?data, "parse_packet");
+        tracing::trace!(CVM_CONFIDENTIAL, transaction_id, ?data, "parse_packet");
     } else {
-        tracing::debug!(transaction_id, ?data, "parse_packet");
+        tracing::debug!(CVM_CONFIDENTIAL, transaction_id, ?data, "parse_packet");
     }
 
     Ok(Packet {
@@ -825,7 +826,11 @@ impl<T: 'static + Send + Sync + RingMem> AsyncRun<Worker<T>> for WorkerState {
 
         match stop.until_stopped(fut).await? {
             Ok(_) => {}
-            Err(e) => tracing::error!(error = e.as_error(), "process_packets error"),
+            Err(e) => tracing::error!(
+                CVM_CONFIDENTIAL,
+                error = e.as_error(),
+                "process_packets error"
+            ),
         }
         Ok(())
     }
@@ -1254,7 +1259,7 @@ impl WorkerInner {
         let mut payload = [0; 0x14];
         if let Some(sense) = result.sense_data {
             payload[..size_of_val(&sense)].copy_from_slice(sense.as_bytes());
-            tracing::trace!(sense_info = ?payload, sense_key = payload[2], asc = payload[12], "execute_scsi");
+            tracing::trace!(CVM_CONFIDENTIAL, sense_info = ?payload, sense_key = payload[2], asc = payload[12], "execute_scsi");
         };
         let response = storvsp_protocol::ScsiRequest {
             length: size_of::<storvsp_protocol::ScsiRequest>() as u16,


### PR DESCRIPTION
Covers `vm/devices/storage` and `openhcl/underhill_core/nvme_manager`

Error statements printed in a trace were presumed to possibly leak confidential information and thus any trace containing an error message has been marked as confidential. Some of these may considered for the removal of this tag in the future, but I am erring on the side of caution here.

#852 