### PR TITLE
underhill_crash: Add openhcl_version to underhill crash traces

### DIFF
--- a/openhcl/underhill_crash/src/lib.rs
+++ b/openhcl/underhill_crash/src/lib.rs
@@ -284,11 +284,13 @@ pub fn main() -> ! {
     let os_version = OsVersionInfo::new();
 
     let crate_revision = option_env!("VERGEN_GIT_SHA").unwrap_or("UNKNOWN_REVISION");
+    let openhcl_version = option_env!("OPENHCL_VERSION").unwrap_or("UNKNOWN_VERSION");
 
     let os_version_major = os_version.major();
     let os_version_minor = os_version.minor();
     tracing::error!(
         ?crate_revision,
+        ?openhcl_version,
         ?options.comm,
         ?options.pid,
         ?options.tid,


### PR DESCRIPTION
This PR simply adds the openhcl_version, pulled from the `OPENHCL_VERSION` environment variable, into our crash trace messages