### PR TITLE
flowey: fix typo checking for installed components

### DIFF
--- a/flowey/flowey_lib_common/src/install_rust.rs
+++ b/flowey/flowey_lib_common/src/install_rust.rs
@@ -135,7 +135,7 @@ impl FlowNode for Node {
                 if let Ok(rustup) = which::which("rustup") {
                     for (thing, expected_things) in [
                         ("target", &additional_target_triples),
-                        ("compoment", &additional_components),
+                        ("component", &additional_components),
                     ] {
                         let output = xshell::cmd!(
                             sh,


### PR DESCRIPTION
Fixes:

```
=== ensure Rust is installed (flowey_lib_common::install_rust) ===
$ rustc -vV
rustc 1.88.0 (6b00bc388 2025-06-23)
binary: rustc
commit-hash: 6b00bc3880198600130e1cf62b8f8a93494488cc
commit-date: 2025-06-23
host: aarch64-unknown-linux-gnu
release: 1.88.0
LLVM version: 20.1.5
Error: missing required compoment: rust-src; to install: `rustup compoment add rust-src`
```