### PR TITLE
CI: Bump up vmm test runtime

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -40,7 +40,8 @@ filter = 'package(~vmm_tests)'
 # Allow VMM tests longer timeouts.
 # Important Note: Petri's watchdogs need to know this value too.
 # If you change it here then change it there!
-slow-timeout = { period = "3m", terminate-after = 2 }
+# Look for TIMEOUT_DURATION_MINUTES.
+slow-timeout = { period = "4m", terminate-after = 2 }
 
 # TEMP (hopefully): For reasons that continue to befuddle, running Windows
 # release-mode unit tests in flowey CI is resulting in seemingly-random

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -233,7 +233,7 @@ impl PetriVmConfigOpenVmm {
     ) -> anyhow::Result<Vec<Task<()>>> {
         // Our CI environment will kill tests after some time. We want to save
         // some information about the VM if it's still running at that point.
-        const TIMEOUT_DURATION_MINUTES: u64 = 6;
+        const TIMEOUT_DURATION_MINUTES: u64 = 8;
         const TIMER_DURATION: Duration = Duration::from_secs(TIMEOUT_DURATION_MINUTES * 60 - 10);
 
         let mut tasks = Vec::new();


### PR DESCRIPTION
Contrary to what I thought in #1741, much of our current test flakiness is being caused by Windows Server 2025 tests rebooting on first boot, not resource contention. This causes these tests to take significantly longer before they reach a 'completed' state. Bump our timeouts up to accommodate. We could explore having different timeouts based on what's being tested, or where, but that'd be complex state that'd need to stay in sync with petri. This is simpler, if a little unfortunate when tests actually do time out.