### PR TITLE
netvsp: handle invalid rndis packets

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -5358,9 +5358,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
         status: protocol::Status,
     ) -> Result<(), WorkerError> {
         let tx_packet = &mut state.pending_tx_packets[id.0 as usize];
-        if status == protocol::Status::SUCCESS {
-            assert_eq!(tx_packet.pending_packet_count, 0);
-        }
+        assert_eq!(tx_packet.pending_packet_count, 0);
         if self.pending_send_size == 0
             && self.try_send_tx_packet(tx_packet.transaction_id, status)?
         {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -936,6 +936,8 @@ impl ActiveState {
                 // This shouldn't be referenced, but set it in case it is in the future.
                 active.pending_tx_packets[id.0 as usize].transaction_id = transaction_id;
             }
+            // Save/Restore does not preserve the status of pending tx completions,
+            // completing any pending completions with 'success' to avoid making changes to saved_state.
             active
                 .pending_tx_completions
                 .push_back(PendingTxCompletion {

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -5088,7 +5088,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
 
             did_some_work = true;
             match packet.data {
-                PacketData::RndisPacket(pkt) => {
+                PacketData::RndisPacket(_) => {
                     assert!(data.tx_segments.is_empty());
                     let id = state.free_tx_packets.pop().unwrap();
                     let result: Result<usize, WorkerError> =
@@ -5096,11 +5096,7 @@ impl<T: 'static + RingMem> NetChannel<T> {
                     let num_packets = match result {
                         Ok(num_packets) => num_packets,
                         Err(err) => {
-                            tracelimit::error_ratelimited!(%err,
-                                packet_data_channel_type = pkt.channel_type,
-                                packet_data_section_index = pkt.send_buffer_section_index,
-                                packet_data_section_size = pkt.send_buffer_section_size,
-                                "failed to handle RNDIS packet");
+                            tracelimit::error_ratelimited!(%err, "failed to handle RNDIS packet");
                             self.complete_failed_tx_packet(state, id)?;
                             continue;
                         }


### PR DESCRIPTION
Netvsp driver does not accept an RNDIS header from Linux NetVSC, if that RNDIS header crosses a 4KB page boundary. handle_rndis_packet_message will return WorkerError::RndisMessageTooSmall. The error bubbles up out of process_ring_buffer causing netvsp to stop processing packets.

RNDIS headers crossing the page boundary has been a longstanding issue with the Linux NetVSC driver, but it has become more frequent recently with the Linux v6.14 kernel due to a recent upstream commit in the Linux networking subsystem that may have slightly affected the way SKBs are constructed.

Making the OpenHCL Netvsp driver more resilient (and more like the Windows Netvsp driver) by adding logic to log the error and complete the packet with a Failure status.