### PR TITLE
Revert "virt_mshv_vtl: Wire up proper memory protections for the monitor page and enable it (#1541)"

### DIFF
--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -454,7 +454,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
                                 .isolated_memory_protector
                                 .as_ref(),
                             tlb_access: &mut B::tlb_flush_lock_access(
-                                Some(self_index),
+                                self_index,
                                 self.vp.partition,
                                 self.vp.shared,
                             ),
@@ -609,7 +609,7 @@ impl<T, B: HardwareIsolatedBacking> UhHypercallHandler<'_, '_, T, B> {
                             .isolated_memory_protector
                             .as_ref(),
                         tlb_access: &mut B::tlb_flush_lock_access(
-                            Some(self_index),
+                            self_index,
                             self.vp.partition,
                             self.vp.shared,
                         ),
@@ -1576,11 +1576,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             protector: B::cvm_partition_state(self.shared)
                 .isolated_memory_protector
                 .as_ref(),
-            tlb_access: &mut B::tlb_flush_lock_access(
-                Some(self_index),
-                self.partition,
-                self.shared,
-            ),
+            tlb_access: &mut B::tlb_flush_lock_access(self_index, self.partition, self.shared),
             guest_memory: &self.partition.gm[vtl],
         };
         let r = hv.msr_write(msr, value, &mut access);
@@ -1801,7 +1797,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
 
     /// Returns the appropriately backed TLB flush and lock access
     pub(crate) fn tlb_flush_lock_access(&self) -> impl TlbFlushLockAccess + use<'_, B> {
-        B::tlb_flush_lock_access(Some(self.vp_index()), self.partition, self.shared)
+        B::tlb_flush_lock_access(self.vp_index(), self.partition, self.shared)
     }
 
     /// Handle checking for cross-VTL interrupts, preempting VTL 0, and setting

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -300,7 +300,7 @@ enum InterceptMessageType {
 
 /// Per-arch state required to generate an intercept message.
 #[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
-pub(crate) struct InterceptMessageState {
+struct InterceptMessageState {
     instruction_length_and_cr8: u8,
     cpl: u8,
     efer_lma: bool,
@@ -417,7 +417,7 @@ impl InterceptMessageType {
 
 /// Trait for processor backings that have hardware isolation support.
 #[cfg(guest_arch = "x86_64")]
-pub(crate) trait HardwareIsolatedBacking: Backing {
+trait HardwareIsolatedBacking: Backing {
     /// Gets CVM specific VP state.
     fn cvm_state(&self) -> &crate::UhCvmVpState;
     /// Gets CVM specific VP state.
@@ -426,14 +426,8 @@ pub(crate) trait HardwareIsolatedBacking: Backing {
     fn cvm_partition_state(shared: &Self::Shared) -> &crate::UhCvmPartitionState;
     /// Gets a struct that can be used to interact with TLB flushing and
     /// locking.
-    ///
-    /// If a `vp_index` is provided, it will be used to cause the specified VP
-    /// to wait for all TLB locks to be released before returning to a lower VTL.
-    //
-    // FUTURE: This probably shouldn't be optional, but right now MNF doesn't know
-    // what VP it's set from and probably doesn't need it?
     fn tlb_flush_lock_access<'a>(
-        vp_index: Option<VpIndex>,
+        vp_index: VpIndex,
         partition: &'a UhPartitionInner,
         shared: &'a Self::Shared,
     ) -> impl TlbFlushLockAccess + 'a;

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -230,7 +230,7 @@ impl HardwareIsolatedBacking for SnpBacked {
     }
 
     fn tlb_flush_lock_access<'a>(
-        vp_index: Option<VpIndex>,
+        vp_index: VpIndex,
         partition: &'a UhPartitionInner,
         shared: &'a Self::Shared,
     ) -> impl TlbFlushLockAccess + 'a {
@@ -2630,7 +2630,7 @@ impl<T: CpuIo> UhHypercallHandler<'_, '_, T, SnpBacked> {
 }
 
 struct SnpTlbLockFlushAccess<'a> {
-    vp_index: Option<VpIndex>,
+    vp_index: VpIndex,
     partition: &'a UhPartitionInner,
     shared: &'a SnpBackedShared,
 }
@@ -2667,13 +2667,11 @@ impl TlbFlushLockAccess for SnpTlbLockFlushAccess<'_> {
     }
 
     fn set_wait_for_tlb_locks(&mut self, vtl: GuestVtl) {
-        if let Some(vp_index) = self.vp_index {
-            hardware_cvm::tlb_lock::TlbLockAccess {
-                vp_index,
-                cvm_partition: &self.shared.cvm,
-            }
-            .set_wait_for_tlb_locks(vtl);
+        hardware_cvm::tlb_lock::TlbLockAccess {
+            vp_index: self.vp_index,
+            cvm_partition: &self.shared.cvm,
         }
+        .set_wait_for_tlb_locks(vtl);
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -501,7 +501,7 @@ impl HardwareIsolatedBacking for TdxBacked {
     }
 
     fn tlb_flush_lock_access<'a>(
-        vp_index: Option<VpIndex>,
+        vp_index: VpIndex,
         partition: &'a UhPartitionInner,
         shared: &'a Self::Shared,
     ) -> impl TlbFlushLockAccess + 'a {
@@ -4364,7 +4364,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressListEx
 
         // Send flush IPIs to the specified VPs.
         TdxTlbLockFlushAccess {
-            vp_index: Some(self.vp.vp_index()),
+            vp_index: self.vp.vp_index(),
             partition: self.vp.partition,
             shared: self.vp.shared,
         }
@@ -4419,7 +4419,7 @@ impl<T: CpuIo> hv1_hypercall::FlushVirtualAddressSpaceEx
 
         // Send flush IPIs to the specified VPs.
         TdxTlbLockFlushAccess {
-            vp_index: Some(self.vp.vp_index()),
+            vp_index: self.vp.vp_index(),
             partition: self.vp.partition,
             shared: self.vp.shared,
         }
@@ -4494,7 +4494,9 @@ impl TdxTlbLockFlushAccess<'_> {
         std::sync::atomic::fence(Ordering::SeqCst);
         self.partition.hcl.kick_cpus(
             processors.into_iter().filter(|&vp| {
-                self.shared.active_vtl[vp as usize].load(Ordering::Relaxed) == target_vtl as u8
+                vp != self.vp_index.index()
+                    && self.shared.active_vtl[vp as usize].load(Ordering::Relaxed)
+                        == target_vtl as u8
             }),
             true,
             true,
@@ -4503,7 +4505,7 @@ impl TdxTlbLockFlushAccess<'_> {
 }
 
 struct TdxTlbLockFlushAccess<'a> {
-    vp_index: Option<VpIndex>,
+    vp_index: VpIndex,
     partition: &'a UhPartitionInner,
     shared: &'a TdxBackedShared,
 }
@@ -4531,13 +4533,11 @@ impl TlbFlushLockAccess for TdxTlbLockFlushAccess<'_> {
     }
 
     fn set_wait_for_tlb_locks(&mut self, vtl: GuestVtl) {
-        if let Some(vp_index) = self.vp_index {
-            hardware_cvm::tlb_lock::TlbLockAccess {
-                vp_index,
-                cvm_partition: &self.shared.cvm,
-            }
-            .set_wait_for_tlb_locks(vtl);
+        hardware_cvm::tlb_lock::TlbLockAccess {
+            vp_index: self.vp_index,
+            cvm_partition: &self.shared.cvm,
         }
+        .set_wait_for_tlb_locks(vtl);
     }
 }
 

--- a/vm/vmcore/src/monitor.rs
+++ b/vm/vmcore/src/monitor.rs
@@ -100,7 +100,7 @@ impl MonitorPage {
 
     /// Sets the GPA of the monitor page currently in use.
     pub fn set_gpa(&self, gpa: Option<u64>) -> Option<u64> {
-        assert!(gpa.is_none() || gpa.unwrap() % HV_PAGE_SIZE == 0);
+        assert!(gpa.is_none_or(|gpa| gpa % HV_PAGE_SIZE == 0));
         let old = self
             .gpa
             .swap(gpa.unwrap_or(INVALID_MONITOR_GPA), Ordering::Relaxed);

--- a/vm/vmcore/src/monitor.rs
+++ b/vm/vmcore/src/monitor.rs
@@ -100,7 +100,7 @@ impl MonitorPage {
 
     /// Sets the GPA of the monitor page currently in use.
     pub fn set_gpa(&self, gpa: Option<u64>) -> Option<u64> {
-        assert!(gpa.is_none_or(|gpa| gpa % HV_PAGE_SIZE == 0));
+        assert!(gpa.is_none() || gpa.unwrap() % HV_PAGE_SIZE == 0);
         let old = self
             .gpa
             .swap(gpa.unwrap_or(INVALID_MONITOR_GPA), Ordering::Relaxed);


### PR DESCRIPTION
We've discovered that the current design for monitor pages on CVMs is incompatible with OpenHCL as it relies on assigning to a shared page, which we can't support. Remove all the code added for this, as it adds complexity and is no longer needed. Vmbus will be going down a different path in the future.