### PR TITLE
Add attestation claim for Azure device filter (#1613)

### DIFF
--- a/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
+++ b/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
@@ -345,6 +345,8 @@ pub mod runtime_claims {
         pub tpm_enabled: bool,
         /// Whether the TPM states is persisted
         pub tpm_persisted: bool,
+        /// Whether certain vPCI devices are allowed through the device filter
+        pub filtered_vpci_devices_allowed: bool,
         /// VM id
         #[serde(rename = "vmUniqueId")]
         pub vm_unique_id: String,

--- a/openhcl/underhill_attestation/src/hardware_key_sealing.rs
+++ b/openhcl/underhill_attestation/src/hardware_key_sealing.rs
@@ -232,6 +232,7 @@ mod tests {
             secure_boot: false,
             tpm_enabled: false,
             tpm_persisted: false,
+            filtered_vpci_devices_allowed: true,
             vm_unique_id: "".to_string(),
         };
         let mock_call = Box::new(MockTeeCall {}) as Box<dyn tee_call::TeeCall>;

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn test_vm_configuration_no_time() {
-        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"vmUniqueId":""}"#;
+        const EXPECTED_JWK: &str = r#"{"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"filtered-vpci-devices-allowed":true,"vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,
@@ -292,6 +292,7 @@ mod tests {
             secure_boot: false,
             tpm_enabled: false,
             tpm_persisted: false,
+            filtered_vpci_devices_allowed: true,
             vm_unique_id: String::new(),
         };
         let result = serde_json::to_string(&attestation_vm_config);
@@ -303,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_vm_configuration_with_time() {
-        const EXPECTED_JWK: &str = r#"{"current-time":1691103220,"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"vmUniqueId":""}"#;
+        const EXPECTED_JWK: &str = r#"{"current-time":1691103220,"root-cert-thumbprint":"","console-enabled":false,"secure-boot":false,"tpm-enabled":false,"tpm-persisted":false,"filtered-vpci-devices-allowed":true,"vmUniqueId":""}"#;
 
         let attestation_vm_config = AttestationVmConfig {
             current_time: None,
@@ -312,6 +313,7 @@ mod tests {
             secure_boot: false,
             tpm_enabled: false,
             tpm_persisted: false,
+            filtered_vpci_devices_allowed: true,
             vm_unique_id: String::new(),
         };
         let attestation_vm_config =

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1603,6 +1603,9 @@ async fn new_underhill_vm(
         secure_boot: dps.general.secure_boot_enabled,
         tpm_enabled: dps.general.tpm_enabled,
         tpm_persisted: !dps.general.suppress_attestation.unwrap_or(false),
+        filtered_vpci_devices_allowed: with_vmbus_relay
+            && dps.general.vpci_boot_enabled
+            && isolation.is_isolated(),
         vm_unique_id: dps.general.bios_guid.to_string(),
     };
 
@@ -3060,6 +3063,7 @@ fn validate_isolated_configuration(dps: &DevicePlatformSettings) -> Result<(), a
         com2_vmbus_redirector: _,
         suppress_attestation: _,
         bios_guid: _,
+        vpci_boot_enabled: _,
 
         // Validated below
         battery_enabled,
@@ -3094,7 +3098,6 @@ fn validate_isolated_configuration(dps: &DevicePlatformSettings) -> Result<(), a
         generation_id: _,
         pause_after_boot_failure: _,
         disable_frontpage: _,
-        vpci_boot_enabled: _,
         num_lock_enabled: _,
         pcat_boot_device_order: _,
         vpci_instance_filter: _,


### PR DESCRIPTION
Add an attestation claim indicating whether the vmbus relay is active for an isolated VM, which indicates that our vPCI filter will allow Azure-specific devices into the VM.