### PR TITLE
firmware_uefi: Flush EfiDiagnostics on Watchdog Timeout and Inspect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,6 +1739,7 @@ dependencies = [
  "open_enum",
  "openssl",
  "pal_async",
+ "parking_lot",
  "test_with_tracing",
  "thiserror 2.0.12",
  "time",

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3466,7 +3466,7 @@ struct WatchdogTimeoutNmi {
 #[cfg(guest_arch = "x86_64")]
 #[async_trait::async_trait]
 impl WatchdogCallback for WatchdogTimeoutNmi {
-    async fn on_timeout(&self) {
+    async fn on_timeout(&mut self) {
         crate::livedump::livedump().await;
 
         // Unlike Hyper-V, we only send the NMI to the BSP.
@@ -3483,7 +3483,7 @@ struct WatchdogTimeoutReset {
 
 #[async_trait::async_trait]
 impl WatchdogCallback for WatchdogTimeoutReset {
-    async fn on_timeout(&self) {
+    async fn on_timeout(&mut self) {
         crate::livedump::livedump().await;
 
         self.halt_vps.halt(HaltReason::Reset)

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -3001,7 +3001,7 @@ struct WatchdogTimeoutNmi {
 #[cfg(guest_arch = "x86_64")]
 #[async_trait::async_trait]
 impl WatchdogCallback for WatchdogTimeoutNmi {
-    async fn on_timeout(&self) {
+    async fn on_timeout(&mut self) {
         // Unlike Hyper-V, we only send the NMI to the BSP.
         self.partition.request_msi(
             Vtl::Vtl0,
@@ -3016,7 +3016,7 @@ struct WatchdogTimeoutReset {
 
 #[async_trait::async_trait]
 impl WatchdogCallback for WatchdogTimeoutReset {
-    async fn on_timeout(&self) {
+    async fn on_timeout(&mut self) {
         self.halt_vps.halt(HaltReason::Reset)
     }
 }

--- a/vm/devices/firmware/firmware_uefi/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/Cargo.toml
@@ -45,6 +45,7 @@ bitfield-struct.workspace = true
 der = { workspace = true, features = ["derive", "alloc", "oid"], optional = true }
 getrandom.workspace = true
 openssl = { optional = true, workspace = true }
+parking_lot.workspace = true
 thiserror.workspace = true
 time = { workspace = true, features = ["local-offset"] }
 tracelimit.workspace = true

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -277,7 +277,7 @@ impl UefiDevice {
     }
 
     fn inspect_extra(&mut self, _resp: &mut inspect::Response<'_>) {
-        self.force_process_diagnostics();
+        self.force_process_diagnostics("inspect");
     }
 }
 

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -142,6 +142,7 @@ pub struct UefiRuntimeDeps<'a> {
 
 /// The Hyper-V UEFI services chipset device.
 #[derive(InspectMut)]
+#[inspect(extra = "UefiDevice::inspect_extra")]
 pub struct UefiDevice {
     // Fixed configuration
     use_mmio: bool,
@@ -273,6 +274,10 @@ impl UefiDevice {
             UefiCommand::PROCESS_EFI_DIAGNOSTICS => self.process_diagnostics(),
             _ => tracelimit::warn_ratelimited!(addr, data, "unknown uefi write"),
         }
+    }
+
+    fn inspect_extra(&mut self, _resp: &mut inspect::Response<'_>) {
+        self.process_diagnostics();
     }
 }
 

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -271,13 +271,13 @@ impl UefiDevice {
                 tracelimit::info_ratelimited!(?addr, data, "set gpa for diagnostics");
                 self.service.diagnostics.lock().set_gpa(data)
             }
-            UefiCommand::PROCESS_EFI_DIAGNOSTICS => self.process_diagnostics(),
+            UefiCommand::PROCESS_EFI_DIAGNOSTICS => self.ratelimited_process_diagnostics(),
             _ => tracelimit::warn_ratelimited!(addr, data, "unknown uefi write"),
         }
     }
 
     fn inspect_extra(&mut self, _resp: &mut inspect::Response<'_>) {
-        self.process_diagnostics();
+        self.force_process_diagnostics();
     }
 }
 

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -293,6 +293,7 @@ impl ChangeDeviceState for UefiDevice {
         self.service.event_log.reset();
         self.service.uefi_watchdog.watchdog.reset();
         self.service.generation_id.reset();
+        self.service.diagnostics.lock().reset();
     }
 }
 

--- a/vm/devices/firmware/firmware_uefi/src/service/diagnostics.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/diagnostics.rs
@@ -448,6 +448,13 @@ impl DiagnosticsServices {
 impl UefiDevice {
     /// Process the diagnostics buffer and log the entries to tracing
     pub(crate) fn process_diagnostics(&mut self) {
+        // Do not proceed if we have already processed before
+        if self.service.diagnostics.lock().did_process {
+            tracelimit::warn_ratelimited!("Already processed diagnostics, skipping");
+            return;
+        }
+        self.service.diagnostics.lock().did_process = true;
+
         match self
             .service
             .diagnostics

--- a/vm/devices/watchdog/watchdog_core/src/platform.rs
+++ b/vm/devices/watchdog/watchdog_core/src/platform.rs
@@ -48,8 +48,7 @@ pub trait WatchdogPlatform: Send {
     /// Callback fired when the timer expires.
     async fn on_timeout(&mut self);
 
-    // Check if the watchdog previously timed-out, clearing the bit in the
-    // process.
+    // Check the vmgs store for boot status and clear it.
     async fn read_and_clear_boot_status(&mut self) -> bool;
 
     /// Add a callback, which executes when the watchdog times out

--- a/vm/devices/watchdog/watchdog_core/src/platform.rs
+++ b/vm/devices/watchdog/watchdog_core/src/platform.rs
@@ -25,7 +25,7 @@ use watchdog_vmgs_format::WatchdogVmgsFormatStoreError;
 #[async_trait::async_trait]
 pub trait WatchdogCallback: Send + Sync {
     /// Called when the watchdog timer expires
-    async fn on_timeout(&self);
+    async fn on_timeout(&mut self);
 }
 
 /// Blanket implementation of [`WatchdogCallback`] for closures.
@@ -37,7 +37,7 @@ impl<F> WatchdogCallback for F
 where
     F: Fn() + Send + Sync,
 {
-    async fn on_timeout(&self) {
+    async fn on_timeout(&mut self) {
         self();
     }
 }
@@ -94,7 +94,7 @@ impl WatchdogPlatform for BaseWatchdogPlatform {
         }
 
         // Invoke all callbacks
-        for callback in &self.callbacks {
+        for callback in &mut self.callbacks {
             callback.on_timeout().await;
         }
     }


### PR DESCRIPTION
Today, we do not issue an NMI when ARM64 VMs encounter a UEFI watchdog timeout. This prevents UEFI from going through the `ReportCrash()` path, failing to issue the signal to process UEFI diagnostics.

This PR solves this by forcing EfiDiagnostics to flush when learning about a watchdog timeout.

Additionally, if you use `uhdiag` to inspect the `UefiDevice`, this will also trigger EfiDiagnostics to flush.

For the watchdog path, here is an example from an OpenHCL build of this with a private UEFI that forces RngDxe to stall for > 2 minutes:
```
[121.383009] watchdog_core: ERROR  Encountered a watchdog timeout name="uefi-watchdog"
[121.566205] underhill_core::livedump: INFO  livedump succeeded
[121.566769] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd3713 phase=PEI_CORE log_message="PcdPeim.efi"
[121.567081] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd37a2 phase=PEI_CORE log_message="ResetSystemPei.efi"
[121.567241] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd37e5 phase=PEI_CORE log_message="RngPei.efi"
[121.567504] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd3824 phase=PEI_CORE log_message="PlatformPei.efi"
[121.567653] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd49de phase=PEI_CORE log_message="PeiCore.efi"
[121.567796] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd4a8b phase=PEI_CORE log_message="PcdPeim.efi"
[121.567938] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd4b10 phase=PEI_CORE log_message="DxeIpl.efi"
[121.568083] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd4ba2 phase=PEI_CORE log_message="MsUiThemePpi.efi"
[121.568229] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd4c69 phase=PEI_CORE log_message="DebugConfigPei.efi"
[121.568371] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd4cec phase=PEI_CORE log_message="CryptoPei.efi"
[121.568627] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd4d90 phase=PEI_CORE log_message="Tcg2Pei.efi"
[121.568775] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdd5025 phase=PEI_CORE log_message="DxeCore.efi"
[121.568920] firmware_uefi::service::diagnostics: ERROR  EFI log entry debug_level=ERROR ticks=0xdd5f9e phase=PEI_CORE log_message="PeiDelayedDispatchOnEndOfPei Count of dispatch cycles is 0"
[121.569063] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde5107 phase=DXE log_message="PcdDxe.efi"
[121.569257] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde55e4 phase=DXE log_message="CpuDxe.efi"
[121.569399] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde6201 phase=DXE log_message="EfiHvDxe.efi"
[121.569587] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde67d6 phase=DXE log_message="Metronome.efi"
[121.569734] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde6ac4 phase=DXE log_message="RuntimeDxe.efi"
[121.569875] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde6eb6 phase=DXE log_message="ResetSystemRuntimeDxe.efi"
[121.570022] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde728b phase=DXE log_message="ReportStatusCodeRouterRuntimeDxe.efi"
[121.570165] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde76d0 phase=DXE log_message="EventLogDxe.efi"
[121.570311] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde7b22 phase=DXE log_message="SynicTimerDxe.efi"
[121.570507] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde8045 phase=DXE log_message="VariableRuntimeDxe.efi"
[121.570660] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xde84e7 phase=DXE log_message="PlatformDeviceStateHelper.efi"
[121.570805] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdea739 phase=DXE log_message="AcpiTableDxe.efi"
[121.570950] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdeaa19 phase=DXE log_message="CapsuleRuntimeDxe.efi"
[121.571090] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdead58 phase=DXE log_message="DevicePathDxe.efi"
[121.571234] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdeb174 phase=DXE log_message="HiiDatabase.efi"
[121.571379] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdeb4d1 phase=DXE log_message="NullMemoryTestDxe.efi"
[121.571654] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xdeb7ad phase=DXE log_message="MonotonicCounterRuntimeDxe.efi"
[121.571797] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xe0948d phase=DXE log_message="SmbiosDxe.efi"
[121.571941] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xe098b6 phase=DXE log_message="EmclDxe.efi"
[121.572087] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xe09c72 phase=DXE log_message="MsvmPcRtc.efi"
[121.572288] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xe4170a phase=DXE log_message="VmbusDxe.efi"
[121.572473] firmware_uefi::service::diagnostics: WARN  EFI log entry debug_level=WARNING ticks=0xe458b5 phase=DXE log_message="VmbusRootIsChannelAllowed: Channel not allowed during boot (525074DC-8985-46E2-8057-A307DC18A502)."
[121.572656] firmware_uefi::service::diagnostics: WARN  EFI log entry debug_level=WARNING ticks=0xe45919 phase=DXE log_message="VmbusRootIsChannelAllowed: Channel not allowed during boot (F8E65716-3CB3-4A06-9A60-1889C5CCCAB5)."
[121.572803] firmware_uefi::service::diagnostics: WARN  EFI log entry debug_level=WARNING ticks=0xe45a04 phase=DXE log_message="VmbusRootIsChannelAllowed: Channel not allowed during boot (3375BAF4-9E15-4B30-B765-67ACB10D607B)."
[121.572949] firmware_uefi::service::diagnostics: WARN  EFI log entry debug_level=WARNING ticks=0xe45a44 phase=DXE log_message="VmbusRootIsChannelAllowed: Channel not allowed during boot (57164F39-9115-4E78-AB55-382F3BD5422D)."
[121.573093] firmware_uefi::service::diagnostics: WARN  EFI log entry debug_level=WARNING ticks=0xe45a82 phase=DXE log_message="VmbusRootIsChannelAllowed: Channel not allowed during boot (A9A0F4E7-5A45-4D96-B827-8A841E8C03E6)."
[121.573238] firmware_uefi::service::diagnostics: WARN  EFI log entry debug_level=WARNING ticks=0xe45ac0 phase=DXE log_message="VmbusRootIsChannelAllowed: Channel not allowed during boot (9527E630-D0AE-497B-ADCE-E80AB0175CAF)."
[121.573384] firmware_uefi::service::diagnostics: WARN  EFI log entry debug_level=WARNING ticks=0xe45afe phase=DXE log_message="VmbusRootIsChannelAllowed: Channel not allowed during boot (35FA2E29-EA23-4236-96AE-3A6EBACBA440)."
[121.573670] firmware_uefi::service::diagnostics: WARN  EFI log entry debug_level=WARNING ticks=0xe45b3c phase=DXE log_message="VmbusRootIsChannelAllowed: Channel not allowed during boot (276AACF4-AC15-426C-98DD-7521AD3F01FE)."
[121.573815] firmware_uefi::service::diagnostics: WARN  EFI log entry debug_level=WARNING ticks=0xe45c37 phase=DXE log_message="VmbusRootIsChannelAllowed: Channel not allowed during boot (CFA8B69E-5B4A-4CC0-B98B-8BA1A1F3F95A)."
[121.573961] firmware_uefi::service::diagnostics: WARN  EFI log entry debug_level=WARNING ticks=0xe45c77 phase=DXE log_message="VmbusRootIsChannelAllowed: Channel not allowed during boot (0E0B6031-5213-4934-818B-38D90CED39DB)."
[121.574104] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xe46037 phase=DXE log_message="WatchdogTimer.efi"
[121.574246] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xe46b10 phase=DXE log_message="DpcDxe.efi"
[121.574389] firmware_uefi::service::diagnostics: INFO  EFI log entry debug_level=LOAD+ERROR ticks=0xe46fce phase=DXE log_message="RngDxe.efi"
[121.574655] firmware_uefi::service::diagnostics: INFO  processed EFI log entries entries_processed=0x2f bytes_read=0x1000
[121.574790] firmware_uefi::service::diagnostics: INFO  Processed EFI Diagnostics successfully on watchdog timeout
```

For the inspect path, the output will be similar but dependent on _when_ the user inspects the UefiDevice.