### PR TITLE
ci: update size check to use release/2505 branch baseline

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/check_openvmm_hcl_size.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Compares the size of the OpenHCL binary in the current PR with the size of the binary from the last successful merge to main.
+//! Compares the size of the OpenHCL binary in the current PR with the size of the binary from the last successful merge to release/2505.
 
 use crate::artifact_openhcl_igvm_from_recipe_extras;
 use crate::build_openhcl_igvm_from_recipe;
@@ -75,7 +75,7 @@ impl SimpleFlowNode for Node {
         let merge_commit = ctx.reqv(|v| git_merge_commit::Request {
             repo_path: openvmm_repo_path.clone(),
             merge_commit: v,
-            base_branch: "main".into(),
+            base_branch: "release/2505".into(),
         });
 
         let merge_run = ctx.reqv(|v| gh_workflow_id::Request {


### PR DESCRIPTION
The current size check is failing in the release/2505 branch because it's currently comparing against main and the branches have diverged.