### PR TITLE
GET: Be tolerant of unexpected host responses (#1637)

### DIFF
--- a/vm/devices/get/guest_emulation_transport/src/lib.rs
+++ b/vm/devices/get/guest_emulation_transport/src/lib.rs
@@ -525,9 +525,89 @@ mod tests {
         assert_eq!(result.utc, 1);
         assert_eq!(result.time_zone, 2);
 
-        let _host_result = get.guest_task.await;
+        // The GET can tolerate extraneous responses, ensure it doesn't crash
+        assert!(futures::poll!(get.guest_task).is_pending());
+    }
 
-        assert!(matches!(FatalError::NoPendingRequest, _host_result));
+    #[async_test]
+    async fn host_send_mismatched_multiple_response(driver: DefaultDriver) {
+        let responses = TestGetResponses::new(Event::Response(
+            get_protocol::VpciDeviceControlResponse::new(
+                get_protocol::VpciDeviceControlStatus::SUCCESS,
+            )
+            .as_bytes()
+            .to_vec(),
+        ))
+        .add_response(Event::Response(
+            get_protocol::TimeResponse::new(0, 1, 2, false)
+                .as_bytes()
+                .to_vec(),
+        ))
+        .add_response(Event::Response(
+            get_protocol::VpciDeviceControlResponse::new(
+                get_protocol::VpciDeviceControlStatus::SUCCESS,
+            )
+            .as_bytes()
+            .to_vec(),
+        ));
+
+        let ged_responses = vec![responses];
+
+        let get =
+            new_transport_pair(driver, Some(ged_responses), ProtocolVersion::NICKEL_REV2).await;
+
+        let time_req = get.client.host_time();
+
+        let result = time_req.await;
+        assert_eq!(result.utc, 1);
+        assert_eq!(result.time_zone, 2);
+    }
+
+    #[async_test]
+    async fn host_send_mismatched_multiple_request_response(driver: DefaultDriver) {
+        let responses = TestGetResponses::new(Event::Response(
+            get_protocol::TimeResponse::new(0, 1, 2, false)
+                .as_bytes()
+                .to_vec(),
+        ))
+        .add_response(Event::Response(
+            get_protocol::VpciDeviceControlResponse::new(
+                get_protocol::VpciDeviceControlStatus::SUCCESS,
+            )
+            .as_bytes()
+            .to_vec(),
+        ))
+        .add_response(Event::Response(
+            get_protocol::TimeResponse::new(0, 1, 2, false)
+                .as_bytes()
+                .to_vec(),
+        ))
+        .add_response(Event::Response(
+            get_protocol::VpciDeviceControlResponse::new(
+                get_protocol::VpciDeviceControlStatus::SUCCESS,
+            )
+            .as_bytes()
+            .to_vec(),
+        ));
+
+        let ged_responses = vec![responses];
+
+        let get =
+            new_transport_pair(driver, Some(ged_responses), ProtocolVersion::NICKEL_REV2).await;
+
+        let time_req = get.client.host_time();
+        let mut vpci_req = std::pin::pin!(get.client.offer_vpci_device(guid::Guid::new_random()));
+
+        // Start the VPCI request going so it enters the queue.
+        assert!(futures::poll!(&mut vpci_req).is_pending());
+
+        // Run the full time request, ensuring it can handle the other responses.
+        let result = time_req.await;
+        assert_eq!(result.utc, 1);
+        assert_eq!(result.time_zone, 2);
+
+        // Now let the VPCI request finish with one of the responses.
+        vpci_req.await.unwrap();
     }
 
     #[async_test]

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -817,9 +817,9 @@ impl<T: RingMem> ProcessLoop<T> {
                             .try_recv()
                         {
                             let id = get_protocol::HeaderRaw::read_from_prefix(&resp)
-                                    .map(|head| HostRequests(head.0.message_id))
-                                    .unwrap_or(HostRequests::INVALID);
-                                tracing::warn!(?id, "received extra response after processing request");
+                                .map(|head| HostRequests(head.0.message_id))
+                                .unwrap_or(HostRequests::INVALID);
+                            tracing::warn!(?id, "received extra response after processing request");
                         }
                     }
                     pending().await


### PR DESCRIPTION
We have an ICM where we believe we are receiving a GET response intended for a previous instance of the VM after a reset has completed. While we are going to fix the host to not do this, we also need to tolerate it in the meantime. We now warn on this happening, but then just drop the unexpected response. 

Cherry-pick of #1637, but note that this was not clean and required some tweaking. I also had to remove some of the newly added tests, as they won't work on this branch.