### PR TITLE
Fix CreateRamGpaRangeFlags to match host definition

### DIFF
--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -1762,10 +1762,12 @@ impl BatteryStatusNotification {
 #[bitfield(u64)]
 #[derive(IntoBytes, FromBytes, Immutable, KnownLayout)]
 pub struct CreateRamGpaRangeFlags {
-    /// writes are discarded
+    _reserved1: bool,
+
+    /// Writes are discarded
     pub rom_mb: bool,
 
-    #[bits(63)]
+    #[bits(62)]
     _reserved: u64,
 }
 


### PR DESCRIPTION
Even though there's only the one flag, it's offset by one bit. This allows these calls to succeed now.