### PR TITLE
openvmm_entry: fix file disk openvmm cli

### DIFF
--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -774,7 +774,7 @@ impl FromStr for DiskCliKind {
                 }
                 "prwrap" => DiskCliKind::PersistentReservationsWrapper(Box::new(arg.parse()?)),
                 "file" => {
-                    let (path, create_with_len) = parse_path_and_len(s)?;
+                    let (path, create_with_len) = parse_path_and_len(arg)?;
                     DiskCliKind::File {
                         path,
                         create_with_len,


### PR DESCRIPTION
Fixes a bug in the openvmm cli where the argument without `file:` stripped was incorrectly used as the path.