### PR TITLE
underhill_core: serialize sidecar VP online (#1443)

### DIFF
--- a/openhcl/underhill_core/src/vp.rs
+++ b/openhcl/underhill_core/src/vp.rs
@@ -9,6 +9,7 @@ use futures::future::try_join_all;
 use pal_async::task::Spawn;
 use pal_async::task::SpawnLocal;
 use pal_uring::IdleControl;
+use std::sync::LazyLock;
 use underhill_threadpool::AffinitizedThreadpool;
 
 pub(crate) async fn spawn_vps(
@@ -19,11 +20,21 @@ pub(crate) async fn spawn_vps(
     isolation: virt::IsolationType,
 ) -> anyhow::Result<()> {
     // Start the VP tasks on the thread pool.
-    let _: Vec<()> =
-        try_join_all(vps.into_iter().zip(runners).map(|(vp, runner)| {
-            VpSpawner::new(vp, chipset.clone(), runner, isolation).spawn_vp(tp)
-        }))
-        .await?;
+    let _: Vec<()> = try_join_all(vps.into_iter().zip(runners).map(|(vp, runner)| {
+        // TODO: get CPU index for VP
+        let cpu = vp.vp_index().index();
+        let spawner = VpSpawner {
+            vp,
+            cpu,
+            chipset: chipset.clone(),
+            runner,
+            isolation,
+            tp: tp.clone(),
+        };
+
+        spawner.spawn_vp()
+    }))
+    .await?;
     Ok(())
 }
 
@@ -34,31 +45,14 @@ struct VpSpawner {
     chipset: vmm_core::vmotherboard_adapter::ChipsetPlusSynic,
     runner: vmm_core::partition_unit::VpRunner,
     isolation: virt::IsolationType,
+    tp: AffinitizedThreadpool,
 }
 
 impl VpSpawner {
-    /// Creates a new spawner.
-    pub fn new(
-        vp: virt_mshv_vtl::UhProcessorBox,
-        chipset: vmm_core::vmotherboard_adapter::ChipsetPlusSynic,
-        runner: vmm_core::partition_unit::VpRunner,
-        isolation: virt::IsolationType,
-    ) -> Self {
-        // TODO: get CPU index for VP
-        let cpu = vp.vp_index().index();
-        Self {
-            vp,
-            cpu,
-            chipset,
-            runner,
-            isolation,
-        }
-    }
-
     /// Spawns the VP on the appropriate thread pool thread.
-    pub async fn spawn_vp(self, tp: &AffinitizedThreadpool) -> anyhow::Result<()> {
+    pub async fn spawn_vp(self) -> anyhow::Result<()> {
         if underhill_threadpool::is_cpu_online(self.cpu)? {
-            self.spawn_main_vp(tp, None, false).await
+            self.spawn_main_vp().await
         } else {
             // The CPU is not online, so this should be a sidecar VP. Run the VP
             // remotely via the sidecar kernel.
@@ -68,7 +62,7 @@ impl VpSpawner {
                     self.cpu
                 );
             }
-            self.spawn_sidecar_vp(tp).await;
+            self.spawn_sidecar_vp().await;
             Ok(())
         }
     }
@@ -77,7 +71,6 @@ impl VpSpawner {
         &mut self,
         saved_state: Option<vmcore::save_restore::SavedStateBlob>,
         control: Option<&mut IdleControl>,
-        save_on_cancel: bool,
     ) -> anyhow::Result<Option<vmcore::save_restore::SavedStateBlob>>
     where
         for<'a> virt_mshv_vtl::UhProcessor<'a, T>: vmcore::save_restore::ProtobufSaveRestore,
@@ -95,15 +88,32 @@ impl VpSpawner {
             vmcore::save_restore::ProtobufSaveRestore::restore(&mut vp, saved_state)
                 .context("failed to restore saved state")?;
         }
+        let mut spawned = false;
         let state = loop {
             match self.runner.run(&mut vp, &self.chipset).await {
                 Ok(()) => break None,
-                Err(vmm_core::partition_unit::RunCancelled) => {
-                    if save_on_cancel {
+                Err(cancelled) => {
+                    if cancelled.is_user_cancelled() {
+                        // The target thread notifier explicitly cancelled the
+                        // VP in order to migrate it. Save the state and return.
                         break Some(
                             vmcore::save_restore::ProtobufSaveRestore::save(&mut vp)
                                 .context("failed to save state")?,
                         );
+                    } else if !spawned
+                        && thread.with_driver(|driver| driver.target_cpu() != self.cpu)
+                    {
+                        // We are running on a remote CPU via sidecar. Spawn a
+                        // task on the correct CPU to cause the target thread to
+                        // be spawned, which in its notifier will explicitly
+                        // cancel the VP in order to migrate it to the target
+                        // CPU.
+                        self.tp
+                            .driver(self.cpu)
+                            .spawn("cancel-vp", async move {})
+                            .detach();
+
+                        spawned = true;
                     }
                 }
             }
@@ -115,25 +125,20 @@ impl VpSpawner {
         &mut self,
         saved_state: Option<vmcore::save_restore::SavedStateBlob>,
         control: Option<&mut IdleControl>,
-        save_on_cancel: bool,
     ) -> Option<vmcore::save_restore::SavedStateBlob> {
         let r = match self.isolation {
             virt::IsolationType::None | virt::IsolationType::Vbs => {
-                self.run_backed_vp::<virt_mshv_vtl::HypervisorBacked>(
-                    saved_state,
-                    control,
-                    save_on_cancel,
-                )
-                .await
+                self.run_backed_vp::<virt_mshv_vtl::HypervisorBacked>(saved_state, control)
+                    .await
             }
             #[cfg(guest_arch = "x86_64")]
             virt::IsolationType::Snp => {
-                self.run_backed_vp::<virt_mshv_vtl::SnpBacked>(saved_state, control, save_on_cancel)
+                self.run_backed_vp::<virt_mshv_vtl::SnpBacked>(saved_state, control)
                     .await
             }
             #[cfg(guest_arch = "x86_64")]
             virt::IsolationType::Tdx => {
-                self.run_backed_vp::<virt_mshv_vtl::TdxBacked>(saved_state, control, save_on_cancel)
+                self.run_backed_vp::<virt_mshv_vtl::TdxBacked>(saved_state, control)
                     .await
             }
             #[cfg(guest_arch = "aarch64")]
@@ -150,41 +155,20 @@ impl VpSpawner {
         }
     }
 
-    async fn spawn_main_vp(
-        mut self,
-        tp: &AffinitizedThreadpool,
-        mut saved_state: Option<vmcore::save_restore::SavedStateBlob>,
-        was_sidecar: bool,
-    ) -> anyhow::Result<()> {
-        let vp_index = self.vp.vp_index();
-        tp.driver(vp_index.index())
+    async fn spawn_main_vp(mut self) -> anyhow::Result<()> {
+        self.tp
+            .driver(self.cpu)
+            .clone()
             .spawn("vp-init", async move {
                 let thread = underhill_threadpool::Thread::current().unwrap();
-
-                // If this was a relaunch of a sidecar VP, set the initial task
-                // (which may have caused the sidecar VP to be removed) for
-                // diagnostics purposes.
-                if was_sidecar {
-                    self.vp.set_sidecar_exit_due_to_task(
-                        thread
-                            .first_task()
-                            .map_or_else(|| "<unknown>".into(), |t| t.name),
-                    );
-                }
-
-                // Ensure this thread pool thread has its affinity set.
-                let affinity_set = thread
-                    .try_set_affinity()
-                    .context("failed to set affinity")?;
-                if !affinity_set {
-                    anyhow::bail!("processor {} not online", vp_index.index());
-                }
+                assert!(
+                    thread.with_driver(|driver| driver.is_affinity_set()),
+                    "cpu {} should already be online",
+                    self.cpu
+                );
 
                 thread.set_idle_task(async move |mut control| {
-                    let state = self
-                        .run_vp(saved_state.take(), Some(&mut control), false)
-                        .await;
-
+                    let state = self.run_vp(None, Some(&mut control)).await;
                     assert!(state.is_none());
                 });
                 Ok(())
@@ -192,59 +176,129 @@ impl VpSpawner {
             .await
     }
 
-    async fn spawn_sidecar_vp(mut self, tp: &AffinitizedThreadpool) {
+    async fn spawn_sidecar_vp(mut self) {
+        // Initially, run any sidecar VP handling on the base CPU, which is
+        // guaranteed to be online.
         let base_cpu = self.vp.sidecar_base_cpu().expect("missing sidecar");
-        tp.driver(base_cpu)
-            .spawn("sidecar-init", {
-                let tp = tp.clone();
-                async move {
-                    let thread = underhill_threadpool::Thread::current().unwrap();
-                    let tp = tp.clone();
-                    thread
-                        .spawn_local(
-                            format!("sidecar-{}", self.vp.vp_index().index()),
-                            async move {
-                                // Cancel running the VP when the thread pool
-                                // thread is spawned so that we can hotplug the
-                                // processor and continue running locally.
-                                let mut canceller = self.runner.canceller();
-                                let offline = tp.driver(self.cpu).set_spawn_notifier(move || {
-                                    canceller.cancel();
-                                });
+        self.tp
+            .driver(base_cpu)
+            .clone()
+            .spawn("sidecar-init", async move {
+                let thread = underhill_threadpool::Thread::current().unwrap();
+                thread
+                    .spawn_local(
+                        format!("sidecar-{}", self.vp.vp_index().index()),
+                        async move {
+                            let canceller = self.runner.canceller();
+                            let (state_send, state_recv) = mesh::oneshot();
+                            // When the target CPU thread gets spawned for any
+                            // reason, kick off a task to online the CPU and
+                            // restart the VP.
+                            let r = self.tp.driver(self.cpu).set_spawn_notifier(move || {
+                                underhill_threadpool::Thread::current()
+                                    .unwrap()
+                                    .spawn_local(
+                                        "online-sidecar",
+                                        Self::notify_main_vp_thread_start(
+                                            self.cpu, state_recv, canceller,
+                                        ),
+                                    )
+                                    .detach();
+                            });
 
-                                let saved_state = if offline {
+                            let saved_state = match r {
+                                Ok(()) => {
                                     // Run until the VP is finished or cancelled. If
                                     // it is cancelled, we will hotplug the
                                     // processor and respawn the VP.
-                                    let saved_state = self.run_vp(None, None, true).await;
+                                    let saved_state = self.run_vp(None, None).await;
                                     if saved_state.is_none() {
                                         // The VP is done.
                                         return;
                                     }
                                     saved_state
-                                } else {
-                                    // The thread has already been spawned, so
-                                    // online the processor and continue without
-                                    // saved state.
-                                    None
-                                };
-
-                                tracing::info!(CVM_ALLOWED, cpu = self.cpu, "onlining sidecar VP");
-                                online_cpu(self.cpu).await;
-
-                                // Respawn the VP on the new thread.
-                                let vp_index = self.vp.vp_index().index();
-                                if let Err(err) = self.spawn_main_vp(&tp, saved_state, true).await {
-                                    panic!(
-                                        "failed to spawn VP {vp_index} for onlined sidecar: {err:#}"
-                                    );
                                 }
-                            },
-                        )
-                        .detach()
-                }
+                                Err(notifier) => {
+                                    // The thread has already been spawned,
+                                    // so run the notifier over on the
+                                    // thread without running the VP.
+                                    self.tp
+                                        .driver(self.cpu)
+                                        .spawn("spawn-remote", async move { notifier() })
+                                        .detach();
+                                    None
+                                }
+                            };
+
+                            // Send the VP and its saved state to the main thread.
+                            state_send.send((self, saved_state));
+                        },
+                    )
+                    .detach()
             })
             .await;
+    }
+
+    async fn notify_main_vp_thread_start(
+        cpu: u32,
+        state_recv: mesh::OneshotReceiver<(Self, Option<vmcore::save_restore::SavedStateBlob>)>,
+        mut canceller: vmm_core::partition_unit::RunnerCanceller,
+    ) {
+        tracing::info!(
+            CVM_ALLOWED,
+            cpu,
+            "thread spawned for sidecar VP, waiting to online"
+        );
+        let thread = underhill_threadpool::Thread::current().unwrap();
+
+        let mut this: Self;
+        let saved_state: Option<vmcore::save_restore::SavedStateBlob>;
+        // Only online one CPU at a time, since this operation serializes in the
+        // kernel, and the online process prevents the CPU from being used by
+        // the guest. This approach ensures that the guest only sees blackout of
+        // one CPU at a time, rather than all CPUs at once.
+        {
+            static ONLINE_LOCK: LazyLock<futures::lock::Mutex<()>> =
+                LazyLock::new(|| futures::lock::Mutex::new(()));
+            let _lock = ONLINE_LOCK.lock().await;
+            // Notify the runner that we are ready for the VP to be stopped and
+            // the saved state to be sent.
+            canceller.cancel();
+
+            // Wait for the VP to stop running and get its spawner and saved
+            // state.
+            (this, saved_state) = match state_recv.await {
+                Ok(r) => r,
+                Err(_) => {
+                    // The VP is done. Presumably the VM is shutting down.
+                    return;
+                }
+            };
+
+            tracing::info!(CVM_ALLOWED, cpu = this.cpu, "onlining sidecar VP");
+            online_cpu(this.cpu).await;
+
+            // Set the affinity on the thread pool thread now that the CPU is
+            // online.
+            let affinity_set = thread.try_set_affinity().expect("failed to set affinity");
+            if !affinity_set {
+                panic!("processor {} not online", this.cpu);
+            }
+        }
+
+        // Set the initial task (which may have caused the sidecar VP to be
+        // removed) for diagnostics purposes.
+        this.vp.set_sidecar_exit_due_to_task(
+            thread
+                .first_task()
+                .map_or_else(|| "<unknown>".into(), |t| t.name),
+        );
+
+        // Start the run VP task.
+        thread.set_idle_task(async move |mut control| {
+            let state = this.run_vp(saved_state, Some(&mut control)).await;
+            assert!(state.is_none());
+        });
     }
 }
 

--- a/openvmm/hvlite_core/src/partition.rs
+++ b/openvmm/hvlite_core/src/partition.rs
@@ -379,6 +379,6 @@ impl<T: Processor> HvliteVp for T {
         mut runner: VpRunner,
         chipset: &vmm_core::vmotherboard_adapter::ChipsetPlusSynic,
     ) {
-        while let Err(RunCancelled) = runner.run(&mut WrappedVp(self), chipset).await {}
+        while let Err(RunCancelled { .. }) = runner.run(&mut WrappedVp(self), chipset).await {}
     }
 }


### PR DESCRIPTION
The Linux kernel serializes CPU hotplug. If multiple sidecar VPs need to be onlined into OpenVMM simultaneously, they will all stop running the guest while associated Linux threads call into the Linux kernel to online the CPU (which will block on the CPU hotplug lock or whatever).

This means the average blackout time for a VP that's onlined early in boot is linear in the number of early-onlined VPs. And thanks to typical device configurations, this is usually linear in the total number of VPs. This is a performance problem.

To avoid this, explicitly serialize VP online _before_ the target VP is stopped. This allows the VP to continue running the guest until it reaches the front of the online queue. This reduces the average blackout time to just the time to online one CPU, meaning this solution should scale to any number of VPs.

Cherry-pick of #1443