### PR TITLE
flowey: Fix regen break from changing build profile

### DIFF
--- a/flowey/flowey_cli/src/cli/regen.rs
+++ b/flowey/flowey_cli/src/cli/regen.rs
@@ -64,11 +64,11 @@ impl Regen {
                                 .unwrap_or("target"),
                         )
                         .join(std::env::var("CARGO_BUILD_TARGET").as_deref().unwrap_or(""))
-                        .join("flowey")
+                        .join("debug")
                         .join(&exe_name);
 
                     if !bin.exists() {
-                        panic!("should have found built {bin_name}");
+                        panic!("should have found built {bin_name} at {}", bin.display());
                     }
 
                     // stash result for future consumers


### PR DESCRIPTION
In https://github.com/microsoft/openvmm/pull/1481 I removed the `flowey` build profile, because it was no longer necessary. This changed the output directory for cargo, since it was now using the normal debug profile. However I didn't catch this since I still had leftover binaries at the previous path, so there were no errors. Running a cargo clean then trying to run regen reveals the bug. Fix it by just updating to the right folder name.