### PR TITLE
IDE: Dont warn on reads from undefined cfg space offsets (#1745)

### DIFF
--- a/vm/devices/storage/ide/src/lib.rs
+++ b/vm/devices/storage/ide/src/lib.rs
@@ -917,7 +917,7 @@ impl PciConfigSpace for IdeDevice {
                 HeaderType00::BAR4 => self.bus_master_state.port_addr_reg,
                 offset => {
                     tracing::debug!(?offset, "undefined type00 header read");
-                    return IoResult::Err(IoError::InvalidRegister);
+                    0
                 }
             }
         } else {

--- a/vmm_core/vmotherboard/src/base_chipset.rs
+++ b/vmm_core/vmotherboard/src/base_chipset.rs
@@ -450,7 +450,7 @@ impl<'a> BaseChipsetBuilder<'a> {
         }) = deps_hyperv_ide
         {
             builder
-                .arc_mutex_device("ide")
+                .arc_mutex_device("pci-ide")
                 .on_pci_bus(attached_to)
                 .try_add(|services| {
                     // hard-coded to iRQ lines 14 and 15, as per PIIX4 spec


### PR DESCRIPTION
Most guests like to read the entire Header00 range of their PCI devices, but IDE didn't implement those. Just return 0 to quiet the warnings.

Cherry-pick of #1745