### PR TITLE
netvsp, mana_driver: add instrumentation around parts of mana servicing

### DIFF
--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -30,6 +30,7 @@ use pal_async::driver::SpawnDriver;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
 use std::sync::Arc;
+use tracing::Instrument;
 use user_driver::DeviceBacking;
 use user_driver::DmaClient;
 use user_driver::interrupt::DeviceInterrupt;
@@ -77,7 +78,9 @@ impl<T: DeviceBacking> ManaDevice<T> {
         num_vps: u32,
         max_queues_per_vport: u16,
     ) -> anyhow::Result<Self> {
-        let mut gdma = GdmaDriver::new(driver, device, num_vps).await?;
+        let mut gdma = GdmaDriver::new(driver, device, num_vps)
+            .instrument(tracing::info_span!("new_gdma_driver"))
+            .await?;
         gdma.test_eq().await?;
 
         gdma.verify_vf_driver_version().await?;


### PR DESCRIPTION
Currently, it's difficult to ascertain where time is spent on mana during servicing as we don't have instrumentation around some vital parts of servicing. This PR adds some instrumentation to inform us where time is being spent so that we can prioritize keepalive in the right places.