### PR TITLE
kernel: update main and dev kernels with fix for sidecar

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -29,8 +29,8 @@ pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly
 //      comparable. They originate from separate branches, and the fourth digit
 //      increases with each release from the respective branch.
-pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.9.4";
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.9.5";
+pub const OPENHCL_KERNEL_DEV_VERSION: &str = "6.12.9.5";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.12.9.7";
 pub const OPENVMM_DEPS: &str = "0.1.0-20250403.3";
 pub const PROTOC: &str = "27.1";
 


### PR DESCRIPTION
Update the kernel to the latest available version which contains this sidecar fixes:
https://github.com/microsoft/OHCL-Linux-Kernel/pull/82
https://github.com/microsoft/OHCL-Linux-Kernel/pull/83