### PR TITLE
Fix TDX TLB flush offload enabled inversion (#1699)

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -1552,7 +1552,7 @@ impl UhProcessor<'_, TdxBacked> {
                 .private_regs
                 .vp_entry_flags
                 .invd_translations()
-                != 0;
+                == 0;
         let x2apic_enabled = self.backing.cvm.lapics[next_vtl].lapic.x2apic_enabled();
 
         let offload_flags = hcl_intr_offload_flags::new()


### PR DESCRIPTION
This code got refactored a dozen times, and at some point this check ended up inverted. Offloading can be enabled when there is no pending TLB flush.

Clean cherry-pick of #1699.