### PR TITLE
petri: logview: parse keys with spaces

### DIFF
--- a/petri/logview/inspect.html
+++ b/petri/logview/inspect.html
@@ -108,12 +108,18 @@
                 while (/\s/.test(input[i])) i++;
             }
 
+            /**
+             * Parses a key from the input string.
+             * A key is defined as a sequence of characters followed by a colon and whitespace.
+             * Of note: a key can contain any character (including spaces and colons).
+             * Throws an error if the key is invalid.
+             */
             function parseKey() {
                 skipWhitespace();
-                const match = /.*:\s/.exec(input.slice(i));
+                const match = /^(.+?):\s/.exec(input.slice(i));
                 if (!match) throw new Error(`Invalid key at position ${i}: '${input.slice(i, i + 10)}'`);
                 i += match[0].length;
-                return match[0].slice(0, -2); // Remove the trailing ': '
+                return match[1];
             }
 
             function parseString() {

--- a/petri/logview/inspect.html
+++ b/petri/logview/inspect.html
@@ -110,10 +110,10 @@
 
             function parseKey() {
                 skipWhitespace();
-                const match = /^\S*:/.exec(input.slice(i));
+                const match = /.*:\s/.exec(input.slice(i));
                 if (!match) throw new Error(`Invalid key at position ${i}: '${input.slice(i, i + 10)}'`);
                 i += match[0].length;
-                return match[0].slice(0, -1); // Remove the trailing ':'
+                return match[0].slice(0, -2); // Remove the trailing ': '
             }
 
             function parseString() {
@@ -144,21 +144,21 @@
                 if (input[i] === '_') return { type: 'unevaluated' };
                 if (input[i] === 't') {
                     if (input.slice(i, i + 4) !== 'true') {
-                        throw new Error(`Expected 'true' at position ${i}`);
+                        throw new Error(`Expected 'true' at position ${i}, saw '${input.slice(i, i + 10)}'`);
                     }
                     i += 4; // skip 'true'
                     return { type: 'boolean', value: true };
                 }
                 if (input[i] === 'f') {
                     if (input.slice(i, i + 5) !== 'false') {
-                        throw new Error(`Expected 'false' at position ${i}`);
+                        throw new Error(`Expected 'false' at position ${i}, saw '${input.slice(i, i + 10)}'`);
                     }
                     i += 5; // skip 'false'
                     return { type: 'boolean', value: false };
                 }
                 if (input[i] === 'e') {
                     if (input.slice(i, i + 7) !== 'error (') {
-                        throw new Error(`Expected 'error (' at position ${i}`);
+                        throw new Error(`Expected 'error (' at position ${i}, saw '${input.slice(i, i + 10)}'`);
                     }
                     i += 7; // skip 'error ('
                     const start = i;


### PR DESCRIPTION
As a follow-on to #1620, fix the inspect parser to handle keys with spaces in the name.

The changes to `parseString` made it easier to debug issues in my regex changes.