### PR TITLE
build_info: add internal build info

### DIFF
--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -15,6 +15,10 @@ pub struct BuildInfo {
     revision: &'static str,
     #[inspect(safe, rename = "scm_branch")]
     branch: &'static str,
+    #[inspect(safe)]
+    internal_scm_revision: &'static str,
+    #[inspect(safe)]
+    internal_scm_branch: &'static str,
 }
 
 impl BuildInfo {
@@ -32,6 +36,16 @@ impl BuildInfo {
             },
             branch: if let Some(b) = option_env!("VERGEN_GIT_BRANCH") {
                 b
+            } else {
+                ""
+            },
+            internal_scm_revision: if let Some(r) = option_env!("INTERNAL_GIT_SHA") {
+                r
+            } else {
+                ""
+            },
+            internal_scm_branch: if let Some(r) = option_env!("INTERNAL_GIT_BRANCH") {
+                r
             } else {
                 ""
             },

--- a/openhcl/build_info/src/lib.rs
+++ b/openhcl/build_info/src/lib.rs
@@ -19,6 +19,8 @@ pub struct BuildInfo {
     internal_scm_revision: &'static str,
     #[inspect(safe)]
     internal_scm_branch: &'static str,
+    #[inspect(safe)]
+    openhcl_version: &'static str,
 }
 
 impl BuildInfo {
@@ -45,6 +47,11 @@ impl BuildInfo {
                 ""
             },
             internal_scm_branch: if let Some(r) = option_env!("INTERNAL_GIT_BRANCH") {
+                r
+            } else {
+                ""
+            },
+            openhcl_version: if let Some(r) = option_env!("OPENHCL_VERSION") {
                 r
             } else {
                 ""


### PR DESCRIPTION
Adds `internal_scm_revision`, `internal_scm_branch`, and `openhcl_version`, which are filled out by the build pipeline and make it easier to identify what version of OpenHCL is running.