### PR TITLE
vmm_tests: support aarch64 dev kernel

### DIFF
--- a/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
+++ b/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
@@ -312,6 +312,7 @@ impl SimpleFlowNode for Node {
                                 "openhcl-x64-test-linux-direct.bin"
                             }
                             OpenhclIgvmRecipe::Aarch64 => "openhcl-aarch64.bin",
+                            OpenhclIgvmRecipe::Aarch64Devkern => "openhcl-aarch64-devkern.bin",
                             _ => {
                                 log::info!("petri doesn't support this OpenHCL recipe: {recipe:?}");
                                 continue;

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -55,6 +55,7 @@ impl petri_artifacts_core::ResolveTestArtifact for OpenvmmKnownPathsTestArtifact
             _ if id == openhcl_igvm::LATEST_CVM_X64 => openhcl_bin_path(MachineArch::X86_64, OpenhclVersion::Latest, OpenhclFlavor::Cvm),
             _ if id == openhcl_igvm::LATEST_LINUX_DIRECT_TEST_X64 => openhcl_bin_path(MachineArch::X86_64, OpenhclVersion::Latest, OpenhclFlavor::LinuxDirect),
             _ if id == openhcl_igvm::LATEST_STANDARD_AARCH64 => openhcl_bin_path(MachineArch::Aarch64, OpenhclVersion::Latest, OpenhclFlavor::Standard),
+            _ if id == openhcl_igvm::LATEST_STANDARD_DEV_KERNEL_AARCH64 => openhcl_bin_path(MachineArch::Aarch64, OpenhclVersion::Latest, OpenhclFlavor::StandardDevKernel),
 
             _ if id == openhcl_igvm::um_bin::LATEST_LINUX_DIRECT_TEST_X64 => openhcl_extras_path(OpenhclVersion::Latest,OpenhclFlavor::LinuxDirect,OpenhclExtras::UmBin),
             _ if id == openhcl_igvm::um_dbg::LATEST_LINUX_DIRECT_TEST_X64 => openhcl_extras_path(OpenhclVersion::Latest,OpenhclFlavor::LinuxDirect,OpenhclExtras::UmDbg),
@@ -365,6 +366,14 @@ fn openhcl_bin_path(
             MissingCommand::XFlowey {
                 description: "OpenHCL IGVM file",
                 xflowey_args: &["build-igvm", "aarch64"],
+            },
+        ),
+        (MachineArch::Aarch64, OpenhclVersion::Latest, OpenhclFlavor::StandardDevKernel) => (
+            "flowey-out/artifacts/build-igvm/debug/aarch64",
+            "openhcl-aarch64-devkern.bin",
+            MissingCommand::XFlowey {
+                description: "OpenHCL IGVM file",
+                xflowey_args: &["build-igvm", "aarch64-devkern"],
             },
         ),
         _ => anyhow::bail!("no openhcl bin with given arch, version, and flavor"),

--- a/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
+++ b/vmm_tests/petri_artifact_resolver_openvmm_known_paths/src/lib.rs
@@ -369,7 +369,7 @@ fn openhcl_bin_path(
             },
         ),
         (MachineArch::Aarch64, OpenhclVersion::Latest, OpenhclFlavor::StandardDevKernel) => (
-            "flowey-out/artifacts/build-igvm/debug/aarch64",
+            "flowey-out/artifacts/build-igvm/debug/aarch64-devkern",
             "openhcl-aarch64-devkern.bin",
             MissingCommand::XFlowey {
                 description: "OpenHCL IGVM file",

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -145,6 +145,8 @@ pub mod artifacts {
             LATEST_LINUX_DIRECT_TEST_X64,
             /// OpenHCL IGVM (standard AARCH64)
             LATEST_STANDARD_AARCH64,
+            /// OpenHCL IGVM (standard AARCH64, with VTL2 dev kernel)
+            LATEST_STANDARD_DEV_KERNEL_AARCH64
         }
 
         impl IsLoadable for LATEST_STANDARD_X64 {
@@ -171,6 +173,11 @@ pub mod artifacts {
             const ARCH: MachineArch = MachineArch::Aarch64;
         }
         impl IsOpenhclIgvm for LATEST_STANDARD_AARCH64 {}
+
+        impl IsLoadable for LATEST_STANDARD_DEV_KERNEL_AARCH64 {
+            const ARCH: MachineArch = MachineArch::Aarch64;
+        }
+        impl IsOpenhclIgvm for LATEST_STANDARD_DEV_KERNEL_AARCH64 {}
 
         /// OpenHCL usermode binary
         pub mod um_bin {


### PR DESCRIPTION
I noticed "petri doesn't support this OpenHCL recipe:" printed to my console when running the vmm tests via xflowey. Looks like this was straightforward to hook up.