### PR TITLE
nvme: print controller GUID in logging spans

### DIFF
--- a/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
+++ b/openhcl/underhill_core/src/dispatch/vtl2_settings_worker.rs
@@ -995,6 +995,7 @@ async fn make_disk_type_from_physical_device(
         // We can't validate yet that this namespace actually exists. That will
         // be checked later.
         return Ok(Resource::new(NvmeDiskConfig {
+            controller_instance_id: controller_instance_id.to_string(),
             pci_id,
             nsid: sub_device_path,
         }));

--- a/openhcl/underhill_core/src/nvme_manager/mod.rs
+++ b/openhcl/underhill_core/src/nvme_manager/mod.rs
@@ -104,6 +104,7 @@ pub trait CreateNvmeDriver: Inspect + Send + Sync {
     async fn create_driver(
         &self,
         driver_source: &VmTaskDriverSource,
+        controller_instance_id: Option<String>,
         pci_id: &str,
         vp_count: u32,
         save_restore_supported: bool,

--- a/openhcl/underhill_core/src/nvme_manager/save_restore.rs
+++ b/openhcl/underhill_core/src/nvme_manager/save_restore.rs
@@ -20,4 +20,6 @@ pub struct NvmeSavedDiskConfig {
     pub pci_id: String,
     #[mesh(2)]
     pub driver_state: nvme_driver::NvmeDriverSavedState,
+    #[mesh(3)]
+    pub controller_instance_id: Option<String>,
 }


### PR DESCRIPTION
This allows us to directly connect the NVMe device to the controller attached to the VM in one log line.