### PR TITLE
virt_mshv_vtl: Fix TODO relating to translating gpas to overlay pages (#1552)

### DIFF
--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -917,6 +917,12 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         tlb_access.flush(vtl);
     }
 
+    fn is_overlay_page(&self, vtl: GuestVtl, gpn: u64) -> bool {
+        self.inner.lock().overlay_pages[vtl]
+            .iter()
+            .any(|p| p.gpn == gpn)
+    }
+
     fn set_vtl1_protections_enabled(&self) {
         self.vtl1_protections_enabled
             .store(true, std::sync::atomic::Ordering::Relaxed);

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1431,6 +1431,9 @@ pub trait ProtectIsolatedMemory: Send + Sync {
     /// Disables the overlay for the hypercall code page for a target VTL.
     fn disable_hypercall_overlay(&self, vtl: GuestVtl, tlb_access: &mut dyn TlbFlushLockAccess);
 
+    /// Checks whether a page is currently registered as an overlay page.
+    fn is_overlay_page(&self, vtl: GuestVtl, gpn: u64) -> bool;
+
     /// Alerts the memory protector that vtl 1 is ready to set vtl protections
     /// on lower-vtl memory, and that these protections should be enforced.
     fn set_vtl1_protections_enabled(&self);

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1449,18 +1449,6 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::TranslateVirtualAddressX64
             virt_support_x86emu::translate::TranslateFlags::from_hv_flags(control_flags),
         ) {
             Ok(virt_support_x86emu::translate::TranslateResult { gpa, cache_info }) => {
-                // TODO GUEST VSM: at the moment, the guest is only using this
-                // to check for overlay pages related to drivers and executable
-                // code. Only the hypercall code page overlay matches that
-                // description. However, for full correctness this should be
-                // extended to check for all overlay pages.
-                let overlay_page = hvdef::hypercall::MsrHypercallContents::from(
-                    self.vp.backing.cvm_state_mut().hv[target_vtl]
-                        .msr_read(hvdef::HV_X64_MSR_HYPERCALL)
-                        .unwrap(),
-                )
-                .gpn();
-
                 let cache_type = match cache_info {
                     TranslateCachingInfo::NoPaging => HvCacheType::HvCacheTypeWriteBack.0 as u8,
                     TranslateCachingInfo::Paging { pat_index } => {
@@ -1474,7 +1462,12 @@ impl<T, B: HardwareIsolatedBacking> hv1_hypercall::TranslateVirtualAddressX64
                 Ok(hvdef::hypercall::TranslateVirtualAddressOutput {
                     translation_result: hvdef::hypercall::TranslateGvaResult::new()
                         .with_result_code(TranslateGvaResultCode::SUCCESS.0)
-                        .with_overlay_page(gpn == overlay_page)
+                        .with_overlay_page(
+                            self.vp
+                                .cvm_partition()
+                                .isolated_memory_protector
+                                .is_overlay_page(self.intercepted_vtl, gpn),
+                        )
                         .with_cache_type(cache_type),
                     gpa_page: gpn,
                 })


### PR DESCRIPTION
Pretty straightforward wiring. The hypercall page is one of these registered pages, so nothing here is lost.

Cherry-pick of #1552 