### PR TITLE
CI: update mirror repo workflow to update submodule in the 2505 staging branch

### DIFF
--- a/.github/scripts/refresh_mirror/refresh-mirror.py
+++ b/.github/scripts/refresh_mirror/refresh-mirror.py
@@ -19,7 +19,7 @@ def main(pipeline_id: str, token: str, organization: str, project: str, debug: b
 
         build = {
                     'definition': {'id': pipeline_id},
-                    'templateParameters': {'branchToMirror': 'release/2505', 'branchToUpdateSubmodule': 'release/1.6.2505', 'updateSubmodule': 'true'},
+                    'templateParameters': {'branchToMirror': 'release/2505', 'branchToUpdateSubmodule': 'staging/1.6.2505', 'updateSubmodule': 'true'},
                 }
         build = client.queue_build(build, project=project)
         print(f'Scheduled build: {build.id}. Url: {organization}/{project}/_build/results?buildId={build.id}&view=results', file=sys.stderr)


### PR DESCRIPTION
Now that we are in ask mode for the upcoming release, this change updates the mirroring workflow to submit OSS changes to a staging branch instead of directly to the release branch. This means that we will need to periodically merge staging into release (after getting approval). This is the same flow we did for the 2411 release.