### PR TITLE
guide: add pkg-config for linux users

### DIFF
--- a/Guide/src/dev_guide/getting_started/linux.md
+++ b/Guide/src/dev_guide/getting_started/linux.md
@@ -57,7 +57,8 @@ $ sudo apt install \
   binutils              \
   build-essential       \
   gcc-aarch64-linux-gnu \
-  libssl-dev
+  libssl-dev            \
+  pkg-config
 ```
 
 ## Cloning the OpenVMM source


### PR DESCRIPTION
Some components depend on openssl, which won't build unless you've installed `pkg-config`. Mention that in the guide.