### PR TITLE
firmware_uefi: EfiDiagnostics switch to polling instead of Arc<Mutex<>>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,7 +1739,6 @@ dependencies = [
  "open_enum",
  "openssl",
  "pal_async",
- "parking_lot",
  "test_with_tracing",
  "thiserror 2.0.12",
  "time",

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2082,6 +2082,7 @@ async fn new_underhill_vm(
                 },
             };
 
+            let (watchdog_send, watchdog_recv) = mesh::channel();
             deps_hyperv_firmware_uefi = Some(dev::HyperVFirmwareUefi {
                 config,
                 logger: Box::new(UnderhillLogger {
@@ -2121,12 +2122,14 @@ async fn new_underhill_vm(
                     #[cfg(guest_arch = "x86_64")]
                     let watchdog_callback = WatchdogTimeoutNmi {
                         partition: partition.clone(),
+                        watchdog_send: Some(watchdog_send),
                     };
 
                     // ARM64 does not have NMI support yet, so halt instead
                     #[cfg(guest_arch = "aarch64")]
                     let watchdog_callback = WatchdogTimeoutReset {
                         halt_vps: halt_vps.clone(),
+                        watchdog_send: Some(watchdog_send),
                     };
 
                     // Add the callback
@@ -2134,6 +2137,7 @@ async fn new_underhill_vm(
 
                     Box::new(underhill_watchdog_platform)
                 },
+                watchdog_recv,
                 vsm_config: Some(Box::new(UnderhillVsmConfig {
                     partition: Arc::downgrade(&partition),
                 })),
@@ -2460,6 +2464,7 @@ async fn new_underhill_vm(
 
                 let trigger_reset = WatchdogTimeoutReset {
                     halt_vps: halt_vps.clone(),
+                    watchdog_send: None,
                 };
 
                 let mut underhill_watchdog_platform =
@@ -3461,6 +3466,7 @@ impl ChipsetDevice for FallbackMmioDevice {
 #[cfg(guest_arch = "x86_64")]
 struct WatchdogTimeoutNmi {
     partition: Arc<UhPartition>,
+    watchdog_send: Option<mesh::Sender<()>>,
 }
 
 #[cfg(guest_arch = "x86_64")]
@@ -3474,11 +3480,16 @@ impl WatchdogCallback for WatchdogTimeoutNmi {
             Vtl::Vtl0,
             MsiRequest::new_x86(virt::irqcon::DeliveryMode::NMI, 0, false, 0, false),
         );
+
+        if let Some(watchdog_send) = self.watchdog_send.take() {
+            watchdog_send.send(());
+        }
     }
 }
 
 struct WatchdogTimeoutReset {
     halt_vps: Arc<Halt>,
+    watchdog_send: Option<mesh::Sender<()>>,
 }
 
 #[async_trait::async_trait]
@@ -3486,6 +3497,10 @@ impl WatchdogCallback for WatchdogTimeoutReset {
     async fn on_timeout(&mut self) {
         crate::livedump::livedump().await;
 
-        self.halt_vps.halt(HaltReason::Reset)
+        self.halt_vps.halt(HaltReason::Reset);
+
+        if let Some(watchdog_notify_send) = self.watchdog_send.take() {
+            watchdog_notify_send.send(());
+        }
     }
 }

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1051,6 +1051,7 @@ impl InitializedVm {
         let mut deps_hyperv_firmware_uefi = None;
         match &cfg.load_mode {
             LoadMode::Uefi { .. } => {
+                let (watchdog_send, watchdog_recv) = mesh::channel();
                 deps_hyperv_firmware_uefi = Some(dev::HyperVFirmwareUefi {
                     config: firmware_uefi::UefiConfig {
                         custom_uefi_vars: cfg.custom_uefi_vars,
@@ -1102,12 +1103,14 @@ impl InitializedVm {
                         #[cfg(guest_arch = "x86_64")]
                         let watchdog_callback = WatchdogTimeoutNmi {
                             partition: partition.clone(),
+                            watchdog_send: Some(watchdog_send),
                         };
 
                         // ARM64 does not have NMI support yet, so halt instead
                         #[cfg(guest_arch = "aarch64")]
                         let watchdog_callback = WatchdogTimeoutReset {
                             halt_vps: halt_vps.clone(),
+                            watchdog_send: Some(watchdog_send),
                         };
 
                         // Add callbacks
@@ -1115,6 +1118,7 @@ impl InitializedVm {
 
                         Box::new(base_watchdog_platform)
                     },
+                    watchdog_recv,
                     vsm_config: None,
                     // TODO: persist SystemTimeClock time across reboots.
                     time_source: Box::new(local_clock::SystemTimeClock::new(
@@ -1335,6 +1339,7 @@ impl InitializedVm {
                     // Create callback to reset on watchdog timeout
                     let watchdog_callback = WatchdogTimeoutReset {
                         halt_vps: halt_vps.clone(),
+                        watchdog_send: None,
                     };
 
                     // Add callbacks
@@ -2996,6 +3001,7 @@ fn add_devices_to_dsdt(
 #[cfg(guest_arch = "x86_64")]
 struct WatchdogTimeoutNmi {
     partition: Arc<dyn HvlitePartition>,
+    watchdog_send: Option<mesh::Sender<()>>,
 }
 
 #[cfg(guest_arch = "x86_64")]
@@ -3007,16 +3013,25 @@ impl WatchdogCallback for WatchdogTimeoutNmi {
             Vtl::Vtl0,
             virt::irqcon::MsiRequest::new_x86(virt::irqcon::DeliveryMode::NMI, 0, false, 0, false),
         );
+
+        if let Some(watchdog_send) = self.watchdog_send.take() {
+            watchdog_send.send(());
+        }
     }
 }
 
 struct WatchdogTimeoutReset {
     halt_vps: Arc<Halt>,
+    watchdog_send: Option<mesh::Sender<()>>,
 }
 
 #[async_trait::async_trait]
 impl WatchdogCallback for WatchdogTimeoutReset {
     async fn on_timeout(&mut self) {
-        self.halt_vps.halt(HaltReason::Reset)
+        self.halt_vps.halt(HaltReason::Reset);
+
+        if let Some(watchdog_send) = self.watchdog_send.take() {
+            watchdog_send.send(());
+        }
     }
 }

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1339,7 +1339,8 @@ impl InitializedVm {
                     // Create callback to reset on watchdog timeout
                     let watchdog_callback = WatchdogTimeoutReset {
                         halt_vps: halt_vps.clone(),
-                        watchdog_send: None,
+                        watchdog_send: None, // This is not the UEFI watchdog, so no need to send
+                                             // watchdog notifications
                     };
 
                     // Add callbacks
@@ -3014,7 +3015,7 @@ impl WatchdogCallback for WatchdogTimeoutNmi {
             virt::irqcon::MsiRequest::new_x86(virt::irqcon::DeliveryMode::NMI, 0, false, 0, false),
         );
 
-        if let Some(watchdog_send) = self.watchdog_send.take() {
+        if let Some(watchdog_send) = &self.watchdog_send {
             watchdog_send.send(());
         }
     }
@@ -3030,7 +3031,7 @@ impl WatchdogCallback for WatchdogTimeoutReset {
     async fn on_timeout(&mut self) {
         self.halt_vps.halt(HaltReason::Reset);
 
-        if let Some(watchdog_send) = self.watchdog_send.take() {
+        if let Some(watchdog_send) = &self.watchdog_send {
             watchdog_send.send(());
         }
     }

--- a/vm/devices/firmware/firmware_uefi/Cargo.toml
+++ b/vm/devices/firmware/firmware_uefi/Cargo.toml
@@ -45,7 +45,6 @@ bitfield-struct.workspace = true
 der = { workspace = true, features = ["derive", "alloc", "oid"], optional = true }
 getrandom.workspace = true
 openssl = { optional = true, workspace = true }
-parking_lot.workspace = true
 thiserror.workspace = true
 time = { workspace = true, features = ["local-offset"] }
 tracelimit.workspace = true

--- a/vm/devices/firmware/firmware_uefi/src/lib.rs
+++ b/vm/devices/firmware/firmware_uefi/src/lib.rs
@@ -316,12 +316,9 @@ impl PollDevice for UefiDevice {
         self.service.generation_id.poll(cx);
 
         // Poll watchdog timeout events
-        match self.watchdog_recv.poll_recv(cx) {
-            Poll::Ready(Ok(())) => {
-                tracing::info!("watchdog timeout received");
-                self.process_diagnostics(true, "watchdog timeout");
-            }
-            _ => { /* Do nothing */ }
+        if let Poll::Ready(Ok(())) = self.watchdog_recv.poll_recv(cx) {
+            tracing::info!("watchdog timeout received");
+            self.process_diagnostics(true, "watchdog timeout");
         }
     }
 }

--- a/vm/devices/firmware/firmware_uefi/src/service/diagnostics.rs
+++ b/vm/devices/firmware/firmware_uefi/src/service/diagnostics.rs
@@ -138,8 +138,6 @@ pub fn handle_efi_diagnostics_log<'a>(log: EfiDiagnosticsLog<'a>) {
 pub enum EntryParseError {
     #[error("Expected: {0:#x}, got: {1:#x}")]
     SignatureMismatch(u32, u32),
-    #[error("Expected non-zero timestamp, got: {0:#x}")]
-    Timestamp(u64),
     #[error("Expected message length < {0:#x}, got: {1:#x}")]
     MessageLength(u16, u16),
     #[error("Failed to read from buffer slice")]

--- a/vm/devices/watchdog/watchdog_core/src/lib.rs
+++ b/vm/devices/watchdog/watchdog_core/src/lib.rs
@@ -193,8 +193,8 @@ impl WatchdogServices {
             }
             Register::Resolution => return Err(WatchdogServiceError::WriteResolution),
             Register::Count => {
-                self.state.count = 10;
-                self.state.configured_count = 10;
+                self.state.count = val;
+                self.state.configured_count = val;
             }
         }
 

--- a/vm/devices/watchdog/watchdog_core/src/lib.rs
+++ b/vm/devices/watchdog/watchdog_core/src/lib.rs
@@ -193,8 +193,8 @@ impl WatchdogServices {
             }
             Register::Resolution => return Err(WatchdogServiceError::WriteResolution),
             Register::Count => {
-                self.state.count = val;
-                self.state.configured_count = val;
+                self.state.count = 10;
+                self.state.configured_count = 10;
             }
         }
 

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -605,6 +605,7 @@ impl<'a> BaseChipsetBuilder<'a> {
             nvram_storage,
             generation_id_recv,
             watchdog_platform,
+            watchdog_recv,
             vsm_config,
             time_source,
         }) = deps_hyperv_firmware_uefi
@@ -628,6 +629,7 @@ impl<'a> BaseChipsetBuilder<'a> {
                         logger,
                         vmtime,
                         watchdog_platform,
+                        watchdog_recv,
                         generation_id_deps: generation_id::GenerationIdRuntimeDeps {
                             generation_id_recv,
                             gm,
@@ -1324,6 +1326,8 @@ pub mod options {
             /// Device-specific functions the platform must provide in order
             /// to use the UEFI watchdog device.
             pub watchdog_platform: Box<dyn watchdog_core::platform::WatchdogPlatform>,
+            /// Channel receiver for watchdog timeout notifications.
+            pub watchdog_recv: mesh::Receiver<()>,
             /// Interface to revoke VSM on `ExitBootServices()` if requested
             /// by the guest.
             pub vsm_config: Option<Box<dyn firmware_uefi::platform::nvram::VsmConfig>>,


### PR DESCRIPTION
This PR aims to take a different approach to flushing EfiDiagnostics on Watchdog timeout. 

- Removes Arc<Mutex<>>, which was originally used to share the diagnostics service between UefiDevice and its WatchdogPlatform
- Creates a mesh::channel before creating the UefiDevice. The watchdog_callback that gets added to the UefiDevice has its `on_timeout` method modified to invoke the sender to send a notification.
- The mesh::receiver end gets sent down the UefiDevice, and it is used in `poll_device()` to freely respond to watchdog events