### PR TITLE
Add attestation for host command line and debug tracing

### DIFF
--- a/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
+++ b/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
@@ -345,6 +345,8 @@ pub mod runtime_claims {
         pub tpm_enabled: bool,
         /// Whether the TPM states is persisted
         pub tpm_persisted: bool,
+        /// Whether confidential debugging is enabled
+        pub debug_enabled: bool,
         /// VM id
         #[serde(rename = "vmUniqueId")]
         pub vm_unique_id: String,

--- a/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
+++ b/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
@@ -347,8 +347,8 @@ pub mod runtime_claims {
         pub tpm_persisted: bool,
         /// Whether confidential debugging is enabled
         pub debug_enabled: bool,
-        /// Whether the dynamic command line is populated
-        pub has_dyn_cmd_line: bool,
+        /// Dynamic command line provided by the host
+        pub dyn_cmd_line: String,
         /// VM id
         #[serde(rename = "vmUniqueId")]
         pub vm_unique_id: String,

--- a/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
+++ b/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
@@ -347,6 +347,8 @@ pub mod runtime_claims {
         pub tpm_persisted: bool,
         /// Whether confidential debugging is enabled
         pub debug_enabled: bool,
+        /// Whether the dynamic command line is populated
+        pub has_dyn_cmd_line: bool,
         /// VM id
         #[serde(rename = "vmUniqueId")]
         pub vm_unique_id: String,

--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -483,6 +483,12 @@ pub fn write_dt(
         openhcl_builder = openhcl_builder.add_u64(p_vtl0_alias_map, data)?;
     }
 
+    let p_host_provided_cmdline = openhcl_builder.add_string("host-provided-cmdline")?;
+    openhcl_builder = openhcl_builder.add_str(
+        p_host_provided_cmdline,
+        partition_info.host_provided_cmdline.as_str(),
+    )?;
+
     #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     struct Vtl2MemoryEntry {
         range: MemoryRange,

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -350,6 +350,7 @@ impl PartitionInfo {
         )
         .map_err(|_| DtError::CommandLineSize)?;
 
+        // COMMENT ME OUT / DECIDE WHAT TO DO
         // Depending on policy, write what the host specified in the chosen node.
         if can_trust_host && command_line.policy == CommandLinePolicy::APPEND_CHOSEN {
             // Parse in extra options from the host provided command line.
@@ -357,6 +358,10 @@ impl PartitionInfo {
             write!(storage.cmdline, " {}", &parsed.command_line)
                 .map_err(|_| DtError::CommandLineSize)?;
         }
+
+        // Write the host provided command line.
+        write!(storage.host_provided_cmdline, "{}", parsed.command_line)
+            .map_err(|_| DtError::CommandLineSize)?;
 
         // TODO: Decide if isolated guests always use VTL2 allocation mode.
 
@@ -523,6 +528,7 @@ impl PartitionInfo {
             vmbus_vtl0: _,
             vmbus_vtl2: _,
             cmdline: _,
+            host_provided_cmdline: _,
             com3_serial_available: com3_serial,
             gic,
             memory_allocation_mode: _,

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -325,7 +325,6 @@ impl PartitionInfo {
         params: &'a ShimParams,
         storage: &'a mut Self,
         mut options: BootCommandLineOptions,
-        can_trust_host: bool,
     ) -> Result<Option<&'a mut Self>, DtError> {
         let dt = params.device_tree();
 
@@ -508,7 +507,7 @@ impl PartitionInfo {
         }
 
         // If we can trust the host, use the provided alias map
-        if can_trust_host {
+        if params.isolation_type == IsolationType::None {
             storage.vtl0_alias_map = parsed.vtl0_alias_map;
         }
 

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -350,7 +350,6 @@ impl PartitionInfo {
         )
         .map_err(|_| DtError::CommandLineSize)?;
 
-        // COMMENT ME OUT / DECIDE WHAT TO DO
         // Depending on policy, write what the host specified in the chosen node.
         if can_trust_host && command_line.policy == CommandLinePolicy::APPEND_CHOSEN {
             // Parse in extra options from the host provided command line.

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -351,7 +351,7 @@ impl PartitionInfo {
         .map_err(|_| DtError::CommandLineSize)?;
 
         // Depending on policy, write what the host specified in the chosen node.
-        if can_trust_host && command_line.policy == CommandLinePolicy::APPEND_CHOSEN {
+        if command_line.policy == CommandLinePolicy::APPEND_CHOSEN {
             // Parse in extra options from the host provided command line.
             options.parse(&parsed.command_line);
             write!(storage.cmdline, " {}", &parsed.command_line)

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -506,7 +506,7 @@ impl PartitionInfo {
             storage.vtl2_pool_memory = pool;
         }
 
-        // If we can trust the host, use the provided alias map
+        // If we are not isolated, use the provided alias map
         if params.isolation_type == IsolationType::None {
             storage.vtl0_alias_map = parsed.vtl0_alias_map;
         }

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -83,6 +83,8 @@ pub struct PartitionInfo {
     pub vmbus_vtl0: VmbusInfo,
     /// Command line to be used for the underhill kernel.
     pub cmdline: ArrayString<COMMAND_LINE_SIZE>,
+    /// Dynamic command line provided by the host.
+    pub host_provided_cmdline: ArrayString<COMMAND_LINE_SIZE>,
     /// Com3 serial device is available
     pub com3_serial_available: bool,
     /// GIC information
@@ -122,6 +124,7 @@ impl PartitionInfo {
                 connection_id: 0,
             },
             cmdline: ArrayString::new_const(),
+            host_provided_cmdline: ArrayString::new_const(),
             com3_serial_available: false,
             gic: None,
             memory_allocation_mode: MemoryAllocationMode::Host,

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -946,6 +946,7 @@ mod test {
             bsp_reg: cpus[0].reg as u32,
             cpus,
             cmdline: ArrayString::new(),
+            host_provided_cmdline: ArrayString::new(),
             vmbus_vtl2: VmbusInfo {
                 mmio,
                 connection_id: 0,

--- a/openhcl/underhill_attestation/src/hardware_key_sealing.rs
+++ b/openhcl/underhill_attestation/src/hardware_key_sealing.rs
@@ -232,6 +232,7 @@ mod tests {
             secure_boot: false,
             tpm_enabled: false,
             tpm_persisted: false,
+            debug_enabled: false,
             vm_unique_id: "".to_string(),
         };
         let mock_call = Box::new(MockTeeCall {}) as Box<dyn tee_call::TeeCall>;

--- a/openhcl/underhill_attestation/src/hardware_key_sealing.rs
+++ b/openhcl/underhill_attestation/src/hardware_key_sealing.rs
@@ -233,7 +233,7 @@ mod tests {
             tpm_enabled: false,
             tpm_persisted: false,
             debug_enabled: false,
-            has_dyn_cmd_line: false,
+            dyn_cmd_line: "".to_string(),
             vm_unique_id: "".to_string(),
         };
         let mock_call = Box::new(MockTeeCall {}) as Box<dyn tee_call::TeeCall>;

--- a/openhcl/underhill_attestation/src/hardware_key_sealing.rs
+++ b/openhcl/underhill_attestation/src/hardware_key_sealing.rs
@@ -233,6 +233,7 @@ mod tests {
             tpm_enabled: false,
             tpm_persisted: false,
             debug_enabled: false,
+            has_dyn_cmd_line: false,
             vm_unique_id: "".to_string(),
         };
         let mock_call = Box::new(MockTeeCall {}) as Box<dyn tee_call::TeeCall>;

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn test_vm_configuration_no_time() {
-        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"vmUniqueId":""}"#;
+        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,
@@ -292,6 +292,7 @@ mod tests {
             secure_boot: false,
             tpm_enabled: false,
             tpm_persisted: false,
+            debug_enabled: false,
             vm_unique_id: String::new(),
         };
         let result = serde_json::to_string(&attestation_vm_config);
@@ -303,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_vm_configuration_with_time() {
-        const EXPECTED_JWK: &str = r#"{"current-time":1691103220,"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"vmUniqueId":""}"#;
+        const EXPECTED_JWK: &str = r#"{"current-time":1691103220,"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,
@@ -312,6 +313,7 @@ mod tests {
             secure_boot: false,
             tpm_enabled: false,
             tpm_persisted: false,
+            debug_enabled: false,
             vm_unique_id: String::new(),
         };
         let attestation_vm_config =

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -330,8 +330,8 @@ mod tests {
     #[test]
     fn test_dyn_cmd_line() {
         // Try round-tripping a dynamic command line with quotes and other nasty things.
-        const CMDLINE: &str = "FOO=\"bar\" BAZ=\"\"\"";
-        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"dyn-cmd-line":"FOO=\"bar\" BAZ=\"\"\"","vmUniqueId":""}"#;
+        const CMDLINE: &str = "FOO=\"bar\" BAZ=\"\"\"\\";
+        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"dyn-cmd-line":"FOO=\"bar\" BAZ=\"\"\"\\","vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn test_vm_configuration_no_time() {
-        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"vmUniqueId":""}"#;
+        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"has-dyn-cmd-line":false,"vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,
@@ -293,6 +293,7 @@ mod tests {
             tpm_enabled: false,
             tpm_persisted: false,
             debug_enabled: false,
+            has_dyn_cmd_line: false,
             vm_unique_id: String::new(),
         };
         let result = serde_json::to_string(&attestation_vm_config);
@@ -304,7 +305,7 @@ mod tests {
 
     #[test]
     fn test_vm_configuration_with_time() {
-        const EXPECTED_JWK: &str = r#"{"current-time":1691103220,"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"vmUniqueId":""}"#;
+        const EXPECTED_JWK: &str = r#"{"current-time":1691103220,"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"has-dyn-cmd-line":false,"vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,
@@ -314,6 +315,7 @@ mod tests {
             tpm_enabled: false,
             tpm_persisted: false,
             debug_enabled: false,
+            has_dyn_cmd_line: false,
             vm_unique_id: String::new(),
         };
         let attestation_vm_config =

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn test_vm_configuration_no_time() {
-        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"has-dyn-cmd-line":false,"vmUniqueId":""}"#;
+        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"dyn-cmd-line":"","vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,
@@ -293,7 +293,7 @@ mod tests {
             tpm_enabled: false,
             tpm_persisted: false,
             debug_enabled: false,
-            has_dyn_cmd_line: false,
+            dyn_cmd_line: String::new(),
             vm_unique_id: String::new(),
         };
         let result = serde_json::to_string(&attestation_vm_config);
@@ -305,7 +305,7 @@ mod tests {
 
     #[test]
     fn test_vm_configuration_with_time() {
-        const EXPECTED_JWK: &str = r#"{"current-time":1691103220,"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"has-dyn-cmd-line":false,"vmUniqueId":""}"#;
+        const EXPECTED_JWK: &str = r#"{"current-time":1691103220,"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"dyn-cmd-line":"","vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,
@@ -315,7 +315,7 @@ mod tests {
             tpm_enabled: false,
             tpm_persisted: false,
             debug_enabled: false,
-            has_dyn_cmd_line: false,
+            dyn_cmd_line: String::new(),
             vm_unique_id: String::new(),
         };
         let attestation_vm_config =

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -326,4 +326,32 @@ mod tests {
         let vm_config = result.unwrap();
         assert_eq!(vm_config, EXPECTED_JWK);
     }
+
+    #[test]
+    fn test_dyn_cmd_line() {
+        // Try round-tripping a dynamic command line with quotes and other nasty things.
+        const CMDLINE: &str = "FOO=\"bar\" BAZ=\"\"\"";
+        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"debug-enabled":false,"dyn-cmd-line":"FOO=\"bar\" BAZ=\"\"\"","vmUniqueId":""}"#;
+
+        let attestation_vm_config = AttestationVmConfig {
+            current_time: None,
+            root_cert_thumbprint: String::new(),
+            console_enabled: false,
+            secure_boot: false,
+            tpm_enabled: false,
+            tpm_persisted: false,
+            debug_enabled: false,
+            dyn_cmd_line: CMDLINE.into(),
+            vm_unique_id: String::new(),
+        };
+        let result = serde_json::to_string(&attestation_vm_config);
+        assert!(result.is_ok());
+
+        let vm_config = result.unwrap();
+        assert_eq!(vm_config, EXPECTED_JWK);
+
+        // Make sure it round-trips correctly.
+        let parsed_config: AttestationVmConfig = serde_json::from_str(&vm_config).unwrap();
+        assert_eq!(parsed_config.dyn_cmd_line, CMDLINE);
+    }
 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -127,6 +127,7 @@ use tracing::Instrument;
 use tracing::instrument;
 use uevent::UeventListener;
 use underhill_attestation::AttestationType;
+use underhill_confidentiality::confidential_debug_enabled;
 use underhill_threadpool::AffinitizedThreadpool;
 use underhill_threadpool::ThreadpoolBuilder;
 use virt::Partition;
@@ -1602,6 +1603,7 @@ async fn new_underhill_vm(
         secure_boot: dps.general.secure_boot_enabled,
         tpm_enabled: dps.general.tpm_enabled,
         tpm_persisted: !dps.general.suppress_attestation.unwrap_or(false),
+        debug_enabled: confidential_debug_enabled(),
         vm_unique_id: dps.general.bios_guid.to_string(),
     };
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1604,10 +1604,7 @@ async fn new_underhill_vm(
         tpm_enabled: dps.general.tpm_enabled,
         tpm_persisted: !dps.general.suppress_attestation.unwrap_or(false),
         debug_enabled: confidential_debug_enabled(),
-        has_dyn_cmd_line: !runtime_params
-            .parsed_openhcl_boot()
-            .host_provided_cmdline
-            .is_empty(),
+        dyn_cmd_line: runtime_params.parsed_openhcl_boot().host_provided_cmdline,
         vm_unique_id: dps.general.bios_guid.to_string(),
     };
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1604,7 +1604,10 @@ async fn new_underhill_vm(
         tpm_enabled: dps.general.tpm_enabled,
         tpm_persisted: !dps.general.suppress_attestation.unwrap_or(false),
         debug_enabled: confidential_debug_enabled(),
-        dyn_cmd_line: runtime_params.parsed_openhcl_boot().host_provided_cmdline,
+        dyn_cmd_line: runtime_params
+            .parsed_openhcl_boot()
+            .host_provided_cmdline
+            .clone(),
         vm_unique_id: dps.general.bios_guid.to_string(),
     };
 

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1604,6 +1604,10 @@ async fn new_underhill_vm(
         tpm_enabled: dps.general.tpm_enabled,
         tpm_persisted: !dps.general.suppress_attestation.unwrap_or(false),
         debug_enabled: confidential_debug_enabled(),
+        has_dyn_cmd_line: !runtime_params
+            .parsed_openhcl_boot()
+            .host_provided_cmdline
+            .is_empty(),
         vm_unique_id: dps.general.bios_guid.to_string(),
     };
 


### PR DESCRIPTION
For issue 695: add runtime claims to the attestation that indicate whether confidential debug is enabled and includes any host-provided command line. Note (host_params/dt.rs) that the host-provided command line is currently passed down to OpenHCL only if the host is trusted.