### PR TITLE
petri: use generics instead of Box for backends

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests.rs
@@ -45,7 +45,7 @@ pub struct VmmTestsCli {
     ///
     /// Available flags with default values:
     ///
-    /// `-tdx,-hyperv_vbs,+windows,+ubuntu,+freebsd,+openhcl,+openvmm,+hyperv,+uefi,+pcat,+tmk,+guest_test_uefi`
+    /// `-tdx,-hyperv_vbs,+windows,+ubuntu,+freebsd,+linux,+openhcl,+openvmm,+hyperv,+uefi,+pcat,+tmk,+guest_test_uefi`
     // TODO: Automatically generate the list of possible flags
     #[clap(long)]
     flags: Option<VmmTestSelectionFlags>,

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -89,6 +89,7 @@ define_vmm_test_selection_flags! {
     windows: true,
     ubuntu: true,
     freebsd: true,
+    linux: true,
     openhcl: true,
     openvmm: true,
     hyperv: true,
@@ -215,6 +216,7 @@ impl SimpleFlowNode for Node {
                 windows,
                 mut ubuntu,
                 freebsd,
+                linux,
                 mut openhcl,
                 openvmm,
                 hyperv,
@@ -250,7 +252,6 @@ impl SimpleFlowNode for Node {
                 }
                 if !ubuntu {
                     filter.push_str(" & !test(ubuntu)");
-                    build.pipette_linux = false;
                 }
                 if !windows {
                     filter.push_str(" & !test(windows)");
@@ -258,6 +259,12 @@ impl SimpleFlowNode for Node {
                 }
                 if !freebsd {
                     filter.push_str(" & !test(freebsd)");
+                }
+                if !linux {
+                    filter.push_str(" & !test(linux)");
+                }
+                if !linux && !ubuntu {
+                    build.pipette_linux = false;
                 }
                 if !openhcl {
                     filter.push_str(" & !test(openhcl)");
@@ -297,13 +304,13 @@ impl SimpleFlowNode for Node {
                         if ubuntu {
                             artifacts.push(KnownTestArtifacts::Ubuntu2204ServerX64Vhd);
                         }
-                        if windows {
-                            artifacts.extend_from_slice(&[
-                                KnownTestArtifacts::Gen1WindowsDataCenterCore2022X64Vhd,
-                                KnownTestArtifacts::Gen2WindowsDataCenterCore2022X64Vhd,
-                            ]);
+                        if windows && uefi {
+                            artifacts.push(KnownTestArtifacts::Gen2WindowsDataCenterCore2022X64Vhd);
                         }
-                        if freebsd {
+                        if windows && pcat {
+                            artifacts.push(KnownTestArtifacts::Gen1WindowsDataCenterCore2022X64Vhd);
+                        }
+                        if freebsd && pcat {
                             artifacts.extend_from_slice(&[
                                 KnownTestArtifacts::FreeBsd13_2X64Vhd,
                                 KnownTestArtifacts::FreeBsd13_2X64Iso,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -974,7 +974,7 @@ fn vm_config_from_command_line(
                             get_resources::ged::GuestSecureBootTemplateType::MicrosoftWindows
                         },
                         Some(SecureBootTemplateCli::UefiCa) => {
-                            get_resources::ged::GuestSecureBootTemplateType::MicrosoftUefiCertificateAuthoritiy
+                            get_resources::ged::GuestSecureBootTemplateType::MicrosoftUefiCertificateAuthority
                         }
                         None => {
                             get_resources::ged::GuestSecureBootTemplateType::None

--- a/petri/src/lib.rs
+++ b/petri/src/lib.rs
@@ -10,7 +10,10 @@
 
 pub mod disk_image;
 mod linux_direct_serial_agent;
-mod openhcl_diag;
+// TODO: Add docs and maybe a trait interface for this, or maybe this can
+// remain crate-local somehow without violating interface privacy.
+#[expect(missing_docs)]
+pub mod openhcl_diag;
 mod test;
 mod tracing;
 mod vm;

--- a/petri/src/openhcl_diag.rs
+++ b/petri/src/openhcl_diag.rs
@@ -8,12 +8,11 @@ use diag_client::kmsg_stream::KmsgStream;
 use futures::io::AllowStdIo;
 use std::io::Read;
 
-pub(crate) struct OpenHclDiagHandler(DiagClient);
+pub struct OpenHclDiagHandler(DiagClient);
 
 /// The result of running a VTL2 command.
 #[derive(Debug)]
-#[expect(dead_code)] // Fields output via Debug for debugging purposes.
-pub(crate) struct Vtl2CommandResult {
+pub struct Vtl2CommandResult {
     /// The stdout of the command.
     pub stdout: String,
     /// The stderr of the command.
@@ -74,7 +73,7 @@ impl OpenHclDiagHandler {
         })
     }
 
-    pub(crate) async fn core_dump(&self, name: &str, path: &std::path::Path) -> anyhow::Result<()> {
+    pub async fn core_dump(&self, name: &str, path: &std::path::Path) -> anyhow::Result<()> {
         let client = self.diag_client().await?;
         let pid = client.get_pid(name).await?;
         client
@@ -87,13 +86,13 @@ impl OpenHclDiagHandler {
             .await
     }
 
-    pub(crate) async fn crash(&self, name: &str) -> anyhow::Result<()> {
+    pub async fn crash(&self, name: &str) -> anyhow::Result<()> {
         let client = self.diag_client().await?;
         let pid = client.get_pid(name).await?;
         client.crash(pid).await
     }
 
-    pub(crate) async fn test_inspect(&self) -> anyhow::Result<()> {
+    pub async fn test_inspect(&self) -> anyhow::Result<()> {
         self.diag_client()
             .await?
             .inspect("", None, None)
@@ -101,7 +100,7 @@ impl OpenHclDiagHandler {
             .map(|_| ())
     }
 
-    pub(crate) async fn kmsg(&self) -> anyhow::Result<KmsgStream> {
+    pub async fn kmsg(&self) -> anyhow::Result<KmsgStream> {
         self.diag_client().await?.kmsg(false).await
     }
 

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -10,14 +10,18 @@ use vmsocket::VmSocket;
 use super::ProcessorTopology;
 use crate::Firmware;
 use crate::IsolationType;
+use crate::OpenHclConfig;
 use crate::OpenHclServicingFlags;
-use crate::PetriLogSource;
-use crate::PetriTestParams;
-use crate::PetriVm;
 use crate::PetriVmConfig;
+use crate::PetriVmResources;
+use crate::PetriVmRuntime;
+use crate::PetriVmmBackend;
+use crate::SecureBootTemplate;
 use crate::ShutdownKind;
-use crate::disk_image::AgentImage;
+use crate::UefiConfig;
+use crate::hyperv::powershell::HyperVSecureBootTemplate;
 use crate::openhcl_diag::OpenHclDiagHandler;
+use crate::vm::append_cmdline;
 use anyhow::Context;
 use async_trait::async_trait;
 use get_resources::ged::FirmwareEvent;
@@ -37,317 +41,142 @@ use pipette_client::PipetteClient;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
-use std::path::PathBuf;
 use std::time::Duration;
 use vm::HyperVVM;
 use vmm_core_defs::HaltReason;
 
-/// Hyper-V VM configuration and resources
-pub struct PetriVmConfigHyperV {
-    // Specifies the name of the new virtual machine.
-    name: String,
-    arch: MachineArch,
-    // Specifies the generation for the virtual machine.
-    generation: powershell::HyperVGeneration,
-    // Specifies the Guest State Isolation Type
-    guest_state_isolation_type: powershell::HyperVGuestStateIsolationType,
-    // Specifies the amount of memory, in bytes, to assign to the virtual machine.
-    memory: u64,
-    proc_topology: ProcessorTopology,
-    // Specifies the path to a virtual hard disk file(s) to attach to the
-    // virtual machine as SCSI (Gen2) or IDE (Gen1) drives.
-    vhd_paths: Vec<Vec<PathBuf>>,
-    secure_boot_template: Option<powershell::HyperVSecureBootTemplate>,
-    openhcl_igvm: Option<ResolvedArtifact>,
-    openhcl_command_line: String,
-    disable_frontpage: bool,
-    vmbus_redirect: bool,
+/// The Hyper-V Petri backend
+pub struct HyperVPetriBackend {}
 
-    driver: DefaultDriver,
-    agent_image: AgentImage,
-    openhcl_agent_image: Option<AgentImage>,
-
-    os_flavor: OsFlavor,
-    expected_boot_event: Option<FirmwareEvent>,
-
-    // Folder to store temporary data for this test
-    temp_dir: tempfile::TempDir,
-
-    log_source: PetriLogSource,
-}
-
-#[async_trait]
-impl PetriVmConfig for PetriVmConfigHyperV {
-    async fn run_without_agent(self: Box<Self>) -> anyhow::Result<Box<dyn PetriVm>> {
-        Ok(Box::new(Self::run_without_agent(*self).await?))
-    }
-
-    async fn run_with_lazy_pipette(mut self: Box<Self>) -> anyhow::Result<Box<dyn PetriVm>> {
-        Ok(Box::new(Self::run_with_lazy_pipette(*self).await?))
-    }
-
-    async fn run(self: Box<Self>) -> anyhow::Result<(Box<dyn PetriVm>, PipetteClient)> {
-        let (vm, client) = Self::run(*self).await?;
-        Ok((Box::new(vm), client))
-    }
-
-    fn with_secure_boot(self: Box<Self>) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_secure_boot(*self))
-    }
-
-    fn with_windows_secure_boot_template(self: Box<Self>) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_windows_secure_boot_template(*self))
-    }
-
-    fn with_uefi_ca_secure_boot_template(self: Box<Self>) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_uefi_ca_secure_boot_template(*self))
-    }
-
-    fn with_processor_topology(
-        self: Box<Self>,
-        topology: ProcessorTopology,
-    ) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_processor_topology(*self, topology))
-    }
-
-    fn with_custom_openhcl(self: Box<Self>, artifact: ResolvedArtifact) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_custom_openhcl(*self, artifact))
-    }
-
-    fn with_openhcl_command_line(self: Box<Self>, command_line: &str) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_openhcl_command_line(*self, command_line))
-    }
-
-    fn with_agent_file(
-        self: Box<Self>,
-        name: &str,
-        artifact: ResolvedArtifact,
-    ) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_agent_file(*self, name, artifact))
-    }
-
-    fn with_openhcl_agent_file(
-        self: Box<Self>,
-        name: &str,
-        artifact: ResolvedArtifact,
-    ) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_openhcl_agent_file(*self, name, artifact))
-    }
-
-    fn with_uefi_frontpage(self: Box<Self>, enable: bool) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_uefi_frontpage(*self, enable))
-    }
-
-    fn with_vmbus_redirect(self: Box<Self>, enable: bool) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_vmbus_redirect(*self, enable))
-    }
-
-    fn os_flavor(&self) -> OsFlavor {
-        self.os_flavor
-    }
-}
-
-/// A running VM that tests can interact with.
-pub struct PetriVmHyperV {
-    config: PetriVmConfigHyperV,
+/// Resources needed at runtime for a Hyper-V Petri VM
+pub struct HyperVPetriRuntime {
     vm: HyperVVM,
-    openhcl_diag_handler: Option<OpenHclDiagHandler>,
     log_tasks: Vec<Task<anyhow::Result<()>>>,
+    temp_dir: tempfile::TempDir,
+    openhcl_diag_handler: Option<OpenHclDiagHandler>,
+    driver: DefaultDriver,
 }
 
 #[async_trait]
-impl PetriVm for PetriVmHyperV {
-    fn arch(&self) -> MachineArch {
-        self.config.arch
+impl PetriVmmBackend for HyperVPetriBackend {
+    type VmmConfig = ();
+    type VmRuntime = HyperVPetriRuntime;
+
+    fn check_compat(firmware: &Firmware, arch: MachineArch) -> bool {
+        arch == MachineArch::host()
+            && !firmware.is_linux_direct()
+            && !(firmware.is_pcat() && arch == MachineArch::Aarch64)
     }
 
-    async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason> {
-        Self::wait_for_halt(self).await
+    fn new(_resolver: &ArtifactResolver<'_>) -> Self {
+        HyperVPetriBackend {}
     }
 
-    async fn wait_for_teardown(self: Box<Self>) -> anyhow::Result<HaltReason> {
-        Self::wait_for_teardown(*self).await
-    }
-
-    async fn test_inspect_openhcl(&mut self) -> anyhow::Result<()> {
-        Self::test_inspect_openhcl(self).await
-    }
-
-    async fn wait_for_agent(&mut self) -> anyhow::Result<PipetteClient> {
-        Self::wait_for_agent(self).await
-    }
-
-    async fn wait_for_vtl2_agent(&mut self) -> anyhow::Result<PipetteClient> {
-        Self::wait_for_vtl2_agent(self).await
-    }
-
-    async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()> {
-        Self::wait_for_vtl2_ready(self).await
-    }
-
-    async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()> {
-        Self::wait_for_successful_boot_event(self).await
-    }
-
-    async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent> {
-        Self::wait_for_boot_event(self).await
-    }
-
-    async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()> {
-        Self::send_enlightened_shutdown(self, kind).await
-    }
-
-    async fn restart_openhcl(
-        &mut self,
-        new_openhcl: &ResolvedArtifact,
-        flags: OpenHclServicingFlags,
-    ) -> anyhow::Result<()> {
-        Self::restart_openhcl(self, new_openhcl, flags).await
-    }
-}
-
-/// Artifacts needed to create a [`PetriVmConfigHyperV`].
-pub struct PetriVmArtifactsHyperV {
-    arch: MachineArch,
-    agent_image: AgentImage,
-    openhcl_agent_image: Option<AgentImage>,
-    firmware: Firmware,
-}
-
-impl PetriVmArtifactsHyperV {
-    /// Resolves the artifacts needed to instantiate a [`PetriVmConfigHyperV`].
-    ///
-    /// Returns `None` if the supplied configuration is not supported on this platform.
-    pub fn new(
-        resolver: &ArtifactResolver<'_>,
-        firmware: Firmware,
-        arch: MachineArch,
-    ) -> Option<Self> {
-        if arch != MachineArch::host() {
-            return None;
-        }
-        Some(Self {
+    async fn run(
+        self,
+        config: PetriVmConfig,
+        _vmm_config: Option<impl FnOnce(Self::VmmConfig) -> Self::VmmConfig + Send>,
+        resources: &PetriVmResources,
+    ) -> anyhow::Result<Self::VmRuntime> {
+        let PetriVmConfig {
+            name,
             arch,
-            agent_image: AgentImage::new(resolver, arch, firmware.os_flavor()),
-            openhcl_agent_image: if firmware.is_openhcl() {
-                Some(AgentImage::new(resolver, arch, OsFlavor::Linux))
-            } else {
-                None
-            },
             firmware,
-        })
-    }
-}
-
-impl PetriVmConfigHyperV {
-    /// Create a new Hyper-V petri VM config
-    pub fn new(
-        params: &PetriTestParams<'_>,
-        artifacts: PetriVmArtifactsHyperV,
-        driver: &DefaultDriver,
-    ) -> anyhow::Result<Self> {
-        let PetriVmArtifactsHyperV {
-            arch,
+            memory,
+            proc_topology,
             agent_image,
             openhcl_agent_image,
-            firmware,
-        } = artifacts;
+        } = &config;
+
+        let PetriVmResources {
+            driver,
+            output_dir: _,
+            log_source,
+        } = resources;
+
         let temp_dir = tempfile::tempdir()?;
 
-        let (guest_state_isolation_type, generation, guest_artifact, igvm_artifact) =
-            match &firmware {
-                Firmware::LinuxDirect { .. } | Firmware::OpenhclLinuxDirect { .. } => {
-                    todo!("linux direct not supported on hyper-v")
-                }
-                Firmware::Pcat { guest, .. } => (
-                    powershell::HyperVGuestStateIsolationType::Disabled,
-                    powershell::HyperVGeneration::One,
-                    Some(guest.artifact()),
-                    None,
-                ),
-                Firmware::Uefi { guest, .. } => (
-                    powershell::HyperVGuestStateIsolationType::Disabled,
-                    powershell::HyperVGeneration::Two,
-                    guest.artifact(),
-                    None,
-                ),
-                Firmware::OpenhclUefi {
-                    guest,
-                    isolation,
-                    igvm_path,
-                    vtl2_nvme_boot: _, // TODO, see #1649.
-                } => (
-                    match isolation {
-                        Some(IsolationType::Vbs) => powershell::HyperVGuestStateIsolationType::Vbs,
-                        Some(IsolationType::Snp) => powershell::HyperVGuestStateIsolationType::Snp,
-                        Some(IsolationType::Tdx) => powershell::HyperVGuestStateIsolationType::Tdx,
-                        None => powershell::HyperVGuestStateIsolationType::TrustedLaunch,
-                    },
-                    powershell::HyperVGeneration::Two,
-                    guest.artifact(),
-                    Some(igvm_path),
-                ),
-                // TODO: OpenHCL PCAT
-            };
+        let (
+            guest_state_isolation_type,
+            generation,
+            guest_artifact,
+            uefi_config,
+            mut openhcl_config,
+        ) = match &firmware {
+            Firmware::LinuxDirect { .. } | Firmware::OpenhclLinuxDirect { .. } => {
+                todo!("linux direct not supported on hyper-v")
+            }
+            Firmware::Pcat {
+                guest,
+                bios_firmware: _, // TODO
+                svga_firmware: _, // TODO
+            } => (
+                powershell::HyperVGuestStateIsolationType::Disabled,
+                powershell::HyperVGeneration::One,
+                Some(guest.artifact()),
+                None,
+                None,
+            ),
+            Firmware::OpenhclPcat {
+                guest,
+                igvm_path,
+                bios_firmware: _, // TODO
+                svga_firmware: _, // TODO
+                openhcl_config,
+            } => (
+                powershell::HyperVGuestStateIsolationType::OpenHCL,
+                powershell::HyperVGeneration::One,
+                Some(guest.artifact()),
+                None,
+                Some((igvm_path, openhcl_config.clone())),
+            ),
+            Firmware::Uefi {
+                guest,
+                uefi_firmware: _, // TODO
+                vmgs_file: _,     // TODO
+                uefi_config,
+            } => (
+                powershell::HyperVGuestStateIsolationType::Disabled,
+                powershell::HyperVGeneration::Two,
+                guest.artifact(),
+                Some(uefi_config),
+                None,
+            ),
+            Firmware::OpenhclUefi {
+                guest,
+                isolation,
+                igvm_path,
+                vmgs_file: _, // TODO
+                uefi_config,
+                openhcl_config,
+            } => (
+                match isolation {
+                    Some(IsolationType::Vbs) => powershell::HyperVGuestStateIsolationType::Vbs,
+                    Some(IsolationType::Snp) => powershell::HyperVGuestStateIsolationType::Snp,
+                    Some(IsolationType::Tdx) => powershell::HyperVGuestStateIsolationType::Tdx,
+                    None => powershell::HyperVGuestStateIsolationType::TrustedLaunch,
+                },
+                powershell::HyperVGeneration::Two,
+                guest.artifact(),
+                Some(uefi_config),
+                Some((igvm_path, openhcl_config.clone())),
+            ),
+        };
 
         let vhd_paths = guest_artifact
-            .map(|artifact| vec![vec![artifact.into()]])
+            .map(|artifact| vec![vec![artifact.get()]])
             .unwrap_or_default();
-        let openhcl_igvm = igvm_artifact.cloned();
 
-        Ok(PetriVmConfigHyperV {
-            name: params.test_name.to_owned(),
-            arch,
+        let mut log_tasks = Vec::new();
+
+        let mut vm = HyperVVM::new(
+            name,
             generation,
             guest_state_isolation_type,
-            memory: 0x1_0000_0000,
-            proc_topology: ProcessorTopology::default(),
-            vhd_paths,
-            secure_boot_template: None,
-            openhcl_igvm,
-            agent_image,
-            openhcl_agent_image,
-            driver: driver.clone(),
-            os_flavor: firmware.os_flavor(),
-            expected_boot_event: firmware.expected_boot_event(),
-            temp_dir,
-            log_source: params.logger.clone(),
-            disable_frontpage: true,
-            vmbus_redirect: false,
-            openhcl_command_line: String::new(),
-        })
-    }
-
-    /// Build and boot the requested VM. Does not configure and start pipette.
-    /// Should only be used for testing platforms that pipette does not support.
-    pub async fn run_without_agent(self) -> anyhow::Result<PetriVmHyperV> {
-        self.run_core(false).await
-    }
-
-    /// Run the VM, configuring pipette to automatically start, but do not wait
-    /// for it to connect. This is useful for tests where the first boot attempt
-    /// is expected to not succeed, but pipette functionality is still desired.
-    pub async fn run_with_lazy_pipette(self) -> anyhow::Result<PetriVmHyperV> {
-        self.run_core(true).await
-    }
-
-    /// Run the VM, launching pipette and returning a client to it.
-    pub async fn run(self) -> anyhow::Result<(PetriVmHyperV, PipetteClient)> {
-        let mut vm = self.run_core(true).await?;
-        let client = vm.wait_for_agent().await?;
-        Ok((vm, client))
-    }
-
-    /// Build and boot the requested VM
-    async fn run_core(mut self, with_agent: bool) -> anyhow::Result<PetriVmHyperV> {
-        let mut vm = HyperVVM::new(
-            &self.name,
-            self.generation,
-            self.guest_state_isolation_type,
-            self.memory,
-            self.log_source.log_file("hyperv")?,
-            self.expected_boot_event,
-            self.driver.clone(),
+            memory.startup_bytes,
+            log_source.log_file("hyperv")?,
+            firmware.expected_boot_event(),
+            driver.clone(),
         )?;
 
         {
@@ -356,7 +185,7 @@ impl PetriVmConfigHyperV {
                 vps_per_socket,
                 enable_smt,
                 apic_mode,
-            } = self.proc_topology;
+            } = proc_topology;
             // TODO: fix this mapping, and/or update petri to better match
             // Hyper-V's capabilities.
             let apic_mode = apic_mode
@@ -365,33 +194,55 @@ impl PetriVmConfigHyperV {
                     super::ApicMode::X2apicSupported => powershell::HyperVApicMode::X2Apic,
                     super::ApicMode::X2apicEnabled => powershell::HyperVApicMode::X2Apic,
                 })
-                .or((self.arch == MachineArch::X86_64
-                    && self.generation == powershell::HyperVGeneration::Two)
+                .or((*arch == MachineArch::X86_64
+                    && generation == powershell::HyperVGeneration::Two)
                     .then_some({
                         // This is necessary for some tests to pass. TODO: fix.
                         powershell::HyperVApicMode::X2Apic
                     }));
             vm.set_processor(&powershell::HyperVSetVMProcessorArgs {
-                count: Some(vp_count),
+                count: Some(*vp_count),
                 apic_mode,
                 hw_thread_count_per_core: enable_smt.map(|smt| if smt { 2 } else { 1 }),
-                maximum_count_per_numa_node: vps_per_socket,
+                maximum_count_per_numa_node: *vps_per_socket,
             })?;
         }
 
-        if let Some(secure_boot_template) = self.secure_boot_template {
-            vm.set_secure_boot_template(secure_boot_template)?;
+        if let Some(UefiConfig {
+            secure_boot_enabled,
+            secure_boot_template,
+            disable_frontpage,
+        }) = uefi_config
+        {
+            vm.set_secure_boot(
+                *secure_boot_enabled,
+                secure_boot_template.map(|t| match t {
+                    SecureBootTemplate::MicrosoftWindows => {
+                        HyperVSecureBootTemplate::MicrosoftWindows
+                    }
+                    SecureBootTemplate::MicrosoftUefiCertificateAuthority => {
+                        HyperVSecureBootTemplate::MicrosoftUEFICertificateAuthority
+                    }
+                }),
+            )?;
+
+            if *disable_frontpage {
+                // TODO: Disable frontpage for non-OpenHCL Hyper-V VMs
+                if let Some((_, config)) = openhcl_config.as_mut() {
+                    append_cmdline(&mut config.command_line, "OPENHCL_DISABLE_UEFI_FRONTPAGE=1");
+                };
+            }
         }
 
-        for (i, vhds) in self.vhd_paths.iter().enumerate() {
-            let (controller_type, controller_number) = match self.generation {
+        for (i, vhds) in vhd_paths.iter().enumerate() {
+            let (controller_type, controller_number) = match generation {
                 powershell::HyperVGeneration::One => (powershell::ControllerType::Ide, i as u32),
                 powershell::HyperVGeneration::Two => {
                     (powershell::ControllerType::Scsi, vm.add_scsi_controller(0)?)
                 }
             };
             for (controller_location, vhd) in vhds.iter().enumerate() {
-                let diff_disk_path = self.temp_dir.path().join(format!(
+                let diff_disk_path = temp_dir.path().join(format!(
                     "{}_{}_{}",
                     controller_number,
                     controller_location,
@@ -410,23 +261,20 @@ impl PetriVmConfigHyperV {
             }
         }
 
-        if with_agent {
+        if let Some(agent_image) = agent_image {
             // Construct the agent disk.
-            let agent_disk_path = self.temp_dir.path().join("cidata.vhd");
+            let agent_disk_path = temp_dir.path().join("cidata.vhd");
             {
-                let agent_disk = self
-                    .agent_image
-                    .build()
-                    .context("failed to build agent image")?;
+                let agent_disk = agent_image.build().context("failed to build agent image")?;
                 disk_vhd1::Vhd1Disk::make_fixed(agent_disk.as_file())
                     .context("failed to make vhd for agent image")?;
                 agent_disk.persist(&agent_disk_path)?;
             }
 
-            if matches!(self.os_flavor, OsFlavor::Windows) {
+            if matches!(firmware.os_flavor(), OsFlavor::Windows) {
                 // Make a file for the IMC hive. It's not guaranteed to be at a fixed
                 // location at runtime.
-                let imc_hive = self.temp_dir.path().join("imc.hiv");
+                let imc_hive = temp_dir.path().join("imc.hiv");
                 {
                     let mut imc_hive_file = fs::File::create_new(&imc_hive)?;
                     imc_hive_file
@@ -447,10 +295,18 @@ impl PetriVmConfigHyperV {
             )?;
         }
 
-        if let Some(src_igvm_file) = &self.openhcl_igvm {
+        let openhcl_diag_handler = if let Some((
+            src_igvm_file,
+            OpenHclConfig {
+                vtl2_nvme_boot: _, // TODO, see #1649.
+                vmbus_redirect,
+                command_line,
+            },
+        )) = &openhcl_config
+        {
             // Copy the IGVM file locally, since it may not be accessible by
             // Hyper-V (e.g., if it is in a WSL filesystem).
-            let igvm_file = self.temp_dir.path().join("igvm.bin");
+            let igvm_file = temp_dir.path().join("igvm.bin");
             fs_err::copy(src_igvm_file, &igvm_file).context("failed to copy igvm file")?;
             acl_read_for_vm(&igvm_file, Some(*vm.vmid()))
                 .context("failed to set ACL for igvm file")?;
@@ -460,65 +316,42 @@ impl PetriVmConfigHyperV {
                 &igvm_file,
                 // don't increase VTL2 memory on CVMs
                 !matches!(
-                    self.guest_state_isolation_type,
+                    guest_state_isolation_type,
                     powershell::HyperVGuestStateIsolationType::Vbs
                         | powershell::HyperVGuestStateIsolationType::Snp
                         | powershell::HyperVGuestStateIsolationType::Tdx
                 ),
             )?;
 
-            if self.disable_frontpage {
-                self.openhcl_command_line
-                    .push_str(" OPENHCL_DISABLE_UEFI_FRONTPAGE=1");
-            }
-            vm.set_vm_firmware_command_line(&self.openhcl_command_line)?;
-
-            // Construct the agent disk.
-            let agent_disk_path = self.temp_dir.path().join("paravisor_cidata.vhd");
-            {
-                let agent_disk = self
-                    .openhcl_agent_image
-                    .as_ref()
-                    .unwrap()
-                    .build()
-                    .context("failed to build openhcl agent image")?;
-                disk_vhd1::Vhd1Disk::make_fixed(agent_disk.as_file())
-                    .context("failed to make vhd for agent image")?;
-                agent_disk.persist(&agent_disk_path)?;
+            if let Some(command_line) = command_line {
+                vm.set_vm_firmware_command_line(command_line)?;
             }
 
-            let controller_number = vm.add_scsi_controller(2)?;
-            vm.add_vhd(
-                &agent_disk_path,
-                powershell::ControllerType::Scsi,
-                Some(0),
-                Some(controller_number),
-            )?;
+            vm.set_vmbus_redirect(*vmbus_redirect)?;
 
-            // Enable/Disable VMBusRedirect if requested in config
-            vm.set_vmbus_redirect(self.vmbus_redirect)?;
-        }
+            if let Some(openhcl_agent_image) = openhcl_agent_image {
+                let agent_disk_path = temp_dir.path().join("paravisor_cidata.vhd");
+                {
+                    let agent_disk = openhcl_agent_image
+                        .build()
+                        .context("failed to build openhcl agent image")?;
+                    disk_vhd1::Vhd1Disk::make_fixed(agent_disk.as_file())
+                        .context("failed to make vhd for agent image")?;
+                    agent_disk.persist(&agent_disk_path)?;
+                }
 
-        let mut log_tasks = Vec::new();
-
-        let serial_pipe_path = vm.set_vm_com_port(1)?;
-        let serial_log_file = self.log_source.log_file("guest")?;
-        log_tasks.push(self.driver.spawn("guest-log", {
-            let driver = self.driver.clone();
-            async move {
-                let serial = diag_client::hyperv::open_serial_port(
-                    &driver,
-                    diag_client::hyperv::ComPortAccessInfo::PortPipePath(&serial_pipe_path),
-                )
-                .await?;
-                crate::log_stream(serial_log_file, PolledPipe::new(&driver, serial)?).await
+                let controller_number = vm.add_scsi_controller(2)?;
+                vm.add_vhd(
+                    &agent_disk_path,
+                    powershell::ControllerType::Scsi,
+                    Some(0),
+                    Some(controller_number),
+                )?;
             }
-        }));
 
-        let openhcl_diag_handler = if self.openhcl_igvm.is_some() {
-            let openhcl_log_file = self.log_source.log_file("openhcl")?;
-            log_tasks.push(self.driver.spawn("openhcl-log", {
-                let driver = self.driver.clone();
+            let openhcl_log_file = log_source.log_file("openhcl")?;
+            log_tasks.push(driver.spawn("openhcl-log", {
+                let driver = driver.clone();
                 let vmid = *vm.vmid();
                 async move {
                     let diag_client = diag_client::DiagClient::from_hyperv_id(driver.clone(), vmid);
@@ -532,185 +365,55 @@ impl PetriVmConfigHyperV {
                     }
                 }
             }));
+
             Some(OpenHclDiagHandler::new(
-                diag_client::DiagClient::from_hyperv_id(self.driver.clone(), *vm.vmid()),
+                diag_client::DiagClient::from_hyperv_id(driver.clone(), *vm.vmid()),
             ))
         } else {
             None
         };
 
+        let serial_pipe_path = vm.set_vm_com_port(1)?;
+        let serial_log_file = log_source.log_file("guest")?;
+        log_tasks.push(driver.spawn("guest-log", {
+            let driver = driver.clone();
+            async move {
+                let serial = diag_client::hyperv::open_serial_port(
+                    &driver,
+                    diag_client::hyperv::ComPortAccessInfo::PortPipePath(&serial_pipe_path),
+                )
+                .await?;
+                crate::log_stream(serial_log_file, PolledPipe::new(&driver, serial)?).await
+            }
+        }));
+
         vm.start().await?;
 
-        Ok(PetriVmHyperV {
-            config: self,
+        Ok(HyperVPetriRuntime {
             vm,
-            openhcl_diag_handler,
             log_tasks,
+            temp_dir,
+            openhcl_diag_handler,
+            driver: driver.clone(),
         })
-    }
-
-    /// Set the VM to use the specified number of virtual processors.
-    pub fn with_processor_topology(mut self, topology: ProcessorTopology) -> Self {
-        self.proc_topology = topology;
-        self
-    }
-
-    /// Set the VM to enable secure boot and inject the templates per OS flavor.
-    pub fn with_secure_boot(self) -> Self {
-        if !matches!(self.generation, powershell::HyperVGeneration::Two) {
-            panic!("Secure boot is only supported for UEFI firmware.");
-        }
-
-        match self.os_flavor {
-            OsFlavor::Windows => self.with_windows_secure_boot_template(),
-            OsFlavor::Linux => self.with_uefi_ca_secure_boot_template(),
-            _ => panic!("Secure boot unsupported for OS flavor {:?}", self.os_flavor),
-        }
-    }
-
-    /// Inject Windows secure boot templates into the VM's UEFI.
-    pub fn with_windows_secure_boot_template(mut self) -> Self {
-        if !matches!(self.generation, powershell::HyperVGeneration::Two) {
-            panic!("Secure boot is only supported for UEFI firmware.");
-        }
-        self.secure_boot_template = Some(powershell::HyperVSecureBootTemplate::MicrosoftWindows);
-        self
-    }
-
-    /// Inject UEFI CA secure boot templates into the VM's UEFI.
-    pub fn with_uefi_ca_secure_boot_template(mut self) -> Self {
-        if !matches!(self.generation, powershell::HyperVGeneration::Two) {
-            panic!("Secure boot is only supported for UEFI firmware.");
-        }
-        self.secure_boot_template =
-            Some(powershell::HyperVSecureBootTemplate::MicrosoftUEFICertificateAuthority);
-        self
-    }
-
-    /// Sets a custom OpenHCL IGVM image to use.
-    pub fn with_custom_openhcl(mut self, artifact: ResolvedArtifact) -> Self {
-        self.openhcl_igvm = Some(artifact);
-        self
-    }
-
-    /// Appends to the OpenHCL command line.
-    pub fn with_openhcl_command_line(mut self, command_line: &str) -> Self {
-        assert!(self.openhcl_igvm.is_some());
-        self.openhcl_command_line.push(' ');
-        self.openhcl_command_line.push_str(command_line);
-        self
-    }
-
-    /// Adds a file to the agent image.
-    pub fn with_agent_file(mut self, name: &str, artifact: ResolvedArtifact) -> Self {
-        self.agent_image.add_file(name, artifact);
-        self
-    }
-
-    /// Adds a file to the OpenHCL agent image.
-    pub fn with_openhcl_agent_file(mut self, name: &str, artifact: ResolvedArtifact) -> Self {
-        self.openhcl_agent_image
-            .as_mut()
-            .unwrap()
-            .add_file(name, artifact);
-        self
-    }
-
-    /// Set whether to disable the UEFI frontpage.
-    pub fn with_uefi_frontpage(mut self, enable: bool) -> Self {
-        self.disable_frontpage = !enable;
-        self
-    }
-
-    /// Enables VMBus relay for the VM
-    pub fn with_vmbus_redirect(mut self, enable: bool) -> Self {
-        self.vmbus_redirect = enable;
-        self
     }
 }
 
-impl PetriVmHyperV {
-    /// Wait for the VM to halt, returning the reason for the halt.
-    pub async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason> {
+#[async_trait]
+impl PetriVmRuntime for HyperVPetriRuntime {
+    async fn teardown(self) -> anyhow::Result<()> {
+        for t in self.log_tasks {
+            _ = t.cancel();
+        }
+        self.vm.remove()
+    }
+
+    async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason> {
         self.vm.wait_for_halt().await?;
         Ok(HaltReason::PowerOff) // TODO: Get actual halt reason
     }
 
-    /// Wait for the VM to halt, returning the reason for the halt,
-    /// and cleanly tear down the VM.
-    pub async fn wait_for_teardown(mut self) -> anyhow::Result<HaltReason> {
-        let halt_reason = self.wait_for_halt().await?;
-        for t in self.log_tasks {
-            _ = t.cancel();
-        }
-        self.vm.remove()?;
-        Ok(halt_reason)
-    }
-
-    /// Test that we are able to inspect OpenHCL.
-    pub async fn test_inspect_openhcl(&mut self) -> anyhow::Result<()> {
-        self.openhcl_diag()?.test_inspect().await
-    }
-
-    /// Wait for VTL 2 to report that it is ready to respond to commands.
-    /// Will fail if the VM is not running OpenHCL.
-    ///
-    /// This should only be necessary if you're doing something manual. All
-    /// Petri-provided methods will wait for VTL 2 to be ready automatically.
-    pub async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()> {
-        self.openhcl_diag()?.wait_for_vtl2().await
-    }
-
-    /// Wait for a connection from a pipette agent running in the guest.
-    /// Useful if you've rebooted the vm or are otherwise expecting a fresh connection.
-    pub async fn wait_for_agent(&mut self) -> anyhow::Result<PipetteClient> {
-        self.wait_for_agent_core(false).await
-    }
-
-    /// Waits for a connection from a pipette agent running in the paravisor.
-    pub async fn wait_for_vtl2_agent(&mut self) -> anyhow::Result<PipetteClient> {
-        // VTL 2's pipette doesn't auto launch, only launch it on demand
-        self.launch_vtl2_pipette().await?;
-        self.wait_for_agent_core(true).await
-    }
-
-    /// Waits for an event emitted by the firmware about its boot status, and
-    /// verifies that it is the expected success value.
-    ///
-    /// * Linux Direct guests do not emit a boot event, so this method immediately returns Ok.
-    /// * PCAT guests may not emit an event depending on the PCAT version, this
-    ///   method is best effort for them.
-    pub async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()> {
-        self.vm.wait_for_successful_boot_event().await
-    }
-
-    /// Waits for an event emitted by the firmware about its boot status, and
-    /// returns that status.
-    pub async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent> {
-        self.vm.wait_for_boot_event().await
-    }
-
-    /// Instruct the guest to shutdown via the Hyper-V shutdown IC.
-    pub async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()> {
-        match kind {
-            ShutdownKind::Shutdown => self.vm.stop().await?,
-            ShutdownKind::Reboot => self.vm.restart().await?,
-        }
-
-        Ok(())
-    }
-
-    /// Restart the OpenHCL firmware in the VM. (Run OpenHCL servicing)
-    pub async fn restart_openhcl(
-        &mut self,
-        _new_openhcl: &ResolvedArtifact,
-        flags: OpenHclServicingFlags,
-    ) -> anyhow::Result<()> {
-        // TODO: Updating the file causes failure ... self.vm.set_openhcl_firmware(new_openhcl.get(), false)?;
-        self.vm.restart_openhcl(flags).await
-    }
-
-    async fn wait_for_agent_core(&self, set_high_vtl: bool) -> anyhow::Result<PipetteClient> {
+    async fn wait_for_agent(&mut self, set_high_vtl: bool) -> anyhow::Result<PipetteClient> {
         let socket = VmSocket::new().context("failed to create AF_HYPERV socket")?;
         socket
             .set_connect_timeout(Duration::from_secs(5))
@@ -726,7 +429,7 @@ impl PetriVmHyperV {
         let connect_timeout = 240.seconds();
         let start = Timestamp::now();
 
-        let mut socket = PolledSocket::new(&self.config.driver, socket)?.convert();
+        let mut socket = PolledSocket::new(&self.driver, socket)?.convert();
         while let Err(e) = socket
             .connect(
                 &VmAddress::hyperv_vsock(*self.vm.vmid(), pipette_client::PIPETTE_VSOCK_PORT)
@@ -737,42 +440,44 @@ impl PetriVmHyperV {
             if connect_timeout.compare(Timestamp::now() - start)? == std::cmp::Ordering::Less {
                 anyhow::bail!("Pipette connection timed out: {e}")
             }
-            PolledTimer::new(&self.config.driver)
+            PolledTimer::new(&self.driver)
                 .sleep(Duration::from_secs(1))
                 .await;
         }
 
-        PipetteClient::new(&self.config.driver, socket, self.config.temp_dir.path())
+        PipetteClient::new(&self.driver, socket, self.temp_dir.path())
             .await
             .context("failed to connect to pipette")
     }
 
-    fn openhcl_diag(&self) -> anyhow::Result<&OpenHclDiagHandler> {
-        if let Some(ohd) = &self.openhcl_diag_handler {
-            Ok(ohd)
-        } else {
-            anyhow::bail!("VM is not configured with OpenHCL")
-        }
+    fn openhcl_diag(&self) -> Option<&OpenHclDiagHandler> {
+        self.openhcl_diag_handler.as_ref()
     }
 
-    async fn launch_vtl2_pipette(&self) -> anyhow::Result<()> {
-        // Start pipette through DiagClient
-        let res = self
-            .openhcl_diag()?
-            .run_vtl2_command(
-                "sh",
-                &[
-                    "-c",
-                    "mkdir /cidata && mount LABEL=cidata /cidata && sh -c '/cidata/pipette &'",
-                ],
-            )
-            .await?;
+    async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()> {
+        self.vm.wait_for_successful_boot_event().await
+    }
 
-        if !res.exit_status.success() {
-            anyhow::bail!("Failed to start VTL 2 pipette: {:?}", res);
+    async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent> {
+        self.vm.wait_for_boot_event().await
+    }
+
+    async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()> {
+        match kind {
+            ShutdownKind::Shutdown => self.vm.stop().await?,
+            ShutdownKind::Reboot => self.vm.restart().await?,
         }
 
         Ok(())
+    }
+
+    async fn restart_openhcl(
+        &mut self,
+        _new_openhcl: &ResolvedArtifact,
+        flags: OpenHclServicingFlags,
+    ) -> anyhow::Result<()> {
+        // TODO: Updating the file causes failure ... self.vm.set_openhcl_firmware(new_openhcl.get(), false)?;
+        self.vm.restart_openhcl(flags).await
     }
 }
 

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -75,9 +75,13 @@ impl PetriVmmBackend for HyperVPetriBackend {
     async fn run(
         self,
         config: PetriVmConfig,
-        _vmm_config: Option<impl FnOnce(Self::VmmConfig) -> Self::VmmConfig + Send>,
+        modify_vmm_config: Option<impl FnOnce(Self::VmmConfig) -> Self::VmmConfig + Send>,
         resources: &PetriVmResources,
     ) -> anyhow::Result<Self::VmRuntime> {
+        if modify_vmm_config.is_some() {
+            panic!("specified modify_vmm_config, but that is not supported for hyperv");
+        }
+
         let PetriVmConfig {
             name,
             arch,

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -90,6 +90,7 @@ impl PetriVmmBackend for HyperVPetriBackend {
             proc_topology,
             agent_image,
             openhcl_agent_image,
+            vmgs: _, // TODO
         } = &config;
 
         let PetriVmResources {
@@ -137,7 +138,6 @@ impl PetriVmmBackend for HyperVPetriBackend {
             Firmware::Uefi {
                 guest,
                 uefi_firmware: _, // TODO
-                vmgs_file: _,     // TODO
                 uefi_config,
             } => (
                 powershell::HyperVGuestStateIsolationType::Disabled,
@@ -150,7 +150,6 @@ impl PetriVmmBackend for HyperVPetriBackend {
                 guest,
                 isolation,
                 igvm_path,
-                vmgs_file: _, // TODO
                 uefi_config,
                 openhcl_config,
             } => (

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -127,6 +127,7 @@ impl HyperVVM {
         if generation == powershell::HyperVGeneration::Two {
             powershell::run_set_vm_firmware(powershell::HyperVSetVMFirmwareArgs {
                 vmid: &vmid,
+                secure_boot_enabled: Some(false),
                 secure_boot_template: None,
             })?;
         }
@@ -228,14 +229,16 @@ impl HyperVVM {
         )
     }
 
-    /// Set the secure boot template
-    pub fn set_secure_boot_template(
+    /// Configure secure boot
+    pub fn set_secure_boot(
         &mut self,
-        secure_boot_template: powershell::HyperVSecureBootTemplate,
+        secure_boot_enabled: bool,
+        secure_boot_template: Option<powershell::HyperVSecureBootTemplate>,
     ) -> anyhow::Result<()> {
         powershell::run_set_vm_firmware(powershell::HyperVSetVMFirmwareArgs {
             vmid: &self.vmid,
-            secure_boot_template: Some(secure_boot_template),
+            secure_boot_enabled: Some(secure_boot_enabled),
+            secure_boot_template,
         })
     }
 

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -255,7 +255,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
     }
 
     /// Sets a custom OpenHCL IGVM file to use.
-    pub fn with_custom_openhcl<O: IsOpenhclIgvm>(mut self, artifact: ResolvedArtifact<O>) -> Self {
+    pub fn with_custom_openhcl(mut self, artifact: ResolvedArtifact<impl IsOpenhclIgvm>) -> Self {
         match &mut self.config.firmware {
             Firmware::OpenhclLinuxDirect { igvm_path, .. }
             | Firmware::OpenhclPcat { igvm_path, .. }
@@ -363,7 +363,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
     }
 
     /// Use the specified backing VMGS file
-    pub fn with_backing_vmgs<V: IsTestVmgs>(mut self, disk: ResolvedArtifact<V>) -> Self {
+    pub fn with_backing_vmgs(mut self, disk: ResolvedArtifact<impl IsTestVmgs>) -> Self {
         match &mut self.config.vmgs {
             PetriVmgsResource::Disk(installed_disk)
             | PetriVmgsResource::ReprovisionOnFailure(installed_disk)

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -7,10 +7,16 @@ pub mod hyperv;
 /// OpenVMM VM management
 pub mod openvmm;
 
+use crate::PetriLogSource;
+use crate::PetriTestParams;
 use crate::ShutdownKind;
+use crate::disk_image::AgentImage;
+use crate::openhcl_diag::OpenHclDiagHandler;
 use async_trait::async_trait;
 use get_resources::ged::FirmwareEvent;
+use pal_async::DefaultDriver;
 use petri_artifacts_common::tags::GuestQuirks;
+use petri_artifacts_common::tags::IsOpenhclIgvm;
 use petri_artifacts_common::tags::IsTestVmgs;
 use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_common::tags::OsFlavor;
@@ -18,58 +24,495 @@ use petri_artifacts_core::ArtifactResolver;
 use petri_artifacts_core::ResolvedArtifact;
 use petri_artifacts_core::ResolvedOptionalArtifact;
 use pipette_client::PipetteClient;
+use std::path::PathBuf;
 use vmm_core_defs::HaltReason;
 
-/// Configuration state for a test VM.
-///
-/// R is the type of the struct used to interact with the VM once it is created
+/// The set of artifacts and resources needed to instantiate a
+/// [`PetriVmBuilder`].
+pub struct PetriVmArtifacts<T: PetriVmmBackend> {
+    /// Artifacts needed to launch the host VMM used for the test
+    pub backend: T,
+    /// Firmware and/or OS to load into the VM and associated settings
+    pub firmware: Firmware,
+    /// The architecture of the VM
+    pub arch: MachineArch,
+    /// Agent to run in the guest
+    pub agent_image: Option<AgentImage>,
+    /// Agent to run in OpenHCL
+    pub openhcl_agent_image: Option<AgentImage>,
+}
+
+impl<T: PetriVmmBackend> PetriVmArtifacts<T> {
+    /// Resolves the artifacts needed to instantiate a [`PetriVmBuilder`].
+    ///
+    /// Returns `None` if the supplied configuration is not supported on this platform.
+    pub fn new(
+        resolver: &ArtifactResolver<'_>,
+        firmware: Firmware,
+        arch: MachineArch,
+    ) -> Option<Self> {
+        if !T::check_compat(&firmware, arch) {
+            return None;
+        }
+        Some(Self {
+            backend: T::new(resolver),
+            arch,
+            agent_image: Some(AgentImage::new(resolver, arch, firmware.os_flavor())),
+            openhcl_agent_image: if firmware.is_openhcl() {
+                Some(AgentImage::new(resolver, arch, OsFlavor::Linux))
+            } else {
+                None
+            },
+            firmware,
+        })
+    }
+}
+
+/// Petri VM builder
+pub struct PetriVmBuilder<T: PetriVmmBackend> {
+    /// Artifacts needed to launch the host VMM used for the test
+    backend: T,
+    /// VM configuration
+    config: PetriVmConfig,
+    /// VMM-specific configuration
+    vmm_config: Option<Box<dyn FnOnce(T::VmmConfig) -> T::VmmConfig + Send>>,
+    /// VMM-agnostic resources
+    resources: PetriVmResources,
+}
+
+/// Petri VM configuration
+pub struct PetriVmConfig {
+    /// The name of the VM
+    pub name: String,
+    /// The architecture of the VM
+    pub arch: MachineArch,
+    /// Firmware and/or OS to load into the VM and associated settings
+    pub firmware: Firmware,
+    /// The amount of memory, in bytes, to assign to the VM
+    pub memory: MemoryConfig,
+    /// The processor tology for the VM
+    pub proc_topology: ProcessorTopology,
+    /// Agent to run in the guest
+    pub agent_image: Option<AgentImage>,
+    /// Agent to run in OpenHCL
+    pub openhcl_agent_image: Option<AgentImage>,
+}
+
+/// Resources used by a Petri VM during contruction and runtime
+pub struct PetriVmResources {
+    driver: DefaultDriver,
+    output_dir: PathBuf,
+    log_source: PetriLogSource,
+}
+
+/// Trait for VMM-specific contruction and runtime resources
 #[async_trait]
-pub trait PetriVmConfig: Send {
+pub trait PetriVmmBackend {
+    /// VMM-specific configuration
+    type VmmConfig;
+
+    /// Runtime object
+    type VmRuntime: PetriVmRuntime;
+
+    /// Check whether the combination of firmware and architecture is
+    /// supported on the VMM.
+    fn check_compat(firmware: &Firmware, arch: MachineArch) -> bool;
+
+    /// Resolve any artifacts needed to use this backend
+    fn new(resolver: &ArtifactResolver<'_>) -> Self;
+
+    /// Create and start VM from the generic config using the VMM backend
+    async fn run(
+        self,
+        config: PetriVmConfig,
+        vmm_config: Option<impl FnOnce(Self::VmmConfig) -> Self::VmmConfig + Send>,
+        resources: &PetriVmResources,
+    ) -> anyhow::Result<Self::VmRuntime>;
+}
+
+/// A constructed Petri VM
+pub struct PetriVm<T: PetriVmmBackend> {
+    arch: MachineArch,
+    _resources: PetriVmResources,
+    runtime: T::VmRuntime,
+}
+
+impl<T: PetriVmmBackend> PetriVmBuilder<T> {
+    /// Create a new VM configuration.
+    pub fn new(
+        params: &PetriTestParams<'_>,
+        artifacts: PetriVmArtifacts<T>,
+        driver: &DefaultDriver,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            backend: artifacts.backend,
+            config: PetriVmConfig {
+                name: params.test_name.to_owned(),
+                arch: artifacts.arch,
+                firmware: artifacts.firmware,
+                memory: Default::default(),
+                proc_topology: Default::default(),
+                agent_image: artifacts.agent_image,
+                openhcl_agent_image: artifacts.openhcl_agent_image,
+            },
+            vmm_config: None,
+            resources: PetriVmResources {
+                driver: driver.clone(),
+                output_dir: params.output_dir.to_owned(),
+                log_source: params.logger.clone(),
+            },
+        })
+    }
+}
+
+impl<T: PetriVmmBackend> PetriVmBuilder<T> {
     /// Build and boot the requested VM. Does not configure and start pipette.
     /// Should only be used for testing platforms that pipette does not support.
-    async fn run_without_agent(self: Box<Self>) -> anyhow::Result<Box<dyn PetriVm>>;
+    pub async fn run_without_agent(mut self) -> anyhow::Result<PetriVm<T>> {
+        self.config.agent_image = None;
+        self.run_core().await
+    }
+
     /// Run the VM, configuring pipette to automatically start, but do not wait
     /// for it to connect. This is useful for tests where the first boot attempt
     /// is expected to not succeed, but pipette functionality is still desired.
-    async fn run_with_lazy_pipette(self: Box<Self>) -> anyhow::Result<Box<dyn PetriVm>>;
+    pub async fn run_with_lazy_pipette(self) -> anyhow::Result<PetriVm<T>> {
+        assert!(self.config.agent_image.is_some());
+        self.run_core().await
+    }
+
     /// Run the VM, launching pipette and returning a client to it.
-    async fn run(self: Box<Self>) -> anyhow::Result<(Box<dyn PetriVm>, PipetteClient)>;
+    pub async fn run(self) -> anyhow::Result<(PetriVm<T>, PipetteClient)> {
+        let mut vm = self.run_with_lazy_pipette().await?;
+        let client = vm.wait_for_agent().await?;
+        Ok((vm, client))
+    }
+
+    async fn run_core(self) -> anyhow::Result<PetriVm<T>> {
+        let arch = self.config.arch;
+        let runtime = self
+            .backend
+            .run(self.config, self.vmm_config, &self.resources)
+            .await?;
+        Ok(PetriVm {
+            arch,
+            _resources: self.resources,
+            runtime,
+        })
+    }
+
+    // TODO: Make sure all of the below are parsed in openvmm construct
 
     /// Set the VM to enable secure boot and inject the templates per OS flavor.
-    fn with_secure_boot(self: Box<Self>) -> Box<dyn PetriVmConfig>;
+    pub fn with_secure_boot(mut self) -> Self {
+        self.config
+            .firmware
+            .uefi_config_mut()
+            .expect("Secure boot is only supported for UEFI firmware.")
+            .secure_boot_enabled = true;
+
+        match self.os_flavor() {
+            OsFlavor::Windows => self.with_windows_secure_boot_template(),
+            OsFlavor::Linux => self.with_uefi_ca_secure_boot_template(),
+            _ => panic!(
+                "Secure boot unsupported for OS flavor {:?}",
+                self.os_flavor()
+            ),
+        }
+    }
+
     /// Inject Windows secure boot templates into the VM's UEFI.
-    fn with_windows_secure_boot_template(self: Box<Self>) -> Box<dyn PetriVmConfig>;
+    pub fn with_windows_secure_boot_template(mut self) -> Self {
+        self.config
+            .firmware
+            .uefi_config_mut()
+            .expect("Secure boot is only supported for UEFI firmware.")
+            .secure_boot_template = Some(SecureBootTemplate::MicrosoftWindows);
+        self
+    }
+
     /// Inject UEFI CA secure boot templates into the VM's UEFI.
-    fn with_uefi_ca_secure_boot_template(self: Box<Self>) -> Box<dyn PetriVmConfig>;
+    pub fn with_uefi_ca_secure_boot_template(mut self) -> Self {
+        self.config
+            .firmware
+            .uefi_config_mut()
+            .expect("Secure boot is only supported for UEFI firmware.")
+            .secure_boot_template = Some(SecureBootTemplate::MicrosoftUefiCertificateAuthority);
+        self
+    }
+
     /// Set the VM to use the specified processor topology.
-    fn with_processor_topology(
-        self: Box<Self>,
-        topology: ProcessorTopology,
-    ) -> Box<dyn PetriVmConfig>;
+    pub fn with_processor_topology(mut self, topology: ProcessorTopology) -> Self {
+        self.config.proc_topology = topology;
+        self
+    }
+
+    /// Set the VM to use the specified processor topology.
+    pub fn with_memory(mut self, memory: MemoryConfig) -> Self {
+        self.config.memory = memory;
+        self
+    }
 
     /// Sets a custom OpenHCL IGVM file to use.
-    fn with_custom_openhcl(self: Box<Self>, artifact: ResolvedArtifact) -> Box<dyn PetriVmConfig>;
-    /// Sets the command line for the paravisor.
-    fn with_openhcl_command_line(self: Box<Self>, command_line: &str) -> Box<dyn PetriVmConfig>;
-    /// Adds a file to the VM's pipette agent image.
-    fn with_agent_file(
-        self: Box<Self>,
-        name: &str,
-        artifact: ResolvedArtifact,
-    ) -> Box<dyn PetriVmConfig>;
-    /// Adds a file to the paravisor's pipette agent image.
-    fn with_openhcl_agent_file(
-        self: Box<Self>,
-        name: &str,
-        artifact: ResolvedArtifact,
-    ) -> Box<dyn PetriVmConfig>;
-    /// Sets whether UEFI frontpage is enabled.
-    fn with_uefi_frontpage(self: Box<Self>, enable: bool) -> Box<dyn PetriVmConfig>;
-    /// Run the VM with Enable VMBus relay enabled
-    fn with_vmbus_redirect(self: Box<Self>, enable: bool) -> Box<dyn PetriVmConfig>;
+    pub fn with_custom_openhcl<O: IsOpenhclIgvm>(mut self, artifact: ResolvedArtifact<O>) -> Self {
+        match &mut self.config.firmware {
+            Firmware::OpenhclLinuxDirect { igvm_path, .. }
+            | Firmware::OpenhclPcat { igvm_path, .. }
+            | Firmware::OpenhclUefi { igvm_path, .. } => {
+                *igvm_path = artifact.erase();
+            }
+            Firmware::LinuxDirect { .. } | Firmware::Uefi { .. } | Firmware::Pcat { .. } => {
+                panic!("Custom OpenHCL is only supported for OpenHCL firmware.")
+            }
+        }
+        self
+    }
 
-    /// Get the OS that the VM will boot into.
-    fn os_flavor(&self) -> OsFlavor;
+    /// Sets the command line for the paravisor.
+    pub fn with_openhcl_command_line(mut self, additional_command_line: &str) -> Self {
+        append_cmdline(
+            &mut self
+                .config
+                .firmware
+                .openhcl_config_mut()
+                .expect("OpenHCL command line is only supported for OpenHCL firmware.")
+                .command_line,
+            additional_command_line,
+        );
+        self
+    }
+
+    /// Enable confidential filtering, even if the VM is not confidential.
+    pub fn with_confidential_filtering(self) -> Self {
+        if !self.config.firmware.is_openhcl() {
+            panic!("Confidential filtering is only supported for OpenHCL");
+        }
+        self.with_openhcl_command_line(&format!(
+            "{}=1 {}=0",
+            underhill_confidentiality::OPENHCL_CONFIDENTIAL_ENV_VAR_NAME,
+            underhill_confidentiality::OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME
+        ))
+    }
+
+    /// Adds a file to the VM's pipette agent image.
+    pub fn with_agent_file(mut self, name: &str, artifact: ResolvedArtifact) -> Self {
+        self.config
+            .agent_image
+            .as_mut()
+            .expect("no guest pipette")
+            .add_file(name, artifact);
+        self
+    }
+
+    /// Adds a file to the paravisor's pipette agent image.
+    pub fn with_openhcl_agent_file(mut self, name: &str, artifact: ResolvedArtifact) -> Self {
+        self.config
+            .openhcl_agent_image
+            .as_mut()
+            .expect("no openhcl pipette")
+            .add_file(name, artifact);
+        self
+    }
+
+    /// Sets whether UEFI frontpage is enabled.
+    pub fn with_uefi_frontpage(mut self, enable: bool) -> Self {
+        self.config
+            .firmware
+            .uefi_config_mut()
+            .expect("UEFI frontpage is only supported for UEFI firmware.")
+            .disable_frontpage = !enable;
+        self
+    }
+
+    /// Run the VM with Enable VMBus relay enabled
+    pub fn with_vmbus_redirect(mut self, enable: bool) -> Self {
+        self.config
+            .firmware
+            .openhcl_config_mut()
+            .expect("VMBus redirection is only supported for OpenHCL firmware.")
+            .vmbus_redirect = enable;
+        self
+    }
+
+    /// Use the specified VMGS file
+    pub fn with_vmgs<V: IsTestVmgs>(mut self, vmgs: PetriVmgsResource<V>) -> Self {
+        match &mut self.config.firmware {
+            Firmware::Uefi { vmgs_file, .. } | Firmware::OpenhclUefi { vmgs_file, .. } => {
+                *vmgs_file = vmgs.erase()
+            }
+            Firmware::LinuxDirect { .. }
+            | Firmware::OpenhclLinuxDirect { .. }
+            | Firmware::Pcat { .. }
+            | Firmware::OpenhclPcat { .. } => {
+                panic!("VMGS file is only supported for UEFI firmware.")
+            }
+        }
+        self
+    }
+
+    /// Get VM's guest OS flavor
+    pub fn os_flavor(&self) -> OsFlavor {
+        self.config.firmware.os_flavor()
+    }
+
+    /// Get whether the VM will use OpenHCL
+    pub fn is_openhcl(&self) -> bool {
+        self.config.firmware.is_openhcl()
+    }
+
+    /// Get the backend-specific config builder
+    pub fn modify_backend(
+        mut self,
+        f: impl FnOnce(T::VmmConfig) -> T::VmmConfig + 'static + Send,
+    ) -> Self {
+        self.vmm_config = Some(Box::new(f));
+        self
+    }
+}
+
+impl<T: PetriVmmBackend> PetriVm<T> {
+    /// Wait for the VM to halt, returning the reason for the halt.
+    pub async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason> {
+        self.runtime.wait_for_halt().await
+    }
+
+    /// Wait for the VM to halt, returning the reason for the halt,
+    /// and cleanly tear down the VM.
+    pub async fn wait_for_teardown(mut self) -> anyhow::Result<HaltReason> {
+        let halt_reason = self.runtime.wait_for_halt().await?;
+        self.runtime.teardown().await?;
+        Ok(halt_reason)
+    }
+    /// Test that we are able to inspect OpenHCL.
+    pub async fn test_inspect_openhcl(&mut self) -> anyhow::Result<()> {
+        self.openhcl_diag()?.test_inspect().await
+    }
+    /// Wait for VTL 2 to report that it is ready to respond to commands.
+    /// Will fail if the VM is not running OpenHCL.
+    ///
+    /// This should only be necessary if you're doing something manual. All
+    /// Petri-provided methods will wait for VTL 2 to be ready automatically.
+    pub async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()> {
+        self.openhcl_diag()?.wait_for_vtl2().await
+    }
+
+    /// Wait for a connection from a pipette agent running in the guest.
+    /// Useful if you've rebooted the vm or are otherwise expecting a fresh connection.
+    pub async fn wait_for_agent(&mut self) -> anyhow::Result<PipetteClient> {
+        self.runtime.wait_for_agent(false).await
+    }
+
+    /// Wait for a connection from a pipette agent running in VTL 2.
+    /// Useful if you've reset VTL 2 or are otherwise expecting a fresh connection.
+    /// Will fail if the VM is not running OpenHCL.
+    pub async fn wait_for_vtl2_agent(&mut self) -> anyhow::Result<PipetteClient> {
+        // VTL 2's pipette doesn't auto launch, only launch it on demand
+        self.launch_vtl2_pipette().await?;
+        self.runtime.wait_for_agent(true).await
+    }
+
+    /// Waits for an event emitted by the firmware about its boot status, and
+    /// verifies that it is the expected success value.
+    ///
+    /// * Linux Direct guests do not emit a boot event, so this method immediately returns Ok.
+    /// * PCAT guests may not emit an event depending on the PCAT version, this
+    ///   method is best effort for them.
+    pub async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()> {
+        self.runtime.wait_for_successful_boot_event().await
+    }
+
+    /// Waits for an event emitted by the firmware about its boot status, and
+    /// returns that status.
+    pub async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent> {
+        self.runtime.wait_for_boot_event().await
+    }
+
+    /// Instruct the guest to shutdown via the Hyper-V shutdown IC.
+    pub async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()> {
+        self.runtime.send_enlightened_shutdown(kind).await
+    }
+
+    /// Instruct the OpenHCL to restart the VTL2 paravisor. Will fail if the VM
+    /// is not running OpenHCL. Will also fail if the VM is not running.
+    pub async fn restart_openhcl(
+        &mut self,
+        new_openhcl: ResolvedArtifact<impl IsOpenhclIgvm>,
+        flags: OpenHclServicingFlags,
+    ) -> anyhow::Result<()> {
+        self.runtime
+            .restart_openhcl(&new_openhcl.erase(), flags)
+            .await
+    }
+
+    /// Get VM's guest OS flavor
+    pub fn arch(&self) -> MachineArch {
+        self.arch
+    }
+
+    /// Get the inner runtime backend to make backend-specific calls
+    pub fn backend(&mut self) -> &mut T::VmRuntime {
+        &mut self.runtime
+    }
+
+    async fn launch_vtl2_pipette(&self) -> anyhow::Result<()> {
+        // Start pipette through DiagClient
+        let res = self
+            .openhcl_diag()?
+            .run_vtl2_command(
+                "sh",
+                &[
+                    "-c",
+                    "mkdir /cidata && mount LABEL=cidata /cidata && sh -c '/cidata/pipette &'",
+                ],
+            )
+            .await?;
+
+        if !res.exit_status.success() {
+            anyhow::bail!("Failed to start VTL 2 pipette: {:?}", res);
+        }
+
+        Ok(())
+    }
+
+    fn openhcl_diag(&self) -> anyhow::Result<&OpenHclDiagHandler> {
+        if let Some(ohd) = self.runtime.openhcl_diag() {
+            Ok(ohd)
+        } else {
+            anyhow::bail!("VM is not configured with OpenHCL")
+        }
+    }
+}
+
+/// A running VM that tests can interact with.
+#[async_trait]
+pub trait PetriVmRuntime {
+    /// Cleanly tear down the VM immediately.
+    async fn teardown(self) -> anyhow::Result<()>;
+    /// Wait for the VM to halt, returning the reason for the halt.
+    async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason>;
+    /// Wait for a connection from a pipette agent
+    async fn wait_for_agent(&mut self, set_high_vtl: bool) -> anyhow::Result<PipetteClient>;
+    /// Get an OpenHCL diagnostics handler for the VM
+    fn openhcl_diag(&self) -> Option<&OpenHclDiagHandler>;
+    /// Waits for an event emitted by the firmware about its boot status, and
+    /// verifies that it is the expected success value.
+    ///
+    /// * Linux Direct guests do not emit a boot event, so this method immediately returns Ok.
+    /// * PCAT guests may not emit an event depending on the PCAT version, this
+    ///   method is best effort for them.
+    async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()>;
+    /// Waits for an event emitted by the firmware about its boot status, and
+    /// returns that status.
+    async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent>;
+    /// Instruct the guest to shutdown via the Hyper-V shutdown IC.
+    async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()>;
+    /// Instruct the OpenHCL to restart the VTL2 paravisor. Will fail if the VM
+    /// is not running OpenHCL. Will also fail if the VM is not running.
+    async fn restart_openhcl(
+        &mut self,
+        new_openhcl: &ResolvedArtifact,
+        flags: OpenHclServicingFlags,
+    ) -> anyhow::Result<()>;
 }
 
 /// Common processor topology information for the VM.
@@ -106,49 +549,57 @@ pub enum ApicMode {
     X2apicEnabled,
 }
 
-/// A running VM that tests can interact with.
-#[async_trait]
-pub trait PetriVm: Send {
-    /// Returns the guest architecture.
-    fn arch(&self) -> MachineArch;
-    /// Wait for the VM to halt, returning the reason for the halt.
-    async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason>;
-    /// Wait for the VM to halt, returning the reason for the halt,
-    /// and cleanly tear down the VM.
-    async fn wait_for_teardown(self: Box<Self>) -> anyhow::Result<HaltReason>;
-    /// Test that we are able to inspect OpenHCL.
-    async fn test_inspect_openhcl(&mut self) -> anyhow::Result<()>;
-    /// Wait for a connection from a pipette agent running in the guest.
-    /// Useful if you've rebooted the vm or are otherwise expecting a fresh connection.
-    async fn wait_for_agent(&mut self) -> anyhow::Result<PipetteClient>;
-    /// Wait for a connection from a pipette agent running in VTL 2.
-    /// Useful if you've reset VTL 2 or are otherwise expecting a fresh connection.
-    /// Will fail if the VM is not running OpenHCL.
-    async fn wait_for_vtl2_agent(&mut self) -> anyhow::Result<PipetteClient>;
-    /// Wait for VTL 2 to report that it is ready to respond to commands.
-    /// Will fail if the VM is not running OpenHCL.
+/// Common memory configuration information for the VM.
+pub struct MemoryConfig {
+    /// Specifies the amount of memory, in bytes, to assign to the
+    /// virtual machine.
+    pub startup_bytes: u64,
+    /// Specifies the minimum and maximum amount of dynamic memory, in bytes.
     ///
-    /// This should only be necessary if you're doing something manual. All
-    /// Petri-provided methods will wait for VTL 2 to be ready automatically.
-    async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()>;
-    /// Waits for an event emitted by the firmware about its boot status, and
-    /// verifies that it is the expected success value.
-    ///
-    /// * Linux Direct guests do not emit a boot event, so this method immediately returns Ok.
-    /// * PCAT guests may not emit an event depending on the PCAT version, this
-    /// method is best effort for them.
-    async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()>;
-    /// Waits for an event emitted by the firmware about its boot status, and
-    /// returns that status.
-    async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent>;
-    /// Instruct the guest to shutdown via the Hyper-V shutdown IC.
-    async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()>;
-    /// Instruct the OpenHCL to restart the VTL2 paravisor. Will fail if the VM is not running OpenHCL. Will also fail if the VM is not running.
-    async fn restart_openhcl(
-        &mut self,
-        new_openhcl: &ResolvedArtifact,
-        flags: OpenHclServicingFlags,
-    ) -> anyhow::Result<()>;
+    /// Dynamic memory will be disabled if this is `None`.
+    pub dynamic_memory_range: Option<(u64, u64)>,
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            startup_bytes: 0x1_0000_0000,
+            dynamic_memory_range: None,
+        }
+    }
+}
+
+/// UEFI firmware configuration
+#[derive(Debug)]
+pub struct UefiConfig {
+    /// Enable secure boot
+    pub secure_boot_enabled: bool,
+    /// Secure boot template
+    pub secure_boot_template: Option<SecureBootTemplate>,
+    /// Disable the UEFI frontpage which will cause the VM to shutdown instead when unable to boot.
+    pub disable_frontpage: bool,
+}
+
+impl Default for UefiConfig {
+    fn default() -> Self {
+        Self {
+            secure_boot_enabled: false,
+            secure_boot_template: None,
+            disable_frontpage: true,
+        }
+    }
+}
+
+/// OpenHCL configuration
+#[derive(Debug, Default, Clone)]
+pub struct OpenHclConfig {
+    /// Emulate SCSI via NVME to VTL2, with the provided namespace ID on
+    /// the controller with `BOOT_NVME_INSTANCE`.
+    pub vtl2_nvme_boot: bool,
+    /// Whether to enable VMBus redirection
+    pub vmbus_redirect: bool,
+    /// Command line to pass to OpenHCL
+    pub command_line: Option<String>,
 }
 
 /// Firmware to load into the test VM.
@@ -165,6 +616,8 @@ pub enum Firmware {
     OpenhclLinuxDirect {
         /// The path to the IGVM file to use.
         igvm_path: ResolvedArtifact,
+        /// OpenHCL configuration
+        openhcl_config: OpenHclConfig,
     },
     /// Boot a PCAT-based VM.
     Pcat {
@@ -175,12 +628,29 @@ pub enum Firmware {
         /// The SVGA firmware to use.
         svga_firmware: ResolvedOptionalArtifact,
     },
+    /// Boot a PCAT-based VM with OpenHCL in VTL2.
+    OpenhclPcat {
+        /// The guest OS the VM will boot into.
+        guest: PcatGuest,
+        /// The path to the IGVM file to use.
+        igvm_path: ResolvedArtifact,
+        /// The firmware to use.
+        bios_firmware: ResolvedOptionalArtifact,
+        /// The SVGA firmware to use.
+        svga_firmware: ResolvedOptionalArtifact,
+        /// OpenHCL configuration
+        openhcl_config: OpenHclConfig,
+    },
     /// Boot a UEFI-based VM.
     Uefi {
         /// The guest OS the VM will boot into.
         guest: UefiGuest,
         /// The firmware to use.
         uefi_firmware: ResolvedArtifact,
+        /// The VMGS file to use
+        vmgs_file: PetriVmgsResource,
+        /// UEFI configuration
+        uefi_config: UefiConfig,
     },
     /// Boot a UEFI-based VM with OpenHCL in VTL2.
     OpenhclUefi {
@@ -188,11 +658,14 @@ pub enum Firmware {
         guest: UefiGuest,
         /// The isolation type of the VM.
         isolation: Option<IsolationType>,
-        /// Emulate SCSI via NVME to VTL2, with the provided namespace ID on
-        /// the controller with `BOOT_NVME_INSTANCE`.
-        vtl2_nvme_boot: bool,
         /// The path to the IGVM file to use.
         igvm_path: ResolvedArtifact,
+        /// The VMGS file to use
+        vmgs_file: PetriVmgsResource,
+        /// UEFI configuration
+        uefi_config: UefiConfig,
+        /// OpenHCL configuration
+        openhcl_config: OpenHclConfig,
     },
 }
 
@@ -218,6 +691,7 @@ impl Firmware {
         match arch {
             MachineArch::X86_64 => Firmware::OpenhclLinuxDirect {
                 igvm_path: resolver.require(LATEST_LINUX_DIRECT_TEST_X64).erase(),
+                openhcl_config: Default::default(),
             },
             MachineArch::Aarch64 => todo!("Linux direct not yet supported on aarch64"),
         }
@@ -243,6 +717,8 @@ impl Firmware {
         Firmware::Uefi {
             guest,
             uefi_firmware,
+            vmgs_file: PetriVmgsResource::Ephemeral,
+            uefi_config: Default::default(),
         }
     }
 
@@ -263,14 +739,21 @@ impl Firmware {
         Firmware::OpenhclUefi {
             guest,
             isolation,
-            vtl2_nvme_boot,
             igvm_path,
+            vmgs_file: PetriVmgsResource::Ephemeral,
+            uefi_config: Default::default(),
+            openhcl_config: OpenHclConfig {
+                vtl2_nvme_boot,
+                ..Default::default()
+            },
         }
     }
 
     fn is_openhcl(&self) -> bool {
         match self {
-            Firmware::OpenhclLinuxDirect { .. } | Firmware::OpenhclUefi { .. } => true,
+            Firmware::OpenhclLinuxDirect { .. }
+            | Firmware::OpenhclUefi { .. }
+            | Firmware::OpenhclPcat { .. } => true,
             Firmware::LinuxDirect { .. } | Firmware::Pcat { .. } | Firmware::Uefi { .. } => false,
         }
     }
@@ -281,23 +764,28 @@ impl Firmware {
             Firmware::LinuxDirect { .. }
             | Firmware::Pcat { .. }
             | Firmware::Uefi { .. }
-            | Firmware::OpenhclLinuxDirect { .. } => None,
+            | Firmware::OpenhclLinuxDirect { .. }
+            | Firmware::OpenhclPcat { .. } => None,
         }
     }
 
     fn is_linux_direct(&self) -> bool {
         match self {
             Firmware::LinuxDirect { .. } | Firmware::OpenhclLinuxDirect { .. } => true,
-            Firmware::Pcat { .. } | Firmware::Uefi { .. } | Firmware::OpenhclUefi { .. } => false,
+            Firmware::Pcat { .. }
+            | Firmware::Uefi { .. }
+            | Firmware::OpenhclUefi { .. }
+            | Firmware::OpenhclPcat { .. } => false,
         }
     }
 
-    fn is_uefi(&self) -> bool {
+    fn is_pcat(&self) -> bool {
         match self {
-            Firmware::Uefi { .. } | Firmware::OpenhclUefi { .. } => true,
-            Firmware::LinuxDirect { .. }
-            | Firmware::OpenhclLinuxDirect { .. }
-            | Firmware::Pcat { .. } => false,
+            Firmware::Pcat { .. } | Firmware::OpenhclPcat { .. } => true,
+            Firmware::Uefi { .. }
+            | Firmware::OpenhclUefi { .. }
+            | Firmware::LinuxDirect { .. }
+            | Firmware::OpenhclLinuxDirect { .. } => false,
         }
     }
 
@@ -316,6 +804,10 @@ impl Firmware {
                 guest: PcatGuest::Vhd(cfg),
                 ..
             }
+            | Firmware::OpenhclPcat {
+                guest: PcatGuest::Vhd(cfg),
+                ..
+            }
             | Firmware::Uefi {
                 guest: UefiGuest::Vhd(cfg),
                 ..
@@ -325,6 +817,10 @@ impl Firmware {
                 ..
             } => cfg.os_flavor,
             Firmware::Pcat {
+                guest: PcatGuest::Iso(cfg),
+                ..
+            }
+            | Firmware::OpenhclPcat {
                 guest: PcatGuest::Iso(cfg),
                 ..
             } => cfg.os_flavor,
@@ -356,7 +852,7 @@ impl Firmware {
     fn expected_boot_event(&self) -> Option<FirmwareEvent> {
         match self {
             Firmware::LinuxDirect { .. } | Firmware::OpenhclLinuxDirect { .. } => None,
-            Firmware::Pcat { .. } => {
+            Firmware::Pcat { .. } | Firmware::OpenhclPcat { .. } => {
                 // TODO: Handle older PCAT versions that don't fire the event
                 Some(FirmwareEvent::BootAttempt)
             }
@@ -371,6 +867,48 @@ impl Firmware {
             Firmware::Uefi { .. } | Firmware::OpenhclUefi { .. } => {
                 Some(FirmwareEvent::BootSuccess)
             }
+        }
+    }
+
+    fn openhcl_config(&self) -> Option<&OpenHclConfig> {
+        match self {
+            Firmware::OpenhclLinuxDirect { openhcl_config, .. }
+            | Firmware::OpenhclUefi { openhcl_config, .. }
+            | Firmware::OpenhclPcat { openhcl_config, .. } => Some(openhcl_config),
+            Firmware::LinuxDirect { .. } | Firmware::Pcat { .. } | Firmware::Uefi { .. } => None,
+        }
+    }
+
+    fn openhcl_config_mut(&mut self) -> Option<&mut OpenHclConfig> {
+        match self {
+            Firmware::OpenhclLinuxDirect { openhcl_config, .. }
+            | Firmware::OpenhclUefi { openhcl_config, .. }
+            | Firmware::OpenhclPcat { openhcl_config, .. } => Some(openhcl_config),
+            Firmware::LinuxDirect { .. } | Firmware::Pcat { .. } | Firmware::Uefi { .. } => None,
+        }
+    }
+
+    fn uefi_config(&self) -> Option<&UefiConfig> {
+        match self {
+            Firmware::Uefi { uefi_config, .. } | Firmware::OpenhclUefi { uefi_config, .. } => {
+                Some(uefi_config)
+            }
+            Firmware::LinuxDirect { .. }
+            | Firmware::OpenhclLinuxDirect { .. }
+            | Firmware::Pcat { .. }
+            | Firmware::OpenhclPcat { .. } => None,
+        }
+    }
+
+    fn uefi_config_mut(&mut self) -> Option<&mut UefiConfig> {
+        match self {
+            Firmware::Uefi { uefi_config, .. } | Firmware::OpenhclUefi { uefi_config, .. } => {
+                Some(uefi_config)
+            }
+            Firmware::LinuxDirect { .. }
+            | Firmware::OpenhclLinuxDirect { .. }
+            | Firmware::Pcat { .. }
+            | Firmware::OpenhclPcat { .. } => None,
         }
     }
 }
@@ -518,7 +1056,8 @@ pub struct OpenHclServicingFlags {
 }
 
 /// Virtual machine guest state resource
-pub enum PetriVmgsResource<T: IsTestVmgs> {
+#[derive(Debug, Clone)]
+pub enum PetriVmgsResource<T = ()> {
     /// Use disk to store guest state
     Disk(ResolvedArtifact<T>),
     /// Use disk to store guest state, reformatting if corrupted.
@@ -527,4 +1066,38 @@ pub enum PetriVmgsResource<T: IsTestVmgs> {
     Reprovision(ResolvedArtifact<T>),
     /// Store guest state in memory
     Ephemeral,
+    /// Use a temporary disk that preserves guest state across reboots
+    TempDisk,
+}
+
+impl<T> PetriVmgsResource<T> {
+    fn erase(self) -> PetriVmgsResource {
+        match self {
+            PetriVmgsResource::Disk(a) => PetriVmgsResource::Disk(a.erase()),
+            PetriVmgsResource::ReprovisionOnFailure(a) => {
+                PetriVmgsResource::ReprovisionOnFailure(a.erase())
+            }
+            PetriVmgsResource::Reprovision(a) => PetriVmgsResource::Reprovision(a.erase()),
+            PetriVmgsResource::Ephemeral => PetriVmgsResource::Ephemeral,
+            PetriVmgsResource::TempDisk => PetriVmgsResource::TempDisk,
+        }
+    }
+}
+
+/// UEFI secure boot template
+#[derive(Debug, Clone, Copy)]
+pub enum SecureBootTemplate {
+    /// The Microsoft Windows template.
+    MicrosoftWindows,
+    /// The Microsoft UEFI certificate authority template.
+    MicrosoftUefiCertificateAuthority,
+}
+
+fn append_cmdline(cmd: &mut Option<String>, add_cmd: &str) {
+    if let Some(cmd) = cmd.as_mut() {
+        cmd.push(' ');
+        cmd.push_str(add_cmd);
+    } else {
+        *cmd = Some(add_cmd.to_string());
+    }
 }

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -7,24 +7,28 @@
 use super::BOOT_NVME_INSTANCE;
 use super::BOOT_NVME_LUN;
 use super::BOOT_NVME_NSID;
-use super::PetriVmArtifactsOpenVmm;
 use super::PetriVmConfigOpenVmm;
 use super::PetriVmResourcesOpenVmm;
 use super::SCSI_INSTANCE;
 use super::memdiff_disk_from_artifact;
 use crate::Firmware;
 use crate::IsolationType;
+use crate::MemoryConfig;
+use crate::OpenHclConfig;
 use crate::PcatGuest;
 use crate::PetriLogSource;
-use crate::PetriTestParams;
+use crate::PetriVmConfig;
+use crate::PetriVmResources;
 use crate::ProcessorTopology;
 use crate::SIZE_1_GB;
+use crate::SecureBootTemplate;
+use crate::UefiConfig;
 use crate::UefiGuest;
 use crate::linux_direct_serial_agent::LinuxDirectSerialAgent;
 use crate::openhcl_diag::OpenHclDiagHandler;
+use crate::openvmm::mem_diff_vmgs_from_artifact;
+use crate::vm::append_cmdline;
 use anyhow::Context;
-use disk_backend_resources::LayeredDiskHandle;
-use disk_backend_resources::layer::RamDiskLayerHandle;
 use framebuffer::FRAMEBUFFER_SIZE;
 use framebuffer::Framebuffer;
 use framebuffer::FramebufferAccess;
@@ -43,7 +47,6 @@ use hvlite_defs::config::DeviceVtl;
 use hvlite_defs::config::HypervisorConfig;
 use hvlite_defs::config::LateMapVtl0MemoryPolicy;
 use hvlite_defs::config::LoadMode;
-use hvlite_defs::config::MemoryConfig;
 use hvlite_defs::config::ProcessorTopologyConfig;
 use hvlite_defs::config::SerialInformation;
 use hvlite_defs::config::VmbusConfig;
@@ -62,6 +65,7 @@ use pal_async::socket::PolledSocket;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
 use petri_artifacts_common::tags::MachineArch;
+use petri_artifacts_core::ResolvedArtifact;
 use pipette_client::PIPETTE_VSOCK_PORT;
 use scsidisk_resources::SimpleScsiDiskHandle;
 use scsidisk_resources::SimpleScsiDvdHandle;
@@ -69,7 +73,6 @@ use serial_16550_resources::ComPort;
 use serial_core::resources::DisconnectedSerialBackendHandle;
 use serial_socket::net::OpenSocketSerialConfig;
 use sparse_mmap::alloc_shared_memory;
-use std::fmt::Write as _;
 use storvsp_resources::ScsiControllerHandle;
 use storvsp_resources::ScsiDeviceAndPath;
 use storvsp_resources::ScsiPath;
@@ -91,23 +94,31 @@ use vtl2_settings_proto::Vtl2Settings;
 impl PetriVmConfigOpenVmm {
     /// Create a new VM configuration.
     pub fn new(
-        params: &PetriTestParams<'_>,
-        artifacts: PetriVmArtifactsOpenVmm,
-        driver: &DefaultDriver,
+        openvmm_path: &ResolvedArtifact,
+        petri_vm_config: PetriVmConfig,
+        resources: &PetriVmResources,
     ) -> anyhow::Result<Self> {
-        let PetriVmArtifactsOpenVmm {
-            firmware,
+        let PetriVmConfig {
+            name: _,
             arch,
-            agent_image,
-            openhcl_agent_image,
-            openvmm_path,
-        } = artifacts;
+            firmware,
+            memory,
+            proc_topology,
+            agent_image: _,
+            openhcl_agent_image: _,
+        } = &petri_vm_config;
+
+        let PetriVmResources {
+            driver,
+            output_dir,
+            log_source,
+        } = resources;
 
         let setup = PetriVmConfigSetupCore {
-            arch,
-            firmware: &firmware,
+            arch: *arch,
+            firmware,
             driver,
-            logger: params.logger,
+            logger: log_source,
         };
 
         let mut chipset = VmManifestBuilder::new(
@@ -121,6 +132,7 @@ impl PetriVmConfigOpenVmm {
                 Firmware::OpenhclUefi { .. } => vm_manifest_builder::BaseChipsetType::HclHost,
                 Firmware::Pcat { .. } => vm_manifest_builder::BaseChipsetType::HypervGen1,
                 Firmware::Uefi { .. } => vm_manifest_builder::BaseChipsetType::HypervGen2Uefi,
+                Firmware::OpenhclPcat { .. } => todo!("OpenVMM OpenHCL PCAT"),
             },
             match arch {
                 MachineArch::X86_64 => vm_manifest_builder::MachineArch::X86_64,
@@ -134,7 +146,7 @@ impl PetriVmConfigOpenVmm {
             mut emulated_serial_config,
             serial_tasks: log_stream_tasks,
             linux_direct_serial_agent,
-        } = setup.configure_serial(params.logger)?;
+        } = setup.configure_serial(log_source)?;
 
         let (video_dev, framebuffer, framebuffer_access) = match setup.config_video()? {
             Some((v, fb, fba)) => {
@@ -267,18 +279,18 @@ impl PetriVmConfigOpenVmm {
             .build()
             .context("failed to build chipset configuration")?;
 
-        let config = Config {
-            // Firmware
-            load_mode,
-            firmware_event_send: Some(firmware_event_send),
+        let memory = {
+            let MemoryConfig {
+                startup_bytes,
+                dynamic_memory_range,
+            } = memory;
 
-            // CPU and RAM
-            memory: MemoryConfig {
-                mem_size: if firmware.is_openhcl() {
-                    4 * SIZE_1_GB
-                } else {
-                    SIZE_1_GB
-                },
+            if dynamic_memory_range.is_some() {
+                anyhow::bail!("dynamic memory not supported in OpenVMM");
+            }
+
+            hvlite_defs::config::MemoryConfig {
+                mem_size: *startup_bytes,
                 mmio_gaps: if firmware.is_openhcl() {
                     match arch {
                         MachineArch::X86_64 => DEFAULT_MMIO_GAPS_X86_WITH_VTL2.into(),
@@ -291,13 +303,88 @@ impl PetriVmConfigOpenVmm {
                     }
                 },
                 prefetch_memory: false,
+            }
+        };
+
+        let processor_topology = {
+            let ProcessorTopology {
+                vp_count,
+                enable_smt,
+                vps_per_socket,
+                apic_mode,
+            } = proc_topology;
+
+            ProcessorTopologyConfig {
+                proc_count: *vp_count,
+                vps_per_socket: *vps_per_socket,
+                enable_smt: *enable_smt,
+                arch: Some(match arch {
+                    MachineArch::X86_64 => hvlite_defs::config::ArchTopologyConfig::X86(
+                        hvlite_defs::config::X86TopologyConfig {
+                            x2apic: match apic_mode {
+                                None => hvlite_defs::config::X2ApicConfig::Auto,
+                                Some(x) => match x {
+                                    crate::ApicMode::Xapic => {
+                                        hvlite_defs::config::X2ApicConfig::Unsupported
+                                    }
+                                    crate::ApicMode::X2apicSupported => {
+                                        hvlite_defs::config::X2ApicConfig::Supported
+                                    }
+                                    crate::ApicMode::X2apicEnabled => {
+                                        hvlite_defs::config::X2ApicConfig::Enabled
+                                    }
+                                },
+                            },
+                            ..Default::default()
+                        },
+                    ),
+                    MachineArch::Aarch64 => hvlite_defs::config::ArchTopologyConfig::Aarch64(
+                        hvlite_defs::config::Aarch64TopologyConfig::default(),
+                    ),
+                }),
+            }
+        };
+
+        let (secure_boot_enabled, custom_uefi_vars) = firmware.uefi_config().map_or_else(
+            || (false, Default::default()),
+            |c| {
+                (
+                    c.secure_boot_enabled,
+                    match (arch, c.secure_boot_template) {
+                        (MachineArch::X86_64, Some(SecureBootTemplate::MicrosoftWindows)) => {
+                            hyperv_secure_boot_templates::x64::microsoft_windows()
+                        }
+                        (
+                            MachineArch::X86_64,
+                            Some(SecureBootTemplate::MicrosoftUefiCertificateAuthority),
+                        ) => hyperv_secure_boot_templates::x64::microsoft_uefi_ca(),
+                        (MachineArch::Aarch64, Some(SecureBootTemplate::MicrosoftWindows)) => {
+                            hyperv_secure_boot_templates::aarch64::microsoft_windows()
+                        }
+                        (
+                            MachineArch::Aarch64,
+                            Some(SecureBootTemplate::MicrosoftUefiCertificateAuthority),
+                        ) => hyperv_secure_boot_templates::aarch64::microsoft_uefi_ca(),
+                        (_, None) => Default::default(),
+                    },
+                )
             },
-            processor_topology: ProcessorTopologyConfig {
-                proc_count: 2,
-                vps_per_socket: None,
-                enable_smt: None,
-                arch: None,
-            },
+        );
+
+        let vmgs = if let Firmware::Uefi { vmgs_file, .. } = firmware {
+            Some(mem_diff_vmgs_from_artifact(vmgs_file)?)
+        } else {
+            None
+        };
+
+        let config = Config {
+            // Firmware
+            load_mode,
+            firmware_event_send: Some(firmware_event_send),
+
+            // CPU and RAM
+            memory,
+            processor_topology,
 
             // Base chipset
             chipset: chipset.chipset,
@@ -319,7 +406,7 @@ impl PetriVmConfigOpenVmm {
                 vsock_listener: Some(vmbus_vsock_listener),
                 vsock_path: Some(vmbus_vsock_path.to_string_lossy().into_owned()),
                 vmbus_max_version: None,
-                vtl2_redirect: false,
+                vtl2_redirect: firmware.openhcl_config().is_some_and(|c| c.vmbus_redirect),
                 #[cfg(windows)]
                 vmbusproxy_handle: None,
             }),
@@ -335,8 +422,9 @@ impl PetriVmConfigOpenVmm {
             framebuffer,
             vga_firmware,
 
-            // Reasonable defaults
-            custom_uefi_vars: Default::default(),
+            secure_boot_enabled,
+            custom_uefi_vars,
+            vmgs,
 
             // Disabled for VMM tests by default
             #[cfg(windows)]
@@ -348,12 +436,6 @@ impl PetriVmConfigOpenVmm {
             virtio_devices: vec![],
             #[cfg(windows)]
             vpci_resources: vec![],
-            vmgs: if firmware.is_openhcl() {
-                None
-            } else {
-                Some(VmgsResource::Ephemeral)
-            },
-            secure_boot_enabled: false,
             debugger_rpc: None,
             generation_id_recv: None,
             rtc_delta_milliseconds: 0,
@@ -380,8 +462,8 @@ impl PetriVmConfigOpenVmm {
         };
 
         Ok(Self {
-            firmware,
-            arch,
+            firmware: petri_vm_config.firmware,
+            arch: petri_vm_config.arch,
             config,
 
             resources: PetriVmResourcesOpenVmm {
@@ -396,22 +478,21 @@ impl PetriVmConfigOpenVmm {
                 openhcl_diag_handler,
                 linux_direct_serial_agent,
                 driver: driver.clone(),
-                output_dir: params.output_dir.to_owned(),
-                agent_image,
-                openhcl_agent_image,
-                openvmm_path,
-                log_source: params.logger.clone(),
+                output_dir: output_dir.to_owned(),
+                agent_image: petri_vm_config.agent_image,
+                openhcl_agent_image: petri_vm_config.openhcl_agent_image,
+                openvmm_path: openvmm_path.clone(),
+                log_source: log_source.clone(),
                 vtl2_vsock_path,
                 _vmbus_vsock_path: vmbus_vsock_path,
+                vtl2_settings,
             },
 
-            openvmm_log_file: params.logger.log_file("openvmm")?,
+            openvmm_log_file: log_source.log_file("openvmm")?,
 
             ged,
-            vtl2_settings,
             framebuffer_access,
-        }
-        .with_processor_topology(ProcessorTopology::default()))
+        })
     }
 }
 
@@ -445,7 +526,7 @@ impl PetriVmConfigSetupCore<'_> {
 
         let serial0_log_file = logger.log_file(match self.firmware {
             Firmware::LinuxDirect { .. } | Firmware::OpenhclLinuxDirect { .. } => "linux",
-            Firmware::Pcat { .. } => "pcat",
+            Firmware::Pcat { .. } | Firmware::OpenhclPcat { .. } => "pcat",
             Firmware::Uefi { .. } | Firmware::OpenhclUefi { .. } => "uefi",
         })?;
 
@@ -553,7 +634,8 @@ impl PetriVmConfigSetupCore<'_> {
                 MachineArch::X86_64,
                 Firmware::Pcat {
                     bios_firmware: firmware,
-                    ..
+                    guest: _,         // load_boot_disk
+                    svga_firmware: _, // config_video
                 },
             ) => {
                 let firmware = hvlite_pcat_locator::find_pcat_bios(firmware.get())
@@ -567,7 +649,14 @@ impl PetriVmConfigSetupCore<'_> {
                 _,
                 Firmware::Uefi {
                     uefi_firmware: firmware,
-                    ..
+                    guest: _,     // load_boot_disk
+                    vmgs_file: _, // new
+                    uefi_config:
+                        UefiConfig {
+                            secure_boot_enabled: _,  // new
+                            secure_boot_template: _, // new
+                            disable_frontpage,
+                        },
                 },
             ) => {
                 let firmware = File::open(firmware.clone())
@@ -577,7 +666,7 @@ impl PetriVmConfigSetupCore<'_> {
                     firmware,
                     enable_debugging: false,
                     enable_memory_protections: false,
-                    disable_frontpage: true,
+                    disable_frontpage: *disable_frontpage,
                     enable_tpm: false,
                     enable_battery: false,
                     enable_serial: true,
@@ -588,18 +677,41 @@ impl PetriVmConfigSetupCore<'_> {
             }
             (
                 MachineArch::X86_64,
-                Firmware::OpenhclLinuxDirect { igvm_path, .. }
-                | Firmware::OpenhclUefi { igvm_path, .. },
+                Firmware::OpenhclLinuxDirect {
+                    igvm_path,
+                    openhcl_config,
+                }
+                | Firmware::OpenhclUefi {
+                    igvm_path,
+                    guest: _,       // load_boot_disk
+                    isolation: _,   // new via Firmware::isolation
+                    vmgs_file: _,   // config_openhcl_vmbus_devices
+                    uefi_config: _, // config_openhcl_vmbus_devices
+                    openhcl_config,
+                },
             ) => {
-                let mut cmdline =
-                    format!("panic=-1 reboot=triple {openhcl_tracing} {openhcl_show_spans}");
+                let OpenHclConfig {
+                    vtl2_nvme_boot: _, // load_boot_disk
+                    vmbus_redirect: _, // config_openhcl_vmbus_devices
+                    command_line,
+                } = openhcl_config;
+
+                let mut cmdline = command_line.clone();
+
+                append_cmdline(
+                    &mut cmdline,
+                    &format!("panic=-1 reboot=triple {openhcl_tracing} {openhcl_show_spans}"),
+                );
 
                 let isolated = match self.firmware {
                     Firmware::OpenhclLinuxDirect { .. } => {
                         // Set UNDERHILL_SERIAL_WAIT_FOR_RTS=1 so that we don't pull serial data
                         // until the guest is ready. Otherwise, Linux will drop the input serial
                         // data on the floor during boot.
-                        write!(cmdline, " UNDERHILL_SERIAL_WAIT_FOR_RTS=1 UNDERHILL_CMDLINE_APPEND=\"rdinit=/bin/sh\"").unwrap();
+                        append_cmdline(
+                            &mut cmdline,
+                            "UNDERHILL_SERIAL_WAIT_FOR_RTS=1 UNDERHILL_CMDLINE_APPEND=\"rdinit=/bin/sh\"",
+                        );
                         false
                     }
                     Firmware::OpenhclUefi { isolation, .. } if isolation.is_some() => true,
@@ -610,7 +722,7 @@ impl PetriVmConfigSetupCore<'_> {
                     .into();
                 LoadMode::Igvm {
                     file,
-                    cmdline,
+                    cmdline: cmdline.unwrap_or_default(),
                     vtl2_base_address: if isolated {
                         // Isolated VMs must load at the location specified by
                         // the file, as they do not support relocation.
@@ -651,7 +763,7 @@ impl PetriVmConfigSetupCore<'_> {
             } => {
                 // Nothing to do, no guest
             }
-            Firmware::Pcat { guest, .. } => {
+            Firmware::Pcat { guest, .. } | Firmware::OpenhclPcat { guest, .. } => {
                 let disk_path = guest.artifact();
                 let guest_media = match guest {
                     PcatGuest::Vhd(_) => GuestMedia::Disk {
@@ -678,7 +790,11 @@ impl PetriVmConfigSetupCore<'_> {
             Firmware::Uefi { guest, .. }
             | Firmware::OpenhclUefi {
                 guest,
-                vtl2_nvme_boot: false,
+                openhcl_config:
+                    OpenHclConfig {
+                        vtl2_nvme_boot: false,
+                        ..
+                    },
                 ..
             } => {
                 let disk_path = guest.artifact();
@@ -710,7 +826,11 @@ impl PetriVmConfigSetupCore<'_> {
             }
             Firmware::OpenhclUefi {
                 guest,
-                vtl2_nvme_boot: true,
+                openhcl_config:
+                    OpenHclConfig {
+                        vtl2_nvme_boot: true,
+                        ..
+                    },
                 ..
             } => {
                 let disk_path = guest.artifact();
@@ -811,31 +931,61 @@ impl PetriVmConfigSetupCore<'_> {
 
         let (guest_request_send, guest_request_recv) = mesh::channel();
 
+        let (
+            UefiConfig {
+                secure_boot_enabled,
+                secure_boot_template,
+                disable_frontpage,
+            },
+            vmgs,
+            OpenHclConfig { vmbus_redirect, .. },
+        ) = match self.firmware {
+            Firmware::OpenhclUefi {
+                uefi_config,
+                vmgs_file,
+                openhcl_config,
+                ..
+            } => (
+                uefi_config,
+                mem_diff_vmgs_from_artifact(vmgs_file)?,
+                openhcl_config,
+            ),
+            Firmware::OpenhclLinuxDirect { openhcl_config, .. } => (
+                &UefiConfig::default(),  // TODO: does linux direct use this?
+                VmgsResource::Ephemeral, // TODO: does linux direct use this?
+                openhcl_config,
+            ),
+            _ => anyhow::bail!("not a supported openhcl firmware config"),
+        };
+
         // Save the GED handle to add later after configuration is complete.
         let ged = get_resources::ged::GuestEmulationDeviceHandle {
             firmware: get_resources::ged::GuestFirmwareConfig::Uefi {
                 firmware_debug: false,
-                disable_frontpage: true,
+                disable_frontpage: *disable_frontpage,
                 enable_vpci_boot: false,
                 console_mode: get_resources::ged::UefiConsoleMode::COM1,
                 default_boot_always_attempt: false,
             },
             com1: true,
             com2: true,
-            vmbus_redirection: false,
+            vmbus_redirection: *vmbus_redirect,
             vtl2_settings: None, // Will be added at startup to allow tests to modify
-            vmgs: VmgsResource::Disk(
-                LayeredDiskHandle::single_layer(RamDiskLayerHandle {
-                    len: Some(vmgs_format::VMGS_DEFAULT_CAPACITY),
-                })
-                .into_resource(),
-            ),
+            vmgs,
             framebuffer: framebuffer.then(|| SharedFramebufferHandle.into_resource()),
             guest_request_recv,
             enable_tpm: false,
             firmware_event_send: Some(firmware_event_send.clone()),
-            secure_boot_enabled: false,
-            secure_boot_template: get_resources::ged::GuestSecureBootTemplateType::None,
+            secure_boot_enabled: *secure_boot_enabled,
+            secure_boot_template: match secure_boot_template {
+                Some(SecureBootTemplate::MicrosoftWindows) => {
+                    get_resources::ged::GuestSecureBootTemplateType::MicrosoftWindows
+                }
+                Some(SecureBootTemplate::MicrosoftUefiCertificateAuthority) => {
+                    get_resources::ged::GuestSecureBootTemplateType::MicrosoftUefiCertificateAuthority
+                }
+                None => get_resources::ged::GuestSecureBootTemplateType::None,
+            },
             enable_battery: false,
             no_persistent_secrets: true,
             igvm_attest_test_config: None,
@@ -852,10 +1002,12 @@ impl PetriVmConfigSetupCore<'_> {
         }
 
         let video_dev = match self.firmware {
-            Firmware::Pcat { svga_firmware, .. } => Some(VideoDevice::Vga(
-                hvlite_pcat_locator::find_svga_bios(svga_firmware.get())
-                    .context("Failed to load VGA BIOS")?,
-            )),
+            Firmware::Pcat { svga_firmware, .. } | Firmware::OpenhclPcat { svga_firmware, .. } => {
+                Some(VideoDevice::Vga(
+                    hvlite_pcat_locator::find_svga_bios(svga_firmware.get())
+                        .context("Failed to load VGA BIOS")?,
+                ))
+            }
             Firmware::Uefi { .. } | Firmware::OpenhclUefi { .. } => Some(VideoDevice::Synth(
                 DeviceVtl::Vtl0,
                 SynthVideoHandle {

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -100,12 +100,12 @@ impl PetriVmmBackend for OpenVmmPetriBackend {
     async fn run(
         self,
         config: PetriVmConfig,
-        vmm_config: Option<impl FnOnce(PetriVmConfigOpenVmm) -> PetriVmConfigOpenVmm + Send>,
+        modify_vmm_config: Option<impl FnOnce(PetriVmConfigOpenVmm) -> PetriVmConfigOpenVmm + Send>,
         resources: &PetriVmResources,
     ) -> anyhow::Result<Self::VmRuntime> {
         let mut config = PetriVmConfigOpenVmm::new(&self.openvmm_path, config, resources)?;
 
-        if let Some(f) = vmm_config {
+        if let Some(f) = modify_vmm_config {
             config = f(config);
         }
 

--- a/petri/src/vm/openvmm/mod.rs
+++ b/petri/src/vm/openvmm/mod.rs
@@ -15,12 +15,13 @@ mod start;
 
 pub use runtime::PetriVmOpenVmm;
 
-use super::ProcessorTopology;
 use crate::Firmware;
 use crate::PetriLogFile;
 use crate::PetriLogSource;
-use crate::PetriVm;
 use crate::PetriVmConfig;
+use crate::PetriVmResources;
+use crate::PetriVmgsResource;
+use crate::PetriVmmBackend;
 use crate::disk_image::AgentImage;
 use crate::linux_direct_serial_agent::LinuxDirectSerialAgent;
 use crate::openhcl_diag::OpenHclDiagHandler;
@@ -45,13 +46,13 @@ use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_common::tags::OsFlavor;
 use petri_artifacts_core::ArtifactResolver;
 use petri_artifacts_core::ResolvedArtifact;
-use pipette_client::PipetteClient;
 use std::path::PathBuf;
 use tempfile::TempPath;
 use unix_socket::UnixListener;
 use vm_resource::IntoResource;
 use vm_resource::Resource;
 use vm_resource::kind::DiskHandleKind;
+use vmgs_resources::VmgsResource;
 use vtl2_settings_proto::Vtl2Settings;
 
 /// The instance guid used for all of our SCSI drives.
@@ -72,49 +73,43 @@ pub(crate) const BOOT_NVME_LUN: u32 = 1;
 /// The MAC address used by the NIC assigned with [`PetriVmConfigOpenVmm::with_nic`].
 pub const NIC_MAC_ADDRESS: MacAddress = MacAddress::new([0x00, 0x15, 0x5D, 0x12, 0x12, 0x12]);
 
-/// The set of artifacts and resources needed to instantiate a
-/// [`PetriVmConfigOpenVmm`].
-pub struct PetriVmArtifactsOpenVmm {
-    firmware: Firmware,
-    arch: MachineArch,
-    agent_image: AgentImage,
-    openhcl_agent_image: Option<AgentImage>,
+/// OpenVMM Petri Backend
+pub struct OpenVmmPetriBackend {
     openvmm_path: ResolvedArtifact,
 }
 
-impl PetriVmArtifactsOpenVmm {
-    /// Resolves the artifacts needed to instantiate a [`PetriVmConfigOpenVmm`].
-    ///
-    /// Returns `None` if the supplied configuration is not supported on this platform.
-    pub fn new(
-        resolver: &ArtifactResolver<'_>,
-        firmware: Firmware,
-        arch: MachineArch,
-    ) -> Option<Self> {
-        if arch != MachineArch::host() {
-            return None;
-        }
-        if firmware.is_openhcl() {
-            // Only limited support for using OpenHCL on OpenVMM.
-            if !cfg!(windows) || arch != MachineArch::X86_64 {
-                return None;
-            }
-        }
-        let agent_image = AgentImage::new(resolver, arch, firmware.os_flavor());
-        let openhcl_agent_image = if firmware.is_openhcl() {
-            Some(AgentImage::new(resolver, arch, OsFlavor::Linux))
-        } else {
-            None
-        };
-        Some(Self {
-            firmware,
-            arch,
-            agent_image,
-            openhcl_agent_image,
+#[async_trait]
+impl PetriVmmBackend for OpenVmmPetriBackend {
+    type VmmConfig = PetriVmConfigOpenVmm;
+    type VmRuntime = PetriVmOpenVmm;
+
+    fn check_compat(firmware: &Firmware, arch: MachineArch) -> bool {
+        arch == MachineArch::host()
+            && !(firmware.is_openhcl() && (!cfg!(windows) || arch == MachineArch::Aarch64))
+            && !(firmware.is_pcat() && arch == MachineArch::Aarch64)
+    }
+
+    fn new(resolver: &ArtifactResolver<'_>) -> Self {
+        OpenVmmPetriBackend {
             openvmm_path: resolver
                 .require(petri_artifacts_vmm_test::artifacts::OPENVMM_NATIVE)
                 .erase(),
-        })
+        }
+    }
+
+    async fn run(
+        self,
+        config: PetriVmConfig,
+        vmm_config: Option<impl FnOnce(PetriVmConfigOpenVmm) -> PetriVmConfigOpenVmm + Send>,
+        resources: &PetriVmResources,
+    ) -> anyhow::Result<Self::VmRuntime> {
+        let mut config = PetriVmConfigOpenVmm::new(&self.openvmm_path, config, resources)?;
+
+        if let Some(f) = vmm_config {
+            config = f(config);
+        }
+
+        config.run().await
     }
 }
 
@@ -133,81 +128,8 @@ pub struct PetriVmConfigOpenVmm {
 
     // Resources that are only used during startup.
     ged: Option<get_resources::ged::GuestEmulationDeviceHandle>,
-    vtl2_settings: Option<Vtl2Settings>,
     framebuffer_access: Option<FramebufferAccess>,
 }
-
-#[async_trait]
-impl PetriVmConfig for PetriVmConfigOpenVmm {
-    async fn run_without_agent(self: Box<Self>) -> anyhow::Result<Box<dyn PetriVm>> {
-        Ok(Box::new(Self::run_without_agent(*self).await?))
-    }
-
-    async fn run_with_lazy_pipette(mut self: Box<Self>) -> anyhow::Result<Box<dyn PetriVm>> {
-        Ok(Box::new(Self::run_with_lazy_pipette(*self).await?))
-    }
-
-    async fn run(self: Box<Self>) -> anyhow::Result<(Box<dyn PetriVm>, PipetteClient)> {
-        let (vm, client) = Self::run(*self).await?;
-        Ok((Box::new(vm), client))
-    }
-
-    fn with_secure_boot(self: Box<Self>) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_secure_boot(*self))
-    }
-
-    fn with_windows_secure_boot_template(self: Box<Self>) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_windows_secure_boot_template(*self))
-    }
-
-    fn with_uefi_ca_secure_boot_template(self: Box<Self>) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_uefi_ca_secure_boot_template(*self))
-    }
-
-    fn with_processor_topology(
-        self: Box<Self>,
-        topology: ProcessorTopology,
-    ) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_processor_topology(*self, topology))
-    }
-
-    fn with_custom_openhcl(self: Box<Self>, artifact: ResolvedArtifact) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_custom_openhcl(*self, artifact))
-    }
-
-    fn with_openhcl_command_line(self: Box<Self>, command_line: &str) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_openhcl_command_line(*self, command_line))
-    }
-
-    fn with_agent_file(
-        self: Box<Self>,
-        name: &str,
-        artifact: ResolvedArtifact,
-    ) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_agent_file(*self, name, artifact))
-    }
-
-    fn with_openhcl_agent_file(
-        self: Box<Self>,
-        name: &str,
-        artifact: ResolvedArtifact,
-    ) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_openhcl_agent_file(*self, name, artifact))
-    }
-
-    fn with_uefi_frontpage(self: Box<Self>, enable: bool) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_uefi_frontpage(*self, enable))
-    }
-
-    fn with_vmbus_redirect(self: Box<Self>, _: bool) -> Box<dyn PetriVmConfig> {
-        Box::new(Self::with_vmbus_redirect(*self))
-    }
-
-    fn os_flavor(&self) -> OsFlavor {
-        self.firmware.os_flavor()
-    }
-}
-
 /// Various channels and resources used to interact with the VM while it is running.
 struct PetriVmResourcesOpenVmm {
     log_stream_tasks: Vec<Task<anyhow::Result<()>>>,
@@ -223,7 +145,7 @@ struct PetriVmResourcesOpenVmm {
 
     // Externally injected management stuff also needed at runtime.
     driver: DefaultDriver,
-    agent_image: AgentImage,
+    agent_image: Option<AgentImage>,
     openhcl_agent_image: Option<AgentImage>,
     openvmm_path: ResolvedArtifact,
     output_dir: PathBuf,
@@ -232,6 +154,8 @@ struct PetriVmResourcesOpenVmm {
     // TempPaths that cannot be dropped until the end.
     vtl2_vsock_path: Option<TempPath>,
     _vmbus_vsock_path: TempPath,
+
+    vtl2_settings: Option<Vtl2Settings>,
 }
 
 impl PetriVmConfigOpenVmm {
@@ -254,4 +178,23 @@ fn memdiff_disk_from_artifact(
         ],
     }
     .into_resource())
+}
+
+fn mem_diff_vmgs_from_artifact(vmgs: &PetriVmgsResource) -> anyhow::Result<VmgsResource> {
+    Ok(match vmgs {
+        PetriVmgsResource::Disk(disk) => VmgsResource::Disk(memdiff_disk_from_artifact(disk)?),
+        PetriVmgsResource::ReprovisionOnFailure(disk) => {
+            VmgsResource::ReprovisionOnFailure(memdiff_disk_from_artifact(disk)?)
+        }
+        PetriVmgsResource::Reprovision(disk) => {
+            VmgsResource::Reprovision(memdiff_disk_from_artifact(disk)?)
+        }
+        PetriVmgsResource::Ephemeral => VmgsResource::Ephemeral,
+        PetriVmgsResource::TempDisk => VmgsResource::Disk(
+            LayeredDiskHandle::single_layer(RamDiskLayerHandle {
+                len: Some(vmgs_format::VMGS_DEFAULT_CAPACITY),
+            })
+            .into_resource(),
+        ),
+    })
 }

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -3,15 +3,15 @@
 
 //! Helpers to modify a [`PetriVmConfigOpenVmm`] from its defaults.
 
+// TODO: Delete all modification functions that are not backend-specific
+// from this file, add necessary settings to the backend-agnostic
+// `PetriVmConfig`, and add corresponding functions to `PetriVmBuilder`.
+
 use super::MANA_INSTANCE;
 use super::NIC_MAC_ADDRESS;
 use super::PetriVmConfigOpenVmm;
-use super::memdiff_disk_from_artifact;
-use crate::PetriVmgsResource;
-use crate::ProcessorTopology;
 use chipset_resources::battery::BatteryDeviceHandleX64;
 use chipset_resources::battery::HostBatteryUpdate;
-use fs_err::File;
 use gdma_resources::GdmaDeviceHandle;
 use gdma_resources::VportDefinition;
 use get_resources::ged::IgvmAttestTestConfig;
@@ -20,35 +20,14 @@ use hvlite_defs::config::DeviceVtl;
 use hvlite_defs::config::LoadMode;
 use hvlite_defs::config::VpciDeviceConfig;
 use hvlite_defs::config::Vtl2BaseAddressType;
-use petri_artifacts_common::tags::IsTestVmgs;
-use petri_artifacts_common::tags::MachineArch;
-use petri_artifacts_common::tags::OsFlavor;
-use petri_artifacts_core::ResolvedArtifact;
 use tpm_resources::TpmDeviceHandle;
 use tpm_resources::TpmRegisterLayout;
 use vm_resource::IntoResource;
 use vmcore::non_volatile_store::resources::EphemeralNonVolatileStoreHandle;
-use vmgs_resources::VmgsResource;
 use vmotherboard::ChipsetDeviceHandle;
 use vtl2_settings_proto::Vtl2Settings;
 
 impl PetriVmConfigOpenVmm {
-    /// Enable VMBus redirection.
-    pub fn with_vmbus_redirect(mut self) -> Self {
-        self.config
-            .vmbus
-            .as_mut()
-            .expect("vmbus not configured")
-            .vtl2_redirect = true;
-
-        let Some(ged) = &mut self.ged else {
-            panic!("VMBus redirection is only supported for OpenHCL.")
-        };
-        ged.vmbus_redirection = true;
-
-        self
-    }
-
     /// Enable the VTL0 alias map.
     // TODO: Remove once #912 is fixed.
     pub fn with_vtl0_alias_map(mut self) -> Self {
@@ -82,101 +61,6 @@ impl PetriVmConfigOpenVmm {
             if let LoadMode::Uefi { enable_tpm, .. } = &mut self.config.load_mode {
                 *enable_tpm = true;
             }
-        }
-
-        self
-    }
-
-    /// Set the VM to use the specified number of virtual processors.
-    ///
-    /// Using 1 CPU is useful for heavier OpenHCL tests, as our WHP emulation
-    /// layer is rather slow when dealing with cross-cpu communication.
-    pub fn with_processor_topology(mut self, topology: ProcessorTopology) -> Self {
-        let ProcessorTopology {
-            vp_count,
-            enable_smt,
-            vps_per_socket,
-            apic_mode,
-        } = topology;
-        self.config.processor_topology.proc_count = vp_count;
-        self.config.processor_topology.enable_smt = enable_smt;
-        self.config.processor_topology.vps_per_socket = vps_per_socket;
-        self.config.processor_topology.arch = Some(match self.arch {
-            MachineArch::X86_64 => hvlite_defs::config::ArchTopologyConfig::X86(
-                hvlite_defs::config::X86TopologyConfig {
-                    x2apic: match apic_mode {
-                        None => hvlite_defs::config::X2ApicConfig::Auto,
-                        Some(x) => match x {
-                            crate::ApicMode::Xapic => {
-                                hvlite_defs::config::X2ApicConfig::Unsupported
-                            }
-                            crate::ApicMode::X2apicSupported => {
-                                hvlite_defs::config::X2ApicConfig::Supported
-                            }
-                            crate::ApicMode::X2apicEnabled => {
-                                hvlite_defs::config::X2ApicConfig::Enabled
-                            }
-                        },
-                    },
-                    ..Default::default()
-                },
-            ),
-            MachineArch::Aarch64 => hvlite_defs::config::ArchTopologyConfig::Aarch64(
-                hvlite_defs::config::Aarch64TopologyConfig::default(),
-            ),
-        });
-        self
-    }
-
-    /// Set the VM to enable secure boot and inject the templates per OS flavor.
-    pub fn with_secure_boot(mut self) -> Self {
-        if !self.firmware.is_uefi() {
-            panic!("Secure boot is only supported for UEFI firmware.");
-        }
-
-        if self.firmware.is_openhcl() {
-            self.ged.as_mut().unwrap().secure_boot_enabled = true;
-        } else {
-            self.config.secure_boot_enabled = true;
-        }
-
-        match self.os_flavor() {
-            OsFlavor::Windows => self.with_windows_secure_boot_template(),
-            OsFlavor::Linux => self.with_uefi_ca_secure_boot_template(),
-            _ => panic!(
-                "Secure boot unsupported for OS flavor {:?}",
-                self.os_flavor()
-            ),
-        }
-    }
-
-    /// Inject Windows secure boot templates into the VM's UEFI.
-    pub fn with_windows_secure_boot_template(mut self) -> Self {
-        if !self.firmware.is_uefi() {
-            panic!("Secure boot is only supported for UEFI firmware.");
-        }
-
-        if self.firmware.is_openhcl() {
-            self.ged.as_mut().unwrap().secure_boot_template =
-                get_resources::ged::GuestSecureBootTemplateType::MicrosoftWindows;
-        } else {
-            self.config.custom_uefi_vars = hyperv_secure_boot_templates::x64::microsoft_windows();
-        }
-
-        self
-    }
-
-    /// Inject UEFI CA secure boot templates into the VM's UEFI.
-    pub fn with_uefi_ca_secure_boot_template(mut self) -> Self {
-        if !self.firmware.is_uefi() {
-            panic!("Secure boot is only supported for UEFI firmware.");
-        }
-
-        if self.firmware.is_openhcl() {
-            self.ged.as_mut().unwrap().secure_boot_template =
-                get_resources::ged::GuestSecureBootTemplateType::MicrosoftUefiCertificateAuthoritiy;
-        } else {
-            self.config.custom_uefi_vars = hyperv_secure_boot_templates::x64::microsoft_uefi_ca();
         }
 
         self
@@ -239,7 +123,7 @@ impl PetriVmConfigOpenVmm {
     pub fn with_nic(mut self) -> Self {
         let endpoint =
             net_backend_resources::consomme::ConsommeHandle { cidr: None }.into_resource();
-        if self.vtl2_settings.is_some() {
+        if self.resources.vtl2_settings.is_some() {
             self.config.vpci_devices.push(VpciDeviceConfig {
                 vtl: DeviceVtl::Vtl2,
                 instance_id: MANA_INSTANCE,
@@ -252,7 +136,8 @@ impl PetriVmConfigOpenVmm {
                 .into_resource(),
             });
 
-            self.vtl2_settings
+            self.resources
+                .vtl2_settings
                 .as_mut()
                 .unwrap()
                 .dynamic
@@ -278,37 +163,6 @@ impl PetriVmConfigOpenVmm {
             ));
         }
 
-        self
-    }
-
-    /// Specifies whether the UEFI frontpage app is enabled.
-    ///
-    /// If it is disabled, then the VM will shutdown if there are no configured
-    /// boot apps.
-    pub fn with_uefi_frontpage(mut self, enable_frontpage: bool) -> Self {
-        match self.config.load_mode {
-            LoadMode::Uefi {
-                ref mut disable_frontpage,
-                ..
-            } => {
-                *disable_frontpage = !enable_frontpage;
-            }
-            LoadMode::Igvm { .. } => {
-                let ged = self.ged.as_mut().expect("no GED to configure DPS");
-                match ged.firmware {
-                    get_resources::ged::GuestFirmwareConfig::Uefi {
-                        ref mut disable_frontpage,
-                        ..
-                    } => {
-                        *disable_frontpage = !enable_frontpage;
-                    }
-                    _ => {
-                        panic!("not a UEFI boot");
-                    }
-                }
-            }
-            _ => panic!("not a UEFI boot"),
-        }
         self
     }
 
@@ -340,70 +194,12 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
-    /// Specifies an existing VMGS file to use
-    pub fn with_vmgs<T: IsTestVmgs>(mut self, vmgs: PetriVmgsResource<T>) -> Self {
-        let vmgs = match vmgs {
-            PetriVmgsResource::Disk(disk) => {
-                VmgsResource::Disk(memdiff_disk_from_artifact(&disk.erase()).expect("open VMGS"))
-            }
-            PetriVmgsResource::ReprovisionOnFailure(disk) => VmgsResource::ReprovisionOnFailure(
-                memdiff_disk_from_artifact(&disk.erase()).expect("open VMGS"),
-            ),
-            PetriVmgsResource::Reprovision(disk) => VmgsResource::Reprovision(
-                memdiff_disk_from_artifact(&disk.erase()).expect("open VMGS"),
-            ),
-            PetriVmgsResource::Ephemeral => VmgsResource::Ephemeral,
-        };
-
-        if self.firmware.is_openhcl() {
-            self.ged.as_mut().unwrap().vmgs = vmgs;
-        } else {
-            self.config.vmgs = Some(vmgs);
-        }
-        self
-    }
-
-    /// Add custom command line arguments to OpenHCL.
-    pub fn with_openhcl_command_line(mut self, additional_cmdline: &str) -> Self {
-        if !self.firmware.is_openhcl() {
-            panic!("Not an OpenHCL firmware.");
-        }
-        let LoadMode::Igvm { cmdline, .. } = &mut self.config.load_mode else {
-            unreachable!()
-        };
-        cmdline.push(' ');
-        cmdline.push_str(additional_cmdline);
-        self
-    }
-
-    /// Enable confidential filtering, even if the VM is not confidential.
-    pub fn with_confidential_filtering(self) -> Self {
-        if !self.firmware.is_openhcl() {
-            panic!("Confidential filtering is only supported for OpenHCL");
-        }
-        self.with_openhcl_command_line(&format!(
-            "{}=1 {}=0",
-            underhill_confidentiality::OPENHCL_CONFIDENTIAL_ENV_VAR_NAME,
-            underhill_confidentiality::OPENHCL_CONFIDENTIAL_DEBUG_ENV_VAR_NAME
-        ))
-    }
-
-    /// Load a custom OpenHCL firmware file.
-    pub fn with_custom_openhcl(mut self, artifact: ResolvedArtifact) -> Self {
-        let LoadMode::Igvm { file, .. } = &mut self.config.load_mode else {
-            panic!("Custom OpenHCL is only supported for OpenHCL firmware.")
-        };
-        *file = File::open(artifact)
-            .expect("Failed to open custom OpenHCL file")
-            .into();
-        self
-    }
-
     /// Add custom VTL 2 settings.
     // TODO: At some point we want to replace uses of this with nicer with_disk,
     // with_nic, etc. methods.
     pub fn with_custom_vtl2_settings(mut self, f: impl FnOnce(&mut Vtl2Settings)) -> Self {
         f(self
+            .resources
             .vtl2_settings
             .as_mut()
             .expect("Custom VTL 2 settings are only supported with OpenHCL."));
@@ -427,22 +223,6 @@ impl PetriVmConfigOpenVmm {
     /// pattern.
     pub fn with_custom_config(mut self, f: impl FnOnce(&mut Config)) -> Self {
         f(&mut self.config);
-        self
-    }
-
-    /// Adds a file to the agent image.
-    pub fn with_agent_file(mut self, name: &str, artifact: ResolvedArtifact) -> Self {
-        self.resources.agent_image.add_file(name, artifact);
-        self
-    }
-
-    /// Adds a file to the OpenHCL agent image.
-    pub fn with_openhcl_agent_file(mut self, name: &str, artifact: ResolvedArtifact) -> Self {
-        self.resources
-            .openhcl_agent_image
-            .as_mut()
-            .unwrap()
-            .add_file(name, artifact);
         self
     }
 

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -5,7 +5,7 @@
 
 use super::PetriVmResourcesOpenVmm;
 use crate::OpenHclServicingFlags;
-use crate::PetriVm;
+use crate::PetriVmRuntime;
 use crate::ShutdownKind;
 use crate::openhcl_diag::OpenHclDiagHandler;
 use crate::worker::Worker;
@@ -28,7 +28,6 @@ use pal_async::socket::PolledSocket;
 use pal_async::task::Task;
 use pal_async::timer::PolledTimer;
 use petri_artifacts_common::tags::GuestQuirks;
-use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_core::ResolvedArtifact;
 use pipette_client::PipetteClient;
 use std::future::Future;
@@ -37,6 +36,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use unix_socket::UnixListener;
 use vmm_core_defs::HaltReason;
+use vtl2_settings_proto::Vtl2Settings;
 
 /// A running VM that tests can interact with.
 // DEVNOTE: Really the PetriVmInner is the actual VM and channels that we interact
@@ -48,29 +48,48 @@ pub struct PetriVmOpenVmm {
 }
 
 #[async_trait]
-impl PetriVm for PetriVmOpenVmm {
-    fn arch(&self) -> MachineArch {
-        self.inner.arch
+impl PetriVmRuntime for PetriVmOpenVmm {
+    async fn teardown(self) -> anyhow::Result<()> {
+        tracing::info!("cancelling watchdogs");
+        futures::future::join_all(self.inner.watchdog_tasks.into_iter().map(|t| t.cancel())).await;
+
+        tracing::info!("Cancelled watchdogs, waiting for worker");
+        let worker = Arc::into_inner(self.inner.worker)
+            .expect("Watchdog task was cancelled, we should be the only ref left");
+        worker.shutdown().await?;
+
+        tracing::info!("Worker quit, waiting for mesh");
+        self.inner.mesh.shutdown().await;
+
+        tracing::info!("Mesh shutdown, waiting for logging tasks");
+        for t in self.inner.resources.log_stream_tasks {
+            t.await?;
+        }
+
+        Ok(())
     }
 
     async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason> {
-        Self::wait_for_halt(self).await
+        let halt_reason = if let Some(already) = self.halt.already_received.take() {
+            already.map_err(anyhow::Error::from)
+        } else {
+            self.halt
+                .halt_notif
+                .recv()
+                .await
+                .context("Failed to get halt reason")
+        }?;
+
+        tracing::info!(?halt_reason, "Got halt reason");
+        Ok(halt_reason)
     }
 
-    async fn wait_for_teardown(self: Box<Self>) -> anyhow::Result<HaltReason> {
-        Self::wait_for_teardown(*self).await
+    async fn wait_for_agent(&mut self, set_high_vtl: bool) -> anyhow::Result<PipetteClient> {
+        Self::wait_for_agent(self, set_high_vtl).await
     }
 
-    async fn test_inspect_openhcl(&mut self) -> anyhow::Result<()> {
-        Self::test_inspect_openhcl(self).await
-    }
-
-    async fn wait_for_agent(&mut self) -> anyhow::Result<PipetteClient> {
-        Self::wait_for_agent(self).await
-    }
-
-    async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()> {
-        Self::wait_for_vtl2_ready(self).await
+    fn openhcl_diag(&self) -> Option<&OpenHclDiagHandler> {
+        self.inner.resources.openhcl_diag_handler.as_ref()
     }
 
     async fn wait_for_successful_boot_event(&mut self) -> anyhow::Result<()> {
@@ -85,10 +104,6 @@ impl PetriVm for PetriVmOpenVmm {
         Self::send_enlightened_shutdown(self, kind).await
     }
 
-    async fn wait_for_vtl2_agent(&mut self) -> anyhow::Result<PipetteClient> {
-        Self::wait_for_vtl2_agent(self).await
-    }
-
     async fn restart_openhcl(
         &mut self,
         new_openhcl: &ResolvedArtifact,
@@ -99,7 +114,6 @@ impl PetriVm for PetriVmOpenVmm {
 }
 
 pub(super) struct PetriVmInner {
-    pub(super) arch: MachineArch,
     pub(super) resources: PetriVmResourcesOpenVmm,
     pub(super) mesh: Mesh,
     pub(super) worker: Arc<Worker>,
@@ -123,6 +137,8 @@ macro_rules! petri_vm_fn {
     };
 }
 
+// TODO: Add all runtime functions that are not backend specific
+// to the `PetriVmRuntime` trait
 impl PetriVmOpenVmm {
     pub(super) fn new(inner: PetriVmInner, halt_notif: Receiver<HaltReason>) -> Self {
         Self {
@@ -143,39 +159,12 @@ impl PetriVmOpenVmm {
             .context("VM is not configured with OpenHCL")
     }
 
-    /// Wait for the VM to halt, returning the reason for the halt.
-    pub async fn wait_for_halt(&mut self) -> anyhow::Result<HaltReason> {
-        if let Some(already) = self.halt.already_received.take() {
-            already.map_err(anyhow::Error::from)
-        } else {
-            self.halt
-                .halt_notif
-                .recv()
-                .await
-                .context("Failed to get halt reason")
-        }
-    }
-
     /// Wait for the VM to halt, returning the reason for the halt,
     /// and cleanly tear down the VM.
     pub async fn wait_for_teardown(mut self) -> anyhow::Result<HaltReason> {
         let halt_reason = self.wait_for_halt().await?;
 
-        tracing::info!(?halt_reason, "Got halt reason, cancelling watchdogs");
-        futures::future::join_all(self.inner.watchdog_tasks.into_iter().map(|t| t.cancel())).await;
-
-        tracing::info!(?halt_reason, "Cancelled watchdogs, waiting for worker");
-        let worker = Arc::into_inner(self.inner.worker)
-            .expect("Watchdog task was cancelled, we should be the only ref left");
-        worker.shutdown().await?;
-
-        tracing::info!("Worker quit, waiting for mesh");
-        self.inner.mesh.shutdown().await;
-
-        tracing::info!("Mesh shutdown, waiting for logging tasks");
-        for t in self.inner.resources.log_stream_tasks {
-            t.await?;
-        }
+        self.teardown().await?;
 
         Ok(halt_reason)
     }
@@ -238,11 +227,6 @@ impl PetriVmOpenVmm {
         pub async fn kmsg(&mut self) -> anyhow::Result<KmsgStream>
     );
     petri_vm_fn!(
-        /// Wait for a connection from a pipette agent running in the guest.
-        /// Useful if you've rebooted the vm or are otherwise expecting a fresh connection.
-        pub async fn wait_for_agent(&mut self) -> anyhow::Result<PipetteClient>
-    );
-    petri_vm_fn!(
         /// Wait for VTL 2 to report that it is ready to respond to commands.
         /// Will fail if the VM is not running OpenHCL.
         ///
@@ -251,14 +235,12 @@ impl PetriVmOpenVmm {
         pub async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()>
     );
     petri_vm_fn!(
-        /// Wait for a connection from a pipette agent running in VTL 2.
-        /// Useful if you've reset VTL 2 or are otherwise expecting a fresh connection.
-        /// Will fail if the VM is not running OpenHCL.
-        pub async fn wait_for_vtl2_agent(&mut self) -> anyhow::Result<PipetteClient>
+        /// Wait for a connection from a pipette agent
+        pub async fn wait_for_agent(&mut self, set_high_vtl: bool) -> anyhow::Result<PipetteClient>
     );
     petri_vm_fn!(
         /// Modifies OpenHCL VTL2 settings.
-        pub async fn modify_vtl2_settings(&mut self, settings: &vtl2_settings_proto::Vtl2Settings) -> anyhow::Result<()>
+        pub async fn modify_vtl2_settings(&mut self, f: impl FnOnce(&mut Vtl2Settings)) -> anyhow::Result<()>
     );
 
     petri_vm_fn!(pub(crate) async fn resume(&mut self) -> anyhow::Result<()>);
@@ -449,9 +431,11 @@ impl PetriVmInner {
     }
 
     async fn modify_vtl2_settings(
-        &self,
-        settings: &vtl2_settings_proto::Vtl2Settings,
+        &mut self,
+        f: impl FnOnce(&mut Vtl2Settings),
     ) -> anyhow::Result<()> {
+        f(self.resources.vtl2_settings.as_mut().unwrap());
+
         let ged_send = self
             .resources
             .ged_send
@@ -461,7 +445,7 @@ impl PetriVmInner {
         ged_send
             .call_failable(
                 get_resources::ged::GuestEmulationRequest::ModifyVtl2Settings,
-                prost::Message::encode_to_vec(settings),
+                prost::Message::encode_to_vec(self.resources.vtl2_settings.as_ref().unwrap()),
             )
             .await?;
 
@@ -487,28 +471,21 @@ impl PetriVmInner {
         self.openhcl_diag()?.kmsg().await
     }
 
-    async fn wait_for_agent(&mut self) -> anyhow::Result<PipetteClient> {
-        Self::wait_for_agent_core(
-            &self.resources.driver,
-            &mut self.resources.pipette_listener,
-            &self.resources.output_dir,
-        )
-        .await
-    }
-
     async fn wait_for_vtl2_ready(&mut self) -> anyhow::Result<()> {
         self.openhcl_diag()?.wait_for_vtl2().await
     }
 
-    async fn wait_for_vtl2_agent(&mut self) -> anyhow::Result<PipetteClient> {
-        // VTL 2's pipette doesn't auto launch, only launch it on demand
-        self.launch_vtl2_pipette().await?;
+    async fn wait_for_agent(&mut self, set_high_vtl: bool) -> anyhow::Result<PipetteClient> {
         Self::wait_for_agent_core(
             &self.resources.driver,
-            self.resources
-                .vtl2_pipette_listener
-                .as_mut()
-                .context("VM is not configured with VTL 2")?,
+            if set_high_vtl {
+                self.resources
+                    .vtl2_pipette_listener
+                    .as_mut()
+                    .context("VM is not configured with VTL 2")?
+            } else {
+                &mut self.resources.pipette_listener
+            },
             &self.resources.output_dir,
         )
         .await
@@ -568,26 +545,6 @@ impl PetriVmInner {
             .unwrap()
             .run_command("mkdir /cidata && mount LABEL=cidata /cidata && sh -c '/cidata/pipette &'")
             .await?;
-        Ok(())
-    }
-
-    async fn launch_vtl2_pipette(&mut self) -> anyhow::Result<()> {
-        // Start pipette through DiagClient
-        let res = self
-            .openhcl_diag()?
-            .run_vtl2_command(
-                "sh",
-                &[
-                    "-c",
-                    "mkdir /cidata && mount LABEL=cidata /cidata && sh -c '/cidata/pipette &'",
-                ],
-            )
-            .await?;
-
-        if !res.exit_status.success() {
-            anyhow::bail!("Failed to start VTL 2 pipette: {:?}", res);
-        }
-
         Ok(())
     }
 

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -194,7 +194,8 @@ fn resolve_openhcl_tmks<T: PetriVmmBackend>(
 ) -> Option<OpenhclTmkArtifacts<T>> {
     let arch = MachineArch::host();
     if MachineArch::host() != MachineArch::X86_64 {
-        // TODO: aarch64 currently hangs, fix
+        // TODO: aarch64 currently hangs on hyperv, fix
+        // not supported with OpenVMM
         return None;
     }
 

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -9,8 +9,11 @@ use anyhow::Context as _;
 use pal_async::DefaultDriver;
 use pal_async::DefaultPool;
 use pal_async::task::Spawn as _;
+use petri::PetriVm;
+use petri::PetriVmmBackend;
 use petri::ProcessorTopology;
 use petri::ResolvedArtifact;
+use petri::openvmm::OpenVmmPetriBackend;
 use petri_artifacts_common::tags::MachineArch;
 
 petri::test!(host_tmks, |resolver| resolve_host_tmks(resolver, false));
@@ -136,10 +139,10 @@ fn resolve_paravisor_tmk_artifacts(
 const OPENHCL_COMMAND_LINE: &str =
     "OPENHCL_WAIT_FOR_START=1 OPENHCL_SIGNAL_VTL0_STARTED=1 OPENHCL_WAIT_FOR_MODULES=1";
 
-async fn openhcl_tmks(
+async fn openhcl_tmks_inner<T: PetriVmmBackend>(
     driver: &DefaultDriver,
     params: &petri::PetriTestParams<'_>,
-    vm: &mut dyn petri::PetriVm,
+    vm: &mut PetriVm<T>,
 ) -> anyhow::Result<()> {
     let agent = vm.wait_for_vtl2_agent().await?;
     let mut child = agent
@@ -175,39 +178,49 @@ async fn openhcl_tmks(
     Ok(())
 }
 
-petri::test!(openvmm_openhcl_tmks, resolve_openvmm_openhcl_tmks);
+petri::test!(
+    openvmm_openhcl_tmks,
+    resolve_openhcl_tmks::<OpenVmmPetriBackend>
+);
 
-struct OpenvmmOpenhclArtifacts {
-    vm: petri::openvmm::PetriVmArtifactsOpenVmm,
+struct OpenhclTmkArtifacts<T: PetriVmmBackend> {
+    vm: petri::PetriVmArtifacts<T>,
     tmk_vmm: ResolvedArtifact,
     tmk: ResolvedArtifact,
 }
 
-fn resolve_openvmm_openhcl_tmks(
+fn resolve_openhcl_tmks<T: PetriVmmBackend>(
     resolver: &petri::ArtifactResolver<'_>,
-) -> Option<OpenvmmOpenhclArtifacts> {
+) -> Option<OpenhclTmkArtifacts<T>> {
     let arch = MachineArch::host();
+    if MachineArch::host() != MachineArch::X86_64 {
+        // TODO: aarch64 currently hangs, fix
+        return None;
+    }
+
     let (igvm_path, tmk_vmm, tmk) = resolve_paravisor_tmk_artifacts(resolver, arch);
 
-    let vm = petri::openvmm::PetriVmArtifactsOpenVmm::new(
+    let vm = petri::PetriVmArtifacts::new(
         resolver,
         petri::Firmware::OpenhclUefi {
             guest: petri::UefiGuest::None,
             isolation: None,
-            vtl2_nvme_boot: false,
             igvm_path,
+            vmgs_file: petri::PetriVmgsResource::Ephemeral,
+            uefi_config: Default::default(),
+            openhcl_config: Default::default(),
         },
         arch,
     )?;
-    Some(OpenvmmOpenhclArtifacts { vm, tmk_vmm, tmk })
+    Some(OpenhclTmkArtifacts { vm, tmk_vmm, tmk })
 }
 
 fn openvmm_openhcl_tmks(
     params: petri::PetriTestParams<'_>,
-    artifacts: OpenvmmOpenhclArtifacts,
+    artifacts: OpenhclTmkArtifacts<OpenVmmPetriBackend>,
 ) -> anyhow::Result<()> {
     DefaultPool::run_with(async |driver| {
-        let mut vm = petri::openvmm::PetriVmConfigOpenVmm::new(&params, artifacts.vm, &driver)?
+        let mut vm = petri::PetriVmBuilder::new(&params, artifacts.vm, &driver)?
             .with_openhcl_command_line(OPENHCL_COMMAND_LINE)
             .with_openhcl_agent_file("tmk_vmm", artifacts.tmk_vmm)
             .with_openhcl_agent_file("simple_tmk", artifacts.tmk)
@@ -215,11 +228,14 @@ fn openvmm_openhcl_tmks(
                 vp_count: 1,
                 ..Default::default()
             })
-            .with_allow_early_vtl0_access(true) // TODO: remove once the TMK VMM initializes memory properly.
+            // TODO: remove once the TMK VMM initializes memory properly.
+            // and unify test functions into one generic function
+            .modify_backend(|b| b.with_allow_early_vtl0_access(true))
             .run_without_agent()
             .await?;
 
-        openhcl_tmks(&driver, &params, &mut vm).await?;
+        tracing::info!("started vm");
+        openhcl_tmks_inner(&driver, &params, &mut vm).await?;
 
         Ok(())
     })
@@ -227,52 +243,20 @@ fn openvmm_openhcl_tmks(
 
 #[cfg(windows)]
 mod hyperv {
-    use super::OPENHCL_COMMAND_LINE;
-    use crate::openhcl_tmks;
-    use crate::resolve_paravisor_tmk_artifacts;
+    use crate::OPENHCL_COMMAND_LINE;
+    use crate::OpenhclTmkArtifacts;
+    use crate::openhcl_tmks_inner;
+    use crate::resolve_openhcl_tmks;
     use pal_async::DefaultPool;
     use petri::ProcessorTopology;
-    use petri::ResolvedArtifact;
-    use petri_artifacts_common::tags::MachineArch;
-
-    petri::test!(hyperv_openhcl_tmks, resolve_hyperv_openhcl_tmks);
-
-    struct HypervOpenhclArtifacts {
-        vm: petri::hyperv::PetriVmArtifactsHyperV,
-        tmk_vmm: ResolvedArtifact,
-        tmk: ResolvedArtifact,
-    }
-
-    fn resolve_hyperv_openhcl_tmks(
-        resolver: &petri::ArtifactResolver<'_>,
-    ) -> Option<HypervOpenhclArtifacts> {
-        let arch = MachineArch::host();
-        if MachineArch::host() != MachineArch::X86_64 {
-            // TODO: aarch64 currently hangs, fix
-            return None;
-        }
-
-        let (igvm_path, tmk_vmm, tmk) = resolve_paravisor_tmk_artifacts(resolver, arch);
-
-        let vm = petri::hyperv::PetriVmArtifactsHyperV::new(
-            resolver,
-            petri::Firmware::OpenhclUefi {
-                guest: petri::UefiGuest::None,
-                isolation: None,
-                vtl2_nvme_boot: false,
-                igvm_path,
-            },
-            arch,
-        )?;
-        Some(HypervOpenhclArtifacts { vm, tmk_vmm, tmk })
-    }
+    use petri::hyperv::HyperVPetriBackend;
 
     fn hyperv_openhcl_tmks(
         params: petri::PetriTestParams<'_>,
-        artifacts: HypervOpenhclArtifacts,
+        artifacts: OpenhclTmkArtifacts<HyperVPetriBackend>,
     ) -> anyhow::Result<()> {
         DefaultPool::run_with(async |driver| {
-            let mut vm = petri::hyperv::PetriVmConfigHyperV::new(&params, artifacts.vm, &driver)?
+            let mut vm = petri::PetriVmBuilder::new(&params, artifacts.vm, &driver)?
                 .with_openhcl_command_line(OPENHCL_COMMAND_LINE)
                 .with_openhcl_agent_file("tmk_vmm", artifacts.tmk_vmm)
                 .with_openhcl_agent_file("simple_tmk", artifacts.tmk)
@@ -284,8 +268,14 @@ mod hyperv {
                 .await?;
 
             tracing::info!("started vm");
-            openhcl_tmks(&driver, &params, &mut vm).await?;
+            openhcl_tmks_inner(&driver, &params, &mut vm).await?;
+
             Ok(())
         })
     }
+
+    petri::test!(
+        hyperv_openhcl_tmks,
+        resolve_openhcl_tmks::<HyperVPetriBackend>
+    );
 }

--- a/tmk/tmk_tests/src/lib.rs
+++ b/tmk/tmk_tests/src/lib.rs
@@ -207,7 +207,6 @@ fn resolve_openhcl_tmks<T: PetriVmmBackend>(
             guest: petri::UefiGuest::None,
             isolation: None,
             igvm_path,
-            vmgs_file: petri::PetriVmgsResource::Ephemeral,
             uefi_config: Default::default(),
             openhcl_config: Default::default(),
         },

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -134,7 +134,7 @@ pub mod ged {
         /// The microsoft windows template.
         MicrosoftWindows,
         /// The Microsoft UEFI certificate authority template.
-        MicrosoftUefiCertificateAuthoritiy,
+        MicrosoftUefiCertificateAuthority,
     }
 
     /// The boot devices for a PC/AT BIOS.

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -150,7 +150,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                     GuestSecureBootTemplateType::MicrosoftWindows => {
                         SecureBootTemplateType::MICROSOFT_WINDOWS
                     }
-                    GuestSecureBootTemplateType::MicrosoftUefiCertificateAuthoritiy => {
+                    GuestSecureBootTemplateType::MicrosoftUefiCertificateAuthority => {
                         SecureBootTemplateType::MICROSOFT_UEFI_CERTIFICATE_AUTHORITY
                     }
                 },

--- a/vmm_tests/vmm_test_macros/src/lib.rs
+++ b/vmm_tests/vmm_test_macros/src/lib.rs
@@ -638,25 +638,22 @@ fn make_vmm_test(args: Args, item: ItemFn, specific_vmm: Option<Vmm>) -> syn::Re
             | (Some(Vmm::HyperV), None)
             | (None, Some(Vmm::HyperV)) => (
                 quote!(#[cfg(windows)]),
-                quote!(::petri::hyperv::PetriVmArtifactsHyperV),
-                quote!(::petri::hyperv::PetriVmConfigHyperV),
+                quote!(::petri::PetriVmArtifacts::<::petri::hyperv::HyperVPetriBackend>),
+                quote!(::petri::PetriVmBuilder::<::petri::hyperv::HyperVPetriBackend>),
             ),
 
             (Some(Vmm::OpenVmm), Some(Vmm::OpenVmm))
             | (Some(Vmm::OpenVmm), None)
             | (None, Some(Vmm::OpenVmm)) => (
                 quote!(),
-                quote!(::petri::openvmm::PetriVmArtifactsOpenVmm),
-                quote!(::petri::openvmm::PetriVmConfigOpenVmm),
+                quote!(::petri::PetriVmArtifacts::<::petri::openvmm::OpenVmmPetriBackend>),
+                quote!(::petri::PetriVmBuilder::<::petri::openvmm::OpenVmmPetriBackend>),
             ),
             (None, None) => return Err(Error::new(config.span, "vmm must be specified")),
             _ => return Err(Error::new(config.span, "vmm mismatch")),
         };
 
-        let mut petri_vm_config = quote!(#petri_vm_config::new(&params, artifacts, &driver)?);
-        if specific_vmm.is_none() {
-            petri_vm_config = quote!(Box::new(#petri_vm_config));
-        }
+        let petri_vm_config = quote!(#petri_vm_config::new(&params, artifacts, &driver)?);
 
         let test = quote! {
             #cfg_conditions

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -9,13 +9,15 @@ use get_resources::ged::FirmwareEvent;
 use hyperv_ic_resources::kvp::KvpRpc;
 use jiff::SignedDuration;
 use mesh::rpc::RpcSend;
-use petri::PetriVmConfig;
+use petri::MemoryConfig;
+use petri::PetriVmBuilder;
+use petri::PetriVmmBackend;
 use petri::ProcessorTopology;
 use petri::ResolvedArtifact;
 use petri::SIZE_1_GB;
 use petri::ShutdownKind;
 use petri::openvmm::NIC_MAC_ADDRESS;
-use petri::openvmm::PetriVmConfigOpenVmm;
+use petri::openvmm::OpenVmmPetriBackend;
 use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_common::tags::OsFlavor;
 use petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_BOOT_ENTRY;
@@ -35,7 +37,7 @@ pub(crate) mod openhcl_servicing;
     hyperv_openhcl_uefi_aarch64(none),
     hyperv_openhcl_uefi_x64(none)
 )]
-async fn frontpage(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+async fn frontpage<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let mut vm = config.run_without_agent().await?;
     vm.wait_for_successful_boot_event().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
@@ -65,7 +67,7 @@ async fn frontpage(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
-async fn boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+async fn boot<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let (vm, agent) = config.run().await?;
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
@@ -88,7 +90,7 @@ async fn boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
-async fn secure_boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+async fn secure_boot<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let (vm, agent) = config.with_secure_boot().run().await?;
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
@@ -112,7 +114,9 @@ async fn secure_boot(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
-async fn secure_boot_mismatched_template(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+async fn secure_boot_mismatched_template<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+) -> anyhow::Result<()> {
     let mut vm = match config.os_flavor() {
         OsFlavor::Windows => {
             config
@@ -143,10 +147,10 @@ async fn secure_boot_mismatched_template(config: Box<dyn PetriVmConfig>) -> anyh
 // means. At that point, we can also use Windows Server 2025 for x64 tests.
 // Hyper-V VMs work for now since we don't notice that they reboot
 #[openvmm_test(openvmm_uefi_aarch64(vhd(windows_11_enterprise_aarch64)))]
-async fn boot_reset_expected(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+async fn boot_reset_expected(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let mut vm = config.run_with_lazy_pipette().await?;
     assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
-    vm.reset().await?;
+    vm.backend().reset().await?;
     let agent = vm.wait_for_agent().await?;
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
@@ -159,7 +163,9 @@ async fn boot_reset_expected(config: PetriVmConfigOpenVmm) -> anyhow::Result<()>
 ///   - openhcl_uefi_aarch64 support
 ///   - uefi_x64 + uefi_aarch64 trace searching support
 #[openvmm_test(openhcl_uefi_x64(none))]
-async fn efi_diagnostics_no_boot(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+async fn efi_diagnostics_no_boot(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> anyhow::Result<()> {
     let mut vm = config.with_uefi_frontpage(true).run_without_agent().await?;
 
     // Boot the VM first
@@ -169,7 +175,7 @@ async fn efi_diagnostics_no_boot(config: PetriVmConfigOpenVmm) -> anyhow::Result
     const NO_BOOT_MSG: &str = "[Bds] Unable to boot!";
 
     // Get kmsg stream
-    let mut kmsg = vm.kmsg().await?;
+    let mut kmsg = vm.backend().kmsg().await?;
 
     // Search for the message
     while let Some(data) = kmsg.next().await {
@@ -189,10 +195,10 @@ async fn efi_diagnostics_no_boot(config: PetriVmConfigOpenVmm) -> anyhow::Result
 /// Windows-only right now, because the Linux images do not include the KVP IC
 /// daemon.
 #[openvmm_test(uefi_x64(vhd(windows_datacenter_core_2022_x64)))]
-async fn kvp_ic(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+async fn kvp_ic(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     // Run with a NIC to perform IP address tests.
-    let (mut vm, agent) = config.with_nic().run().await?;
-    let kvp = vm.wait_for_kvp().await?;
+    let (mut vm, agent) = config.modify_backend(|c| c.with_nic()).run().await?;
+    let kvp = vm.backend().wait_for_kvp().await?;
 
     // Perform a basic set and enumerate test.
     let test_key = "test_key";
@@ -273,12 +279,14 @@ async fn kvp_ic(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
     linux_direct_x64
 )]
-async fn timesync_ic(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+async fn timesync_ic(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let (vm, agent) = config
-        .with_custom_config(|c| {
-            // Start with the clock half a day in the past so that the clock is
-            // initially wrong.
-            c.rtc_delta_milliseconds = -(Duration::from_secs(40000).as_millis() as i64)
+        .modify_backend(|b| {
+            b.with_custom_config(|c| {
+                // Start with the clock half a day in the past so that the clock is
+                // initially wrong.
+                c.rtc_delta_milliseconds = -(Duration::from_secs(40000).as_millis() as i64)
+            })
         })
         .run()
         .await?;
@@ -321,14 +329,14 @@ async fn timesync_ic(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     // openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     // openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
-async fn reboot(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn reboot(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     let (mut vm, agent) = config.run().await?;
 
     agent.ping().await?;
 
     agent.reboot().await?;
     assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
-    vm.reset().await?;
+    vm.backend().reset().await?;
 
     let agent = vm.wait_for_agent().await?;
 
@@ -365,7 +373,7 @@ async fn reboot(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
 )]
-async fn boot_no_agent(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+async fn boot_no_agent<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let mut vm = config.run_without_agent().await?;
     vm.wait_for_successful_boot_event().await?;
     vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
@@ -396,10 +404,17 @@ async fn boot_no_agent(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
 )]
-async fn boot_no_agent_heavy(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+async fn boot_no_agent_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
+    let is_openhcl = config.is_openhcl();
     let mut vm = config
         .with_processor_topology(ProcessorTopology {
             vp_count: 16,
+            ..Default::default()
+        })
+        // multiarch::openvmm_uefi_x64_windows_datacenter_core_2022_x64_boot_no_agent_heavy
+        // fails with 4GB of RAM (the default), and openhcl tests fail with 1GB.
+        .with_memory(MemoryConfig {
+            startup_bytes: if is_openhcl { 4 * SIZE_1_GB } else { SIZE_1_GB },
             ..Default::default()
         })
         .run_without_agent()
@@ -416,7 +431,7 @@ async fn boot_no_agent_heavy(config: Box<dyn PetriVmConfig>) -> anyhow::Result<(
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
 )]
 #[cfg_attr(not(windows), expect(dead_code))]
-async fn vmbus_relay(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+async fn vmbus_relay<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let mut vm = config.with_vmbus_redirect(true).run_without_agent().await?;
     vm.wait_for_successful_boot_event().await?;
     vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
@@ -430,7 +445,7 @@ async fn vmbus_relay(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
 )]
 #[cfg_attr(not(windows), expect(dead_code))]
-async fn vmbus_relay_heavy(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+async fn vmbus_relay_heavy<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let mut vm = config
         .with_vmbus_redirect(true)
         .with_processor_topology(ProcessorTopology {
@@ -452,7 +467,9 @@ async fn vmbus_relay_heavy(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()>
     hyperv_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2025_x64)),
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
 )]
-async fn boot_no_agent_single_proc(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+async fn boot_no_agent_single_proc<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+) -> anyhow::Result<()> {
     let mut vm = config
         .with_processor_topology(ProcessorTopology {
             vp_count: 1,
@@ -482,12 +499,12 @@ async fn boot_no_agent_single_proc(config: Box<dyn PetriVmConfig>) -> anyhow::Re
     openvmm_openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64)),
 )]
-async fn reboot_no_agent(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+async fn reboot_no_agent(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let mut vm = config.run_without_agent().await?;
     vm.wait_for_successful_boot_event().await?;
     vm.send_enlightened_shutdown(ShutdownKind::Reboot).await?;
     assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
-    vm.reset().await?;
+    vm.backend().reset().await?;
     vm.wait_for_successful_boot_event().await?;
     vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
@@ -502,7 +519,7 @@ async fn reboot_no_agent(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     openvmm_uefi_aarch64(guest_test_uefi_aarch64),
     openvmm_openhcl_uefi_x64(guest_test_uefi_x64)
 )]
-async fn guest_test_uefi(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
+async fn guest_test_uefi<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let vm = config
         .with_windows_secure_boot_template()
         .run_without_agent()
@@ -533,7 +550,9 @@ async fn guest_test_uefi(config: Box<dyn PetriVmConfig>) -> anyhow::Result<()> {
     hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
-async fn file_transfer_test(config: Box<dyn PetriVmConfig>) -> Result<(), anyhow::Error> {
+async fn file_transfer_test<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+) -> Result<(), anyhow::Error> {
     const TEST_CONTENT: &str = "hello world!";
     const FILE_NAME: &str = "test.txt";
 
@@ -550,12 +569,12 @@ async fn file_transfer_test(config: Box<dyn PetriVmConfig>) -> Result<(), anyhow
 
 /// Boot Linux and have it write the visible memory size.
 #[openvmm_test(linux_direct_x64, uefi_aarch64(vhd(ubuntu_2404_server_aarch64)))]
-async fn five_gb(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn five_gb(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     let configured_size = 5 * SIZE_1_GB;
     let expected_size = configured_size - configured_size / 10; // 10% buffer; TODO-figure out where this goes
 
     let (vm, agent) = config
-        .with_custom_config(|c| c.memory.mem_size = configured_size)
+        .modify_backend(move |b| b.with_custom_config(|c| c.memory.mem_size = configured_size))
         .run()
         .await?;
 
@@ -597,12 +616,12 @@ async fn five_gb(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY]
 )]
 async fn default_boot(
-    config: PetriVmConfigOpenVmm,
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
         .with_vmgs(petri::PetriVmgsResource::Disk(initial_vmgs))
-        .with_default_boot_always_attempt(true)
+        .modify_backend(|b| b.with_default_boot_always_attempt(true))
         .run()
         .await?;
 
@@ -623,7 +642,7 @@ async fn default_boot(
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY]
 )]
 async fn clear_vmgs(
-    config: PetriVmConfigOpenVmm,
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
@@ -650,7 +669,7 @@ async fn clear_vmgs(
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[VMGS_WITH_BOOT_ENTRY]
 )]
 async fn boot_expect_fail(
-    config: PetriVmConfigOpenVmm,
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let mut vm = config

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -10,6 +10,7 @@ use hyperv_ic_resources::kvp::KvpRpc;
 use jiff::SignedDuration;
 use mesh::rpc::RpcSend;
 use petri::MemoryConfig;
+use petri::PetriGuestStateLifetime;
 use petri::PetriVmBuilder;
 use petri::PetriVmmBackend;
 use petri::ProcessorTopology;
@@ -620,7 +621,8 @@ async fn default_boot(
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
-        .with_vmgs(petri::PetriVmgsResource::Disk(initial_vmgs))
+        .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
+        .with_backing_vmgs(initial_vmgs)
         .modify_backend(|b| b.with_default_boot_always_attempt(true))
         .run()
         .await?;
@@ -646,7 +648,8 @@ async fn clear_vmgs(
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
-        .with_vmgs(petri::PetriVmgsResource::Reprovision(initial_vmgs))
+        .with_guest_state_lifetime(PetriGuestStateLifetime::Reprovision)
+        .with_backing_vmgs(initial_vmgs)
         .run()
         .await?;
 
@@ -673,7 +676,8 @@ async fn boot_expect_fail(
     (initial_vmgs,): (ResolvedArtifact<VMGS_WITH_BOOT_ENTRY>,),
 ) -> Result<(), anyhow::Error> {
     let mut vm = config
-        .with_vmgs(petri::PetriVmgsResource::Disk(initial_vmgs))
+        .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
+        .with_backing_vmgs(initial_vmgs)
         .run_without_agent()
         .await?;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/openhcl_servicing.rs
@@ -10,9 +10,10 @@ use disk_backend_resources::LayeredDiskHandle;
 use disk_backend_resources::layer::RamDiskLayerHandle;
 use hvlite_defs::config::DeviceVtl;
 use petri::OpenHclServicingFlags;
-use petri::PetriVmConfig;
+use petri::PetriVmBuilder;
+use petri::PetriVmmBackend;
 use petri::ResolvedArtifact;
-use petri::openvmm::PetriVmConfigOpenVmm;
+use petri::openvmm::OpenVmmPetriBackend;
 use petri::pipette::cmd;
 #[allow(unused_imports)]
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_LINUX_DIRECT_TEST_X64;
@@ -68,8 +69,8 @@ fn is_amd_nested_via_cpuid() -> bool {
     is_nested && vendor.is_amd_compatible()
 }
 
-async fn openhcl_servicing_core(
-    config: Box<dyn PetriVmConfig>,
+async fn openhcl_servicing_core<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
     openhcl_cmdline: &str,
     new_openhcl: ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,
     flags: OpenHclServicingFlags,
@@ -79,15 +80,13 @@ async fn openhcl_servicing_core(
         .run()
         .await?;
 
-    let new_openhcl = new_openhcl.erase();
-
     for _ in 0..3 {
         agent.ping().await?;
 
         // Test that inspect serialization works with the old version.
         vm.test_inspect_openhcl().await?;
 
-        vm.restart_openhcl(&new_openhcl, flags).await?;
+        vm.restart_openhcl(new_openhcl.clone(), flags).await?;
 
         agent.ping().await?;
 
@@ -104,11 +103,13 @@ async fn openhcl_servicing_core(
 /// Test servicing an OpenHCL VM from the current version to itself.
 ///
 /// N.B. These Hyper-V tests fail in CI for x64. Tracked by #1652.
-#[vmm_test(openvmm_openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64],
+#[vmm_test(
+    openvmm_openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64],
     //hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))[LATEST_STANDARD_X64],
-    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[LATEST_STANDARD_AARCH64])]
-async fn basic(
-    config: Box<dyn PetriVmConfig>,
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))[LATEST_STANDARD_AARCH64]
+)]
+async fn basic<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
     (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
 ) -> Result<(), anyhow::Error> {
     if !host_supports_servicing() {
@@ -131,8 +132,8 @@ async fn basic(
 /// Test servicing an OpenHCL VM from the current version to itself
 /// with NVMe keepalive support.
 #[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
-async fn keepalive(
-    config: PetriVmConfigOpenVmm,
+async fn keepalive<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
     (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
 ) -> Result<(), anyhow::Error> {
     if !host_supports_servicing() {
@@ -141,7 +142,7 @@ async fn keepalive(
     }
 
     openhcl_servicing_core(
-        Box::new(config),
+        config,
         "OPENHCL_ENABLE_VTL2_GPA_POOL=512 OPENHCL_SIDECAR=off", // disable sidecar until #1345 is fixed
         igvm_file,
         OpenHclServicingFlags {
@@ -154,7 +155,7 @@ async fn keepalive(
 
 #[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
 async fn shutdown_ic(
-    config: PetriVmConfigOpenVmm,
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
     (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
 ) -> Result<(), anyhow::Error> {
     if !host_supports_servicing() {
@@ -163,36 +164,38 @@ async fn shutdown_ic(
     }
 
     let (mut vm, agent) = config
-        .with_vmbus_redirect()
-        .with_custom_config(|c| {
-            // Add a disk so that we can make sure (non-intercepted) relay
-            // channels are also functional.
-            c.vmbus_devices.push((
-                DeviceVtl::Vtl0,
-                ScsiControllerHandle {
-                    instance_id: guid::Guid::new_random(),
-                    max_sub_channel_count: 1,
-                    devices: vec![ScsiDeviceAndPath {
-                        path: ScsiPath {
-                            path: 0,
-                            target: 0,
-                            lun: 0,
-                        },
-                        device: SimpleScsiDiskHandle {
-                            disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
-                                len: Some(256 * 1024),
-                            })
+        .with_vmbus_redirect(true)
+        .modify_backend(move |b| {
+            b.with_custom_config(|c| {
+                // Add a disk so that we can make sure (non-intercepted) relay
+                // channels are also functional.
+                c.vmbus_devices.push((
+                    DeviceVtl::Vtl0,
+                    ScsiControllerHandle {
+                        instance_id: guid::Guid::new_random(),
+                        max_sub_channel_count: 1,
+                        devices: vec![ScsiDeviceAndPath {
+                            path: ScsiPath {
+                                path: 0,
+                                target: 0,
+                                lun: 0,
+                            },
+                            device: SimpleScsiDiskHandle {
+                                disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
+                                    len: Some(256 * 1024),
+                                })
+                                .into_resource(),
+                                read_only: false,
+                                parameters: Default::default(),
+                            }
                             .into_resource(),
-                            read_only: false,
-                            parameters: Default::default(),
-                        }
-                        .into_resource(),
-                    }],
-                    io_queue_depth: None,
-                    requests: None,
-                }
-                .into_resource(),
-            ));
+                        }],
+                        io_queue_depth: None,
+                        requests: None,
+                    }
+                    .into_resource(),
+                ));
+            })
         })
         .run()
         .await?;
@@ -202,13 +205,13 @@ async fn shutdown_ic(
     // Make sure the disk showed up.
     cmd!(sh, "ls /dev/sda").run().await?;
 
-    let shutdown_ic = vm.wait_for_enlightened_shutdown_ready().await?;
-    vm.restart_openhcl(&igvm_file.erase(), OpenHclServicingFlags::default())
+    let shutdown_ic = vm.backend().wait_for_enlightened_shutdown_ready().await?;
+    vm.restart_openhcl(igvm_file, OpenHclServicingFlags::default())
         .await?;
     // VTL2 will disconnect and then reconnect the shutdown IC across a servicing event.
     tracing::info!("waiting for shutdown IC to close");
     shutdown_ic.await.unwrap_err();
-    vm.wait_for_enlightened_shutdown_ready().await?;
+    vm.backend().wait_for_enlightened_shutdown_ready().await?;
 
     // Make sure the VTL0 disk is still present by reading it.
     agent.read_file("/dev/sda").await?;

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -8,12 +8,14 @@ mod openhcl_uefi;
 
 use anyhow::Context;
 use petri::ApicMode;
-use petri::PetriVmConfig;
+use petri::PetriVmBuilder;
+use petri::PetriVmmBackend;
 use petri::ProcessorTopology;
 use petri::ShutdownKind;
-use petri::openvmm::PetriVmConfigOpenVmm;
+use petri::openvmm::OpenVmmPetriBackend;
 use petri::pipette::cmd;
 use petri_artifacts_common::tags::OsFlavor;
+use petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_BOOT_ENTRY;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;
@@ -25,8 +27,11 @@ use vmm_test_macros::vmm_test;
     openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
-async fn boot_alias_map(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
-    let (vm, agent) = config.with_vtl0_alias_map().run().await?;
+async fn boot_alias_map(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    let (vm, agent) = config
+        .modify_backend(|b| b.with_vtl0_alias_map())
+        .run()
+        .await?;
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
     Ok(())
@@ -37,18 +42,22 @@ async fn boot_alias_map(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
-async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+async fn boot_with_tpm(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
-    let config = config.with_tpm();
+    let config = config.modify_backend(|b| b.with_tpm());
 
     let (vm, agent) = match os_flavor {
         OsFlavor::Windows => config.run().await?,
         OsFlavor::Linux => {
-            let mut vm = config.run_with_lazy_pipette().await?;
+            let mut vm = config
+                // TODO: we shouldn't need to specify a generic here...
+                .with_vmgs::<VMGS_WITH_BOOT_ENTRY>(petri::PetriVmgsResource::TempDisk)
+                .run_with_lazy_pipette()
+                .await?;
             // Workaround to https://github.com/microsoft/openvmm/issues/379
             assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
 
-            vm.reset().await?;
+            vm.backend().reset().await?;
             let agent = vm.wait_for_agent().await?;
             vm.wait_for_successful_boot_event().await?;
 
@@ -69,7 +78,7 @@ async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 // // do have an easy way to interact with TPM without a private
 // // or custom tool.
 // #[openvmm_test(openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)))]
-// async fn tpm_ak_cert_persisted(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+// async fn tpm_ak_cert_persisted(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
 //     let config = config
 //         .with_tpm()
 //         .with_tpm_state_persistence()
@@ -114,7 +123,7 @@ async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 // // do have an easy way to interact with TPM without a private
 // // or custom tool.
 // #[openvmm_test(openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)))]
-// async fn tpm_ak_cert_retry(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+// async fn tpm_ak_cert_retry(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
 //     let config = config
 //         .with_tpm()
 //         .with_tpm_state_persistence()
@@ -170,15 +179,25 @@ async fn boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
     openhcl_uefi_x64[vbs](vhd(windows_datacenter_core_2022_x64)),
     openhcl_uefi_x64[vbs](vhd(ubuntu_2204_server_x64))
 )]
-async fn vbs_boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+async fn vbs_boot_with_tpm(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let os_flavor = config.os_flavor();
-    let mut vm = config.with_tpm().run_without_agent().await?;
+    let config = config.modify_backend(|b| b.with_tpm());
 
-    if matches!(os_flavor, OsFlavor::Linux) {
-        // Workaround to https://github.com/microsoft/openvmm/issues/379
-        assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
-        vm.reset().await?;
-    }
+    let mut vm = match os_flavor {
+        OsFlavor::Windows => config.run_without_agent().await?,
+        OsFlavor::Linux => {
+            let mut vm = config
+                // TODO: we shouldn't need to specify a generic here...
+                .with_vmgs::<VMGS_WITH_BOOT_ENTRY>(petri::PetriVmgsResource::TempDisk)
+                .run_without_agent()
+                .await?;
+            // Workaround to https://github.com/microsoft/openvmm/issues/379
+            assert_eq!(vm.wait_for_halt().await?, HaltReason::Reset);
+            vm.backend().reset().await?;
+            vm
+        }
+        _ => unreachable!(),
+    };
 
     vm.wait_for_successful_boot_event().await?;
     vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
@@ -188,7 +207,7 @@ async fn vbs_boot_with_tpm(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 
 /// Basic VTL 2 pipette functionality test.
 #[openvmm_test(openhcl_linux_direct_x64)]
-async fn vtl2_pipette(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
+async fn vtl2_pipette(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
     let (mut vm, agent) = config.run().await?;
 
     let vtl2_agent = vm.wait_for_vtl2_agent().await?;
@@ -203,7 +222,7 @@ async fn vtl2_pipette(config: PetriVmConfigOpenVmm) -> anyhow::Result<()> {
 
 /// Boot Linux and have it dump MTRR related output.
 #[openvmm_test(linux_direct_x64, openhcl_linux_direct_x64)]
-async fn mtrrs(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn mtrrs(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     let (vm, agent) = config.run().await?;
 
     let sh = agent.unix_shell();
@@ -250,8 +269,8 @@ async fn mtrrs(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     openhcl_linux_direct_x64,
     openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
-async fn vmbus_redirect(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
-    let (mut vm, agent) = config.with_vmbus_redirect().run().await?;
+async fn vmbus_redirect(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
+    let (mut vm, agent) = config.with_vmbus_redirect(true).run().await?;
     vm.wait_for_successful_boot_event().await?;
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
@@ -265,9 +284,11 @@ async fn vmbus_redirect(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Erro
     uefi_x64(vhd(ubuntu_2204_server_x64)),
     uefi_x64(vhd(windows_datacenter_core_2022_x64))
 )]
-async fn battery_capacity(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn battery_capacity(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> Result<(), anyhow::Error> {
     let os_flavor = config.os_flavor();
-    let (mut vm, agent) = config.with_battery().run().await?;
+    let (mut vm, agent) = config.modify_backend(|b| b.with_battery()).run().await?;
     vm.wait_for_successful_boot_event().await?;
 
     let output = match os_flavor {
@@ -304,11 +325,11 @@ async fn battery_capacity(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Er
     Ok(())
 }
 
-fn configure_for_sidecar(
-    config: Box<dyn PetriVmConfig>,
+fn configure_for_sidecar<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
     proc_count: u32,
     node_count: u32,
-) -> Box<dyn PetriVmConfig> {
+) -> PetriVmBuilder<T> {
     config.with_processor_topology({
         ProcessorTopology {
             vp_count: proc_count,
@@ -325,7 +346,9 @@ fn configure_for_sidecar(
 //
 // Sidecar isn't supported on aarch64 yet.
 #[vmm_test(openvmm_openhcl_uefi_x64(none), hyperv_openhcl_uefi_x64(none))]
-async fn sidecar_aps_unused(config: Box<dyn PetriVmConfig>) -> Result<(), anyhow::Error> {
+async fn sidecar_aps_unused<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+) -> Result<(), anyhow::Error> {
     let proc_count = 4;
     let mut vm = configure_for_sidecar(config, proc_count, 1)
         .with_uefi_frontpage(true)
@@ -359,7 +382,7 @@ async fn sidecar_aps_unused(config: Box<dyn PetriVmConfig>) -> Result<(), anyhow
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
     hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
 )]
-async fn sidecar_boot(config: Box<dyn PetriVmConfig>) -> Result<(), anyhow::Error> {
+async fn sidecar_boot<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> Result<(), anyhow::Error> {
     let (vm, agent) = configure_for_sidecar(config, 8, 2).run().await?;
     agent.power_off().await?;
     assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);

--- a/vmm_tests/vmm_tests/tests/tests/x86_64.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64.rs
@@ -8,6 +8,7 @@ mod openhcl_uefi;
 
 use anyhow::Context;
 use petri::ApicMode;
+use petri::PetriGuestStateLifetime;
 use petri::PetriVmBuilder;
 use petri::PetriVmmBackend;
 use petri::ProcessorTopology;
@@ -15,7 +16,6 @@ use petri::ShutdownKind;
 use petri::openvmm::OpenVmmPetriBackend;
 use petri::pipette::cmd;
 use petri_artifacts_common::tags::OsFlavor;
-use petri_artifacts_vmm_test::artifacts::test_vmgs::VMGS_WITH_BOOT_ENTRY;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;
@@ -50,8 +50,7 @@ async fn boot_with_tpm(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::R
         OsFlavor::Windows => config.run().await?,
         OsFlavor::Linux => {
             let mut vm = config
-                // TODO: we shouldn't need to specify a generic here...
-                .with_vmgs::<VMGS_WITH_BOOT_ENTRY>(petri::PetriVmgsResource::TempDisk)
+                .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
                 .run_with_lazy_pipette()
                 .await?;
             // Workaround to https://github.com/microsoft/openvmm/issues/379
@@ -187,8 +186,7 @@ async fn vbs_boot_with_tpm(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyho
         OsFlavor::Windows => config.run_without_agent().await?,
         OsFlavor::Linux => {
             let mut vm = config
-                // TODO: we shouldn't need to specify a generic here...
-                .with_vmgs::<VMGS_WITH_BOOT_ENTRY>(petri::PetriVmgsResource::TempDisk)
+                .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
                 .run_without_agent()
                 .await?;
             // Workaround to https://github.com/microsoft/openvmm/issues/379

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -20,8 +20,9 @@ use mesh::rpc::RpcSend;
 use nvme_resources::NamespaceDefinition;
 use nvme_resources::NvmeControllerHandle;
 use petri::OpenHclServicingFlags;
+use petri::PetriVmBuilder;
 use petri::ResolvedArtifact;
-use petri::openvmm::PetriVmConfigOpenVmm;
+use petri::openvmm::OpenVmmPetriBackend;
 use petri::pipette::PipetteClient;
 use petri::pipette::cmd;
 use petri_artifacts_vmm_test::artifacts::openhcl_igvm::LATEST_LINUX_DIRECT_TEST_X64;
@@ -55,8 +56,12 @@ async fn validate_mana_nic(agent: &PipetteClient) -> Result<(), anyhow::Error> {
 /// Test an OpenHCL Linux direct VM with a MANA nic assigned to VTL2 (backed by
 /// the MANA emulator), and vmbus relay.
 #[openvmm_test(openhcl_linux_direct_x64)]
-async fn mana_nic(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
-    let (vm, agent) = config.with_vmbus_redirect().with_nic().run().await?;
+async fn mana_nic(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
+    let (vm, agent) = config
+        .with_vmbus_redirect(true)
+        .modify_backend(|b| b.with_nic())
+        .run()
+        .await?;
 
     validate_mana_nic(&agent).await?;
 
@@ -70,10 +75,12 @@ async fn mana_nic(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
 /// the MANA emulator), and vmbus relay. Use the shared pool override to test
 /// the shared pool dma path.
 #[openvmm_test(openhcl_linux_direct_x64)]
-async fn mana_nic_shared_pool(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn mana_nic_shared_pool(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
-        .with_vmbus_redirect()
-        .with_nic()
+        .with_vmbus_redirect(true)
+        .modify_backend(|b| b.with_nic())
         .with_openhcl_command_line("OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1")
         .run()
         .await?;
@@ -91,7 +98,7 @@ async fn mana_nic_shared_pool(config: PetriVmConfigOpenVmm) -> Result<(), anyhow
 /// nic is still functional.
 #[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
 async fn mana_nic_servicing(
-    config: PetriVmConfigOpenVmm,
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
     (igvm_file,): (ResolvedArtifact<LATEST_LINUX_DIRECT_TEST_X64>,),
 ) -> Result<(), anyhow::Error> {
     if !host_supports_servicing() {
@@ -100,15 +107,15 @@ async fn mana_nic_servicing(
     }
 
     let (mut vm, agent) = config
-        .with_vmbus_redirect()
-        .with_nic()
+        .with_vmbus_redirect(true)
+        .modify_backend(|b| b.with_nic())
         .with_openhcl_command_line("OPENHCL_ENABLE_SHARED_VISIBILITY_POOL=1")
         .run()
         .await?;
 
     validate_mana_nic(&agent).await?;
 
-    vm.restart_openhcl(&igvm_file.erase(), OpenHclServicingFlags::default())
+    vm.restart_openhcl(igvm_file, OpenHclServicingFlags::default())
         .await?;
 
     validate_mana_nic(&agent).await?;
@@ -151,7 +158,7 @@ fn new_test_vtl2_nvme_device(
 /// Test an OpenHCL Linux direct VM with a SCSI disk assigned to VTL2, and
 /// vmbus relay. This should expose a disk to VTL0 via vmbus.
 #[openvmm_test(openhcl_linux_direct_x64)]
-async fn storvsp(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn storvsp(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     const NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
     let vtl2_lun = 5;
     let vtl0_scsi_lun = 0;
@@ -163,95 +170,100 @@ async fn storvsp(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
     let sector_size = 512;
 
     let (vm, agent) = config
-        .with_vmbus_redirect()
-        .with_custom_config(|c| {
-            c.vmbus_devices.push((
-                DeviceVtl::Vtl2,
-                ScsiControllerHandle {
-                    instance_id: scsi_instance,
-                    max_sub_channel_count: 1,
-                    devices: vec![ScsiDeviceAndPath {
-                        path: ScsiPath {
-                            path: 0,
-                            target: 0,
-                            lun: vtl2_lun as u8,
-                        },
-                        device: SimpleScsiDiskHandle {
-                            disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
-                                len: Some(scsi_disk_sectors * sector_size),
-                            })
+        .with_vmbus_redirect(true)
+        .modify_backend(move |b| {
+            b.with_custom_config(|c| {
+                c.vmbus_devices.push((
+                    DeviceVtl::Vtl2,
+                    ScsiControllerHandle {
+                        instance_id: scsi_instance,
+                        max_sub_channel_count: 1,
+                        devices: vec![ScsiDeviceAndPath {
+                            path: ScsiPath {
+                                path: 0,
+                                target: 0,
+                                lun: vtl2_lun as u8,
+                            },
+                            device: SimpleScsiDiskHandle {
+                                disk: LayeredDiskHandle::single_layer(RamDiskLayerHandle {
+                                    len: Some(scsi_disk_sectors * sector_size),
+                                })
+                                .into_resource(),
+                                read_only: false,
+                                parameters: Default::default(),
+                            }
                             .into_resource(),
-                            read_only: false,
-                            parameters: Default::default(),
-                        }
-                        .into_resource(),
-                    }],
-                    io_queue_depth: None,
-                    requests: None,
-                }
-                .into_resource(),
-            ));
-            c.vpci_devices.push(new_test_vtl2_nvme_device(
-                vtl2_nsid,
-                nvme_disk_sectors * sector_size,
-                NVME_INSTANCE,
-                None,
-            ));
-        })
-        .with_custom_vtl2_settings(|v| {
-            v.dynamic.as_mut().unwrap().storage_controllers.push(
-                vtl2_settings_proto::StorageController {
-                    instance_id: scsi_instance.to_string(),
-                    protocol: vtl2_settings_proto::storage_controller::StorageProtocol::Scsi.into(),
-                    luns: vec![
-                        vtl2_settings_proto::Lun {
-                            location: vtl0_scsi_lun,
-                            device_id: Guid::new_random().to_string(),
-                            vendor_id: "OpenVMM".to_string(),
-                            product_id: "Disk".to_string(),
-                            product_revision_level: "1.0".to_string(),
-                            serial_number: "0".to_string(),
-                            model_number: "1".to_string(),
-                            physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
-                                r#type: vtl2_settings_proto::physical_devices::BackingType::Single
-                                    .into(),
-                                device: Some(vtl2_settings_proto::PhysicalDevice {
-                                    device_type:
-                                        vtl2_settings_proto::physical_device::DeviceType::Vscsi
+                        }],
+                        io_queue_depth: None,
+                        requests: None,
+                    }
+                    .into_resource(),
+                ));
+                c.vpci_devices.push(new_test_vtl2_nvme_device(
+                    vtl2_nsid,
+                    nvme_disk_sectors * sector_size,
+                    NVME_INSTANCE,
+                    None,
+                ));
+            })
+            .with_custom_vtl2_settings(|v| {
+                v.dynamic.as_mut().unwrap().storage_controllers.push(
+                    vtl2_settings_proto::StorageController {
+                        instance_id: scsi_instance.to_string(),
+                        protocol: vtl2_settings_proto::storage_controller::StorageProtocol::Scsi
+                            .into(),
+                        luns: vec![
+                            vtl2_settings_proto::Lun {
+                                location: vtl0_scsi_lun,
+                                device_id: Guid::new_random().to_string(),
+                                vendor_id: "OpenVMM".to_string(),
+                                product_id: "Disk".to_string(),
+                                product_revision_level: "1.0".to_string(),
+                                serial_number: "0".to_string(),
+                                model_number: "1".to_string(),
+                                physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
+                                    r#type:
+                                        vtl2_settings_proto::physical_devices::BackingType::Single
                                             .into(),
-                                    device_path: scsi_instance.to_string(),
-                                    sub_device_path: vtl2_lun,
+                                    device: Some(vtl2_settings_proto::PhysicalDevice {
+                                        device_type:
+                                            vtl2_settings_proto::physical_device::DeviceType::Vscsi
+                                                .into(),
+                                        device_path: scsi_instance.to_string(),
+                                        sub_device_path: vtl2_lun,
+                                    }),
+                                    devices: Vec::new(),
                                 }),
-                                devices: Vec::new(),
-                            }),
-                            ..Default::default()
-                        },
-                        vtl2_settings_proto::Lun {
-                            location: vtl0_nvme_lun,
-                            device_id: Guid::new_random().to_string(),
-                            vendor_id: "OpenVMM".to_string(),
-                            product_id: "Disk".to_string(),
-                            product_revision_level: "1.0".to_string(),
-                            serial_number: "0".to_string(),
-                            model_number: "1".to_string(),
-                            physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
-                                r#type: vtl2_settings_proto::physical_devices::BackingType::Single
-                                    .into(),
-                                device: Some(vtl2_settings_proto::PhysicalDevice {
-                                    device_type:
-                                        vtl2_settings_proto::physical_device::DeviceType::Nvme
+                                ..Default::default()
+                            },
+                            vtl2_settings_proto::Lun {
+                                location: vtl0_nvme_lun,
+                                device_id: Guid::new_random().to_string(),
+                                vendor_id: "OpenVMM".to_string(),
+                                product_id: "Disk".to_string(),
+                                product_revision_level: "1.0".to_string(),
+                                serial_number: "0".to_string(),
+                                model_number: "1".to_string(),
+                                physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
+                                    r#type:
+                                        vtl2_settings_proto::physical_devices::BackingType::Single
                                             .into(),
-                                    device_path: NVME_INSTANCE.to_string(),
-                                    sub_device_path: vtl2_nsid,
+                                    device: Some(vtl2_settings_proto::PhysicalDevice {
+                                        device_type:
+                                            vtl2_settings_proto::physical_device::DeviceType::Nvme
+                                                .into(),
+                                        device_path: NVME_INSTANCE.to_string(),
+                                        sub_device_path: vtl2_nsid,
+                                    }),
+                                    devices: Vec::new(),
                                 }),
-                                devices: Vec::new(),
-                            }),
-                            ..Default::default()
-                        },
-                    ],
-                    io_queue_depth: None,
-                },
-            )
+                                ..Default::default()
+                            },
+                        ],
+                        io_queue_depth: None,
+                    },
+                )
+            })
         })
         .run()
         .await?;
@@ -288,66 +300,66 @@ async fn storvsp(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
 /// relay. This should expose a DVD to VTL0 via vmbus. Start with an empty
 /// drive, then add and remove media.
 #[openvmm_test(openhcl_linux_direct_x64)]
-async fn openhcl_linux_storvsp_dvd(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn openhcl_linux_storvsp_dvd(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> Result<(), anyhow::Error> {
     let vtl2_lun = 5;
     let vtl0_scsi_lun = 0;
     let scsi_instance = Guid::new_random();
 
     let (hot_plug_send, hot_plug_recv) = mesh::channel();
 
-    let mut vtl2_settings = None;
-
     let (mut vm, agent) = config
-        .with_vmbus_redirect()
-        .with_custom_config(|c| {
-            c.vmbus_devices.push((
-                DeviceVtl::Vtl2,
-                ScsiControllerHandle {
-                    instance_id: scsi_instance,
-                    max_sub_channel_count: 1,
-                    devices: vec![ScsiDeviceAndPath {
-                        path: ScsiPath {
-                            path: 0,
-                            target: 0,
-                            lun: vtl2_lun as u8,
-                        },
-                        device: SimpleScsiDvdHandle {
-                            media: None,
-                            requests: Some(hot_plug_recv),
-                        }
-                        .into_resource(),
-                    }],
-                    io_queue_depth: None,
-                    requests: None,
-                }
-                .into_resource(),
-            ));
-        })
-        .with_custom_vtl2_settings(|v| {
-            v.dynamic.as_mut().unwrap().storage_controllers.push(
-                vtl2_settings_proto::StorageController {
-                    instance_id: scsi_instance.to_string(),
-                    protocol: vtl2_settings_proto::storage_controller::StorageProtocol::Scsi.into(),
-                    luns: vec![vtl2_settings_proto::Lun {
-                        location: vtl0_scsi_lun,
-                        device_id: Guid::new_random().to_string(),
-                        vendor_id: "OpenVMM".to_string(),
-                        product_id: "Disk".to_string(),
-                        product_revision_level: "1.0".to_string(),
-                        serial_number: "0".to_string(),
-                        model_number: "1".to_string(),
-                        is_dvd: true,
-                        ..Default::default()
-                    }],
-                    io_queue_depth: None,
-                },
-            );
-            vtl2_settings = Some(v.clone());
+        .with_vmbus_redirect(true)
+        .modify_backend(move |b| {
+            b.with_custom_config(|c| {
+                c.vmbus_devices.push((
+                    DeviceVtl::Vtl2,
+                    ScsiControllerHandle {
+                        instance_id: scsi_instance,
+                        max_sub_channel_count: 1,
+                        devices: vec![ScsiDeviceAndPath {
+                            path: ScsiPath {
+                                path: 0,
+                                target: 0,
+                                lun: vtl2_lun as u8,
+                            },
+                            device: SimpleScsiDvdHandle {
+                                media: None,
+                                requests: Some(hot_plug_recv),
+                            }
+                            .into_resource(),
+                        }],
+                        io_queue_depth: None,
+                        requests: None,
+                    }
+                    .into_resource(),
+                ));
+            })
+            .with_custom_vtl2_settings(|v| {
+                v.dynamic.as_mut().unwrap().storage_controllers.push(
+                    vtl2_settings_proto::StorageController {
+                        instance_id: scsi_instance.to_string(),
+                        protocol: vtl2_settings_proto::storage_controller::StorageProtocol::Scsi
+                            .into(),
+                        luns: vec![vtl2_settings_proto::Lun {
+                            location: vtl0_scsi_lun,
+                            device_id: Guid::new_random().to_string(),
+                            vendor_id: "OpenVMM".to_string(),
+                            product_id: "Disk".to_string(),
+                            product_revision_level: "1.0".to_string(),
+                            serial_number: "0".to_string(),
+                            model_number: "1".to_string(),
+                            is_dvd: true,
+                            ..Default::default()
+                        }],
+                        io_queue_depth: None,
+                    },
+                )
+            })
         })
         .run()
         .await?;
-
-    let mut vtl2_settings = vtl2_settings.unwrap();
 
     let read_drive = || agent.read_file("/dev/sr0");
 
@@ -380,19 +392,19 @@ async fn openhcl_linux_storvsp_dvd(config: PetriVmConfigOpenVmm) -> Result<(), a
         .await
         .context("failed to change media")?;
 
-    // Insert media.
-    vtl2_settings.dynamic.as_mut().unwrap().storage_controllers[0].luns[0].physical_devices =
-        Some(vtl2_settings_proto::PhysicalDevices {
-            r#type: vtl2_settings_proto::physical_devices::BackingType::Single.into(),
-            device: Some(vtl2_settings_proto::PhysicalDevice {
-                device_type: vtl2_settings_proto::physical_device::DeviceType::Vscsi.into(),
-                device_path: scsi_instance.to_string(),
-                sub_device_path: vtl2_lun,
-            }),
-            devices: Vec::new(),
-        });
-
-    vm.modify_vtl2_settings(&vtl2_settings)
+    vm.backend()
+        .modify_vtl2_settings(|v| {
+            v.dynamic.as_mut().unwrap().storage_controllers[0].luns[0].physical_devices =
+                Some(vtl2_settings_proto::PhysicalDevices {
+                    r#type: vtl2_settings_proto::physical_devices::BackingType::Single.into(),
+                    device: Some(vtl2_settings_proto::PhysicalDevice {
+                        device_type: vtl2_settings_proto::physical_device::DeviceType::Vscsi.into(),
+                        device_path: scsi_instance.to_string(),
+                        sub_device_path: vtl2_lun,
+                    }),
+                    devices: Vec::new(),
+                })
+        })
         .await
         .context("failed to modify vtl2 settings")?;
 
@@ -406,8 +418,10 @@ async fn openhcl_linux_storvsp_dvd(config: PetriVmConfigOpenVmm) -> Result<(), a
     );
 
     // Remove media.
-    vtl2_settings.dynamic.as_mut().unwrap().storage_controllers[0].luns[0].physical_devices = None;
-    vm.modify_vtl2_settings(&vtl2_settings)
+    vm.backend()
+        .modify_vtl2_settings(|v| {
+            v.dynamic.as_mut().unwrap().storage_controllers[0].luns[0].physical_devices = None
+        })
         .await
         .context("failed to modify vtl2 settings")?;
 
@@ -428,7 +442,9 @@ async fn openhcl_linux_storvsp_dvd(config: PetriVmConfigOpenVmm) -> Result<(), a
 /// Test an OpenHCL Linux direct VM with a SCSI DVD assigned to VTL2, using NVMe
 /// backing, and vmbus relay. This should expose a DVD to VTL0 via vmbus.
 #[openvmm_test(openhcl_linux_direct_x64)]
-async fn openhcl_linux_storvsp_dvd_nvme(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn openhcl_linux_storvsp_dvd_nvme(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> Result<(), anyhow::Error> {
     const NVME_INSTANCE: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
     let vtl2_nsid = 1;
     let nvme_disk_sectors: u64 = 0x4000;
@@ -450,46 +466,50 @@ async fn openhcl_linux_storvsp_dvd_nvme(config: PetriVmConfigOpenVmm) -> Result<
     backing_file.write_all(&bytes)?;
 
     let (vm, agent) = config
-        .with_vmbus_redirect()
-        .with_custom_config(|c| {
-            c.vpci_devices.extend([new_test_vtl2_nvme_device(
-                vtl2_nsid,
-                disk_len,
-                NVME_INSTANCE,
-                Some(backing_file),
-            )]);
-        })
-        .with_custom_vtl2_settings(|v| {
-            v.dynamic.as_mut().unwrap().storage_controllers.push(
-                vtl2_settings_proto::StorageController {
-                    instance_id: scsi_instance.to_string(),
-                    protocol: vtl2_settings_proto::storage_controller::StorageProtocol::Scsi.into(),
-                    luns: vec![vtl2_settings_proto::Lun {
-                        location: vtl2_lun,
-                        device_id: Guid::new_random().to_string(),
-                        vendor_id: "OpenVMM".to_string(),
-                        product_id: "DVD".to_string(),
-                        product_revision_level: "1.0".to_string(),
-                        serial_number: "0".to_string(),
-                        model_number: "1".to_string(),
-                        is_dvd: true,
-                        physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
-                            r#type: vtl2_settings_proto::physical_devices::BackingType::Single
-                                .into(),
-                            device: Some(vtl2_settings_proto::PhysicalDevice {
-                                device_type: vtl2_settings_proto::physical_device::DeviceType::Nvme
+        .with_vmbus_redirect(true)
+        .modify_backend(move |b| {
+            b.with_custom_config(|c| {
+                c.vpci_devices.extend([new_test_vtl2_nvme_device(
+                    vtl2_nsid,
+                    disk_len,
+                    NVME_INSTANCE,
+                    Some(backing_file),
+                )]);
+            })
+            .with_custom_vtl2_settings(|v| {
+                v.dynamic.as_mut().unwrap().storage_controllers.push(
+                    vtl2_settings_proto::StorageController {
+                        instance_id: scsi_instance.to_string(),
+                        protocol: vtl2_settings_proto::storage_controller::StorageProtocol::Scsi
+                            .into(),
+                        luns: vec![vtl2_settings_proto::Lun {
+                            location: vtl2_lun,
+                            device_id: Guid::new_random().to_string(),
+                            vendor_id: "OpenVMM".to_string(),
+                            product_id: "DVD".to_string(),
+                            product_revision_level: "1.0".to_string(),
+                            serial_number: "0".to_string(),
+                            model_number: "1".to_string(),
+                            is_dvd: true,
+                            physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
+                                r#type: vtl2_settings_proto::physical_devices::BackingType::Single
                                     .into(),
-                                device_path: NVME_INSTANCE.to_string(),
-                                sub_device_path: vtl2_nsid,
+                                device: Some(vtl2_settings_proto::PhysicalDevice {
+                                    device_type:
+                                        vtl2_settings_proto::physical_device::DeviceType::Nvme
+                                            .into(),
+                                    device_path: NVME_INSTANCE.to_string(),
+                                    sub_device_path: vtl2_nsid,
+                                }),
+                                devices: vec![],
                             }),
-                            devices: vec![],
-                        }),
-                        ..Default::default()
-                    }],
-                    io_queue_depth: None,
-                },
-            );
-            vtl2_settings = Some(v.clone());
+                            ..Default::default()
+                        }],
+                        io_queue_depth: None,
+                    },
+                );
+                vtl2_settings = Some(v.clone());
+            })
         })
         .run()
         .await?;
@@ -515,7 +535,9 @@ async fn openhcl_linux_storvsp_dvd_nvme(config: PetriVmConfigOpenVmm) -> Result<
 
 /// Test an OpenHCL Linux Stripe VM with two SCSI disk assigned to VTL2 via NVMe Emulator
 #[openvmm_test(openhcl_linux_direct_x64)]
-async fn openhcl_linux_stripe_storvsp(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn openhcl_linux_stripe_storvsp(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> Result<(), anyhow::Error> {
     const NVME_INSTANCE_1: Guid = guid::guid!("dce4ebad-182f-46c0-8d30-8446c1c62ab3");
     const NVME_INSTANCE_2: Guid = guid::guid!("06a97a09-d5ad-4689-b638-9419d7346a68");
     let vtl0_nvme_lun = 0;
@@ -526,64 +548,67 @@ async fn openhcl_linux_stripe_storvsp(config: PetriVmConfigOpenVmm) -> Result<()
     let scsi_instance = Guid::new_random();
 
     let (vm, agent) = config
-        .with_vmbus_redirect()
-        .with_custom_config(|c| {
-            c.vpci_devices.extend([
-                new_test_vtl2_nvme_device(
-                    vtl2_nsid,
-                    nvme_disk_sectors * sector_size,
-                    NVME_INSTANCE_1,
-                    None,
-                ),
-                new_test_vtl2_nvme_device(
-                    vtl2_nsid,
-                    nvme_disk_sectors * sector_size,
-                    NVME_INSTANCE_2,
-                    None,
-                ),
-            ]);
-        })
-        .with_custom_vtl2_settings(|v| {
-            v.dynamic.as_mut().unwrap().storage_controllers.push(
-                vtl2_settings_proto::StorageController {
-                    instance_id: scsi_instance.to_string(),
-                    protocol: vtl2_settings_proto::storage_controller::StorageProtocol::Scsi.into(),
-                    luns: vec![vtl2_settings_proto::Lun {
-                        location: vtl0_nvme_lun,
-                        device_id: Guid::new_random().to_string(),
-                        vendor_id: "OpenVMM".to_string(),
-                        product_id: "Disk".to_string(),
-                        product_revision_level: "1.0".to_string(),
-                        serial_number: "0".to_string(),
-                        model_number: "1".to_string(),
-                        chunk_size_in_kb: 128,
-                        is_dvd: false,
-                        physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
-                            r#type: vtl2_settings_proto::physical_devices::BackingType::Striped
-                                .into(),
-                            device: None,
-                            devices: vec![
-                                vtl2_settings_proto::PhysicalDevice {
-                                    device_type:
-                                        vtl2_settings_proto::physical_device::DeviceType::Nvme
-                                            .into(),
-                                    device_path: NVME_INSTANCE_1.to_string(),
-                                    sub_device_path: vtl2_nsid,
-                                },
-                                vtl2_settings_proto::PhysicalDevice {
-                                    device_type:
-                                        vtl2_settings_proto::physical_device::DeviceType::Nvme
-                                            .into(),
-                                    device_path: NVME_INSTANCE_2.to_string(),
-                                    sub_device_path: vtl2_nsid,
-                                },
-                            ],
-                        }),
-                        ..Default::default()
-                    }],
-                    io_queue_depth: None,
-                },
-            )
+        .with_vmbus_redirect(true)
+        .modify_backend(move |b| {
+            b.with_custom_config(|c| {
+                c.vpci_devices.extend([
+                    new_test_vtl2_nvme_device(
+                        vtl2_nsid,
+                        nvme_disk_sectors * sector_size,
+                        NVME_INSTANCE_1,
+                        None,
+                    ),
+                    new_test_vtl2_nvme_device(
+                        vtl2_nsid,
+                        nvme_disk_sectors * sector_size,
+                        NVME_INSTANCE_2,
+                        None,
+                    ),
+                ]);
+            })
+            .with_custom_vtl2_settings(|v| {
+                v.dynamic.as_mut().unwrap().storage_controllers.push(
+                    vtl2_settings_proto::StorageController {
+                        instance_id: scsi_instance.to_string(),
+                        protocol: vtl2_settings_proto::storage_controller::StorageProtocol::Scsi
+                            .into(),
+                        luns: vec![vtl2_settings_proto::Lun {
+                            location: vtl0_nvme_lun,
+                            device_id: Guid::new_random().to_string(),
+                            vendor_id: "OpenVMM".to_string(),
+                            product_id: "Disk".to_string(),
+                            product_revision_level: "1.0".to_string(),
+                            serial_number: "0".to_string(),
+                            model_number: "1".to_string(),
+                            chunk_size_in_kb: 128,
+                            is_dvd: false,
+                            physical_devices: Some(vtl2_settings_proto::PhysicalDevices {
+                                r#type: vtl2_settings_proto::physical_devices::BackingType::Striped
+                                    .into(),
+                                device: None,
+                                devices: vec![
+                                    vtl2_settings_proto::PhysicalDevice {
+                                        device_type:
+                                            vtl2_settings_proto::physical_device::DeviceType::Nvme
+                                                .into(),
+                                        device_path: NVME_INSTANCE_1.to_string(),
+                                        sub_device_path: vtl2_nsid,
+                                    },
+                                    vtl2_settings_proto::PhysicalDevice {
+                                        device_type:
+                                            vtl2_settings_proto::physical_device::DeviceType::Nvme
+                                                .into(),
+                                        device_path: NVME_INSTANCE_2.to_string(),
+                                        sub_device_path: vtl2_nsid,
+                                    },
+                                ],
+                            }),
+                            ..Default::default()
+                        }],
+                        io_queue_depth: None,
+                    },
+                )
+            })
         })
         .run()
         .await?;
@@ -611,33 +636,35 @@ async fn openhcl_linux_stripe_storvsp(config: PetriVmConfigOpenVmm) -> Result<()
 /// amount of ram.
 #[openvmm_test(openhcl_linux_direct_x64)]
 async fn openhcl_linux_vtl2_ram_self_allocate(
-    config: PetriVmConfigOpenVmm,
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
 ) -> Result<(), anyhow::Error> {
     let vtl2_ram_size = 1024 * 1024 * 1024; // 1GB
     let vm_ram_size = 6 * 1024 * 1024 * 1024; // 6GB
     let (mut vm, agent) = config
-        .with_custom_config(|cfg| {
-            if let hvlite_defs::config::LoadMode::Igvm {
-                ref mut vtl2_base_address,
-                ..
-            } = cfg.load_mode
-            {
-                *vtl2_base_address = Vtl2BaseAddressType::Vtl2Allocate {
-                    size: Some(vtl2_ram_size),
+        .modify_backend(move |b| {
+            b.with_custom_config(|cfg| {
+                if let hvlite_defs::config::LoadMode::Igvm {
+                    ref mut vtl2_base_address,
+                    ..
+                } = cfg.load_mode
+                {
+                    *vtl2_base_address = Vtl2BaseAddressType::Vtl2Allocate {
+                        size: Some(vtl2_ram_size),
+                    }
+                } else {
+                    panic!("unexpected load mode, must be igvm");
                 }
-            } else {
-                panic!("unexpected load mode, must be igvm");
-            }
 
-            // Disable late map vtl0 memory when vtl2 allocation mode is used.
-            cfg.hypervisor
-                .with_vtl2
-                .as_mut()
-                .unwrap()
-                .late_map_vtl0_memory = None;
+                // Disable late map vtl0 memory when vtl2 allocation mode is used.
+                cfg.hypervisor
+                    .with_vtl2
+                    .as_mut()
+                    .unwrap()
+                    .late_map_vtl0_memory = None;
 
-            // Set overall VM ram.
-            cfg.memory.mem_size = vm_ram_size;
+                // Set overall VM ram.
+                cfg.memory.mem_size = vm_ram_size;
+            })
         })
         .run()
         .await?;

--- a/vmm_tests/vmm_tests/tests/tests/x86_64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64_exclusive.rs
@@ -7,19 +7,22 @@ use hvlite_defs::config::ArchTopologyConfig;
 use hvlite_defs::config::ProcessorTopologyConfig;
 use hvlite_defs::config::X2ApicConfig;
 use hvlite_defs::config::X86TopologyConfig;
-use petri::openvmm::PetriVmConfigOpenVmm;
+use petri::PetriVmBuilder;
+use petri::openvmm::OpenVmmPetriBackend;
 use vmm_core_defs::HaltReason;
 use vmm_test_macros::openvmm_test;
 
 /// Validate we can run with VP index != APIC ID.
 #[openvmm_test(linux_direct_x64)]
-async fn apicid_offset(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn apicid_offset(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
-        .with_custom_config(|c| {
-            let Some(ArchTopologyConfig::X86(arch)) = &mut c.processor_topology.arch else {
-                unreachable!()
-            };
-            arch.apic_id_offset = 16;
+        .modify_backend(|b| {
+            b.with_custom_config(|c| {
+                let Some(ArchTopologyConfig::X86(arch)) = &mut c.processor_topology.arch else {
+                    unreachable!()
+                };
+                arch.apic_id_offset = 16;
+            })
         })
         .run()
         .await?;
@@ -34,18 +37,20 @@ async fn apicid_offset(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error
 
 /// Boot Linux with legacy xapic with 2 VPs and apic_ids of 253 and 254, the maximum.
 #[openvmm_test(linux_direct_x64)]
-async fn legacy_xapic(config: PetriVmConfigOpenVmm) -> Result<(), anyhow::Error> {
+async fn legacy_xapic(config: PetriVmBuilder<OpenVmmPetriBackend>) -> Result<(), anyhow::Error> {
     let (vm, agent) = config
-        .with_custom_config(|c| {
-            c.processor_topology = ProcessorTopologyConfig {
-                proc_count: 2,
-                vps_per_socket: Some(1),
-                enable_smt: None,
-                arch: Some(ArchTopologyConfig::X86(X86TopologyConfig {
-                    x2apic: X2ApicConfig::Unsupported,
-                    apic_id_offset: 253,
-                })),
-            }
+        .modify_backend(|b| {
+            b.with_custom_config(|c| {
+                c.processor_topology = ProcessorTopologyConfig {
+                    proc_count: 2,
+                    vps_per_socket: Some(1),
+                    enable_smt: None,
+                    arch: Some(ArchTopologyConfig::X86(X86TopologyConfig {
+                        x2apic: X2ApicConfig::Unsupported,
+                        apic_id_offset: 253,
+                    })),
+                }
+            })
         })
         .run()
         .await?;


### PR DESCRIPTION
Refactors petri to use generics instead of Box for backends. This should reduce duplicate code going forward and makes it possible to use generics in backend-agnostic configuration functions.