### PR TITLE
CVM: Move logic around memory faults from TDX to be shared with SNP, send memory intercepts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7706,6 +7706,7 @@ dependencies = [
  "parking_lot",
  "sparse_mmap",
  "thiserror 2.0.12",
+ "tracelimit",
  "tracing",
  "underhill_threadpool",
  "virt",

--- a/openhcl/underhill_mem/Cargo.toml
+++ b/openhcl/underhill_mem/Cargo.toml
@@ -22,6 +22,7 @@ cvm_tracing.workspace = true
 inspect.workspace = true
 pal_async.workspace = true
 sparse_mmap.workspace = true
+tracelimit.workspace = true
 
 anyhow.workspace = true
 futures.workspace = true

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -249,7 +249,7 @@ unsafe impl GuestMemoryAccess for GuestMemoryView {
                     };
 
                     if !check_bitmap.page_state(gpn) {
-                        tracing::warn!(?address, ?len, ?write, ?self.view_type, "VTL 1 permissions violation");
+                        tracelimit::warn_ratelimited!(?address, ?len, ?write, ?self.view_type, "VTL 1 permissions violation");
 
                         return guestmem::PageFaultAction::Fail(guestmem::PageFaultError::new(
                             guestmem::GuestMemoryErrorKind::VtlProtected,

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -2539,6 +2539,8 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                             "guest accessed protected gpa, sending intercept"
                         );
                         let state = B::intercept_message_state(self, vtl, false);
+                        // TODO: We may want to fill in tpr_priority and gva
+                        // but tests pass without them.
                         self.send_intercept_message(
                             GuestVtl::Vtl1,
                             &HvMessage::new(
@@ -2560,9 +2562,9 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                                     },
                                     cache_type: HvCacheType::HvCacheTypeWriteBack,
                                     memory_access_info: HvX64MemoryAccessInfo::new(),
-                                    tpr_priority: 0, // TODO?
+                                    tpr_priority: 0,
                                     reserved: 0,
-                                    guest_virtual_address: 0, // TODO?
+                                    guest_virtual_address: 0,
                                     guest_physical_address: gpa,
                                     instruction_byte_count: 0,
                                     instruction_bytes: [0; 16],

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -2509,7 +2509,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     tracelimit::warn_ratelimited!(
                         CVM_ALLOWED,
                         gpa,
-                        vtl,
+                        ?vtl,
                         ?extra_info,
                         "possible spurious memory violation write, ignoring"
                     );
@@ -2518,7 +2518,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     tracelimit::warn_ratelimited!(
                         CVM_ALLOWED,
                         gpa,
-                        vtl,
+                        ?vtl,
                         ?extra_info,
                         "possible spurious memory violation read, ignoring"
                     );
@@ -2538,7 +2538,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     tracelimit::warn_ratelimited!(
                         CVM_ALLOWED,
                         gpa,
-                        vtl,
+                        ?vtl,
                         is_shared,
                         ?extra_info,
                         "guest accessed inaccessible gpa, injecting MC"
@@ -2568,7 +2568,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     tracelimit::warn_ratelimited!(
                         CVM_ALLOWED,
                         gpa,
-                        vtl,
+                        ?vtl,
                         is_shared,
                         ?extra_info,
                         "guest accessed gpa not described in memory layout, emulating anyways"

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -2509,6 +2509,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     tracelimit::warn_ratelimited!(
                         CVM_ALLOWED,
                         gpa,
+                        vtl,
                         ?extra_info,
                         "possible spurious memory violation write, ignoring"
                     );
@@ -2517,6 +2518,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     tracelimit::warn_ratelimited!(
                         CVM_ALLOWED,
                         gpa,
+                        vtl,
                         ?extra_info,
                         "possible spurious memory violation read, ignoring"
                     );
@@ -2536,6 +2538,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     tracelimit::warn_ratelimited!(
                         CVM_ALLOWED,
                         gpa,
+                        vtl,
                         is_shared,
                         ?extra_info,
                         "guest accessed inaccessible gpa, injecting MC"
@@ -2565,6 +2568,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     tracelimit::warn_ratelimited!(
                         CVM_ALLOWED,
                         gpa,
+                        vtl,
                         is_shared,
                         ?extra_info,
                         "guest accessed gpa not described in memory layout, emulating anyways"

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -77,7 +77,6 @@ use virt_support_x86emu::emulate::emulate_insn_memory_op;
 use virt_support_x86emu::emulate::emulate_io;
 use virt_support_x86emu::emulate::emulate_translate_gva;
 use virt_support_x86emu::translate::TranslationRegisters;
-use vm_topology::memory::AddressType;
 use vmcore::vmtime::VmTimeAccess;
 use x86defs::RFlags;
 use x86defs::X64_CR0_ET;
@@ -2063,7 +2062,17 @@ impl UhProcessor<'_, TdxBacked> {
                         .into();
                     assert!(!old_interruptibility.blocked_by_nmi());
                 } else {
-                    self.handle_ept(intercepted_vtl, dev, gpa, ept_info).await?;
+                    if self.check_mem_fault(intercepted_vtl, gpa) {
+                        self.emulate(
+                            dev,
+                            self.backing.vtls[intercepted_vtl]
+                                .interruption_information
+                                .valid(),
+                            intercepted_vtl,
+                            TdxEmulationCache::default(),
+                        )
+                        .await?;
+                    }
                 }
 
                 &mut self.backing.vtls[intercepted_vtl].exit_stats.ept_violation
@@ -2443,120 +2452,6 @@ impl UhProcessor<'_, TdxBacked> {
             .with_interruption_type(INTERRUPT_TYPE_HARDWARE_EXCEPTION)
             .with_deliver_error_code(true);
         self.backing.vtls[vtl].exception_error_code = 0;
-    }
-
-    fn inject_mc(&mut self, vtl: GuestVtl) {
-        self.backing.vtls[vtl].interruption_information = InterruptionInformation::new()
-            .with_valid(true)
-            .with_vector(x86defs::Exception::MACHINE_CHECK.0)
-            .with_interruption_type(INTERRUPT_TYPE_HARDWARE_EXCEPTION);
-    }
-
-    async fn handle_ept(
-        &mut self,
-        intercepted_vtl: GuestVtl,
-        dev: &impl CpuIo,
-        gpa: u64,
-        ept_info: VmxEptExitQualification,
-    ) -> Result<(), VpHaltReason<UhRunVpError>> {
-        let vtom = self.partition.caps.vtom.unwrap_or(0);
-        let is_shared = (gpa & vtom) == vtom && vtom != 0;
-        let canonical_gpa = gpa & !vtom;
-
-        // Only emulate the access if the gpa is mmio or outside of ram.
-        let address_type = self
-            .partition
-            .lower_vtl_memory_layout
-            .probe_address(canonical_gpa);
-
-        match address_type {
-            Some(AddressType::Mmio) => {
-                // Emulate the access.
-                self.emulate(
-                    dev,
-                    self.backing.vtls[intercepted_vtl]
-                        .interruption_information
-                        .valid(),
-                    intercepted_vtl,
-                    TdxEmulationCache::default(),
-                )
-                .await?;
-            }
-            Some(AddressType::Ram) => {
-                // TODO TDX: This path changes when we support VTL page
-                // protections and MNF. That will require injecting events to
-                // VTL1 or other handling.
-                //
-                // For now, we just check if the exit was suprious or if we
-                // should inject a machine check. An exit is considered spurious
-                // if the gpa is accessible.
-                if self.partition.gm[intercepted_vtl]
-                    .probe_gpa_readable(gpa)
-                    .is_ok()
-                {
-                    tracelimit::warn_ratelimited!(
-                        CVM_ALLOWED,
-                        gpa,
-                        "possible spurious EPT violation, ignoring"
-                    );
-                } else {
-                    // TODO: It would be better to show what exact bitmap check
-                    // failed, but that requires some refactoring of how the
-                    // different bitmaps are stored. Do this when we support VTL
-                    // protections or MNF.
-                    //
-                    // If we entered this path, it means the bitmap check on
-                    // `check_gpa_readable` failed, so we can assume that if the
-                    // address is shared, the actual state of the page is
-                    // private, and vice versa. This is because the address
-                    // should have already been checked to be valid memory
-                    // described to the guest or not.
-                    tracelimit::warn_ratelimited!(
-                        CVM_ALLOWED,
-                        gpa,
-                        is_shared,
-                        ?ept_info,
-                        "guest accessed inaccessible gpa, injecting MC"
-                    );
-
-                    // TODO: Implement IA32_MCG_STATUS MSR for more reporting
-                    self.inject_mc(intercepted_vtl);
-                }
-            }
-            None => {
-                if !self.cvm_partition().hide_isolation {
-                    // TODO: Addresses outside of ram and mmio probably should
-                    // not be accessed by the guest, if it has been told about
-                    // isolation. While it's okay as we will return FFs or
-                    // discard writes for addresses that are not mmio, we should
-                    // consider if instead we should also inject a machine check
-                    // for such accesses. The guest should not access any
-                    // addresses not described to it.
-                    //
-                    // For now, log that the guest did this.
-                    tracelimit::warn_ratelimited!(
-                        CVM_ALLOWED,
-                        gpa,
-                        is_shared,
-                        ?ept_info,
-                        "guest accessed gpa not described in memory layout, emulating anyways"
-                    );
-                }
-
-                // Emulate the access.
-                self.emulate(
-                    dev,
-                    self.backing.vtls[intercepted_vtl]
-                        .interruption_information
-                        .valid(),
-                    intercepted_vtl,
-                    TdxEmulationCache::default(),
-                )
-                .await?;
-            }
-        }
-
-        Ok(())
     }
 
     fn handle_tdvmcall(&mut self, dev: &impl CpuIo, intercepted_vtl: GuestVtl) {

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -2062,7 +2062,8 @@ impl UhProcessor<'_, TdxBacked> {
                         .into();
                     assert!(!old_interruptibility.blocked_by_nmi());
                 } else {
-                    if self.check_mem_fault(intercepted_vtl, gpa) {
+                    let is_write = ept_info.access_mask() & 0b10 != 0;
+                    if self.check_mem_fault(intercepted_vtl, gpa, is_write, ept_info) {
                         self.emulate(
                             dev,
                             self.backing.vtls[intercepted_vtl]

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1956,6 +1956,14 @@ impl GuestMemory {
         self.read_at_inner(gpa, &mut b).map_err(|err| err.kind)
     }
 
+    /// Check if a given GPA is writeable or not.
+    /// Note that this does read the given address first.
+    pub fn probe_gpa_writable(&self, gpa: u64) -> Result<(), GuestMemoryErrorKind> {
+        let mut b = [0];
+        self.read_at_inner(gpa, &mut b).map_err(|err| err.kind)?;
+        self.write_at_inner(gpa, &b).map_err(|err| err.kind)
+    }
+
     /// Gets a slice of guest memory assuming the memory was already locked via
     /// [`GuestMemory::lock_gpns`].
     ///

--- a/vm/vmcore/guestmem/src/lib.rs
+++ b/vm/vmcore/guestmem/src/lib.rs
@@ -1957,11 +1957,11 @@ impl GuestMemory {
     }
 
     /// Check if a given GPA is writeable or not.
-    /// Note that this does read the given address first.
     pub fn probe_gpa_writable(&self, gpa: u64) -> Result<(), GuestMemoryErrorKind> {
-        let mut b = [0];
-        self.read_at_inner(gpa, &mut b).map_err(|err| err.kind)?;
-        self.write_at_inner(gpa, &b).map_err(|err| err.kind)
+        let _ = self
+            .compare_exchange(gpa, 0u8, 0)
+            .map_err(|err| err.kind())?;
+        Ok(())
     }
 
     /// Gets a slice of guest memory assuming the memory was already locked via

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -188,7 +188,7 @@ pub struct SevIoAccessInfo {
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq, Eq)]
 pub struct SevNpfInfo {
     pub present: bool,
-    pub read_write: bool,
+    pub is_write: bool,
     pub user: bool,
     pub reserved_bit_set: bool,
     pub fetch: bool,


### PR DESCRIPTION
This fixes some crashes within OpenHCL when memory protections are violated in SNP that were already handled properly in TDX. Also updates the logic to send memory intercepts on VTL 1 permissions violations.

Fixes #689, and some OS repo tests