### PR TITLE
PCI: Also log the offset on access failures

### DIFF
--- a/vm/devices/pci/pci_bus/src/lib.rs
+++ b/vm/devices/pci/pci_bus/src/lib.rs
@@ -328,6 +328,7 @@ impl GenericPciBus {
         };
         tracelimit::warn_ratelimited!(
             address = %self.state.pio_addr_reg.address(),
+            offset = self.state.pio_addr_reg.register(),
             "pci config space {} operation error: {}",
             operation,
             error
@@ -337,6 +338,7 @@ impl GenericPciBus {
     fn trace_recv_error(&self, e: mesh::RecvError, operation: &'static str) {
         tracelimit::warn_ratelimited!(
             address = %self.state.pio_addr_reg.address(),
+            offset = self.state.pio_addr_reg.register(),
             "pci config space {} operation recv error: {:?}",
             operation,
             e,


### PR DESCRIPTION
Otherwise it's a lot harder to figure out why things are failing.