### PR TITLE
netvsp: fix race between VF device arrival and switch data path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4481,6 +4481,7 @@ dependencies = [
  "event-listener",
  "futures",
  "futures-concurrency",
+ "getrandom 0.3.2",
  "guestmem",
  "guid",
  "hvdef",

--- a/vm/devices/net/netvsp/Cargo.toml
+++ b/vm/devices/net/netvsp/Cargo.toml
@@ -46,5 +46,8 @@ hvdef.workspace = true
 event-listener.workspace = true
 test_with_tracing.workspace = true
 
+getrandom.workspace = true
+
+
 [lints]
 workspace = true


### PR DESCRIPTION
Adding a VF to the guest should block and only restart the primary worker if it is not waiting for an action

Port of #1615 