### PR TITLE
petri/logview: fix time output

### DIFF
--- a/petri/logview/test.html
+++ b/petri/logview/test.html
@@ -228,7 +228,7 @@
 
         function formatRelative(from, to) {
             const deltaMs = new Date(to) - new Date(from);
-            const sec = (deltaMs % 1000000) / 1000;
+            const sec = ((deltaMs / 1000) % 60).toFixed(3);
             const min = Math.floor((deltaMs / 60000) % 60);
             const hr = Math.floor(deltaMs / 3600000);
 


### PR DESCRIPTION
Correctly compute the number of seconds, to avoid showing more than
60 seconds.
