### PR TITLE
guide: recommend one installs llvm-dev for cross compilation

### DIFF
--- a/Guide/src/dev_guide/getting_started/cross_compile.md
+++ b/Guide/src/dev_guide/getting_started/cross_compile.md
@@ -25,7 +25,7 @@ rustup target add x86_64-pc-windows-msvc
 Additional build tools must be installed as well. If your distro has LLVM 14
 available (Ubuntu 22.04 or newer):
 ```bash
-sudo apt install clang-tools-14 lld-14
+sudo apt install clang-tools-14 lld-14 llvm-dev
 ```
 
 Otherwise, follow the steps at https://apt.llvm.org/ to install a specific

--- a/build_support/setup_windows_cross.sh
+++ b/build_support/setup_windows_cross.sh
@@ -5,7 +5,7 @@
 # Validate that a tool is present.
 function check_cross_tool {
     if ! command -v "$1" >/dev/null 2>/dev/null; then
-        >&2 echo "missing $1 - Try 'sudo apt install clang-tools-14 lld-14' or check the guide."
+        >&2 echo "missing $1 - Try 'sudo apt install clang-tools-14 lld-14 llvm-dev' or check the guide."
         false
     fi
 }


### PR DESCRIPTION
Installing `llvm-dev` will fix this:

```
warning: libsqlite3-sys@0.32.0:   File "/home/mattkur/openvmm/build_support/windows_cross/x86_64-clang-cl", line 206, in <module>
warning: libsqlite3-sys@0.32.0:     config = get_config(arch, tool, ignore_cache)
warning: libsqlite3-sys@0.32.0:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
warning: libsqlite3-sys@0.32.0:   File "/home/mattkur/openvmm/build_support/windows_cross/x86_64-clang-cl", line 147, in get_config
warning: libsqlite3-sys@0.32.0:     raise Exception(
warning: libsqlite3-sys@0.32.0: Exception: tool 'clang-cl' not found, try installing it
error: failed to run custom build command for `libsqlite3-sys v0.32.0`
```