### PR TITLE
nvme_driver: don't flr nvme devices

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -323,6 +323,7 @@ async fn launch_workers(
         gdbstub: opt.gdbstub,
         hide_isolation: opt.hide_isolation,
         nvme_keep_alive: opt.nvme_keep_alive,
+        nvme_always_flr: opt.nvme_always_flr,
         test_configuration: opt.test_configuration,
         disable_uefi_frontpage: opt.disable_uefi_frontpage,
     };

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -400,7 +400,6 @@ impl NvmeManagerWorker {
                     dma_client,
                 )
                 .await?;
-                //.map_err(InnerError::DeviceInitFailed)?;
 
                 entry.insert(driver)
             }

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -272,7 +272,7 @@ async fn create_nvme_device(
         .await
         {
             Ok(device) => {
-                if !matches!(reset_method, PciDeviceResetMethod::NoReset) {
+                if !nvme_always_flr && !matches!(reset_method, PciDeviceResetMethod::NoReset) {
                     update_reset(PciDeviceResetMethod::NoReset);
                 }
                 return Ok(device);
@@ -408,6 +408,9 @@ impl NvmeManagerWorker {
                     self.nvme_always_flr,
                     self.is_isolated,
                     dma_client,
+                )
+                .instrument(
+                    tracing::info_span!("create_nvme_device", %pci_id, self.nvme_always_flr),
                 )
                 .await?;
 

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -256,12 +256,12 @@ async fn create_nvme_device(
     };
     let mut last_err = None;
     let reset_methods = if nvme_always_flr {
-        vec![PciDeviceResetMethod::Flr]
+        &[PciDeviceResetMethod::Flr][..]
     } else {
-        vec![PciDeviceResetMethod::NoReset, PciDeviceResetMethod::Flr]
+        &[PciDeviceResetMethod::NoReset, PciDeviceResetMethod::Flr][..]
     };
     for reset_method in reset_methods {
-        update_reset(reset_method);
+        update_reset(*reset_method);
         match try_create_nvme_device(
             driver_source,
             pci_id,

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -138,6 +138,11 @@ pub struct Options {
     /// (OPENHCL_NVME_KEEP_ALIVE=1) Enable nvme keep alive when servicing.
     pub nvme_keep_alive: bool,
 
+    /// (OPENHCL_NVME_ALWAYS_FLR=1)
+    /// Always use the FLR (Function Level Reset) path for NVMe devices,
+    /// even if we would otherwise attempt to use VFIO's NoReset support.
+    pub nvme_always_flr: bool,
+
     /// (OPENHCL_TEST_CONFIG=\<TestScenarioConfig\>)
     /// Test configurations are designed to replicate specific behaviors and
     /// conditions in order to simulate various test scenarios.
@@ -233,6 +238,7 @@ impl Options {
         let gdbstub = parse_legacy_env_bool("OPENHCL_GDBSTUB");
         let gdbstub_port = parse_legacy_env_number("OPENHCL_GDBSTUB_PORT")?.map(|x| x as u32);
         let nvme_keep_alive = parse_env_bool("OPENHCL_NVME_KEEP_ALIVE");
+        let nvme_always_flr = parse_env_bool("OPENHCL_NVME_ALWAYS_FLR");
         let test_configuration = parse_env_string("OPENHCL_TEST_CONFIG").and_then(|x| {
             x.to_string_lossy()
                 .parse::<TestScenarioConfig>()
@@ -299,6 +305,7 @@ impl Options {
             halt_on_guest_halt,
             no_sidecar_hotplug,
             nvme_keep_alive,
+            nvme_always_flr,
             test_configuration,
             disable_uefi_frontpage,
         })

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -282,7 +282,7 @@ pub struct UnderhillEnvCfg {
     pub hide_isolation: bool,
     /// Enable nvme keep alive.
     pub nvme_keep_alive: bool,
-    /// The NVMe reset option to use.
+    /// Don't skip FLR for NVMe devices.
     pub nvme_always_flr: bool,
     /// test configuration
     pub test_configuration: Option<TestScenarioConfig>,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -282,6 +282,8 @@ pub struct UnderhillEnvCfg {
     pub hide_isolation: bool,
     /// Enable nvme keep alive.
     pub nvme_keep_alive: bool,
+    /// The NVMe reset option to use.
+    pub nvme_always_flr: bool,
     /// test configuration
     pub test_configuration: Option<TestScenarioConfig>,
     /// Disable the UEFI front page.
@@ -1881,6 +1883,7 @@ async fn new_underhill_vm(
             &driver_source,
             processor_topology.vp_count(),
             save_restore_supported,
+            env_cfg.nvme_always_flr,
             isolation.is_isolated(),
             servicing_state.nvme_state.unwrap_or(None),
             dma_manager.client_spawner(),


### PR DESCRIPTION
The default `vfio` device behavior is to issue a function level reset when attaching or detaching devices. It does so because the device is in an unknown or untrusted state. However, within the context of a trusted virtualization stack, OpenHCL can reasonably trust the state and behavior of the device. So, optimize performance by removing these function level resets for nvme devices. This follows the same model as already exists for MANA devices.

The `nvme_driver` already shuts down the device (see `NvmeDriver::reset()`) and waits for the device to become disabled. A well behaved nvme device will not issue DMA after this point. That same device should tolerate a graceful start without an FLR.

Pending work before this PR is ready to commit:

- [x] Initial poc
- [x] Parameterize via command line (provide a way to disable, and also easily run A/B tests)
- [x] Fix https://github.com/microsoft/openvmm/pull/1714#issuecomment-3085846035
- [x] Check no regressions on CI
- [x] Test servicing locally with real NVMe devices
