### PR TITLE
Cargo.toml: Remove disk_delay from members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ members = [
   "vm/loader/igvmfilegen",
   "vm/vmgs/vmgs_lib",
   "vm/vmgs/vmgstool",
-  "vm/devices/storage/disk_delay",  # Used for internal microsoft testing
 ]
 exclude = [
   "xsync",


### PR DESCRIPTION
Now that it's been added as a dependency to openvmm it isn't needed in members anymore.