### PR TITLE
guide: update table for 2505 release to 'Ask Mode'

### DIFF
--- a/Guide/src/dev_guide/contrib/release.md
+++ b/Guide/src/dev_guide/contrib/release.md
@@ -39,7 +39,7 @@ Please reach out to the maintainers before staging that PR if you have any doubt
 | Release | Phase | Notes |
 |--------|-------|-------|
 | release/2411 | Servicing | |
-| release/2505 | Stabilization | |
+| release/2505 | Ask Mode | |
 
 ## Depending on Releases
 


### PR DESCRIPTION
We have now entered ask mode for the 2505 release of OpenHCL.