### PR TITLE
underhill_core: use correct uefi template on arm (#1605)

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2005,14 +2005,25 @@ async fn new_underhill_vm(
             use vmm_core::emuplat::hcl_compat_uefi_nvram_storage::VmgsStorageBackendAdapter;
 
             // map the GET's template enum onto the hardcoded secureboot template type
-            // TODO: will need to update this code for underhill on ARM
             let base_vars = match dps.general.secure_boot_template {
                 SecureBootTemplateType::None => CustomVars::default(),
                 SecureBootTemplateType::MicrosoftWindows => {
-                    hyperv_secure_boot_templates::x64::microsoft_windows()
+                    if cfg!(guest_arch = "x86_64") {
+                        hyperv_secure_boot_templates::x64::microsoft_windows()
+                    } else if cfg!(guest_arch = "aarch64") {
+                        hyperv_secure_boot_templates::aarch64::microsoft_windows()
+                    } else {
+                        anyhow::bail!("no secure boot template for current guest_arch")
+                    }
                 }
                 SecureBootTemplateType::MicrosoftUefiCertificateAuthority => {
-                    hyperv_secure_boot_templates::x64::microsoft_uefi_ca()
+                    if cfg!(guest_arch = "x86_64") {
+                        hyperv_secure_boot_templates::x64::microsoft_uefi_ca()
+                    } else if cfg!(guest_arch = "aarch64") {
+                        hyperv_secure_boot_templates::aarch64::microsoft_uefi_ca()
+                    } else {
+                        anyhow::bail!("no secure boot template for current guest_arch")
+                    }
                 }
             };
 


### PR DESCRIPTION
Fix an old TODO to use the correct UEFI template on ARM.