### PR TITLE
Fix panic output not getting sent to the host

### DIFF
--- a/openhcl/underhill_core/src/get_tracing/kmsg_stream.rs
+++ b/openhcl/underhill_core/src/get_tracing/kmsg_stream.rs
@@ -74,9 +74,9 @@ macro_rules! kmsg_enabled {
                 tracing::enabled!(target: $target, Level::ERROR)
             }
             kmsg_defs::LOGLEVEL_WARNING => tracing::enabled!(target: $target, Level::WARN),
-            kmsg_defs::LOGLEVEL_NOTICE => tracing::enabled!(target: $target, Level::INFO),
-            kmsg_defs::LOGLEVEL_INFO => tracing::enabled!(target: $target, Level::DEBUG),
-            kmsg_defs::LOGLEVEL_DEBUG.. => tracing::enabled!(target: $target, Level::TRACE),
+            kmsg_defs::LOGLEVEL_NOTICE | kmsg_defs::LOGLEVEL_INFO => tracing::enabled!(target: $target, Level::INFO),
+            kmsg_defs::LOGLEVEL_DEBUG => tracing::enabled!(target: $target, Level::DEBUG),
+            _ => tracing::enabled!(target: $target, Level::TRACE),
         }
     };
 }
@@ -116,8 +116,10 @@ impl Stream for KmsgStream {
                         kmsg_defs::LOGLEVEL_EMERG..=kmsg_defs::LOGLEVEL_CRIT => LogLevel::CRITICAL,
                         kmsg_defs::LOGLEVEL_ERR => LogLevel::ERROR,
                         kmsg_defs::LOGLEVEL_WARNING => LogLevel::WARNING,
-                        kmsg_defs::LOGLEVEL_NOTICE => LogLevel::INFORMATION,
-                        kmsg_defs::LOGLEVEL_INFO.. => LogLevel::VERBOSE,
+                        kmsg_defs::LOGLEVEL_NOTICE | kmsg_defs::LOGLEVEL_INFO => {
+                            LogLevel::INFORMATION
+                        }
+                        kmsg_defs::LOGLEVEL_DEBUG.. => LogLevel::VERBOSE,
                     };
 
                     let mut message = [0; TRACE_LOGGING_MESSAGE_MAX_SIZE];

--- a/openhcl/underhill_init/src/syslog.rs
+++ b/openhcl/underhill_init/src/syslog.rs
@@ -28,7 +28,7 @@ impl log::Log for SysLog {
             log::Level::Error => kmsg_defs::LOGLEVEL_ERR,
             log::Level::Warn => kmsg_defs::LOGLEVEL_WARNING,
             log::Level::Info => kmsg_defs::LOGLEVEL_NOTICE,
-            log::Level::Debug => kmsg_defs::LOGLEVEL_INFO,
+            log::Level::Debug => kmsg_defs::LOGLEVEL_DEBUG,
             log::Level::Trace => kmsg_defs::LOGLEVEL_DEBUG,
         };
 


### PR DESCRIPTION
When a usermode process crashes Rust prints the panic string to kmsg at LOGLEVEL_INFO. This is one of the most important pieces of information we have for debugging crashes, and we want it to get forwarded to the host and to end up in kusto. Fix our level filtering to do that.

Fixes https://github.com/microsoft/openvmm/issues/439