### PR TITLE
Repo: Clean up some lint attributes

### DIFF
--- a/flowey/flowey_core/src/pipeline/artifact.rs
+++ b/flowey/flowey_core/src/pipeline/artifact.rs
@@ -4,9 +4,6 @@
 //! Internal nodes for publishing (well, preparing to publish) and resolving
 //! artifacts.
 
-// UNSAFETY: using internal macros which use linkme.
-#![expect(unsafe_code)]
-
 use anyhow::Context as _;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -156,6 +153,8 @@ fn tag_path(mut path: PathBuf) -> PathBuf {
     path
 }
 
+// UNSAFETY: Needed to invoke new_simple_flow_node! in the same crate as it is defined.
+#[expect(unsafe_code)]
 pub mod publish {
     use super::Artifact;
     use crate::flowey_request;
@@ -239,6 +238,8 @@ pub mod publish {
     }
 }
 
+// UNSAFETY: Needed to invoke new_simple_flow_node! in the same crate as it is defined.
+#[expect(unsafe_code)]
 pub mod resolve {
     use super::Artifact;
     use crate::flowey_request;

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -3,8 +3,6 @@
 
 //! CPUID definitions and implementation specific to Underhill in hardware CVMs.
 
-#![warn(missing_docs)]
-
 use self::tdx::TdxCpuidInitializer;
 use core::arch::x86_64::CpuidResult;
 use cvm_tracing::CVM_ALLOWED;

--- a/vm/devices/pci/pci_core/src/cfg_space_emu.rs
+++ b/vm/devices/pci/pci_core/src/cfg_space_emu.rs
@@ -6,8 +6,6 @@
 //! To be clear: PCI devices are not required to use these helpers, and may
 //! choose to implement configuration space accesses manually.
 
-#![warn(missing_docs)]
-
 use crate::PciInterruptPin;
 use crate::bar_mapping::BarMappings;
 use crate::capabilities::PciCapability;

--- a/vm/hv1/hv1_structs/src/vtl_array.rs
+++ b/vm/hv1/hv1_structs/src/vtl_array.rs
@@ -3,9 +3,6 @@
 
 //! Container data structures indexable by [`Vtl`].
 
-#![forbid(unsafe_code)]
-#![warn(missing_docs)]
-
 use bitvec::array::BitArray;
 use core::ops::Deref;
 use core::ops::DerefMut;

--- a/vm/vmcore/src/device_state.rs
+++ b/vm/vmcore/src/device_state.rs
@@ -3,6 +3,8 @@
 
 //! Trait definition for chipset device state transitions.
 
+#![forbid(unsafe_code)]
+
 use std::future::Future;
 
 /// Trait for transitioning device state.

--- a/vm/vmcore/src/interrupt.rs
+++ b/vm/vmcore/src/interrupt.rs
@@ -3,6 +3,8 @@
 
 //! Types to support delivering notifications to the guest.
 
+#![forbid(unsafe_code)]
+
 use crate::local_only::LocalOnly;
 use mesh::MeshPayload;
 use std::fmt::Debug;

--- a/vm/vmcore/src/isa_dma_channel.rs
+++ b/vm/vmcore/src/isa_dma_channel.rs
@@ -3,6 +3,8 @@
 
 //! Infrastructure to support legacy ISA DMA channels.
 
+#![forbid(unsafe_code)]
+
 /// ISA DMA transfer direction
 #[derive(PartialEq, Debug)]
 pub enum IsaDmaDirection {

--- a/vm/vmcore/src/lib.rs
+++ b/vm/vmcore/src/lib.rs
@@ -6,9 +6,6 @@
 //! across both HvLite and Hyper-V, so it should not contain any references to
 //! HvLite-specific infrastructure (such as WHP).
 
-// UNSAFETY: linkme uses link_section which is unsafe.
-#![expect(unsafe_code)]
-
 // Needed for `save_restore_derive`.
 extern crate self as vmcore;
 

--- a/vm/vmcore/src/line_interrupt.rs
+++ b/vm/vmcore/src/line_interrupt.rs
@@ -3,7 +3,7 @@
 
 //! Infrastructure to support line interrupts.
 
-#![warn(missing_docs)]
+#![forbid(unsafe_code)]
 
 use inspect::Inspect;
 use parking_lot::Mutex;

--- a/vm/vmcore/src/local_only.rs
+++ b/vm/vmcore/src/local_only.rs
@@ -3,6 +3,8 @@
 
 //! Type definitions for types that cannot cross a mesh process boundary.
 
+#![forbid(unsafe_code)]
+
 use mesh::payload::Error;
 use mesh::payload::FieldDecode;
 use mesh::payload::FieldEncode;

--- a/vm/vmcore/src/monitor.rs
+++ b/vm/vmcore/src/monitor.rs
@@ -3,6 +3,8 @@
 
 //! Types for supporting hypervisor monitor pages.
 
+#![forbid(unsafe_code)]
+
 use hvdef::HV_PAGE_SIZE;
 use hvdef::HvMonitorPage;
 use hvdef::HvMonitorPageSmall;

--- a/vm/vmcore/src/non_volatile_store.rs
+++ b/vm/vmcore/src/non_volatile_store.rs
@@ -3,7 +3,6 @@
 
 //! Defines the [`NonVolatileStore`] trait.
 
-#![warn(missing_docs)]
 #![forbid(unsafe_code)]
 
 use thiserror::Error;

--- a/vm/vmcore/src/notify.rs
+++ b/vm/vmcore/src/notify.rs
@@ -4,6 +4,8 @@
 //! Guest-to-host notification infrastructure, abstracting over [platform
 //! events](pal_event::Event), and [task events](SlimEvent).
 
+#![forbid(unsafe_code)]
+
 use crate::interrupt::Interrupt;
 use crate::local_only::LocalOnly;
 use crate::slim_event::SlimEvent;

--- a/vm/vmcore/src/reference_time.rs
+++ b/vm/vmcore/src/reference_time.rs
@@ -3,6 +3,8 @@
 
 //! Types for hypervisor reference time sources.
 
+#![forbid(unsafe_code)]
+
 use inspect::Inspect;
 use std::convert::Infallible;
 use std::sync::Arc;

--- a/vm/vmcore/src/save_restore.rs
+++ b/vm/vmcore/src/save_restore.rs
@@ -38,6 +38,7 @@
 //!    device-specific trait that provides additional parameters. But the
 //!    pattern should be the same.
 
+// UNSAFETY: Needed to use linkme for deriving SavedStateRoot.
 #![expect(unsafe_code)]
 
 /// Derives [`SavedStateRoot`] for a type.

--- a/vm/vmcore/src/save_restore.rs
+++ b/vm/vmcore/src/save_restore.rs
@@ -38,7 +38,7 @@
 //!    device-specific trait that provides additional parameters. But the
 //!    pattern should be the same.
 
-#![warn(missing_docs)]
+#![expect(unsafe_code)]
 
 /// Derives [`SavedStateRoot`] for a type.
 ///

--- a/vm/vmcore/src/slim_event.rs
+++ b/vm/vmcore/src/slim_event.rs
@@ -3,6 +3,8 @@
 
 //! Event support.
 
+#![forbid(unsafe_code)]
+
 use futures::Stream;
 use parking_lot::Mutex;
 use std::future::Future;

--- a/vm/vmcore/src/synic.rs
+++ b/vm/vmcore/src/synic.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![expect(missing_docs)]
-
 //! Synic interface definitions used by VmBus.
+
+#![forbid(unsafe_code)]
+#![expect(missing_docs)]
 
 use crate::interrupt::Interrupt;
 use crate::monitor::MonitorId;

--- a/vm/vmcore/src/vm_task.rs
+++ b/vm/vmcore/src/vm_task.rs
@@ -4,7 +4,7 @@
 //! Infrastructure for spawning tasks and issuing async IO related to VM
 //! activity.
 
-#![warn(missing_docs)]
+#![forbid(unsafe_code)]
 
 use inspect::Inspect;
 use pal_async::driver::Driver;

--- a/vm/vmcore/src/vm_task.rs
+++ b/vm/vmcore/src/vm_task.rs
@@ -4,7 +4,8 @@
 //! Infrastructure for spawning tasks and issuing async IO related to VM
 //! activity.
 
-#![forbid(unsafe_code)]
+// UNSAFETY: Needed to implement the unsafe new_dyn_overlapped_file method.
+#![cfg_attr(windows, expect(unsafe_code))]
 
 use inspect::Inspect;
 use pal_async::driver::Driver;

--- a/vm/vmcore/src/vmtime.rs
+++ b/vm/vmcore/src/vmtime.rs
@@ -21,6 +21,8 @@
 //! in the same OS (but not across machines, virtual or physical). See the
 //! comments on [`VmTimeSourceBuilder`] for more information.
 
+pub use saved_state::SavedState;
+
 use futures::StreamExt;
 use futures::future::join_all;
 use futures_concurrency::future::Race;
@@ -40,7 +42,6 @@ use pal_async::timer::Instant;
 use pal_async::timer::PollTimer;
 use parking_lot::RwLock;
 use save_restore_derive::SavedStateRoot;
-pub use saved_state::SavedState;
 use slab::Slab;
 use std::future::poll_fn;
 use std::sync::Arc;

--- a/vm/vmcore/src/vmtime.rs
+++ b/vm/vmcore/src/vmtime.rs
@@ -345,10 +345,8 @@ pub struct VmTimeKeeper {
     time: TimeState,
 }
 
-#[expect(
-    unsafe_code,
-    reason = "Needed to derive SavedStateRoot in the same crate it is declared"
-)]
+// UNSAFETY: Needed to derive SavedStateRoot in the same crate it is declared
+#[expect(unsafe_code)]
 mod saved_state {
     use super::*;
 

--- a/vm/vmcore/src/vpci_msi.rs
+++ b/vm/vmcore/src/vpci_msi.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![expect(missing_docs)]
-
 //! Trait to model host-assisted MSI/MSI-X configuration (when using VPCI).
+
+#![forbid(unsafe_code)]
+#![expect(missing_docs)]
 
 use async_trait::async_trait;
 use inspect::Inspect;


### PR DESCRIPTION
Notably this removes the crate-level expect(unsafe_code) from vmcore, replacing it with much more narrowly scoped expects, and adding forbid(unsafe_code) to its other modules. This expect is needed due to our use of linkme inside the implementation of deriving SavedStateRoot. It is not needed on our derivations of this trait elsewhere, as the lint is suppressed when it comes from a macro invocation from a different crate. This is the only place we derive SavedStateRoot in vmcore itself.