### PR TITLE
tpm: mitigate corruption due to corrupted TPM NVRAM blob

### DIFF
--- a/vm/devices/tpm/src/lib.rs
+++ b/vm/devices/tpm/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod ak_cert;
 pub mod logger;
+mod recover;
 pub mod resolver;
 mod tpm20proto;
 mod tpm_helper;
@@ -85,6 +86,7 @@ const TPM_GUEST_SECRET_HANDLE: ReservedHandle = ReservedHandle::new(TPM20_HT_PER
 
 // Reserved handles for Microsoft (Component OEM) ranges from 0x01c101c0 to 0x01c101ff
 const TPM_NV_INDEX_AIK_CERT: u32 = NV_INDEX_RANGE_BASE_TCG_ASSIGNED + 0x000101d0;
+const TPM_NV_INDEX_MITIGATED: u32 = NV_INDEX_RANGE_BASE_TCG_ASSIGNED + 0x000101d2;
 const TPM_NV_INDEX_ATTESTATION_REPORT: u32 = NV_INDEX_RANGE_BASE_PLATFORM_MANUFACTURER + 0x1;
 const TPM_NV_INDEX_GUEST_ATTESTATION_INPUT: u32 = NV_INDEX_RANGE_BASE_PLATFORM_MANUFACTURER + 0x2;
 
@@ -96,6 +98,9 @@ const ATTESTATION_REPORT_DATA_SIZE: usize = 0x40;
 const AK_CERT_RENEW_PERIOD: std::time::Duration = std::time::Duration::new(24 * 60 * 60, 0);
 // 2 seconds
 const REPORT_TIMER_PERIOD: std::time::Duration = std::time::Duration::new(2, 0);
+
+// 16kB: vtpmservice provisions a 16kB blob for the vTPM; HCL/OpenHCL provisions a 32k blob
+const LEGACY_VTPM_SIZE: usize = 16384;
 
 #[derive(Debug, Copy, Clone, Inspect)]
 #[repr(C)]
@@ -437,6 +442,7 @@ impl Tpm {
 
     async fn on_first_boot(&mut self, guest_secret_key: Option<Vec<u8>>) -> Result<(), TpmError> {
         use ms_tpm_20_ref::NvError;
+        let fixup_16k_ak_cert;
 
         // Check whether or not we need to pave-over the blank TPM with our
         // existing nvmem state.
@@ -446,7 +452,13 @@ impl Tpm {
                 .await
                 .map_err(TpmErrorKind::ReadNvramState)?;
 
-            if let Some(blob) = existing_nvmem_blob {
+            if let Some(mut blob) = existing_nvmem_blob {
+                // Previous versions before this code had a bug where sizes
+                // smaller than 32K would be reported as 32K. Fixup the blob so
+                // that the TPM nvram is consistent - this code can be removed
+                // once the fix for reporting the NVRAM size correctly is
+                // everywhere.
+                recover::recover_blob(&mut blob);
                 if let Err(e) = self.tpm_engine_helper.tpm_engine.reset(Some(&blob)) {
                     if let ms_tpm_20_ref::Error::NvMem(NvError::MismatchedBlobSize) = e {
                         self.logger
@@ -456,6 +468,12 @@ impl Tpm {
 
                     return Err(TpmErrorKind::ResetTpmWithState(e).into());
                 }
+
+                // If this is a small vTPM blob, potentially fixup the AK cert.
+                fixup_16k_ak_cert = blob.len() == LEGACY_VTPM_SIZE;
+            } else {
+                // No fixup is required, because there is no existing NVRAM blob.
+                fixup_16k_ak_cert = false;
             }
         }
 
@@ -541,11 +559,16 @@ impl Tpm {
                     auth_value,
                     !self.refresh_tpm_seeds, // Preserve AK cert if TPM seeds are not refreshed
                     matches!(self.ak_cert_type, TpmAkCertType::HwAttested(_)),
+                    fixup_16k_ak_cert,
                 )
                 .map_err(TpmErrorKind::AllocateGuestAttestationNvIndices)?;
 
             // Initialize `TPM_NV_INDEX_AIK_CERT` and `TPM_NV_INDEX_ATTESTATION_REPORT`
-            self.renew_ak_cert()?;
+            //
+            // Only renew AK cert if hardware isolated.
+            if matches!(self.ak_cert_type, TpmAkCertType::HwAttested(_)) {
+                self.renew_ak_cert()?;
+            }
         }
 
         // If guest secret key is passed in, import the key into TPM.
@@ -1204,10 +1227,7 @@ impl MmioIntercept for Tpm {
                         "executing guest tpm cmd",
                     );
 
-                    if matches!(
-                        self.ak_cert_type,
-                        TpmAkCertType::Trusted(_) | TpmAkCertType::HwAttested(_)
-                    ) {
+                    if matches!(self.ak_cert_type, TpmAkCertType::HwAttested(_)) {
                         if let Some(CommandCodeEnum::NV_Read) = cmd_header {
                             self.refresh_device_attestation_data_on_nv_read()
                         }

--- a/vm/devices/tpm/src/recover.rs
+++ b/vm/devices/tpm/src/recover.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Code to recover a corrupt TPM NVRAM blob due to truncation.
+
+use crate::LEGACY_VTPM_SIZE;
+
+/// Check if the TPM blob's persistent data structures all fit inside it.
+///
+/// This can return false if the blob was incorrectly truncated (by a previous
+/// bug that reported a 32KB blob size for a 16KB blob).
+fn check_blob(blob: &[u8]) -> Result<(), usize> {
+    const NV_USER_DYNAMIC: usize = 3508; // from the TPM reference implementation
+    let mut i = NV_USER_DYNAMIC;
+    loop {
+        let size = u32::from_ne_bytes(blob[i..].get(..4).ok_or(i)?.try_into().unwrap());
+        if size == 0 {
+            break;
+        }
+        if blob[i..].get(..size as usize).is_none() {
+            return Err(i);
+        }
+        i += size as usize;
+    }
+    Ok(())
+}
+
+/// Fixup an NVRAM blob that has data past the end, by zeroing out the last
+/// header that refers to data past the end.
+pub fn recover_blob(blob: &mut [u8]) {
+    let original_size = blob.len();
+    if original_size != LEGACY_VTPM_SIZE {
+        tracing::debug!("TPM NVRAM size is not legacy size, skipping recovery");
+        return;
+    }
+
+    match check_blob(blob) {
+        Ok(()) => {
+            tracing::info!("TPM NVRAM is already good, skipping recovery");
+        }
+        Err(bad_offset) => {
+            tracing::warn!("TPM NVRAM blob is corrupt, truncating at offset {bad_offset}");
+            blob[bad_offset..].fill(0);
+        }
+    }
+}

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -39,6 +39,7 @@ use crate::TPM_AZURE_AIK_HANDLE;
 use crate::TPM_GUEST_SECRET_HANDLE;
 use crate::TPM_NV_INDEX_AIK_CERT;
 use crate::TPM_NV_INDEX_ATTESTATION_REPORT;
+use crate::TPM_NV_INDEX_MITIGATED;
 use crate::TPM_RSA_SRK_HANDLE;
 use inspect::InspectMut;
 use ms_tpm_20_ref::MsTpm20RefPlatform;
@@ -169,6 +170,12 @@ pub enum NvIndexState {
     Unallocated,
     /// The NV index existed but uninitialized
     Uninitialized,
+}
+
+enum AkCertType {
+    None,
+    PlatformOwned(Vec<u8>),
+    OwnerOwned,
 }
 
 impl TpmEngineHelper {
@@ -447,55 +454,34 @@ impl TpmEngineHelper {
         Ok(())
     }
 
-    /// Allocate NV indices under platform hierarchy that are necessary for guest
-    /// attestation.
+    /// Read the existing AK cert and clear the nv index if:
+    ///  - the nv index is present, and is platform owned
+    ///  - the nv index is present, but has no data
     ///
-    /// # Arguments
-    /// * `auth_value`: The password used during the NV indices allocation.
-    /// * `preserve_ak_cert`: Whether to preserve the previous AK cert into newly-create NV index.
-    /// * `support_attestation_report`: Whether to allocate NV index for attestation report.
-    ///
-    pub fn allocate_guest_attestation_nv_indices(
-        &mut self,
-        auth_value: u64,
-        preserve_ak_cert: bool,
-        support_attestation_report: bool,
-    ) -> Result<(), TpmHelperError> {
-        let (define_index, previous_ak_cert) = {
-            let mut output = [0u8; MAX_NV_INDEX_SIZE as usize];
+    /// Owner owned nv index is left as-is.
+    fn take_existing_ak_cert(&mut self) -> Result<AkCertType, TpmHelperError> {
+        let mut output = vec![0; MAX_NV_INDEX_SIZE as usize];
 
-            // If the existing TPM_NV_INDEX_AIK_CERT is platform-defined, delete and recreate it.
-            // Doing so ensures that the NV index is created with the newly-created auth_value (which
-            // does not persist across boots) and consistent index size.
-            //
-            // If the existing TPM_NV_INDEX_AIK_CERT is not platform-defined, the vTPM blob may not
-            // have enough space to recreate the index with a larger size. In that case, don't
-            // change anything.
-            match self.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output)? {
-                NvIndexState::Available => {
-                    tracing::info!("AK cert nv index with available data");
+        // Read the AK cert from the index. If the index is not owner owned, the
+        // index will be removed.
+        match self.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output)? {
+            NvIndexState::Available => {
+                let res = self
+                    .find_nv_index(TPM_NV_INDEX_AIK_CERT)?
+                    .expect("nv index exists");
+                let nv_bits = TpmaNvBits::from(res.nv_public.nv_public.attributes.0.get());
+                let size = res.nv_public.nv_public.data_size.get();
 
-                    let res = self.find_nv_index(TPM_NV_INDEX_AIK_CERT)?.unwrap();
-                    let nv_bits = TpmaNvBits::from(res.nv_public.nv_public.attributes.0.get());
+                // Resize the output vector to match exactly what the nv index
+                // size is.
+                assert!(size <= MAX_NV_INDEX_SIZE);
+                output.resize(size as usize, 0);
 
-                    if nv_bits.nv_platformcreate() {
-                        self.nv_undefine_space(TPM20_RH_PLATFORM, TPM_NV_INDEX_AIK_CERT)
-                            .map_err(|error| TpmHelperError::TpmCommandError {
-                                command_debug_info: CommandDebugInfo {
-                                    command_code: CommandCodeEnum::NV_UndefineSpace,
-                                    auth_handle: Some(TPM20_RH_PLATFORM),
-                                    nv_index: Some(TPM_NV_INDEX_AIK_CERT),
-                                },
-                                error,
-                            })?;
-                        (true, Some(output))
-                    } else {
-                        (false, Some(output))
-                    }
-                }
-                NvIndexState::Uninitialized => {
-                    tracing::info!("AK cert nv index allocated but uninitialized");
+                let platform_cert = nv_bits.nv_platformcreate();
+                tracing::info!(platform_cert, "AK cert nv index with available data");
 
+                if nv_bits.nv_platformcreate() {
+                    tracing::info!("clearing platform owned AK cert");
                     self.nv_undefine_space(TPM20_RH_PLATFORM, TPM_NV_INDEX_AIK_CERT)
                         .map_err(|error| TpmHelperError::TpmCommandError {
                             command_debug_info: CommandDebugInfo {
@@ -506,45 +492,180 @@ impl TpmEngineHelper {
                             error,
                         })?;
 
-                    (true, None)
-                }
-                NvIndexState::Unallocated => {
-                    tracing::info!("AK cert nv index not allocated yet");
-                    (true, None)
+                    Ok(AkCertType::PlatformOwned(output))
+                } else {
+                    tracing::info!("Existing AK cert is owner-defined");
+                    Ok(AkCertType::OwnerOwned)
                 }
             }
-        };
+            NvIndexState::Uninitialized => {
+                tracing::info!("AK cert nv index allocated but uninitialized");
 
-        if define_index {
-            tracing::info!(
-                nv_index = format!("{:x}", TPM_NV_INDEX_AIK_CERT),
-                size = MAX_NV_INDEX_SIZE,
-                "Allocate nv index for AK cert"
-            );
+                self.nv_undefine_space(TPM20_RH_PLATFORM, TPM_NV_INDEX_AIK_CERT)
+                    .map_err(|error| TpmHelperError::TpmCommandError {
+                        command_debug_info: CommandDebugInfo {
+                            command_code: CommandCodeEnum::NV_UndefineSpace,
+                            auth_handle: Some(TPM20_RH_PLATFORM),
+                            nv_index: Some(TPM_NV_INDEX_AIK_CERT),
+                        },
+                        error,
+                    })?;
 
-            self.nv_define_space(
-                TPM20_RH_PLATFORM,
-                auth_value,
-                TPM_NV_INDEX_AIK_CERT,
-                MAX_NV_INDEX_SIZE,
-            )
-            .map_err(|error| TpmHelperError::TpmCommandError {
-                command_debug_info: CommandDebugInfo {
-                    command_code: CommandCodeEnum::NV_DefineSpace,
-                    auth_handle: Some(TPM20_RH_PLATFORM),
-                    nv_index: Some(TPM_NV_INDEX_AIK_CERT),
-                },
-                error,
-            })?;
+                Ok(AkCertType::None)
+            }
+            NvIndexState::Unallocated => {
+                tracing::info!("AK cert nv index not allocated yet");
+                Ok(AkCertType::None)
+            }
+        }
+    }
 
-            if preserve_ak_cert {
-                if let Some(data) = previous_ak_cert {
-                    // For resiliency, write the previous AK cert to the newly created nv index
-                    // in case the following boot-time AK cert request fails.
-                    tracing::info!("Preserve previous AK cert across boot");
+    /// Allocate NV indices under platform hierarchy that are necessary for guest
+    /// attestation.
+    ///
+    /// # Arguments
+    /// * `auth_value`: The password used during the NV indices allocation.
+    /// * `preserve_ak_cert`: Whether to preserve the previous AK cert into newly-create NV index.
+    /// * `support_attestation_report`: Whether to allocate NV index for attestation report.
+    /// * `mitigate_legacy_akcert`: If this VM should be attempted to be mitigated.
+    ///
+    pub fn allocate_guest_attestation_nv_indices(
+        &mut self,
+        auth_value: u64,
+        preserve_ak_cert: bool,
+        support_attestation_report: bool,
+        mitigate_legacy_akcert: bool,
+    ) -> Result<(), TpmHelperError> {
+        if mitigate_legacy_akcert && self.has_mitigation_marker() {
+            // VM has a small-vTPM mitigation marker. Don't touch anything, but
+            // log whether the AK cert exists, as that previous write might have
+            // failed.
+            let mut output = [0u8; MAX_NV_INDEX_SIZE as usize];
+            let r = self.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut output);
+            tracing::warn!("VM has 16k vTPM mitigation marker; not resizing AKCert index");
+            match r {
+                Err(e) => tracing::error!(
+                    err = &e as &dyn std::error::Error,
+                    "error reading AKCert index with mitigation marker"
+                ),
+                Ok(NvIndexState::Available) => {
+                    let res = self
+                        .find_nv_index(TPM_NV_INDEX_AIK_CERT)?
+                        .expect("akcert nv index present");
+                    let nv_bits = TpmaNvBits::from(res.nv_public.nv_public.attributes.0.get());
+                    let size = res.nv_public.nv_public.data_size.get();
 
-                    self.write_to_nv_index(auth_value, TPM_NV_INDEX_AIK_CERT, &data)?;
+                    tracing::info!(?nv_bits, size, "AKCert index exists")
                 }
+                Ok(NvIndexState::Uninitialized) => {
+                    tracing::warn!("AKCert index uninitialized with mitigation marker")
+                }
+                Ok(NvIndexState::Unallocated) => {
+                    tracing::warn!("AKCert index unallocated with mitigation marker")
+                }
+            }
+
+            return Ok(());
+        } else {
+            tracing::info!(
+                "No small-vTPM mitigation marker; proceeding to resize AKCert index if needed"
+            );
+        }
+
+        let previous_ak_cert = self.take_existing_ak_cert()?;
+
+        match previous_ak_cert {
+            AkCertType::None => {
+                let size = MAX_NV_INDEX_SIZE;
+
+                tracing::info!(
+                    nv_index = format!("{:x}", TPM_NV_INDEX_AIK_CERT),
+                    size,
+                    "Allocate nv index for AK cert"
+                );
+
+                self.nv_define_space(TPM20_RH_PLATFORM, auth_value, TPM_NV_INDEX_AIK_CERT, size)
+                    .map_err(|error| TpmHelperError::TpmCommandError {
+                        command_debug_info: CommandDebugInfo {
+                            command_code: CommandCodeEnum::NV_DefineSpace,
+                            auth_handle: Some(TPM20_RH_PLATFORM),
+                            nv_index: Some(TPM_NV_INDEX_AIK_CERT),
+                        },
+                        error,
+                    })?;
+            }
+            AkCertType::PlatformOwned(mut cert) => {
+                let will_mitigate_cert =
+                    mitigate_legacy_akcert && cert.len() == MAX_NV_INDEX_SIZE as usize;
+
+                if will_mitigate_cert {
+                    self.write_mitigation_marker(auth_value);
+                }
+
+                let size = if will_mitigate_cert {
+                    // To save space in the NVRAM, if the AKCert index contents
+                    // look like a DER-encoded X.509 certificate, use its actual
+                    // size (plus 4 bytes for the DER header).
+                    if let &[0x30, 0x82, len0, len1, ..] = cert.as_slice() {
+                        let len = u16::from_be_bytes([len0, len1]);
+                        let parsed_size = len.saturating_add(4).min(MAX_NV_INDEX_SIZE);
+                        tracing::warn!(parsed_size, "redefining AKCert index with limited size");
+                        assert!(parsed_size as usize <= cert.len());
+                        cert.resize(parsed_size as usize, 0);
+                        parsed_size
+                    } else {
+                        MAX_NV_INDEX_SIZE
+                    }
+                } else {
+                    MAX_NV_INDEX_SIZE
+                };
+
+                tracing::info!(
+                    nv_index = format!("{:x}", TPM_NV_INDEX_AIK_CERT),
+                    size,
+                    "allocate nv index for previous platform AK cert"
+                );
+
+                let result = self
+                    .nv_define_space(TPM20_RH_PLATFORM, auth_value, TPM_NV_INDEX_AIK_CERT, size)
+                    .map_err(|error| TpmHelperError::TpmCommandError {
+                        command_debug_info: CommandDebugInfo {
+                            command_code: CommandCodeEnum::NV_DefineSpace,
+                            auth_handle: Some(TPM20_RH_PLATFORM),
+                            nv_index: Some(TPM_NV_INDEX_AIK_CERT),
+                        },
+                        error,
+                    });
+
+                match result {
+                    Err(e) => {
+                        tracing::error!(
+                            error = &e as &dyn std::error::Error,
+                            "Failed to allocate AK cert nv index"
+                        );
+
+                        // Unless this VM was mitigated, bubble this error up to
+                        // the caller.
+                        if !will_mitigate_cert {
+                            return Err(e);
+                        }
+                    }
+                    Ok(_) => {
+                        tracing::info!("Successfully allocated AK cert nv index");
+
+                        if preserve_ak_cert {
+                            // For resiliency, write the previous AK cert to the
+                            // newly created nv index in case the following
+                            // boot-time AK cert request fails.
+                            tracing::info!("Preserve previous AK cert across boot");
+
+                            self.write_to_nv_index(auth_value, TPM_NV_INDEX_AIK_CERT, &cert)?;
+                        }
+                    }
+                }
+            }
+            AkCertType::OwnerOwned => {
+                // Owner owned AK certs are left as-is.
             }
         }
 
@@ -589,6 +710,25 @@ impl TpmEngineHelper {
         }
 
         Ok(())
+    }
+
+    fn has_mitigation_marker(&mut self) -> bool {
+        self.find_nv_index(TPM_NV_INDEX_MITIGATED)
+            .is_ok_and(|v| v.is_some())
+    }
+
+    fn write_mitigation_marker(&mut self, auth_value: u64) {
+        match self.nv_define_space(TPM20_RH_PLATFORM, auth_value, TPM_NV_INDEX_MITIGATED, 1) {
+            Ok(_) => {
+                tracing::warn!(TPM_NV_INDEX_MITIGATED, "wrote tpm mitigation marker");
+            }
+            Err(e) => {
+                tracing::error!(
+                    error = &e as &dyn std::error::Error,
+                    "failed to write mitigation marker"
+                );
+            }
+        }
     }
 
     /// Check if the nv index is present using NV_ReadPublic command.
@@ -1917,8 +2057,8 @@ mod tests {
 
             restart_tpm_engine(&mut tpm_engine_helper, true, true);
 
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
+            let result = tpm_engine_helper
+                .allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false, false);
             assert!(result.is_ok());
 
             // Ensure ak cert nv index becomes uninitialized
@@ -1953,8 +2093,8 @@ mod tests {
             );
             assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
 
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
+            let result = tpm_engine_helper
+                .allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false, false);
             assert!(result.is_ok());
 
             // Ensure only ak cert index remains present but uninitialized
@@ -2007,8 +2147,8 @@ mod tests {
             );
             assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
 
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
+            let result = tpm_engine_helper
+                .allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false, false);
             assert!(result.is_ok());
 
             // Ensure only ak cert index remains available
@@ -2072,8 +2212,8 @@ mod tests {
             );
             assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
 
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, false, false);
+            let result = tpm_engine_helper
+                .allocate_guest_attestation_nv_indices(AUTH_VALUE, false, false, false);
             assert!(result.is_ok());
 
             // Ensure read to fail given that the ak cert index is re-created and data is not preserved
@@ -2126,8 +2266,8 @@ mod tests {
             );
             assert!(matches!(result.unwrap(), NvIndexState::Unallocated));
 
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, false, true);
+            let result = tpm_engine_helper
+                .allocate_guest_attestation_nv_indices(AUTH_VALUE, false, true, false);
             assert!(result.is_ok());
 
             // Ensure read to fail given that the ak cert index is re-created and data is not preserved
@@ -2202,8 +2342,8 @@ mod tests {
             );
             assert!(matches!(result.unwrap(), NvIndexState::Available));
 
-            let result =
-                tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, false, true);
+            let result = tpm_engine_helper
+                .allocate_guest_attestation_nv_indices(AUTH_VALUE, false, true, false);
             assert!(result.is_ok());
 
             // Expect read to return Ok(false) given that the nv index is re-created and data is not preserved
@@ -2226,7 +2366,7 @@ mod tests {
         restart_tpm_engine(&mut tpm_engine_helper, false, true);
 
         let result =
-            tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, true);
+            tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, true, false);
         assert!(result.is_ok());
 
         let result = tpm_engine_helper.find_nv_index(TPM_NV_INDEX_AIK_CERT);
@@ -2458,7 +2598,7 @@ mod tests {
 
         // Ensure allocate_guest_attestation_nv_indices with preserve_ak_cert = true preserves the ak cert data
         let result =
-            tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false);
+            tpm_engine_helper.allocate_guest_attestation_nv_indices(AUTH_VALUE, true, false, false);
         assert!(result.is_ok());
 
         // Ensure nv index has the same size

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -39,57 +39,58 @@ async fn boot_alias_map(config: PetriVmConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Basic boot tests with TPM enabled.
-#[vmm_test(
-    openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
-    openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
-)]
-async fn boot_with_tpm(config: PetriVmConfig) -> anyhow::Result<()> {
-    let os_flavor = config.os_flavor();
-    let config = config.with_tpm().with_tpm_state_persistence();
-
-    let (vm, agent) = match os_flavor {
-        OsFlavor::Windows => {
-            // TODO: Add in-guest TPM tests for Windows as we currently
-            // do have an easy way to interact with TPM without a private
-            // or custom tool.
-            config.run().await?
-        }
-        OsFlavor::Linux => {
-            // First boot - AK cert request will be served by GED
-            let mut vm = config.run_with_lazy_pipette().await?;
-            // Workaround to https://github.com/microsoft/openvmm/issues/379
-            assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
-
-            // Second boot - Ak cert request will be bypassed by GED
-            vm.reset().await?;
-            let agent = vm.wait_for_agent().await?;
-            vm.wait_for_successful_boot_event().await?;
-
-            // Use the python script to read AK cert from TPM nv index
-            // and verify that the AK cert preserves across boot.
-            // TODO: Replace the script with tpm2-tools
-            const TEST_FILE: &str = "tpm.py";
-            const TEST_CONTENT: &str = include_str!("../../test_data/tpm.py");
-
-            agent.write_file(TEST_FILE, TEST_CONTENT.as_bytes()).await?;
-            assert_eq!(agent.read_file(TEST_FILE).await?, TEST_CONTENT.as_bytes());
-
-            let sh = agent.unix_shell();
-            let output = cmd!(sh, "python3 tpm.py").read().await?;
-
-            // Check if the content is as expected
-            assert!(output.contains("succeeded"));
-
-            (vm, agent)
-        }
-        _ => unreachable!(),
-    };
-
-    agent.power_off().await?;
-    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
-    Ok(())
-}
+// TODO: Test disabled because AK cert renewal with non-hardware isolation is
+// disabled.
+//
+// /// Basic boot tests with TPM enabled. #[vmm_test(
+// openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+//     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)) )] async fn
+//     boot_with_tpm(config: PetriVmConfig) -> anyhow::Result<()> { let
+// os_flavor = config.os_flavor(); let config =
+// config.with_tpm().with_tpm_state_persistence();
+//
+//     let (vm, agent) = match os_flavor {
+//         OsFlavor::Windows => {
+//             // TODO: Add in-guest TPM tests for Windows as we currently
+//             // do have an easy way to interact with TPM without a private
+//             // or custom tool.
+//             config.run().await?
+//         }
+//         OsFlavor::Linux => {
+//             // First boot - AK cert request will be served by GED
+//             let mut vm = config.run_with_lazy_pipette().await?;
+//             // Workaround to https://github.com/microsoft/openvmm/issues/379
+//             assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
+//
+//             // Second boot - Ak cert request will be bypassed by GED
+//             vm.reset().await?;
+//             let agent = vm.wait_for_agent().await?;
+//             vm.wait_for_successful_boot_event().await?;
+//
+//             // Use the python script to read AK cert from TPM nv index
+//             // and verify that the AK cert preserves across boot.
+//             // TODO: Replace the script with tpm2-tools
+//             const TEST_FILE: &str = "tpm.py";
+//             const TEST_CONTENT: &str = include_str!("../../test_data/tpm.py");
+//
+//             agent.write_file(TEST_FILE, TEST_CONTENT.as_bytes()).await?;
+//             assert_eq!(agent.read_file(TEST_FILE).await?, TEST_CONTENT.as_bytes());
+//
+//             let sh = agent.unix_shell();
+//             let output = cmd!(sh, "python3 tpm.py").read().await?;
+//
+//             // Check if the content is as expected
+//             assert!(output.contains("succeeded"));
+//
+//             (vm, agent)
+//         }
+//         _ => unreachable!(),
+//     };
+//
+//     agent.power_off().await?;
+//     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+//     Ok(())
+// }
 
 /// Basic VBS boot test.
 #[vmm_test(


### PR DESCRIPTION
Mitigate TPM corruption due to previous VMs having a 16K TPM NVRAM reported as 32K, and commited bad state to the vTPM NVRAM.

This involves the following:

For every 16K TPM NVRAM, walk the dynamic section and truncate the last header if it points to data past the end.

Additionally, run the following mitigation steps for 16K NVRAM:
1. Check for a 4K bytes AK cert nv index. 1. This VM needs to be mitigated. 2. Undefine the 4K AK cert to save space. 3. Attempt to write a 1 byte mitigation platform marker, which can fail. 4. Attempt to write a just-sized platform ak cert.
2. Else, check for a mitigated marker or no platform cert 1. Log that this vm is mitigated, and if an ak cert is present or not
3. Else, check for an owner cert 1. Log that this VM is in the expected state