### PR TITLE
hypestv: support `paravisor reload`

### DIFF
--- a/Guide/src/dev_guide/dev_tools/hypestv.md
+++ b/Guide/src/dev_guide/dev_tools/hypestv.md
@@ -21,6 +21,7 @@ Currently, it can:
   terminal window
 * Enable paravisor log output to standard output or another terminal window
 * Inspect paravisor state
+* Modify the paravisor (update the paravisor command line, reload the paravisor)
 
 In the future, it might be able to:
 

--- a/hyperv/tools/hypestv/src/windows/mod.rs
+++ b/hyperv/tools/hypestv/src/windows/mod.rs
@@ -151,6 +151,9 @@ pub(crate) enum ParavisorCommand {
 
     /// Get or set the paravisor command line.
     CommandLine { command_line: Option<String> },
+
+    /// Reload the paravisor.
+    Reload,
 }
 
 #[derive(ValueEnum, Copy, Clone)]

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -346,6 +346,27 @@ impl Vm {
                 .context("failed to update vssd")?;
                 println!("{}", output.trim());
             }
+            ParavisorCommand::Reload => {
+                let output = powershell_script(
+                    r#"
+                    param([string]$id)
+                    $ErrorActionPreference = "Stop"
+                    $guestManagementService = Get-CimInstance -namespace "root\virtualization\v2" -ClassName "Msvm_VirtualSystemGuestManagementService"
+                    $options = 1; # Override version checks
+                    $TimeoutHintSecs = (New-TimeSpan -Minutes 15).TotalSeconds; # Keep less than 30 minutes to avoid a separate failfast path
+                    $result = $guestManagementService | Invoke-CimMethod -name "ReloadManagementVtl" -Arguments @{
+                        "VmId"            = $id
+                        "Options"         = $options
+                        "TimeoutHintSecs" = $TimeoutHintSecs
+                    }
+                    "#,
+                    &[&self.inner.id.to_string()],
+                )
+                .context("failed to reload paravisor")?;
+                // TODO: the result here is a Msvm_ConcreteJob, which this code should inspect to wait for completion and check for success.
+                // For now, we just print the output.
+                println!("{}", output.trim());
+            }
         }
         Ok(())
     }

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -353,7 +353,7 @@ impl Vm {
                     $ErrorActionPreference = "Stop"
                     $guestManagementService = Get-CimInstance -namespace "root\virtualization\v2" -ClassName "Msvm_VirtualSystemGuestManagementService"
                     $options = 1; # Override version checks
-                    $TimeoutHintSecs = (New-TimeSpan -Minutes 15).TotalSeconds; # Keep less than 30 minutes to avoid a separate failfast path
+                    $TimeoutHintSecs = 15; # Ends up as the deadline in GuestSaveRequest (see the handling of SaveGuestVtl2StateNotification in guest_emulation_transport). Keep O(15 seconds).
                     $result = $guestManagementService | Invoke-CimMethod -name "ReloadManagementVtl" -Arguments @{
                         "VmId"            = $id
                         "Options"         = $options


### PR DESCRIPTION
This is a quick implementation of reloading a running paravisor (e.g. issuing an openhcl servicing workflow). As the comment in the code indicates, the code could do much more to parse the `Msvm_ConcreteJob` that is returned (see `Trace-CimMethodExecution` in Set-OpenHCL-HyperV-VM.ps1)