### PR TITLE
[disk_delay] Moving delay disk dependency in the Cargo.toml file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,6 +1241,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "disk_delay"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "disk_backend",
+ "disk_backend_resources",
+ "inspect",
+ "mesh",
+ "pal_async",
+ "scsi_buffers",
+ "vm_resource",
+ "vmcore",
+]
+
+[[package]]
 name = "disk_file"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
   "vm/loader/igvmfilegen",
   "vm/vmgs/vmgs_lib",
   "vm/vmgs/vmgstool",
+  "vm/devices/storage/disk_delay",  # Used for internal microsoft testing
 ]
 exclude = [
   "xsync",


### PR DESCRIPTION
Needed for internal testing