### PR TITLE
hv1_emulator: Wire up VTL protections for hypercall and tsc pages (#1502)

### DIFF
--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -946,17 +946,13 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         // changed.
         guestmem::rcu().synchronize_blocking();
 
-        // Flush any threads accessing pages that had their VTL protections
-        // changed.
-        guestmem::rcu().synchronize_blocking();
-      
         // Since page protections were modified, we must invalidate the TLB to
         // ensure that the new permissions are observed, and wait for other CPUs
         // to release all guest mappings before declaring that the VTL
         // protection change has completed.
         tlb_access.flush(vtl);
         tlb_access.set_wait_for_tlb_locks(vtl);
-      
+
         Ok(())
     }
 

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -31,7 +31,6 @@ use hvdef::HV_PAGE_SIZE;
 use hvdef::HvError;
 use hvdef::HvMapGpaFlags;
 use hvdef::HypercallCode;
-use hvdef::Vtl;
 use hvdef::hypercall::AcceptMemoryType;
 use hvdef::hypercall::HostVisibilityType;
 use hvdef::hypercall::HvInputVtl;
@@ -39,7 +38,9 @@ use mapping::GuestMemoryMapping;
 use mapping::GuestValidMemory;
 use memory_range::MemoryRange;
 use parking_lot::Mutex;
+use parking_lot::MutexGuard;
 use registrar::RegisterMemory;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use thiserror::Error;
@@ -342,12 +343,6 @@ pub struct HardwareIsolatedMemoryProtector {
     // TODO GUEST VSM: synchronize vtl protection bitmaps
     vtl0: Arc<GuestMemoryMapping>,
     vtl1_protections_enabled: AtomicBool,
-    hypercall_overlay: VtlArray<Arc<Mutex<Option<HypercallOverlay>>>, 2>,
-}
-
-struct HypercallOverlay {
-    gpn: u64,
-    permissions: HvMapGpaFlags,
 }
 
 struct HardwareIsolatedMemoryProtectorInner {
@@ -355,6 +350,12 @@ struct HardwareIsolatedMemoryProtectorInner {
     valid_shared: Arc<GuestValidMemory>,
     encrypted: Arc<GuestMemoryMapping>,
     default_vtl_permissions: DefaultVtlPermissions,
+    overlay_pages: VtlArray<Vec<OverlayPage>, 2>,
+}
+
+struct OverlayPage {
+    gpn: u64,
+    previous_permissions: HvMapGpaFlags,
 }
 
 impl HardwareIsolatedMemoryProtector {
@@ -381,55 +382,51 @@ impl HardwareIsolatedMemoryProtector {
                     vtl0: HV_MAP_GPA_PERMISSIONS_ALL,
                     vtl1: None,
                 },
+                overlay_pages: VtlArray::from_fn(|_| Vec::new()),
             }),
             layout,
             acceptor,
             vtl0,
             vtl1_protections_enabled: AtomicBool::new(false),
-            hypercall_overlay: VtlArray::from_fn(|_| Arc::new(Mutex::new(None))),
         }
     }
 
     fn apply_protections_with_overlay_handling(
         &self,
+        range: MemoryRange,
         vtl: GuestVtl,
-        ranges: &[MemoryRange],
         protections: HvMapGpaFlags,
+        inner: &mut MutexGuard<'_, HardwareIsolatedMemoryProtectorInner>,
     ) -> Result<(), ApplyVtlProtectionsError> {
-        // The overlay page cannot change over the course of this operation
-        let mut overlay_lock = self.hypercall_overlay[vtl].lock();
-        for range in ranges {
-            match overlay_lock.as_mut() {
-                Some(overlay) if range.contains_addr(overlay.gpn * HV_PAGE_SIZE) => {
-                    overlay.permissions = protections;
+        let mut range_queue = VecDeque::new();
+        range_queue.push_back(range);
 
-                    let overlay_address = overlay.gpn * HV_PAGE_SIZE;
-                    let overlay_offset = range.offset_of(overlay_address).unwrap();
-                    let (left, right) = range.split_at_offset(overlay_offset);
-
-                    self.apply_protections(left, vtl, protections)?;
-                    let sub_range = MemoryRange::new((overlay.gpn + 1) * HV_PAGE_SIZE..right.end());
-                    if !sub_range.is_empty() {
-                        self.apply_protections(sub_range, vtl, protections)?;
+        'outer: while let Some(range) = range_queue.pop_front() {
+            for overlay_page in inner.overlay_pages[vtl].iter_mut() {
+                let overlay_addr = overlay_page.gpn * HV_PAGE_SIZE;
+                if range.contains_addr(overlay_addr) {
+                    // If the overlay page is within the range, update the
+                    // permissions that will be restored when it is unlocked.
+                    overlay_page.previous_permissions = protections;
+                    // And split the range around it.
+                    let (left, right_with_overlay) =
+                        range.split_at_offset(range.offset_of(overlay_addr).unwrap());
+                    let (overlay, right) = right_with_overlay.split_at_offset(HV_PAGE_SIZE);
+                    debug_assert_eq!(overlay.start_4k_gpn(), overlay_page.gpn);
+                    debug_assert_eq!(overlay.len(), HV_PAGE_SIZE);
+                    if !left.is_empty() {
+                        range_queue.push_back(left);
                     }
-                }
-                _ => {
-                    self.apply_protections(*range, vtl, protections)?;
+                    if !right.is_empty() {
+                        range_queue.push_back(right);
+                    }
+                    continue 'outer;
                 }
             }
+            // We can only reach here if the range does not contain any overlay
+            // pages, so now we can apply the protections to the range.
+            self.apply_protections(range, vtl, protections)?
         }
-        Ok(())
-    }
-
-    /// Restore the original protections on the page that is overlaid.
-    fn restore_overlay_permissions(
-        &self,
-        vtl: GuestVtl,
-        overlay: &HypercallOverlay,
-    ) -> Result<(), ApplyVtlProtectionsError> {
-        let range = MemoryRange::new(overlay.gpn * HV_PAGE_SIZE..(overlay.gpn + 1) * HV_PAGE_SIZE);
-
-        self.apply_protections(range, vtl, overlay.permissions)?;
 
         Ok(())
     }
@@ -447,6 +444,35 @@ impl HardwareIsolatedMemoryProtector {
         }
         self.acceptor.apply_protections(range, vtl, protections)
     }
+
+    /// Get the permissions that the given VTL has to the given GPN.
+    ///
+    /// This function does not check for any protections applied by VTL 2,
+    /// only those applied by lower VTLs.
+    fn query_lower_vtl_permissions(
+        &self,
+        vtl: GuestVtl,
+        gpn: u64,
+    ) -> Result<HvMapGpaFlags, HvError> {
+        if !self
+            .layout
+            .ram()
+            .iter()
+            .any(|r| r.range.contains_addr(gpn * HV_PAGE_SIZE))
+        {
+            return Err(HvError::OperationDenied);
+        }
+
+        let res = match vtl {
+            GuestVtl::Vtl0 => self
+                .vtl0
+                .query_access_permission(gpn)
+                .unwrap_or(HV_MAP_GPA_PERMISSIONS_ALL),
+            GuestVtl::Vtl1 => HV_MAP_GPA_PERMISSIONS_ALL,
+        };
+
+        Ok(res)
+    }
 }
 
 impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
@@ -457,8 +483,10 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         gpns: &[u64],
         tlb_access: &mut dyn TlbFlushLockAccess,
     ) -> Result<(), (HvError, usize)> {
-        // Validate the ranges are RAM.
+        let inner = self.inner.lock();
+
         for &gpn in gpns {
+            // Validate the ranges are RAM.
             if !self
                 .layout
                 .ram()
@@ -468,20 +496,13 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
                 return Err((HvError::OperationDenied, 0));
             }
 
-            // Don't allow the hypercall overlay to have shared visibility.
-            if shared {
-                for vtl in [Vtl::Vtl1, Vtl::Vtl0] {
-                    let overlay = self.hypercall_overlay[vtl].lock();
-                    if let Some(overlay) = &*overlay {
-                        if overlay.gpn == gpn {
-                            return Err((HvError::OperationDenied, 0));
-                        }
-                    }
-                }
+            // TODO: Don't allow changing visibility of locked pages.
+
+            // Don't allow overlay pages to be shared.
+            if shared && inner.overlay_pages[vtl].iter().any(|p| p.gpn == gpn) {
+                return Err((HvError::OperationDenied, 0));
             }
         }
-
-        let inner = self.inner.lock();
 
         // Filter out the GPNs that are already in the correct state. If the
         // page is becoming shared, make sure the requesting VTL has read/write
@@ -669,10 +690,9 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         }
 
         if !shared {
-            // Apply vtl protections so that the guest can use them. The
-            // hypercall overlay should not be host visible, so just apply
-            // the default protections directly without handling of the
-            // hypercall overlay.
+            // Apply vtl protections so that the guest can use them. Any
+            // overlay pages won't be host visible, so just apply the default
+            // protections directly without handling them.
             for &range in &ranges {
                 self.apply_protections(range, GuestVtl::Vtl0, inner.default_vtl_permissions.vtl0)
                     .expect("should be able to apply default protections");
@@ -774,8 +794,10 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             }
         }
 
-        self.apply_protections_with_overlay_handling(vtl, &ranges, vtl_protections)
-            .expect("applying vtl protections should succeed");
+        for range in ranges {
+            self.apply_protections_with_overlay_handling(range, vtl, vtl_protections, &mut inner)
+                .unwrap();
+        }
 
         // Invalidate the entire VTL 0 TLB to ensure that the new permissions
         // are observed.
@@ -801,13 +823,15 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             {
                 return Err((HvError::OperationDenied, 0));
             }
+
+            // TODO: Don't allow changing protections of locked pages.
         }
 
         // Prevent visibility changes while VTL protections are being
         // applied. This does not need to be synchronized against other
         // threads performing VTL protection changes; whichever thread
         // finishes last will control the outcome.
-        let inner = self.inner.lock();
+        let mut inner = self.inner.lock();
 
         // Protections cannot be applied to a host-visible page
         if gpns.iter().any(|&gpn| inner.valid_shared.check_valid(gpn)) {
@@ -821,8 +845,10 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             .collect::<Result<Vec<_>, _>>()
             .unwrap(); // Ok to unwrap, we've validated the gpns above.
 
-        self.apply_protections_with_overlay_handling(vtl, &ranges, protections)
-            .expect("applying vtl protections should succeed");
+        for range in ranges {
+            self.apply_protections_with_overlay_handling(range, vtl, protections, &mut inner)
+                .unwrap();
+        }
 
         // Since page protections were modified, we must invalidate the entire
         // VTL 0 TLB to ensure that the new permissions are observed, and wait for
@@ -834,77 +860,97 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         Ok(())
     }
 
-    fn change_hypercall_overlay(
+    fn register_overlay_page(
+        &self,
+        vtl: GuestVtl,
+        gpn: u64,
+        check_perms: HvMapGpaFlags,
+        new_perms: Option<HvMapGpaFlags>,
+        tlb_access: &mut dyn TlbFlushLockAccess,
+    ) -> Result<(), HvError> {
+        let mut inner = self.inner.lock();
+
+        // Check that this isn't already registered.
+        if inner.overlay_pages[vtl].iter().any(|p| p.gpn == gpn) {
+            return Err(HvError::OperationDenied);
+        }
+
+        // Check that the required permissions are present.
+        let current_perms = self.query_lower_vtl_permissions(vtl, gpn)?;
+        if current_perms.into_bits() | check_perms.into_bits() != current_perms.into_bits() {
+            return Err(HvError::OperationDenied);
+        }
+
+        // Protections cannot be applied to a host-visible page.
+        if inner.valid_shared.check_valid(gpn) {
+            return Err(HvError::OperationDenied);
+        }
+
+        // TODO: Don't allow changing protections of locked pages.
+
+        // Everything's validated, change the permissions.
+        if let Some(new_perms) = new_perms {
+            self.apply_protections(MemoryRange::from_4k_gpn_range(gpn..gpn + 1), vtl, new_perms)
+                .map_err(|_| HvError::OperationDenied)?;
+        }
+
+        // Nothing from this point on can fail, so we can safely register the overlay page.
+        inner.overlay_pages[vtl].push(OverlayPage {
+            gpn,
+            previous_permissions: current_perms,
+        });
+
+        // Flush any threads accessing pages that had their VTL protections
+        // changed.
+        guestmem::rcu().synchronize_blocking();
+
+        // Since page protections were modified, we must invalidate the TLB to
+        // ensure that the new permissions are observed, and wait for other CPUs
+        // to release all guest mappings before declaring that the VTL
+        // protection change has completed.
+        tlb_access.flush(vtl);
+        tlb_access.set_wait_for_tlb_locks(vtl);
+
+        Ok(())
+    }
+
+    fn unregister_overlay_page(
         &self,
         vtl: GuestVtl,
         gpn: u64,
         tlb_access: &mut dyn TlbFlushLockAccess,
-    ) {
-        // Should already have written contents to the page via the guest
-        // memory object, confirming that this is a guest page
-        assert!(
-            self.layout
-                .ram()
-                .iter()
-                .any(|r| r.range.contains_addr(gpn * HV_PAGE_SIZE))
-        );
+    ) -> Result<(), HvError> {
+        let mut inner = self.inner.lock();
+        let overlay_pages = &mut inner.overlay_pages[vtl];
 
-        // Ensure no host visibility changes while changing protections on the
-        // overlay page.
-        let _lock = self.inner.lock();
+        // Find the overlay page.
+        let index = overlay_pages
+            .iter()
+            .position(|p| p.gpn == gpn)
+            .ok_or(HvError::OperationDenied)?;
 
-        let mut overlay = self.hypercall_overlay[vtl].lock();
-
-        // Restore permissions on the previous overlay
-        if let Some(overlay) = overlay.as_ref() {
-            self.restore_overlay_permissions(vtl, overlay)
-                .expect("applying vtl protections should succeed");
-        }
-
-        let current_permissions = match self.acceptor.isolation {
-            IsolationType::None | IsolationType::Vbs => unreachable!(),
-            IsolationType::Snp | IsolationType::Tdx => {
-                if vtl == GuestVtl::Vtl0 {
-                    self.vtl0
-                        .query_access_permission(gpn)
-                        .unwrap_or(HV_MAP_GPA_PERMISSIONS_ALL)
-                } else {
-                    // The permissions should be the same as when VTL 2
-                    // initialized guest memory.
-                    HV_MAP_GPA_PERMISSIONS_ALL
-                }
-            }
-        };
-
-        *overlay = Some(HypercallOverlay {
-            gpn,
-            permissions: current_permissions,
-        });
-
+        // Restore its permissions.
         self.apply_protections(
-            MemoryRange::new(gpn * HV_PAGE_SIZE..(gpn + 1) * HV_PAGE_SIZE),
+            MemoryRange::from_4k_gpn_range(gpn..gpn + 1),
             vtl,
-            HV_MAP_GPA_PERMISSIONS_ALL.with_writable(false),
+            overlay_pages[index].previous_permissions,
         )
-        .expect("applying vtl protections should succeed");
+        .map_err(|_| HvError::OperationDenied)?;
 
-        // Flush the guest TLB to ensure that the new permissions are observed.
+        // Nothing from this point on can fail, so we can safely unregister the overlay page.
+        overlay_pages.remove(index);
+
+        // Flush any threads accessing pages that had their VTL protections
+        // changed.
+        guestmem::rcu().synchronize_blocking();
+
+        // Since page protections were modified, we must invalidate the TLB to
+        // ensure that the new permissions are observed, and wait for other CPUs
+        // to release all guest mappings before declaring that the VTL
+        // protection change has completed.
         tlb_access.flush(vtl);
-    }
-
-    fn disable_hypercall_overlay(&self, vtl: GuestVtl, tlb_access: &mut dyn TlbFlushLockAccess) {
-        let _lock = self.inner.lock();
-
-        let mut overlay = self.hypercall_overlay[vtl].lock();
-
-        if let Some(overlay) = overlay.as_ref() {
-            self.restore_overlay_permissions(vtl, overlay)
-                .expect("applying vtl protections should succeed");
-        }
-
-        *overlay = None;
-
-        tlb_access.flush(vtl);
+        tlb_access.set_wait_for_tlb_locks(vtl);
+        Ok(())
     }
 
     fn set_vtl1_protections_enabled(&self) {

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1414,16 +1414,25 @@ pub trait ProtectIsolatedMemory: Send + Sync {
         tlb_access: &mut dyn TlbFlushLockAccess,
     ) -> Result<(), (HvError, usize)>;
 
-    /// Changes the overlay for the hypercall code page for a target VTL.
-    fn change_hypercall_overlay(
+    /// Registers a page as an overlay page by first validating it has the
+    /// required permissions, optionally modifying them, then locking them.
+    fn register_overlay_page(
+        &self,
+        vtl: GuestVtl,
+        gpn: u64,
+        check_perms: HvMapGpaFlags,
+        new_perms: Option<HvMapGpaFlags>,
+        tlb_access: &mut dyn TlbFlushLockAccess,
+    ) -> Result<(), HvError>;
+
+    /// Unregisters an overlay page, removing its permission lock and restoring
+    /// the previous permissions.
+    fn unregister_overlay_page(
         &self,
         vtl: GuestVtl,
         gpn: u64,
         tlb_access: &mut dyn TlbFlushLockAccess,
-    );
-
-    /// Disables the overlay for the hypercall code page for a target VTL.
-    fn disable_hypercall_overlay(&self, vtl: GuestVtl, tlb_access: &mut dyn TlbFlushLockAccess);
+    ) -> Result<(), HvError>;
 
     /// Alerts the memory protector that vtl 1 is ready to set vtl protections
     /// on lower-vtl memory, and that these protections should be enforced.
@@ -1731,7 +1740,6 @@ impl<'a> UhProtoPartition<'a> {
                 &params,
                 late_params.cvm_params.unwrap(),
                 &caps,
-                late_params.gm.clone(),
                 guest_vsm_available,
             )?)
         } else {
@@ -1745,7 +1753,6 @@ impl<'a> UhProtoPartition<'a> {
             &params,
             BackingSharedParams {
                 cvm_state,
-                guest_memory: late_params.gm.clone(),
                 #[cfg(guest_arch = "x86_64")]
                 cpuid: &cpuid,
                 hcl: &hcl,
@@ -1890,7 +1897,6 @@ impl UhProtoPartition<'_> {
         params: &UhPartitionNewParams<'_>,
         late_params: CvmLateParams,
         caps: &PartitionCapabilities,
-        guest_memory: VtlArray<GuestMemory, 2>,
         guest_vsm_available: bool,
     ) -> Result<UhCvmPartitionState, Error> {
         use vmcore::reference_time::ReferenceTimeSource;
@@ -1929,7 +1935,6 @@ impl UhProtoPartition<'_> {
             tsc_frequency,
             ref_time,
             is_ref_time_backed_by_tsc: true,
-            guest_memory,
         });
 
         Ok(UhCvmPartitionState {

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -42,7 +42,6 @@ use crate::GuestVtl;
 use crate::WakeReason;
 use cvm_tracing::CVM_ALLOWED;
 use cvm_tracing::CVM_CONFIDENTIAL;
-use guestmem::GuestMemory;
 use hcl::ioctl::Hcl;
 use hcl::ioctl::ProcessorRunner;
 use hv1_emulator::message_queues::MessageQueues;
@@ -277,7 +276,6 @@ impl<T: BackingPrivate> Backing for T {}
 #[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
 pub(crate) struct BackingSharedParams<'a> {
     pub cvm_state: Option<crate::UhCvmPartitionState>,
-    pub guest_memory: VtlArray<GuestMemory, 2>,
     #[cfg(guest_arch = "x86_64")]
     pub cpuid: &'a virt::CpuidLeafSet,
     pub hcl: &'a Hcl,

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -23,9 +23,9 @@ use crate::UhPartitionInner;
 use crate::UhPartitionNewParams;
 use crate::UhProcessor;
 use crate::WakeReason;
-use crate::processor::hardware_cvm::CvmVtlProtectAccess;
 use cvm_tracing::CVM_ALLOWED;
 use cvm_tracing::CVM_CONFIDENTIAL;
+use guestmem::GuestMemory;
 use hcl::ioctl::ProcessorRunner;
 use hcl::ioctl::tdx::Tdx;
 use hcl::ioctl::tdx::TdxPrivateRegs;
@@ -798,6 +798,29 @@ impl TdxBacked {
     }
 }
 
+// The memory used to back the untrusted synic is not guest-visible, but rather
+// is allocated from our shared pool. Therefore it does not need to go through
+// the normal memory protections path.
+struct UntrustedSynicVtlProts<'a>(&'a GuestMemory);
+
+impl hv1_emulator::VtlProtectAccess for UntrustedSynicVtlProts<'_> {
+    fn check_modify_and_lock_overlay_page(
+        &mut self,
+        gpn: u64,
+        _check_perms: hvdef::HvMapGpaFlags,
+        _new_perms: Option<hvdef::HvMapGpaFlags>,
+    ) -> Result<guestmem::LockedPages, HvError> {
+        self.0
+            .lock_gpns(false, &[gpn])
+            .map_err(|_| HvError::OperationFailed)
+    }
+
+    fn unlock_overlay_page(&mut self, _gpn: u64) -> Result<(), HvError> {
+        // TODO: call unlock once its added
+        Ok(())
+    }
+}
+
 #[expect(private_interfaces)]
 impl BackingPrivate for TdxBacked {
     type HclBacking<'tdx> = Tdx<'tdx>;
@@ -1015,18 +1038,8 @@ impl BackingPrivate for TdxBacked {
             ),
         ];
 
-        let this_index = this.vp_index();
         let reg_count = if let Some(synic) = &mut this.backing.untrusted_synic {
-            let prot_access = &mut CvmVtlProtectAccess {
-                vtl: GuestVtl::Vtl0,
-                protector: this.shared.cvm.isolated_memory_protector.as_ref(),
-                tlb_access: &mut TdxBacked::tlb_flush_lock_access(
-                    this_index,
-                    this.partition,
-                    this.shared,
-                ),
-                guest_memory: &this.partition.gm[GuestVtl::Vtl0],
-            };
+            let prot_access = &mut UntrustedSynicVtlProts(&this.partition.gm[GuestVtl::Vtl0]);
 
             synic
                 .set_simp(reg(pfns[UhDirectOverlay::Sipp as usize]), prot_access)
@@ -2659,7 +2672,6 @@ impl UhProcessor<'_, TdxBacked> {
                 // If we get here we must have an untrusted synic, as otherwise
                 // we wouldn't be handling the TDVMCALL that ends up here. Therefore
                 // this is fine to unwrap.
-                let self_index = self.vp_index();
                 self.backing
                     .untrusted_synic
                     .as_mut()
@@ -2667,16 +2679,7 @@ impl UhProcessor<'_, TdxBacked> {
                     .write_nontimer_msr(
                         msr,
                         value,
-                        &mut CvmVtlProtectAccess {
-                            vtl: intercepted_vtl,
-                            protector: self.shared.cvm.isolated_memory_protector.as_ref(),
-                            tlb_access: &mut TdxBacked::tlb_flush_lock_access(
-                                self_index,
-                                self.partition,
-                                self.shared,
-                            ),
-                            guest_memory: &self.partition.gm[intercepted_vtl],
-                        },
+                        &mut UntrustedSynicVtlProts(&self.partition.gm[GuestVtl::Vtl0]),
                     )?;
                 // Propagate sint MSR writes to the hypervisor as well
                 // so that the hypervisor can directly inject events.

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -23,6 +23,7 @@ use crate::UhPartitionInner;
 use crate::UhPartitionNewParams;
 use crate::UhProcessor;
 use crate::WakeReason;
+use crate::processor::hardware_cvm::CvmVtlProtectAccess;
 use cvm_tracing::CVM_ALLOWED;
 use cvm_tracing::CVM_CONFIDENTIAL;
 use hcl::ioctl::ProcessorRunner;
@@ -757,12 +758,7 @@ impl TdxBackedShared {
         // performance would be poor for cases where the L1 implements
         // high-performance devices.
         let untrusted_synic = (partition_params.handle_synic && !partition_params.hide_isolation)
-            .then(|| {
-                GlobalSynic::new(
-                    params.guest_memory[GuestVtl::Vtl0].clone(),
-                    partition_params.topology.vp_count(),
-                )
-            });
+            .then(|| GlobalSynic::new(partition_params.topology.vp_count()));
 
         // TODO TDX: Consider just using MSR kernel module instead of explicit ioctl.
         let cr4_fixed1 = params.hcl.read_vmx_cr4_fixed1();
@@ -1019,12 +1015,24 @@ impl BackingPrivate for TdxBacked {
             ),
         ];
 
+        let this_index = this.vp_index();
         let reg_count = if let Some(synic) = &mut this.backing.untrusted_synic {
+            let prot_access = &mut CvmVtlProtectAccess {
+                vtl: GuestVtl::Vtl0,
+                protector: this.shared.cvm.isolated_memory_protector.as_ref(),
+                tlb_access: &mut TdxBacked::tlb_flush_lock_access(
+                    this_index,
+                    this.partition,
+                    this.shared,
+                ),
+                guest_memory: &this.partition.gm[GuestVtl::Vtl0],
+            };
+
             synic
-                .set_simp(reg(pfns[UhDirectOverlay::Sipp as usize]))
+                .set_simp(reg(pfns[UhDirectOverlay::Sipp as usize]), prot_access)
                 .unwrap();
             synic
-                .set_siefp(reg(pfns[UhDirectOverlay::Sifp as usize]))
+                .set_siefp(reg(pfns[UhDirectOverlay::Sifp as usize]), prot_access)
                 .unwrap();
             // Set the SIEFP in the hypervisor so that the hypervisor can
             // directly signal synic events. Don't set the SIMP, since the
@@ -2651,11 +2659,25 @@ impl UhProcessor<'_, TdxBacked> {
                 // If we get here we must have an untrusted synic, as otherwise
                 // we wouldn't be handling the TDVMCALL that ends up here. Therefore
                 // this is fine to unwrap.
+                let self_index = self.vp_index();
                 self.backing
                     .untrusted_synic
                     .as_mut()
                     .unwrap()
-                    .write_nontimer_msr(msr, value)?;
+                    .write_nontimer_msr(
+                        msr,
+                        value,
+                        &mut CvmVtlProtectAccess {
+                            vtl: intercepted_vtl,
+                            protector: self.shared.cvm.isolated_memory_protector.as_ref(),
+                            tlb_access: &mut TdxBacked::tlb_flush_lock_access(
+                                self_index,
+                                self.partition,
+                                self.shared,
+                            ),
+                            guest_memory: &self.partition.gm[intercepted_vtl],
+                        },
+                    )?;
                 // Propagate sint MSR writes to the hypervisor as well
                 // so that the hypervisor can directly inject events.
                 if matches!(msr, hvdef::HV_X64_MSR_SINT0..=hvdef::HV_X64_MSR_SINT15) {

--- a/vm/hv1/hv1_emulator/src/lib.rs
+++ b/vm/hv1/hv1_emulator/src/lib.rs
@@ -36,3 +36,18 @@ impl<T: FnMut(u32, bool)> RequestInterrupt for T {
         self(vector, auto_eoi)
     }
 }
+
+/// A trait for managing the vtl protections on pages.
+pub trait VtlProtectAccess {
+    /// Check if the given GPN has the specified VTL permissions, optionally
+    /// modify them, then lock them.
+    fn check_modify_and_lock_overlay_page(
+        &mut self,
+        gpn: u64,
+        check_perms: hvdef::HvMapGpaFlags,
+        new_perms: Option<hvdef::HvMapGpaFlags>,
+    ) -> Result<guestmem::LockedPages, hvdef::HvError>;
+
+    /// Unlocks an overlay page by its GPN, restoring its previous permissions.
+    fn unlock_overlay_page(&mut self, gpn: u64) -> Result<(), hvdef::HvError>;
+}

--- a/vmm_core/virt_hvf/src/hypercall.rs
+++ b/vmm_core/virt_hvf/src/hypercall.rs
@@ -167,7 +167,7 @@ impl<T> SetVpRegisters for HvfHypercallHandler<'_, '_, T> {
 }
 
 struct HvfNoVtlProtections<'a>(&'a guestmem::GuestMemory);
-impl<'a> hv1_emulator::VtlProtectAccess for HvfNoVtlProtections<'a> {
+impl hv1_emulator::VtlProtectAccess for HvfNoVtlProtections<'_> {
     fn check_modify_and_lock_overlay_page(
         &mut self,
         gpn: u64,

--- a/vmm_core/virt_hvf/src/hypercall.rs
+++ b/vmm_core/virt_hvf/src/hypercall.rs
@@ -135,12 +135,18 @@ impl<T> SetVpRegisters for HvfHypercallHandler<'_, '_, T> {
                 HvArm64RegisterName::Sipp => self
                     .vp
                     .hv1
-                    .set_simp(value.as_u64())
+                    .set_simp(
+                        value.as_u64(),
+                        &mut HvfNoVtlProtections(&self.vp.partition.guest_memory),
+                    )
                     .map_err(|_| (HvError::InvalidParameter, 1))?,
                 HvArm64RegisterName::Sifp => self
                     .vp
                     .hv1
-                    .set_siefp(value.as_u64())
+                    .set_siefp(
+                        value.as_u64(),
+                        &mut HvfNoVtlProtections(&self.vp.partition.guest_memory),
+                    )
                     .map_err(|_| (HvError::InvalidParameter, 1))?,
                 HvArm64RegisterName::Scontrol => self.vp.hv1.set_scontrol(value.as_u64()),
                 HvArm64RegisterName::Eom => {}
@@ -156,6 +162,22 @@ impl<T> SetVpRegisters for HvfHypercallHandler<'_, '_, T> {
                 }
             }
         }
+        Ok(())
+    }
+}
+
+struct HvfNoVtlProtections<'a>(&'a guestmem::GuestMemory);
+impl<'a> hv1_emulator::VtlProtectAccess for HvfNoVtlProtections<'a> {
+    fn check_modify_and_lock_overlay_page(
+        &mut self,
+        gpn: u64,
+        _check_perms: hvdef::HvMapGpaFlags,
+        _new_perms: Option<hvdef::HvMapGpaFlags>,
+    ) -> Result<guestmem::LockedPages, HvError> {
+        Ok(self.0.lock_gpns(false, &[gpn]).unwrap())
+    }
+
+    fn unlock_overlay_page(&mut self, _gpn: u64) -> Result<(), HvError> {
         Ok(())
     }
 }

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -123,10 +123,7 @@ impl virt::ProtoPartition for HvfProtoPartition<'_> {
         // SAFETY: no safety requirements.
         unsafe { abi::hv_vm_create(null_mut()) }.chk()?;
 
-        let hv1 = HvfHv1State::new(
-            config.guest_memory.clone(),
-            self.config.processor_topology.vp_count(),
-        );
+        let hv1 = HvfHv1State::new(self.config.processor_topology.vp_count());
         let hv1_vps = self
             .config
             .processor_topology
@@ -462,10 +459,10 @@ struct HvfHv1State {
 }
 
 impl HvfHv1State {
-    fn new(guest_memory: GuestMemory, max_vp_count: u32) -> Self {
+    fn new(max_vp_count: u32) -> Self {
         Self {
             guest_os_id: 0.into(),
-            synic: GlobalSynic::new(guest_memory, max_vp_count),
+            synic: GlobalSynic::new(max_vp_count),
         }
     }
 }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -29,7 +29,6 @@ use hv1_emulator::hv::GlobalHv;
 use hv1_emulator::hv::GlobalHvParams;
 use hv1_emulator::hv::ProcessorVtlHv;
 use hv1_emulator::message_queues::MessageQueues;
-use hv1_structs::VtlArray;
 use hv1_structs::VtlSet;
 use hvdef::HvDeliverabilityNotificationsRegister;
 use hvdef::HvMessage;
@@ -451,7 +450,7 @@ impl virt::ResetPartition for WhpPartition {
                 .reset(true);
         }
 
-        self.inner.hvstate.reset();
+        self.inner.hvstate.reset(&self.inner.gm);
 
         Ok(())
     }
@@ -1045,7 +1044,6 @@ impl WhpPartitionInner {
                     tsc_frequency,
                     ref_time,
                     is_ref_time_backed_by_tsc: false,
-                    guest_memory: VtlArray::from_fn(|_| config.guest_memory.clone()),
                 }))
             }
         } else {
@@ -1450,20 +1448,31 @@ impl VtlPartition {
     }
 }
 
-struct WhpNoVtlProtections;
-impl hv1_emulator::hv::VtlProtectHypercallOverlay for WhpNoVtlProtections {
-    fn change_overlay(&mut self, _gpn: u64) {}
-    fn disable_overlay(&mut self) {}
+struct WhpNoVtlProtections<'a>(&'a GuestMemory);
+impl<'a> hv1_emulator::VtlProtectAccess for WhpNoVtlProtections<'a> {
+    fn check_modify_and_lock_overlay_page(
+        &mut self,
+        gpn: u64,
+        _check_perms: hvdef::HvMapGpaFlags,
+        _new_perms: Option<hvdef::HvMapGpaFlags>,
+    ) -> Result<guestmem::LockedPages, hvdef::HvError> {
+        Ok(self.0.lock_gpns(false, &[gpn]).unwrap())
+    }
+
+    fn unlock_overlay_page(&mut self, _gpn: u64) -> Result<(), hvdef::HvError> {
+        Ok(())
+    }
 }
 
 impl Hv1State {
-    fn reset(&self) {
+    fn reset(&self, guest_memory: &GuestMemory) {
         match self {
             Hv1State::Emulated(hv) => hv.reset(
                 [
-                    &mut WhpNoVtlProtections
-                        as &mut dyn hv1_emulator::hv::VtlProtectHypercallOverlay,
-                    &mut WhpNoVtlProtections,
+                    &mut WhpNoVtlProtections(guest_memory)
+                        as &mut dyn hv1_emulator::VtlProtectAccess,
+                    &mut WhpNoVtlProtections(guest_memory),
+                    &mut WhpNoVtlProtections(guest_memory),
                 ]
                 .into(),
             ),

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1449,7 +1449,7 @@ impl VtlPartition {
 }
 
 struct WhpNoVtlProtections<'a>(&'a GuestMemory);
-impl<'a> hv1_emulator::VtlProtectAccess for WhpNoVtlProtections<'a> {
+impl hv1_emulator::VtlProtectAccess for WhpNoVtlProtections<'_> {
     fn check_modify_and_lock_overlay_page(
         &mut self,
         gpn: u64,

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -1322,7 +1322,11 @@ mod x86 {
                     }
                     0x40000000..=0x4fffffff => {
                         if let Some(hv) = &mut self.state.vtls[self.state.active_vtl].hv {
-                            hv.msr_write(msr, v, &mut crate::WhpNoVtlProtections)
+                            hv.msr_write(
+                                msr,
+                                v,
+                                &mut crate::WhpNoVtlProtections(&self.vp.partition.gm),
+                            )
                         } else {
                             match msr {
                                 hvdef::HV_X64_MSR_VP_ASSIST_PAGE


### PR DESCRIPTION
Move tracking of VTL protections for hv1 specific pages into hv1_emulator itself with a new ReadOnlyLockedPage helper struct. Then use this to ensure the hypercall code page and tsc reference page have proper protections and access checks. It also applies similar checks to the VP assist page and synic's simp and siefp pages.

Tested SNP with VSM still boots

cherry-pick of #1502 and https://github.com/microsoft/openvmm/pull/1566