### PR TITLE
cvm guest vsm: track vtl 1 permissions in bitmaps

### DIFF
--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -401,6 +401,8 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
             acceptor.as_ref().unwrap().clone(),
         )) as Arc<dyn ProtectIsolatedMemory>;
 
+        // TODO GUEST VSM: create guest memory objects using execute permissions
+        // for the instruction emulator to use when reading instructions.
         MemoryMappings {
             vtl0: vtl0_mapping,
             vtl1: vtl1_mapping,

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -12,6 +12,7 @@ use guestmem::GuestMemoryBackingError;
 use guestmem::PAGE_SIZE;
 use hcl::ioctl::Mshv;
 use hcl::ioctl::MshvVtlLow;
+use hvdef::HvMapGpaFlags;
 use inspect::Inspect;
 use memory_range::MemoryRange;
 use parking_lot::Mutex;
@@ -134,6 +135,8 @@ pub struct GuestMemoryMapping {
     access_bitmap_lock: Mutex<()>,
     #[inspect(with = "Option::is_some")]
     access_permission_bitmaps: Option<AccessPermissionBitmaps>,
+    #[inspect(skip)]
+    access_permission_bitmaps_lock: Mutex<()>,
     // #[inspect(with = "Option::is_some")]
     // write_bitmap: Option<SparseMapping>,
     // #[inspect(with = "Option::is_some")]
@@ -232,6 +235,32 @@ impl GuestMemoryBitmap {
 
     fn as_ptr(&self) -> *mut u8 {
         self.bitmap.as_ptr().cast()
+    }
+
+    fn update(&self, range: MemoryRange, state: bool) {
+        for gpn in range.start() / PAGE_SIZE as u64..range.end() / PAGE_SIZE as u64 {
+            // TODO: use `fill_at` for the aligned part of the range.
+            let mut b = 0;
+            self.bitmap
+                .read_at(gpn as usize / 8, std::slice::from_mut(&mut b))
+                .unwrap();
+            if state {
+                b |= 1 << (gpn % 8);
+            } else {
+                b &= !(1 << (gpn % 8));
+            }
+            self.bitmap
+                .write_at(gpn as usize / 8, std::slice::from_ref(&b))
+                .unwrap();
+        }
+    }
+
+    fn get_page_state(&self, gpn: u64) -> bool {
+        let mut b = 0;
+        self.bitmap
+            .read_at(gpn as usize / 8, std::slice::from_mut(&mut b))
+            .unwrap();
+        b & (1 << (gpn % 8)) != 0
     }
 }
 
@@ -492,6 +521,7 @@ impl GuestMemoryMappingBuilder {
             valid_memory: self.valid_memory.clone(),
             access_bitmap_lock: Default::default(),
             access_permission_bitmaps,
+            access_permission_bitmaps_lock: Default::default(),
             registrar,
         })
     }
@@ -513,6 +543,31 @@ impl GuestMemoryMapping {
             dma_base_address: None,
             ignore_registration_failure: false,
         }
+    }
+
+    /// Panics if the range is outside of guest RAM.
+    pub fn update_access_permission_bitmaps(&self, range: MemoryRange, flags: HvMapGpaFlags) {
+        let _lock = self.access_permission_bitmaps_lock.lock();
+        // TODO: check if copying straight from kernel/user executable is correct
+        let bitmaps = self.access_permission_bitmaps.as_ref().unwrap();
+        bitmaps.read_bitmap.update(range, flags.readable());
+        bitmaps.write_bitmap.update(range, flags.writable());
+        bitmaps
+            .kernel_execute_bitmap
+            .update(range, flags.kernel_executable());
+        bitmaps
+            .user_execute_bitmap
+            .update(range, flags.user_executable());
+    }
+
+    /// Panics if the range is outside of guest RAM.
+    pub fn query_access_permission(&self, gpn: u64) -> HvMapGpaFlags {
+        let bitmaps = self.access_permission_bitmaps.as_ref().unwrap();
+        HvMapGpaFlags::new()
+            .with_readable(bitmaps.read_bitmap.get_page_state(gpn))
+            .with_writable(bitmaps.write_bitmap.get_page_state(gpn))
+            .with_kernel_executable(bitmaps.kernel_execute_bitmap.get_page_state(gpn))
+            .with_user_executable(bitmaps.user_execute_bitmap.get_page_state(gpn))
     }
 
     /// Zero the given range of memory.

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1513,7 +1513,7 @@ impl<'a> UhProtoPartition<'a> {
 
         set_vtl2_vsm_partition_config(&hcl)?;
 
-        let guest_vsm_available = Self::check_guest_vsm_support(&hcl, &params)?;
+        let guest_vsm_available = Self::check_guest_vsm_support(&hcl)?;
 
         #[cfg(guest_arch = "x86_64")]
         let cpuid = match params.isolation {
@@ -1861,34 +1861,7 @@ impl UhPartition {
 impl UhProtoPartition<'_> {
     /// Whether Guest VSM is available to the guest. If so, for hardware CVMs,
     /// it is safe to expose Guest VSM support via cpuid.
-    fn check_guest_vsm_support(
-        hcl: &Hcl,
-        params: &UhPartitionNewParams<'_>,
-    ) -> Result<bool, Error> {
-        match params.isolation {
-            IsolationType::None | IsolationType::Vbs => {}
-            #[cfg(guest_arch = "x86_64")]
-            IsolationType::Tdx => {
-                // No additional checks needed
-            }
-            #[cfg(guest_arch = "x86_64")]
-            IsolationType::Snp => {
-                // Require RMP Query
-                let rmp_query = x86defs::cpuid::ExtendedSevFeaturesEax::from(
-                    safe_intrinsics::cpuid(x86defs::cpuid::CpuidFunction::ExtendedSevFeatures.0, 0)
-                        .eax,
-                )
-                .rmp_query();
-
-                if !rmp_query {
-                    tracing::info!(CVM_ALLOWED, "rmp query not supported, cannot enable vsm");
-                    return Ok(false);
-                }
-            }
-            #[allow(unreachable_patterns)]
-            isolation => panic!("unsupported isolation type {:?}", isolation),
-        }
-
+    fn check_guest_vsm_support(hcl: &Hcl) -> Result<bool, Error> {
         #[cfg(guest_arch = "x86_64")]
         let privs = {
             let result = safe_intrinsics::cpuid(hvdef::HV_CPUID_FUNCTION_MS_HV_FEATURES, 0);

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1379,6 +1379,7 @@ pub trait ProtectIsolatedMemory: Send + Sync {
     /// Changes host visibility on guest memory.
     fn change_host_visibility(
         &self,
+        vtl: GuestVtl,
         shared: bool,
         gpns: &[u64],
         tlb_access: &mut dyn TlbFlushLockAccess,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1722,13 +1722,6 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             }
         }
 
-        // TODO GUEST VSM: currently don't have a good way of supporting no
-        // enforcement of vtl 1 protections, as the related guest memory objects
-        // are initialized before this call.
-        if !value.enable_vtl_protection() {
-            return Err(HvError::InvalidRegisterValue);
-        }
-
         protector.change_default_vtl_protections(
             targeted_vtl,
             protections,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1166,11 +1166,11 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::ModifyVtlProtectionMask
             return Err((HvError::InvalidRegisterValue, 0));
         }
 
-        // The contract for VSM is that the VTL protections describe what
-        // the lower VTLs are allowed to access. Hardware CVMs set the
-        // protections on the VTL itself. Therefore, for a hardware CVM,
-        // given that only VTL 1 can set the protections, the default
-        // permissions should be changed for VTL 0.
+        // The contract for VSM is that the VTL protections describe what the
+        // lower VTLs are allowed to access. Hardware CVMs set the protections
+        // on the VTL itself. Therefore, for a hardware CVM, given that only VTL
+        // 1 can set the protections, the permissions should be changed for VTL
+        // 0.
         protector.change_vtl_protections(
             GuestVtl::Vtl0,
             gpa_pages,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1735,8 +1735,6 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             &mut self.tlb_flush_lock_access(),
         )?;
 
-        // TODO GUEST VSM: actually use the enable_vtl_protection value when
-        // deciding whether to check vtl access()
         // TODO GUEST VSM: should only be set if enable_vtl_protection is true?
         protector.set_vtl1_protections_enabled();
 

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -260,7 +260,8 @@ impl ProcessorVtlHv {
                     && (!mutable.hypercall_reg.enable() || hc.gpn() != mutable.hypercall_reg.gpn())
                 {
                     // TODO GUEST VSM: make sure the guest has writable vtl
-                    // permissions to this page
+                    // permissions to this page and that it's not in shared
+                    // memory.
                     let new_page = LockedPage::new(&self.guest_memory, hc.gpn())
                         .map_err(|_| MsrError::InvalidAccess)?;
                     self.write_hypercall_page(&new_page);

--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -259,6 +259,8 @@ impl ProcessorVtlHv {
                 if hc.enable()
                     && (!mutable.hypercall_reg.enable() || hc.gpn() != mutable.hypercall_reg.gpn())
                 {
+                    // TODO GUEST VSM: make sure the guest has writable vtl
+                    // permissions to this page
                     let new_page = LockedPage::new(&self.guest_memory, hc.gpn())
                         .map_err(|_| MsrError::InvalidAccess)?;
                     self.write_hypercall_page(&new_page);

--- a/vm/vmcore/guestmem/fuzz/fuzz_guestmem.rs
+++ b/vm/vmcore/guestmem/fuzz/fuzz_guestmem.rs
@@ -41,7 +41,8 @@ unsafe impl GuestMemoryAccess for GuestMemoryMapping {
         self.bitmap.as_ref().map(|bm| BitmapInfo {
             read_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
             write_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
-            execute_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
+            kernel_execute_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
+            user_execute_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
             bit_offset: 0,
         })
     }

--- a/vm/vmcore/guestmem/fuzz/fuzz_guestmem.rs
+++ b/vm/vmcore/guestmem/fuzz/fuzz_guestmem.rs
@@ -41,8 +41,6 @@ unsafe impl GuestMemoryAccess for GuestMemoryMapping {
         self.bitmap.as_ref().map(|bm| BitmapInfo {
             read_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
             write_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
-            kernel_execute_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
-            user_execute_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
             bit_offset: 0,
         })
     }

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -642,10 +642,6 @@ pub struct BitmapInfo {
     pub read_bitmap: NonNull<u8>,
     /// A pointer to the bitmap for write access.
     pub write_bitmap: NonNull<u8>,
-    /// A pointer to the bitmap for kernel execute access.
-    pub kernel_execute_bitmap: NonNull<u8>,
-    /// A pointer to the bitmap for user execute access.
-    pub user_execute_bitmap: NonNull<u8>,
     /// The bit offset of the beginning of the bitmap.
     ///
     /// Typically this is zero, but it is needed to support subranges that are
@@ -787,12 +783,7 @@ unsafe impl GuestMemoryAccess for GuestMemoryAccessRange {
         region.bitmaps.map(|bitmaps| {
             let offset = self.offset & self.base.region_def.region_mask;
             let bit_offset = region.bitmap_start as u64 + offset / PAGE_SIZE64;
-            let [
-                read_bitmap,
-                write_bitmap,
-                kernel_execute_bitmap,
-                user_execute_bitmap,
-            ] = bitmaps.map(|SendPtrU8(ptr)| {
+            let [read_bitmap, write_bitmap] = bitmaps.map(|SendPtrU8(ptr)| {
                 // SAFETY: the bitmap is guaranteed to be big enough for the region
                 // by construction.
                 NonNull::new(unsafe { ptr.as_ptr().add((bit_offset / 8) as usize) }).unwrap()
@@ -801,8 +792,6 @@ unsafe impl GuestMemoryAccess for GuestMemoryAccessRange {
             BitmapInfo {
                 read_bitmap,
                 write_bitmap,
-                kernel_execute_bitmap,
-                user_execute_bitmap,
                 bit_offset: bitmap_start,
             }
         })
@@ -1039,7 +1028,7 @@ impl<T: ?Sized> Debug for GuestMemoryInner<T> {
 struct MemoryRegion {
     mapping: Option<SendPtrU8>,
     #[cfg(feature = "bitmap")]
-    bitmaps: Option<[SendPtrU8; 4]>,
+    bitmaps: Option<[SendPtrU8; 2]>,
     #[cfg(feature = "bitmap")]
     bitmap_start: u8,
     len: u64,
@@ -1051,9 +1040,6 @@ struct MemoryRegion {
 enum AccessType {
     Read = 0,
     Write = 1,
-    // FUTURE: add method to read for execute permission.
-    _KernelExecute = 2,
-    _UserExecute = 3,
 }
 
 /// `NonNull<u8>` that implements `Send+Sync`.
@@ -1080,14 +1066,9 @@ impl MemoryRegion {
         #[cfg(feature = "bitmap")]
         let (bitmaps, bitmap_start) = {
             let bitmap_info = imp.access_bitmap();
-            let bitmaps = bitmap_info.as_ref().map(|bm| {
-                [
-                    SendPtrU8(bm.read_bitmap),
-                    SendPtrU8(bm.write_bitmap),
-                    SendPtrU8(bm.kernel_execute_bitmap),
-                    SendPtrU8(bm.user_execute_bitmap),
-                ]
-            });
+            let bitmaps = bitmap_info
+                .as_ref()
+                .map(|bm| [SendPtrU8(bm.read_bitmap), SendPtrU8(bm.write_bitmap)]);
             let bitmap_start = bitmap_info.map_or(0, |bi| bi.bit_offset);
             (bitmaps, bitmap_start)
         };
@@ -2494,8 +2475,6 @@ mod tests {
             self.bitmap.as_ref().map(|bm| crate::BitmapInfo {
                 read_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
                 write_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
-                kernel_execute_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
-                user_execute_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
                 bit_offset: 0,
             })
         }

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1078,16 +1078,19 @@ unsafe impl Sync for SendPtrU8 {}
 impl MemoryRegion {
     fn new(imp: &impl GuestMemoryAccess) -> Self {
         #[cfg(feature = "bitmap")]
-        let bitmap_info = imp.access_bitmap();
-        let bitmaps = bitmap_info.as_ref().map(|bm| {
-            [
-                SendPtrU8(bm.read_bitmap),
-                SendPtrU8(bm.write_bitmap),
-                SendPtrU8(bm.kernel_execute_bitmap),
-                SendPtrU8(bm.user_execute_bitmap),
-            ]
-        });
-        let bitmap_start = bitmap_info.map_or(0, |bi| bi.bit_offset);
+        let (bitmaps, bitmap_start) = {
+            let bitmap_info = imp.access_bitmap();
+            let bitmaps = bitmap_info.as_ref().map(|bm| {
+                [
+                    SendPtrU8(bm.read_bitmap),
+                    SendPtrU8(bm.write_bitmap),
+                    SendPtrU8(bm.kernel_execute_bitmap),
+                    SendPtrU8(bm.user_execute_bitmap),
+                ]
+            });
+            let bitmap_start = bitmap_info.map_or(0, |bi| bi.bit_offset);
+            (bitmaps, bitmap_start)
+        };
         Self {
             mapping: imp.mapping().map(SendPtrU8),
             #[cfg(feature = "bitmap")]


### PR DESCRIPTION
When VTL 2 accesses VTL 0 memory on behalf of VTL 0, it needs to be able to check whether VTL 1 has restricted access to the memory. This change introduces tracking of VTL 1 permissions using bitmaps and adds some of the enforcement of these permissions.

Tested:
SNP +/- guest VSM boots