### PR TITLE
cvm guest vsm: add logging around vtl protection violations via the g…

### DIFF
--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -227,7 +227,11 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
         tracing::debug!("Building valid encrypted memory view");
         let encrypted_memory_view = {
             let _span = tracing::info_span!("create encrypted memory view", CVM_ALLOWED).entered();
-            GuestPartitionMemoryView::new(params.mem_layout, true)?
+            GuestPartitionMemoryView::new(
+                params.mem_layout,
+                crate::mapping::GuestValidMemoryType::Encrypted,
+                true,
+            )?
         };
 
         tracing::debug!("Building encrypted memory map");
@@ -321,7 +325,11 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
 
         let shared_memory_view = {
             let _span = tracing::info_span!("create shared memory view", CVM_ALLOWED).entered();
-            GuestPartitionMemoryView::new(params.complete_memory_layout, false)?
+            GuestPartitionMemoryView::new(
+                params.complete_memory_layout,
+                crate::mapping::GuestValidMemoryType::Shared,
+                false,
+            )?
         };
 
         let valid_shared_memory = shared_memory_view.partition_valid_memory();


### PR DESCRIPTION
…uest memory object (#1544)

Adds some handling of page faults in the path of accessing memory via a guest memory object to detect certain access failure types, including VTL 1 protection violations for CVMs. For now, this change only logs the type of access failure for purposes of debugging and triage, but does not specifically try to handle these access failures.

Tested:
SNP +/- guest vsm boots
TVM + guest vsm boots