### PR TITLE
petri: extra wait for shutdown ic, move to generic

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -390,7 +390,7 @@ impl PetriVmmBackend for HyperVPetriBackend {
             }
         }));
 
-        vm.start().await?;
+        vm.start()?;
 
         Ok(HyperVPetriRuntime {
             vm,
@@ -465,10 +465,14 @@ impl PetriVmRuntime for HyperVPetriRuntime {
         self.vm.wait_for_boot_event().await
     }
 
+    async fn wait_for_enlightened_shutdown_ready(&mut self) -> anyhow::Result<()> {
+        self.vm.wait_for_enlightened_shutdown_ready().await
+    }
+
     async fn send_enlightened_shutdown(&mut self, kind: ShutdownKind) -> anyhow::Result<()> {
         match kind {
-            ShutdownKind::Shutdown => self.vm.stop().await?,
-            ShutdownKind::Reboot => self.vm.restart().await?,
+            ShutdownKind::Shutdown => self.vm.stop()?,
+            ShutdownKind::Reboot => self.vm.restart()?,
         }
 
         Ok(())

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -130,7 +130,6 @@ impl PetriVmConfigOpenVmm {
                 mesh,
                 worker,
                 watchdog_tasks,
-                quirks: firmware.quirks(),
             },
             halt_notif,
         );

--- a/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
+++ b/vmm_tests/petri_artifacts_vmm_test/src/lib.rs
@@ -291,7 +291,7 @@ pub mod artifacts {
                 GuestQuirks {
                     // FreeBSD will ignore shutdown requests that arrive too
                     // early in the boot process.
-                    hyperv_shutdown_ic_sleep: Some(std::time::Duration::from_secs(15)),
+                    hyperv_shutdown_ic_sleep: Some(std::time::Duration::from_secs(20)),
                 }
             }
         }


### PR DESCRIPTION
Always wait an extra second after the shutdown IC reports OK to hopefully get around some occasional flakiness where the shutdown IC hangs if the request is sent too early. This seems to happen most often with "heavy" tests: [Example](https://openvmm.dev/test-results/test.html?run=16451062380&job=x64-windows-intel-tdx-vmm-tests-logs&test=multiarch__hyperv_openhcl_uefi_x64_windows_datacenter_core_2025_x64_tdx_boot_no_agent_heavy)

This change also moves the handling of the delay, including guest quirks, into the generic `PetriVm` instead of being backend-specific. Backends could still add extra time via an additional wait in `wait_for_enlightened_shutdown_ready` if necessary.