### PR TITLE
deps: update mu_msvm to release v25.1.4

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -23,7 +23,7 @@ pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
 pub const RUSTUP_TOOLCHAIN: &str = "1.87.0";
-pub const MU_MSVM: &str = "25.1.3";
+pub const MU_MSVM: &str = "25.1.4";
 pub const NEXTEST: &str = "0.9.96";
 pub const NODEJS: &str = "18.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly


### PR DESCRIPTION
Update mu_msvm to point to latest release: mu_msvm release (https://github.com/microsoft/mu_msvm/releases/tag/v25.1.4)