### PR TITLE
virt_mshv_vtl: Wire up proper memory protections for the monitor page and enable it

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -41,6 +41,7 @@ mod processor;
 pub use processor::Backing;
 pub use processor::UhProcessor;
 
+use crate::processor::HardwareIsolatedBacking;
 use anyhow::Context as AnyhowContext;
 use bitfield_struct::bitfield;
 use bitvec::boxed::BitBox;
@@ -1018,26 +1019,49 @@ impl virt::Synic for UhPartition {
 
 impl virt::SynicMonitor for UhPartition {
     fn set_monitor_page(&self, vtl: Vtl, gpa: Option<u64>) -> anyhow::Result<()> {
+        let vp_index = VpIndex::BSP; // TODO
+        let vtl = GuestVtl::try_from(vtl).unwrap();
         let old_gpa = self.inner.monitor_page.set_gpa(gpa);
 
         if let Some(old_gpa) = old_gpa {
-            if let Some(cvm) = self.inner.backing_shared.cvm_state() {
-                cvm.isolated_memory_protector
+            let old_gpn = old_gpa.checked_div(HV_PAGE_SIZE).unwrap();
+
+            match &self.inner.backing_shared {
+                BackingShared::Snp(snp_backed_shared) => snp_backed_shared
+                    .cvm
+                    .isolated_memory_protector
                     .unregister_overlay_page(
-                        vtl.try_into().unwrap(),
-                        old_gpa.checked_div(HV_PAGE_SIZE).unwrap(),
-                        (),
+                        vtl,
+                        old_gpn,
+                        &mut SnpBacked::tlb_flush_lock_access(
+                            vp_index,
+                            self.inner.as_ref(),
+                            snp_backed_shared,
+                        ),
                     )
-                    .map_err(|e| anyhow::anyhow!(e))
-            } else {
-                self.inner
+                    .map_err(|e| anyhow::anyhow!(e)),
+                BackingShared::Tdx(tdx_backed_shared) => tdx_backed_shared
+                    .cvm
+                    .isolated_memory_protector
+                    .unregister_overlay_page(
+                        vtl,
+                        old_gpn,
+                        &mut TdxBacked::tlb_flush_lock_access(
+                            vp_index,
+                            self.inner.as_ref(),
+                            tdx_backed_shared,
+                        ),
+                    )
+                    .map_err(|e| anyhow::anyhow!(e)),
+                BackingShared::Hypervisor(_) => self
+                    .inner
                     .hcl
                     .modify_vtl_protection_mask(
-                        MemoryRange::new(old_gpa..old_gpa + HV_PAGE_SIZE),
+                        MemoryRange::from_4k_gpn_range(old_gpn..old_gpn + 1),
                         hvdef::HV_MAP_GPA_PERMISSIONS_ALL,
                         HvInputVtl::CURRENT_VTL,
                     )
-                    .map_err(|e| anyhow::anyhow!(e))
+                    .map_err(|e| anyhow::anyhow!(e)),
             }
             .context("failed to unregister old monitor page")?;
 
@@ -1045,27 +1069,54 @@ impl virt::SynicMonitor for UhPartition {
         }
 
         if let Some(gpa) = gpa {
+            let gpn = gpa.checked_div(HV_PAGE_SIZE).unwrap();
+            let check_perms = HvMapGpaFlags::new().with_readable(true).with_writable(true);
             // Disallow VTL0 from writing to the page, so we'll get an intercept. Note that read
             // permissions must be enabled or this doesn't work correctly.
-            let result = if let Some(cvm) = self.inner.backing_shared.cvm_state() {
-                cvm.isolated_memory_protector
+            let new_perms = HvMapGpaFlags::new()
+                .with_readable(true)
+                .with_writable(false);
+
+            let result = match &self.inner.backing_shared {
+                BackingShared::Snp(snp_backed_shared) => snp_backed_shared
+                    .cvm
+                    .isolated_memory_protector
                     .register_overlay_page(
-                        vtl.try_into().unwrap(),
-                        gpa.checked_div(HV_PAGE_SIZE).unwrap(),
-                        HvMapGpaFlags::new().with_readable(true).with_writable(true),
-                        Some(HvMapGpaFlags::new().with_readable(true)),
-                        (),
+                        vtl,
+                        gpn,
+                        check_perms,
+                        Some(new_perms),
+                        &mut SnpBacked::tlb_flush_lock_access(
+                            vp_index,
+                            self.inner.as_ref(),
+                            snp_backed_shared,
+                        ),
                     )
-                    .map_err(|e| anyhow::anyhow!(e))
-            } else {
-                self.inner
+                    .map_err(|e| anyhow::anyhow!(e)),
+                BackingShared::Tdx(tdx_backed_shared) => tdx_backed_shared
+                    .cvm
+                    .isolated_memory_protector
+                    .register_overlay_page(
+                        vtl,
+                        gpn,
+                        check_perms,
+                        Some(new_perms),
+                        &mut TdxBacked::tlb_flush_lock_access(
+                            vp_index,
+                            self.inner.as_ref(),
+                            tdx_backed_shared,
+                        ),
+                    )
+                    .map_err(|e| anyhow::anyhow!(e)),
+                BackingShared::Hypervisor(_) => self
+                    .inner
                     .hcl
                     .modify_vtl_protection_mask(
-                        MemoryRange::new(gpa..gpa + HV_PAGE_SIZE),
-                        HvMapGpaFlags::new().with_readable(true),
+                        MemoryRange::from_4k_gpn_range(gpn..gpn + 1),
+                        new_perms,
                         HvInputVtl::CURRENT_VTL,
                     )
-                    .map_err(|e| anyhow::anyhow!(e))
+                    .map_err(|e| anyhow::anyhow!(e)),
             }
             .context("failed to register monitor page");
 

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1019,7 +1019,6 @@ impl virt::Synic for UhPartition {
 
 impl virt::SynicMonitor for UhPartition {
     fn set_monitor_page(&self, vtl: Vtl, gpa: Option<u64>) -> anyhow::Result<()> {
-        let vp_index = VpIndex::BSP; // TODO
         let vtl = GuestVtl::try_from(vtl).unwrap();
         let old_gpa = self.inner.monitor_page.set_gpa(gpa);
 
@@ -1034,7 +1033,7 @@ impl virt::SynicMonitor for UhPartition {
                         vtl,
                         old_gpn,
                         &mut SnpBacked::tlb_flush_lock_access(
-                            vp_index,
+                            None,
                             self.inner.as_ref(),
                             snp_backed_shared,
                         ),
@@ -1047,7 +1046,7 @@ impl virt::SynicMonitor for UhPartition {
                         vtl,
                         old_gpn,
                         &mut TdxBacked::tlb_flush_lock_access(
-                            vp_index,
+                            None,
                             self.inner.as_ref(),
                             tdx_backed_shared,
                         ),
@@ -1087,7 +1086,7 @@ impl virt::SynicMonitor for UhPartition {
                         check_perms,
                         Some(new_perms),
                         &mut SnpBacked::tlb_flush_lock_access(
-                            vp_index,
+                            None,
                             self.inner.as_ref(),
                             snp_backed_shared,
                         ),
@@ -1102,7 +1101,7 @@ impl virt::SynicMonitor for UhPartition {
                         check_perms,
                         Some(new_perms),
                         &mut TdxBacked::tlb_flush_lock_access(
-                            vp_index,
+                            None,
                             self.inner.as_ref(),
                             tdx_backed_shared,
                         ),

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -454,7 +454,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
                                 .isolated_memory_protector
                                 .as_ref(),
                             tlb_access: &mut B::tlb_flush_lock_access(
-                                self_index,
+                                Some(self_index),
                                 self.vp.partition,
                                 self.vp.shared,
                             ),
@@ -609,7 +609,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
                             .isolated_memory_protector
                             .as_ref(),
                         tlb_access: &mut B::tlb_flush_lock_access(
-                            self_index,
+                            Some(self_index),
                             self.vp.partition,
                             self.vp.shared,
                         ),
@@ -1576,7 +1576,11 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             protector: B::cvm_partition_state(self.shared)
                 .isolated_memory_protector
                 .as_ref(),
-            tlb_access: &mut B::tlb_flush_lock_access(self_index, self.partition, self.shared),
+            tlb_access: &mut B::tlb_flush_lock_access(
+                Some(self_index),
+                self.partition,
+                self.shared,
+            ),
             guest_memory: &self.partition.gm[vtl],
         };
         let r = hv.msr_write(msr, value, &mut access);
@@ -1797,7 +1801,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
     /// Returns the appropriately backed TLB flush and lock access
     pub(crate) fn tlb_flush_lock_access(&self) -> impl TlbFlushLockAccess + use<'_, B> {
-        B::tlb_flush_lock_access(self.vp_index(), self.partition, self.shared)
+        B::tlb_flush_lock_access(Some(self.vp_index()), self.partition, self.shared)
     }
 
     /// Handle checking for cross-VTL interrupts, preempting VTL 0, and setting

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -426,8 +426,14 @@ pub(crate) trait HardwareIsolatedBacking: Backing {
     fn cvm_partition_state(shared: &Self::Shared) -> &crate::UhCvmPartitionState;
     /// Gets a struct that can be used to interact with TLB flushing and
     /// locking.
+    ///
+    /// If a `vp_index` is provided, it will be used to cause the specified VP
+    /// to wait for all TLB locks to be released before returning to a lower VTL.
+    //
+    // FUTURE: This probably shouldn't be optional, but right now MNF doesn't know
+    // what VP it's set from and probably doesn't need it?
     fn tlb_flush_lock_access<'a>(
-        vp_index: VpIndex,
+        vp_index: Option<VpIndex>,
         partition: &'a UhPartitionInner,
         shared: &'a Self::Shared,
     ) -> impl TlbFlushLockAccess + 'a;

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -300,7 +300,7 @@ enum InterceptMessageType {
 
 /// Per-arch state required to generate an intercept message.
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-struct InterceptMessageState {
+pub(crate) struct InterceptMessageState {
     instruction_length_and_cr8: u8,
     cpl: u8,
     efer_lma: bool,
@@ -417,7 +417,7 @@ impl InterceptMessageType {
 
 /// Trait for processor backings that have hardware isolation support.
 #[cfg(guest_arch = "x86_64")]
-trait HardwareIsolatedBacking: Backing {
+pub(crate) trait HardwareIsolatedBacking: Backing {
     /// Gets CVM specific VP state.
     fn cvm_state(&self) -> &crate::UhCvmVpState;
     /// Gets CVM specific VP state.

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -230,7 +230,7 @@ impl HardwareIsolatedBacking for SnpBacked {
     }
 
     fn tlb_flush_lock_access<'a>(
-        vp_index: VpIndex,
+        vp_index: Option<VpIndex>,
         partition: &'a UhPartitionInner,
         shared: &'a Self::Shared,
     ) -> impl TlbFlushLockAccess + 'a {
@@ -2630,7 +2630,7 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, SnpBacked> {
 }
 
 struct SnpTlbLockFlushAccess<'a> {
-    vp_index: VpIndex,
+    vp_index: Option<VpIndex>,
     partition: &'a UhPartitionInner,
     shared: &'a SnpBackedShared,
 }
@@ -2667,11 +2667,13 @@ impl TlbFlushLockAccess for SnpTlbLockFlushAccess<'_> {
     }
 
     fn set_wait_for_tlb_locks(&mut self, vtl: GuestVtl) {
-        hardware_cvm::tlb_lock::TlbLockAccess {
-            vp_index: self.vp_index,
-            cvm_partition: &self.shared.cvm,
+        if let Some(vp_index) = self.vp_index {
+            hardware_cvm::tlb_lock::TlbLockAccess {
+                vp_index,
+                cvm_partition: &self.shared.cvm,
+            }
+            .set_wait_for_tlb_locks(vtl);
         }
-        .set_wait_for_tlb_locks(vtl);
     }
 }
 

--- a/vm/vmcore/src/monitor.rs
+++ b/vm/vmcore/src/monitor.rs
@@ -100,7 +100,7 @@ impl MonitorPage {
 
     /// Sets the GPA of the monitor page currently in use.
     pub fn set_gpa(&self, gpa: Option<u64>) -> Option<u64> {
-        assert!(gpa.is_none() || gpa.unwrap() % HV_PAGE_SIZE == 0);
+        assert!(gpa.is_none_or(|gpa| gpa % HV_PAGE_SIZE == 0));
         let old = self
             .gpa
             .swap(gpa.unwrap_or(INVALID_MONITOR_GPA), Ordering::Relaxed);


### PR DESCRIPTION
This code is ugly, but we need to do per-backend things here despite being on the partition level, so it's necessary. We could maybe clean and split it up later somehow. Fixes https://github.com/microsoft/openvmm/issues/694