### PR TITLE
flowey: Properly propagate regen error codes

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/mod.rs
+++ b/flowey/flowey_hvlite/src/pipelines/mod.rs
@@ -46,12 +46,12 @@ impl IntoPipeline for OpenvmmPipelines {
     fn into_pipeline(self, pipeline_hint: PipelineBackendHint) -> anyhow::Result<Pipeline> {
         match self {
             OpenvmmPipelines::Regen { args } => {
-                std::process::Command::new("cargo")
+                let status = std::process::Command::new("cargo")
                     .args(["run", "-p", "flowey_hvlite", "--", "regen"])
                     .args(args)
                     .spawn()?
                     .wait()?;
-                std::process::exit(0)
+                std::process::exit(status.code().unwrap_or(-1));
             }
             OpenvmmPipelines::BuildIgvm(cmd) => cmd.into_pipeline(pipeline_hint),
             OpenvmmPipelines::CustomVmfirmwareigvmDll(cmd) => cmd.into_pipeline(pipeline_hint),


### PR DESCRIPTION
When you sawn a Command in Rust exiting with a non-zero exit code is still considered a "successful" execution, as you successfully waited for the process to finish running. You need to check its exit code to know how the process really did. We weren't doing that in this shim, resulting in `--check` errors being lost, which ultimately broke `xtask fmt`.

Fixes that recent yaml regen mess up that got into main.

This has always been broken, but the prior mechanism of flowey_trampoline would panic rather than exit with a non-zero code on failure, which worked around this. flowey_trampoline was removed in https://github.com/microsoft/openvmm/commit/94875c52369380a182f5219afb4e5639aa88f625.