### PR TITLE
Set can_trust_host if TDX debug bit is set (#1501)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,7 +3399,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
- "underhill_confidentiality",
  "vbs_defs",
  "x86defs",
  "zerocopy 0.8.24",
@@ -4828,6 +4827,7 @@ dependencies = [
  "sha2",
  "sidecar_defs",
  "tdcall",
+ "tdx_guest_device",
  "underhill_confidentiality",
  "x86defs",
  "zerocopy 0.8.24",
@@ -6728,6 +6728,7 @@ version = "0.0.0"
 dependencies = [
  "hvdef",
  "memory_range",
+ "tdx_guest_device",
  "thiserror 2.0.12",
  "tracing",
  "x86defs",
@@ -6737,6 +6738,7 @@ dependencies = [
 name = "tdx_guest_device"
 version = "0.0.0"
 dependencies = [
+ "bitfield-struct 0.10.1",
  "nix 0.27.1",
  "static_assertions",
  "thiserror 2.0.12",

--- a/openhcl/openhcl_attestation_protocol/Cargo.toml
+++ b/openhcl/openhcl_attestation_protocol/Cargo.toml
@@ -11,7 +11,7 @@ open_enum.workspace = true
 guid.workspace = true
 mesh.workspace = true
 sev_guest_device.workspace = true
-tdx_guest_device.workspace = true
+tdx_guest_device = { workspace = true, features = ["std"] }
 
 base64.workspace = true
 base64-serde.workspace = true

--- a/openhcl/openhcl_boot/Cargo.toml
+++ b/openhcl/openhcl_boot/Cargo.toml
@@ -30,6 +30,7 @@ zerocopy.workspace = true
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 safe_intrinsics.workspace = true
 tdcall.workspace = true
+tdx_guest_device.workspace = true
 x86defs.workspace = true
 
 [build-dependencies]

--- a/openhcl/openhcl_boot/src/arch/x86_64/tdx.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/tdx.rs
@@ -13,6 +13,8 @@ use tdcall::Tdcall;
 use tdcall::TdcallInput;
 use tdcall::TdcallOutput;
 use tdcall::tdcall_map_gpa;
+use tdx_guest_device::protocol::TdReport;
+use x86defs::tdx::TdCallResult;
 
 /// Perform a tdcall instruction with the specified inputs.
 fn tdcall(input: TdcallInput) -> TdcallOutput {
@@ -118,4 +120,9 @@ pub fn get_tdx_tsc_reftime() -> Option<u64> {
         return Some(count_100ns as u64);
     }
     None
+}
+
+/// Gets the TdReport.
+pub fn get_tdreport(report: &mut TdReport) -> Result<(), TdCallResult> {
+    tdcall::tdcall_mr_report(&mut TdcallInstruction, report)
 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -127,6 +127,7 @@ use tracing::Instrument;
 use tracing::instrument;
 use uevent::UeventListener;
 use underhill_attestation::AttestationType;
+use underhill_confidentiality::confidential_debug_enabled;
 use underhill_threadpool::AffinitizedThreadpool;
 use underhill_threadpool::ThreadpoolBuilder;
 use virt::Partition;
@@ -1587,6 +1588,10 @@ async fn new_underhill_vm(
                 })
                 .context("get dma client")?,
         );
+    }
+
+    if confidential_debug_enabled() {
+        tracing::warn!(CVM_ALLOWED, "confidential debug enabled");
     }
 
     // Create the `AttestationVmConfig` from `dps`, which will be used in

--- a/support/tdx_guest_device/Cargo.toml
+++ b/support/tdx_guest_device/Cargo.toml
@@ -6,7 +6,11 @@ name = "tdx_guest_device"
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+std = []
+
 [dependencies]
+bitfield-struct.workspace = true
 static_assertions.workspace = true
 zerocopy.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/support/tdx_guest_device/src/ioctl.rs
+++ b/support/tdx_guest_device/src/ioctl.rs
@@ -3,6 +3,7 @@
 
 //! The module implements the Linux TDX Guest APIs based on ioctl.
 
+#![cfg(feature = "std")]
 // UNSAFETY: unsafe needed to make ioctl calls.
 #![expect(unsafe_code)]
 

--- a/support/tdx_guest_device/src/lib.rs
+++ b/support/tdx_guest_device/src/lib.rs
@@ -4,6 +4,8 @@
 //! The crate includes the abstraction layer of Linux TDX Guest APIs and
 //! definitions of data structures according to TDX specification.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod protocol;
 
 #[cfg(target_os = "linux")]

--- a/support/tdx_guest_device/src/protocol.rs
+++ b/support/tdx_guest_device/src/protocol.rs
@@ -3,6 +3,7 @@
 
 //! The module includes the definitions of data structures according to TDX specification.
 
+use bitfield_struct::bitfield;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -135,12 +136,52 @@ pub struct TdInfo {
 /// Run-time extendable measurement register.
 pub type Rtmr = [u8; 48];
 
+/// See `ATTRIBUTES` in Table 3.9, "Intel TDX Module v1.5 ABI specification", March 2024.
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct TdAttributes {
+    #[bits(1)]
+    pub debug: bool,
+    #[bits(3)]
+    _reserved1: u8,
+    #[bits(1)]
+    pub hgs_plus_prof: bool,
+    #[bits(1)]
+    pub perf_prof: bool,
+    #[bits(1)]
+    pub pmt_prof: bool,
+    #[bits(9)]
+    _reserved2: u16,
+    #[bits(7)]
+    _reserved_p: u8,
+    #[bits(4)]
+    _reserved_n: u8,
+    #[bits(1)]
+    pub lass: bool,
+    #[bits(1)]
+    pub sept_ve_disable: bool,
+    #[bits(1)]
+    pub migratable: bool,
+    #[bits(1)]
+    pub pks: bool,
+    #[bits(1)]
+    pub kl: bool,
+    #[bits(24)]
+    _reserved3: u32,
+    #[bits(6)]
+    _reserved4: u32,
+    #[bits(1)]
+    pub tpa: bool,
+    #[bits(1)]
+    pub perfmon: bool,
+}
+
 /// See `TDINFO_BASE` in Table 3.34, "Intel TDX Module v1.5 ABI specification", March 2024.
 #[repr(C)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct TdInfoBase {
     /// TD's attributes
-    pub attributes: [u8; 8],
+    pub attributes: TdAttributes,
     /// TD's XFAM
     pub xfam: [u8; 8],
     /// Measurement of the initial contents of the TDX in SHA384

--- a/support/tee_call/Cargo.toml
+++ b/support/tee_call/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sev_guest_device.workspace = true
-tdx_guest_device.workspace = true
+tdx_guest_device = { workspace = true, features = ["std"] }
 
 static_assertions.workspace = true
 thiserror.workspace = true

--- a/vm/loader/igvmfilegen/Cargo.toml
+++ b/vm/loader/igvmfilegen/Cargo.toml
@@ -14,7 +14,6 @@ loader_defs.workspace = true
 hvdef.workspace = true
 
 memory_range.workspace = true
-underhill_confidentiality.workspace = true
 vbs_defs.workspace = true
 x86defs.workspace = true
 

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -40,7 +40,6 @@ use std::io::Write;
 use std::path::PathBuf;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::filter::LevelFilter;
-use underhill_confidentiality::OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME;
 use zerocopy::FromBytes;
 use zerocopy::IntoBytes;
 
@@ -633,20 +632,10 @@ fn load_image<'a, R: IgvmfilegenRegister + GuestArch + 'static>(
                 }
             };
 
-            let command_line = if loader.loader().confidential_debug() {
-                tracing::info!("enabling underhill confidential debug environment flag");
-                format!(
-                    "{command_line} {}=1",
-                    OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME
-                )
-            } else {
-                command_line.clone()
-            };
-
             let command_line = if static_command_line {
-                CommandLineType::Static(&command_line)
+                CommandLineType::Static(command_line)
             } else {
-                CommandLineType::HostAppendable(&command_line)
+                CommandLineType::HostAppendable(command_line)
             };
 
             R::load_openhcl(

--- a/vm/x86/tdcall/Cargo.toml
+++ b/vm/x86/tdcall/Cargo.toml
@@ -13,8 +13,12 @@ tracing = ["dep:tracing"]
 [dependencies]
 hvdef.workspace = true
 memory_range.workspace = true
+tdx_guest_device.workspace = true
 thiserror.workspace = true
 x86defs.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tdx_guest_device = { workspace = true, features = ["std"] }
 
 tracing = { workspace = true, optional = true }
 


### PR DESCRIPTION
If the debug bit is set in the VM's TDX attributes, the host can be trusted. This change gets the TD report in the boot shim and checks the debug bit. If it's set, parse the dynamic command line to allow enabling, e.g., confidential debugging.