### PR TITLE
vmgs: support ephemeral guest state in OpenHCL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7536,6 +7536,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing_helpers",
+ "uefi_nvram_storage",
  "uevent",
  "uidevices_resources",
  "underhill_attestation",

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -84,6 +84,7 @@ storvsp_resources.workspace = true
 tpm_resources.workspace = true
 tpm = { workspace = true, features = ["tpm"] }
 tracelimit.workspace = true
+uefi_nvram_storage.workspace = true
 uidevices_resources.workspace = true
 underhill_attestation.workspace = true
 underhill_confidentiality = { workspace = true, features = ["std"] }

--- a/openhcl/underhill_core/src/emuplat/non_volatile_store.rs
+++ b/openhcl/underhill_core/src/emuplat/non_volatile_store.rs
@@ -8,7 +8,7 @@ use vmgs_broker::non_volatile_store::EncryptionNotSupported;
 use vmgs_broker::non_volatile_store::VmgsNonVolatileStore;
 
 /// An API for interacting with VMGS as an opaque [`NonVolatileStore`]
-pub trait VmbsBrokerNonVolatileStore {
+pub trait VmgsBrokerNonVolatileStore {
     /// Return a new [`NonVolatileStore`] object backed by a particular VMGS
     /// file-id.
     fn as_non_volatile_store(
@@ -18,7 +18,7 @@ pub trait VmbsBrokerNonVolatileStore {
     ) -> Result<Box<dyn NonVolatileStore>, EncryptionNotSupported>;
 }
 
-impl VmbsBrokerNonVolatileStore for vmgs_broker::VmgsClient {
+impl VmgsBrokerNonVolatileStore for vmgs_broker::VmgsClient {
     fn as_non_volatile_store(
         &self,
         file_id: vmgs::FileId,

--- a/openhcl/underhill_core/src/servicing.rs
+++ b/openhcl/underhill_core/src/servicing.rs
@@ -69,10 +69,10 @@ mod state {
         pub flush_logs_result: Option<FlushLogsResult>,
         /// VMGS related saved state
         #[mesh(6)]
-        pub vmgs: (
+        pub vmgs: Option<(
             vmgs::save_restore::state::SavedVmgsState,
             disk_get_vmgs::save_restore::SavedBlockStorageMetadata,
-        ),
+        )>,
         /// Intercept the host-provided shutdown IC device.
         #[mesh(7)]
         pub overlay_shutdown_device: bool,
@@ -243,7 +243,7 @@ pub mod transposed {
                         netvsp_state: Some(netvsp_state),
                     },
                     flush_logs_result: Some(flush_logs_result),
-                    vmgs: Some(vmgs),
+                    vmgs,
                     overlay_shutdown_device: Some(overlay_shutdown_device),
                     nvme_state: Some(nvme_state),
                     dma_manager_state: Some(dma_manager_state),

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -33,7 +33,7 @@ use crate::emuplat::netvsp::HclNetworkVFManager;
 use crate::emuplat::netvsp::HclNetworkVFManagerEndpointInfo;
 use crate::emuplat::netvsp::HclNetworkVFManagerShutdownInProgress;
 use crate::emuplat::netvsp::RuntimeSavedState;
-use crate::emuplat::non_volatile_store::VmbsBrokerNonVolatileStore;
+use crate::emuplat::non_volatile_store::VmgsBrokerNonVolatileStore;
 use crate::emuplat::tpm::resources::GetTpmLoggerHandle;
 use crate::emuplat::tpm::resources::GetTpmRequestAkCertHelperHandle;
 use crate::emuplat::vga_proxy::UhRegisterHostIoFastPath;
@@ -1357,33 +1357,27 @@ async fn new_underhill_vm(
         with_vmbus_relay = !hide_isolation;
     }
 
-    if matches!(
-        dps.general.guest_state_lifetime,
-        GuestStateLifetime::Ephemeral
-    ) {
-        todo!("OpenHCL ephemeral guest state")
-    }
-
     // also construct the VMGS nice and early, as much like the GET, it also
     // plays an important role during initial bringup
-    let (vmgs_disk_metadata, mut vmgs) = match servicing_state.vmgs {
-        Some((vmgs_state, vmgs_get_meta_state)) => {
+    let mut vmgs = match (dps.general.guest_state_lifetime, servicing_state.vmgs) {
+        (GuestStateLifetime::Ephemeral, _) => None,
+        (_, Some((vmgs_state, vmgs_get_meta_state))) => {
             // fast path, with zero .await calls
             let disk = disk_get_vmgs::GetVmgsDisk::restore_with_meta(
                 get_client.clone(),
                 vmgs_get_meta_state,
             )
             .context("failed to open VMGS disk")?;
-            (
+            Some((
                 disk.save_meta(),
                 Vmgs::open_from_saved(
                     Disk::new(disk).context("invalid vmgs disk")?,
                     vmgs_state,
                     Some(Arc::new(GetVmgsLogger::new(get_client.clone()))),
                 ),
-            )
+            ))
         }
-        None => {
+        (_, None) => {
             let disk = disk_get_vmgs::GetVmgsDisk::new(get_client.clone())
                 .instrument(tracing::info_span!("vmgs_get_storage", CVM_ALLOWED))
                 .await
@@ -1418,7 +1412,7 @@ async fn new_underhill_vm(
                 .context("failed to open vmgs")?
             };
 
-            (meta, vmgs)
+            Some((meta, vmgs))
         }
     };
 
@@ -1632,7 +1626,7 @@ async fn new_underhill_vm(
     // `agent_data` and `guest_secret_key` may also be used by vTPM
     // initialization.
     let platform_attestation_data = {
-        if is_restoring {
+        if is_restoring || vmgs.is_none() {
             // TODO CVM: Save and restore last returned data when live servicing is supported.
             // We also need to revisit what states should be saved and restored.
             //
@@ -1660,7 +1654,7 @@ async fn new_underhill_vm(
                 &get_client,
                 dps.general.bios_guid,
                 &attestation_vm_config,
-                &mut vmgs,
+                &mut vmgs.as_mut().unwrap().1,
                 attestation_type,
                 suppress_attestation,
                 early_init_driver,
@@ -1678,15 +1672,24 @@ async fn new_underhill_vm(
     // Make the GET available for other resources.
     resolver.add_resolver(get_client.clone());
 
-    // Spawn the VMGS client for multi-task access.
-    let (vmgs_client, vmgs_handle) = spawn_vmgs_broker(get_spawner, vmgs);
-    resolver.add_resolver(VmgsFileResolver::new(vmgs_client.clone()));
+    let (vmgs_client, vmgs) = if let Some((meta, vmgs)) = vmgs {
+        // Spawn the VMGS client for multi-task access.
+        let (vmgs_client, vmgs_handle) = spawn_vmgs_broker(get_spawner, vmgs);
+        resolver.add_resolver(VmgsFileResolver::new(vmgs_client.clone()));
 
-    // ...and then we immediately "API-slice" the fully featured `vmgs_client`
-    // into smaller, more focused objects. This promotes good code hygiene and
-    // predictable performance characteristics in downstream code.
-    let vmgs_thin_client = vmgs_broker::VmgsThinClient::new(vmgs_client.clone());
-    let vmgs_client: &dyn VmbsBrokerNonVolatileStore = &vmgs_client;
+        // ...and then we immediately "API-slice" the fully featured `vmgs_client`
+        // into smaller, more focused objects. This promotes good code hygiene and
+        // predictable performance characteristics in downstream code.
+        let vmgs_thin_client = vmgs_broker::VmgsThinClient::new(vmgs_client.clone());
+        // let vmgs_client: &dyn VmgsBrokerNonVolatileStore = &vmgs_client;
+
+        (
+            Some(Box::new(vmgs_client) as Box<dyn VmgsBrokerNonVolatileStore>),
+            Some((vmgs_thin_client, meta, vmgs_handle)),
+        )
+    } else {
+        (None, None)
+    };
 
     // Read measured config from VTL0 memory. When restoring, it is already gone.
     let (firmware_type, measured_vtl0_info, load_kind) = {
@@ -1902,9 +1905,13 @@ async fn new_underhill_vm(
     let rtc_time_source = ArcMutexUnderhillLocalClock(Arc::new(Mutex::new(
         UnderhillLocalClock::new(
             get_client.clone(),
-            vmgs_client
-                .as_non_volatile_store(vmgs::FileId::RTC_SKEW, false)
-                .context("failed to instantiate RTC skew store")?,
+            if let Some(vmgs_client) = vmgs_client.as_ref() {
+                vmgs_client
+                    .as_non_volatile_store(vmgs::FileId::RTC_SKEW, false)
+                    .context("failed to instantiate RTC skew store")?
+            } else {
+                EphemeralNonVolatileStore::new_boxed()
+            },
             servicing_state.emuplat.rtc_local_clock,
         )
         .await
@@ -2025,12 +2032,16 @@ async fn new_underhill_vm(
             };
 
             // check if vmgs includes custom UEFI JSON
-            let custom_uefi_json_data = vmgs_client
-                .as_non_volatile_store(vmgs::FileId::CUSTOM_UEFI, false)
-                .context("failed to instantiate custom UEFI JSON store")?
-                .restore()
-                .await
-                .context("failed to get custom UEFI JSON data")?;
+            let custom_uefi_json_data = if let Some(vmgs_client) = vmgs_client.as_ref() {
+                vmgs_client
+                    .as_non_volatile_store(vmgs::FileId::CUSTOM_UEFI, false)
+                    .context("failed to instantiate custom UEFI JSON store")?
+                    .restore()
+                    .await
+                    .context("failed to get custom UEFI JSON data")?
+            } else {
+                None
+            };
 
             // obtain the final custom uefi vars by applying the delta onto
             // the base vars
@@ -2072,20 +2083,24 @@ async fn new_underhill_vm(
                 logger: Box::new(UnderhillLogger {
                     get: get_client.clone(),
                 }),
-                nvram_storage: Box::new(
-                    HclCompatNvram::new(
-                        VmgsStorageBackendAdapter(
-                            vmgs_client
-                                .as_non_volatile_store(vmgs::FileId::BIOS_NVRAM, true)
-                                .context("failed to instantiate UEFI NVRAM store")?,
-                        ),
-                        Some(HclCompatNvramQuirks {
-                            skip_corrupt_vars_with_missing_null_term: true,
-                        }),
-                        is_restoring,
+                nvram_storage: if let Some(vmgs_client) = vmgs_client.as_ref() {
+                    Box::new(
+                        HclCompatNvram::new(
+                            VmgsStorageBackendAdapter(
+                                vmgs_client
+                                    .as_non_volatile_store(vmgs::FileId::BIOS_NVRAM, true)
+                                    .context("failed to instantiate UEFI NVRAM store")?,
+                            ),
+                            Some(HclCompatNvramQuirks {
+                                skip_corrupt_vars_with_missing_null_term: true,
+                            }),
+                            is_restoring,
+                        )
+                        .await?,
                     )
-                    .await?,
-                ),
+                } else {
+                    Box::new(uefi_nvram_storage::in_memory::InMemoryNvram::new())
+                },
                 generation_id_recv: get_client
                     .take_generation_id_recv()
                     .await
@@ -2422,9 +2437,13 @@ async fn new_underhill_vm(
         Some(dev::HyperVGuestWatchdogDeps {
             port_base: WDAT_PORT,
             watchdog_platform: {
-                let store = vmgs_client
-                    .as_non_volatile_store(vmgs::FileId::GUEST_WATCHDOG, false)
-                    .context("failed to instantiate guest watchdog store")?;
+                let store = if let Some(vmgs_client) = vmgs_client.as_ref() {
+                    vmgs_client
+                        .as_non_volatile_store(vmgs::FileId::GUEST_WATCHDOG, false)
+                        .context("failed to instantiate guest watchdog store")?
+                } else {
+                    EphemeralNonVolatileStore::new_boxed()
+                };
                 let trigger_reset = WatchdogTimeoutHalt {
                     halt_vps: halt_vps.clone(),
                 };
@@ -3047,9 +3066,7 @@ async fn new_underhill_vm(
         network_settings,
         shutdown_relay,
 
-        vmgs_thin_client,
-        vmgs_disk_metadata,
-        _vmgs_handle: vmgs_handle,
+        vmgs,
 
         get_client: get_client.clone(),
         device_platform_settings: dps,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -910,18 +910,6 @@ fn vm_config_from_command_line(
         resources.ged_rpc = Some(send);
 
         let vmgs = vmgs.take().unwrap();
-        // OpenHCL doesn't support ephemeral guest state yet,
-        // so give it a memory-backed VMGS
-        let vmgs = if matches!(vmgs, VmgsResource::Ephemeral) {
-            VmgsResource::Disk(
-                disk_backend_resources::LayeredDiskHandle::single_layer(RamDiskLayerHandle {
-                    len: Some(vmgs_format::VMGS_DEFAULT_CAPACITY),
-                })
-                .into_resource(),
-            )
-        } else {
-            vmgs
-        };
 
         vmbus_devices.extend([
             (


### PR DESCRIPTION
Support ephemeral guest state for everything that would otherwise use the VMGS file in OpenHCL. This allows the host to avoid providing a VMGS file over the GET entirely if it is not needed. This is useful for testing purposes and could help to avoid issues with production ephemeral VMs in the future (for example, boot failures caused by stale guest state after a guest image swap).