### PR TITLE
vmm_core: slightly more info on how pci device IDs are constructed

### DIFF
--- a/openvmm/hvlite_defs/src/config.rs
+++ b/openvmm/hvlite_defs/src/config.rs
@@ -165,6 +165,8 @@ pub enum Vtl2BaseAddressType {
 #[derive(Debug, MeshPayload)]
 pub struct VpciDeviceConfig {
     pub vtl: DeviceVtl,
+    /// The ID of the device. Vpci devices are identified by a portion of `data2` and `data3` of the
+    /// instance ID, which is used to generate the guest-visible device ID.
     pub instance_id: Guid,
     pub resource: Resource<PciDeviceHandleKind>,
 }

--- a/vmm_core/src/device_builder.rs
+++ b/vmm_core/src/device_builder.rs
@@ -71,7 +71,11 @@ pub async fn build_vpci_device(
             .arc_mutex_device(vpci_bus_name)
             .try_add_async(async |services| {
                 let (msi_controller, interrupt_mapper) =
-                    new_virtual_device(device_id).context("failed to create virtual device")?;
+                    new_virtual_device(device_id).context(format!(
+                        "failed to create virtual device, device_id {device_id} = {} | {}",
+                        instance_id.data2,
+                        instance_id.data3 as u64 & 0xfff8
+                    ))?;
 
                 msi_set.connect(msi_controller.as_ref());
 


### PR DESCRIPTION
Found when debugging a test (I was confused where duplicate ID 0's were coming from).