### PR TITLE
virt_whp/pal: merge whp delayload into pal::delayload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9302,6 +9302,7 @@ name = "whp"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "pal",
  "winapi",
 ]
 

--- a/support/pal/src/windows.rs
+++ b/support/pal/src/windows.rs
@@ -1063,7 +1063,8 @@ macro_rules! delayload {
         }
 
         pub mod is_supported {
-            #![expect(dead_code, non_snake_case)]
+            #![expect(non_snake_case)]
+            #![allow(dead_code)]
             $(
                 $(#[$a])*
                 pub fn $name() -> bool {

--- a/support/pal/src/windows.rs
+++ b/support/pal/src/windows.rs
@@ -994,15 +994,18 @@ unsafe impl Sync for Overlapped {}
 
 #[macro_export]
 macro_rules! delayload {
-    {$dll:literal {$($($idents:ident)+ ($($params:ident : $types:ty),* $(,)?) -> $result:ty;)*}} => {
-        fn get_module() -> Result<::winapi::shared::minwindef::HINSTANCE, u32> {
+    {$dll:literal {
+        $(
+            $(#[$a:meta])*
+            $visibility:vis fn $name:ident($($params:ident : $types:ty),* $(,)?) -> $result:ty;
+        )*
+    }} => {
+        fn get_module() -> Result<::winapi::shared::minwindef::HINSTANCE, ::winapi::shared::minwindef::DWORD> {
             use ::std::ptr::null_mut;
             use ::std::sync::atomic::{AtomicPtr, Ordering};
-            use ::winapi::{
-                um::{
-                    errhandlingapi::GetLastError,
-                    libloaderapi::{FreeLibrary, LoadLibraryA},
-                },
+            use ::winapi::um::{
+                errhandlingapi::GetLastError,
+                libloaderapi::{FreeLibrary, LoadLibraryA},
             };
 
             static MODULE: AtomicPtr<::winapi::shared::minwindef::HINSTANCE__> = AtomicPtr::new(null_mut());
@@ -1020,60 +1023,71 @@ macro_rules! delayload {
             Ok(module)
         }
 
-        $(
-            $crate::delayload! { @func $($idents)* ($($params:$types),*) -> $result }
-        )*
-    };
+        mod funcs {
+            #![expect(non_snake_case)]
+            $(
+                $(#[$a])*
+                pub fn $name() -> Result<usize, ::winapi::shared::minwindef::DWORD> {
+                    use ::std::concat;
+                    use ::std::sync::atomic::{AtomicUsize, Ordering};
+                    use ::winapi::{
+                        shared::winerror::ERROR_PROC_NOT_FOUND,
+                        um::libloaderapi::GetProcAddress,
+                    };
 
-    (@func pub fn $name:ident($($params:ident : $types:ty),* $(,)?) -> $result:ty) => {
-        #[expect(non_snake_case, clippy::too_many_arguments, clippy::diverging_sub_expression)]
-        pub unsafe fn $name($($params: $types,)*) -> $result {
-            $crate::delayload!(@body $name($($params : $types),*) -> $result)
-        }
-    };
-
-    (@func fn $name:ident($($params:ident : $types:ty),* $(,)?) -> $result:ty) => {
-        #[expect(non_snake_case, clippy::diverging_sub_expression)]
-        unsafe fn $name($($params: $types,)*) -> $result {
-            $crate::delayload!(@body $name($($params : $types),*) -> $result)
-        }
-    };
-
-    (@body $name:ident($($params:ident : $types:ty),* $(,)?) -> $result:ty) => {
-        {
-            use ::winapi::{
-                shared::winerror::ERROR_PROC_NOT_FOUND,
-                um::libloaderapi::GetProcAddress,
-            };
-            use ::std::concat;
-            use ::std::sync::atomic::{AtomicUsize, Ordering};
-
-            static FNCELL: AtomicUsize = AtomicUsize::new(0);
-            let mut fnval = FNCELL.load(Ordering::Relaxed);
-            if fnval == 0 {
-                #[allow(unreachable_code)]
-                match get_module() {
-                    Ok(module) => {
-                        fnval = GetProcAddress(
+                    // A FNCELL value 0 denotes that GetProcAddress has never been
+                    // called for the given function.
+                    // A FNCELL value 1 denotes that GetProcAddress has been called
+                    // but the procedure does not exist.
+                    // Any other FNCELL value denotes the result of GetProcAddress,
+                    // the callable adress of the function.
+                    static FNCELL: AtomicUsize = AtomicUsize::new(0);
+                    let mut fnval = FNCELL.load(Ordering::Relaxed);
+                    if fnval == 0 {
+                        let module = super::get_module()?;
+                        fnval = unsafe { GetProcAddress(
                             module,
-                            concat!(stringify!($name), "\0").as_ptr() as *const i8)
+                            concat!(stringify!($name), "\0").as_ptr() as *const i8) }
                         as usize;
+                        if fnval == 0 {
+                            fnval = 1;
+                        }
+                        FNCELL.store(fnval, Ordering::Relaxed);
                     }
-                    Err(e) => return $crate::delayload!(@result_from_win32(($result), e)),
+                    if fnval == 1 {
+                        return Err(ERROR_PROC_NOT_FOUND)
+                    }
+                    Ok(fnval)
                 }
-                if fnval == 0 {
-                    fnval = 1;
-                }
-                FNCELL.store(fnval, Ordering::Relaxed);
-            }
-            if fnval == 1 {
-                #[allow(unreachable_code)]
-                return $crate::delayload!(@result_from_win32(($result), ERROR_PROC_NOT_FOUND));
-            }
-            type FnType = unsafe extern "stdcall" fn($($params: $types,)*) -> $result;
-            let fnptr: FnType = ::std::mem::transmute(fnval);
-            fnptr($($params,)*)
+            )*
         }
+
+        pub mod is_supported {
+            #![expect(dead_code, non_snake_case)]
+            $(
+                $(#[$a])*
+                pub fn $name() -> bool {
+                    super::funcs::$name().is_ok()
+                }
+            )*
+        }
+
+        $(
+            $(#[$a])*
+            #[expect(non_snake_case)]
+            $visibility unsafe fn $name($($params: $types,)*) -> $result {
+                match funcs::$name() {
+                    Ok(fnval) => {
+                        type FnType = unsafe extern "stdcall" fn($($params: $types,)*) -> $result;
+                        let fnptr: FnType = ::std::mem::transmute(fnval);
+                        fnptr($($params,)*)
+                    },
+                    Err(win32) => {
+                        $crate::delayload!(@result_from_win32(($result), win32))
+                    }
+                }
+            }
+        )*
     };
 
     (@result_from_win32((i32), $val:expr)) => { ::winapi::shared::winerror::HRESULT_FROM_WIN32($val) };

--- a/vm/whp/Cargo.toml
+++ b/vm/whp/Cargo.toml
@@ -9,6 +9,9 @@ rust-version.workspace = true
 [features]
 unstable_whp = []
 
+[dependencies]
+pal.workspace = true
+
 [target.'cfg(windows)'.dependencies.winapi]
 workspace = true
 features = [

--- a/vm/whp/src/api.rs
+++ b/vm/whp/src/api.rs
@@ -4,70 +4,9 @@
 use super::abi::*;
 use std::ffi::c_void;
 use winapi::shared::guiddef::GUID;
-use winapi::shared::winerror::ERROR_PROC_NOT_FOUND;
 use winapi::shared::winerror::HRESULT;
-use winapi::shared::winerror::HRESULT_FROM_WIN32;
-use winapi::um::libloaderapi::GetModuleHandleA;
-use winapi::um::libloaderapi::GetProcAddress;
 use winapi::um::winnt::DEVICE_POWER_STATE;
 use winapi::um::winnt::HANDLE;
-
-unsafe fn get_proc(name: &[u8]) -> usize {
-    unsafe {
-        GetProcAddress(
-            GetModuleHandleA(c"winhvplatform.dll".as_ptr().cast()),
-            name.as_ptr().cast(),
-        ) as usize
-    }
-}
-
-macro_rules! delayload {
-    {$(
-        $(#[$a:meta])*
-        pub fn $name:ident($($params:ident : $types:ty),* $(,)?) -> HRESULT;
-    )*} => {
-        mod funcs {
-            #![expect(non_snake_case)]
-            $(
-                $(#[$a])*
-                pub fn $name() -> usize {
-                    use std::sync::atomic::{AtomicUsize, Ordering};
-                    static FNCELL: AtomicUsize = AtomicUsize::new(1);
-                    let mut fnval = FNCELL.load(Ordering::Relaxed);
-                    if fnval == 1 {
-                        fnval = unsafe { super::get_proc(concat!(stringify!($name), "\0").as_bytes()) };
-                        FNCELL.store(fnval, Ordering::Relaxed);
-                    }
-                    fnval
-                }
-            )*
-        }
-        pub mod is_supported {
-            #![expect(dead_code, non_snake_case)]
-            $(
-                $(#[$a])*
-                pub fn $name() -> bool {
-                    super::funcs::$name() != 0
-                }
-            )*
-        }
-        $(
-            $(#[$a])*
-            #[expect(non_snake_case)]
-            pub unsafe fn $name($($params: $types,)*) -> HRESULT {
-                let fnval = funcs::$name();
-                if fnval == 0 {
-                    return HRESULT_FROM_WIN32(ERROR_PROC_NOT_FOUND);
-                }
-                type FnType = unsafe extern "stdcall" fn($($params: $types,)*) -> HRESULT;
-                unsafe {
-                    let fnptr: FnType =  std::mem::transmute(fnval);
-                    fnptr($($params,)*)
-                }
-            }
-        )*
-    }
-}
 
 pub const WHV_E_UNKNOWN_CAPABILITY: HRESULT = 0x80370300u32 as HRESULT;
 pub const WHV_E_INSUFFICIENT_BUFFER: HRESULT = 0x80370301u32 as HRESULT;
@@ -162,7 +101,7 @@ unsafe extern "system" {
 }
 
 // These APIs were added after the first release and so may not be present.
-delayload! {
+pal::delayload!("WinHvPlatform.dll" {
     pub fn WHvResetPartition(partition: WHV_PARTITION_HANDLE) -> HRESULT;
 
     pub fn WHvRegisterPartitionDoorbellEvent(
@@ -446,4 +385,4 @@ delayload! {
     pub fn WHvResumePartitionTime(
         Partition: WHV_PARTITION_HANDLE,
     ) -> HRESULT;
-}
+});

--- a/vm/whp/src/lib.rs
+++ b/vm/whp/src/lib.rs
@@ -5,7 +5,7 @@
 #![cfg(windows)]
 // UNSAFETY: Calling WHP APIs.
 #![expect(unsafe_code)]
-#![expect(clippy::undocumented_unsafe_blocks, clippy::missing_safety_doc)]
+#![expect(clippy::undocumented_unsafe_blocks)]
 
 pub mod abi;
 mod api;


### PR DESCRIPTION
This change addresses bugs in virt_whp's `delayload` macro (it doesn't try to load the module) by merging it with the shared `pal::delayload`.

`pal::delayload` was missing support for `is_supported` checks and per-function `[#cfg(...)]` attributes, both of which WHP was using, so those have been ported over.