### PR TITLE
vmm-tests: don't request hardware isolation reg key on arm64 when user specifies custom filter

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests.rs
@@ -160,7 +160,7 @@ impl IntoPipeline for VmmTestsCli {
                                     VmmTestsDepSelections::Windows {
                                         hyperv: true,
                                         whp: true,
-                                        // No hardware isolation support on Aarch64, so don't default to needing in when the
+                                        // No hardware isolation support on Aarch64, so don't default to needing it when the
                                         // user specifies a custom filter.
                                         hardware_isolation: match target_architecture {
                                             target_lexicon::Architecture::Aarch64(_) => false,


### PR DESCRIPTION
The `vmm-tests` default filters correctly discern that the `EnableHardwareIsolation` registry key is not required (there is no hardware isolation support in openhcl for aarch64, after all). These default filters aren't used when a user specifies a custom filter, so also make that check here.