### PR TITLE
1.6 CVM Guest VSM: synchronization around VTL permission bitmaps (#1483)

### DIFF
--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -339,7 +339,6 @@ pub struct HardwareIsolatedMemoryProtector {
     inner: Mutex<HardwareIsolatedMemoryProtectorInner>,
     layout: MemoryLayout,
     acceptor: Arc<MemoryAcceptor>,
-    // TODO GUEST VSM: synchronize vtl protection bitmaps
     vtl0: Arc<GuestMemoryMapping>,
     vtl1_protections_enabled: AtomicBool,
     hypercall_overlay: VtlArray<Arc<Mutex<Option<HypercallOverlay>>>, 2>,
@@ -434,7 +433,6 @@ impl HardwareIsolatedMemoryProtector {
         Ok(())
     }
 
-    // TODO rename
     fn apply_protections(
         &self,
         range: MemoryRange,
@@ -499,7 +497,6 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
                         .query_access_permission(gpn)
                         .expect("vtl 1 protections enabled, vtl permissions should be tracked");
                     if !permissions.readable() || !permissions.writable() {
-                        // TODO GUEST VSM: should this send a memory intercept instead?
                         failed_vtl_permission_index = Some(index);
                         false
                     } else {
@@ -737,9 +734,6 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         // TODO: This does not need to be synchronized against other
         // threads performing VTL protection changes; whichever thread
         // finishes last will control the outcome.
-        //
-        // TODO GUEST VSM: Changes to vtl protections will need to be
-        // synchronized with any checks for VTL protections (e.g. rmpquery)
         let mut inner = self.inner.lock();
 
         inner.default_vtl_permissions.set(vtl, vtl_protections);
@@ -776,6 +770,10 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
 
         self.apply_protections_with_overlay_handling(vtl, &ranges, vtl_protections)
             .expect("applying vtl protections should succeed");
+
+        // Flush any threads accessing pages that had their VTL protections
+        // changed.
+        guestmem::rcu().synchronize_blocking();
 
         // Invalidate the entire VTL 0 TLB to ensure that the new permissions
         // are observed.
@@ -823,6 +821,10 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
 
         self.apply_protections_with_overlay_handling(vtl, &ranges, protections)
             .expect("applying vtl protections should succeed");
+
+        // Flush any threads accessing pages that had their VTL protections
+        // changed.
+        guestmem::rcu().synchronize_blocking();
 
         // Since page protections were modified, we must invalidate the entire
         // VTL 0 TLB to ensure that the new permissions are observed, and wait for
@@ -888,6 +890,10 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         )
         .expect("applying vtl protections should succeed");
 
+        // Flush any threads accessing pages that had their VTL protections
+        // changed.
+        guestmem::rcu().synchronize_blocking();
+
         // Flush the guest TLB to ensure that the new permissions are observed.
         tlb_access.flush(vtl);
     }
@@ -903,6 +909,10 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         }
 
         *overlay = None;
+
+        // Flush any threads accessing pages that had their VTL protections
+        // changed.
+        guestmem::rcu().synchronize_blocking();
 
         tlb_access.flush(vtl);
     }

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -130,7 +130,6 @@ pub struct GuestMemoryMapping {
     iova_offset: Option<u64>,
     #[inspect(with = "Option::is_some")]
     valid_memory: Option<Arc<GuestValidMemory>>,
-    // TODO GUEST VSM: synchronize bitmap access
     #[inspect(with = "Option::is_some")]
     permission_bitmaps: Option<PermissionBitmaps>,
     registrar: Option<MemoryRegistrar<MshvVtlWithPolicy>>,
@@ -266,8 +265,6 @@ pub struct GuestMemoryMappingBuilder {
 }
 
 impl GuestMemoryMappingBuilder {
-    /// FUTURE: use bitmaps to track VTL permissions as well, to support guest
-    /// VSM for hardware-isolated VMs.
     fn use_partition_valid_memory(
         &mut self,
         valid_memory: Option<Arc<GuestValidMemory>>,
@@ -480,7 +477,6 @@ impl GuestMemoryMapping {
     /// Panics if the range is outside of guest RAM.
     pub fn update_permission_bitmaps(&self, range: MemoryRange, flags: HvMapGpaFlags) {
         if let Some(bitmaps) = self.permission_bitmaps.as_ref() {
-            // TODO GUEST VSM: synchronize with reading the bitmaps
             let _lock = bitmaps.permission_update_lock.lock();
             bitmaps.read_bitmap.update(range, flags.readable());
             bitmaps.write_bitmap.update(range, flags.writable());


### PR DESCRIPTION
Uses RCU implementation to synchronize reads and writes of the VTL 1 permission bitmaps.

Tested:
SNP +/- guest vsm boots