### PR TITLE
nvme_driver: Added the qid field to the pending commands

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -1169,8 +1169,6 @@ pub mod save_restore {
         pub next_cid_high_bits: u16,
         #[mesh(3)]
         pub cid_key_bits: u32,
-        #[mesh(4)]
-        pub qid: u16,
     }
 
     /// NVMe namespace data.

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/driver.rs
@@ -1169,6 +1169,8 @@ pub mod save_restore {
         pub next_cid_high_bits: u16,
         #[mesh(3)]
         pub cid_key_bits: u32,
+        #[mesh(4)]
+        pub qid: u16,
     }
 
     /// NVMe namespace data.

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -246,7 +246,7 @@ impl QueuePair {
                 QueueHandler {
                     sq: SubmissionQueue::new(qid, sq_entries, sq_mem_block),
                     cq: CompletionQueue::new(qid, cq_entries, cq_mem_block),
-                    commands: PendingCommands::new(),
+                    commands: PendingCommands::new(qid),
                     stats: Default::default(),
                     drain_after_restore: false,
                 }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -114,11 +114,9 @@ impl PendingCommands {
         assert_eq!(
             command.command.cdw0.cid(),
             cid,
-            "cid sequence number mismatch: queue_id={}, command_opcode={:#x}, expected_cid={:#x}, actual_cid={:#x}",
+            "cid sequence number mismatch: queue_id={}, command_opcode={:#x}",
             self.qid,
             command.command.cdw0.opcode(),
-            cid,
-            command.command.cdw0.cid()
         );
         command.respond
     }
@@ -137,6 +135,7 @@ impl PendingCommands {
             next_cid_high_bits: self.next_cid_high_bits.0,
             // TODO: Not used today, added for future compatibility.
             cid_key_bits: Self::CID_KEY_BITS,
+            qid: self.qid,
         }
     }
 
@@ -146,6 +145,7 @@ impl PendingCommands {
             commands,
             next_cid_high_bits,
             cid_key_bits: _, // TODO: For future use.
+            qid,
         } = saved_state;
 
         Ok(Self {
@@ -166,6 +166,7 @@ impl PendingCommands {
                 })
                 .collect::<Slab<PendingCommand>>(),
             next_cid_high_bits: Wrapping(*next_cid_high_bits),
+            qid: *qid,
         })
     }
 }

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -135,17 +135,15 @@ impl PendingCommands {
             next_cid_high_bits: self.next_cid_high_bits.0,
             // TODO: Not used today, added for future compatibility.
             cid_key_bits: Self::CID_KEY_BITS,
-            qid: self.qid,
         }
     }
 
     /// Restore pending commands from the saved state.
-    pub fn restore(saved_state: &PendingCommandsSavedState) -> anyhow::Result<Self> {
+    pub fn restore(saved_state: &PendingCommandsSavedState, qid: &u16) -> anyhow::Result<Self> {
         let PendingCommandsSavedState {
             commands,
             next_cid_high_bits,
             cid_key_bits: _, // TODO: For future use.
-            qid,
         } = saved_state;
 
         Ok(Self {
@@ -756,7 +754,7 @@ impl QueueHandler {
         Ok(Self {
             sq: SubmissionQueue::restore(sq_mem_block, sq_state)?,
             cq: CompletionQueue::restore(cq_mem_block, cq_state)?,
-            commands: PendingCommands::restore(pending_cmds)?,
+            commands: PendingCommands::restore(pending_cmds, &sq_state.sqid)?,
             stats: Default::default(),
             // Only drain pending commands for I/O queues.
             // Admin queue is expected to have pending Async Event requests.

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -110,7 +110,7 @@ impl PendingCommands {
         let command = self
             .commands
             .try_remove((cid & Self::CID_KEY_MASK) as usize)
-            .expect("completion for unknown cid");
+            .unwrap_or_else(|| panic!("completion for unknown cid: qid={}, cid={}", self.qid, cid));
         assert_eq!(
             command.command.cdw0.cid(),
             cid,

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -139,7 +139,7 @@ impl PendingCommands {
     }
 
     /// Restore pending commands from the saved state.
-    pub fn restore(saved_state: &PendingCommandsSavedState, qid: &u16) -> anyhow::Result<Self> {
+    pub fn restore(saved_state: &PendingCommandsSavedState, qid: u16) -> anyhow::Result<Self> {
         let PendingCommandsSavedState {
             commands,
             next_cid_high_bits,
@@ -164,7 +164,7 @@ impl PendingCommands {
                 })
                 .collect::<Slab<PendingCommand>>(),
             next_cid_high_bits: Wrapping(*next_cid_high_bits),
-            qid: *qid,
+            qid,
         })
     }
 }
@@ -754,7 +754,7 @@ impl QueueHandler {
         Ok(Self {
             sq: SubmissionQueue::restore(sq_mem_block, sq_state)?,
             cq: CompletionQueue::restore(cq_mem_block, cq_state)?,
-            commands: PendingCommands::restore(pending_cmds, &sq_state.sqid)?,
+            commands: PendingCommands::restore(pending_cmds, sq_state.sqid)?,
             stats: Default::default(),
             // Only drain pending commands for I/O queues.
             // Admin queue is expected to have pending Async Event requests.

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -114,7 +114,7 @@ impl PendingCommands {
         assert_eq!(
             command.command.cdw0.cid(),
             cid,
-            "cid sequence number mismatch: queue_id={}, command_opcode={:#x}",
+            "cid sequence number mismatch: qid={}, command_opcode={:#x}",
             self.qid,
             command.command.cdw0.opcode(),
         );

--- a/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/src/queue_pair.rs
@@ -246,7 +246,7 @@ impl QueuePair {
                 QueueHandler {
                     sq: SubmissionQueue::new(qid, sq_entries, sq_mem_block),
                     cq: CompletionQueue::new(qid, cq_entries, cq_mem_block),
-                    commands: PendingCommands::new(qid),
+                    commands: PendingCommands::new(),
                     stats: Default::default(),
                     drain_after_restore: false,
                 }


### PR DESCRIPTION
Adding the qid field to the assert output during failures (Mismatched completion ids). Fixes: #1685