### PR TITLE
uh_core: Avoid potential time underflow in tracing math

### DIFF
--- a/openhcl/underhill_core/src/get_tracing/json_layer.rs
+++ b/openhcl/underhill_core/src/get_tracing/json_layer.rs
@@ -438,7 +438,7 @@ where
             // bigger than the current time.
             let time = pal_async::timer::Instant::now();
             if let Some(enter) = span_data.enter_time.take() {
-                span_data.active_time += time - enter;
+                span_data.active_time += time.saturating_sub(enter);
             }
         }
     }

--- a/support/pal/pal_async/src/timer.rs
+++ b/support/pal/pal_async/src/timer.rs
@@ -49,6 +49,12 @@ impl Instant {
                 .saturating_add(duration.as_nanos().try_into().unwrap_or(u64::MAX)),
         )
     }
+
+    /// Calculate the duration between this instant and another instant,
+    /// saturating at zero if the other instant is later than this one.
+    pub fn saturating_sub(self, rhs: Instant) -> Duration {
+        Duration::from_nanos(self.0.saturating_sub(rhs.0))
+    }
 }
 
 impl std::ops::Sub for Instant {


### PR DESCRIPTION
We already had a comment here indicating underflow is possible, we just weren't doing anything about it. We should do something about it. Fixes ICM 645583617