### PR TITLE
openhcl/CVM: disable mnf support

### DIFF
--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1007,8 +1007,8 @@ impl virt::Synic for UhPartition {
     }
 
     fn monitor_support(&self) -> Option<&dyn virt::SynicMonitor> {
-        // TODO: MNF does not work on TDX, tracked by GH issue 1711.
-        if matches!(self.inner.isolation, IsolationType::Tdx) {
+        // TODO: MNF does not work on CVM, tracked by GH issue 1711.
+        if self.inner.isolation.is_hardware_isolated() {
             None
         } else {
             Some(self)

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1009,7 +1009,7 @@ impl virt::Synic for UhPartition {
     fn monitor_support(&self) -> Option<&dyn virt::SynicMonitor> {
         // TODO: MNF does not work on TDX, tracked by GH issue 1711.
         if matches!(self.inner.isolation, IsolationType::Tdx) {
-            return None;
+            None
         } else {
             Some(self)
         }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1007,7 +1007,12 @@ impl virt::Synic for UhPartition {
     }
 
     fn monitor_support(&self) -> Option<&dyn virt::SynicMonitor> {
-        Some(self)
+        // TODO: MNF does not work on TDX, tracked by GH issue 1711.
+        if matches!(self.inner.isolation, IsolationType::Tdx) {
+            return None;
+        } else {
+            Some(self)
+        }
     }
 }
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -441,7 +441,11 @@ async fn vmbus_relay<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::R
 }
 
 /// Openhcl boot test with MNF enabled in vmbus relay.
+///
 /// TODO: Remove the no_agent version below once agents are supported in CVMs.
+///
+/// TODO: validate in this test that MNF actually works by querying guests
+/// properties via the agent.
 #[vmm_test(
     openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
     openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -467,12 +467,15 @@ async fn vmbus_relay_force_mnf<T: PetriVmmBackend>(
     Ok(())
 }
 
-// Test for vmbus relay, with MNF enabled via cmdline.
+// Test for vmbus relay, with MNF enabled via cmdline on TDX.
+//
+// TODO: Shortened test name to make it work on Hyper-V, but it should use the
+// full name once petri is fixed.
 #[vmm_test(
     hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
 )]
 #[cfg_attr(not(windows), expect(dead_code))]
-async fn vmbus_relay_force_mnf_no_agent<T: PetriVmmBackend>(
+async fn vmbr_force_mnf_no_agent<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,
 ) -> anyhow::Result<()> {
     let mut vm = config

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -440,6 +440,48 @@ async fn vmbus_relay<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::R
     Ok(())
 }
 
+/// Openhcl boot test with MNF enabled in vmbus relay.
+/// TODO: Remove the no_agent version below once agents are supported in CVMs.
+#[vmm_test(
+    openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    openvmm_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64)),
+    hyperv_openhcl_uefi_aarch64(vhd(windows_11_enterprise_aarch64)),
+    hyperv_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64)),
+    hyperv_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+    hyperv_openhcl_uefi_x64(vhd(ubuntu_2204_server_x64))
+)]
+async fn vmbus_relay_force_mnf<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+) -> anyhow::Result<()> {
+    let (vm, agent) = config
+        .with_vmbus_redirect(true)
+        .with_openhcl_command_line("OPENHCL_VMBUS_ENABLE_MNF=1")
+        .run()
+        .await?;
+    agent.power_off().await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+    Ok(())
+}
+
+// Test for vmbus relay, with MNF enabled via cmdline.
+#[vmm_test(
+    hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64))
+)]
+#[cfg_attr(not(windows), expect(dead_code))]
+async fn vmbus_relay_force_mnf_no_agent<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+) -> anyhow::Result<()> {
+    let mut vm = config
+        .with_vmbus_redirect(true)
+        .with_openhcl_command_line("OPENHCL_VMBUS_ENABLE_MNF=1")
+        .run_without_agent()
+        .await?;
+    vm.wait_for_successful_boot_event().await?;
+    vm.send_enlightened_shutdown(ShutdownKind::Shutdown).await?;
+    assert_eq!(vm.wait_for_teardown().await?, HaltReason::PowerOff);
+    Ok(())
+}
+
 // Test for vmbus relay
 // TODO: VBS isolation was failing and other targets too
 #[vmm_test(


### PR DESCRIPTION
MNF support does not work on CVM. Disable it for now to unbreak scenarios such as MANA nic relay, while we root cause the actual issue. Tracked by #1711. 

Onboard a test that forces MNF for TDX and other flavors. Note that this test is not complete, as we do need to verify within the guest that MNF is actually present. But at a minimum, we can at least see that toggling this property does not break the guest. Tracked by #1713. 