### PR TITLE
openhcl_boot: refactor address space management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4877,6 +4877,7 @@ dependencies = [
  "sha2",
  "sidecar_defs",
  "tdcall",
+ "thiserror 2.0.12",
  "underhill_confidentiality",
  "x86defs",
  "zerocopy 0.8.24",

--- a/openhcl/openhcl_boot/Cargo.toml
+++ b/openhcl/openhcl_boot/Cargo.toml
@@ -26,7 +26,9 @@ crc32fast.workspace = true
 # exception handler. Using the force-soft feature flag enables a software
 # implementation of the hashing algorithms that does not use cpuid.
 sha2 = { workspace = true, features = ["force-soft"] }
+thiserror.workspace = true
 zerocopy.workspace = true
+
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 safe_intrinsics.workspace = true
 tdcall.workspace = true

--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -159,7 +159,6 @@ fn write_vmbus<'a, T>(
 pub fn write_dt(
     buffer: &mut [u8],
     partition_info: &PartitionInfo,
-    reserved_memory: &[(MemoryRange, ReservedMemoryType)],
     accepted_ranges: impl IntoIterator<Item = MemoryRange>,
     initrd: Range<u64>,
     cmdline: &ArrayString<COMMAND_LINE_SIZE>,

--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -4,11 +4,11 @@
 //! Module used to write the device tree used by the OpenHCL kernel and
 //! usermode.
 
-use crate::MAX_RESERVED_MEM_RANGES;
-use crate::ReservedMemoryType;
 use crate::host_params::COMMAND_LINE_SIZE;
 use crate::host_params::PartitionInfo;
 use crate::host_params::shim_params::IsolationType;
+use crate::memory::AddressSpaceManager;
+use crate::memory::MAX_RESERVED_MEM_RANGES;
 use crate::sidecar::SidecarConfig;
 use crate::single_threaded::off_stack;
 use arrayvec::ArrayString;
@@ -159,6 +159,7 @@ fn write_vmbus<'a, T>(
 pub fn write_dt(
     buffer: &mut [u8],
     partition_info: &PartitionInfo,
+    address_space: &AddressSpaceManager,
     accepted_ranges: impl IntoIterator<Item = MemoryRange>,
     initrd: Range<u64>,
     cmdline: &ArrayString<COMMAND_LINE_SIZE>,
@@ -176,9 +177,11 @@ pub fn write_dt(
     let mut memory_reservations =
         off_stack!(ArrayVec<fdt::ReserveEntry, MAX_RESERVED_MEM_RANGES>, ArrayVec::new_const());
 
-    memory_reservations.extend(reserved_memory.iter().map(|(r, _)| fdt::ReserveEntry {
-        address: r.start().into(),
-        size: r.len().into(),
+    memory_reservations.extend(address_space.reserved_vtl2_ranges().map(|(r, _)| {
+        fdt::ReserveEntry {
+            address: r.start().into(),
+            size: r.len().into(),
+        }
     }));
 
     // Build the actual device tree.
@@ -542,53 +545,7 @@ pub fn write_dt(
         openhcl_builder = openhcl_builder.add_u64(p_vtl0_alias_map, data)?;
     }
 
-    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-    struct Vtl2MemoryEntry {
-        range: MemoryRange,
-        memory_type: MemoryVtlType,
-    }
-
-    // First, construct the unified VTL2 memory map.
-    let mut vtl2_memory_map = off_stack!(ArrayVec::<Vtl2MemoryEntry, 512>, ArrayVec::new_const());
-    for (range, result) in walk_ranges(
-        partition_info
-            .vtl2_ram
-            .iter()
-            .map(|r| (r.range, MemoryVtlType::VTL2_RAM)),
-        reserved_memory.iter().map(|&(r, typ)| {
-            (
-                r,
-                match typ {
-                    ReservedMemoryType::Vtl2Config => MemoryVtlType::VTL2_CONFIG,
-                    ReservedMemoryType::SidecarImage => MemoryVtlType::VTL2_SIDECAR_IMAGE,
-                    ReservedMemoryType::SidecarNode => MemoryVtlType::VTL2_SIDECAR_NODE,
-                    ReservedMemoryType::Vtl2Reserved => MemoryVtlType::VTL2_RESERVED,
-                    ReservedMemoryType::Vtl2GpaPool => MemoryVtlType::VTL2_GPA_POOL,
-                },
-            )
-        }),
-    ) {
-        match result {
-            RangeWalkResult::Left(typ) | RangeWalkResult::Both(_, typ) => {
-                // This range is for VTL2. If only in Left, it's ram, but if in
-                // Both, it's the reserve type indicated in right.
-                vtl2_memory_map.push(Vtl2MemoryEntry {
-                    range,
-                    memory_type: typ,
-                });
-            }
-            RangeWalkResult::Right(typ) => {
-                panic!(
-                    "reserved vtl2 range {:?} with type {:?} not contained in vtl2 ram",
-                    range, typ
-                );
-            }
-            // Ignore ranges not in both.
-            RangeWalkResult::Neither => {}
-        }
-    }
-
-    // Now, report the unified memory map to usermode describing which memory is
+    // Report the unified memory map to usermode describing which memory is
     // used by what.
     //
     // NOTE: Use a different device type for memory ranges, as the Linux kernel
@@ -597,7 +554,7 @@ pub fn write_dt(
     let memory_openhcl_type = "memory-openhcl";
     for (range, result) in walk_ranges(
         partition_info.partition_ram.iter().map(|r| (r.range, r)),
-        vtl2_memory_map.iter().map(|r| (r.range, r)),
+        address_space.vtl2_ranges(),
     ) {
         match result {
             RangeWalkResult::Left(entry) => {
@@ -612,7 +569,7 @@ pub fn write_dt(
                     .add_u32(p_openhcl_memory, MemoryVtlType::VTL0.0)?
                     .end_node()?;
             }
-            RangeWalkResult::Both(partition_entry, vtl2_entry) => {
+            RangeWalkResult::Both(partition_entry, vtl2_type) => {
                 // This range is in use by VTL2. Indicate that.
                 let name = format_fixed!(64, "memory@{:x}", range.start());
                 openhcl_builder = openhcl_builder
@@ -621,7 +578,7 @@ pub fn write_dt(
                     .add_u64_array(p_reg, &[range.start(), range.len()])?
                     .add_u32(p_numa_node_id, partition_entry.vnode)?
                     .add_u32(p_igvm_type, partition_entry.mem_type.0.into())?
-                    .add_u32(p_openhcl_memory, vtl2_entry.memory_type.0)?
+                    .add_u32(p_openhcl_memory, vtl2_type.0)?
                     .end_node()?;
             }
             RangeWalkResult::Right(..) => {

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -24,6 +24,7 @@ use core::fmt::Write;
 use host_fdt_parser::MemoryAllocationMode;
 use host_fdt_parser::MemoryEntry;
 use host_fdt_parser::ParsedDeviceTree;
+use hvdef::HV_PAGE_SIZE;
 use igvm_defs::MemoryMapEntryType;
 use loader_defs::paravisor::CommandLinePolicy;
 use memory_range::MemoryRange;
@@ -485,10 +486,11 @@ impl PartitionInfo {
         if vtl2_gpa_pool_size != 0 {
             // Reserve the specified number of pages for the pool. Use the used
             // ranges to figure out which VTL2 memory is free to allocate from.
+            let pool_size_bytes = vtl2_gpa_pool_size * HV_PAGE_SIZE;
 
             match address_space.allocate(
                 None,
-                vtl2_gpa_pool_size.try_into().expect("gpa pool is nonzero"),
+                pool_size_bytes,
                 AllocationType::GpaPool,
                 AllocationPolicy::LowMemory,
             ) {
@@ -496,7 +498,7 @@ impl PartitionInfo {
                     log!("allocated VTL2 pool at {:#x?}", pool.range);
                 }
                 None => {
-                    panic!("failed to allocate VTL2 pool of size {vtl2_gpa_pool_size:#x} pages");
+                    panic!("failed to allocate VTL2 pool of size {pool_size_bytes:#x} bytes");
                 }
             };
         }

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -5,7 +5,6 @@
 
 use super::PartitionInfo;
 use super::shim_params::ShimParams;
-use crate::boot_logger::debug_log;
 use crate::boot_logger::log;
 use crate::cmdline::BootCommandLineOptions;
 use crate::host_params::COMMAND_LINE_SIZE;
@@ -492,8 +491,6 @@ impl PartitionInfo {
             page_tables,
         );
 
-        debug_log!("init address_space: {:#?}", address_space);
-
         // Decide if we will reserve memory for a VTL2 private pool. Parse this
         // from the final command line, or the host provided device tree value.
         let vtl2_gpa_pool_size = {
@@ -525,8 +522,6 @@ impl PartitionInfo {
         if can_trust_host {
             storage.vtl0_alias_map = parsed.vtl0_alias_map;
         }
-
-        debug_log!("read_from_dt final address_space: {:#?}", address_space);
 
         // Set remaining struct fields before returning.
         let Self {

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -531,9 +531,6 @@ impl PartitionInfo {
         // Set remaining struct fields before returning.
         let Self {
             vtl2_ram: _,
-            vtl2_full_config_region: vtl2_config_region,
-            vtl2_config_region_reclaim: vtl2_config_region_reclaim_struct,
-            vtl2_reserved_region,
             vtl2_pool_memory: _,
             partition_ram: _,
             isolation,
@@ -554,16 +551,6 @@ impl PartitionInfo {
 
         *isolation = params.isolation_type;
 
-        *vtl2_config_region = MemoryRange::new(
-            params.parameter_region_start
-                ..(params.parameter_region_start + params.parameter_region_size),
-        );
-        *vtl2_config_region_reclaim_struct = vtl2_config_region_reclaim;
-        assert!(vtl2_config_region.contains(&vtl2_config_region_reclaim));
-        *vtl2_reserved_region = MemoryRange::new(
-            params.vtl2_reserved_region_start
-                ..(params.vtl2_reserved_region_start + params.vtl2_reserved_region_size),
-        );
         *bsp_reg = parsed.boot_cpuid_phys;
         cpus.extend(parsed.cpus.iter().copied());
         *com3_serial = parsed.com3_serial;

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -482,14 +482,16 @@ impl PartitionInfo {
             None
         };
 
-        address_space.init(
-            &storage.vtl2_ram,
-            params.used,
-            subtract_ranges([vtl2_config_region], [vtl2_config_region_reclaim]),
-            vtl2_reserved_range,
-            sidecar_image,
-            page_tables,
-        );
+        address_space
+            .init(
+                &storage.vtl2_ram,
+                params.used,
+                subtract_ranges([vtl2_config_region], [vtl2_config_region_reclaim]),
+                vtl2_reserved_range,
+                sidecar_image,
+                page_tables,
+            )
+            .expect("failed to initialize address space manager");
 
         // Decide if we will reserve memory for a VTL2 private pool. Parse this
         // from the final command line, or the host provided device tree value.

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -451,7 +451,7 @@ impl PartitionInfo {
             storage.partition_ram.push(*entry);
         }
 
-        // initialize address space manager
+        // Initialize the address space manager with fixed at build time ranges.
         let vtl2_config_region = MemoryRange::new(
             params.parameter_region_start
                 ..(params.parameter_region_start + params.parameter_region_size),
@@ -505,19 +505,19 @@ impl PartitionInfo {
             // ranges to figure out which VTL2 memory is free to allocate from.
             let pool_size_bytes = vtl2_gpa_pool_size * HV_PAGE_SIZE;
 
-            let pool = match address_space.allocate(
+            match address_space.allocate(
                 None,
                 pool_size_bytes,
                 AllocationType::GpaPool,
                 AllocationPolicy::LowMemory,
             ) {
-                Some(pool) => pool.range,
+                Some(pool) => {
+                    log!("allocated VTL2 pool at {:#x?}", pool.range);
+                }
                 None => {
                     panic!("failed to allocate VTL2 pool of size {pool_size_bytes:#x} bytes");
                 }
             };
-
-            storage.vtl2_pool_memory = pool;
         }
 
         // If we can trust the host, use the provided alias map
@@ -528,7 +528,6 @@ impl PartitionInfo {
         // Set remaining struct fields before returning.
         let Self {
             vtl2_ram: _,
-            vtl2_pool_memory: _,
             partition_ram: _,
             isolation,
             bsp_reg,

--- a/openhcl/openhcl_boot/src/host_params/dt.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt.rs
@@ -456,21 +456,15 @@ impl PartitionInfo {
             params.parameter_region_start
                 ..(params.parameter_region_start + params.parameter_region_size),
         );
-        let vtl2_reserved_range = if params.vtl2_reserved_region_size != 0 {
-            Some(MemoryRange::new(
+        let vtl2_reserved_range = (params.vtl2_reserved_region_size != 0).then(|| {
+            MemoryRange::new(
                 params.vtl2_reserved_region_start
                     ..(params.vtl2_reserved_region_start + params.vtl2_reserved_region_size),
-            ))
-        } else {
-            None
-        };
-        let sidecar_image = if params.sidecar_size != 0 {
-            Some(MemoryRange::new(
-                params.sidecar_base..(params.sidecar_base + params.sidecar_size),
-            ))
-        } else {
-            None
-        };
+            )
+        });
+        let sidecar_image = (params.sidecar_size != 0).then(|| {
+            MemoryRange::new(params.sidecar_base..(params.sidecar_base + params.sidecar_size))
+        });
 
         // Only specify pagetables as a reserved region on TDX, as they are used
         // for AP startup via the mailbox protocol. On other platforms, the

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -6,7 +6,6 @@
 
 use crate::cmdline::BootCommandLineOptions;
 use crate::host_params::shim_params::IsolationType;
-use crate::memory::AddressSpaceManager;
 use arrayvec::ArrayString;
 use arrayvec::ArrayVec;
 use host_fdt_parser::CpuEntry;
@@ -41,9 +40,6 @@ const MAX_PARTITION_RAM_RANGES: usize = 1024;
 
 /// Maximum size of the host-provided entropy
 pub const MAX_ENTROPY_SIZE: usize = 256;
-
-/// Maximum number of supported VTL2 used ranges.
-pub const MAX_VTL2_USED_RANGES: usize = 16;
 
 /// Information about the guest partition.
 #[derive(Debug)]
@@ -140,13 +136,5 @@ impl PartitionInfo {
             gic: None,
             pmu_gsiv: None,
         }
-    }
-
-    /// Returns the parameter regions that are not being reclaimed.
-    pub fn vtl2_config_regions(&self) -> impl Iterator<Item = MemoryRange> + use<> {
-        subtract_ranges(
-            [self.vtl2_full_config_region],
-            [self.vtl2_config_region_reclaim],
-        )
     }
 }

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -86,7 +86,6 @@ impl PartitionInfo {
     pub const fn new() -> Self {
         PartitionInfo {
             vtl2_ram: ArrayVec::new_const(),
-            // vtl2_used_ranges: ArrayVec::new_const(),
             partition_ram: ArrayVec::new_const(),
             isolation: IsolationType::None,
             bsp_reg: 0,

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -78,10 +78,6 @@ pub struct PartitionInfo {
     pub nvme_keepalive: bool,
     /// Parsed boot command line options.
     pub boot_options: BootCommandLineOptions,
-    /// The address space manager for VTL2.
-    ///
-    /// TODO: replace all fields above with this as needed.
-    pub address_space_manager: AddressSpaceManager,
 
     /// GIC information on AArch64.
     pub gic: Option<GicInfo>,
@@ -115,7 +111,6 @@ impl PartitionInfo {
             vtl0_alias_map: None,
             nvme_keepalive: false,
             boot_options: BootCommandLineOptions::new(),
-            address_space_manager: AddressSpaceManager::new_const(),
             gic: None,
             pmu_gsiv: None,
         }

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -33,7 +33,7 @@ pub const COMMAND_LINE_SIZE: usize = 0x2000;
 ///
 /// Today, Hyper-V has a max limit of 64 NUMA nodes, so we should only ever see
 /// 64 ram ranges.
-const MAX_VTL2_RAM_RANGES: usize = 64;
+pub const MAX_VTL2_RAM_RANGES: usize = 64;
 
 /// The maximum number of ram ranges that can be read from the host.
 const MAX_PARTITION_RAM_RANGES: usize = 1024;

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -14,7 +14,6 @@ use host_fdt_parser::MemoryAllocationMode;
 use host_fdt_parser::MemoryEntry;
 use host_fdt_parser::VmbusInfo;
 use memory_range::MemoryRange;
-use memory_range::subtract_ranges;
 
 mod dt;
 mod mmio;
@@ -45,27 +44,14 @@ pub const MAX_ENTROPY_SIZE: usize = 256;
 #[derive(Debug)]
 pub struct PartitionInfo {
     /// Ram assigned to VTL2. This is either parsed from the host via IGVM
-    /// parameters, or the fixed at build value.
+    /// parameters, allocated dynamically, or the fixed at build value.
     ///
     /// This vec is guaranteed to be sorted, and non-overlapping.
     pub vtl2_ram: ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>,
-    /// The parameter region.
-    pub vtl2_full_config_region: MemoryRange,
-    /// Additional ram that can be reclaimed from the parameter region. Today,
-    /// this is the whole device tree provided by the host.
-    pub vtl2_config_region_reclaim: MemoryRange,
-    /// The vtl2 reserved region, that is reserved to both the kernel and
-    /// usermode.
-    pub vtl2_reserved_region: MemoryRange,
     /// Memory used for the VTL2 private pool.
+    /// FIXME: move into address_manager
     pub vtl2_pool_memory: MemoryRange,
-    /// Memory ranges that are in use by the bootshim, and any other persisted
-    /// ranges, such as the VTL2 private pool.
-    ///
-    /// TODO: Refactor these different ranges and consolidate address space
-    /// management.
-    // pub vtl2_used_ranges: ArrayVec<MemoryRange, MAX_VTL2_USED_RANGES>,
-    ///  The full memory map provided by the host.
+    /// The full memory map provided by the host.
     pub partition_ram: ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>,
     /// The partiton's isolation type.
     pub isolation: IsolationType,
@@ -108,9 +94,6 @@ impl PartitionInfo {
     pub const fn new() -> Self {
         PartitionInfo {
             vtl2_ram: ArrayVec::new_const(),
-            vtl2_full_config_region: MemoryRange::EMPTY,
-            vtl2_config_region_reclaim: MemoryRange::EMPTY,
-            vtl2_reserved_region: MemoryRange::EMPTY,
             vtl2_pool_memory: MemoryRange::EMPTY,
             // vtl2_used_ranges: ArrayVec::new_const(),
             partition_ram: ArrayVec::new_const(),

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -6,6 +6,7 @@
 
 use crate::cmdline::BootCommandLineOptions;
 use crate::host_params::shim_params::IsolationType;
+use crate::memory::AddressSpaceManager;
 use arrayvec::ArrayString;
 use arrayvec::ArrayVec;
 use host_fdt_parser::CpuEntry;
@@ -67,7 +68,7 @@ pub struct PartitionInfo {
     ///
     /// TODO: Refactor these different ranges and consolidate address space
     /// management.
-    pub vtl2_used_ranges: ArrayVec<MemoryRange, MAX_VTL2_USED_RANGES>,
+    // pub vtl2_used_ranges: ArrayVec<MemoryRange, MAX_VTL2_USED_RANGES>,
     ///  The full memory map provided by the host.
     pub partition_ram: ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>,
     /// The partiton's isolation type.
@@ -95,6 +96,10 @@ pub struct PartitionInfo {
     pub nvme_keepalive: bool,
     /// Parsed boot command line options.
     pub boot_options: BootCommandLineOptions,
+    /// The address space manager for VTL2.
+    ///
+    /// TODO: replace all fields above with this as needed.
+    pub address_space_manager: AddressSpaceManager,
 
     /// GIC information on AArch64.
     pub gic: Option<GicInfo>,
@@ -111,7 +116,7 @@ impl PartitionInfo {
             vtl2_config_region_reclaim: MemoryRange::EMPTY,
             vtl2_reserved_region: MemoryRange::EMPTY,
             vtl2_pool_memory: MemoryRange::EMPTY,
-            vtl2_used_ranges: ArrayVec::new_const(),
+            // vtl2_used_ranges: ArrayVec::new_const(),
             partition_ram: ArrayVec::new_const(),
             isolation: IsolationType::None,
             bsp_reg: 0,
@@ -131,6 +136,7 @@ impl PartitionInfo {
             vtl0_alias_map: None,
             nvme_keepalive: false,
             boot_options: BootCommandLineOptions::new(),
+            address_space_manager: AddressSpaceManager::new_const(),
             gic: None,
             pmu_gsiv: None,
         }

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -13,7 +13,6 @@ use host_fdt_parser::GicInfo;
 use host_fdt_parser::MemoryAllocationMode;
 use host_fdt_parser::MemoryEntry;
 use host_fdt_parser::VmbusInfo;
-use memory_range::MemoryRange;
 
 mod dt;
 mod mmio;
@@ -48,9 +47,6 @@ pub struct PartitionInfo {
     ///
     /// This vec is guaranteed to be sorted, and non-overlapping.
     pub vtl2_ram: ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>,
-    /// Memory used for the VTL2 private pool.
-    /// FIXME: move into address_manager
-    pub vtl2_pool_memory: MemoryRange,
     /// The full memory map provided by the host.
     pub partition_ram: ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>,
     /// The partiton's isolation type.
@@ -90,7 +86,6 @@ impl PartitionInfo {
     pub const fn new() -> Self {
         PartitionInfo {
             vtl2_ram: ArrayVec::new_const(),
-            vtl2_pool_memory: MemoryRange::EMPTY,
             // vtl2_used_ranges: ArrayVec::new_const(),
             partition_ram: ArrayVec::new_const(),
             isolation: IsolationType::None,

--- a/openhcl/openhcl_boot/src/host_params/shim_params.rs
+++ b/openhcl/openhcl_boot/src/host_params/shim_params.rs
@@ -17,7 +17,6 @@ pub enum IsolationType {
     Vbs,
     #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     Snp,
-    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     Tdx,
 }
 

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -15,6 +15,7 @@ mod cmdline;
 mod dt;
 mod host_params;
 mod hypercall;
+mod memory;
 mod rt;
 mod sidecar;
 mod single_threaded;

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -1099,7 +1099,6 @@ mod test {
     }
 
     const ONE_MB: u64 = 0x10_0000;
-    const PAGE_SIZE_4K: u64 = 0x1000;
 
     #[test]
     fn test_e820_basic() {
@@ -1274,7 +1273,7 @@ mod test {
             let _allocated = address_space
                 .allocate(
                     None,
-                    (ONE_MB / PAGE_SIZE_4K).try_into().unwrap(),
+                    ONE_MB,
                     if i % 2 == 0 {
                         AllocationType::GpaPool
                     } else {

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -1212,9 +1212,7 @@ mod test {
                 (2 * ONE_MB..3 * ONE_MB, E820_RESERVED),
                 (3 * ONE_MB..4 * ONE_MB, E820_RAM),
                 (4 * ONE_MB..5 * ONE_MB, E820_RESERVED),
-                (5 * ONE_MB..6 * ONE_MB, E820_RAM),
-                (6 * ONE_MB..7 * ONE_MB, E820_RAM),
-                (7 * ONE_MB..8 * ONE_MB, E820_RAM),
+                (5 * ONE_MB..8 * ONE_MB, E820_RAM),
             ],
         );
     }

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -1099,6 +1099,7 @@ mod test {
     }
 
     const ONE_MB: u64 = 0x10_0000;
+    const PAGE_SIZE_4K: u64 = 0x1000;
 
     #[test]
     fn test_e820_basic() {
@@ -1273,7 +1274,7 @@ mod test {
             let _allocated = address_space
                 .allocate(
                     None,
-                    ONE_MB,
+                    (ONE_MB / PAGE_SIZE_4K).try_into().unwrap(),
                     if i % 2 == 0 {
                         AllocationType::GpaPool
                     } else {

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -921,7 +921,7 @@ mod test {
         write_dt(
             &mut buf,
             &new_partition_info(MAX_CPUS),
-            todo!(),
+            &AddressSpaceManager::new_const(),
             [],
             0..0,
             &ArrayString::from("test").unwrap_or_default(),
@@ -995,7 +995,7 @@ mod test {
         write_dt(
             &mut buf,
             &new_partition_info(MAX_CPUS),
-            todo!(),
+            &AddressSpaceManager::new_const(),
             [],
             0..0,
             &ArrayString::from("test").unwrap_or_default(),
@@ -1024,7 +1024,7 @@ mod test {
         write_dt(
             &mut buf,
             &new_partition_info(MAX_CPUS),
-            todo!(),
+            &AddressSpaceManager::new_const(),
             [],
             0..0,
             &ArrayString::from("test").unwrap_or_default(),
@@ -1064,7 +1064,7 @@ mod test {
         address_space.init(
             &ram,
             bootshim_used,
-            subtract_ranges([parameter_range], reclaim.into_iter()),
+            subtract_ranges([parameter_range], reclaim),
             None,
             None,
             None,

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -1018,6 +1018,7 @@ mod test {
             vtl0_alias_map: None,
             nvme_keepalive: false,
             boot_options: BootCommandLineOptions::new(),
+            address_space_manager: todo!(),
         }
     }
 

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -996,7 +996,6 @@ mod test {
             vtl2_config_region_reclaim: MemoryRange::EMPTY,
             vtl2_reserved_region: MemoryRange::EMPTY,
             vtl2_pool_memory: MemoryRange::EMPTY,
-            vtl2_used_ranges: ArrayVec::new(),
             partition_ram: ArrayVec::new(),
             isolation: IsolationType::None,
             bsp_reg: cpus[0].reg as u32,

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -44,9 +44,7 @@ use hvdef::Vtl;
 use loader_defs::linux::SETUP_DTB;
 use loader_defs::linux::setup_data;
 use loader_defs::shim::ShimParamsRaw;
-use memory_range::MemoryRange;
 use memory_range::RangeWalkResult;
-use memory_range::merge_adjacent_ranges;
 use memory_range::walk_ranges;
 use minimal_rt::enlightened_panic::enable_enlightened_panic;
 use sidecar::SidecarConfig;
@@ -861,8 +859,6 @@ mod test {
     use loader_defs::linux::boot_params;
     use loader_defs::linux::e820entry;
     use memory_range::MemoryRange;
-    use memory_range::RangeWalkResult;
-    use memory_range::walk_ranges;
     use zerocopy::FromZeros;
 
     const HIGH_MMIO_GAP_END: u64 = 0x1000000000; //  64 GiB
@@ -885,9 +881,6 @@ mod test {
 
         PartitionInfo {
             vtl2_ram: ArrayVec::new(),
-            vtl2_full_config_region: MemoryRange::EMPTY,
-            vtl2_config_region_reclaim: MemoryRange::EMPTY,
-            vtl2_reserved_region: MemoryRange::EMPTY,
             vtl2_pool_memory: MemoryRange::EMPTY,
             partition_ram: ArrayVec::new(),
             isolation: IsolationType::None,
@@ -1065,12 +1058,6 @@ mod test {
                 vnode: 0,
             })
             .collect();
-
-        info.vtl2_full_config_region = parameter_range;
-
-        info.vtl2_config_region_reclaim = reclaim
-            .map(|r| MemoryRange::try_new(r).unwrap())
-            .unwrap_or(MemoryRange::EMPTY);
 
         info
     }

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -50,7 +50,6 @@ use minimal_rt::enlightened_panic::enable_enlightened_panic;
 use sidecar::SidecarConfig;
 use sidecar_defs::SidecarOutput;
 use sidecar_defs::SidecarParams;
-use single_threaded::OffStackRef;
 use zerocopy::FromBytes;
 use zerocopy::FromZeros;
 use zerocopy::Immutable;
@@ -664,6 +663,7 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
 
     #[cfg(target_arch = "x86_64")]
     if p.isolation_type == IsolationType::Snp {
+        use single_threaded::OffStackRef;
         let cc_blob = OffStackRef::leak(off_stack!(loader_defs::linux::cc_blob_sev_info, zeroed()));
         build_cc_blob_sev_info(cc_blob, &p);
 

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -74,6 +74,7 @@ fn build_kernel_command_line(
     can_trust_host: bool,
     is_confidential_debug: bool,
     sidecar: Option<&SidecarConfig<'_>>,
+    vtl2_pool_supported: bool,
 ) -> Result<(), CommandLineTooLong> {
     // For reference:
     // https://www.kernel.org/doc/html/v5.15/admin-guide/kernel-parameters.html
@@ -264,7 +265,7 @@ fn build_kernel_command_line(
 
     // Only when explicitly supported by Host.
     // TODO: Move from command line to device tree when stabilized.
-    if partition_info.nvme_keepalive && !partition_info.vtl2_pool_memory.is_empty() {
+    if partition_info.nvme_keepalive && vtl2_pool_supported {
         write!(cmdline, "OPENHCL_NVME_KEEP_ALIVE=1 ")?;
     }
 
@@ -648,6 +649,7 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
         can_trust_host,
         is_confidential_debug,
         sidecar.as_ref(),
+        address_space.vtl2_pool().is_some(),
     )
     .unwrap();
 
@@ -883,7 +885,6 @@ mod test {
 
         PartitionInfo {
             vtl2_ram: ArrayVec::new(),
-            vtl2_pool_memory: MemoryRange::EMPTY,
             partition_ram: ArrayVec::new(),
             isolation: IsolationType::None,
             bsp_reg: cpus[0].reg as u32,

--- a/openhcl/openhcl_boot/src/memory.rs
+++ b/openhcl/openhcl_boot/src/memory.rs
@@ -3,7 +3,6 @@
 
 //! Address space allocator for VTL2 memory used by the bootshim.
 
-use crate::boot_logger::debug_log;
 use crate::host_params::MAX_VTL2_RAM_RANGES;
 use arrayvec::ArrayVec;
 use core::panic;
@@ -166,8 +165,6 @@ impl AddressSpaceManager {
             }
         }
 
-        debug_log!("used ranges {:#x?}", used_ranges);
-
         // Construct the initial state of VTL2 address space by walking ram and reserved ranges
         assert!(self.address_space.is_empty());
         for (entry, r) in walk_ranges(
@@ -197,8 +194,6 @@ impl AddressSpaceManager {
                 RangeWalkResult::Neither => {}
             }
         }
-
-        debug_log!("asm done");
     }
 
     /// Split a free range into two, with allocation policy deciding if we
@@ -343,6 +338,8 @@ pub enum AllocationPolicy {
     // prefer low memory
     LowMemory,
     // prefer high memory
+    // TODO: only used in tests, but will be used in an upcoming change
+    #[allow(dead_code)]
     HighMemory,
 }
 

--- a/openhcl/openhcl_boot/src/memory.rs
+++ b/openhcl/openhcl_boot/src/memory.rs
@@ -333,7 +333,7 @@ impl AddressSpaceManager {
             })
         }
 
-        // Walk ranges in reverse order until one is free that has enough space
+        // Walk ranges in forward/reverse order, depending on allocation policy.
         let index = {
             let iter = self.address_space.iter().enumerate();
             match allocation_policy {

--- a/openhcl/openhcl_boot/src/memory.rs
+++ b/openhcl/openhcl_boot/src/memory.rs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Address space allocator for VTL2 memory used by the bootshim.
+
+use crate::host_params::MAX_VTL2_RAM_RANGES;
+use arrayvec::ArrayVec;
+use core::alloc;
+use core::cell::RefCell;
+use host_fdt_parser::MemoryEntry;
+use igvm_defs::MemoryMapEntryType;
+use memory_range::MemoryRange;
+
+/// The maximum number of reserved memory ranges that we might use.
+/// See ReservedMemoryType definition for details.
+const MAX_RESERVED_MEM_RANGES: usize = 5 + sidecar_defs::MAX_NODES;
+
+const MAX_MEMORY_RANGES: usize = MAX_VTL2_RAM_RANGES + MAX_RESERVED_MEM_RANGES;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReservedMemoryType {
+    /// VTL2 parameter regions (could be up to 2).
+    Vtl2Config,
+    /// Reserved memory that should not be used by the kernel or usermode. There
+    /// should only be one.
+    Vtl2Reserved,
+    /// Sidecar image. There should only be one.
+    SidecarImage,
+    /// A reserved range per sidecar node.
+    SidecarNode,
+    /// Persistent VTL2 memory used for page allocations in usermode. This
+    /// memory is persisted, both location and contents, across servicing.
+    /// Today, we only support a single range.
+    Vtl2GpaPool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AddressUsage {
+    Free,
+    Used,
+    Reserved(ReservedMemoryType),
+}
+
+struct AddressRange {
+    range: MemoryRange,
+    mem_type: MemoryMapEntryType,
+    vnode: u32,
+    usage: AddressUsage,
+}
+
+pub struct AllocatedRange {
+    pub range: MemoryRange,
+    pub vnode: u32,
+}
+
+pub struct AddressSpaceManager {
+    /// tracks address space, must be sorted
+    address_space: ArrayVec<AddressRange, MAX_MEMORY_RANGES>,
+}
+
+impl AddressSpaceManager {
+    /// Initialize the address space manager.
+    ///
+    /// Some regions are known to be used at construction time, as these ranges
+    /// are allocated at boot time.
+    pub fn new(
+        vtl2_ram: &[MemoryEntry],
+        vtl2_config: &[MemoryRange],
+        reserved_range: MemoryRange,
+        sidecar_image: Option<MemoryRange>,
+    ) -> Self {
+        assert!(vtl2_config.len() <= 2);
+        assert!(vtl2_ram.len() <= MAX_VTL2_RAM_RANGES);
+
+        todo!()
+    }
+
+    /// Split a free range into two, with the allocated range coming from the top end of the range.
+    fn split_range(&mut self, index: usize, len: u64, usage: AddressUsage) -> AllocatedRange {
+        assert!(usage != AddressUsage::Free);
+        let range = self.address_space.get_mut(index).expect("valid index");
+        assert_eq!(range.usage, AddressUsage::Free);
+
+        let offset = range.range.len() - len;
+        let (remainder, used) = range.range.split_at_offset(offset);
+        let remainder = if !remainder.is_empty() {
+            Some(AddressRange {
+                range: remainder,
+                mem_type: range.mem_type,
+                vnode: range.vnode,
+                usage: AddressUsage::Free,
+            })
+        } else {
+            None
+        };
+
+        // Update this range to mark it as used
+        range.usage = usage;
+        range.range = used;
+        let allocated = AllocatedRange {
+            range: used,
+            vnode: range.vnode,
+        };
+
+        if let Some(remainder) = remainder {
+            self.address_space.insert(index, remainder);
+        }
+
+        allocated
+    }
+}

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -10,7 +10,6 @@ use crate::host_params::shim_params::ShimParams;
 use crate::memory::AddressSpaceManager;
 use crate::memory::AllocationPolicy;
 use crate::memory::AllocationType;
-use sidecar_defs::PAGE_SIZE;
 use sidecar_defs::SidecarNodeOutput;
 use sidecar_defs::SidecarNodeParams;
 use sidecar_defs::SidecarOutput;
@@ -140,10 +139,7 @@ pub fn start_sidecar<'a>(
         let mut base_vp = 0;
         total_ram = 0;
         for (cpus, node) in cpus_by_node().zip(nodes) {
-            let required_ram = ((sidecar_defs::required_memory(cpus.len() as u32) / PAGE_SIZE)
-                as u64)
-                .try_into()
-                .expect("sidecar memory required is nonzero");
+            let required_ram = sidecar_defs::required_memory(cpus.len() as u32) as u64;
             // Take some VTL2 RAM for sidecar use. Try to use the same NUMA node
             // as the first CPU.
             let local_vnode = cpus[0].vnode as usize;
@@ -186,7 +182,7 @@ pub fn start_sidecar<'a>(
             };
             base_vp += cpus.len() as u32;
             *node_count += 1;
-            total_ram += required_ram.get();
+            total_ram += required_ram;
         }
     }
 

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -10,7 +10,6 @@ use crate::host_params::shim_params::ShimParams;
 use crate::memory::AddressSpaceManager;
 use crate::memory::AllocationPolicy;
 use crate::memory::AllocationType;
-use memory_range::MemoryRange;
 use sidecar_defs::SidecarNodeOutput;
 use sidecar_defs::SidecarNodeParams;
 use sidecar_defs::SidecarOutput;
@@ -27,7 +26,6 @@ const _: () = assert!(
 );
 
 pub struct SidecarConfig<'a> {
-    pub image: MemoryRange,
     pub node_params: &'a [SidecarNodeParams],
     pub nodes: &'a [SidecarNodeOutput],
     pub start_reftime: u64,
@@ -79,8 +77,6 @@ pub fn start_sidecar<'a>(
         log!("sidecar: disabled via command line");
         return None;
     }
-
-    let image = MemoryRange::new(p.sidecar_base..p.sidecar_base + p.sidecar_size);
 
     // Ensure the host didn't provide an out-of-bounds NUMA node.
     let max_vnode = partition_info
@@ -212,7 +208,6 @@ pub fn start_sidecar<'a>(
 
     let SidecarOutput { nodes, error: _ } = sidecar_output;
     Some(SidecarConfig {
-        image,
         start_reftime: boot_start_reftime,
         end_reftime: boot_end_reftime,
         node_params: &sidecar_params.nodes[..node_count],

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -10,6 +10,7 @@ use crate::host_params::shim_params::ShimParams;
 use crate::memory::AddressSpaceManager;
 use crate::memory::AllocationPolicy;
 use crate::memory::AllocationType;
+use sidecar_defs::PAGE_SIZE;
 use sidecar_defs::SidecarNodeOutput;
 use sidecar_defs::SidecarNodeParams;
 use sidecar_defs::SidecarOutput;
@@ -139,7 +140,10 @@ pub fn start_sidecar<'a>(
         let mut base_vp = 0;
         total_ram = 0;
         for (cpus, node) in cpus_by_node().zip(nodes) {
-            let required_ram = sidecar_defs::required_memory(cpus.len() as u32) as u64;
+            let required_ram = ((sidecar_defs::required_memory(cpus.len() as u32) / PAGE_SIZE)
+                as u64)
+                .try_into()
+                .expect("sidecar memory required is nonzero");
             // Take some VTL2 RAM for sidecar use. Try to use the same NUMA node
             // as the first CPU.
             let local_vnode = cpus[0].vnode as usize;
@@ -182,7 +186,7 @@ pub fn start_sidecar<'a>(
             };
             base_vp += cpus.len() as u32;
             *node_count += 1;
-            total_ram += required_ram;
+            total_ram += required_ram.get();
         }
     }
 

--- a/vm/loader/loader_defs/src/shim.rs
+++ b/vm/loader/loader_defs/src/shim.rs
@@ -105,6 +105,9 @@ open_enum! {
         /// This memory is part of VTL2's address space, not VTL0's. It is
         /// marked as reserved to the kernel.
         VTL2_GPA_POOL = 8,
+        /// This memory is used by VTL2 for TDX AP startup page tables, and is
+        /// marked as reserved to the kernel.
+        VTL2_TDX_PAGE_TABLES = 9,
     }
 }
 
@@ -120,6 +123,7 @@ impl MemoryVtlType {
                 | MemoryVtlType::VTL2_SIDECAR_NODE
                 | MemoryVtlType::VTL2_RESERVED
                 | MemoryVtlType::VTL2_GPA_POOL
+                | MemoryVtlType::VTL2_TDX_PAGE_TABLES
         )
     }
 }


### PR DESCRIPTION
Over time, openhcl_boot has gotten more and more complicated with different components carving out different sections of the address space. In preparation for some future changes, refactor openhcl_boot to have a central module responsible for managing and allocating address space, and reporting information about the address space to the kernel. 

This greatly simplifies address space management and makes it easier to add new functionality in the future that requires new ranges. 