### PR TITLE
openvmm_entry: Adding delay disk as a cli args option for openvmm disks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5074,6 +5074,7 @@ dependencies = [
  "debug_worker",
  "disk_blob",
  "disk_crypt",
+ "disk_delay",
  "disk_file",
  "disk_layered",
  "disk_prwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,6 +266,7 @@ disk_file = { path = "vm/devices/storage/disk_file" }
 disk_get_vmgs = { path = "vm/devices/storage/disk_get_vmgs" }
 disk_layered = { path = "vm/devices/storage/disk_layered" }
 disk_nvme = { path = "vm/devices/storage/disk_nvme" }
+disk_delay = { path = "vm/devices/storage/disk_delay" }
 disk_prwrap = { path = "vm/devices/storage/disk_prwrap" }
 disk_striped = { path = "vm/devices/storage/disk_striped" }
 disk_vhd1 = { path = "vm/devices/storage/disk_vhd1" }

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -684,6 +684,11 @@ pub enum DiskCliKind {
         key_file: PathBuf,
         disk: Box<DiskCliKind>,
     },
+    // delay:<delay_ms>:<kind>
+    DelayDiskWrapper {
+        delay_ms: u64,
+        disk: Box<DiskCliKind>,
+    },
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq)]

--- a/openvmm/openvmm_resources/Cargo.toml
+++ b/openvmm/openvmm_resources/Cargo.toml
@@ -35,6 +35,7 @@ serial_socket.workspace = true
 # Disks
 disk_blob = { workspace = true, optional = true }
 disk_crypt = { workspace = true, optional = true }
+disk_delay.workspace = true
 disk_file.workspace = true
 disk_layered.workspace = true
 disk_prwrap.workspace = true

--- a/openvmm/openvmm_resources/src/lib.rs
+++ b/openvmm/openvmm_resources/src/lib.rs
@@ -46,6 +46,7 @@ vm_resource::register_static_resolvers! {
     disk_crypt::resolver::DiskCryptResolver,
     disk_file::FileDiskResolver,
     disk_prwrap::DiskWithReservationsResolver,
+    disk_delay::resolver::DelayDiskResolver,
     disk_vhd1::Vhd1Resolver,
     #[cfg(windows)]
     disk_vhdmp::VhdmpDiskResolver,


### PR DESCRIPTION
Adding delay disk as an option for openvmm upon entry. This should make it such that the disk_delay crate is actually being used in the openvmm project (And not just in internal microsoft testing). Fixed #1680