### PR TITLE
netvsp, mana_driver: add instrumentation around parts of mana servicing (#1584)

### DIFF
--- a/vm/devices/net/mana_driver/src/mana.rs
+++ b/vm/devices/net/mana_driver/src/mana.rs
@@ -30,6 +30,7 @@ use pal_async::driver::SpawnDriver;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
 use std::sync::Arc;
+use tracing::Instrument;
 use user_driver::DeviceBacking;
 use user_driver::DmaClient;
 use user_driver::interrupt::DeviceInterrupt;
@@ -77,7 +78,9 @@ impl<T: DeviceBacking> ManaDevice<T> {
         num_vps: u32,
         max_queues_per_vport: u16,
     ) -> anyhow::Result<Self> {
-        let mut gdma = GdmaDriver::new(driver, device, num_vps).await?;
+        let mut gdma = GdmaDriver::new(driver, device, num_vps)
+            .instrument(tracing::info_span!("new_gdma_driver"))
+            .await?;
         gdma.test_eq().await?;
 
         gdma.verify_vf_driver_version().await?;

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -77,6 +77,7 @@ use task_control::InspectTaskMut;
 use task_control::StopTask;
 use task_control::TaskControl;
 use thiserror::Error;
+use tracing::Instrument;
 use vmbus_async::queue;
 use vmbus_async::queue::ExternalDataError;
 use vmbus_async::queue::IncomingPacket;
@@ -3708,7 +3709,11 @@ impl Coordinator {
                 stop.until_stopped(self.stop_workers()).await?;
                 // The queue restart operation is not restartable, so do not
                 // poll on `stop` here.
-                if let Err(err) = self.restart_queues(state).await {
+                if let Err(err) = self
+                    .restart_queues(state)
+                    .instrument(tracing::info_span!("netvsp_restart_queues"))
+                    .await
+                {
                     tracing::error!(
                         error = &err as &dyn std::error::Error,
                         "failed to restart queues"
@@ -4270,6 +4275,7 @@ impl Coordinator {
             c_state
                 .endpoint
                 .get_queues(queue_config, rss.as_ref(), &mut queues)
+                .instrument(tracing::info_span!("netvsp_get_queues"))
                 .await
                 .map_err(WorkerError::Endpoint)?;
 


### PR DESCRIPTION
Currently, it's difficult to ascertain where time is spent on mana during servicing as we don't have instrumentation around some vital parts of servicing. This PR adds some instrumentation to inform us where time is being spent so that we can prioritize keepalive in the right places.

Cherry-pick of #1584