### PR TITLE
fuse_hello: ignore fuse_hello since it requires root.

### DIFF
--- a/vm/devices/support/fs/fuse/tests/fuse_hello.rs
+++ b/vm/devices/support/fs/fuse/tests/fuse_hello.rs
@@ -16,6 +16,7 @@ use zerocopy::FromZeros;
 // This test is excluded from CI because it requires root.
 #[cfg_attr(not(feature = "ci"), test_with_tracing::test)]
 #[cfg_attr(feature = "ci", expect(dead_code))]
+#[ignore]
 fn fuse_hello() {
     let mount_point = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
`fuse_hello` is the only test that fails when one runs `cargo nextest run --workspace --exclude guest_test_uefi --exclude vmm_tests`. It is already ignored for CI, so also just mark it as ignored with requiring manual tests. Run manually with `cargo nextest run -p fuse -- --ignored` or equivalent.