### PR TITLE
flowey: rename the xtask build profile to 'light', use it for igvmfilegen

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@
 
 [alias]
 xflowey = "run -p flowey_hvlite -- pipeline run"
-xtask = "run -p xtask --profile xtask --"
+xtask = "run -p xtask --profile light --"
 
 [env]
 # Use the packaged openssl libraries on musl targets.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -557,9 +557,10 @@ lto = 'fat'
 [profile.dev]
 panic = 'abort'
 
-[profile.xtask]
+# Used for dev tooling that benefits from some CPU optimizations, but that still
+# wants debug checks
+[profile.light]
 inherits = 'dev'
-# xtask is CPU bound in places, so enable light optimizations
 opt-level = 1
 
 [profile.flowey-ci]

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -300,7 +300,7 @@ impl IntoPipeline for CheckinGatesCli {
                             arch,
                             platform: CommonPlatform::WindowsMsvc,
                         },
-                        profile: CommonProfile::from_release(release),
+                        profile: CommonProfile::from_release(release).into(),
                     },
                     igvmfilegen: ctx.publish_typed_artifact(pub_igvmfilegen),
                 })
@@ -486,7 +486,7 @@ impl IntoPipeline for CheckinGatesCli {
                             arch,
                             platform: CommonPlatform::LinuxGnu,
                         },
-                        profile: CommonProfile::from_release(release),
+                        profile: CommonProfile::from_release(release).into(),
                     },
                     igvmfilegen: ctx.publish_typed_artifact(pub_igvmfilegen),
                 })

--- a/flowey/flowey_lib_hvlite/src/build_igvmfilegen.rs
+++ b/flowey/flowey_lib_hvlite/src/build_igvmfilegen.rs
@@ -3,7 +3,7 @@
 
 //! Build `igvmfilegen` binaries
 
-use crate::run_cargo_build::common::CommonProfile;
+use crate::run_cargo_build::BuildProfile;
 use crate::run_cargo_build::common::CommonTriple;
 use flowey::node::prelude::*;
 use std::collections::BTreeMap;
@@ -30,7 +30,7 @@ impl Artifact for IgvmfilegenOutput {}
 #[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct IgvmfilegenBuildParams {
     pub target: CommonTriple,
-    pub profile: CommonProfile,
+    pub profile: BuildProfile,
 }
 
 flowey_request! {
@@ -67,7 +67,7 @@ impl FlowNode for Node {
                 crate_name: "igvmfilegen".into(),
                 out_name: "igvmfilegen".into(),
                 crate_type: flowey_lib_common::run_cargo_build::CargoCrateType::Bin,
-                profile: profile.into(),
+                profile,
                 features: Default::default(),
                 target: target.as_triple(),
                 no_split_dbg_info: false,

--- a/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
+++ b/flowey/flowey_lib_hvlite/src/build_openhcl_igvm_from_recipe.rs
@@ -16,9 +16,9 @@ use crate::download_openhcl_kernel_package::OpenhclKernelPackageArch;
 use crate::download_openhcl_kernel_package::OpenhclKernelPackageKind;
 use crate::download_openvmm_deps::OpenvmmDepsArch;
 use crate::download_uefi_mu_msvm::MuMsvmArch;
+use crate::run_cargo_build::BuildProfile;
 use crate::run_cargo_build::common::CommonArch;
 use crate::run_cargo_build::common::CommonPlatform;
-use crate::run_cargo_build::common::CommonProfile;
 use crate::run_cargo_build::common::CommonTriple;
 use flowey::node::prelude::*;
 use igvmfilegen_config::ResourceType;
@@ -464,17 +464,15 @@ impl SimpleFlowNode for Node {
             arch => anyhow::bail!("unsupported arch {arch}"),
         };
 
-        let igvmfilegen = ctx.reqv(|v| {
-            crate::build_igvmfilegen::Request {
-                build_params: crate::build_igvmfilegen::IgvmfilegenBuildParams {
-                    target: CommonTriple::Common {
-                        arch: igvmfilegen_arch,
-                        platform: CommonPlatform::LinuxGnu,
-                    },
-                    profile: CommonProfile::Release, // debug igvmfilegen is real slow
+        let igvmfilegen = ctx.reqv(|v| crate::build_igvmfilegen::Request {
+            build_params: crate::build_igvmfilegen::IgvmfilegenBuildParams {
+                target: CommonTriple::Common {
+                    arch: igvmfilegen_arch,
+                    platform: CommonPlatform::LinuxGnu,
                 },
-                igvmfilegen: v,
-            }
+                profile: BuildProfile::Light,
+            },
+            igvmfilegen: v,
         });
 
         // build openhcl_boot

--- a/flowey/flowey_lib_hvlite/src/build_xtask.rs
+++ b/flowey/flowey_lib_hvlite/src/build_xtask.rs
@@ -37,7 +37,7 @@ impl SimpleFlowNode for Node {
             crate_name: "xtask".into(),
             out_name: "xtask".into(),
             crate_type: CargoCrateType::Bin,
-            profile: BuildProfile::Xtask,
+            profile: BuildProfile::Light,
             features: [].into(),
             target: target.as_triple(),
             no_split_dbg_info: false,

--- a/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
+++ b/flowey/flowey_lib_hvlite/src/run_cargo_build.rs
@@ -270,7 +270,7 @@ pub enum BuildProfile {
     UnderhillShip,
     BootDev,
     BootRelease,
-    Xtask,
+    Light,
 }
 
 flowey_request! {
@@ -414,7 +414,7 @@ impl FlowNode for Node {
                     }
                     BuildProfile::BootDev => CargoBuildProfile::Custom("boot-dev".into()),
                     BuildProfile::BootRelease => CargoBuildProfile::Custom("boot-release".into()),
-                    BuildProfile::Xtask => CargoBuildProfile::Custom("xtask".into()),
+                    BuildProfile::Light => CargoBuildProfile::Custom("light".into()),
                 },
                 features,
                 output_kind: crate_type,


### PR DESCRIPTION
This makes sure we still get debug checks in igvmfilegen, but keeps it fast. Fixes #42.