### PR TITLE
vm_loaders: support kernels below 2MB

### DIFF
--- a/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/hvlite_core/src/worker/vm_loaders/linux.rs
@@ -60,7 +60,7 @@ pub fn load_linux_x86(
     const CMDLINE_BASE: u64 = 0x3000;
     const ACPI_BASE: u64 = 0xe0000;
 
-    let kaddr: u64 = 2 * 1024 * 1024;
+    let kaddr: u64 = 0x100000;
     let mut kernel_file = cfg.kernel;
 
     let mut initrd = Vec::new();

--- a/vm/loader/src/elf.rs
+++ b/vm/loader/src/elf.rs
@@ -250,9 +250,11 @@ where
         let page_base = mem_offset / HV_PAGE_SIZE;
         let page_count =
             ((mem_offset & page_mask) + phdr.p_memsz.get(LE) + page_mask) / HV_PAGE_SIZE;
-        importer
-            .import_pages(page_base, page_count, tag, acceptance, &v)
-            .map_err(Error::ImportPages)?;
+        if page_count > 0 {
+            importer
+                .import_pages(page_base, page_count, tag, acceptance, &v)
+                .map_err(Error::ImportPages)?;
+        }
     }
 
     Ok(LoadInfo {


### PR DESCRIPTION
Allow loading Linux kernels as low as 1MB in OpenVMM. Also, fix
handling for zero-sided program headers.
