### PR TITLE
vmbus_server: allow inspect to access ring buffers without full memory mapping

### DIFF
--- a/vm/devices/vmbus/vmbus_ring/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_ring/src/lib.rs
@@ -1203,27 +1203,16 @@ impl<M: RingMem> Inspect for InnerRing<M> {
 
 /// Inspects ring buffer state without creating an IncomingRing or OutgoingRing
 /// structure.
-pub fn inspect_ring<M: RingMem>(mem: M, req: inspect::Request<'_>) {
-    let _ = InnerRing::new(mem).map(|ring| ring.inspect(req));
-}
-
-pub fn inspect_ring_control(
-    size: u64,
-    control_gpn: u64,
-    mem: &guestmem::GuestMemory,
-    req: inspect::Request<'_>,
-) -> Result<(), guestmem::GuestMemoryError> {
-    let pages = mem.lock_gpns(false, &[control_gpn])?;
-    let control = pages.pages()[0].as_atomic_slice().unwrap()[..CONTROL_WORD_COUNT]
+///
+/// # Panics
+///
+/// Panics if control_page is not aligned.
+pub fn inspect_ring(control_page: &guestmem::Page, response: &mut inspect::Response<'_>) {
+    let control = control_page.as_atomic_slice().unwrap()[..CONTROL_WORD_COUNT]
         .try_into()
         .unwrap();
 
-    let control = Control(control);
-    req.respond()
-        .hex("ring_size", size)
-        .field("control", control);
-
-    Ok(())
+    response.field("control", Control(control));
 }
 
 /// Returns whether a ring buffer is in a state where the receiving end might

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -1729,11 +1729,7 @@ impl ServerTaskInner {
 
         // Use a subrange to access the interrupt page to give GuestMemory's without a full mapping
         // a chance to create one.
-        let interrupt_page = self
-            .gm
-            .lockable_subrange(interrupt_page, PAGE_SIZE as u64)?
-            .lock_gpns(false, &[0])?;
-
+        let interrupt_page = lock_page_with_subrange(&self.gm, interrupt_page)?;
         let channel_bitmap = Arc::new(ChannelBitmap::new(interrupt_page));
         self.channel_bitmap = Some(channel_bitmap.clone());
 
@@ -1928,40 +1924,34 @@ fn inspect_rings(
 
     let aligned = AlignedGpadlView::new(gpadl).ok()?;
     let (in_gpadl, out_gpadl) = aligned.split(open_data.ring_offset).ok()?;
-
-    if let Ok(incoming_mem) =
-        gm.lockable_subrange(in_gpadl.gpns()[0] * PAGE_SIZE as u64, PAGE_SIZE as u64)
-    {
-        resp.child("incoming_ring", |req| {
-            tracing::info!("inspecting ring");
-            if let Err(e) = ring::inspect_ring_control(
-                ((in_gpadl.gpns().len() - 1) * PAGE_SIZE) as u64,
-                0,
-                &incoming_mem,
-                req,
-            ) {
-                tracing::error!(
-                    error = &e as &dyn std::error::Error,
-                    "failed to inspect incoming ring"
-                );
-            }
-        });
-    }
-
-    if let Ok(outgoing_mem) =
-        gm.lockable_subrange(out_gpadl.gpns()[0] * PAGE_SIZE as u64, PAGE_SIZE as u64)
-    {
-        resp.child("outgoing_ring", |req| {
-            let _ = ring::inspect_ring_control(
-                ((in_gpadl.gpns().len() - 1) * PAGE_SIZE) as u64,
-                0,
-                &outgoing_mem,
-                req,
-            );
-        });
-    }
-
+    resp.child("incoming_ring", |req| inspect_ring(req, &in_gpadl, gm));
+    resp.child("outgoing_ring", |req| inspect_ring(req, &out_gpadl, gm));
     Some(())
+}
+
+/// Inspects the incoming or outgoing ring buffer by directly accessing guest memory.
+fn inspect_ring(req: inspect::Request<'_>, gpadl: &AlignedGpadlView, gm: &GuestMemory) {
+    let mut resp = req.respond();
+
+    // Data size excluding the control page.
+    let ring_size = (gpadl.gpns().len() - 1) * PAGE_SIZE;
+    resp.hex("ring_size", ring_size);
+
+    // Lock just the control page. Use a subrange to allow a GuestMemory without a full mapping to
+    // create one.
+    if let Ok(pages) = lock_page_with_subrange(gm, gpadl.gpns()[0] * PAGE_SIZE as u64) {
+        ring::inspect_ring(pages.pages()[0], &mut resp);
+    }
+}
+
+/// Helper to create a subrange before locking a single page.
+///
+/// This allows us to lock a page in a `GuestMemory` that doesn't have a full mapping, but can
+/// create one for a subrange.
+fn lock_page_with_subrange(gm: &GuestMemory, offset: u64) -> anyhow::Result<guestmem::LockedPages> {
+    Ok(gm
+        .lockable_subrange(offset, PAGE_SIZE as u64)?
+        .lock_gpns(false, &[0])?)
 }
 
 pub(crate) struct MessageSender {


### PR DESCRIPTION
This change updates how "inspect" accesses channel ring buffers by only mapping the control page, and using `lockable_subrange` so that a `GuestMemory` implementation that doesn't have a full mapping has the opportunity to create a partial mapping.

This allows inspecting the ring buffers to work with alternative `GuestMemory` implementations used in Hyper-V.

The data included in the "inspect" output is unchanged; the only change is how it's retrieved.