### PR TITLE
[WIP] Change mu_msvm version to v25.1.3

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -23,7 +23,7 @@ pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
 pub const RUSTUP_TOOLCHAIN: &str = "1.86.0";
-pub const MU_MSVM: &str = "24.0.4";
+pub const MU_MSVM: &str = "25.1.3";
 pub const NEXTEST: &str = "0.9.74";
 pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly


### PR DESCRIPTION
This is a temporary PR to see if this branch will pass the underhill binary size check. If this works, I'll abandon the other one and make this one primary.