### PR TITLE
virt_mshv_vtl: Fix TODO relating to translating gpas to overlay pages

### DIFF
--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -955,6 +955,12 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         Ok(())
     }
 
+    fn is_overlay_page(&self, vtl: GuestVtl, gpn: u64) -> bool {
+        self.inner.lock().overlay_pages[vtl]
+            .iter()
+            .any(|p| p.gpn == gpn)
+    }
+
     fn set_vtl1_protections_enabled(&self) {
         self.vtl1_protections_enabled
             .store(true, std::sync::atomic::Ordering::Relaxed);

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1440,6 +1440,9 @@ pub trait ProtectIsolatedMemory: Send + Sync {
         tlb_access: &mut dyn TlbFlushLockAccess,
     ) -> Result<(), HvError>;
 
+    /// Checks whether a page is currently registered as an overlay page.
+    fn is_overlay_page(&self, vtl: GuestVtl, gpn: u64) -> bool;
+
     /// Alerts the memory protector that vtl 1 is ready to set vtl protections
     /// on lower-vtl memory, and that these protections should be enforced.
     fn set_vtl1_protections_enabled(&self);


### PR DESCRIPTION
Pretty straightforward wiring. The hypercall page is one of these registered pages, so nothing here is lost.