### PR TITLE
Fix up AKCert index attributes

### DIFF
--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -716,15 +716,24 @@ impl TpmEngineHelper {
                             // boot-time AK cert request fails.
                             tracing::info!("Preserve previous AK cert across boot");
 
-                            self.nv_write(handle, auth, TPM_NV_INDEX_AIK_CERT, &cert)
-                                .map_err(|error| TpmHelperError::TpmCommandError {
+                            self.nv_write(
+                                ReservedHandle(TPM_NV_INDEX_AIK_CERT.into()),
+                                auth,
+                                TPM_NV_INDEX_AIK_CERT,
+                                &cert,
+                            )
+                            .map_err(|error| {
+                                TpmHelperError::TpmCommandError {
                                     command_debug_info: CommandDebugInfo {
                                         command_code: CommandCodeEnum::NV_Write,
-                                        auth_handle: Some(handle),
+                                        auth_handle: Some(ReservedHandle(
+                                            TPM_NV_INDEX_AIK_CERT.into(),
+                                        )),
                                         nv_index: Some(TPM_NV_INDEX_AIK_CERT),
                                     },
                                     error,
-                                })?;
+                                }
+                            })?;
                         }
                     }
                 }

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -2274,9 +2274,8 @@ mod tests {
             assert_eq!(&ak_cert_output, input_with_padding.as_slice());
 
             // Write to ak cert nv
-            let result = tpm_engine_helper.nv_write(
-                TPM20_RH_OWNER,
-                None,
+            let result: Result<(), TpmCommandError> = tpm_engine_helper.write_to_nv_index(
+                AUTH_VALUE,
                 TPM_NV_INDEX_AIK_CERT,
                 &AK_CERT_INPUT_1024,
             );

--- a/vm/devices/tpm/src/tpm_helper.rs
+++ b/vm/devices/tpm/src/tpm_helper.rs
@@ -2274,7 +2274,7 @@ mod tests {
             assert_eq!(&ak_cert_output, input_with_padding.as_slice());
 
             // Write to ak cert nv
-            let result: Result<(), TpmCommandError> = tpm_engine_helper.write_to_nv_index(
+            let result = tpm_engine_helper.write_to_nv_index(
                 AUTH_VALUE,
                 TPM_NV_INDEX_AIK_CERT,
                 &AK_CERT_INPUT_1024,


### PR DESCRIPTION
For now, the AKCert index needs to be owner-defined, not platform-defined. This change will fix up a mitigated vTPM appropriately.