### PR TITLE
ci: add .github/copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+This is a Rust based repository. Please follow these guidelines when contributing:
+
+## Code Standards
+
+### Required Before Each Commit
+- Run `cargo xtask fmt --fix` before committing any changes to ensure proper code formatting.
+- This will ensure all source code and generated pipeline files maintain consistent style and content.
+
+## Key Guidelines
+1. Follow Rust best practices and idiomatic patterns.
+2. Maintain existing code structure and organization.
+3. Write unit tests for new functionality.
+4. Document public APIs and complex logic. Suggest changes to the `Guide/` folder when appropriate.


### PR DESCRIPTION
This change adds a copilot-instructions.md file which will be used by @copilot to give more context on how to develop for the openvmm repo.

See: https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/agents/copilot-coding-agent/best-practices-for-using-copilot-to-work-on-tasks