### PR TITLE
uh_core: Fix incorrect time calculation resulting in spurious warning (#1663)

### DIFF
--- a/openhcl/underhill_core/src/emuplat/local_clock.rs
+++ b/openhcl/underhill_core/src/emuplat/local_clock.rs
@@ -13,7 +13,7 @@ use vmcore::save_restore::SaveRestore;
 
 const NANOS_IN_SECOND: i64 = 1_000_000_000;
 const NANOS_100_IN_SECOND: i64 = NANOS_IN_SECOND / 100;
-const MILLIS_IN_TWO_DAYS: i64 = 100 * 60 * 60 * 24 * 2;
+const MILLIS_IN_TWO_DAYS: i64 = 1000 * 60 * 60 * 24 * 2;
 
 /// Implementation of [`LocalClock`], backed a real time source on the host.
 ///


### PR DESCRIPTION
here are 1000 milliseconds in a second, not 100.

Cherry-pick of #1663