### PR TITLE
virt_support_apic: Remove vector tracing filter (#1469)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8041,7 +8041,6 @@ dependencies = [
 name = "virt_support_apic"
 version = "0.0.0"
 dependencies = [
- "address_filter",
  "bitfield-struct 0.10.1",
  "hvdef",
  "inspect",

--- a/clippy.toml
+++ b/clippy.toml
@@ -12,6 +12,7 @@ disallowed-types = [
 disallowed-macros = [
     { path = "futures::pin_mut", reason = "use std::pin::pin" },
     { path = "futures::ready", reason = "use std::task::ready" },
+    { path = "tracing::enabled", reason = "https://github.com/tokio-rs/tracing/issues/2519" },
     { path = "openhcl_boot::boot_logger::debug_log", reason = "only use in local debugging, use log! if you want a production log message"},
 ]
 

--- a/vmm_core/virt_support_apic/Cargo.toml
+++ b/vmm_core/virt_support_apic/Cargo.toml
@@ -13,7 +13,6 @@ vmcore.workspace = true
 virt.workspace = true
 x86defs.workspace = true
 
-address_filter.workspace = true
 inspect.workspace = true
 inspect_counters.workspace = true
 tracelimit.workspace = true


### PR DESCRIPTION
This removes functionality added in
https://github.com/microsoft/openvmm/commit/7278a20daf243507baab1a912b1bd335a8c534d0 to avoid hitting https://github.com/tokio-rs/tracing/issues/2519. While the functionality is nice to have, it is not so important as to be worth potentially dropping events, and there is no performant way to implement it that can avoid this bug.

Then ban the tracing::enabled macro codebase-wide.

Cherry-pick of #1469