### PR TITLE
floppy: no spaces in interrupt debug name

### DIFF
--- a/vm/devices/chipset_legacy/src/winbond83977_sio/mod.rs
+++ b/vm/devices/chipset_legacy/src/winbond83977_sio/mod.rs
@@ -81,7 +81,7 @@ impl<FDC: MaybeStubFloppyDiskController> Winbond83977FloppySioDevice<FDC> {
         secondary_dma: Box<dyn IsaDmaChannel>,
     ) -> Result<Self, NewWinbond83977FloppySioDeviceError<FDC::NewError>> {
         let secondary_interrupt = interrupt
-            .new_shared("floppy-secondary")
+            .new_shared("floppy_secondary")
             .map_err(NewWinbond83977FloppySioDeviceError::LineShare)?;
 
         Ok(Self {


### PR DESCRIPTION
The vmm test log helper attempts to download inspect logs, but fails when a json key includes a space. Change the debug name for the floppy device; it's the only one causing a problem.

See https://openvmm.dev/test-results/test.html?run=15934647441&job=x64-windows-amd-vmm-tests-logs&test=multiarch__openvmm_pcat_x64_freebsd_13_2_x64_boot_no_agent#log-0

```
Error fetching https://openvmmghtestresults.blob.core.windows.net/results/15934647441/x64-windows-amd-vmm-tests-logs/multiarch__openvmm_pcat_x64_freebsd_13_2_x64_boot_no_agent/timeout_inspect.log: Invalid key at position 57275: 'floppy sec'
```