### PR TITLE
flowey: vmm-tests: allow default flags if none specified

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests.rs
@@ -149,7 +149,7 @@ impl IntoPipeline for VmmTestsCli {
                             build: BuildSelections::default(),
                         }
                     } else {
-                        VmmTestSelections::Flags(flags.unwrap())
+                        VmmTestSelections::Flags(flags.unwrap_or_default())
                     },
                     unstable_whp,
                     release,


### PR DESCRIPTION
Without this change, `cargo xflowey vmm-tests` simply panics.