### PR TITLE
cvm guest vsm: enforce vtl 1 execute permissions during instruction e…

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1764,6 +1764,8 @@ async fn new_underhill_vm(
             gm.vtl1().cloned().unwrap_or(GuestMemory::empty()),
         ]
         .into(),
+        vtl0_kernel_exec_gm: gm.vtl0_kernel_execute().clone(),
+        vtl0_user_exec_gm: gm.vtl0_user_execute().clone(),
         #[cfg(guest_arch = "x86_64")]
         cpuid,
         crash_notification_send,

--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -6,6 +6,8 @@
 use crate::HardwareIsolatedMemoryProtector;
 use crate::MemoryAcceptor;
 use crate::mapping::GuestMemoryMapping;
+use crate::mapping::GuestMemoryView;
+use crate::mapping::GuestMemoryViewReadType;
 use crate::mapping::GuestPartitionMemoryView;
 use anyhow::Context;
 use cvm_tracing::CVM_ALLOWED;
@@ -36,6 +38,10 @@ pub struct MemoryMappings {
     #[inspect(skip)]
     vtl0_gm: GuestMemory,
     #[inspect(skip)]
+    vtl0_kx_gm: GuestMemory,
+    #[inspect(skip)]
+    vtl0_ux_gm: GuestMemory,
+    #[inspect(skip)]
     vtl1_gm: Option<GuestMemory>,
     #[inspect(flatten)]
     cvm_memory: Option<CvmMemory>,
@@ -59,6 +65,14 @@ impl MemoryMappings {
     /// Includes all VTL0-accessible memory (private and shared).
     pub fn vtl0(&self) -> &GuestMemory {
         &self.vtl0_gm
+    }
+
+    pub fn vtl0_kernel_execute(&self) -> &GuestMemory {
+        &self.vtl0_kx_gm
+    }
+
+    pub fn vtl0_user_execute(&self) -> &GuestMemory {
+        &self.vtl0_ux_gm
     }
 
     pub fn vtl1(&self) -> Option<&GuestMemory> {
@@ -334,7 +348,16 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
         let vtl0_gm = GuestMemory::new_multi_region(
             "vtl0",
             vtom,
-            vec![Some(vtl0_mapping.clone()), Some(shared_mapping.clone())],
+            vec![
+                Some(GuestMemoryView::new(
+                    vtl0_mapping.clone(),
+                    GuestMemoryViewReadType::Read,
+                )),
+                Some(GuestMemoryView::new(
+                    shared_mapping.clone(),
+                    GuestMemoryViewReadType::Read,
+                )),
+            ],
         )
         .context("failed to make vtl0 guest memory")?;
 
@@ -350,8 +373,14 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                         "vtl1",
                         vtom,
                         vec![
-                            Some(encrypted_mapping.clone()),
-                            Some(shared_mapping.clone()),
+                            Some(GuestMemoryView::new(
+                                encrypted_mapping.clone(),
+                                GuestMemoryViewReadType::Read,
+                            )),
+                            Some(GuestMemoryView::new(
+                                shared_mapping.clone(),
+                                GuestMemoryViewReadType::Read,
+                            )),
                         ],
                     )
                     .context("failed to make vtl1 guest memory")?,
@@ -386,11 +415,23 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
         let shared_gm = GuestMemory::new_multi_region(
             "shared",
             vtom,
-            vec![Some(shared_mapping.clone()), Some(shared_mapping.clone())],
+            vec![
+                Some(GuestMemoryView::new(
+                    shared_mapping.clone(),
+                    GuestMemoryViewReadType::Read,
+                )),
+                Some(GuestMemoryView::new(
+                    shared_mapping.clone(),
+                    GuestMemoryViewReadType::Read,
+                )),
+            ],
         )
         .context("failed to make shared guest memory")?;
 
-        let private_vtl0_memory = GuestMemory::new("trusted", vtl0_mapping.clone());
+        let private_vtl0_memory = GuestMemory::new(
+            "trusted",
+            GuestMemoryView::new(vtl0_mapping.clone(), GuestMemoryViewReadType::Read),
+        );
 
         let protector = Arc::new(HardwareIsolatedMemoryProtector::new(
             encrypted_memory_view.partition_valid_memory().clone(),
@@ -403,10 +444,47 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
 
         // TODO GUEST VSM: create guest memory objects using execute permissions
         // for the instruction emulator to use when reading instructions.
+
+        tracing::debug!("Creating VTL0 guest memory for kernel execute access");
+        let vtl0_kx_gm = GuestMemory::new_multi_region(
+            "vtl0_kx",
+            vtom,
+            vec![
+                Some(GuestMemoryView::new(
+                    vtl0_mapping.clone(),
+                    GuestMemoryViewReadType::KernelExecute,
+                )),
+                Some(GuestMemoryView::new(
+                    shared_mapping.clone(),
+                    GuestMemoryViewReadType::KernelExecute,
+                )),
+            ],
+        )
+        .context("failed to make vtl0 guest memory with kernel execute access")?;
+
+        tracing::debug!("Creating VTL0 guest memory for user execute access");
+        let vtl0_ux_gm = GuestMemory::new_multi_region(
+            "vtl0_ux",
+            vtom,
+            vec![
+                Some(GuestMemoryView::new(
+                    vtl0_mapping.clone(),
+                    GuestMemoryViewReadType::UserExecute,
+                )),
+                Some(GuestMemoryView::new(
+                    shared_mapping.clone(),
+                    GuestMemoryViewReadType::UserExecute,
+                )),
+            ],
+        )
+        .context("failed to make vtl0 guest memory with user execute access")?;
+
         MemoryMappings {
             vtl0: vtl0_mapping,
             vtl1: vtl1_mapping,
             vtl0_gm,
+            vtl0_kx_gm,
+            vtl0_ux_gm,
             vtl1_gm,
             cvm_memory: Some(CvmMemory {
                 shared_gm,
@@ -430,7 +508,10 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                     .context("failed to map vtl0 memory")?,
             )
         };
-        let vtl0_gm = GuestMemory::new("vtl0", vtl0_mapping.clone());
+        let vtl0_gm = GuestMemory::new(
+            "vtl0",
+            GuestMemoryView::new(vtl0_mapping.clone(), GuestMemoryViewReadType::Read),
+        );
 
         let vtl1_mapping = if params.maximum_vtl >= Vtl::Vtl1 {
             if params.vtl0_alias_map_bit.is_none() {
@@ -472,16 +553,23 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
 
         let vtl1_gm = if let Some(vtl1_mapping) = &vtl1_mapping {
             tracing::info!(CVM_ALLOWED, "VTL 1 memory map created");
-            Some(GuestMemory::new("vtl1", vtl1_mapping.clone()))
+            Some(GuestMemory::new(
+                "vtl1",
+                GuestMemoryView::new(vtl1_mapping.clone(), GuestMemoryViewReadType::Read),
+            ))
         } else {
             tracing::info!(CVM_ALLOWED, "Skipping VTL 1 memory map creation");
             None
         };
 
+        // TODO: make kernel/user execute guest memory objects that use a
+        // fallback path to query the hypervisor for the permissions.
         MemoryMappings {
             vtl0: vtl0_mapping,
             vtl1: vtl1_mapping,
-            vtl0_gm,
+            vtl0_gm: vtl0_gm.clone(),
+            vtl0_kx_gm: vtl0_gm.clone(),
+            vtl0_ux_gm: vtl0_gm.clone(),
             vtl1_gm,
             cvm_memory: None,
         }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -209,6 +209,8 @@ struct UhPartitionInner {
     cpuid: virt::CpuidLeafSet,
     lower_vtl_memory_layout: MemoryLayout,
     gm: VtlArray<GuestMemory, 2>,
+    vtl0_kernel_exec_gm: GuestMemory,
+    vtl0_user_exec_gm: GuestMemory,
     #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
     #[inspect(skip)]
     crash_notification_send: mesh::Sender<VtlCrash>,
@@ -1348,6 +1350,10 @@ pub struct UhPartitionNewParams<'a> {
 pub struct UhLateParams<'a> {
     /// Guest memory for lower VTLs.
     pub gm: VtlArray<GuestMemory, 2>,
+    /// Guest memory for VTL 0 kernel execute access.
+    pub vtl0_kernel_exec_gm: GuestMemory,
+    /// Guest memory for VTL 0 user execute access.
+    pub vtl0_user_exec_gm: GuestMemory,
     /// The CPUID leaves to expose to the guest.
     #[cfg(guest_arch = "x86_64")]
     pub cpuid: Vec<CpuidLeaf>,
@@ -1763,6 +1769,8 @@ impl<'a> UhProtoPartition<'a> {
             enter_modes: Mutex::new(enter_modes),
             enter_modes_atomic: u8::from(hcl::protocol::EnterModes::from(enter_modes)).into(),
             gm: late_params.gm,
+            vtl0_kernel_exec_gm: late_params.vtl0_kernel_exec_gm,
+            vtl0_user_exec_gm: late_params.vtl0_user_exec_gm,
             #[cfg(guest_arch = "x86_64")]
             cpuid,
             crash_notification_send: late_params.crash_notification_send,

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -1125,6 +1125,18 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
             virt_support_x86emu::emulate::EmulatorSupport<Error = UhRunVpError>,
     {
         let guest_memory = &self.partition.gm[vtl];
+        let (kx_guest_memory, ux_guest_memory) = match vtl {
+            GuestVtl::Vtl0 => (
+                &self.partition.vtl0_kernel_exec_gm,
+                &self.partition.vtl0_user_exec_gm,
+            ),
+            GuestVtl::Vtl1 => (guest_memory, guest_memory),
+        };
+        let emu_mem = virt_support_x86emu::emulate::EmulatorMemoryAccess {
+            gm: guest_memory,
+            kx_gm: kx_guest_memory,
+            ux_gm: ux_guest_memory,
+        };
         let mut emulation_state = UhEmulationState {
             vp: &mut *self,
             interruption_pending,
@@ -1132,7 +1144,8 @@ impl<'a, T: Backing> UhProcessor<'a, T> {
             vtl,
             cache,
         };
-        virt_support_x86emu::emulate::emulate(&mut emulation_state, guest_memory, devices).await
+
+        virt_support_x86emu::emulate::emulate(&mut emulation_state, &emu_mem, devices).await
     }
 
     /// Emulates an instruction due to a memory access exit.

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -1777,8 +1777,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, SnpBacked> {
         _gpa: u64,
         _mode: virt_support_x86emu::emulate::TranslateMode,
     ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError<Self::Error>> {
-        // TODO GUEST VSM
-        // TODO lock tlb?
+        // Nothing to do here, the guest memory object will handle the check.
         Ok(())
     }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -3002,8 +3002,7 @@ impl<T: CpuIo> X86EmulatorSupport for UhEmulationState<'_, '_, T, TdxBacked> {
         _gpa: u64,
         _mode: TranslateMode,
     ) -> Result<(), virt_support_x86emu::emulate::EmuCheckVtlAccessError<Self::Error>> {
-        // Lock Vtl TLB
-        // TODO TDX GUEST VSM: VTL1 not yet supported
+        // Nothing to do here, the guest memory object will handle the check.
         Ok(())
     }
 

--- a/tmk/tmk_vmm/src/paravisor_vmm.rs
+++ b/tmk/tmk_vmm/src/paravisor_vmm.rs
@@ -56,6 +56,8 @@ impl RunContext<'_> {
                     m.vtl1().cloned().unwrap_or(GuestMemory::empty()),
                 ]
                 .into(),
+                vtl0_kernel_exec_gm: m.vtl0().clone(),
+                vtl0_user_exec_gm: m.vtl0().clone(),
                 #[cfg(guest_arch = "x86_64")]
                 cpuid: Vec::new(),
                 crash_notification_send: mesh::channel().0,

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -455,6 +455,12 @@ impl MshvProcessor<'_> {
         interruption_pending: bool,
     ) -> Result<(), VpHaltReason<MshvError>> {
         let cache = self.emulation_cache().map_err(VpHaltReason::Hypervisor)?;
+        let emu_mem = virt_support_x86emu::emulate::EmulatorMemoryAccess {
+            gm: &self.partition.gm,
+            kx_gm: &self.partition.gm,
+            ux_gm: &self.partition.gm,
+        };
+
         let mut support = MshvEmulationState {
             partition: self.partition,
             processor: self.inner,
@@ -463,7 +469,7 @@ impl MshvProcessor<'_> {
             interruption_pending,
             cache,
         };
-        virt_support_x86emu::emulate::emulate(&mut support, &self.partition.gm, devices).await
+        virt_support_x86emu::emulate::emulate(&mut support, &emu_mem, devices).await
     }
 
     async fn handle_io_port_intercept(

--- a/vmm_core/virt_support_x86emu/tests/tests/checkvtlaccess.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/checkvtlaccess.rs
@@ -157,6 +157,12 @@ async fn run_emulation(
     const TEST_VALUE: u64 = 0x123456789abcdef0;
 
     let gm = GuestMemory::allocate(4096);
+    let emu_mem = EmulatorMemoryAccess {
+        gm: &gm,
+        kx_gm: &gm,
+        ux_gm: &gm,
+    };
+
     gm.write_at(TEST_ADDRESS, &TEST_VALUE.to_le_bytes())
         .unwrap();
 
@@ -181,7 +187,7 @@ async fn run_emulation(
         gm.write_at(support.state.rip, &instruction_bytes).unwrap();
     }
 
-    emulate(&mut support, &gm, &MockCpu).await.unwrap();
+    emulate(&mut support, &emu_mem, &MockCpu).await.unwrap();
 
     if fail_vtl_access.is_none() {
         assert_eq!(support.gp(Gp::RAX), TEST_VALUE);

--- a/vmm_core/virt_support_x86emu/tests/tests/emulate.rs
+++ b/vmm_core/virt_support_x86emu/tests/tests/emulate.rs
@@ -135,6 +135,11 @@ async fn basic_mov() {
     const TEST_VALUE: u64 = 0x123456789abcdef0;
 
     let gm = GuestMemory::allocate(4096);
+    let emu_mem = virt_support_x86emu::emulate::EmulatorMemoryAccess {
+        gm: &gm,
+        kx_gm: &gm,
+        ux_gm: &gm,
+    };
     gm.write_at(TEST_ADDRESS, &TEST_VALUE.to_le_bytes())
         .unwrap();
 
@@ -153,7 +158,7 @@ async fn basic_mov() {
         interruption_pending: false,
     };
 
-    emulate(&mut support, &gm, &MockCpu).await.unwrap();
+    emulate(&mut support, &emu_mem, &MockCpu).await.unwrap();
 
     assert_eq!(support.gp(Gp::RAX), TEST_VALUE);
 }
@@ -164,6 +169,11 @@ async fn not_enough_bytes() {
     const TEST_VALUE: u64 = 0x123456789abcdef0;
 
     let gm = GuestMemory::allocate(4096);
+    let emu_mem = virt_support_x86emu::emulate::EmulatorMemoryAccess {
+        gm: &gm,
+        kx_gm: &gm,
+        ux_gm: &gm,
+    };
     gm.write_at(TEST_ADDRESS, &TEST_VALUE.to_le_bytes())
         .unwrap();
 
@@ -185,7 +195,7 @@ async fn not_enough_bytes() {
 
     gm.write_at(support.state.rip, &instruction_bytes).unwrap();
 
-    emulate(&mut support, &gm, &MockCpu).await.unwrap();
+    emulate(&mut support, &emu_mem, &MockCpu).await.unwrap();
 
     assert_eq!(support.gp(Gp::RAX), TEST_VALUE);
 }
@@ -197,6 +207,11 @@ async fn trap_from_interrupt() {
     const TEST_VALUE: u64 = 0x123456789abcdef0;
 
     let gm = GuestMemory::allocate(4096);
+    let emu_mem = virt_support_x86emu::emulate::EmulatorMemoryAccess {
+        gm: &gm,
+        kx_gm: &gm,
+        ux_gm: &gm,
+    };
     gm.write_at(TEST_ADDRESS, &TEST_VALUE.to_le_bytes())
         .unwrap();
 
@@ -215,7 +230,7 @@ async fn trap_from_interrupt() {
         interruption_pending: true,
     };
 
-    emulate(&mut support, &gm, &MockCpu).await.unwrap();
+    emulate(&mut support, &emu_mem, &MockCpu).await.unwrap();
 }
 
 #[async_test]
@@ -225,6 +240,11 @@ async fn trap_from_debug() {
     const TEST_VALUE: u64 = 0x123456789abcdef0;
 
     let gm = GuestMemory::allocate(4096);
+    let emu_mem = virt_support_x86emu::emulate::EmulatorMemoryAccess {
+        gm: &gm,
+        kx_gm: &gm,
+        ux_gm: &gm,
+    };
     gm.write_at(TEST_ADDRESS, &TEST_VALUE.to_le_bytes())
         .unwrap();
 
@@ -246,5 +266,5 @@ async fn trap_from_debug() {
         interruption_pending: false,
     };
 
-    emulate(&mut support, &gm, &MockCpu).await.unwrap();
+    emulate(&mut support, &emu_mem, &MockCpu).await.unwrap();
 }

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -1566,7 +1566,12 @@ mod x86 {
         ) -> Result<(), VpHaltReason<WhpRunVpError>> {
             let vp = self.vp;
             let mut state = emu::WhpEmulationState::new(access, self, exit, dev);
-            virt_support_x86emu::emulate::emulate(&mut state, &vp.partition.gm, dev).await
+            let emu_mem = virt_support_x86emu::emulate::EmulatorMemoryAccess {
+                gm: &vp.partition.gm,
+                kx_gm: &vp.partition.gm,
+                ux_gm: &vp.partition.gm,
+            };
+            virt_support_x86emu::emulate::emulate(&mut state, &emu_mem, dev).await
         }
 
         pub(super) fn finish_reset_arch(&mut self, vtl: Vtl) {


### PR DESCRIPTION
…mulation (#1513)

Adds two guest memory objects, backed by kernel/usermode execute VTL 1 permission bitmaps (for cvms), to be used on the emulation path to enforce VTL 1 protections when accessing instructions during instruction emulation.

Tested:
SNP +/- guest vsm boots
TVM boots