### PR TITLE
local_clock: Add output to flaky test

### DIFF
--- a/support/local_clock/src/clock_impls.rs
+++ b/support/local_clock/src/clock_impls.rs
@@ -143,8 +143,8 @@ mod tests {
 
         // cannot use assert_eq, because there is a *bit* of extra time elapsed
         // aside from the thread sleep.
-        assert!(delta >= LocalClockDelta::from_millis(1000));
-        assert!(delta < LocalClockDelta::from_millis(2000)); // sanity check
+        assert!(delta >= LocalClockDelta::from_millis(1000), "{delta:?}");
+        assert!(delta < LocalClockDelta::from_millis(2000), "{delta:?}"); // sanity check
     }
 
     #[test]


### PR DESCRIPTION
This test is naturally a tiny bit flaky, as it depends on the passage of real time. However in a first step to determine if we can improve it at all, let's see what exactly is going wrong when it does go wrong. Add a bit of output to the asserts so we can see why they fail. Part of https://github.com/microsoft/openvmm/issues/1475.