### PR TITLE
uefi_nvram_storage: save restore nvram contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,7 +2788,6 @@ dependencies = [
  "cvm_tracing",
  "guid",
  "inspect",
- "mesh_protobuf",
  "open_enum",
  "pal_async",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,6 +2788,7 @@ dependencies = [
  "cvm_tracing",
  "guid",
  "inspect",
+ "mesh_protobuf",
  "open_enum",
  "pal_async",
  "static_assertions",
@@ -2795,6 +2796,7 @@ dependencies = [
  "tracing",
  "ucs2 0.0.0",
  "uefi_nvram_storage",
+ "vmcore",
  "wchar",
  "zerocopy 0.8.24",
 ]
@@ -7297,10 +7299,12 @@ dependencies = [
  "async-trait",
  "guid",
  "inspect",
+ "mesh_protobuf",
  "pal_async",
  "thiserror 2.0.12",
  "ucs2 0.0.0",
  "uefi_specs",
+ "vmcore",
  "wchar",
  "zerocopy 0.8.24",
 ]

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -56,7 +56,7 @@ hyperv_ic_resources.workspace = true
 hyperv_secure_boot_templates.workspace = true
 hyperv_uefi_custom_vars_json.workspace = true
 framebuffer.workspace = true
-hcl_compat_uefi_nvram_storage = { workspace = true, features = ["inspect"] }
+hcl_compat_uefi_nvram_storage = { workspace = true, features = ["inspect", "save_restore"] }
 get_helpers.workspace = true
 get_protocol.workspace = true
 guest_emulation_transport.workspace = true

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2056,16 +2056,20 @@ async fn new_underhill_vm(
                 logger: Box::new(UnderhillLogger {
                     get: get_client.clone(),
                 }),
-                nvram_storage: Box::new(HclCompatNvram::new(
-                    VmgsStorageBackendAdapter(
-                        vmgs_client
-                            .as_non_volatile_store(vmgs::FileId::BIOS_NVRAM, true)
-                            .context("failed to instantiate UEFI NVRAM store")?,
-                    ),
-                    Some(HclCompatNvramQuirks {
-                        skip_corrupt_vars_with_missing_null_term: true,
-                    }),
-                )),
+                nvram_storage: Box::new(
+                    HclCompatNvram::new(
+                        VmgsStorageBackendAdapter(
+                            vmgs_client
+                                .as_non_volatile_store(vmgs::FileId::BIOS_NVRAM, true)
+                                .context("failed to instantiate UEFI NVRAM store")?,
+                        ),
+                        Some(HclCompatNvramQuirks {
+                            skip_corrupt_vars_with_missing_null_term: true,
+                        }),
+                        is_restoring,
+                    )
+                    .await?,
+                ),
                 generation_id_recv: get_client
                     .take_generation_id_recv()
                     .await

--- a/openvmm/hvlite_core/Cargo.toml
+++ b/openvmm/hvlite_core/Cargo.toml
@@ -52,10 +52,10 @@ disk_backend.workspace = true
 firmware_pcat.workspace = true
 firmware_uefi_custom_vars.workspace = true
 firmware_uefi.workspace = true
-uefi_nvram_storage.workspace = true
+uefi_nvram_storage = { workspace = true, features = ["save_restore"] }
 framebuffer.workspace = true
 get_resources.workspace = true
-hcl_compat_uefi_nvram_storage = { workspace = true, features = ["inspect"] }
+hcl_compat_uefi_nvram_storage = { workspace = true, features = ["inspect", "save_restore"] }
 ide.workspace = true
 floppy.workspace = true
 input_core.workspace = true

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1067,13 +1067,17 @@ impl InitializedVm {
                         use vmm_core::emuplat::hcl_compat_uefi_nvram_storage::VmgsStorageBackendAdapter;
 
                         match vmgs_client {
-                            Some(vmgs) => Box::new(HclCompatNvram::new(
-                                VmgsStorageBackendAdapter(
-                                    vmgs.as_non_volatile_store(vmgs::FileId::BIOS_NVRAM, true)
-                                        .context("failed to instantiate UEFI NVRAM store")?,
-                                ),
-                                None,
-                            )),
+                            Some(vmgs) => Box::new(
+                                HclCompatNvram::new(
+                                    VmgsStorageBackendAdapter(
+                                        vmgs.as_non_volatile_store(vmgs::FileId::BIOS_NVRAM, true)
+                                            .context("failed to instantiate UEFI NVRAM store")?,
+                                    ),
+                                    None,
+                                    false,
+                                )
+                                .await?,
+                            ),
                             None => Box::new(InMemoryNvram::new()),
                         }
                     },

--- a/vm/devices/firmware/firmware_uefi/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/Cargo.toml
@@ -22,7 +22,7 @@ fuzzing = []
 
 [dependencies]
 firmware_uefi_custom_vars.workspace = true
-uefi_nvram_storage = { workspace = true, features = ["inspect"] }
+uefi_nvram_storage = { workspace = true, features = ["inspect", "save_restore"] }
 uefi_specs.workspace = true
 uefi_nvram_specvars.workspace = true
 generation_id.workspace = true

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -74,7 +74,7 @@ use std::convert::TryInto;
 use std::ops::RangeInclusive;
 use std::task::Context;
 use thiserror::Error;
-use uefi_nvram_storage::InspectableNvramStorage;
+use uefi_nvram_storage::VmmNvramStorage;
 use vmcore::device_state::ChangeDeviceState;
 use vmcore::vmtime::VmTimeSource;
 use watchdog_core::platform::WatchdogPlatform;
@@ -129,7 +129,7 @@ pub struct UefiConfig {
 /// Various runtime objects used by the UEFI device + underlying services.
 pub struct UefiRuntimeDeps<'a> {
     pub gm: GuestMemory,
-    pub nvram_storage: Box<dyn InspectableNvramStorage>,
+    pub nvram_storage: Box<dyn VmmNvramStorage>,
     pub logger: Box<dyn UefiLogger>,
     pub vmtime: &'a VmTimeSource,
     pub watchdog_platform: Box<dyn WatchdogPlatform>,

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/mod.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/mod.rs
@@ -24,7 +24,7 @@ use inspect::Inspect;
 use std::borrow::Cow;
 use std::fmt::Debug;
 use thiserror::Error;
-use uefi_nvram_storage::InspectableNvramStorage;
+use uefi_nvram_storage::VmmNvramStorage;
 use uefi_specs::uefi::common::EfiStatus;
 use uefi_specs::uefi::nvram::EfiVariableAttributes;
 use zerocopy::IntoBytes;
@@ -67,12 +67,12 @@ pub struct NvramServices {
 
     // Sub-emulators
     #[inspect(flatten)]
-    services: NvramSpecServices<Box<dyn InspectableNvramStorage>>,
+    services: NvramSpecServices<Box<dyn VmmNvramStorage>>,
 }
 
 impl NvramServices {
     pub async fn new(
-        nvram_storage: Box<dyn InspectableNvramStorage>,
+        nvram_storage: Box<dyn VmmNvramStorage>,
         custom_vars: CustomVars,
         secure_boot_enabled: bool,
         vsm_config: Option<Box<dyn VsmConfig>>,
@@ -622,15 +622,14 @@ mod save_restore {
     mod state {
         use crate::service::nvram::NvramSpecServices;
         use mesh::payload::Protobuf;
-        use uefi_nvram_storage::InspectableNvramStorage;
+        use uefi_nvram_storage::VmmNvramStorage;
         use vmcore::save_restore::SaveRestore;
 
         #[derive(Protobuf)]
         #[mesh(package = "firmware.uefi.nvram")]
         pub struct SavedState {
             #[mesh(1)]
-            pub services:
-                <NvramSpecServices<Box<dyn InspectableNvramStorage>> as SaveRestore>::SavedState,
+            pub services: <NvramSpecServices<Box<dyn VmmNvramStorage>> as SaveRestore>::SavedState,
         }
     }
 

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/mod.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/mod.rs
@@ -1453,7 +1453,8 @@ mod save_restore {
 
     mod state {
         use mesh::payload::Protobuf;
-        use vmcore::save_restore::SavedStateBlob;
+        use uefi_nvram_storage::in_memory::InMemoryNvram;
+        use vmcore::save_restore::SaveRestore;
 
         #[derive(Protobuf)]
         #[mesh(package = "firmware.uefi.nvram.spec")]
@@ -1472,7 +1473,7 @@ mod save_restore {
             #[mesh(1)]
             pub runtime_state: SavedRuntimeState,
             #[mesh(2)]
-            pub storage: SavedStateBlob,
+            pub storage: <InMemoryNvram as SaveRestore>::SavedState,
         }
     }
 

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/mod.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/mod.rs
@@ -23,9 +23,9 @@ use ucs2::Ucs2LeSlice;
 use ucs2::Ucs2ParseError;
 use uefi_nvram_specvars::signature_list;
 use uefi_nvram_specvars::signature_list::ParseSignatureLists;
-use uefi_nvram_storage::InspectableNvramStorage;
 use uefi_nvram_storage::NextVariable;
 use uefi_nvram_storage::NvramStorageError;
+use uefi_nvram_storage::VmmNvramStorage;
 use uefi_specs::uefi::common::EfiStatus;
 use uefi_specs::uefi::nvram::EfiVariableAttributes;
 use uefi_specs::uefi::time::EFI_TIME;
@@ -224,12 +224,12 @@ impl RuntimeState {
 /// `NvramError` type provides additional context as to what error occurred in
 /// OpenVMM (i.e: for logging purposes).
 #[derive(Debug, Inspect)]
-pub struct NvramSpecServices<S: InspectableNvramStorage> {
+pub struct NvramSpecServices<S: VmmNvramStorage> {
     storage: S,
     runtime_state: RuntimeState,
 }
 
-impl<S: InspectableNvramStorage> NvramSpecServices<S> {
+impl<S: VmmNvramStorage> NvramSpecServices<S> {
     /// Construct a new NvramServices instance from an existing storage backend.
     pub fn new(storage: S) -> NvramSpecServices<S> {
         NvramSpecServices {
@@ -1453,6 +1453,7 @@ mod save_restore {
 
     mod state {
         use mesh::payload::Protobuf;
+        use vmcore::save_restore::SavedStateBlob;
 
         #[derive(Protobuf)]
         #[mesh(package = "firmware.uefi.nvram.spec")]
@@ -1470,10 +1471,12 @@ mod save_restore {
         pub struct SavedState {
             #[mesh(1)]
             pub runtime_state: SavedRuntimeState,
+            #[mesh(2)]
+            pub storage: SavedStateBlob,
         }
     }
 
-    impl<S: InspectableNvramStorage> SaveRestore for NvramSpecServices<S> {
+    impl<S: VmmNvramStorage> SaveRestore for NvramSpecServices<S> {
         type SavedState = state::SavedState;
 
         fn save(&mut self) -> Result<Self::SavedState, SaveError> {
@@ -1483,17 +1486,22 @@ mod save_restore {
                     RuntimeState::Boot => state::SavedRuntimeState::Boot,
                     RuntimeState::Runtime => state::SavedRuntimeState::Runtime,
                 },
+                storage: self.storage.save()?,
             })
         }
 
         fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
-            let state::SavedState { runtime_state } = state;
+            let state::SavedState {
+                runtime_state,
+                storage,
+            } = state;
 
             self.runtime_state = match runtime_state {
                 state::SavedRuntimeState::PreBoot => RuntimeState::PreBoot,
                 state::SavedRuntimeState::Boot => RuntimeState::Boot,
                 state::SavedRuntimeState::Runtime => RuntimeState::Runtime,
             };
+            self.storage.restore(storage)?;
 
             Ok(())
         }
@@ -1526,7 +1534,7 @@ mod test {
     }
 
     #[async_trait::async_trait]
-    impl<S: InspectableNvramStorage> NvramServicesTestExt for NvramSpecServices<S> {
+    impl<S: VmmNvramStorage> NvramServicesTestExt for NvramSpecServices<S> {
         async fn set_test_var(&mut self, name: &[u8], attr: u32, data: &[u8]) -> NvramResult<()> {
             let vendor = Guid::default();
 

--- a/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/nvram_services_ext.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/nvram/spec_services/nvram_services_ext.rs
@@ -6,7 +6,7 @@ use super::NvramResult;
 use super::NvramSpecServices;
 use guid::Guid;
 use ucs2::Ucs2LeSlice;
-use uefi_nvram_storage::InspectableNvramStorage;
+use uefi_nvram_storage::VmmNvramStorage;
 use uefi_specs::uefi::common::EfiStatus;
 
 /// Extension trait around `NvramServices` that makes it easier to use the API
@@ -56,7 +56,7 @@ pub trait NvramServicesExt {
 }
 
 #[async_trait::async_trait]
-impl<S: InspectableNvramStorage> NvramServicesExt for NvramSpecServices<S> {
+impl<S: VmmNvramStorage> NvramServicesExt for NvramSpecServices<S> {
     async fn get_variable(
         &mut self,
         vendor: Guid,

--- a/vm/devices/firmware/hcl_compat_uefi_nvram_storage/Cargo.toml
+++ b/vm/devices/firmware/hcl_compat_uefi_nvram_storage/Cargo.toml
@@ -10,13 +10,16 @@ rust-version.workspace = true
 default = []
 
 inspect = ["dep:inspect", "uefi_nvram_storage/inspect"]
+save_restore = ["dep:mesh_protobuf", "dep:vmcore", "uefi_nvram_storage/save_restore"]
 
 [dependencies]
 uefi_nvram_storage.workspace = true
+vmcore = { workspace = true, optional = true }
 
 cvm_tracing.workspace = true
 guid.workspace = true
 inspect = { workspace = true, optional = true }
+mesh_protobuf = { workspace = true, optional = true }
 open_enum.workspace = true
 ucs2.workspace = true
 

--- a/vm/devices/firmware/hcl_compat_uefi_nvram_storage/Cargo.toml
+++ b/vm/devices/firmware/hcl_compat_uefi_nvram_storage/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 default = []
 
 inspect = ["dep:inspect", "uefi_nvram_storage/inspect"]
-save_restore = ["dep:mesh_protobuf", "dep:vmcore", "uefi_nvram_storage/save_restore"]
+save_restore = [ "dep:vmcore", "uefi_nvram_storage/save_restore"]
 
 [dependencies]
 uefi_nvram_storage.workspace = true
@@ -19,7 +19,6 @@ vmcore = { workspace = true, optional = true }
 cvm_tracing.workspace = true
 guid.workspace = true
 inspect = { workspace = true, optional = true }
-mesh_protobuf = { workspace = true, optional = true }
 open_enum.workspace = true
 ucs2.workspace = true
 

--- a/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
+++ b/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
@@ -473,32 +473,15 @@ mod save_restore {
     use vmcore::save_restore::SaveError;
     use vmcore::save_restore::SaveRestore;
 
-    mod state {
-        use uefi_nvram_storage::in_memory;
-        use vmcore::save_restore::SaveRestore;
-        use vmcore::save_restore::SavedStateRoot;
-
-        #[derive(mesh_protobuf::Protobuf, SavedStateRoot)]
-        #[mesh(package = "firmware.hcl_compat_nvram")]
-        pub struct SavedState {
-            #[mesh(1)]
-            pub in_memory: <in_memory::InMemoryNvram as SaveRestore>::SavedState,
-        }
-    }
-
     impl<S: StorageBackend> SaveRestore for HclCompatNvram<S> {
-        type SavedState = state::SavedState;
+        type SavedState = <in_memory::InMemoryNvram as SaveRestore>::SavedState;
 
         fn save(&mut self) -> Result<Self::SavedState, SaveError> {
-            Ok(state::SavedState {
-                in_memory: self.in_memory.save()?,
-            })
+            self.in_memory.save()
         }
 
         fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
-            let state::SavedState { in_memory } = state;
-            self.in_memory.restore(in_memory)?;
-            Ok(())
+            self.in_memory.restore(state)
         }
     }
 }

--- a/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
+++ b/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
@@ -118,8 +118,12 @@ pub struct HclCompatNvramQuirks {
 
 impl<S: StorageBackend> HclCompatNvram<S> {
     /// Create a new [`HclCompatNvram`]
-    pub fn new(storage: S, quirks: Option<HclCompatNvramQuirks>) -> Self {
-        Self {
+    pub async fn new(
+        storage: S,
+        quirks: Option<HclCompatNvramQuirks>,
+        is_restoring: bool,
+    ) -> Result<Self, NvramStorageError> {
+        let mut nvram = Self {
             quirks: quirks.unwrap_or(HclCompatNvramQuirks {
                 skip_corrupt_vars_with_missing_null_term: false,
             }),
@@ -129,11 +133,16 @@ impl<S: StorageBackend> HclCompatNvram<S> {
             in_memory: in_memory::InMemoryNvram::new(),
 
             nvram_buf: Vec::new(),
+        };
+        if !is_restoring {
+            nvram.load_from_storage().await?;
         }
+        Ok(nvram)
     }
 
-    async fn lazy_load_from_storage(&mut self) -> Result<(), NvramStorageError> {
-        let res = self.lazy_load_from_storage_inner().await;
+    async fn load_from_storage(&mut self) -> Result<(), NvramStorageError> {
+        tracing::info!("loading uefi nvram from storage");
+        let res = self.load_from_storage_inner().await;
         if let Err(e) = &res {
             tracing::error!(CVM_ALLOWED, "storage contains corrupt nvram state");
             tracing::error!(
@@ -145,11 +154,7 @@ impl<S: StorageBackend> HclCompatNvram<S> {
         res
     }
 
-    async fn lazy_load_from_storage_inner(&mut self) -> Result<(), NvramStorageError> {
-        if !self.nvram_buf.is_empty() {
-            return Ok(());
-        }
-
+    async fn load_from_storage_inner(&mut self) -> Result<(), NvramStorageError> {
         let nvram_buf = self
             .storage
             .restore()
@@ -293,6 +298,7 @@ impl<S: StorageBackend> HclCompatNvram<S> {
 
     /// Dump in-memory nvram to the underlying storage device.
     async fn flush_storage(&mut self) -> Result<(), NvramStorageError> {
+        tracing::info!("flushing uefi nvram to storage");
         self.nvram_buf.clear();
 
         for in_memory::VariableEntry {
@@ -337,11 +343,8 @@ impl<S: StorageBackend> HclCompatNvram<S> {
 
     /// Iterate over the NVRAM entries. This function asynchronously loads the
     /// NVRAM contents into memory from the backing storage if necessary.
-    pub async fn iter(
-        &mut self,
-    ) -> Result<impl Iterator<Item = in_memory::VariableEntry<'_>>, NvramStorageError> {
-        self.lazy_load_from_storage().await?;
-        Ok(self.in_memory.iter())
+    pub fn iter(&mut self) -> impl Iterator<Item = in_memory::VariableEntry<'_>> {
+        self.in_memory.iter()
     }
 }
 
@@ -352,8 +355,6 @@ impl<S: StorageBackend> NvramStorage for HclCompatNvram<S> {
         name: &Ucs2LeSlice,
         vendor: Guid,
     ) -> Result<Option<(u32, Vec<u8>, EFI_TIME)>, NvramStorageError> {
-        self.lazy_load_from_storage().await?;
-
         if name.as_bytes().len() > EFI_MAX_VARIABLE_NAME_SIZE {
             return Err(NvramStorageError::VariableNameTooLong);
         }
@@ -369,8 +370,6 @@ impl<S: StorageBackend> NvramStorage for HclCompatNvram<S> {
         data: Vec<u8>,
         timestamp: EFI_TIME,
     ) -> Result<(), NvramStorageError> {
-        self.lazy_load_from_storage().await?;
-
         if name.as_bytes().len() > EFI_MAX_VARIABLE_NAME_SIZE {
             return Err(NvramStorageError::VariableNameTooLong);
         }
@@ -413,8 +412,6 @@ impl<S: StorageBackend> NvramStorage for HclCompatNvram<S> {
         data: Vec<u8>,
         timestamp: EFI_TIME,
     ) -> Result<bool, NvramStorageError> {
-        self.lazy_load_from_storage().await?;
-
         if name.as_bytes().len() > EFI_MAX_VARIABLE_NAME_SIZE {
             return Err(NvramStorageError::VariableNameTooLong);
         }
@@ -445,8 +442,6 @@ impl<S: StorageBackend> NvramStorage for HclCompatNvram<S> {
         name: &Ucs2LeSlice,
         vendor: Guid,
     ) -> Result<bool, NvramStorageError> {
-        self.lazy_load_from_storage().await?;
-
         if name.as_bytes().len() > EFI_MAX_VARIABLE_NAME_SIZE {
             return Err(NvramStorageError::VariableNameTooLong);
         }
@@ -461,8 +456,6 @@ impl<S: StorageBackend> NvramStorage for HclCompatNvram<S> {
         &mut self,
         name_vendor: Option<(&Ucs2LeSlice, Guid)>,
     ) -> Result<NextVariable, NvramStorageError> {
-        self.lazy_load_from_storage().await?;
-
         if let Some((name, _)) = name_vendor {
             if name.as_bytes().len() > EFI_MAX_VARIABLE_NAME_SIZE {
                 return Err(NvramStorageError::VariableNameTooLong);
@@ -470,6 +463,43 @@ impl<S: StorageBackend> NvramStorage for HclCompatNvram<S> {
         }
 
         self.in_memory.next_variable(name_vendor).await
+    }
+}
+
+#[cfg(feature = "save_restore")]
+mod save_restore {
+    use super::*;
+    use vmcore::save_restore::RestoreError;
+    use vmcore::save_restore::SaveError;
+    use vmcore::save_restore::SaveRestore;
+
+    mod state {
+        use uefi_nvram_storage::in_memory;
+        use vmcore::save_restore::SaveRestore;
+        use vmcore::save_restore::SavedStateRoot;
+
+        #[derive(mesh_protobuf::Protobuf, SavedStateRoot)]
+        #[mesh(package = "firmware.hcl_compat_nvram")]
+        pub struct SavedState {
+            #[mesh(1)]
+            pub in_memory: <in_memory::InMemoryNvram as SaveRestore>::SavedState,
+        }
+    }
+
+    impl<S: StorageBackend> SaveRestore for HclCompatNvram<S> {
+        type SavedState = state::SavedState;
+
+        fn save(&mut self) -> Result<Self::SavedState, SaveError> {
+            Ok(state::SavedState {
+                in_memory: self.in_memory.save()?,
+            })
+        }
+
+        fn restore(&mut self, state: Self::SavedState) -> Result<(), RestoreError> {
+            let state::SavedState { in_memory } = state;
+            self.in_memory.restore(in_memory)?;
+            Ok(())
+        }
     }
 }
 
@@ -503,28 +533,36 @@ mod test {
     #[async_test]
     async fn test_single_variable() {
         let mut storage = EphemeralStorageBackend::default();
-        let mut nvram = HclCompatNvram::new(&mut storage, None);
+        let mut nvram = HclCompatNvram::new(&mut storage, None, false)
+            .await
+            .unwrap();
         impl_agnostic_tests::test_single_variable(&mut nvram).await;
     }
 
     #[async_test]
     async fn test_multiple_variable() {
         let mut storage = EphemeralStorageBackend::default();
-        let mut nvram = HclCompatNvram::new(&mut storage, None);
+        let mut nvram = HclCompatNvram::new(&mut storage, None, false)
+            .await
+            .unwrap();
         impl_agnostic_tests::test_multiple_variable(&mut nvram).await;
     }
 
     #[async_test]
     async fn test_next() {
         let mut storage = EphemeralStorageBackend::default();
-        let mut nvram = HclCompatNvram::new(&mut storage, None);
+        let mut nvram = HclCompatNvram::new(&mut storage, None, false)
+            .await
+            .unwrap();
         impl_agnostic_tests::test_next(&mut nvram).await;
     }
 
     #[async_test]
     async fn boundary_conditions() {
         let mut storage = EphemeralStorageBackend::default();
-        let mut nvram = HclCompatNvram::new(&mut storage, None);
+        let mut nvram = HclCompatNvram::new(&mut storage, None, false)
+            .await
+            .unwrap();
 
         let vendor = Guid::new_random();
         let attr = 0x1234;
@@ -612,7 +650,9 @@ mod test {
         let data = vec![0x1, 0x2, 0x3, 0x4, 0x5];
         let timestamp = EFI_TIME::default();
 
-        let mut nvram = HclCompatNvram::new(&mut storage, None);
+        let mut nvram = HclCompatNvram::new(&mut storage, None, false)
+            .await
+            .unwrap();
         nvram
             .set_variable(name1, vendor1, attr, data.clone(), timestamp)
             .await
@@ -629,7 +669,9 @@ mod test {
         drop(nvram);
 
         // reload
-        let mut nvram = HclCompatNvram::new(&mut storage, None);
+        let mut nvram = HclCompatNvram::new(&mut storage, None, false)
+            .await
+            .unwrap();
 
         let (result_attr, result_data, result_timestamp) =
             nvram.get_variable(name1, vendor1).await.unwrap().unwrap();

--- a/vm/devices/firmware/uefi_nvram_storage/Cargo.toml
+++ b/vm/devices/firmware/uefi_nvram_storage/Cargo.toml
@@ -10,12 +10,15 @@ rust-version.workspace = true
 default = []
 
 inspect = ["dep:inspect", "uefi_specs/inspect"]
+save_restore = ["inspect", "dep:mesh_protobuf", "dep:vmcore"]
 
 [dependencies]
 guid.workspace = true
 inspect = { workspace = true, optional = true }
+mesh_protobuf = { workspace = true, optional = true }
 ucs2.workspace = true
 uefi_specs.workspace = true
+vmcore = { workspace = true, optional = true }
 
 async-trait.workspace = true
 thiserror.workspace = true

--- a/vm/devices/firmware/uefi_nvram_storage/src/lib.rs
+++ b/vm/devices/firmware/uefi_nvram_storage/src/lib.rs
@@ -11,8 +11,8 @@ pub use uefi_specs::uefi::time::EFI_TIME;
 pub mod in_memory;
 
 use guid::Guid;
-#[cfg(feature = "inspect")]
-pub use inspect_ext::InspectableNvramStorage;
+#[cfg(feature = "save_restore")]
+pub use save_restore::VmmNvramStorage;
 use std::fmt::Debug;
 use thiserror::Error;
 use ucs2::Ucs2LeSlice;
@@ -169,18 +169,18 @@ impl NvramStorage for Box<dyn NvramStorage> {
     }
 }
 
-/// Defines a trait that combines NvramStorage and Inspect
-#[cfg(feature = "inspect")]
-mod inspect_ext {
+/// Defines a trait that combines NvramStorage, Inspect, and SaveRestore
+#[cfg(feature = "save_restore")]
+mod save_restore {
     use super::*;
     use inspect::Inspect;
+    use vmcore::save_restore::ProtobufSaveRestore;
 
-    /// Extends [`NvramStorage`] with a bound on [`Inspect`]
-    pub trait InspectableNvramStorage: NvramStorage + Inspect {}
-    impl<T: NvramStorage + Inspect> InspectableNvramStorage for T {}
+    pub trait VmmNvramStorage: NvramStorage + Inspect + ProtobufSaveRestore {}
+    impl<T> VmmNvramStorage for T where T: NvramStorage + Inspect + ProtobufSaveRestore {}
 
     #[async_trait::async_trait]
-    impl NvramStorage for Box<dyn InspectableNvramStorage> {
+    impl NvramStorage for Box<dyn VmmNvramStorage> {
         async fn get_variable(
             &mut self,
             name: &Ucs2LeSlice,
@@ -227,6 +227,21 @@ mod inspect_ext {
             name_vendor: Option<(&Ucs2LeSlice, Guid)>,
         ) -> Result<NextVariable, NvramStorageError> {
             (**self).next_variable(name_vendor).await
+        }
+    }
+
+    impl ProtobufSaveRestore for Box<dyn VmmNvramStorage> {
+        fn save(
+            &mut self,
+        ) -> Result<vmcore::save_restore::SavedStateBlob, vmcore::save_restore::SaveError> {
+            (**self).save()
+        }
+
+        fn restore(
+            &mut self,
+            state: vmcore::save_restore::SavedStateBlob,
+        ) -> Result<(), vmcore::save_restore::RestoreError> {
+            (**self).restore(state)
         }
     }
 }

--- a/vm/devices/firmware/uefi_specs/src/uefi/time.rs
+++ b/vm/devices/firmware/uefi_specs/src/uefi/time.rs
@@ -102,7 +102,6 @@ pub const EFI_UNSPECIFIED_TIMEZONE: EfiTimezone = EfiTimezone(0x07FF);
 #[derive(Copy, Clone, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 #[repr(transparent)]
 #[cfg_attr(feature = "inspect", derive(inspect::Inspect), inspect(transparent))]
-#[cfg_attr(feature = "mesh", derive(mesh_protobuf::Protobuf), mesh(transparent))]
 pub struct EfiTimezone(pub i16);
 
 impl EfiTimezone {
@@ -116,7 +115,6 @@ impl EfiTimezone {
 #[bitfield(u8)]
 #[derive(IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 #[cfg_attr(feature = "inspect", derive(inspect::Inspect), inspect(transparent))]
-#[cfg_attr(feature = "mesh", derive(mesh_protobuf::Protobuf), mesh(transparent))]
 pub struct EfiDaylight {
     /// EFI_TIME_ADJUST_DAYLIGHT
     ///

--- a/vm/devices/firmware/uefi_specs/src/uefi/time.rs
+++ b/vm/devices/firmware/uefi_specs/src/uefi/time.rs
@@ -102,6 +102,7 @@ pub const EFI_UNSPECIFIED_TIMEZONE: EfiTimezone = EfiTimezone(0x07FF);
 #[derive(Copy, Clone, Debug, IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 #[repr(transparent)]
 #[cfg_attr(feature = "inspect", derive(inspect::Inspect), inspect(transparent))]
+#[cfg_attr(feature = "mesh", derive(mesh_protobuf::Protobuf), mesh(transparent))]
 pub struct EfiTimezone(pub i16);
 
 impl EfiTimezone {
@@ -115,6 +116,7 @@ impl EfiTimezone {
 #[bitfield(u8)]
 #[derive(IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq)]
 #[cfg_attr(feature = "inspect", derive(inspect::Inspect), inspect(transparent))]
+#[cfg_attr(feature = "mesh", derive(mesh_protobuf::Protobuf), mesh(transparent))]
 pub struct EfiDaylight {
     /// EFI_TIME_ADJUST_DAYLIGHT
     ///

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -1318,7 +1318,7 @@ pub mod options {
             /// Interface to log UEFI BIOS events
             pub logger: Box<dyn firmware_uefi::platform::logger::UefiLogger>,
             /// Interface for storing/retrieving UEFI NVRAM variables
-            pub nvram_storage: Box<dyn uefi_nvram_storage::InspectableNvramStorage>,
+            pub nvram_storage: Box<dyn uefi_nvram_storage::VmmNvramStorage>,
             /// Channel to receive updated generation ID values
             pub generation_id_recv: mesh::Receiver<[u8; 16]>,
             /// Device-specific functions the platform must provide in order


### PR DESCRIPTION
Implement save/restore for HclCompatNvram/NvramStorage/InMemoryNvram so that OpenHCL doesn't need to re-read from the VMGS file after a servicing or other save-restore operation. This will help avoid panics if the VMGS file is not accessible in certain VM teardown cases.