### PR TITLE
CVM: Audit tracing and add ALLOWED/CONFIDENTIAL where appropriate (#1408)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7984,6 +7984,7 @@ dependencies = [
  "bitvec",
  "build_rs_guest_arch",
  "cfg-if",
+ "cvm_tracing",
  "fs-err",
  "guestmem",
  "hcl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "anyhow",
  "azure_profiler_proto",
  "build_rs_guest_arch",
+ "cvm_tracing",
  "diag_proto",
  "fs-err",
  "futures",
@@ -2758,6 +2759,7 @@ dependencies = [
  "bitfield-struct 0.10.1",
  "bitvec",
  "build_rs_guest_arch",
+ "cvm_tracing",
  "fs-err",
  "getrandom 0.3.2",
  "hv1_structs",
@@ -2787,6 +2789,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "cvm_tracing",
  "guid",
  "inspect",
  "open_enum",
@@ -7055,6 +7058,7 @@ dependencies = [
  "bitfield-struct 0.10.1",
  "chipset_device",
  "chipset_device_resources",
+ "cvm_tracing",
  "getrandom 0.3.2",
  "guestmem",
  "inspect",
@@ -7605,6 +7609,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "build_rs_guest_arch",
+ "cvm_tracing",
  "futures",
  "guestmem",
  "hcl",
@@ -7628,6 +7633,7 @@ dependencies = [
 name = "underhill_threadpool"
 version = "0.0.0"
 dependencies = [
+ "cvm_tracing",
  "fs-err",
  "inspect",
  "loan_cell",
@@ -8796,6 +8802,7 @@ dependencies = [
  "build_rs_guest_arch",
  "cache_topology",
  "chipset",
+ "cvm_tracing",
  "futures",
  "futures-concurrency",
  "guestmem",
@@ -8908,6 +8915,7 @@ dependencies = [
  "chipset_legacy",
  "chipset_resources",
  "closeable_mutex",
+ "cvm_tracing",
  "firmware_pcat",
  "firmware_uefi",
  "floppy",

--- a/openhcl/diag_server/Cargo.toml
+++ b/openhcl/diag_server/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 diag_proto.workspace = true
 
 azure_profiler_proto.workspace = true
+cvm_tracing.workspace = true
 inspect_proto.workspace = true
 inspect = { workspace = true, features = ["defer"] }
 mesh = { workspace = true, features = ["socket2"] }

--- a/openhcl/diag_server/src/diag_service.rs
+++ b/openhcl/diag_server/src/diag_service.rs
@@ -546,7 +546,7 @@ impl DiagServiceHandler {
     }
 
     async fn handle_update(&self, request: &UpdateRequest) -> anyhow::Result<UpdateResponse2> {
-        tracing::info!(
+        tracing::debug!(
             path = request.path.as_str(),
             value = request.value.as_str(),
             "update request"

--- a/openhcl/diag_server/src/lib.rs
+++ b/openhcl/diag_server/src/lib.rs
@@ -12,6 +12,7 @@ pub use diag_service::DiagRequest;
 pub use diag_service::StartParams;
 
 use anyhow::Context;
+use cvm_tracing::CVM_ALLOWED;
 use futures::AsyncWriteExt;
 use futures::FutureExt;
 use mesh::CancelReason;
@@ -48,11 +49,11 @@ pub struct DiagServer {
 impl DiagServer {
     /// Creates a server over VmSockets and starts listening.
     pub fn new_vsock(control_address: VmAddress, data_address: VmAddress) -> anyhow::Result<Self> {
-        tracing::info!(?control_address, "control starting");
+        tracing::info!(CVM_ALLOWED, ?control_address, "control starting");
         let control_listener =
             VmListener::bind(control_address).context("failed to bind socket")?;
 
-        tracing::info!(?data_address, "data starting");
+        tracing::info!(CVM_ALLOWED, ?data_address, "data starting");
         let data_listener = VmListener::bind(data_address).context("failed to bind socket")?;
 
         Ok(Self::new_generic(
@@ -63,11 +64,11 @@ impl DiagServer {
 
     /// Creates a server over Unix sockets and starts listening.
     pub fn new_unix(control_address: &Path, data_address: &Path) -> anyhow::Result<Self> {
-        tracing::info!(?control_address, "control starting");
+        tracing::info!(CVM_ALLOWED, ?control_address, "control starting");
         let control_listener =
             UnixListener::bind(control_address).context("failed to bind socket")?;
 
-        tracing::info!(?data_address, "data starting");
+        tracing::info!(CVM_ALLOWED, ?data_address, "data starting");
         let data_listener = UnixListener::bind(data_address).context("failed to bind socket")?;
 
         Ok(Self::new_generic(

--- a/openhcl/hcl/Cargo.toml
+++ b/openhcl/hcl/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+cvm_tracing.workspace = true
 hv1_structs.workspace = true
 hvdef.workspace = true
 pal.workspace = true

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -24,6 +24,7 @@ use crate::protocol::MSHV_APIC_PAGE_OFFSET;
 use crate::protocol::hcl_intr_offload_flags;
 use crate::protocol::hcl_run;
 use bitvec::vec::BitVec;
+use cvm_tracing::CVM_ALLOWED;
 use deferred::RegisteredDeferredActions;
 use deferred::push_deferred_action;
 use deferred::register_deferred_actions;
@@ -924,7 +925,7 @@ impl MshvHvcall {
             - size_of::<hvdef::hypercall::AcceptGpaPages>())
             / size_of::<u64>();
 
-        let span = tracing::span!(tracing::Level::INFO, "accept_pages", ?range);
+        let span = tracing::info_span!("accept_pages", CVM_ALLOWED, ?range);
         let _enter = span.enter();
 
         let mut current_page = range.start() / HV_PAGE_SIZE;
@@ -1343,7 +1344,7 @@ impl MshvHvcall {
             - size_of::<hvdef::hypercall::ModifyVtlProtectionMask>())
             / size_of::<u64>();
 
-        let span = tracing::span!(tracing::Level::INFO, "modify_vtl_protection_mask", ?range);
+        let span = tracing::info_span!("modify_vtl_protection_mask", CVM_ALLOWED, ?range);
         let _enter = span.enter();
 
         let start = range.start() / HV_PAGE_SIZE;

--- a/openhcl/hcl/src/ioctl/deferred.rs
+++ b/openhcl/hcl/src/ioctl/deferred.rs
@@ -6,6 +6,7 @@
 use super::Hcl;
 use crate::protocol;
 use crate::protocol::hcl_run;
+use cvm_tracing::CVM_ALLOWED;
 use std::cell::Cell;
 use std::cell::UnsafeCell;
 use std::marker::PhantomData;
@@ -129,6 +130,7 @@ impl DeferredAction {
             DeferredAction::SignalEvent { vp, sint, flag } => {
                 if let Err(err) = hcl.hvcall_signal_event_direct(vp, sint, flag) {
                     tracelimit::warn_ratelimited!(
+                        CVM_ALLOWED,
                         error = &err as &dyn std::error::Error,
                         vp,
                         sint,

--- a/openhcl/profiler_worker/src/lib.rs
+++ b/openhcl/profiler_worker/src/lib.rs
@@ -153,7 +153,10 @@ pub async fn profile(request: ProfilerRequest, driver: &impl Driver) -> anyhow::
     let free_mem_mb = match get_free_mem_mb() {
         Ok(m) => m,
         Err(e) => {
-            tracing::error!("Error when getting memory {}", e.to_string());
+            tracing::error!(
+                e = e.as_ref() as &dyn std::error::Error,
+                "Error when getting memory"
+            );
             0
         }
     };
@@ -203,8 +206,8 @@ pub async fn profile(request: ProfilerRequest, driver: &impl Driver) -> anyhow::
             Err(e) => {
                 process_success = false;
                 tracing::error!(
-                    "Running profiler binary failed with error {}",
-                    e.to_string()
+                    e = &e as &dyn std::error::Error,
+                    "Running profiler binary failed",
                 );
                 break;
             }

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -748,7 +748,10 @@ impl LoadedVm {
     }
 
     fn notify_of_vtl_crash(&self, vtl_crash: VtlCrash) {
-        tracing::info!(CVM_ALLOWED, "Notifying the host of the guest system crash {vtl_crash:x?}");
+        tracing::info!(
+            CVM_ALLOWED,
+            "Notifying the host of the guest system crash {vtl_crash:x?}"
+        );
 
         let VtlCrash {
             vp_index,

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -21,6 +21,7 @@ use crate::worker::FirmwareType;
 use crate::worker::NetworkSettingsError;
 use anyhow::Context;
 use async_trait::async_trait;
+use cvm_tracing::CVM_ALLOWED;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures_concurrency::future::Join;
@@ -279,7 +280,7 @@ impl LoadedVm {
                                 }
                             }
                         }
-                        .instrument(tracing::info_span!("restart"))
+                        .instrument(tracing::info_span!("restart", CVM_ALLOWED))
                         .await;
 
                         if let Some((rpc, servicing_state)) = state {
@@ -373,6 +374,7 @@ impl LoadedVm {
                         }
                         Err(err) => {
                             tracing::error!(
+                                CVM_ALLOWED,
                                 error = err.as_ref() as &dyn std::error::Error,
                                 "failed to notify host of servicing result"
                             );
@@ -388,11 +390,12 @@ impl LoadedVm {
                         }
                         let (_, send_guest) =
                             self.shutdown_relay.as_mut().expect("active shutdown_relay");
-                        tracing::info!(params = ?msg, "Relaying shutdown message");
+                        tracing::info!(CVM_ALLOWED, params = ?msg, "Relaying shutdown message");
                         let result = match send_guest.call(ShutdownRpc::Shutdown, msg).await {
                             Ok(result) => result,
                             Err(err) => {
                                 tracing::error!(
+                                    CVM_ALLOWED,
                                     error = &err as &dyn std::error::Error,
                                     "Failed to relay shutdown notification to guest"
                                 );
@@ -400,7 +403,7 @@ impl LoadedVm {
                             }
                         };
                         if !matches!(result, ShutdownResult::Ok) {
-                            tracing::warn!(?result, "Shutdown request failed");
+                            tracing::warn!(CVM_ALLOWED, ?result, "Shutdown request failed");
                             self.handle_hibernate_request(true).await;
                         }
                         result
@@ -464,6 +467,7 @@ impl LoadedVm {
             }
             Err(err) => {
                 tracing::error!(
+                    CVM_ALLOWED,
                     error = err.as_ref() as &dyn std::error::Error,
                     "error while handling servicing"
                 );
@@ -517,7 +521,7 @@ impl LoadedVm {
                 if let Some(network_settings) = self.network_settings.as_mut() {
                     network_settings
                         .unload_for_servicing()
-                        .instrument(tracing::info_span!("shutdown_mana"))
+                        .instrument(tracing::info_span!("shutdown_mana", CVM_ALLOWED))
                         .await;
                 }
             };
@@ -527,7 +531,7 @@ impl LoadedVm {
                 if let Some(nvme_manager) = self.nvme_manager.take() {
                     nvme_manager
                         .shutdown(nvme_keepalive)
-                        .instrument(tracing::info_span!("shutdown_nvme_vfio", %correlation_id, %nvme_keepalive))
+                        .instrument(tracing::info_span!("shutdown_nvme_vfio", CVM_ALLOWED, %correlation_id, %nvme_keepalive))
                         .await;
                 }
             };
@@ -536,7 +540,7 @@ impl LoadedVm {
             // restart.
             let shutdown_pci = async {
                 pci_shutdown::shutdown_pci_devices()
-                    .instrument(tracing::info_span!("shutdown_pci_devices"))
+                    .instrument(tracing::info_span!("shutdown_pci_devices", CVM_ALLOWED))
                     .await
             };
 
@@ -545,7 +549,7 @@ impl LoadedVm {
 
             Ok(state)
         }
-        .instrument(tracing::info_span!("servicing_save_vtl2", %correlation_id))
+        .instrument(tracing::info_span!("servicing_save_vtl2", CVM_ALLOWED, %correlation_id))
         .await;
 
         let mut state = match r {
@@ -593,12 +597,18 @@ impl LoadedVm {
             if !rollback {
                 network_settings
                     .prepare_for_hibernate(rollback)
-                    .instrument(tracing::info_span!("prepare_for_guest_hibernate"))
+                    .instrument(tracing::info_span!(
+                        "prepare_for_guest_hibernate",
+                        CVM_ALLOWED
+                    ))
                     .await;
             } else {
                 network_settings
                     .prepare_for_hibernate(rollback)
-                    .instrument(tracing::info_span!("rollback_prepare_for_guest_hibernate"))
+                    .instrument(tracing::info_span!(
+                        "rollback_prepare_for_guest_hibernate",
+                        CVM_ALLOWED
+                    ))
                     .await;
             };
         }
@@ -611,7 +621,7 @@ impl LoadedVm {
         let reference_time = ReferenceTime::new(self.partition.reference_time());
         if let Some(stopped) = self.last_state_unit_stop {
             let blackout_time = reference_time.since(stopped);
-            tracing::info!(
+            tracing::info!(CVM_ALLOWED,
                 correlation_id = %correlation_id.unwrap_or(Guid::ZERO),
                 blackout_time_ms = blackout_time.map(|t| t.as_millis() as u64),
                 blackout_time = blackout_time
@@ -623,6 +633,7 @@ impl LoadedVm {
             // Assume we started at reference time 0.
             let boot_time = reference_time.since(ReferenceTime::new(0));
             tracing::info!(
+                CVM_ALLOWED,
                 boot_time_ms = boot_time.map(|t| t.as_millis() as u64),
                 boot_time = boot_time
                     .map_or_else(|| "unknown".to_string(), |t| format!("{:?}", t))
@@ -636,7 +647,7 @@ impl LoadedVm {
     async fn stop(&mut self) -> bool {
         if self.state_units.is_running() {
             self.last_state_unit_stop = Some(ReferenceTime::new(self.partition.reference_time()));
-            tracing::info!("stopping VM");
+            tracing::info!(CVM_ALLOWED, "stopping VM");
             self.state_units.stop().await;
             true
         } else {
@@ -672,7 +683,7 @@ impl LoadedVm {
         // was enabled.
         let nvme_state = if let Some(n) = &self.nvme_manager {
             n.save(vf_keepalive_flag)
-                .instrument(tracing::info_span!("nvme_manager_save"))
+                .instrument(tracing::info_span!("nvme_manager_save", CVM_ALLOWED))
                 .await
                 .map(|s| NvmeSavedState { nvme_state: s })
         } else {
@@ -725,19 +736,19 @@ impl LoadedVm {
         Ok(state)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(CVM_ALLOWED))]
     async fn save_units(&mut self) -> anyhow::Result<Vec<SavedStateUnit>> {
         Ok(self.state_units.save().await?)
     }
 
-    #[instrument(skip(self, saved_state))]
+    #[instrument(skip(self, saved_state), fields(CVM_ALLOWED))]
     pub async fn restore_units(&mut self, saved_state: Vec<SavedStateUnit>) -> anyhow::Result<()> {
         self.state_units.restore(saved_state).await?;
         Ok(())
     }
 
     fn notify_of_vtl_crash(&self, vtl_crash: VtlCrash) {
-        tracing::info!("Notifying the host of the guest system crash {vtl_crash:x?}");
+        tracing::info!(CVM_ALLOWED, "Notifying the host of the guest system crash {vtl_crash:x?}");
 
         let VtlCrash {
             vp_index,

--- a/openhcl/underhill_core/src/dispatch/pci_shutdown.rs
+++ b/openhcl/underhill_core/src/dispatch/pci_shutdown.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use blocking::unblock;
+use cvm_tracing::CVM_ALLOWED;
 use fs_err::PathExt;
 use futures::future::try_join_all;
 use std::os::unix::prelude::*;
@@ -47,6 +48,7 @@ pub async fn shutdown_pci_devices() -> Result<(), ShutdownError> {
                 unblock(move || fs_err::write(driver_link.join("unbind"), pci_id.as_bytes()))
                     .instrument(tracing::info_span!(
                         "unbind_pci_device",
+                        CVM_ALLOWED,
                         driver = driver_name.as_ref(),
                         pci_id = pci_id_str.as_str(),
                     ))

--- a/openhcl/underhill_core/src/emuplat/firmware.rs
+++ b/openhcl/underhill_core/src/emuplat/firmware.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use cvm_tracing::CVM_ALLOWED;
 #[cfg(guest_arch = "x86_64")]
 use firmware_pcat::PcatEvent;
 #[cfg(guest_arch = "x86_64")]
@@ -62,6 +63,7 @@ impl firmware_uefi::platform::nvram::VsmConfig for UnderhillVsmConfig {
         if let Some(partition) = self.partition.upgrade() {
             if let Err(err) = partition.revoke_guest_vsm() {
                 tracing::warn!(
+                    CVM_ALLOWED,
                     error = &err as &dyn std::error::Error,
                     "failed to revoke guest vsm"
                 );

--- a/openhcl/underhill_core/src/emuplat/watchdog.rs
+++ b/openhcl/underhill_core/src/emuplat/watchdog.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use cvm_tracing::CVM_ALLOWED;
 use vmcore::non_volatile_store::NonVolatileStore;
 use watchdog_core::platform::WatchdogPlatform;
 use watchdog_vmgs_format::WatchdogVmgsFormatStore;
@@ -39,6 +40,7 @@ impl WatchdogPlatform for UnderhillWatchdog {
         let res = self.store.set_boot_failure().await;
         if let Err(e) = res {
             tracing::error!(
+                CVM_ALLOWED,
                 error = &e as &dyn std::error::Error,
                 "error persisting watchdog status"
             );
@@ -61,6 +63,7 @@ impl WatchdogPlatform for UnderhillWatchdog {
             Ok(status) => status,
             Err(e) => {
                 tracing::error!(
+                    CVM_ALLOWED,
                     error = &e as &dyn std::error::Error,
                     "error reading watchdog status"
                 );

--- a/openhcl/underhill_core/src/get_tracing.rs
+++ b/openhcl/underhill_core/src/get_tracing.rs
@@ -25,6 +25,7 @@ mod kmsg_stream;
 mod kmsg_writer;
 
 use anyhow::Context;
+use cvm_tracing::CVM_ALLOWED;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures_concurrency::stream::Merge;
@@ -80,6 +81,7 @@ pub fn init_tracing_backend(driver: impl 'static + SpawnDriver) -> anyhow::Resul
         .and_then(|dev| vmbus_user_channel::message_pipe(&driver, dev))
         .map_err(|err| {
             tracing::error!(
+                CVM_ALLOWED,
                 error = &err as &dyn std::error::Error,
                 "failed to open the vmbus tracing channel"
             );

--- a/openhcl/underhill_core/src/get_tracing/kmsg_stream.rs
+++ b/openhcl/underhill_core/src/get_tracing/kmsg_stream.rs
@@ -5,6 +5,7 @@
 //! send to the host.
 
 use super::json_common::KmsgMessage;
+use cvm_tracing::CVM_ALLOWED;
 use futures::AsyncRead;
 use futures::Stream;
 use get_helpers::build_tracelogging_notification_buffer;
@@ -161,6 +162,7 @@ impl Stream for KmsgStream {
                 }
                 Err(err) => {
                     tracing::error!(
+                        CVM_ALLOWED,
                         error = &err as &dyn std::error::Error,
                         "failed to read from /dev/kmsg"
                     );

--- a/openhcl/underhill_core/src/inspect_proc.rs
+++ b/openhcl/underhill_core/src/inspect_proc.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use anyhow::Context;
+use cvm_tracing::CVM_ALLOWED;
 use inspect::Request;
 use inspect::Response;
 use inspect::SensitivityLevel;
@@ -209,7 +210,7 @@ pub async fn periodic_telemetry_task(driver: VmTaskDriver) {
         let results = inspection.results();
         let json = results.json();
         // The below message needs to be valid JSON for ease of processing
-        tracing::info!("{{\"periodic_memory_status\":{}}}", json);
+        tracing::info!(CVM_ALLOWED, "{{\"periodic_memory_status\":{}}}", json);
         // Wait a day before logging again
         timer.sleep(Duration::from_secs(60 * 60 * 24)).await;
     }

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -206,7 +206,11 @@ async fn do_main(driver: DefaultDriver, mut tracing: TracingBackend) -> anyhow::
 
     let r = run_control(driver, &mesh, opt, &mut tracing).await;
     if let Err(err) = &r {
-        tracing::error!(error = err.as_ref() as &dyn std::error::Error, "VM failure");
+        tracing::error!(
+            CVM_ALLOWED,
+            error = err.as_ref() as &dyn std::error::Error,
+            "VM failure"
+        );
     }
 
     // Wait a few seconds for child processes to terminate and tracing to finish.
@@ -238,6 +242,7 @@ fn log_boot_times() -> anyhow::Result<()> {
         sidecar_end,
     } = BootTimes::new().context("failed to parse boot times")?;
     tracing::info!(
+        CVM_ALLOWED,
         start,
         end,
         sidecar_start,
@@ -706,10 +711,10 @@ async fn run_control(
             Event::Worker(event) => match event {
                 WorkerEvent::Started => {
                     if let Some(response) = restart_rpc.take() {
-                        tracing::info!("restart complete");
+                        tracing::info!(CVM_ALLOWED, "restart complete");
                         response.complete(Ok(()));
                     } else {
-                        tracing::info!("vm worker started");
+                        tracing::info!(CVM_ALLOWED, "vm worker started");
                     }
                     state = ControlState::Started;
                 }
@@ -720,7 +725,11 @@ async fn run_control(
                     return Err(anyhow::Error::from(err)).context("vm worker failed");
                 }
                 WorkerEvent::RestartFailed(err) => {
-                    tracing::error!(error = &err as &dyn std::error::Error, "restart failed");
+                    tracing::error!(
+                        CVM_ALLOWED,
+                        error = &err as &dyn std::error::Error,
+                        "restart failed"
+                    );
                     restart_rpc.take().unwrap().complete(Err(err));
                     state = ControlState::Started;
                 }
@@ -728,7 +737,7 @@ async fn run_control(
             Event::Control(req) => match req {
                 ControlRequest::FlushLogs(rpc) => {
                     rpc.handle(async |mut ctx| {
-                        tracing::info!("flushing logs");
+                        tracing::info!(CVM_ALLOWED, "flushing logs");
                         ctx.until_cancelled(tracing.flush()).await?;
                         Ok(())
                     })
@@ -742,7 +751,7 @@ async fn run_control(
 }
 
 async fn signal_vtl0_started(driver: &DefaultDriver) -> anyhow::Result<()> {
-    tracing::info!("signaling vtl0 started early");
+    tracing::info!(CVM_ALLOWED, "signaling vtl0 started early");
     let (client, task) = guest_emulation_transport::spawn_get_worker(driver.clone())
         .await
         .context("failed to spawn GET")?;
@@ -750,7 +759,7 @@ async fn signal_vtl0_started(driver: &DefaultDriver) -> anyhow::Result<()> {
     // Disconnect the GET so that it can be reused.
     drop(client);
     task.await.unwrap();
-    tracing::info!("signaled vtl0 start");
+    tracing::info!(CVM_ALLOWED, "signaled vtl0 start");
     Ok(())
 }
 

--- a/openhcl/underhill_core/src/livedump.rs
+++ b/openhcl/underhill_core/src/livedump.rs
@@ -6,7 +6,7 @@ use std::process::Stdio;
 pub(crate) async fn livedump() {
     // If a livedump fails we don't want to panic, just log the error.
     match livedump_core().await {
-        Err(e) => tracing::error!(?e, "livedump failed"),
+        Err(e) => tracing::error!(e = e.as_ref() as &dyn std::error::Error, "livedump failed"),
         Ok(()) => tracing::info!("livedump succeeded"),
     }
 }

--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -6,6 +6,7 @@
 use self::vtl2_config::RuntimeParameters;
 use crate::loader::vtl0_config::LinuxInfo;
 use crate::worker::FirmwareType;
+use cvm_tracing::CVM_ALLOWED;
 use guest_emulation_transport::api::platform_settings::DevicePlatformSettings;
 use guest_emulation_transport::api::platform_settings::General;
 use guestmem::GuestMemory;
@@ -114,11 +115,11 @@ pub fn load(
 ) -> Result<VpContext, Error> {
     let context = match load_kind {
         LoadKind::None => {
-            tracing::info!("loading nothing into VTL0");
+            tracing::info!(CVM_ALLOWED, "loading nothing into VTL0");
             VpContext::Vbs(Vec::new())
         }
         LoadKind::Uefi => {
-            tracing::info!("loading UEFI into VTL0");
+            tracing::info!(CVM_ALLOWED, "loading UEFI into VTL0");
             // UEFI image is already loaded into guest memory, so only the
             // dynamic config needs to be written.
             let uefi_info = vtl0_info.supports_uefi.as_ref().ok_or(Error::UefiSupport)?;
@@ -152,7 +153,7 @@ pub fn load(
         }
         #[cfg(guest_arch = "x86_64")]
         LoadKind::Linux => {
-            tracing::info!("loading Linux into VTL0");
+            tracing::info!(CVM_ALLOWED, "loading Linux into VTL0");
 
             let LinuxInfo {
                 kernel_range,
@@ -190,7 +191,7 @@ pub fn load(
             })?
         }
         LoadKind::Pcat => {
-            tracing::info!("loading pcat into VTL0");
+            tracing::info!(CVM_ALLOWED, "loading pcat into VTL0");
 
             if !vtl0_info.supports_pcat {
                 return Err(Error::PcatSupport);

--- a/openhcl/underhill_core/src/loader/vtl0_config.rs
+++ b/openhcl/underhill_core/src/loader/vtl0_config.rs
@@ -68,7 +68,7 @@ pub struct MeasuredVtl0Info {
 
 impl MeasuredVtl0Info {
     /// Read measured VTL0 load information from guest memory.
-    #[instrument(skip_all)]
+    #[instrument(skip_all, fields(CVM_ALLOWED))]
     pub fn read_from_memory(gm: &GuestMemory) -> Result<Self, Error> {
         // Read the measured config, noting which pages the config was stored
         // in. These pages will need to be zeroed out afterwards (the memory

--- a/openhcl/underhill_core/src/vp.rs
+++ b/openhcl/underhill_core/src/vp.rs
@@ -4,6 +4,7 @@
 //! Code to spawn VP tasks and run VPs.
 
 use anyhow::Context;
+use cvm_tracing::CVM_ALLOWED;
 use futures::future::try_join_all;
 use pal_async::task::Spawn;
 use pal_async::task::SpawnLocal;
@@ -228,7 +229,7 @@ impl VpSpawner {
                                     None
                                 };
 
-                                tracing::info!(cpu = self.cpu, "onlining sidecar VP");
+                                tracing::info!(CVM_ALLOWED, cpu = self.cpu, "onlining sidecar VP");
                                 online_cpu(self.cpu).await;
 
                                 // Respawn the VP on the new thread.
@@ -255,7 +256,7 @@ async fn online_cpu(cpu: u32) {
         .name(format!("online-{cpu}"))
         .spawn(move || {
             send.send({
-                let _span = tracing::info_span!("online_cpu", cpu).entered();
+                let _span = tracing::info_span!("online_cpu", CVM_ALLOWED, cpu).entered();
                 underhill_threadpool::set_cpu_online(cpu)
             })
         })

--- a/openhcl/underhill_mem/Cargo.toml
+++ b/openhcl/underhill_mem/Cargo.toml
@@ -18,6 +18,7 @@ virt_mshv_vtl.workspace = true
 vm_topology.workspace = true
 x86defs.workspace = true
 
+cvm_tracing.workspace = true
 inspect.workspace = true
 pal_async.workspace = true
 sparse_mmap.workspace = true

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -14,6 +14,7 @@ pub use init::Init;
 pub use init::MemoryMappings;
 pub use init::init;
 
+use cvm_tracing::CVM_ALLOWED;
 use guestmem::PAGE_SIZE;
 use guestmem::ranges::PagedRange;
 use hcl::GuestVtl;
@@ -71,6 +72,7 @@ impl RegisterMemory for MshvVtlWithPolicy {
             // TODO: remove this once the kernel driver tracks registration
             Err(err) if self.ignore_registration_failure => {
                 tracing::warn!(
+                    CVM_ALLOWED,
                     error = &err as &dyn std::error::Error,
                     "registration failure, could be expected"
                 );

--- a/openhcl/underhill_mem/src/registrar.rs
+++ b/openhcl/underhill_mem/src/registrar.rs
@@ -19,6 +19,7 @@
 //! initial registration for a chunk small. We track whether a given chunk has
 //! been registered via a small bitmap.
 
+use cvm_tracing::CVM_ALLOWED;
 use inspect::Inspect;
 use memory_range::MemoryRange;
 use memory_range::overlapping_ranges;
@@ -167,9 +168,9 @@ impl<T: RegisterMemory> MemoryRegistrar<T> {
                     self.registration_offset + range.start()
                         ..self.registration_offset + range.end(),
                 );
-                tracing::info!(%range, "registering memory");
+                tracing::info!(CVM_ALLOWED, %range, "registering memory");
                 if let Err(err) = self.register.register_range(range) {
-                    tracing::error!(
+                    tracing::error!(CVM_ALLOWED,
                         %range,
                         registration_offset = self.registration_offset,
                         error = &err as &dyn std::error::Error,

--- a/openhcl/underhill_threadpool/Cargo.toml
+++ b/openhcl/underhill_threadpool/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+cvm_tracing.workspace = true
 inspect = { workspace = true, features = ["std"] }
 loan_cell.workspace = true
 pal.workspace = true

--- a/openhcl/underhill_threadpool/src/lib.rs
+++ b/openhcl/underhill_threadpool/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![forbid(unsafe_code)]
 
+use cvm_tracing::CVM_ALLOWED;
 use inspect::Inspect;
 use loan_cell::LoanCell;
 use pal::unix::affinity::CpuSet;
@@ -163,6 +164,7 @@ impl ThreadpoolBuilder {
                 // because the thread will probably get allocated with the wrong node,
                 // but it's recoverable.
                 tracing::warn!(
+                    CVM_ALLOWED,
                     cpu,
                     error = &err as &dyn std::error::Error,
                     "could not set package affinity for thread pool thread"

--- a/openhcl/virt_mshv_vtl/Cargo.toml
+++ b/openhcl/virt_mshv_vtl/Cargo.toml
@@ -12,6 +12,7 @@ gdb = []
 [target.'cfg(target_os = "linux")'.dependencies]
 aarch64emu.workspace = true
 aarch64defs.workspace = true
+cvm_tracing.workspace = true
 hcl.workspace = true
 virt.workspace = true
 virt_support_aarch64emu.workspace = true

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/mod.rs
@@ -7,6 +7,7 @@
 
 use self::tdx::TdxCpuidInitializer;
 use core::arch::x86_64::CpuidResult;
+use cvm_tracing::CVM_ALLOWED;
 use masking::CpuidResultMask;
 use snp::SnpCpuidInitializer;
 use std::collections::BTreeMap;
@@ -285,6 +286,7 @@ impl CpuidResults {
 
                         if skipped {
                             tracing::warn!(
+                                CVM_ALLOWED,
                                 "cpuid result for leaf {} subleaf {} specified multiple times, ignoring duplicate with eax {}, ebx {}, ecx {}, edx {}",
                                 leaf.0,
                                 subleaf,

--- a/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
+++ b/openhcl/virt_mshv_vtl/src/cvm_cpuid/tdx.rs
@@ -12,6 +12,7 @@ use super::CpuidSubtable;
 use super::ParsedCpuidEntry;
 use super::TopologyError;
 use core::arch::x86_64::CpuidResult;
+use cvm_tracing::CVM_ALLOWED;
 use vm_topology::processor::ProcessorTopology;
 use vm_topology::processor::x86::X86Topology;
 use x86defs::cpuid;
@@ -230,6 +231,7 @@ impl CpuidArchInitializer for TdxCpuidInitializer<'_> {
             || (extended_topology_ecx_0.level_type() != super::CPUID_LEAF_B_LEVEL_TYPE_SMT)
         {
             tracing::error!(
+                CVM_ALLOWED,
                 "Incorrect values received: {:?}. Level Number should represent sub-leaf 0, while Level Type should represent domain type 1 for logical processor.",
                 extended_topology_ecx_0
             );
@@ -244,6 +246,7 @@ impl CpuidArchInitializer for TdxCpuidInitializer<'_> {
             || (extended_topology_ecx_1.level_type() != super::CPUID_LEAF_B_LEVEL_TYPE_CORE)
         {
             tracing::error!(
+                CVM_ALLOWED,
                 "Incorrect values received: {:?}. Level Number should represent sub-leaf 1, while Level Type should represent domain type 2 for Core.",
                 extended_topology_ecx_1
             );

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/apic.rs
@@ -6,6 +6,7 @@
 use super::UhRunVpError;
 use crate::UhProcessor;
 use crate::processor::HardwareIsolatedBacking;
+use cvm_tracing::CVM_ALLOWED;
 use hcl::GuestVtl;
 use virt::Processor;
 use virt::vp::MpState;
@@ -27,7 +28,7 @@ pub(crate) trait ApicBacking<'b, B: HardwareIsolatedBacking> {
     fn handle_interrupt(&mut self, vtl: GuestVtl, vector: u8) -> Result<(), UhRunVpError>;
 
     fn handle_extint(&mut self, vtl: GuestVtl) -> Result<(), UhRunVpError> {
-        tracelimit::warn_ratelimited!(?vtl, "extint not supported");
+        tracelimit::warn_ratelimited!(CVM_ALLOWED, ?vtl, "extint not supported");
         Ok(())
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -19,6 +19,7 @@ use crate::WakeReason;
 use crate::processor::HardwareIsolatedBacking;
 use crate::processor::UhHypercallHandler;
 use crate::validate_vtl_gpa_flags;
+use cvm_tracing::CVM_ALLOWED;
 use guestmem::GuestMemory;
 use hv1_emulator::RequestInterrupt;
 use hv1_hypercall::HvRepResult;
@@ -410,6 +411,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             }
             _ => {
                 tracing::error!(
+                    CVM_ALLOWED,
                     ?name,
                     "guest invoked getvpregister with unsupported register"
                 );
@@ -636,7 +638,8 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
             }
             _ => {
                 tracing::error!(
-                    ?reg,
+                    CVM_ALLOWED,
+                    reg = ?reg.name,
                     "guest invoked SetVpRegisters with unsupported register",
                 );
                 Err(HvError::InvalidParameter)
@@ -967,13 +970,17 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlCall for UhHypercallHandle
         // Only allowed from VTL 0
         if self.intercepted_vtl != GuestVtl::Vtl0 {
             tracelimit::warn_ratelimited!(
+                CVM_ALLOWED,
                 "vtl call not allowed from vtl {:?}",
                 self.intercepted_vtl
             );
             false
         } else if self.vp.backing.cvm_state().vtl1.is_none() {
             // VTL 1 must be active on the vp
-            tracelimit::warn_ratelimited!("vtl call not allowed because vtl 1 is not enabled");
+            tracelimit::warn_ratelimited!(
+                CVM_ALLOWED,
+                "vtl call not allowed because vtl 1 is not enabled"
+            );
             false
         } else {
             true
@@ -993,6 +1000,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::VtlReturn for UhHypercallHand
     fn is_vtl_return_allowed(&self) -> bool {
         if self.intercepted_vtl != GuestVtl::Vtl1 {
             tracelimit::warn_ratelimited!(
+                CVM_ALLOWED,
                 "vtl return not allowed from vtl {:?}",
                 self.intercepted_vtl
             );
@@ -1252,7 +1260,7 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::EnablePartitionVtl
 
         tracing::debug!("Successfully granted vtl 1 access to lower vtl memory");
 
-        tracing::info!("Enabled vtl 1 on the partition");
+        tracing::info!(CVM_ALLOWED, "Enabled vtl 1 on the partition");
 
         Ok(())
     }
@@ -2312,6 +2320,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             // same instruction again, providing another opportunity to
             // deliver the intercept.
             tracelimit::warn_ratelimited!(
+                CVM_ALLOWED,
                 error = &e as &dyn std::error::Error,
                 ?vtl,
                 ?message,
@@ -2406,25 +2415,29 @@ pub(crate) fn validate_xsetbv_exit(input: XsetbvExitInput) -> Option<u64> {
     } = input;
 
     if rcx != 0 {
-        tracelimit::warn_ratelimited!(rcx, "xsetbv exit: rcx is not set to 0");
+        tracelimit::warn_ratelimited!(CVM_ALLOWED, rcx, "xsetbv exit: rcx is not set to 0");
         return None;
     }
 
     if cpl != 0 {
-        tracelimit::warn_ratelimited!(cpl, "xsetbv exit: invalid cpl");
+        tracelimit::warn_ratelimited!(CVM_ALLOWED, cpl, "xsetbv exit: invalid cpl");
         return None;
     }
 
     let osxsave_flag = cr4 & x86defs::X64_CR4_OSXSAVE;
     if osxsave_flag == 0 {
-        tracelimit::warn_ratelimited!(cr4, "xsetbv exit: cr4 osxsave not set");
+        tracelimit::warn_ratelimited!(CVM_ALLOWED, cr4, "xsetbv exit: cr4 osxsave not set");
         return None;
     }
 
     let xfem = (rdx << 32) | (rax & 0xffffffff);
 
     if (xfem & x86defs::xsave::XFEATURE_X87) == 0 {
-        tracelimit::warn_ratelimited!(xfem, "xsetbv exit: xfem legacy x87 bit not set");
+        tracelimit::warn_ratelimited!(
+            CVM_ALLOWED,
+            xfem,
+            "xsetbv exit: xfem legacy x87 bit not set"
+        );
         return None;
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -18,6 +18,8 @@ cfg_if::cfg_if! {
         use crate::VtlCrash;
         use bitvec::prelude::BitArray;
         use bitvec::prelude::Lsb0;
+        use hv1_emulator::synic::ProcessorSynic;
+        use hvdef::HvRegisterCrInterceptControl;
         use hvdef::HvX64RegisterName;
         use virt::vp::MpState;
         use virt::x86::MsrError;
@@ -40,6 +42,8 @@ use super::UhVpInner;
 use crate::ExitActivity;
 use crate::GuestVtl;
 use crate::WakeReason;
+use cvm_tracing::CVM_ALLOWED;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use guestmem::GuestMemory;
 use hcl::ioctl::Hcl;
 use hcl::ioctl::ProcessorRunner;
@@ -562,7 +566,8 @@ impl UhVpInner {
 
     pub fn set_sidecar_exit_reason(&self, reason: SidecarExitReason) {
         self.sidecar_exit_reason.lock().get_or_insert_with(|| {
-            tracing::info!(?reason, "sidecar exit");
+            tracing::info!(CVM_ALLOWED, "sidecar exit");
+            tracing::info!(CVM_CONFIDENTIAL, ?reason, "sidecar exit");
             reason
         });
     }
@@ -1048,6 +1053,34 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
                     parameters: self.crash_reg,
                 };
                 tracelimit::info_ratelimited!(?crash, "Guest has reported system crash");
+                tracelimit::warn_ratelimited!(
+                    CVM_ALLOWED,
+                    ?crash,
+                    "Guest has reported system crash"
+                );
+
+                if crash.control.crash_message() {
+                    let message_gpa = crash.parameters[3];
+                    let message_size = crash.parameters[4];
+                    let mut message = vec![0; message_size as usize];
+                    match self.partition.gm[vtl].read_at(message_gpa, &mut message) {
+                        Ok(()) => {
+                            let message = String::from_utf8_lossy(&message).into_owned();
+                            tracelimit::warn_ratelimited!(
+                                CVM_CONFIDENTIAL,
+                                message,
+                                "Guest has reported a system crash message"
+                            );
+                        }
+                        Err(e) => {
+                            tracelimit::warn_ratelimited!(
+                                CVM_ALLOWED,
+                                ?e,
+                                "Failed to read crash message"
+                            );
+                        }
+                    }
+                }
 
                 self.partition.crash_notification_send.send(crash);
             }
@@ -1203,6 +1236,7 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
 fn signal_mnf(dev: &impl CpuIo, connection_id: u32) {
     if let Err(err) = dev.signal_synic_event(Vtl::Vtl0, connection_id, 0) {
         tracelimit::warn_ratelimited!(
+            CVM_ALLOWED,
             error = &err as &dyn std::error::Error,
             connection_id,
             "failed to signal mnf"

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -18,7 +18,6 @@ cfg_if::cfg_if! {
         use crate::VtlCrash;
         use bitvec::prelude::BitArray;
         use bitvec::prelude::Lsb0;
-        use hv1_emulator::synic::ProcessorSynic;
         use hvdef::HvRegisterCrInterceptControl;
         use hvdef::HvX64RegisterName;
         use virt::vp::MpState;
@@ -27,7 +26,6 @@ cfg_if::cfg_if! {
         use virt_support_x86emu::translate::TranslationRegisters;
         use virt::vp::AccessVpState;
         use zerocopy::IntoBytes;
-        use hvdef::HvRegisterCrInterceptControl;
     } else if #[cfg(guest_arch = "aarch64")] {
         use hv1_hypercall::Arm64RegisterState;
         use hvdef::HvArm64RegisterName;

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -26,6 +26,8 @@ use crate::WakeReason;
 use crate::devmsr;
 use crate::processor::UhHypercallHandler;
 use crate::processor::UhProcessor;
+use cvm_tracing::CVM_ALLOWED;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use hcl::vmsa::VmsaWrapper;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::synic::ProcessorSynic;
@@ -677,7 +679,13 @@ fn init_vmsa(vmsa: &mut VmsaWrapper<'_, &mut SevVmsa>, vtl: GuestVtl, vtom: Opti
     vmsa.set_efer(x86defs::X64_EFER_SVME);
 
     let sev_features = vmsa.sev_features();
-    tracing::info!(?vtl, ?sev_status, ?sev_features, "VMSA features");
+    tracing::info!(
+        CVM_ALLOWED,
+        ?vtl,
+        ?sev_status,
+        ?sev_features,
+        "VMSA features"
+    );
 }
 
 struct SnpApicClient<'a, T> {
@@ -925,6 +933,7 @@ impl UhProcessor<'_, SnpBacked> {
                 // TODO SNP: Should allow arbitrary page to be used for GHCB
                 if ghcb_pfn != ghcb_overlay {
                     tracelimit::warn_ratelimited!(
+                        CVM_ALLOWED,
                         vmgexit_pfn = ghcb_pfn,
                         overlay_pfn = ghcb_overlay,
                         "ghcb page used for vmgexit does not match overlay page"
@@ -1139,7 +1148,10 @@ impl UhProcessor<'_, SnpBacked> {
         //
         // TODO SNP: consider emulating the instruction.
         if !mov_crx_drx.mov_crx() {
-            tracelimit::warn_ratelimited!("Intercepted crx access, instruction is not mov crx");
+            tracelimit::warn_ratelimited!(
+                CVM_ALLOWED,
+                "Intercepted crx access, instruction is not mov crx"
+            );
             return;
         }
 
@@ -1177,7 +1189,7 @@ impl UhProcessor<'_, SnpBacked> {
         let halt = self.backing.cvm.lapics[next_vtl].activity != MpState::Running || tlb_halt;
 
         if halt && next_vtl == GuestVtl::Vtl1 && !tlb_halt {
-            tracelimit::warn_ratelimited!("halting VTL 1, which might halt the guest");
+            tracelimit::warn_ratelimited!(CVM_ALLOWED, "halting VTL 1, which might halt the guest");
         }
 
         self.runner.set_halted(halt);
@@ -1551,6 +1563,7 @@ impl UhProcessor<'_, SnpBacked> {
 
             _ => {
                 tracing::error!(
+                    CVM_CONFIDENTIAL,
                     "SEV exit code {sev_error_code:x?} sev features {:x?} v_intr_control {:x?} event inject {:x?} \
                     vmpl {:x?} cpl {:x?} exit_info1 {:x?} exit_info2 {:x?} exit_int_info {:x?} virtual_tom {:x?} \
                     efer {:x?} cr4 {:x?} cr3 {:x?} cr0 {:x?} rflag {:x?} rip {:x?} next rip {:x?}",
@@ -1599,7 +1612,11 @@ impl UhProcessor<'_, SnpBacked> {
                     // TODO SNP: Figure out why we are getting these.
                 }
                 message_type => {
-                    tracelimit::error_ratelimited!(?message_type, "unknown synthetic exit");
+                    tracelimit::error_ratelimited!(
+                        CVM_ALLOWED,
+                        ?message_type,
+                        "unknown synthetic exit"
+                    );
                 }
             }
         }

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -23,6 +23,8 @@ use crate::UhPartitionInner;
 use crate::UhPartitionNewParams;
 use crate::UhProcessor;
 use crate::WakeReason;
+use cvm_tracing::CVM_ALLOWED;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use hcl::ioctl::ProcessorRunner;
 use hcl::ioctl::tdx::Tdx;
 use hcl::ioctl::tdx::TdxPrivateRegs;
@@ -1080,7 +1082,7 @@ impl BackingPrivate for TdxBacked {
         scan_irr: bool,
     ) -> Result<(), UhRunVpError> {
         if !this.try_poll_apic(vtl, scan_irr)? {
-            tracing::info!("disabling APIC offload due to auto EOI");
+            tracing::info!(CVM_ALLOWED, "disabling APIC offload due to auto EOI");
             let page = this.runner.tdx_apic_page_mut(vtl);
             let (irr, isr) = pull_apic_offload(page);
 
@@ -1102,7 +1104,7 @@ impl BackingPrivate for TdxBacked {
         if let Some(synic) = &mut this.backing.untrusted_synic {
             synic.request_sint_readiness(sints);
         } else {
-            tracelimit::error_ratelimited!("untrusted synic is not configured");
+            tracelimit::error_ratelimited!(CVM_ALLOWED, "untrusted synic is not configured");
         }
     }
 
@@ -1570,6 +1572,7 @@ impl UhProcessor<'_, TdxBacked> {
                     (false, true) => MpState::Idle,
                     (true, true) => {
                         tracelimit::warn_ratelimited!(
+                            CVM_ALLOWED,
                             "Kernel indicates VP is both halted and idle!"
                         );
                         activity
@@ -1820,7 +1823,7 @@ impl UhProcessor<'_, TdxBacked> {
                 let value = match result {
                     Ok(v) => Some(v),
                     Err(MsrError::Unknown) => {
-                        tracelimit::warn_ratelimited!(msr, "unknown tdx vm msr read");
+                        tracelimit::warn_ratelimited!(CVM_ALLOWED, msr, "unknown tdx vm msr read");
                         Some(0)
                     }
                     Err(MsrError::InvalidAccess) => None,
@@ -1872,7 +1875,16 @@ impl UhProcessor<'_, TdxBacked> {
                     let inject_gp = match result {
                         Ok(()) => false,
                         Err(MsrError::Unknown) => {
-                            tracelimit::warn_ratelimited!(msr, value, "unknown tdx vm msr write");
+                            tracelimit::warn_ratelimited!(
+                                CVM_ALLOWED,
+                                msr,
+                                "unknown tdx vm msr write"
+                            );
+                            tracelimit::warn_ratelimited!(
+                                CVM_CONFIDENTIAL,
+                                value,
+                                "unknown tdx vm msr write"
+                            );
                             false
                         }
                         Err(MsrError::InvalidAccess) => true,
@@ -1963,7 +1975,12 @@ impl UhProcessor<'_, TdxBacked> {
                         self.update_execution_mode(intercepted_vtl);
                         self.advance_to_next_instruction(intercepted_vtl);
                     } else {
-                        tracelimit::warn_ratelimited!(?cr, value, "failed to write cr");
+                        tracelimit::warn_ratelimited!(
+                            CVM_ALLOWED,
+                            ?cr,
+                            value,
+                            "failed to write cr"
+                        );
                         self.inject_gpf(intercepted_vtl);
                     }
                 }
@@ -2159,10 +2176,10 @@ impl UhProcessor<'_, TdxBacked> {
     /// Trace processor state for debugging purposes.
     fn trace_processor_state(&self, vtl: GuestVtl) {
         let raw_exit = self.runner.tdx_vp_enter_exit_info();
-        tracing::error!(?raw_exit, "raw tdx vp enter exit info");
+        tracing::error!(CVM_CONFIDENTIAL, ?raw_exit, "raw tdx vp enter exit info");
 
         let gprs = self.runner.tdx_enter_guest_gps();
-        tracing::error!(?gprs, "guest gpr list");
+        tracing::error!(CVM_CONFIDENTIAL, ?gprs, "guest gpr list");
 
         let TdxPrivateRegs {
             rflags,
@@ -2180,6 +2197,7 @@ impl UhProcessor<'_, TdxBacked> {
             vp_entry_flags,
         } = self.backing.vtls[vtl].private_regs;
         tracing::error!(
+            CVM_CONFIDENTIAL,
             rflags,
             rip,
             rsp,
@@ -2203,7 +2221,13 @@ impl UhProcessor<'_, TdxBacked> {
         let cr0_guest_host_mask: u64 = self
             .runner
             .read_vmcs64(vtl, VmcsField::VMX_VMCS_CR0_GUEST_HOST_MASK);
-        tracing::error!(physical_cr0, shadow_cr0, cr0_guest_host_mask, "cr0 values");
+        tracing::error!(
+            CVM_CONFIDENTIAL,
+            physical_cr0,
+            shadow_cr0,
+            cr0_guest_host_mask,
+            "cr0 values"
+        );
 
         let physical_cr4 = self.runner.read_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_CR4);
         let shadow_cr4 = self
@@ -2212,18 +2236,24 @@ impl UhProcessor<'_, TdxBacked> {
         let cr4_guest_host_mask = self
             .runner
             .read_vmcs64(vtl, VmcsField::VMX_VMCS_CR4_GUEST_HOST_MASK);
-        tracing::error!(physical_cr4, shadow_cr4, cr4_guest_host_mask, "cr4 values");
+        tracing::error!(
+            CVM_CONFIDENTIAL,
+            physical_cr4,
+            shadow_cr4,
+            cr4_guest_host_mask,
+            "cr4 values"
+        );
 
         let cr3 = self.runner.read_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_CR3);
-        tracing::error!(cr3, "cr3");
+        tracing::error!(CVM_CONFIDENTIAL, cr3, "cr3");
 
         let cached_efer = self.backing.vtls[vtl].efer;
         let vmcs_efer = self.runner.read_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_EFER);
         let entry_controls = self
             .runner
             .read_vmcs32(vtl, VmcsField::VMX_VMCS_ENTRY_CONTROLS);
-        tracing::error!(cached_efer, vmcs_efer, "efer");
-        tracing::error!(entry_controls, "entry controls");
+        tracing::error!(CVM_CONFIDENTIAL, cached_efer, vmcs_efer, "efer");
+        tracing::error!(CVM_CONFIDENTIAL, entry_controls, "entry controls");
 
         let cs = self.read_segment(vtl, TdxSegmentReg::Cs);
         let ds = self.read_segment(vtl, TdxSegmentReg::Ds);
@@ -2234,12 +2264,23 @@ impl UhProcessor<'_, TdxBacked> {
         let tr = self.read_segment(vtl, TdxSegmentReg::Tr);
         let ldtr = self.read_segment(vtl, TdxSegmentReg::Ldtr);
 
-        tracing::error!(?cs, ?ds, ?es, ?fs, ?gs, ?ss, ?tr, ?ldtr, "segment values");
+        tracing::error!(
+            CVM_CONFIDENTIAL,
+            ?cs,
+            ?ds,
+            ?es,
+            ?fs,
+            ?gs,
+            ?ss,
+            ?tr,
+            ?ldtr,
+            "segment values"
+        );
 
         let exception_bitmap = self
             .runner
             .read_vmcs32(vtl, VmcsField::VMX_VMCS_EXCEPTION_BITMAP);
-        tracing::error!(exception_bitmap, "exception bitmap");
+        tracing::error!(CVM_CONFIDENTIAL, exception_bitmap, "exception bitmap");
 
         let cached_processor_controls = self.backing.vtls[vtl].processor_controls;
         let vmcs_processor_controls = ProcessorControls::from(
@@ -2251,6 +2292,7 @@ impl UhProcessor<'_, TdxBacked> {
                 .read_vmcs32(vtl, VmcsField::VMX_VMCS_SECONDARY_PROCESSOR_CONTROLS),
         );
         tracing::error!(
+            CVM_CONFIDENTIAL,
             ?cached_processor_controls,
             ?vmcs_processor_controls,
             ?vmcs_secondary_processor_controls,
@@ -2258,14 +2300,19 @@ impl UhProcessor<'_, TdxBacked> {
         );
 
         if cached_processor_controls != vmcs_processor_controls {
-            tracing::error!("BUGBUG: processor controls mismatch");
+            tracing::error!(CVM_ALLOWED, "BUGBUG: processor controls mismatch");
         }
 
         let cached_tpr_threshold = self.backing.vtls[vtl].tpr_threshold;
         let vmcs_tpr_threshold = self
             .runner
             .read_vmcs32(vtl, VmcsField::VMX_VMCS_TPR_THRESHOLD);
-        tracing::error!(cached_tpr_threshold, vmcs_tpr_threshold, "tpr threshold");
+        tracing::error!(
+            CVM_CONFIDENTIAL,
+            cached_tpr_threshold,
+            vmcs_tpr_threshold,
+            "tpr threshold"
+        );
 
         let cached_eoi_exit_bitmap = self.backing.eoi_exit_bitmap;
         let vmcs_eoi_exit_bitmap = {
@@ -2281,6 +2328,7 @@ impl UhProcessor<'_, TdxBacked> {
                 .collect::<Vec<_>>()
         };
         tracing::error!(
+            CVM_CONFIDENTIAL,
             ?cached_eoi_exit_bitmap,
             ?vmcs_eoi_exit_bitmap,
             "eoi exit bitmap"
@@ -2295,6 +2343,7 @@ impl UhProcessor<'_, TdxBacked> {
             .runner
             .read_vmcs32(vtl, VmcsField::VMX_VMCS_ENTRY_EXCEPTION_ERROR_CODE);
         tracing::error!(
+            CVM_CONFIDENTIAL,
             ?cached_interrupt_information,
             cached_interruption_set,
             vmcs_interrupt_information,
@@ -2305,7 +2354,11 @@ impl UhProcessor<'_, TdxBacked> {
         let guest_interruptibility = self
             .runner
             .read_vmcs32(vtl, VmcsField::VMX_VMCS_GUEST_INTERRUPTIBILITY);
-        tracing::error!(guest_interruptibility, "guest interruptibility");
+        tracing::error!(
+            CVM_CONFIDENTIAL,
+            guest_interruptibility,
+            "guest interruptibility"
+        );
 
         let vmcs_sysenter_cs = self
             .runner
@@ -2317,6 +2370,7 @@ impl UhProcessor<'_, TdxBacked> {
             .runner
             .read_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_SYSENTER_EIP_MSR);
         tracing::error!(
+            CVM_CONFIDENTIAL,
             vmcs_sysenter_cs,
             vmcs_sysenter_esp,
             vmcs_sysenter_eip,
@@ -2324,7 +2378,7 @@ impl UhProcessor<'_, TdxBacked> {
         );
 
         let vmcs_pat = self.runner.read_vmcs64(vtl, VmcsField::VMX_VMCS_GUEST_PAT);
-        tracing::error!(vmcs_pat, "guest PAT");
+        tracing::error!(CVM_CONFIDENTIAL, vmcs_pat, "guest PAT");
     }
 
     fn handle_vm_enter_failed(
@@ -2337,7 +2391,7 @@ impl UhProcessor<'_, TdxBacked> {
             VmxExitBasic::BAD_GUEST_STATE => {
                 // Log system register state for debugging why we were
                 // unable to enter the guest. This is a VMM bug.
-                tracing::error!("VP.ENTER failed with bad guest state");
+                tracing::error!(CVM_ALLOWED, "VP.ENTER failed with bad guest state");
                 self.trace_processor_state(vtl);
 
                 // TODO: panic instead?
@@ -2419,7 +2473,11 @@ impl UhProcessor<'_, TdxBacked> {
                 // should inject a machine check. An exit is considered spurious
                 // if the gpa is accessible.
                 if self.partition.gm[intercepted_vtl].check_gpa_readable(gpa) {
-                    tracelimit::warn_ratelimited!(gpa, "possible spurious EPT violation, ignoring");
+                    tracelimit::warn_ratelimited!(
+                        CVM_ALLOWED,
+                        gpa,
+                        "possible spurious EPT violation, ignoring"
+                    );
                 } else {
                     // TODO: It would be better to show what exact bitmap check
                     // failed, but that requires some refactoring of how the
@@ -2433,6 +2491,7 @@ impl UhProcessor<'_, TdxBacked> {
                     // should have already been checked to be valid memory
                     // described to the guest or not.
                     tracelimit::warn_ratelimited!(
+                        CVM_ALLOWED,
                         gpa,
                         is_shared,
                         ?ept_info,
@@ -2455,6 +2514,7 @@ impl UhProcessor<'_, TdxBacked> {
                     //
                     // For now, log that the guest did this.
                     tracelimit::warn_ratelimited!(
+                        CVM_ALLOWED,
                         gpa,
                         is_shared,
                         ?ept_info,
@@ -2493,9 +2553,14 @@ impl UhProcessor<'_, TdxBacked> {
                         }
                         Err(err) => {
                             tracelimit::warn_ratelimited!(
+                                CVM_ALLOWED,
                                 msr,
-                                value,
                                 ?err,
+                                "failed tdvmcall msr write"
+                            );
+                            tracelimit::warn_ratelimited!(
+                                CVM_CONFIDENTIAL,
+                                value,
                                 "failed tdvmcall msr write"
                             );
                             TdVmCallR10Result::OPERAND_INVALID
@@ -2511,13 +2576,19 @@ impl UhProcessor<'_, TdxBacked> {
                             TdVmCallR10Result::SUCCESS
                         }
                         Err(err) => {
-                            tracelimit::warn_ratelimited!(msr, ?err, "failed tdvmcall msr read");
+                            tracelimit::warn_ratelimited!(
+                                CVM_ALLOWED,
+                                msr,
+                                ?err,
+                                "failed tdvmcall msr read"
+                            );
                             TdVmCallR10Result::OPERAND_INVALID
                         }
                     }
                 }
                 subfunction => {
                     tracelimit::warn_ratelimited!(
+                        CVM_ALLOWED,
                         ?subfunction,
                         "architectural vmcall not supported"
                     );
@@ -2593,6 +2664,7 @@ impl UhProcessor<'_, TdxBacked> {
                         value.into(),
                     ) {
                         tracelimit::warn_ratelimited!(
+                            CVM_ALLOWED,
                             error = &err as &dyn std::error::Error,
                             "failed to set sint register"
                         );

--- a/vm/devices/firmware/firmware_uefi/src/service/time.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/time.rs
@@ -147,7 +147,7 @@ impl UefiDevice {
                 time,
             },
             Err(e) => {
-                tracing::error!("get_time: {}", e);
+                tracing::debug!("get_time: {}", e);
                 VmEfiTime {
                     status: EfiStatus::DEVICE_ERROR.into(),
                     time: Default::default(),
@@ -166,7 +166,7 @@ impl UefiDevice {
         let status = match self.service.time.set_time(vm_time.time) {
             Ok(_) => EfiStatus::SUCCESS,
             Err(e) => {
-                tracing::error!("set_time: {}", e);
+                tracing::debug!("set_time: {}", e);
                 match e {
                     TimeServiceError::InvalidArg => EfiStatus::INVALID_PARAMETER,
                     _ => EfiStatus::DEVICE_ERROR,

--- a/vm/devices/firmware/hcl_compat_uefi_nvram_storage/Cargo.toml
+++ b/vm/devices/firmware/hcl_compat_uefi_nvram_storage/Cargo.toml
@@ -14,6 +14,7 @@ inspect = ["dep:inspect", "uefi_nvram_storage/inspect"]
 [dependencies]
 uefi_nvram_storage.workspace = true
 
+cvm_tracing.workspace = true
 guid.workspace = true
 inspect = { workspace = true, optional = true }
 open_enum.workspace = true

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -764,7 +764,7 @@ impl<T: RingMem> ProcessLoop<T> {
                 .map_err(|_| FatalError::InvalidResponse)?;
 
             if version_accepted {
-                tracing::info!("[GET] version negotiated: {:?}", protocol);
+                tracing::info!(?protocol, "[GET] version negotiated");
 
                 return Ok(protocol);
             }
@@ -1297,8 +1297,8 @@ impl<T: RingMem> ProcessLoop<T> {
             }
             invalid_notification => {
                 tracing::error!(
-                    "[HOST GET] ignoring invalid guest notification: {:?}",
-                    invalid_notification
+                    ?invalid_notification,
+                    "[HOST GET] ignoring invalid guest notification",
                 );
             }
         }

--- a/vm/devices/tpm/Cargo.toml
+++ b/vm/devices/tpm/Cargo.toml
@@ -17,6 +17,7 @@ tpm_resources.workspace = true
 
 chipset_device.workspace = true
 chipset_device_resources.workspace = true
+cvm_tracing.workspace = true
 guestmem.workspace = true
 vmcore.workspace = true
 vm_resource.workspace = true

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -40,6 +40,7 @@ use crate::tpm20proto::protocol::TpmtPublic;
 use crate::tpm20proto::protocol::TpmtRsaScheme;
 use crate::tpm20proto::protocol::TpmtSymDefObject;
 use crate::tpm20proto::protocol::common::CmdAuth;
+use cvm_tracing::CVM_ALLOWED;
 use inspect::InspectMut;
 use ms_tpm_20_ref::MsTpm20RefPlatform;
 use thiserror::Error;
@@ -212,6 +213,7 @@ impl TpmEngineHelper {
         if let Err(error) = self.clear_control(TPM20_RH_PLATFORM, false) {
             if let TpmCommandError::TpmCommandFailed { response_code } = error {
                 tracelimit::error_ratelimited!(
+                    CVM_ALLOWED,
                     err = &error as &dyn std::error::Error,
                     "tpm ClearControlCmd failed"
                 );
@@ -236,6 +238,7 @@ impl TpmEngineHelper {
             Err(error) => {
                 if let TpmCommandError::TpmCommandFailed { response_code } = error {
                     tracelimit::error_ratelimited!(
+                        CVM_ALLOWED,
                         err = &error as &dyn std::error::Error,
                         "tpm ClearCmd failed"
                     );
@@ -343,6 +346,7 @@ impl TpmEngineHelper {
                     // Guest might cause the command to fail (e.g., taking the ownership of a hierarchy).
                     // Making this failure as non-fatal.
                     tracelimit::error_ratelimited!(
+                        CVM_ALLOWED,
                         err = &error as &dyn std::error::Error,
                         "tpm CreatePrimaryCmd failed"
                     );
@@ -369,7 +373,10 @@ impl TpmEngineHelper {
         if res.out_public.size.get() == 0 {
             // Guest might cause the command to fail (e.g., taking the ownership of a hierarchy).
             // Making this failure as non-fatal.
-            tracelimit::error_ratelimited!("No public data in CreatePrimaryCmd response");
+            tracelimit::error_ratelimited!(
+                CVM_ALLOWED,
+                "No public data in CreatePrimaryCmd response"
+            );
 
             return Ok(TpmRsa2kPublic {
                 modulus: [0u8; RSA_2K_MODULUS_SIZE],
@@ -396,6 +403,7 @@ impl TpmEngineHelper {
                 // Guest might cause the command to fail (e.g., taking the ownership of a hierarchy).
                 // Making this failure as non-fatal.
                 tracelimit::error_ratelimited!(
+                    CVM_ALLOWED,
                     err = &error as &dyn std::error::Error,
                     "tpm FlushContextCmd failed"
                 );
@@ -428,6 +436,7 @@ impl TpmEngineHelper {
                 // Guest might cause the command to fail (e.g., taking the ownership of a hierarchy).
                 // Making this failure as non-fatal.
                 tracelimit::error_ratelimited!(
+                    CVM_ALLOWED,
                     err = &error as &dyn std::error::Error,
                     "tpm EvictControlCmd failed"
                 );

--- a/vmm_core/Cargo.toml
+++ b/vmm_core/Cargo.toml
@@ -19,6 +19,7 @@ vmm_core_defs.workspace = true
 aarch64defs.workspace = true
 acpi_spec = { workspace = true, features = ["std"] }
 acpi.workspace = true
+cvm_tracing.workspace = true
 hcl_compat_uefi_nvram_storage.workspace = true
 hvdef.workspace = true
 memory_range = { workspace = true, features = ["inspect"] }

--- a/vmm_core/src/partition_unit/vp_set.rs
+++ b/vmm_core/src/partition_unit/vp_set.rs
@@ -293,6 +293,8 @@ where
         guest_memory: Option<&GuestMemory>,
         registers: Option<&virt::x86::vp::Registers>,
     ) {
+        use cvm_tracing::CVM_CONFIDENTIAL;
+
         #[cfg(not(feature = "gdb"))]
         let _ = (guest_memory, vtl);
 
@@ -337,6 +339,7 @@ where
             efer,
         } = *registers;
         tracing::error!(
+            CVM_CONFIDENTIAL,
             vp = self.vp_index.index(),
             ?vtl,
             rax,
@@ -360,6 +363,7 @@ where
             "triple fault register state",
         );
         tracing::error!(
+            CVM_CONFIDENTIAL,
             ?vtl,
             vp = self.vp_index.index(),
             ?cs,
@@ -387,6 +391,7 @@ where
                 vp_state::next_instruction(guest_memory, self, vtl, registers)
             {
                 tracing::error!(
+                    CVM_CONFIDENTIAL,
                     instruction = instr.to_string(),
                     ?bytes,
                     "faulting instruction"

--- a/vmm_core/vmotherboard/Cargo.toml
+++ b/vmm_core/vmotherboard/Cargo.toml
@@ -46,6 +46,7 @@ watchdog_core.workspace = true
 address_filter.workspace = true
 arc_cyclic_builder.workspace = true
 closeable_mutex.workspace = true
+cvm_tracing.workspace = true
 inspect_counters.workspace = true
 inspect.workspace = true
 local_clock.workspace = true

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -17,6 +17,7 @@ use chipset_device_resources::GPE0_LINE_SET;
 use chipset_device_resources::IRQ_LINE_SET;
 use chipset_device_resources::ResolveChipsetDeviceHandleParams;
 use closeable_mutex::CloseableMutex;
+use cvm_tracing::CVM_ALLOWED;
 use firmware_uefi::UefiCommandSet;
 use framebuffer::Framebuffer;
 use framebuffer::FramebufferDevice;
@@ -320,8 +321,9 @@ impl<'a> BaseChipsetBuilder<'a> {
                 Box::new(move || power.on_power_event(PowerEvent::Reset))
             };
 
-            let set_a20_signal =
-                Box::new(move |active| tracing::info!(?active, "setting stubbed A20 signal"));
+            let set_a20_signal = Box::new(move |active| {
+                tracing::info!(CVM_ALLOWED, active, "setting stubbed A20 signal")
+            });
 
             builder
                 .arc_mutex_device("piix4-pci-isa-bridge")
@@ -516,7 +518,7 @@ impl<'a> BaseChipsetBuilder<'a> {
         let pm_action = || {
             let power = foundation.power_event_handler.clone();
             move |action: pm::PowerAction| {
-                tracing::info!(?action, "guest initiated");
+                tracing::info!(CVM_ALLOWED, ?action, "guest initiated");
                 let req = match action {
                     pm::PowerAction::PowerOff => PowerEvent::PowerOff,
                     pm::PowerAction::Hibernate => PowerEvent::Hibernate,

--- a/vmm_core/vmotherboard/src/chipset/mod.rs
+++ b/vmm_core/vmotherboard/src/chipset/mod.rs
@@ -18,6 +18,7 @@ use chipset_device::ChipsetDevice;
 use chipset_device::io::IoError;
 use chipset_device::io::IoResult;
 use closeable_mutex::CloseableMutex;
+use cvm_tracing::CVM_CONFIDENTIAL;
 use inspect::Inspect;
 use std::future::poll_fn;
 use std::sync::Arc;
@@ -104,6 +105,7 @@ impl Chipset {
                         // Fill data with !0 to indicate an error to the guest.
                         bytes.fill(!0);
                         tracelimit::warn_ratelimited!(
+                            CVM_CONFIDENTIAL,
                             device = &*lookup.dev_name,
                             address,
                             len,
@@ -113,6 +115,7 @@ impl Chipset {
                         );
                     }
                     IoType::Write(bytes) => tracelimit::warn_ratelimited!(
+                        CVM_CONFIDENTIAL,
                         device = &*lookup.dev_name,
                         address,
                         len,
@@ -147,7 +150,8 @@ impl Chipset {
                 }
             }
             Err(err) => {
-                tracing::error!(
+                tracelimit::error_ratelimited!(
+                    CVM_CONFIDENTIAL,
                     device = &*lookup.dev_name,
                     ?kind,
                     address,


### PR DESCRIPTION
Also includes some drive-by cleanups where I happened to see them.

Areas I did not audit because they are not relevant to CVMs:
- trace and debug level statements
- Non-CVM workers (debug & VNC)
- Test only code (petri, vmm_tests, tmk*)
- ARM-specific code
- Non-CVM virt backends (including virt_mshv_vtl/mshv)
- Host-only code (openvmm, GED, igvmfilegen, etc)
- Gen 1 devices (vga, chipset, etc)
- VirtIO

Areas that still need auditing by owners and area experts:
- Mesh (@jstarks)
- Networking (vm/devices/net/* & underhill_core/netvsp) (networking team)
- Storage (vm/devices/storage/* & underhill_core/nvme_manager) (storage team)
- VMBus (vm/devices/vmbus/*) (@SvenGroot)
- VMGS (vm/vmgs/*) (@tjones60)

Part of #852

Cherry-pick of #1408