### PR TITLE
build_info: introduce extra fields for more revision information

### DIFF
--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -15,6 +15,10 @@ pub struct BuildInfo {
     revision: &'static str,
     #[inspect(safe, rename = "scm_branch")]
     branch: &'static str,
+    #[inspect(safe, rename = "internal_scm_revision")]
+    internal_revision: &'static str,
+    #[inspect(safe, rename = "internal_scm_branch")]
+    internal_branch: &'static str,
 }
 
 impl BuildInfo {
@@ -32,6 +36,16 @@ impl BuildInfo {
             },
             branch: if let Some(b) = option_env!("VERGEN_GIT_BRANCH") {
                 b
+            } else {
+                ""
+            },
+            internal_revision: if let Some(r) = option_env!("INTERNAL_GIT_SHA") {
+                r
+            } else {
+                ""
+            },
+            internal_branch: if let Some(r) = option_env!("INTERNAL_GIT_BRANCH") {
+                r
             } else {
                 ""
             },


### PR DESCRIPTION
Introduces two new fields to `BuildInfo` to store more data about the build.