### PR TITLE
vmbus_server: improve revoke and restore flows for proxy driver channels.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8451,6 +8451,7 @@ dependencies = [
  "bitfield-struct 0.10.1",
  "futures",
  "guestmem",
+ "guid",
  "mesh",
  "pal",
  "pal_async",

--- a/vm/devices/vmbus/vmbus_proxy/Cargo.toml
+++ b/vm/devices/vmbus/vmbus_proxy/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 guestmem.workspace = true
+guid.workspace = true
 vmbus_core.workspace = true
 mesh.workspace = true
 pal.workspace = true

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -334,7 +334,7 @@ impl VmbusProxy {
 
         // Copy the header now that the GPADL count is known.
         buffer[..header_len].copy_from_slice(header.as_bytes());
-        let output = unsafe {
+        Ok(unsafe {
             self.ioctl(
                 proxyioctl::IOCTL_VMBUS_PROXY_RESTORE_CHANNEL,
                 buffer,
@@ -342,9 +342,8 @@ impl VmbusProxy {
             )
             .await?
             .0
-        };
-
-        Ok(output.ProxyId)
+            .ProxyId
+        })
     }
 
     pub async fn revoke_unclaimed_channels(&self) -> Result<()> {
@@ -448,6 +447,7 @@ impl VmbusProxy {
         Ok(())
     }
 
+    /// Adds GPADL ioctl data to a buffer.
     fn add_gpadl(
         buffer: &mut Vec<u8>,
         id: u64,
@@ -467,6 +467,7 @@ impl VmbusProxy {
     }
 }
 
+/// Represents data to be restored for a GPADL.
 pub struct Gpadl<'a> {
     pub gpadl_id: u32,
     pub range_count: u32,

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -317,8 +317,8 @@ impl VmbusProxy {
         };
 
         // Leave space for the header.
-        let header_len = size_of_val(&header);
-        buffer.resize(header_len, 0);
+        const HEADER_LEN: usize = size_of::<proxyioctl::VMBUS_PROXY_RESTORE_CHANNEL_INPUT>();
+        buffer.resize(HEADER_LEN, 0);
 
         // Add GPADLs to the buffer and count them.
         for gpadl in gpadls {
@@ -333,7 +333,7 @@ impl VmbusProxy {
         }
 
         // Copy the header now that the GPADL count is known.
-        buffer[..header_len].copy_from_slice(header.as_bytes());
+        buffer[..HEADER_LEN].copy_from_slice(header.as_bytes());
         Ok(unsafe {
             self.ioctl(
                 proxyioctl::IOCTL_VMBUS_PROXY_RESTORE_CHANNEL,

--- a/vm/devices/vmbus/vmbus_proxy/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/lib.rs
@@ -7,9 +7,9 @@
 #![expect(unsafe_code)]
 #![expect(clippy::undocumented_unsafe_blocks, clippy::missing_safety_doc)]
 
-use bitfield_struct::bitfield;
 use futures::poll;
 use guestmem::GuestMemory;
+use guid::Guid;
 use mesh::CancelContext;
 use mesh::MeshPayload;
 use pal::windows::ObjectAttributes;
@@ -34,7 +34,6 @@ use windows::Win32::Foundation::NTSTATUS;
 use windows::Win32::Storage::FileSystem::FILE_ALL_ACCESS;
 use windows::Win32::Storage::FileSystem::SYNCHRONIZE;
 use windows::Win32::System::IO::DeviceIoControl;
-use windows::core::GUID;
 use zerocopy::IntoBytes;
 
 mod proxyioctl;
@@ -299,36 +298,53 @@ impl VmbusProxy {
 
     pub async fn restore(
         &self,
-        interface_type: GUID,
-        interface_instance: GUID,
+        interface_type: Guid,
+        interface_instance: Guid,
         subchannel_index: u16,
         target_vtl: u8,
-        open_params: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
-        open: bool,
-    ) -> Result<RestoreResult> {
+        open_params: Option<VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS>,
+        gpadls: impl Iterator<Item = Gpadl<'_>>,
+    ) -> Result<u64> {
+        let mut buffer = Vec::new();
+        let mut header = proxyioctl::VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
+            InterfaceType: interface_type,
+            InterfaceInstance: interface_instance,
+            SubchannelIndex: subchannel_index,
+            TargetVtl: target_vtl,
+            GpadlCount: 0,
+            OpenParameters: open_params.unwrap_or_default(),
+            Open: open_params.is_some().into(),
+        };
+
+        // Leave space for the header.
+        let header_len = size_of_val(&header);
+        buffer.resize(header_len, 0);
+
+        // Add GPADLs to the buffer and count them.
+        for gpadl in gpadls {
+            header.GpadlCount += 1;
+            Self::add_gpadl(
+                &mut buffer,
+                0, // Not used for restoring.
+                gpadl.gpadl_id,
+                gpadl.range_count,
+                gpadl.range_buffer.as_bytes(),
+            );
+        }
+
+        // Copy the header now that the GPADL count is known.
+        buffer[..header_len].copy_from_slice(header.as_bytes());
         let output = unsafe {
             self.ioctl(
                 proxyioctl::IOCTL_VMBUS_PROXY_RESTORE_CHANNEL,
-                StaticIoctlBuffer(proxyioctl::VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
-                    InterfaceType: interface_type,
-                    InterfaceInstance: interface_instance,
-                    SubchannelIndex: subchannel_index,
-                    TargetVtl: target_vtl,
-                    Padding: 0,
-                    OpenParameters: open_params,
-                    Open: open.into(),
-                    Padding2: [0; 3],
-                }),
+                buffer,
                 StaticIoctlBuffer(zeroed::<proxyioctl::VMBUS_PROXY_RESTORE_CHANNEL_OUTPUT>()),
             )
             .await?
             .0
         };
 
-        Ok(RestoreResult {
-            proxy_id: output.ProxyId,
-            flags: RestoreFlags::from_bits(output.Flags),
-        })
+        Ok(output.ProxyId)
     }
 
     pub async fn revoke_unclaimed_channels(&self) -> Result<()> {
@@ -372,15 +388,7 @@ impl VmbusProxy {
         range_buf: &[u8],
     ) -> Result<()> {
         let mut buf = Vec::new();
-        let header = proxyioctl::VMBUS_PROXY_CREATE_GPADL_INPUT {
-            ProxyId: id,
-            GpadlId: gpadl_id,
-            RangeCount: range_count,
-            RangeBufferOffset: size_of::<proxyioctl::VMBUS_PROXY_CREATE_GPADL_INPUT>() as u32,
-            RangeBufferSize: range_buf.len() as u32,
-        };
-        buf.extend_from_slice(header.as_bytes());
-        buf.extend_from_slice(range_buf);
+        Self::add_gpadl(&mut buf, id, gpadl_id, range_count, range_buf);
         unsafe {
             self.ioctl(proxyioctl::IOCTL_VMBUS_PROXY_CREATE_GPADL, buf, ())
                 .await
@@ -439,17 +447,28 @@ impl VmbusProxy {
         };
         Ok(())
     }
+
+    fn add_gpadl(
+        buffer: &mut Vec<u8>,
+        id: u64,
+        gpadl_id: u32,
+        range_count: u32,
+        range_buffer: &[u8],
+    ) {
+        let header = proxyioctl::VMBUS_PROXY_CREATE_GPADL_INPUT {
+            ProxyId: id,
+            GpadlId: gpadl_id,
+            RangeCount: range_count,
+            RangeBufferOffset: size_of::<proxyioctl::VMBUS_PROXY_CREATE_GPADL_INPUT>() as u32,
+            RangeBufferSize: range_buffer.len() as u32,
+        };
+        buffer.extend_from_slice(header.as_bytes());
+        buffer.extend_from_slice(range_buffer);
+    }
 }
 
-#[bitfield(u32)]
-pub struct RestoreFlags {
-    pub restore_gpadls: bool,
-    #[bits(31)]
-    pub reserved: u32,
-}
-
-#[derive(Debug, Copy, Clone)]
-pub struct RestoreResult {
-    pub proxy_id: u64,
-    pub flags: RestoreFlags,
+pub struct Gpadl<'a> {
+    pub gpadl_id: u32,
+    pub range_count: u32,
+    pub range_buffer: &'a [u64],
 }

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -152,6 +152,7 @@ pub struct VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_RESTORE_CHANNEL_OUTPUT {
     pub ProxyId: u64,
+    pub Flags: u32,
 }
 
 #[repr(C)]

--- a/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/proxyioctl.rs
@@ -12,6 +12,7 @@
 use super::vmbusioctl::VMBUS_CHANNEL_OFFER;
 use super::vmbusioctl::VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS;
 use bitfield_struct::bitfield;
+use guid::Guid;
 use windows::Win32::Foundation::NTSTATUS;
 use windows::Win32::System::Ioctl::FILE_DEVICE_UNKNOWN;
 use windows::Win32::System::Ioctl::FILE_READ_ACCESS;
@@ -136,23 +137,21 @@ pub struct VMBUS_PROXY_OPEN_CHANNEL_OUTPUT {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, IntoBytes, Immutable)]
 pub struct VMBUS_PROXY_RESTORE_CHANNEL_INPUT {
-    pub InterfaceType: GUID,
-    pub InterfaceInstance: GUID,
+    pub InterfaceType: Guid,
+    pub InterfaceInstance: Guid,
     pub SubchannelIndex: u16,
     pub TargetVtl: u8,
-    pub Padding: u8,
-    pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
     pub Open: BOOLEAN,
-    pub Padding2: [u8; 3],
+    pub OpenParameters: VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS,
+    pub GpadlCount: u32,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct VMBUS_PROXY_RESTORE_CHANNEL_OUTPUT {
     pub ProxyId: u64,
-    pub Flags: u32,
 }
 
 #[repr(C)]

--- a/vm/devices/vmbus/vmbus_proxy/src/vmbusioctl.rs
+++ b/vm/devices/vmbus/vmbus_proxy/src/vmbusioctl.rs
@@ -45,7 +45,7 @@ pub struct VmbusChannelOfferFlags {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, zerocopy::IntoBytes)]
+#[derive(Copy, Clone, Default, zerocopy::IntoBytes, zerocopy::Immutable)]
 pub struct VMBUS_SERVER_OPEN_CHANNEL_OUTPUT_PARAMETERS {
     pub RingBufferGpadlHandle: u32,
     pub DownstreamRingBufferPageOffset: u32,

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -12,6 +12,7 @@ use hvdef::Vtl;
 use inspect::Inspect;
 pub use saved_state::RestoreError;
 pub use saved_state::SavedState;
+pub use saved_state::SavedStateData;
 use slab::Slab;
 use std::cmp::min;
 use std::collections::VecDeque;

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -328,10 +328,17 @@ impl SavedState {
             .map(|s| s.channels.iter().find(|c| c.key == offer))?
     }
 
+    /// Retrieves all the channels and GPADLs from the saved state.
+    /// If disconnected, returns any reserved channels and their GPADLs.
     pub fn channels_and_gpadls(&self) -> Option<(&[Channel], &[Gpadl])> {
         self.state
             .as_ref()
             .map(|s| (s.channels.as_slice(), s.gpadls.as_slice()))
+            .or_else(|| {
+                self.disconnected_state
+                    .as_ref()
+                    .map(|s| (s.reserved_channels.as_slice(), s.reserved_gpadls.as_slice()))
+            })
     }
 }
 
@@ -636,7 +643,7 @@ impl Channel {
     }
 
     pub fn saved_open(&self) -> bool {
-        matches!(self.state, ChannelState::Open { .. })
+        self.open_request().is_some()
     }
 
     pub fn key(&self) -> OfferKey {

--- a/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/saved_state.rs
@@ -328,12 +328,10 @@ impl SavedState {
             .map(|s| s.channels.iter().find(|c| c.key == offer))?
     }
 
-    pub fn channels(&self) -> Option<std::slice::Iter<'_, Channel>> {
-        self.state.as_ref().map(|s| s.channels.iter())
-    }
-
-    pub fn gpadls(&self) -> Option<std::slice::Iter<'_, Gpadl>> {
-        self.state.as_ref().map(|s| s.gpadls.iter())
+    pub fn channels_and_gpadls(&self) -> Option<(&[Channel], &[Gpadl])> {
+        self.state
+            .as_ref()
+            .map(|s| (s.channels.as_slice(), s.gpadls.as_slice()))
     }
 }
 


### PR DESCRIPTION
This change makes some improvements to how revoke (particularly while terminating) and restore are handled for proxy driver channels. These are mainly aimed at situations where the proxy driver may maintain state for some open channels in between save/restore, though they should improve the general reliability as well.

- When the proxy task is being cancelled, only "next action" ioctls are aborted/prevented from issuing. All other ioctls are still allowed, so that state changes are fully propagated to the driver until the server terminates. It's now also possible to wait for proxy task completion.
- When the proxy driver revokes a channel, that is now handled inline using `ChannelServerRequest::Revoke`, so we can wait for its completion and immediately release the channel to the driver.
- Restoring a channel and its associated gpadls is now done in a single ioctl, to make it easier for the driver to distinguish restored gpadls from new ones, in case it had preserved the gpadl state for a channel.

When making these changes, I fixed a few other omissions in the restore path:

- All states that the driver should consider as a channel being open on restore are now properly handled.
- The proxy task will no longer mark a channel as restored if the device specified the "force new channel" flag.
- When saved in the disconnected state, properly restore any saved reserved channels.
- I also refactored how SavedState is used (within the confines of not being able to change its layout for compatibility), so Rust's type system can hopefully guide us into considering both connected and disconnected states in the future.