### PR TITLE
CVM Guest VSM: refactor the shared/encrypted bitmaps to be partition

### DIFF
--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -35,6 +35,7 @@ use hvdef::hypercall::AcceptMemoryType;
 use hvdef::hypercall::HostVisibilityType;
 use hvdef::hypercall::HvInputVtl;
 use mapping::GuestMemoryMapping;
+use mapping::GuestValidMemory;
 use memory_range::MemoryRange;
 use parking_lot::Mutex;
 use registrar::RegisterMemory;
@@ -384,7 +385,8 @@ struct HypercallOverlay {
 }
 
 struct HardwareIsolatedMemoryProtectorInner {
-    shared: Arc<GuestMemoryMapping>,
+    valid_encrypted: Arc<GuestValidMemory>,
+    valid_shared: Arc<GuestValidMemory>,
     encrypted: Arc<GuestMemoryMapping>,
     default_vtl_permissions: DefaultVtlPermissions,
     vtl1_protections_enabled: bool,
@@ -396,14 +398,16 @@ impl HardwareIsolatedMemoryProtector {
     /// `shared` provides the mapping for shared memory. `vtl0` provides the
     /// mapping for encrypted memory.
     pub fn new(
-        shared: Arc<GuestMemoryMapping>,
+        valid_encrypted: Arc<GuestValidMemory>,
+        valid_shared: Arc<GuestValidMemory>,
         encrypted: Arc<GuestMemoryMapping>,
         layout: MemoryLayout,
         acceptor: Arc<MemoryAcceptor>,
     ) -> Self {
         Self {
             inner: Mutex::new(HardwareIsolatedMemoryProtectorInner {
-                shared,
+                valid_encrypted,
+                valid_shared,
                 encrypted,
                 // Grant only VTL 0 all permissions. This will be altered
                 // later by VTL 1 enablement and by VTL 1 itself.
@@ -506,7 +510,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         let gpns = gpns
             .iter()
             .copied()
-            .filter(|&gpn| inner.shared.check_bitmap(gpn) != shared)
+            .filter(|&gpn| inner.valid_shared.check_valid(gpn) != shared)
             .collect::<Vec<_>>();
 
         tracing::debug!(
@@ -526,12 +530,12 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
 
         // Prevent accesses via the wrong address.
         let clear_bitmap = if shared {
-            &inner.encrypted
+            &inner.valid_encrypted
         } else {
-            &inner.shared
+            &inner.valid_shared
         };
         for &range in &ranges {
-            clear_bitmap.update_bitmap(range, false);
+            clear_bitmap.update_valid(range, false);
         }
 
         // There may be other threads concurrently accessing these pages. We
@@ -607,7 +611,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
                         .expect("previous gpns was already checked");
 
                 for &range in &rollback_ranges {
-                    clear_bitmap.update_bitmap(range, true);
+                    clear_bitmap.update_valid(range, true);
                 }
 
                 // Figure out the index of the gpn that failed, in the
@@ -639,12 +643,12 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
 
         // Allow accesses via the correct address.
         let set_bitmap = if shared {
-            &inner.shared
+            &inner.valid_shared
         } else {
-            &inner.encrypted
+            &inner.valid_encrypted
         };
         for &range in &ranges {
-            set_bitmap.update_bitmap(range, true);
+            set_bitmap.update_valid(range, true);
         }
 
         if !shared {
@@ -697,7 +701,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
 
         // Set GPN sharing status in output.
         for (gpn, host_vis) in gpns.iter().zip(host_visibility.iter_mut()) {
-            *host_vis = if inner.shared.check_bitmap(*gpn) {
+            *host_vis = if inner.valid_shared.check_valid(*gpn) {
                 HostVisibilityType::SHARED
             } else {
                 HostVisibilityType::PRIVATE
@@ -741,7 +745,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
                 // find all accepted memory. When lazy acceptance exists,
                 // this should track all pages that have been accepted and
                 // should be used instead.
-                if !inner.encrypted.check_bitmap(gpn) {
+                if !inner.valid_encrypted.check_valid(gpn) {
                     if page_count > 0 {
                         let end_address = protect_start + (page_count * PAGE_SIZE as u64);
                         ranges.push(MemoryRange::new(protect_start..end_address));
@@ -795,7 +799,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         let inner = self.inner.lock();
 
         // Protections cannot be applied to a host-visible page
-        if gpns.iter().any(|&gpn| inner.shared.check_bitmap(gpn)) {
+        if gpns.iter().any(|&gpn| inner.valid_shared.check_valid(gpn)) {
             return Err((HvError::OperationDenied, 0));
         }
 


### PR DESCRIPTION
…wide (#1370)

In preparation for VTL 1 memory support for CVMs, make the shared/encrypted bitmap tracking available on a partition-level, rather than in the GuestMemoryMapping (which ends up being per-VTL). Also includes some refactoring to isolate out the bitmap logic so that it can be reused for vtl protection bitmaps.

Tested: SNP +/- guest vsm boots