### PR TITLE
hcl_compat_uefi_nvram: remove unnecessary async

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2089,19 +2089,16 @@ async fn new_underhill_vm(
                     get: get_client.clone(),
                 }),
                 nvram_storage: if let Some(vmgs_client) = vmgs_client.as_ref() {
-                    Box::new(
-                        HclCompatNvram::new(
-                            VmgsStorageBackendAdapter(
-                                vmgs_client
-                                    .as_non_volatile_store(vmgs::FileId::BIOS_NVRAM, true)
-                                    .context("failed to instantiate UEFI NVRAM store")?,
-                            ),
-                            Some(HclCompatNvramQuirks {
-                                skip_corrupt_vars_with_missing_null_term: true,
-                            }),
-                        )
-                        .await?,
-                    )
+                    Box::new(HclCompatNvram::new(
+                        VmgsStorageBackendAdapter(
+                            vmgs_client
+                                .as_non_volatile_store(vmgs::FileId::BIOS_NVRAM, true)
+                                .context("failed to instantiate UEFI NVRAM store")?,
+                        ),
+                        Some(HclCompatNvramQuirks {
+                            skip_corrupt_vars_with_missing_null_term: true,
+                        }),
+                    ))
                 } else {
                     Box::new(uefi_nvram_storage::in_memory::InMemoryNvram::new())
                 },

--- a/openvmm/hvlite_core/src/worker/dispatch.rs
+++ b/openvmm/hvlite_core/src/worker/dispatch.rs
@@ -1075,16 +1075,13 @@ impl InitializedVm {
                         use vmm_core::emuplat::hcl_compat_uefi_nvram_storage::VmgsStorageBackendAdapter;
 
                         match vmgs_client {
-                            Some(vmgs) => Box::new(
-                                HclCompatNvram::new(
-                                    VmgsStorageBackendAdapter(
-                                        vmgs.as_non_volatile_store(vmgs::FileId::BIOS_NVRAM, true)
-                                            .context("failed to instantiate UEFI NVRAM store")?,
-                                    ),
-                                    None,
-                                )
-                                .await?,
-                            ),
+                            Some(vmgs) => Box::new(HclCompatNvram::new(
+                                VmgsStorageBackendAdapter(
+                                    vmgs.as_non_volatile_store(vmgs::FileId::BIOS_NVRAM, true)
+                                        .context("failed to instantiate UEFI NVRAM store")?,
+                                ),
+                                None,
+                            )),
                             None => Box::new(InMemoryNvram::new()),
                         }
                     },

--- a/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
+++ b/vm/devices/firmware/hcl_compat_uefi_nvram_storage/src/lib.rs
@@ -121,11 +121,8 @@ pub struct HclCompatNvramQuirks {
 
 impl<S: StorageBackend> HclCompatNvram<S> {
     /// Create a new [`HclCompatNvram`]
-    pub async fn new(
-        storage: S,
-        quirks: Option<HclCompatNvramQuirks>,
-    ) -> Result<Self, NvramStorageError> {
-        let nvram = Self {
+    pub fn new(storage: S, quirks: Option<HclCompatNvramQuirks>) -> Self {
+        Self {
             quirks: quirks.unwrap_or(HclCompatNvramQuirks {
                 skip_corrupt_vars_with_missing_null_term: false,
             }),
@@ -137,8 +134,7 @@ impl<S: StorageBackend> HclCompatNvram<S> {
             nvram_buf: Vec::new(),
 
             loaded: false,
-        };
-        Ok(nvram)
+        }
     }
 
     async fn lazy_load_from_storage(&mut self) -> Result<(), NvramStorageError> {
@@ -418,6 +414,7 @@ impl<S: StorageBackend> NvramStorage for HclCompatNvram<S> {
 
         Ok(())
     }
+
     async fn append_variable(
         &mut self,
         name: &Ucs2LeSlice,
@@ -539,28 +536,28 @@ mod test {
     #[async_test]
     async fn test_single_variable() {
         let mut storage = EphemeralStorageBackend::default();
-        let mut nvram = HclCompatNvram::new(&mut storage, None).await.unwrap();
+        let mut nvram = HclCompatNvram::new(&mut storage, None);
         impl_agnostic_tests::test_single_variable(&mut nvram).await;
     }
 
     #[async_test]
     async fn test_multiple_variable() {
         let mut storage = EphemeralStorageBackend::default();
-        let mut nvram = HclCompatNvram::new(&mut storage, None).await.unwrap();
+        let mut nvram = HclCompatNvram::new(&mut storage, None);
         impl_agnostic_tests::test_multiple_variable(&mut nvram).await;
     }
 
     #[async_test]
     async fn test_next() {
         let mut storage = EphemeralStorageBackend::default();
-        let mut nvram = HclCompatNvram::new(&mut storage, None).await.unwrap();
+        let mut nvram = HclCompatNvram::new(&mut storage, None);
         impl_agnostic_tests::test_next(&mut nvram).await;
     }
 
     #[async_test]
     async fn boundary_conditions() {
         let mut storage = EphemeralStorageBackend::default();
-        let mut nvram = HclCompatNvram::new(&mut storage, None).await.unwrap();
+        let mut nvram = HclCompatNvram::new(&mut storage, None);
 
         let vendor = Guid::new_random();
         let attr = 0x1234;
@@ -648,7 +645,7 @@ mod test {
         let data = vec![0x1, 0x2, 0x3, 0x4, 0x5];
         let timestamp = EFI_TIME::default();
 
-        let mut nvram = HclCompatNvram::new(&mut storage, None).await.unwrap();
+        let mut nvram = HclCompatNvram::new(&mut storage, None);
         nvram
             .set_variable(name1, vendor1, attr, data.clone(), timestamp)
             .await
@@ -665,7 +662,7 @@ mod test {
         drop(nvram);
 
         // reload
-        let mut nvram = HclCompatNvram::new(&mut storage, None).await.unwrap();
+        let mut nvram = HclCompatNvram::new(&mut storage, None);
 
         let (result_attr, result_data, result_timestamp) =
             nvram.get_variable(name1, vendor1).await.unwrap().unwrap();

--- a/vm/vmgs/vmgstool/src/uefi_nvram.rs
+++ b/vm/vmgs/vmgstool/src/uefi_nvram.rs
@@ -343,19 +343,17 @@ async fn vmgs_file_open_nvram(
     let vmgs = vmgs_file_open(file_path, key_path, open_mode).await?;
     let encrypted = vmgs.is_encrypted();
 
-    open_nvram(vmgs, encrypted).await
+    open_nvram(vmgs, encrypted)
 }
 
-async fn open_nvram(
-    vmgs: Vmgs,
-    encrypted: bool,
-) -> Result<HclCompatNvram<VmgsStorageBackend>, Error> {
-    Ok(HclCompatNvram::new(
+fn open_nvram(vmgs: Vmgs, encrypted: bool) -> Result<HclCompatNvram<VmgsStorageBackend>, Error> {
+    let nvram_storage = HclCompatNvram::new(
         VmgsStorageBackend::new(vmgs, vmgs::FileId::BIOS_NVRAM, encrypted)
             .map_err(Error::VmgsStorageBackend)?,
         None,
-    )
-    .await?)
+    );
+
+    Ok(nvram_storage)
 }
 
 /// Delete all boot entries in the BIOS NVRAM VMGS file in an attempt to repair a VM that is failing to boot.


### PR DESCRIPTION
while staging my backport, I realized HclCompatNvram::new no longer needs to be async.