### PR TITLE
repo: Disallow the tracing::enabled macro

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -12,6 +12,7 @@ disallowed-types = [
 disallowed-macros = [
     { path = "futures::pin_mut", reason = "use std::pin::pin" },
     { path = "futures::ready", reason = "use std::task::ready" },
+    { path = "tracing::enabled", reason = "https://github.com/tokio-rs/tracing/issues/2519" },
     { path = "openhcl_boot::boot_logger::debug_log", reason = "only use in local debugging, use log! if you want a production log message"},
 ]
 


### PR DESCRIPTION
Due to https://github.com/tokio-rs/tracing/issues/2519, ban this macro codebase-wide. This depends on #1462 and #1463.