### PR TITLE
virt_mshv_vtl: don't use spaces in inspect keys

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -503,7 +503,7 @@ struct UhCvmVpInner {
 
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 #[derive(Inspect)]
-#[inspect(tag = "guest vsm state")]
+#[inspect(tag = "guest_vsm_state")]
 /// Partition-wide state for guest vsm.
 enum GuestVsmState<T: Inspect> {
     NotPlatformSupported,


### PR DESCRIPTION
This breaks petri log parsing and makes inspect harder to use.