### PR TITLE
openhcl/openhcl_dma_manager: disallow lower vtl hypercall on hardware isolated platforms (#1542)

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1523,6 +1523,7 @@ async fn new_underhill_vm(
             .vtom_offset_bit
             .map(|bit| 1 << bit)
             .unwrap_or(0),
+        isolation,
     )
     .context("failed to create global dma manager")?;
 


### PR DESCRIPTION
This hypercall should not be used on hardware isolated platforms, as the hypervisor is untrusted. It shouldn't be used already today, but enforce it.

Cherry pick of (#1542)