### PR TITLE
1.6 cvm guest vsm: track vtl 1 permissions in bitmaps (#1457)

### DIFF
--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -259,6 +259,9 @@ impl ProcessorVtlHv {
                 if hc.enable()
                     && (!mutable.hypercall_reg.enable() || hc.gpn() != mutable.hypercall_reg.gpn())
                 {
+                    // TODO GUEST VSM: make sure the guest has writable vtl
+                    // permissions to this page and that it's not in shared
+                    // memory.
                     let new_page = LockedPage::new(&self.guest_memory, hc.gpn())
                         .map_err(|_| MsrError::InvalidAccess)?;
                     self.write_hypercall_page(&new_page);

--- a/vm/vmcore/guestmem/fuzz/fuzz_guestmem.rs
+++ b/vm/vmcore/guestmem/fuzz/fuzz_guestmem.rs
@@ -41,7 +41,6 @@ unsafe impl GuestMemoryAccess for GuestMemoryMapping {
         self.bitmap.as_ref().map(|bm| BitmapInfo {
             read_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
             write_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
-            execute_bitmap: NonNull::new(bm.as_ptr().cast_mut()).unwrap(),
             bit_offset: 0,
         })
     }


### PR DESCRIPTION
When VTL 2 accesses VTL 0 memory on behalf of VTL 0, it needs to be able to check whether VTL 1 has restricted access to the memory. This change introduces tracking of VTL 1 permissions using bitmaps and adds some of the enforcement of these permissions.

Tested:
SNP +/- guest VSM boots
TVM and TDX VMs also boot