### PR TITLE
firmware_uefi: Backport EFI Diagnostics

### DIFF
--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -104,6 +104,7 @@ struct UefiDeviceServices {
     generation_id: service::generation_id::GenerationIdServices,
     #[inspect(mut)]
     time: service::time::TimeServices,
+    diagnostics: service::diagnostics::DiagnosticsServices,
 }
 
 // Begin and end range are inclusive.
@@ -199,6 +200,7 @@ impl UefiDevice {
                     generation_id_deps,
                 ),
                 time: service::time::TimeServices::new(time_source),
+                diagnostics: service::diagnostics::DiagnosticsServices::new(),
             },
         };
         Ok(uefi)
@@ -252,6 +254,8 @@ impl UefiDevice {
                     );
                 }
             }
+            UefiCommand::SET_EFI_DIAGNOSTICS_GPA => self.service.diagnostics.set_gpa(data),
+            UefiCommand::PROCESS_EFI_DIAGNOSTICS => self.process_diagnostics(),
             _ => tracelimit::warn_ratelimited!(addr, data, "unknown uefi write"),
         }
     }
@@ -400,6 +404,10 @@ open_enum::open_enum! {
         WATCHDOG_RESOLUTION          = 0x28,
         WATCHDOG_COUNT               = 0x29,
 
+        // EFI Diagnostics
+        SET_EFI_DIAGNOSTICS_GPA      = 0x2B,
+        PROCESS_EFI_DIAGNOSTICS      = 0x2C,
+
         // Event Logging (Windows 8.1 MQ/M0)
         EVENT_LOG_FLUSH              = 0x30,
 
@@ -432,6 +440,7 @@ mod save_restore {
     use vmcore::save_restore::SaveRestore;
 
     mod state {
+        use crate::service::diagnostics::DiagnosticsServices;
         use crate::service::event_log::EventLogServices;
         use crate::service::generation_id::GenerationIdServices;
         use crate::service::nvram::NvramServices;
@@ -457,6 +466,8 @@ mod save_restore {
             pub generation_id: <GenerationIdServices as SaveRestore>::SavedState,
             #[mesh(6)]
             pub time: <TimeServices as SaveRestore>::SavedState,
+            #[mesh(7)]
+            pub diagnostics: <DiagnosticsServices as SaveRestore>::SavedState,
         }
     }
 
@@ -475,6 +486,7 @@ mod save_restore {
                         uefi_watchdog,
                         generation_id,
                         time,
+                        diagnostics,
                     },
                 address,
             } = self;
@@ -487,6 +499,7 @@ mod save_restore {
                 watchdog: uefi_watchdog.save()?,
                 generation_id: generation_id.save()?,
                 time: time.save()?,
+                diagnostics: diagnostics.save()?,
             })
         }
 
@@ -499,6 +512,7 @@ mod save_restore {
                 watchdog,
                 generation_id,
                 time,
+                diagnostics,
             } = state;
 
             self.address = address;
@@ -508,6 +522,7 @@ mod save_restore {
             self.service.uefi_watchdog.restore(watchdog)?;
             self.service.generation_id.restore(generation_id)?;
             self.service.time.restore(time)?;
+            self.service.diagnostics.restore(diagnostics)?;
 
             Ok(())
         }

--- a/vm/devices/firmware/firmware_uefi/src/service/diagnostics.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/diagnostics.rs
@@ -1,0 +1,480 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! UEFI diagnostics service
+//!
+//! This service handles processing of the EFI diagnostics buffer,
+//! producing friendly logs for any telemetry during the UEFI boot
+//! process.
+//!
+//! The EFI diagnostics buffer follows the specification of Project Mu's
+//! Advanced Logger package, whose relevant types are defined in the Hyper-V
+//! specification within the uefi_specs crate.
+
+#![warn(missing_docs)]
+
+use crate::UefiDevice;
+use guestmem::GuestMemory;
+use guestmem::GuestMemoryError;
+use inspect::Inspect;
+use std::borrow::Cow;
+use std::fmt::Debug;
+use std::mem::size_of;
+use thiserror::Error;
+use uefi_specs::hyperv::advanced_logger::AdvancedLoggerInfo;
+use uefi_specs::hyperv::advanced_logger::AdvancedLoggerMessageEntryV2;
+use uefi_specs::hyperv::advanced_logger::PHASE_NAMES;
+use uefi_specs::hyperv::advanced_logger::SIG_ENTRY;
+use uefi_specs::hyperv::advanced_logger::SIG_HEADER;
+use uefi_specs::hyperv::debug_level::DEBUG_ERROR;
+use uefi_specs::hyperv::debug_level::DEBUG_FLAG_NAMES;
+use uefi_specs::hyperv::debug_level::DEBUG_WARN;
+use zerocopy::FromBytes;
+
+/// 8-byte alignment for every entry
+const ALIGNMENT: usize = 8;
+
+/// Alignment mask for the entry
+const ALIGNMENT_MASK: usize = ALIGNMENT - 1;
+
+/// Maximum allowed size of the log buffer
+pub const MAX_LOG_BUFFER_SIZE: u32 = 0x400000; // 4MB
+
+/// Maximum allowed size of a single message
+pub const MAX_MESSAGE_LENGTH: u16 = 0x1000; // 4KB
+
+/// Represents a processed log entry from the EFI diagnostics buffer
+#[derive(Debug, Clone)]
+pub struct EfiDiagnosticsLog<'a> {
+    /// The debug level of the log entry
+    pub debug_level: u32,
+    /// Hypervisor reference ticks elapsed from UEFI
+    pub ticks: u64,
+    /// The boot phase that produced this log entry
+    pub phase: u16,
+    /// The log message itself
+    pub message: &'a str,
+}
+
+/// Converts a debug level to a human-readable string
+fn debug_level_to_string(debug_level: u32) -> Cow<'static, str> {
+    // Borrow directly from the table if only one flag is set
+    if debug_level.count_ones() == 1 {
+        if let Some(&(_, name)) = DEBUG_FLAG_NAMES
+            .iter()
+            .find(|&&(flag, _)| flag == debug_level)
+        {
+            return Cow::Borrowed(name);
+        }
+    }
+
+    // Handle combined flags or unknown debug levels
+    let flags: Vec<&str> = DEBUG_FLAG_NAMES
+        .iter()
+        .filter(|&&(flag, _)| debug_level & flag != 0)
+        .map(|&(_, name)| name)
+        .collect();
+
+    if flags.is_empty() {
+        Cow::Borrowed("UNKNOWN")
+    } else {
+        Cow::Owned(flags.join("+"))
+    }
+}
+
+/// Converts a phase value to a human-readable string
+fn phase_to_string(phase: u16) -> &'static str {
+    PHASE_NAMES
+        .iter()
+        .find(|&&(phase_raw, _)| phase_raw == phase)
+        .map(|&(_, name)| name)
+        .unwrap_or("UNKNOWN")
+}
+
+/// Errors that occur when parsing entries
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+pub enum EntryParseError {
+    #[error("Expected: {0:#x}, got: {1:#x}")]
+    SignatureMismatch(u32, u32),
+    #[error("Expected non-zero timestamp, got: {0:#x}")]
+    Timestamp(u64),
+    #[error("Expected message length < {0:#x}, got: {1:#x}")]
+    MessageLength(u16, u16),
+    #[error("Failed to read from buffer slice")]
+    SliceRead,
+    #[error("Arithmetic overflow in {0}")]
+    Overflow(&'static str),
+    #[error("Failed to read UTF-8 string: {0}")]
+    Utf8Error(#[from] std::str::Utf8Error),
+    #[error("message_end ({0:#x}) exceeds buffer slice length ({1:#x})")]
+    BadMessageEnd(usize, usize),
+}
+
+/// Represents a single parsed entry from the EFI diagnostics buffer
+struct EntryData<'a> {
+    /// The debug level of the log entry
+    debug_level: u32,
+    /// Timestamp of when the log entry was created
+    time_stamp: u64,
+    /// The boot phase that produced this log entry
+    phase: u16,
+    /// The log message itself
+    message: &'a str,
+    /// The size of the entry in bytes (including alignment)
+    entry_size: usize,
+}
+
+/// Parse a single entry from a buffer slice
+fn parse_entry(buffer_slice: &[u8]) -> Result<EntryData<'_>, EntryParseError> {
+    // Try to parse an entry from the buffer slice and validate it
+    let (entry, _) = AdvancedLoggerMessageEntryV2::read_from_prefix(buffer_slice)
+        .map_err(|_| EntryParseError::SliceRead)?;
+
+    let signature = entry.signature;
+    if signature != u32::from_le_bytes(SIG_ENTRY) {
+        return Err(EntryParseError::SignatureMismatch(
+            u32::from_le_bytes(SIG_ENTRY),
+            signature,
+        ));
+    }
+
+    if entry.message_len > MAX_MESSAGE_LENGTH {
+        return Err(EntryParseError::MessageLength(
+            MAX_MESSAGE_LENGTH,
+            entry.message_len,
+        ));
+    }
+
+    let message_offset = entry.message_offset;
+    let message_len = entry.message_len;
+
+    // Calculate message start and end offsets for boundary validation
+    let message_start = message_offset as usize;
+    let message_end = message_start
+        .checked_add(message_len as usize)
+        .ok_or(EntryParseError::Overflow("message_end"))?;
+
+    if message_end > buffer_slice.len() {
+        return Err(EntryParseError::BadMessageEnd(
+            message_end,
+            buffer_slice.len(),
+        ));
+    }
+
+    let message = std::str::from_utf8(&buffer_slice[message_start..message_end])?;
+
+    // Calculate size of the entry to find the offset of the next entry
+    let base_offset = size_of::<AdvancedLoggerMessageEntryV2>()
+        .checked_add(message_len as usize)
+        .ok_or(EntryParseError::Overflow("base_offset"))?;
+
+    // Add padding for 8-byte alignment
+    let aligned_offset = base_offset
+        .checked_add(ALIGNMENT_MASK)
+        .ok_or(EntryParseError::Overflow("aligned_offset"))?;
+    let entry_size = aligned_offset & !ALIGNMENT_MASK;
+
+    Ok(EntryData {
+        debug_level: entry.debug_level,
+        time_stamp: entry.time_stamp,
+        phase: entry.phase,
+        message,
+        entry_size,
+    })
+}
+
+/// Errors that occur during processing
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+pub enum DiagnosticsError {
+    #[error("Failed to parse entry: {0}")]
+    EntryParse(#[from] EntryParseError),
+    #[error("Expected: {0:#x}, got: {1:#x}")]
+    HeaderSignatureMismatch(u32, u32),
+    #[error("Expected log buffer size < {0:#x}, got: {1:#x}")]
+    HeaderBufferSize(u32, u32),
+    #[error("Bad GPA value: {0:#x}")]
+    BadGpa(u32),
+    #[error("No GPA set")]
+    NoGpa,
+    #[error("Failed to read from guest memory: {0}")]
+    GuestMemoryRead(#[from] GuestMemoryError),
+    #[error("Arithmetic overflow in {0}")]
+    Overflow(&'static str),
+    #[error("Expected used log buffer size < {0:#x}, got: {1:#x}")]
+    BadUsedBufferSize(u32, u32),
+    #[error("Expected accumulated message length < {0:#x}, got: {1:#x}")]
+    BadAccumulatedMessageLength(u16, u16),
+}
+
+/// Definition of the diagnostics services state
+#[derive(Inspect)]
+pub struct DiagnosticsServices {
+    /// The guest physical address of the diagnostics buffer
+    gpa: Option<u32>,
+    /// Flag to indicate if we have already processed the buffer
+    did_process: bool,
+}
+
+impl DiagnosticsServices {
+    /// Create a new instance of the diagnostics services
+    pub fn new() -> DiagnosticsServices {
+        DiagnosticsServices {
+            gpa: None,
+            did_process: false,
+        }
+    }
+
+    /// Reset the diagnostics services state
+    pub fn reset(&mut self) {
+        self.gpa = None;
+        self.did_process = false;
+    }
+
+    /// Set the GPA of the diagnostics buffer
+    pub fn set_gpa(&mut self, gpa: u32) {
+        self.gpa = match gpa {
+            0 => None,
+            _ => Some(gpa),
+        }
+    }
+
+    /// Process the diagnostics buffer
+    pub fn process_diagnostics<F>(
+        &mut self,
+        gm: &GuestMemory,
+        mut log_handler: F,
+    ) -> Result<(), DiagnosticsError>
+    where
+        F: FnMut(EfiDiagnosticsLog<'_>),
+    {
+        // Validate the GPA
+        let gpa = match self.gpa {
+            Some(gpa) if gpa != 0 && gpa != u32::MAX => gpa,
+            Some(invalid_gpa) => return Err(DiagnosticsError::BadGpa(invalid_gpa)),
+            None => return Err(DiagnosticsError::NoGpa),
+        };
+
+        // Read and validate the header from the guest memory
+        let header: AdvancedLoggerInfo = gm.read_plain(gpa as u64)?;
+
+        let signature = header.signature;
+        if signature != u32::from_le_bytes(SIG_HEADER) {
+            return Err(DiagnosticsError::HeaderSignatureMismatch(
+                u32::from_le_bytes(SIG_HEADER),
+                signature,
+            ));
+        }
+
+        if header.log_buffer_size > MAX_LOG_BUFFER_SIZE {
+            return Err(DiagnosticsError::HeaderBufferSize(
+                MAX_LOG_BUFFER_SIZE,
+                header.log_buffer_size,
+            ));
+        }
+
+        // Calculate the used portion of the log buffer
+        let used_log_buffer_size = header
+            .log_current_offset
+            .checked_sub(header.log_buffer_offset)
+            .ok_or_else(|| DiagnosticsError::Overflow("used_log_buffer_size"))?;
+
+        // Early exit if there is no buffer to process
+        if used_log_buffer_size == 0 {
+            tracelimit::info_ratelimited!(
+                "EFI diagnostics' used log buffer size is 0, ending processing"
+            );
+            return Ok(());
+        }
+
+        if used_log_buffer_size > header.log_buffer_size
+            || used_log_buffer_size > MAX_LOG_BUFFER_SIZE
+        {
+            return Err(DiagnosticsError::BadUsedBufferSize(
+                MAX_LOG_BUFFER_SIZE,
+                used_log_buffer_size,
+            ));
+        }
+
+        // Calculate start address of the log buffer
+        let buffer_start_addr = gpa
+            .checked_add(header.log_buffer_offset)
+            .ok_or_else(|| DiagnosticsError::Overflow("buffer_start_addr"))?;
+
+        // Now read the used log buffer into a vector
+        let mut buffer_data = vec![0u8; used_log_buffer_size as usize];
+        gm.read_at(buffer_start_addr as u64, &mut buffer_data)?;
+
+        // Maintain a slice of the buffer that needs to be processed
+        let mut buffer_slice = &buffer_data[..];
+
+        // Message accumulation state
+        let mut accumulated_message = String::with_capacity(MAX_MESSAGE_LENGTH as usize);
+        let mut debug_level = 0;
+        let mut time_stamp = 0;
+        let mut phase = 0;
+        let mut is_accumulating = false;
+
+        // Used for tracking what has been processed
+        let mut bytes_read: usize = 0;
+        let mut entries_processed: usize = 0;
+
+        // Defines how to handle completed messages
+        let mut process_complete_log = |log: EfiDiagnosticsLog<'_>| {
+            log_handler(log);
+            entries_processed += 1;
+        };
+
+        // Process the buffer slice until all entries are processed
+        while !buffer_slice.is_empty() {
+            let entry = parse_entry(buffer_slice)?;
+
+            // Handle message accumulation
+            if !is_accumulating {
+                debug_level = entry.debug_level;
+                time_stamp = entry.time_stamp;
+                phase = entry.phase;
+                accumulated_message.clear();
+                is_accumulating = true;
+            }
+
+            accumulated_message.push_str(entry.message);
+            if accumulated_message.len() > MAX_MESSAGE_LENGTH as usize {
+                return Err(DiagnosticsError::BadAccumulatedMessageLength(
+                    MAX_MESSAGE_LENGTH,
+                    accumulated_message.len() as u16,
+                ));
+            }
+
+            // Handle completed messages (ending with '\n')
+            if !entry.message.is_empty() && entry.message.ends_with('\n') {
+                process_complete_log(EfiDiagnosticsLog {
+                    debug_level,
+                    ticks: time_stamp,
+                    phase,
+                    message: accumulated_message.trim_end_matches(&['\r', '\n'][..]),
+                });
+                is_accumulating = false;
+            }
+
+            // Update bytes read and move to the next entry
+            bytes_read = bytes_read
+                .checked_add(entry.entry_size)
+                .ok_or_else(|| DiagnosticsError::Overflow("bytes_read"))?;
+
+            if entry.entry_size >= buffer_slice.len() {
+                break; // End of buffer
+            } else {
+                buffer_slice = &buffer_slice[entry.entry_size..];
+            }
+        }
+
+        // Process any remaining accumulated message
+        if is_accumulating && !accumulated_message.is_empty() {
+            process_complete_log(EfiDiagnosticsLog {
+                debug_level,
+                ticks: time_stamp,
+                phase,
+                message: accumulated_message.trim_end_matches(&['\r', '\n'][..]),
+            });
+        }
+
+        // Print summary statistics
+        tracelimit::info_ratelimited!(entries_processed, bytes_read, "processed EFI log entries");
+
+        Ok(())
+    }
+}
+
+impl UefiDevice {
+    /// Process the diagnostics buffer and log the entries to tracing
+    pub(crate) fn process_diagnostics(&mut self) {
+        // Do not proceed if we have already processed before
+        if self.service.diagnostics.did_process {
+            tracelimit::warn_ratelimited!("Already processed diagnostics, skipping");
+            return;
+        }
+        self.service.diagnostics.did_process = true;
+
+        // Process diagnostics logs and send each directly to tracing
+        match self
+            .service
+            .diagnostics
+            .process_diagnostics(&self.gm, |log| {
+                let debug_level_str = debug_level_to_string(log.debug_level);
+                let phase_str = phase_to_string(log.phase);
+
+                match log.debug_level {
+                    DEBUG_WARN => tracing::warn!(
+                        debug_level = %debug_level_str,
+                        ticks = log.ticks,
+                        phase = %phase_str,
+                        log_message = log.message,
+                        "EFI log entry"
+                    ),
+                    DEBUG_ERROR => tracing::error!(
+                        debug_level = %debug_level_str,
+                        ticks = log.ticks,
+                        phase = %phase_str,
+                        log_message = log.message,
+                        "EFI log entry"
+                    ),
+                    _ => tracing::info!(
+                        debug_level = %debug_level_str,
+                        ticks = log.ticks,
+                        phase = %phase_str,
+                        log_message = log.message,
+                        "EFI log entry"
+                    ),
+                }
+            }) {
+            Ok(_) => {}
+            Err(error) => {
+                tracelimit::error_ratelimited!(
+                    error = &error as &dyn std::error::Error,
+                    "Failed to process diagnostics buffer"
+                );
+            }
+        }
+    }
+}
+
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    mod state {
+        use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateRoot;
+
+        #[derive(Protobuf, SavedStateRoot)]
+        #[mesh(package = "firmware.uefi.diagnostics")]
+        pub struct SavedState {
+            #[mesh(1)]
+            pub gpa: Option<u32>,
+            #[mesh(2)]
+            pub did_flush: bool,
+        }
+    }
+
+    impl SaveRestore for DiagnosticsServices {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(state::SavedState {
+                gpa: self.gpa,
+                did_flush: self.did_process,
+            })
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            let state::SavedState { gpa, did_flush } = state;
+            self.gpa = gpa;
+            self.did_process = did_flush;
+            Ok(())
+        }
+    }
+}

--- a/vm/devices/firmware/firmware_uefi/src/service/mod.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/mod.rs
@@ -4,6 +4,7 @@
 //! Various UEFI device subsystems.
 
 pub mod crypto;
+pub mod diagnostics;
 pub mod event_log;
 pub mod generation_id;
 pub mod nvram;

--- a/vm/devices/firmware/uefi_specs/src/hyperv/advanced_logger.rs
+++ b/vm/devices/firmware/uefi_specs/src/hyperv/advanced_logger.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Types and constants defined by Project Mu's Advanced Logger package,
+//! used in the Hyper-V UEFI firmware.
+
+#![warn(missing_docs)]
+
+use crate::uefi::time::EFI_TIME;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::KnownLayout;
+
+/// Phase value for SEC
+pub const SEC_PHASE: u16 = 0x0001;
+
+/// Phase value for PEI CORE
+pub const PEI_CORE_PHASE: u16 = 0x0002;
+
+/// Phase value for PEI64
+pub const PEI64_PHASE: u16 = 0x0003;
+
+/// Phase value for DXE
+pub const DXE_PHASE: u16 = 0x0004;
+
+/// Phase value for RUNTIME
+pub const RUNTIME_PHASE: u16 = 0x0005;
+
+/// Phase value for MM CORE
+pub const MM_CORE_PHASE: u16 = 0x0006;
+
+/// Phase value for MM
+pub const MM_PHASE: u16 = 0x0007;
+
+/// Phase value for SMM CORE
+pub const SMM_CORE_PHASE: u16 = 0x0008;
+
+/// Maps phase values to their descriptive names
+pub const PHASE_NAMES: &[(u16, &str)] = &[
+    (SEC_PHASE, "SEC"),
+    (PEI_CORE_PHASE, "PEI_CORE"),
+    (PEI64_PHASE, "PEI64"),
+    (DXE_PHASE, "DXE"),
+    (RUNTIME_PHASE, "RUNTIME"),
+    (MM_CORE_PHASE, "MM_CORE"),
+    (MM_PHASE, "MM"),
+    (SMM_CORE_PHASE, "SMM_CORE"),
+];
+
+/// Advanced Logger Info signature
+pub const SIG_HEADER: [u8; 4] = *b"ALOG";
+
+/// Advanced Logger Entry signature
+pub const SIG_ENTRY: [u8; 4] = *b"ALM2";
+
+/// UEFI Advanced Logger Info Header, which is shared
+/// with the Advanced Logger Package in UEFI. The entries
+/// live right after.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, FromBytes, Immutable, KnownLayout)]
+pub struct AdvancedLoggerInfo {
+    /// Signature 'ALOG'
+    pub signature: u32,
+    /// Current Version
+    pub version: u16,
+    /// Reserved for future
+    pub reserved: [u16; 3],
+    /// Offset from LoggerInfo to start of log
+    pub log_buffer_offset: u32,
+    /// Reserved field
+    pub reserved4: u32,
+    /// Offset from LoggerInfo to where to store next log entry
+    pub log_current_offset: u32,
+    /// Number of bytes of messages missed
+    pub discarded_size: u32,
+    /// Size of allocated buffer
+    pub log_buffer_size: u32,
+    /// Log in permanent RAM
+    pub in_permanent_ram: u8,
+    /// After ExitBootServices
+    pub at_runtime: u8,
+    /// After VirtualAddressChange
+    pub gone_virtual: u8,
+    /// HdwPort initialized
+    pub hdw_port_initialized: u8,
+    /// HdwPort is Disabled
+    pub hdw_port_disabled: u8,
+    /// Reserved field
+    pub reserved2: [u8; 3],
+    /// Ticks per second for log timing
+    pub timer_frequency: u64,
+    /// Ticks when Time Acquired
+    pub ticks_at_time: u64,
+    /// Uefi Time Field
+    pub time: EFI_TIME,
+    /// Logging level to be printed at hw port
+    pub hw_print_level: u32,
+    /// Reserved field
+    pub reserved3: u32,
+}
+
+/// UEFI Advanced Logger Entry, which is shared with the
+/// Advanced Logger Package in UEFI. The messages live
+/// right after.
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone, FromBytes, Immutable, KnownLayout)]
+pub struct AdvancedLoggerMessageEntryV2 {
+    /// Signature 'ALM2'
+    pub signature: u32,
+    /// Major version of the advanced logger message structure.
+    pub major_version: u8,
+    /// Minor version of the advanced logger message structure.
+    pub minor_version: u8,
+    /// Debug level
+    pub debug_level: u32,
+    /// Time stamp
+    pub time_stamp: u64,
+    /// Boot phase that produced this message entry
+    pub phase: u16,
+    /// Number of bytes in the Message
+    pub message_len: u16,
+    /// Offset of the message from the start of the structure.
+    pub message_offset: u16,
+    // Rust prevents C flexible array members, but "message_text: [u8; _]" would be here
+}

--- a/vm/devices/firmware/uefi_specs/src/hyperv/debug_level.rs
+++ b/vm/devices/firmware/uefi_specs/src/hyperv/debug_level.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Debug level mappings defined by Project Mu's MU_BASECORE package,
+//! used in the Hyper-V UEFI firmware.
+
+#![warn(missing_docs)]
+
+/// Initialization
+pub const DEBUG_INIT: u32 = 0x0000_0001;
+/// Warnings
+pub const DEBUG_WARN: u32 = 0x0000_0002;
+/// Load events
+pub const DEBUG_LOAD: u32 = 0x0000_0004;
+/// EFI File system
+pub const DEBUG_FS: u32 = 0x0000_0008;
+/// Alloc & Free (pool)
+pub const DEBUG_POOL: u32 = 0x0000_0010;
+/// Alloc & Free (page)
+pub const DEBUG_PAGE: u32 = 0x0000_0020;
+/// Informational debug messages
+pub const DEBUG_INFO: u32 = 0x0000_0040;
+/// PEI/DXE/SMM Dispatchers
+pub const DEBUG_DISPATCH: u32 = 0x0000_0080;
+/// Variable
+pub const DEBUG_VARIABLE: u32 = 0x0000_0100;
+/// Boot Manager
+pub const DEBUG_BM: u32 = 0x0000_0400;
+/// BlkIo Driver
+pub const DEBUG_BLKIO: u32 = 0x0000_1000;
+/// Network Io Driver
+pub const DEBUG_NET: u32 = 0x0000_4000;
+/// UNDI Driver
+pub const DEBUG_UNDI: u32 = 0x0001_0000;
+/// LoadFile
+pub const DEBUG_LOADFILE: u32 = 0x0002_0000;
+/// Event messages
+pub const DEBUG_EVENT: u32 = 0x0008_0000;
+/// Global Coherency Database changes
+pub const DEBUG_GCD: u32 = 0x0010_0000;
+/// Memory range cachability changes
+pub const DEBUG_CACHE: u32 = 0x0020_0000;
+/// Detailed debug messages that may significantly impact boot performance
+pub const DEBUG_VERBOSE: u32 = 0x0040_0000;
+/// Detailed debug and payload manageability messages related to modules such as Redfish, IPMI, MCTP etc.
+pub const DEBUG_MANAGEABILITY: u32 = 0x0080_0000;
+/// Error
+pub const DEBUG_ERROR: u32 = 0x8000_0000;
+
+/// Maps debug levels to their descriptive names.
+pub const DEBUG_FLAG_NAMES: &[(u32, &str)] = &[
+    (DEBUG_INIT, "INIT"),
+    (DEBUG_WARN, "WARNING"),
+    (DEBUG_LOAD, "LOAD"),
+    (DEBUG_FS, "FILESYSTEM"),
+    (DEBUG_POOL, "POOL"),
+    (DEBUG_PAGE, "PAGE"),
+    (DEBUG_INFO, "INFO"),
+    (DEBUG_DISPATCH, "DISPATCH"),
+    (DEBUG_VARIABLE, "VARIABLE"),
+    (DEBUG_BM, "BOOTMANAGER"),
+    (DEBUG_BLKIO, "BLOCKIO"),
+    (DEBUG_NET, "NETWORK"),
+    (DEBUG_UNDI, "UNDI"),
+    (DEBUG_LOADFILE, "LOADFILE"),
+    (DEBUG_EVENT, "EVENT"),
+    (DEBUG_GCD, "GCD"),
+    (DEBUG_CACHE, "CACHE"),
+    (DEBUG_VERBOSE, "VERBOSE"),
+    (DEBUG_MANAGEABILITY, "MANAGEABILITY"),
+    (DEBUG_ERROR, "ERROR"),
+];

--- a/vm/devices/firmware/uefi_specs/src/hyperv/mod.rs
+++ b/vm/devices/firmware/uefi_specs/src/hyperv/mod.rs
@@ -7,10 +7,12 @@
 //! in any public spec. Instead, they are transcribed directly from the Hyper-V
 //! C/C++ sources.
 
+pub mod advanced_logger;
 pub mod bios_event_log;
 pub mod boot_bios_log;
 pub mod common;
 pub mod crypto;
+pub mod debug_level;
 pub mod nvram;
 pub mod time;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -4,6 +4,7 @@
 //! Integration tests that run on more than one architecture.
 
 use anyhow::Context;
+use futures::StreamExt;
 use get_resources::ged::FirmwareEvent;
 use hyperv_ic_resources::kvp::KvpRpc;
 use jiff::SignedDuration;
@@ -81,6 +82,37 @@ async fn boot_reset_expected(config: PetriVmConfigOpenVmm) -> anyhow::Result<()>
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
     Ok(())
+}
+
+/// Test EFI diagnostics with no boot devices on OpenVMM.
+/// TODO:
+///   - kmsg support in Hyper-V
+///   - openhcl_uefi_aarch64 support
+///   - uefi_x64 + uefi_aarch64 trace searching support
+#[openvmm_test(openhcl_uefi_x64(none))]
+async fn efi_diagnostics_no_boot(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+    let mut vm = config.with_uefi_frontpage(true).run_without_agent().await?;
+
+    // Boot the VM first
+    vm.wait_for_successful_boot_event().await?;
+
+    // Expected no-boot message.
+    const NO_BOOT_MSG: &str = "[Bds] Unable to boot!";
+
+    // Get kmsg stream
+    let mut kmsg = vm.kmsg().await?;
+
+    // Search for the message
+    while let Some(data) = kmsg.next().await {
+        let data = data.context("reading kmsg")?;
+        let msg = kmsg::KmsgParsedEntry::new(&data)?;
+        let raw = msg.message.as_raw();
+        if raw.contains(NO_BOOT_MSG) {
+            return Ok(());
+        }
+    }
+
+    anyhow::bail!("Did not find expected message in kmsg");
 }
 
 /// Test the KVP IC.


### PR DESCRIPTION
(This is a backport PR)

This PR adds EFI Diagnostics, which is a service used to parse UEFI diagnostics data from an in-memory buffer and send it to our tracing facilities.

The UEFI firmware will write the GPA of the advanced logger buffer to an Io port intercept called `SET_EFI_DIAGNOSTICS_GPA`.

The diagnostics service is responsible for reading guest memory at the specified GPA and parsing the data. This gets triggered when the UEFI firmware writes to an Io port intercept called
`PROCESS_EFI_DIAGNOSTICS`.

The `PROCESS_EFI_DIAGNOSTICS` UefiCommand gets triggered by the following conditions:
- UEFI encounters a failure (guest driven via `PROCESS_EFI_DIAGNOSTICS`)
- UEFI fails to boot any device (guest driven via `PROCESS_EFI_DIAGNOSTICS`)
- UEFI reaches exit boot services

The simplest way to test this is to run:
```
cargo run -- --uefi
```