### PR TITLE
TDX: Don't attempt to set memory protections on untrusted synic overlay pages

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1044,10 +1044,10 @@ impl BackingPrivate for TdxBacked {
             let prot_access = &mut UntrustedSynicVtlProts(&this.partition.gm[GuestVtl::Vtl0]);
 
             synic
-                .set_siefp(reg(pfns[UhDirectOverlay::Sifp as usize]), prot_access)
+                .set_simp(reg(pfns[UhDirectOverlay::Sipp as usize]), prot_access)
                 .unwrap();
             synic
-                .set_simp(reg(pfns[UhDirectOverlay::Sipp as usize]), prot_access)
+                .set_siefp(reg(pfns[UhDirectOverlay::Sifp as usize]), prot_access)
                 .unwrap();
             // Set the SIEFP in the hypervisor so that the hypervisor can
             // directly signal synic events. Don't set the SIMP, since the


### PR DESCRIPTION
Since these pages are not visible to VTL 0 this won't work.