### PR TITLE
Add OPENHCL_CONFIDENTIAL_DEBUG to manifest

### DIFF
--- a/vm/loader/manifests/openhcl-x64-cvm-dev.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-dev.json
@@ -14,7 +14,7 @@
             },
             "image": {
                 "openhcl": {
-                    "command_line": "",
+                    "command_line": "OPENHCL_CONFIDENTIAL_DEBUG=1",
                     "memory_page_count": 163840,
                     "memory_page_base": 32768,
                     "uefi": true
@@ -49,7 +49,7 @@
             },
             "image": {
                 "openhcl": {
-                    "command_line": "",
+                    "command_line": "OPENHCL_CONFIDENTIAL_DEBUG=1",
                     "memory_page_count": 163840,
                     "memory_page_base": 32768,
                     "uefi": true

--- a/vm/loader/manifests/openhcl-x64-cvm-release.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-release.json
@@ -14,7 +14,7 @@
             },
             "image": {
                 "openhcl": {
-                    "command_line": "",
+                    "command_line": "OPENHCL_CONFIDENTIAL_DEBUG=1",
                     "memory_page_count": 163840,
                     "memory_page_base": 32768,
                     "uefi": true
@@ -49,7 +49,7 @@
             },
             "image": {
                 "openhcl": {
-                    "command_line": "",
+                    "command_line": "OPENHCL_CONFIDENTIAL_DEBUG=1",
                     "memory_page_count": 32768,
                     "memory_page_base": 32768,
                     "uefi": true


### PR DESCRIPTION
PR #1501 modified igvmfilegen to no longer explicitly add OPENHCL_CONFIDENTIAL_DEBUG to the static command line if debug is enabled. This broke SNP: SNP cannot yet directly read the debug bit, and the vmbus relay depends on trusting the host for now. This change adds OPENHCL_CONFIDENTIAL_DEBUG to the static command line explicitly in the meantime (except for TDX, because it can directly read the debug bit).