### PR TITLE
virt_hvf: support VENDOR_HYP_UID_MS_HYPERVISOR hypercall

### DIFF
--- a/vm/aarch64/aarch64defs/src/lib.rs
+++ b/vm/aarch64/aarch64defs/src/lib.rs
@@ -8,7 +8,7 @@
 #![no_std]
 
 pub mod gic;
-pub mod psci;
+pub mod smccc;
 
 use bitfield_struct::bitfield;
 use open_enum::open_enum;

--- a/vm/aarch64/aarch64defs/src/smccc.rs
+++ b/vm/aarch64/aarch64defs/src/smccc.rs
@@ -1,12 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Definitions for the Power State Coordination Interface (PSCI).
+//! Definitions for the SMC Calling Convention (SMCCC), including PSCI.
 
 use bitfield_struct::bitfield;
 use open_enum::open_enum;
 
-pub const PSCI: u8 = 0x4;
+open_enum! {
+    pub enum Service: u8 {
+        SMCCC = 0,
+        PSCI = 4,
+        VENDOR_HYP = 6,
+    }
+}
+
+impl Service {
+    const fn from_bits(bits: u8) -> Self {
+        Self(bits)
+    }
+
+    const fn into_bits(self) -> u8 {
+        self.0
+    }
+}
 
 #[bitfield(u32)]
 #[derive(PartialEq, Eq, Ord, PartialOrd, Hash)]
@@ -16,13 +32,16 @@ pub struct FastCall {
     #[bits(7)]
     pub mbz: u8,
     #[bits(6)]
-    pub service: u8,
+    pub service: Service,
     pub smc64: bool,
     pub fast: bool,
 }
 
 open_enum! {
-    pub enum PsciCall: FastCall {
+    pub enum SmcCall: FastCall {
+        SMCCC_VERSION = FastCall(0x8000_0000),
+        SMCCC_ARCH_FEATURES = FastCall(0x8000_0001),
+
         PSCI_VERSION = FastCall(0x8400_0000),
         CPU_SUSPEND = FastCall(0x8400_0001),
         CPU_OFF = FastCall(0x8400_0002),
@@ -45,6 +64,8 @@ open_enum! {
         PSCI_SET_SUSPEND_MODE = FastCall(0x8400_000f),
         PSCI_STAT_RESIDENCY = FastCall(0x8400_0010),
         PSCI_STAT_COUNT = FastCall(0x8400_0011),
+
+        VENDOR_HYP_UID = FastCall(0x8600_FF01),
     }
 }
 

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -49,6 +49,9 @@ pub const VS1_PARTITION_PROPERTIES_EAX_DEBUG_DEVICE_PRESENT: u32 = 0x000000002;
 /// Extended I/O APIC RTEs are supported for the current partition.
 pub const VS1_PARTITION_PROPERTIES_EAX_EXTENDED_IOAPIC_RTE: u32 = 0x000000004;
 
+/// SMCCC UID for the Microsoft Hypervisor.
+pub const VENDOR_HYP_UID_MS_HYPERVISOR: [u32; 4] = [0x4d32ba58, 0xcd244764, 0x8eef6c75, 0x16597024];
+
 #[bitfield(u64)]
 pub struct HvPartitionPrivilege {
     // access to virtual msrs

--- a/vmm_core/virt_hvf/src/hypercall.rs
+++ b/vmm_core/virt_hvf/src/hypercall.rs
@@ -4,7 +4,6 @@
 //! Hypercall exit handling.
 
 use crate::HvfProcessor;
-use crate::abi;
 use hv1_hypercall::Arm64RegisterState;
 use hv1_hypercall::GetVpRegisters;
 use hv1_hypercall::HvRepResult;
@@ -41,24 +40,21 @@ impl<'a, 'b, T: CpuIo> HvfHypercallHandler<'a, 'b, T> {
 
 impl<T: CpuIo> Arm64RegisterState for HvfHypercallHandler<'_, '_, T> {
     fn pc(&mut self) -> u64 {
-        self.vp.vcpu.reg(abi::HvReg::PC).expect("cannot fail")
+        self.vp.vcpu.pc()
     }
 
     fn set_pc(&mut self, pc: u64) {
         tracing::trace!(pc, "set pc");
-        self.vp
-            .vcpu
-            .set_reg(abi::HvReg::PC, pc)
-            .expect("cannot fail");
+        self.vp.vcpu.set_pc(pc)
     }
 
     fn x(&mut self, n: u8) -> u64 {
-        self.vp.vcpu.gp(n).expect("cannot fail")
+        self.vp.vcpu.gp(n)
     }
 
     fn set_x(&mut self, n: u8, v: u64) {
         tracing::trace!(n, v, "set x");
-        self.vp.vcpu.set_gp(n, v).expect("cannot fail")
+        self.vp.vcpu.set_gp(n, v)
     }
 }
 


### PR DESCRIPTION
Add support for the VENDOR_HYP_UID_MS_HYPERVISOR hypercall, which is used to report the hypervisor vendor to the guest kernel. This is needed to support modern vmbus on Linux kernels (6.16+) with devicetree (as opposed to EFI+ACPI).