### PR TITLE
nvme_driver: don't flr nvme devices (#1714)

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -324,6 +324,7 @@ async fn launch_workers(
         halt_on_guest_halt: opt.halt_on_guest_halt,
         no_sidecar_hotplug: opt.no_sidecar_hotplug,
         gdbstub: opt.gdbstub,
+        nvme_always_flr: opt.nvme_always_flr,
         test_configuration: opt.test_configuration,
     };
 

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -165,6 +165,7 @@ struct NvmeManagerWorker {
     #[inspect(iter_by_key)]
     devices: HashMap<String, nvme_driver::NvmeDriver<VfioDevice>>,
     nvme_always_flr: bool,
+    // TODO: Revisit this Box<fn> into maybe a trait, once we refactor DMA to a
     // central manager.
     #[inspect(skip)]
     dma_buffer_spawner: Box<dyn Fn(String) -> anyhow::Result<Arc<dyn VfioDmaBuffer>> + Send>,

--- a/openhcl/underhill_core/src/nvme_manager.rs
+++ b/openhcl/underhill_core/src/nvme_manager.rs
@@ -22,6 +22,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::Instrument;
+use user_driver::vfio::vfio_set_device_reset_method;
+use user_driver::vfio::PciDeviceResetMethod;
 use user_driver::vfio::VfioDevice;
 use user_driver::vfio::VfioDmaBuffer;
 use vm_resource::kind::DiskHandleKind;
@@ -84,6 +86,7 @@ impl NvmeManager {
     pub fn new(
         driver_source: &VmTaskDriverSource,
         vp_count: u32,
+        nvme_always_flr: bool,
         dma_buffer_spawner: Box<dyn Fn(String) -> anyhow::Result<Arc<dyn VfioDmaBuffer>> + Send>,
     ) -> Self {
         let (send, recv) = mesh::channel();
@@ -93,6 +96,7 @@ impl NvmeManager {
             devices: HashMap::new(),
             vp_count,
             dma_buffer_spawner,
+            nvme_always_flr,
         };
         let task = driver.spawn("nvme-manager", async move { worker.run(recv).await });
         Self {
@@ -160,11 +164,84 @@ struct NvmeManagerWorker {
     driver_source: VmTaskDriverSource,
     #[inspect(iter_by_key)]
     devices: HashMap<String, nvme_driver::NvmeDriver<VfioDevice>>,
-    // TODO: Revisit this Box<fn> into maybe a trait, once we refactor DMA to a
+    nvme_always_flr: bool,
     // central manager.
     #[inspect(skip)]
     dma_buffer_spawner: Box<dyn Fn(String) -> anyhow::Result<Arc<dyn VfioDmaBuffer>> + Send>,
     vp_count: u32,
+}
+
+async fn create_nvme_device(
+    driver_source: &VmTaskDriverSource,
+    pci_id: &str,
+    vp_count: u32,
+    nvme_always_flr: bool,
+    dma_buffer: Arc<dyn VfioDmaBuffer>,
+) -> Result<nvme_driver::NvmeDriver<VfioDevice>, InnerError> {
+    // Disable FLR on vfio attach/detach; this allows faster system
+    // startup/shutdown with the caveat that the device needs to be properly
+    // sent through the shutdown path during servicing operations, as that is
+    // the only cleanup performed. If the device fails to initialize, turn FLR
+    // on and try again, so that the reset is invoked on the next attach.
+    let update_reset = |method: PciDeviceResetMethod| {
+        if let Err(err) = vfio_set_device_reset_method(pci_id, method) {
+            tracing::warn!(
+                ?method,
+                err = &err as &dyn std::error::Error,
+                "Failed to update reset_method"
+            );
+        }
+    };
+    let mut last_err = None;
+    let reset_methods = if nvme_always_flr {
+        &[PciDeviceResetMethod::Flr][..]
+    } else {
+        // If this code can't create a device without resetting it, then still try to issue an FLR
+        // in case that unwedges something weird in the device state.
+        // (This is implicit when the code in [`try_create_nvme_device`] opens a handle to the
+        // Vfio device).
+        &[PciDeviceResetMethod::NoReset, PciDeviceResetMethod::Flr][..]
+    };
+    for reset_method in reset_methods {
+        update_reset(*reset_method);
+        match try_create_nvme_device(driver_source, pci_id, vp_count, dma_buffer.clone()).await {
+            Ok(device) => {
+                if !nvme_always_flr && !matches!(reset_method, PciDeviceResetMethod::NoReset) {
+                    update_reset(PciDeviceResetMethod::NoReset);
+                }
+                return Ok(device);
+            }
+            Err(err) => {
+                tracing::error!(
+                    pci_id,
+                    ?reset_method,
+                    err = &err as &dyn std::error::Error,
+                    "failed to create nvme device"
+                );
+                last_err = Some(err);
+            }
+        }
+    }
+    // Return the most reliable error (this code assumes that the reset methods are in increasing order
+    // of reliability).
+    Err(last_err.unwrap())
+}
+
+async fn try_create_nvme_device(
+    driver_source: &VmTaskDriverSource,
+    pci_id: &str,
+    vp_count: u32,
+    dma_buffer: Arc<dyn VfioDmaBuffer>,
+) -> Result<nvme_driver::NvmeDriver<VfioDevice>, InnerError> {
+    let device = VfioDevice::new(driver_source, pci_id, dma_buffer.clone())
+        .instrument(tracing::info_span!("vfio_device_open", pci_id))
+        .await
+        .map_err(InnerError::Vfio)?;
+
+    nvme_driver::NvmeDriver::new(driver_source, vp_count, device)
+        .instrument(tracing::info_span!("nvme_driver_init", pci_id))
+        .await
+        .map_err(InnerError::DeviceInitFailed)
 }
 
 impl NvmeManagerWorker {
@@ -229,24 +306,20 @@ impl NvmeManagerWorker {
         let driver = match self.devices.entry(pci_id.to_owned()) {
             hash_map::Entry::Occupied(entry) => entry.into_mut(),
             hash_map::Entry::Vacant(entry) => {
-                let device = VfioDevice::new(
-                    &self.driver_source,
-                    entry.key(),
-                    (self.dma_buffer_spawner)(format!("nvme_{}", entry.key()))
-                        .map_err(InnerError::DmaBuffer)?,
-                )
-                .instrument(tracing::info_span!("vfio_device_open", pci_id))
-                .await
-                .map_err(InnerError::Vfio)?;
+                let dma_buffer = (self.dma_buffer_spawner)(format!("nvme_{}", pci_id))
+                    .map_err(InnerError::DmaBuffer)?;
 
-                let driver =
-                    nvme_driver::NvmeDriver::new(&self.driver_source, self.vp_count, device)
-                        .instrument(tracing::info_span!(
-                            "nvme_driver_init",
-                            pci_id = entry.key()
-                        ))
-                        .await
-                        .map_err(InnerError::DeviceInitFailed)?;
+                let driver = create_nvme_device(
+                    &self.driver_source,
+                    &pci_id,
+                    self.vp_count,
+                    self.nvme_always_flr,
+                    dma_buffer,
+                )
+                .instrument(
+                    tracing::info_span!("create_nvme_device", %pci_id, self.nvme_always_flr),
+                )
+                .await?;
 
                 entry.insert(driver)
             }

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -131,6 +131,11 @@ pub struct Options {
     /// hit exits.
     pub no_sidecar_hotplug: bool,
 
+    /// (OPENHCL_NVME_ALWAYS_FLR=1)
+    /// Always use the FLR (Function Level Reset) path for NVMe devices,
+    /// even if we would otherwise attempt to use VFIO's NoReset support.
+    pub nvme_always_flr: bool,
+
     /// (OPENHCL_TEST_CONFIG=\<TestScenarioConfig\>)
     /// Test configurations are designed to replicate specific behaviors and
     /// conditions in order to simulate various test scenarios.
@@ -206,6 +211,7 @@ impl Options {
         let no_sidecar_hotplug = parse_legacy_env_bool("OPENHCL_NO_SIDECAR_HOTPLUG");
         let gdbstub = parse_legacy_env_bool("OPENHCL_GDBSTUB");
         let gdbstub_port = parse_legacy_env_number("OPENHCL_GDBSTUB_PORT")?.map(|x| x as u32);
+        let nvme_always_flr = parse_env_bool("OPENHCL_NVME_ALWAYS_FLR");
         let test_configuration = parse_env_string("OPENHCL_TEST_CONFIG").and_then(|x| {
             x.to_string_lossy()
                 .parse::<TestScenarioConfig>()
@@ -269,6 +275,7 @@ impl Options {
             cvm_guest_vsm,
             halt_on_guest_halt,
             no_sidecar_hotplug,
+            nvme_always_flr,
             test_configuration,
         })
     }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -301,6 +301,8 @@ pub struct UnderhillEnvCfg {
     pub no_sidecar_hotplug: bool,
     /// Enables the GDB stub for debugging the guest.
     pub gdbstub: bool,
+    /// Don't skip FLR for NVMe devices.
+    pub nvme_always_flr: bool,
     /// test configuration
     pub test_configuration: Option<TestScenarioConfig>,
 }
@@ -1848,6 +1850,7 @@ async fn new_underhill_vm(
         let manager = NvmeManager::new(
             &driver_source,
             processor_topology.vp_count(),
+            env_cfg.nvme_always_flr,
             vfio_dma_buffer_spawner,
         );
 


### PR DESCRIPTION
The default `vfio` device behavior is to issue a function level reset when attaching or detaching devices. It does so because the device is in an unknown or untrusted state. However, within the context of a trusted virtualization stack, OpenHCL can reasonably trust the state and behavior of the device. So, optimize performance by removing these function level resets for nvme devices. This follows the same model as already exists for MANA devices.

The `nvme_driver` already shuts down the device (see `NvmeDriver::reset()`) and waits for the device to become disabled. A well behaved nvme device will not issue DMA after this point. That same device should tolerate a graceful start without an FLR.

Pending work before this PR is ready to commit:

- [x] Initial poc
- [x] Parameterize via command line (provide a way to disable, and also easily run A/B tests)
- [x] Fix https://github.com/microsoft/openvmm/pull/1714#issuecomment-3085846035
- [x] Check no regressions on CI
- [x] Test servicing locally with real NVMe devices