### PR TITLE
inspect_derive: Support tuple structs

### DIFF
--- a/support/inspect/src/lib.rs
+++ b/support/inspect/src/lib.rs
@@ -2864,6 +2864,7 @@ mod tests {
             ignored: Ignored,
             tr1: Tr1,
             tr2: Tr2,
+            unnamed: Unnamed,
             #[inspect(iter_by_index, hex)]
             hex_array: [u8; 4],
             hex_inner: HexInner,
@@ -2892,6 +2893,9 @@ mod tests {
         struct Transparent {
             inner: Inner,
         }
+
+        #[derive(Inspect)]
+        struct Unnamed(u8, i32);
 
         #[derive(Inspect)]
         #[inspect(transparent)]
@@ -2941,6 +2945,7 @@ mod tests {
             ignored: Ignored { _x: || () },
             tr1: Tr1(10, PhantomData),
             tr2: Tr2(()),
+            unnamed: Unnamed(5, -83),
             hex_array: [100, 101, 102, 103],
             hex_inner: HexInner { val: 100 },
             inner_as_hex: Inner { val: 100 },
@@ -2984,6 +2989,10 @@ mod tests {
                     },
                     tr1: 0xa,
                     tr2: "()",
+                    unnamed: {
+                        0: 5,
+                        1: -83,
+                    },
                     val: 8,
                     var: "bar_baz",
                 }"#]),


### PR DESCRIPTION
I figure there's a good chance we don't actually want to take this, and instead continue requiring devs to give proper names to their fields, but I went down this rabbit hole already so I figured I might as well push it.

This change was prompted by a rust-analyzer bug. rust-analyzer today passes input streams to derive macros **after** expanding any attribute macros inside them, instead of correctly passing the attribute macro into the derive macro (I couldn't find an issue link, but a rust-analzyer dev in discord promised me this is known). When combining an Inspect derivation and a bitfield struct this results in the Inspect derive seeing the single field tuple struct created by the bitfield macro, instead of the pre-transformed list of fields. This causes rust-analyzer to emit nonsensical `macro-error`s on every such struct. Since fixing rust-analyzer would be hard, instead I added support to inspect_derive for tuple structs, naming the fields in the output by their index. This causes the errors to go away, making me happy. 

Note that these rust-analyzer macro-errors don't actually affect anything beyond developer friction. Proper compilation through rustc is of course following the correct behavior. These errors also are hidden most of the time, as rust-analyzer will only show them when the containing file is actually open in an editor. However they do annoy me.