### PR TITLE
ohcl: Work around tracing bug by avoiding calling enabled (#1462)

### DIFF
--- a/openhcl/underhill_core/src/get_tracing/kmsg_stream.rs
+++ b/openhcl/underhill_core/src/get_tracing/kmsg_stream.rs
@@ -22,7 +22,6 @@ use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 use std::task::ready;
-use tracing::Level;
 
 /// A stream of trace logging notifications from `/dev/kmsg`.
 pub struct KmsgStream {
@@ -69,22 +68,6 @@ impl Write for SaturatingWriter<'_> {
     }
 }
 
-macro_rules! kmsg_parmas {
-    ($target:expr, $level:expr, $message:expr $(,)?) => {{
-        let level = $level;
-        let enabled = match level {
-            kmsg_defs::LOGLEVEL_EMERG..=kmsg_defs::LOGLEVEL_ERR => {
-                tracing::enabled!(target: $target, Level::ERROR)
-            }
-            kmsg_defs::LOGLEVEL_WARNING => tracing::enabled!(target: $target, Level::WARN),
-            kmsg_defs::LOGLEVEL_NOTICE => tracing::enabled!(target: $target, Level::INFO),
-            kmsg_defs::LOGLEVEL_INFO => tracing::enabled!(target: $target, Level::DEBUG),
-            kmsg_defs::LOGLEVEL_DEBUG.. => tracing::enabled!(target: $target, Level::TRACE),
-        };
-        enabled.then(|| (const { $target }, level, $message))
-    }};
-}
-
 impl Stream for KmsgStream {
     type Item = Vec<u8>;
 
@@ -97,14 +80,20 @@ impl Stream for KmsgStream {
                     let entry = KmsgParsedEntry::new(&buf[..n]).unwrap();
                     self.missed_entries += entry.seq - self.next_seq;
                     self.next_seq = entry.seq + 1;
-                    let params = match entry.facility {
+
+                    let (target, klevel, message) = match entry.facility {
                         kmsg_defs::UNDERHILL_KMSG_FACILITY => {
                             // Don't re-log messages from Underhill itself.
                             continue;
                         }
                         kmsg_defs::UNDERHILL_INIT_KMSG_FACILITY => {
+                            // Don't log debug init messages.
+                            // TODO: Support configuring this dynamically.
+                            if entry.level > kmsg_defs::LOGLEVEL_NOTICE {
+                                continue;
+                            }
                             // Use a separate target for the init process messages.
-                            kmsg_parmas!("underhill_init", entry.level, entry.message)
+                            ("underhill_init", entry.level, entry.message)
                         }
                         kmsg_defs::KERNEL_FACILITY
                             if entry
@@ -117,7 +106,7 @@ impl Stream for KmsgStream {
                             // processes. Log them with an appropriate level
                             // (the kernel defaults to INFO for these) and a
                             // separate target.
-                            kmsg_parmas!(
+                            (
                                 "panic",
                                 kmsg_defs::LOGLEVEL_CRIT,
                                 // Skip the ttyprintk message prefix.
@@ -128,13 +117,14 @@ impl Stream for KmsgStream {
                         }
                         _ => {
                             // Non-ttyprintk kernel messages and any other
-                            // user-mode facilities are logged as is.
-                            kmsg_parmas!("kmsg", entry.level, entry.message)
+                            // user-mode facilities are logged as is,
+                            // but don't log too many.
+                            // TODO: Support configuring this dynamically.
+                            if entry.level > kmsg_defs::LOGLEVEL_NOTICE {
+                                continue;
+                            }
+                            ("kmsg", entry.level, entry.message)
                         }
-                    };
-                    let Some((target, klevel, message)) = params else {
-                        // The message was not enabled.
-                        continue;
                     };
 
                     let level = match klevel {


### PR DESCRIPTION
https://github.com/tokio-rs/tracing/issues/2519 can cause the tracing
crate to mistakenly drop logs emitted after calling the `enabled!`
macro. Today we only call that macro in two places; this PR removes one
of them, the second is coming in another PR.

We currently are using our dynamic tracing filtering to filter out what
system-level messages get sent to the host, in addition to its normal
purposes. After much investigation and thought I've come to the
conclusion that there is no good way to work around this bug while
maintaining dynamic configuration. So instead just statically code these
levels. Realistically in terms of what these messages can help us
diagnose this is almost certainly fine.

Cherry-pick of #1462