### PR TITLE
Merged PR 13114344: tpm: mitigate corruption due to corrupted TPM NVRAM blob

### DIFF
--- a/vm/devices/tpm/src/recover.rs
+++ b/vm/devices/tpm/src/recover.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Code to recover a corrupt TPM NVRAM blob due to truncation.
+
+use crate::LEGACY_VTPM_SIZE;
+
+/// Check if the TPM blob's persistent data structures all fit inside it.
+///
+/// This can return false if the blob was incorrectly truncated (by a previous
+/// bug that reported a 32KB blob size for a 16KB blob).
+fn check_blob(blob: &[u8]) -> Result<(), usize> {
+    const NV_USER_DYNAMIC: usize = 3508; // from the TPM reference implementation
+    let mut i = NV_USER_DYNAMIC;
+    loop {
+        let size = u32::from_ne_bytes(blob[i..].get(..4).ok_or(i)?.try_into().unwrap());
+        if size == 0 {
+            break;
+        }
+        if blob[i..].get(..size as usize).is_none() {
+            return Err(i);
+        }
+        i += size as usize;
+    }
+    Ok(())
+}
+
+/// Fixup an NVRAM blob that has data past the end, by zeroing out the last
+/// header that refers to data past the end.
+pub fn recover_blob(blob: &mut [u8]) {
+    let original_size = blob.len();
+    if original_size != LEGACY_VTPM_SIZE {
+        tracing::debug!("TPM NVRAM size is not legacy size, skipping recovery");
+        return;
+    }
+
+    match check_blob(blob) {
+        Ok(()) => {
+            tracing::info!("TPM NVRAM is already good, skipping recovery");
+        }
+        Err(bad_offset) => {
+            tracing::warn!("TPM NVRAM blob is corrupt, truncating at offset {bad_offset}");
+            blob[bad_offset..].fill(0);
+        }
+    }
+}

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -63,104 +63,108 @@ async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Test AK cert is persistent across boots on Linux.
-// TODO: Add in-guest TPM tests for Windows as we currently
-// do have an easy way to interact with TPM without a private
-// or custom tool.
-#[openvmm_test(openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)))]
-async fn tpm_ak_cert_persisted(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
-    let config = config
-        .with_tpm()
-        .with_tpm_state_persistence()
-        .with_igvm_attest_test_config(
-            get_resources::ged::IgvmAttestTestConfig::AkCertPersistentAcrossBoot,
-        );
+// TODO: Test disabled because AK cert renewal with non-hardware isolation is
+// disabled.
+// /// Test AK cert is persistent across boots on Linux.
+// // TODO: Add in-guest TPM tests for Windows as we currently
+// // do have an easy way to interact with TPM without a private
+// // or custom tool.
+// #[openvmm_test(openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)))]
+// async fn tpm_ak_cert_persisted(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+//     let config = config
+//         .with_tpm()
+//         .with_tpm_state_persistence()
+//         .with_igvm_attest_test_config(
+//             get_resources::ged::IgvmAttestTestConfig::AkCertPersistentAcrossBoot,
+//         );
 
-    // First boot - AK cert request will be served by GED
-    let mut vm = config.run_with_lazy_pipette().await?;
-    // Workaround to https://github.com/microsoft/openvmm/issues/379
-    assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
+//     // First boot - AK cert request will be served by GED
+//     let mut vm = config.run_with_lazy_pipette().await?;
+//     // Workaround to https://github.com/microsoft/openvmm/issues/379
+//     assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
 
-    // Second boot - Ak cert request will be bypassed by GED
-    vm.reset().await?;
-    let agent = vm.wait_for_agent().await?;
-    vm.wait_for_successful_boot_event().await?;
+//     // Second boot - Ak cert request will be bypassed by GED
+//     vm.reset().await?;
+//     let agent = vm.wait_for_agent().await?;
+//     vm.wait_for_successful_boot_event().await?;
 
-    // Use the python script to read AK cert from TPM nv index
-    // and verify that the AK cert preserves across boot.
-    // TODO: Replace the script with tpm2-tools
-    const TEST_FILE: &str = "tpm.py";
-    const TEST_CONTENT: &str = include_str!("../../test_data/tpm.py");
+//     // Use the python script to read AK cert from TPM nv index
+//     // and verify that the AK cert preserves across boot.
+//     // TODO: Replace the script with tpm2-tools
+//     const TEST_FILE: &str = "tpm.py";
+//     const TEST_CONTENT: &str = include_str!("../../test_data/tpm.py");
 
-    agent.write_file(TEST_FILE, TEST_CONTENT.as_bytes()).await?;
-    assert_eq!(agent.read_file(TEST_FILE).await?, TEST_CONTENT.as_bytes());
+//     agent.write_file(TEST_FILE, TEST_CONTENT.as_bytes()).await?;
+//     assert_eq!(agent.read_file(TEST_FILE).await?, TEST_CONTENT.as_bytes());
 
-    let sh = agent.unix_shell();
-    let output = cmd!(sh, "python3 tpm.py").read().await?;
+//     let sh = agent.unix_shell();
+//     let output = cmd!(sh, "python3 tpm.py").read().await?;
 
-    // Check if the content preserves as expected
-    assert!(output.contains("succeeded"));
+//     // Check if the content preserves as expected
+//     assert!(output.contains("succeeded"));
 
-    agent.power_off().await?;
-    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
-    Ok(())
-}
+//     agent.power_off().await?;
+//     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+//     Ok(())
+// }
 
-/// Test AK cert retry logic on Linux.
-// TODO: Add in-guest TPM tests for Windows as we currently
-// do have an easy way to interact with TPM without a private
-// or custom tool.
-#[openvmm_test(openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)))]
-async fn tpm_ak_cert_retry(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
-    let config = config
-        .with_tpm()
-        .with_tpm_state_persistence()
-        .with_igvm_attest_test_config(
-            get_resources::ged::IgvmAttestTestConfig::AkCertRequestFailureAndRetry,
-        );
+// TODO: Test disabled because AK cert renewal with non-hardware isolation is
+// disabled.
+// /// Test AK cert retry logic on Linux.
+// // TODO: Add in-guest TPM tests for Windows as we currently
+// // do have an easy way to interact with TPM without a private
+// // or custom tool.
+// #[openvmm_test(openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)))]
+// async fn tpm_ak_cert_retry(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+//     let config = config
+//         .with_tpm()
+//         .with_tpm_state_persistence()
+//         .with_igvm_attest_test_config(
+//             get_resources::ged::IgvmAttestTestConfig::AkCertRequestFailureAndRetry,
+//         );
 
-    // First boot - expect no AK cert from GED
-    let mut vm = config.run_with_lazy_pipette().await?;
-    // Workaround to https://github.com/microsoft/openvmm/issues/379
-    assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
+//     // First boot - expect no AK cert from GED
+//     let mut vm = config.run_with_lazy_pipette().await?;
+//     // Workaround to https://github.com/microsoft/openvmm/issues/379
+//     assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
 
-    // Second boot - except get AK cert from GED on the second attempts
-    vm.reset().await?;
-    let agent = vm.wait_for_agent().await?;
-    vm.wait_for_successful_boot_event().await?;
+//     // Second boot - except get AK cert from GED on the second attempts
+//     vm.reset().await?;
+//     let agent = vm.wait_for_agent().await?;
+//     vm.wait_for_successful_boot_event().await?;
 
-    // Use the python script to read AK cert from TPM nv index
-    // and verify that the AK cert preserves across boot.
-    // TODO: Replace the script with tpm2-tools
-    const TEST_FILE: &str = "tpm.py";
-    const TEST_CONTENT: &str = include_str!("../../test_data/tpm.py");
+//     // Use the python script to read AK cert from TPM nv index
+//     // and verify that the AK cert preserves across boot.
+//     // TODO: Replace the script with tpm2-tools
+//     const TEST_FILE: &str = "tpm.py";
+//     const TEST_CONTENT: &str = include_str!("../../test_data/tpm.py");
 
-    agent.write_file(TEST_FILE, TEST_CONTENT.as_bytes()).await?;
-    assert_eq!(agent.read_file(TEST_FILE).await?, TEST_CONTENT.as_bytes());
+//     agent.write_file(TEST_FILE, TEST_CONTENT.as_bytes()).await?;
+//     assert_eq!(agent.read_file(TEST_FILE).await?, TEST_CONTENT.as_bytes());
 
-    // The first AK cert request made during boot is expected to
-    // get invalid response from GED such that no data is set
-    // to nv index. The script should return failure. Also, the nv
-    // read made by the script is expected to trigger another AK cert
-    // request.
-    let sh = agent.unix_shell();
-    let output = cmd!(sh, "python3 tpm.py").read().await?;
+//     // The first AK cert request made during boot is expected to
+//     // get invalid response from GED such that no data is set
+//     // to nv index. The script should return failure. Also, the nv
+//     // read made by the script is expected to trigger another AK cert
+//     // request.
+//     let sh = agent.unix_shell();
+//     let output = cmd!(sh, "python3 tpm.py").read().await?;
 
-    // Check if there is no content yet
-    assert!(!output.contains("succeeded"));
+//     // Check if there is no content yet
+//     assert!(!output.contains("succeeded"));
 
-    // Run the script again to test if the AK cert triggered by nv read
-    // succeeds and the data is written into the nv index.
-    let sh = agent.unix_shell();
-    let output = cmd!(sh, "python3 tpm.py").read().await?;
+//     // Run the script again to test if the AK cert triggered by nv read
+//     // succeeds and the data is written into the nv index.
+//     let sh = agent.unix_shell();
+//     let output = cmd!(sh, "python3 tpm.py").read().await?;
 
-    // Check if the content is now available
-    assert!(output.contains("succeeded"));
+//     // Check if the content is now available
+//     assert!(output.contains("succeeded"));
 
-    agent.power_off().await?;
-    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
-    Ok(())
-}
+//     agent.power_off().await?;
+//     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+//     Ok(())
+// }
 
 /// Basic VBS boot test with TPM enabled.
 #[openvmm_test(


### PR DESCRIPTION
Mitigate TPM corruption due to previous VMs having a 16K TPM NVRAM reported as 32K, and commited bad state to the vTPM NVRAM.

This involves the following:

For every 16K TPM NVRAM, walk the dynamic section and truncate the last header if it points to data past the end.

Additionally, run the following mitigation steps for 16K NVRAM:
1. Check for a 4K bytes AK cert nv index. 1. This VM needs to be mitigated. 2. Undefine the 4K AK cert to save space. 3. Attempt to write a 1 byte mitigation platform marker, which can fail. 4. Attempt to write a just-sized platform ak cert.
2. Else, check for a mitigated marker or no platform cert 1. Log that this vm is mitigated, and if an ak cert is present or not
3. Else, check for an owner cert 1. Log that this VM is in the expected state

Related work items: #57958165